### PR TITLE
fix(cli): interrupt during the gather spinner exits 130, never 0 (#950)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ CI (with `--yes`).
   is always surfaced regardless (as the `skipped=N` footer line or a loud
   `warning:`); `--strict` only decides whether it fails the build.
 - Errors always exit `2`; `revert` exits `1` when drift remains after it.
+- Interrupting a run with **Ctrl-C** (or **ESC**) during the gather/read phase
+  exits `130` (128 + SIGINT) for every verb — never `0`, so an aborted
+  `check --fail` can never be mistaken for "no drift" and an aborted `record` is
+  never a false "written".
 
 ```yaml
 - run: npm ci # cdkrd resolves the CDK app, so its deps must be installed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@
 // writes only .cdkrd/ignore.yaml); revert is the one AWS-mutating command.
 import { readFileSync } from 'node:fs';
 import { flushAndExit } from './exit.js';
+import { installInterruptGuard } from './interrupt.js';
 import { runRecord } from './commands/record.js';
 import { runIgnore } from './commands/ignore.js';
 import { runCheck } from './commands/check.js';
@@ -84,6 +85,7 @@ EXIT CODES
   record: 0 = written   2 = error/refused
   ignore: 0 = rule(s) written / nothing to ignore   2 = error/refused
   revert: 0 = converged/aborted   1 = drift remains   2 = error/apply failure
+  all:    130 = interrupted (Ctrl-C / ESC) during the gather/read phase — never mistaken for clean
 
 The baseline lives at .cdkrd/baselines/<stack>.<accountId>.<region>.json — commit it; review
 its diff in PRs. Ignore rules live in .cdkrd/ignore.yaml — also git-committed.`;
@@ -127,6 +129,10 @@ async function main(argv: string[]): Promise<number> {
       return 2;
   }
 }
+
+// #950: rewrite the gather-phase spinner's hard exit(0) on Ctrl-C / ESC to 130 and give
+// the non-raw-mode phases real SIGINT/SIGTERM handlers. Install before anything runs.
+installInterruptGuard();
 
 const argv = process.argv.slice(2);
 main(argv)

--- a/src/commands/progress.ts
+++ b/src/commands/progress.ts
@@ -6,6 +6,7 @@
 // where the user has no cue anything is happening. Show a spinner while it runs so it is
 // clear cdkrd is working, not hung.
 import { spinner } from '@clack/prompts';
+import { setGatherActive } from '../interrupt.js';
 
 // TTY + text mode only: a spinner would corrupt --json's machine stdout and is noise in
 // a non-TTY / CI pipe, so callers pass `show=false` there and this is a plain
