### PR TITLE
fix(read): Aurora AAS read-replicas falsely 'added' (#801)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -2692,6 +2692,16 @@ export function diffRdsClusterChildren(input: RdsClusterChildInput): AddedChild[
   return added;
 }
 
+// Reader instances created by Aurora read-replica Application Auto Scaling
+// (`rds:cluster:ReadReplicaCount`) are named with the documented, reserved
+// `application-autoscaling-` DBInstanceIdentifier prefix (case-sensitive per AWS's naming).
+// Match the identifier by prefix — not a substring elsewhere — so an unrelated instance that
+// merely contains the string is not folded.
+const AAS_MANAGED_READER_PREFIX = 'application-autoscaling-';
+function isAasManagedReader(dbInstanceIdentifier: string): boolean {
+  return dbInstanceIdentifier.startsWith(AAS_MANAGED_READER_PREFIX);
+}
+
 async function pageDbInstances(client: RDSClient, clusterId: string): Promise<RdsDBInstance[]> {
   const out: RdsDBInstance[] = [];
   let marker: string | undefined;
@@ -2745,7 +2755,14 @@ export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promi
   const liveInstances = instances
     .filter(
       (i): i is RdsDBInstance & { DBInstanceIdentifier: string } =>
-        typeof i.DBInstanceIdentifier === 'string'
+        typeof i.DBInstanceIdentifier === 'string' &&
+        // Skip reader instances created by Aurora read-replica Application Auto Scaling
+        // (`rds:cluster:ReadReplicaCount`). AWS names them `application-autoscaling-<uuid>`;
+        // they are owned by the autoscaler (like an EventBridge `ManagedBy` rule), not an
+        // out-of-band human change, and are not user-revertable — a scale-in/out churns the
+        // identifiers, so they would otherwise be a permanent first-run false `[Added]` that
+        // `record` can never stabilize and `revert` would offer to DeleteResource (#801).
+        !isAasManagedReader(i.DBInstanceIdentifier)
     )
     .map((i) => ({ id: i.DBInstanceIdentifier, label: i.DBInstanceIdentifier }));
 

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1439,6 +1439,78 @@ describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896)', () => {
     expect(added.map((a) => a.identifier)).toEqual(['rogue-oob']);
     rds.restore();
   });
+
+  // #801: Aurora read-replica Application Auto Scaling (`rds:cluster:ReadReplicaCount`)
+  // creates reader instances named `application-autoscaling-<uuid>`. They are owned by the
+  // autoscaler, not an out-of-band human change, so they must NOT surface as `added` (a
+  // permanent first-run false positive; revert would offer to delete an autoscaler reader).
+  it('excludes Application Auto Scaling readers (application-autoscaling-*) while keeping normal instances', async () => {
+    const rds = mockClient(RDSClient);
+    rds
+      .on(DescribeDBInstancesCommand)
+      .resolves({
+        DBInstances: [
+          { DBInstanceIdentifier: 'cluster-writer' },
+          { DBInstanceIdentifier: 'cluster-reader' },
+          { DBInstanceIdentifier: 'application-autoscaling-4d1e2f3a-0b5c-6789-abcd-ef0123456789' },
+        ],
+      })
+      .on(DescribeDBClustersCommand)
+      .resolves({
+        DBClusters: [
+          {
+            DBClusterMembers: [
+              { DBInstanceIdentifier: 'cluster-writer' },
+              { DBInstanceIdentifier: 'cluster-reader' },
+            ],
+          },
+        ],
+      });
+    const ctx = {
+      parent: { physicalId: 'c1' },
+      // Both normal instances are declared in the template.
+      desired: {
+        resources: [
+          {
+            resourceType: 'AWS::RDS::DBInstance',
+            declared: { DBClusterIdentifier: 'c1' },
+            physicalId: 'cluster-writer',
+          },
+          {
+            resourceType: 'AWS::RDS::DBInstance',
+            declared: { DBClusterIdentifier: 'c1' },
+            physicalId: 'cluster-reader',
+          },
+        ],
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateRdsClusterChildren(ctx);
+    // The AAS-managed reader is excluded from the enumeration entirely, so nothing is `added`.
+    expect(added).toEqual([]);
+    rds.restore();
+  });
+
+  // The prefix match is precise: an instance that merely CONTAINS the string elsewhere (not a
+  // prefix) is still flagged if out of band.
+  it('does not fold an instance whose identifier only contains application-autoscaling- as a substring', async () => {
+    const rds = mockClient(RDSClient);
+    rds
+      .on(DescribeDBInstancesCommand)
+      .resolves({
+        DBInstances: [{ DBInstanceIdentifier: 'my-application-autoscaling-reader' }],
+      })
+      .on(DescribeDBClustersCommand)
+      .resolves({ DBClusters: [{ DBClusterMembers: [] }] });
+    const ctx = {
+      parent: { physicalId: 'c1' },
+      desired: { resources: [] },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateRdsClusterChildren(ctx);
+    expect(added.map((a) => a.identifier)).toEqual(['my-application-autoscaling-reader']);
+    rds.restore();
+  });
 });
 
 describe('diffRouteTableChildren (EC2 routes)', () => {


### PR DESCRIPTION
Closes #801.

## Root cause
`enumerateRdsClusterChildren` (`src/read/child-enumerators.ts`) listed `DescribeDBInstances(db-cluster-id=<cluster>)` with no AWS-managed exclusion. Aurora read-replica **Application Auto Scaling** (`rds:cluster:ReadReplicaCount`) materializes reader instances named `application-autoscaling-<uuid>`. They come back from the enumerator, are absent from the template, and were reported as out-of-band `added` on **every** check of **every** autoscaled Aurora cluster — a permanent first-run false positive. `revert` then offered to `DeleteResource` an autoscaler-managed reader, and `record` could not stabilize it (scale-in/out churns the identifiers).

## Fix
Exclude cluster members whose `DBInstanceIdentifier` starts with the documented, reserved `application-autoscaling-` prefix (case-sensitive per AWS naming), matched at the live-instance mapping step — mirroring the existing EventBridge `ManagedBy` skip in the same file. The match is a **prefix** check (`startsWith`), not a substring, so an unrelated instance that merely contains the string is still flagged. Surgical and local to the RDS enumerator; no other enumerator behavior changes.

## Test
`tests/child-enumerators.test.ts` extends the `enumerateRdsClusterChildren` suite:
- mocks `DescribeDBInstances` with a declared writer + reader **and** an `application-autoscaling-<uuid>` instance → asserts the AAS reader is excluded (nothing `added`) while normal instances are enumerated;
- asserts an identifier that only *contains* `application-autoscaling-` as a substring is still flagged.

Test fails without the fix, passes with it. Full suite: 3586 passing, `vp run check` → 0 errors.

## Live test
A full live-test needs a deployed autoscaled Aurora cluster (heavy). The unit test + the documented `application-autoscaling-` naming are the evidence here; the maintainer can run the live integ if desired.