@@ -20,6 +21,12 @@ export async function gatherWithProgress<T>(
 ): Promise<T> {
   if (!show) return run();
   const s = spinner();
+  // #950: mark the window where @clack's spinner owns stdin in raw mode — a Ctrl-C / ESC
+  // here reaches the vendored `block()` handler's hard `process.exit(0)`, which the
+  // interrupt guard rewrites to 130 so an aborted gather never reads as a clean/success
+  // exit. Cleared in `finally` so a normal stop OR a read failure both restore the flag
+  // before the exit path (clean 0 / drift 1 / error 2) runs.
+  setGatherActive(true);
   s.start(`${label}: reading live AWS state & computing drift…`);
   try {
     const gathered = await run();
@@ -28,6 +35,8 @@ export async function gatherWithProgress<T>(
   } catch (e) {
     s.error(`${label}: read failed`);
     throw e;
+  } finally {
+    setGatherActive(false);
   }
 }
 

--- a/src/interrupt.ts
+++ b/src/interrupt.ts
@@ -1,0 +1,56 @@
+// Interrupt handling for the gather phase (#950). `@clack/core`'s `block()` — the
+// raw-mode keypress handler the gather-phase spinner installs — hard-codes
+// `process.exit(0)` on the cancel key (Ctrl-C AND Escape). That is the CLEAN exit code,
+// so an interrupt during the gather (the LONGEST phase of every verb) silently passed
+// `check --fail` ("no drift" → a gated deploy proceeds), faked `record`/`ignore` success
+// with nothing written, and read as "converged" for `revert`. cdkrd installs no signal
+// handling of its own, and the exit-0 lives inside the vendored dependency, unreachable
+// via `spinner({ onCancel })` (that only hooks the SIGNAL path, not the keypress path).
+//
+// We guard it centrally: while the gather spinner holds stdin in raw mode, rewrite an
+// exit-0 to 130 (128 + SIGINT, the conventional interrupt code) via a thin process.exit
+// wrapper, and install real SIGINT/SIGTERM handlers for the phases where stdin is NOT in
+// raw mode (synth/discovery, the interactive prompt gap) so those interrupts also land on
+// 130 with the cursor restored. Outside the gather window the wrapper is a pass-through,
+// so a clean 0 / drift 1 / error 2 exit is unaffected.
+
+let gatherActive = false;
+
+// Set by the gather-phase spinner wrapper (progress.ts) around the exact window where
+// `@clack/core` owns stdin and can hard-exit(0) on a keypress.
+export function setGatherActive(active: boolean): void {
+  gatherActive = active;
+}
+
+// Exposed for tests only.
+export function isGatherActive(): boolean {
+  return gatherActive;
+}
+
+// Pure decision: an exit-0 (or a bare `process.exit()` with no code) fired WHILE the
+// gather spinner is active is an interrupt captured by the spinner's raw-mode handler,
+// not a clean run — map it to 130. An explicit non-zero code (a real error/drift exit)
+// always passes through, as does any exit once the spinner has torn down.
+export function interruptExitCode(code: number | undefined, active: boolean): number {
+  return active && (code === undefined || code === 0) ? 130 : (code ?? 0);
+}
+
+let installed = false;
+
+// Install the process-exit guard + signal handlers exactly once, at CLI startup.
+export function installInterruptGuard(): void {
+  if (installed) return;
+  installed = true;
+  const realExit = process.exit.bind(process) as (code?: number) => never;
+  (process as unknown as { exit: (code?: number) => never }).exit = (code?: number): never =>
+    realExit(interruptExitCode(code, gatherActive));
+  const onSignal = (): never => {
+    // Restore the cursor the spinner may have hidden, then exit with the interrupt code.
+    // (Overrides Node's default SIGINT handler, which would exit 130 anyway but without
+    // the cursor-restore.) Bypass the wrapper — this is unambiguously an interrupt.
+    process.stderr.write('\x1B[?25h');
+    return realExit(130);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+}

--- a/tests/interrupt-exit-950.test.ts
+++ b/tests/interrupt-exit-950.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  installInterruptGuard,
+  interruptExitCode,
+  isGatherActive,
+  setGatherActive,
+} from '../src/interrupt.js';
+
+// #950 — a Ctrl-C / ESC during the gather-phase spinner reached @clack/core's `block()`,
+// whose hard `process.exit(0)` made `check --fail` silently pass, `record` fake success,
+// and `revert` read as converged. The guard rewrites an exit-0 (or bare exit) fired WHILE
+// the spinner owns stdin to 130, and leaves every other exit untouched.
+describe('interruptExitCode (#950)', () => {
+  it('maps a gather-active exit-0 to 130 (the interrupt landed on the clean code)', () => {
+    expect(interruptExitCode(0, true)).toBe(130);
+  });
+
+  it('maps a gather-active bare exit (no code) to 130', () => {
+    expect(interruptExitCode(undefined, true)).toBe(130);
+  });
+
+  it('passes a real error/drift exit through even while gather-active', () => {
+    expect(interruptExitCode(1, true)).toBe(1); // drift
+    expect(interruptExitCode(2, true)).toBe(2); // error
+  });
+
+  it('is a pass-through once the spinner has torn down (gather inactive)', () => {
+    expect(interruptExitCode(0, false)).toBe(0); // clean
+    expect(interruptExitCode(undefined, false)).toBe(0);
+    expect(interruptExitCode(1, false)).toBe(1);
+    expect(interruptExitCode(2, false)).toBe(2);
+  });
+});
+
+describe('setGatherActive / isGatherActive (#950)', () => {
+  it('round-trips the active flag (default false)', () => {
+    expect(isGatherActive()).toBe(false);
+    setGatherActive(true);
+    expect(isGatherActive()).toBe(true);
+    setGatherActive(false);
+    expect(isGatherActive()).toBe(false);
+  });
+});
+
+describe('installInterruptGuard (#950)', () => {
+  it('wraps process.exit so a gather-active exit(0) resolves to 130 without terminating', () => {
+    installInterruptGuard();
+    // Capture what the guarded process.exit would pass to the REAL exit, without dying:
+    // the wrapper computes interruptExitCode then calls the bound real exit. We assert the
+    // decision indirectly via the pure function the wrapper delegates to (the wrapper is a
+    // one-liner over it) plus the SIGINT/SIGTERM listeners being registered.
+    expect(process.listenerCount('SIGINT')).toBeGreaterThan(0);
+    expect(process.listenerCount('SIGTERM')).toBeGreaterThan(0);
+  });
+
+  it('is idempotent — a second install does not stack a second pair of signal handlers', () => {
+    const before = process.listenerCount('SIGINT');
+    installInterruptGuard();
+    installInterruptGuard();
+    expect(process.listenerCount('SIGINT')).toBe(before);
+  });
+});


### PR DESCRIPTION
Closes #950

## Problem
`@clack/core`'s `block()` — the raw-mode keypress handler the gather-phase spinner installs — hard-codes `process.exit(0)` on the cancel key (**Ctrl-C AND ESC**). That is the CLEAN exit code, so an interrupt during the gather (the LONGEST phase of every verb) silently:
- passed `check --fail` ("no drift" → a gated `cdk deploy` proceeds) and `check --strict`,
- faked `record` / `ignore` success with **nothing written**,
- read as "converged" for `revert`.

cdkrd installed no signal handling of its own, and the exit-0 lives inside the vendored dependency, unreachable via `spinner({ onCancel })` (that only hooks the SIGNAL path, not the keypress path).

## Fix
New `src/interrupt.ts`:
- `installInterruptGuard()` (called once at `cli.ts` startup) wraps `process.exit` so that a `0`/bare exit fired **while the gather spinner owns stdin** is rewritten to **130** (128 + SIGINT, the conventional interrupt code). Outside that window it is a pass-through — clean `0` / drift `1` / error `2` are unaffected.
- Real `SIGINT`/`SIGTERM` handlers (cursor-restore + exit 130) for the phases where stdin is NOT in raw mode (synth/discovery, the interactive-prompt gap).
- `progress.ts` sets a `gatherActive` flag around the exact spinner window (cleared in `finally`).

HELP + README `EXIT CODES` document `130`.

## Verification
- Unit: `tests/interrupt-exit-950.test.ts` — `interruptExitCode` decision table (gather-active 0/bare → 130; real 1/2 pass through; inactive = pass-through) + guard idempotency + signal-handler registration. Full suite green (3546).
- **Live (offline PTY, the issue's repro)**: fresh assembly + blackhole endpoint held the gather open under a PTY; sending **Ctrl-C → exit 130** and **ESC → exit 130** (was 0 on `main`). SIGTERM path also confirmed (cursor restored, exit 130).