### PR TITLE
fix(report): --pre-deploy pending-creation footer + deploy-will-delete surface (#883)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -33,6 +33,30 @@ export function parseTemplateBody(body: string): Record<string, unknown> {
   return parseCfnTemplate(body);
 }
 
+// #883: under --pre-deploy the declared source is the LOCAL synth template, so the
+// symmetric half of "resource in the template but not yet deployed" is "resource DEPLOYED
+// but absent from the template" — a live resource the next deploy will DELETE (a rename
+// X->Y, or a construct removed from the app). loadDesired iterates only template Resources,
+// so those deployed-only logical ids are otherwise invisible: the report shows the new
+// resource as pending creation and says NOTHING about the one being torn down (often a
+// stateful resource). Compute it from physIds (the live stack's resources) minus the local
+// template's logical ids — zero extra AWS calls. Returns the info line, or null when none.
+// Pure + exported for unit tests.
+export function deletedResourceInfo(
+  physIds: Record<string, string>,
+  template: Record<string, unknown>,
+  stackName: string
+): string | null {
+  const templateIds = new Set(Object.keys((template.Resources ?? {}) as Record<string, unknown>));
+  const deleted = Object.keys(physIds)
+    .filter((id) => !templateIds.has(id))
+    .sort();
+  if (deleted.length === 0) return null;
+  const shown = deleted.slice(0, 10);
+  const more = deleted.length > shown.length ? `, …(+${deleted.length - shown.length} more)` : '';
+  return `info: ${stackName}: ${deleted.length} deployed resource(s) absent from the local template — the next deploy will DELETE them: ${shown.join(', ')}${more}`;
+}
+
 // The AWS::Partition / AWS::URLSuffix pseudo-parameters are a deterministic function of the
 // region, NOT a commercial-partition constant. CDK env-agnostic stacks emit ${AWS::Partition}
 // inside nearly every Sub/Join-built ARN, so hard-coding `aws` / `amazonaws.com` mis-resolves
@@ -245,6 +269,17 @@ export async function loadDesired(
     // — same treatment as a dynamic reference we cannot resolve.
     if (value === '****') continue;
     stackParams[p.ParameterKey] = value;
+  }
+
+  // #883: under --pre-deploy (templateOverride set), surface deployed resources that are
+  // ABSENT from the local template — the next deploy will DELETE them. This is the symmetric
+  // half of the #727 pending-creation note (which surfaces template resources not yet
+  // deployed); together they answer "will this deploy fight reality?". stderr keeps --json
+  // stdout clean, mirroring the #727 note in check.ts. Only meaningful pre-deploy: on the
+  // deployed path the declared source IS the deployed template, so the two id sets match.
+  if (templateOverride) {
+    const deletedInfo = deletedResourceInfo(physIds, template, stackName);
+    if (deletedInfo) console.error(deletedInfo);
   }
 
   const ctx = buildResolverContext(

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -99,7 +99,21 @@ export interface ReportOptions {
   json?: boolean;
   verbose?: boolean; // expand informational tiers (readGap/unresolved/skipped) to full lists
   expandAtDefault?: boolean; // expand ONLY the atDefault tier to a full list (--show-all inventory mode)
+  // --pre-deploy: a `skipped: no physical id` finding is a not-yet-deployed LOCAL resource
+  // (the declared source is the synth template), NOT a coverage gap — the next deploy will
+  // create it. When set, the footer renders those pending-creation skips as their OWN
+  // `pending creation` group instead of branding them "coverage incomplete", so the text
+  // report agrees with check.ts's #727 stderr note (#883). Genuine gaps (CC-unsupported,
+  // read errors) still render as "coverage incomplete".
+  preDeploy?: boolean;
   log?: (s: string) => void;
+}
+
+// #883: a `skipped: no physical id` finding is a not-yet-deployed LOCAL resource under
+// --pre-deploy (the same predicate check.ts's #727 fix uses). Kept local to the report so
+// the footer can peel pending-creation skips out of the "coverage incomplete" bucket.
+function isPendingCreationSkip(f: Finding): boolean {
+  return f.tier === 'skipped' && f.note === 'no physical id';
 }
 // Unrecorded values (R60, per finding since R62): an undeclared finding tagged
 // `unrecorded` by applyBaseline (no baseline entry, resource never
@@ -536,10 +550,31 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
       return `skipped=${items.length} — NOT checked (coverage incomplete: ${groupReasons(items)})`;
     return `${t}=${items.length} (${groupReasons(items)})`;
   };
+  // #883: under --pre-deploy a `skipped: no physical id` finding is a not-yet-deployed
+  // LOCAL resource (the next deploy creates it), NOT a coverage gap — so it must not carry
+  // the "coverage incomplete" framing (that would contradict check.ts's #727 stderr note).
+  // Peel those pending-creation skips out and render them as their own `pending creation`
+  // line; any GENUINE gap (CC-unsupported, read error) stays in the "coverage incomplete"
+  // skipped line. `pendingSkipSummary` returns null when there are none (non-pre-deploy runs
+  // and pre-deploy runs with only genuine gaps are byte-identical to before).
+  const skippedSummaryFor = (items: Finding[]): string[] => {
+    if (!opts.preDeploy) return [summaryFor('skipped', items)];
+    const pending = items.filter(isPendingCreationSkip);
+    const gaps = items.filter((f) => !isPendingCreationSkip(f));
+    const lines: string[] = [];
+    if (gaps.length > 0) lines.push(summaryFor('skipped', gaps));
+    if (pending.length > 0)
+      lines.push(
+        `pending creation=${pending.length} (not yet deployed — the next deploy will create them, not a coverage gap)`
+      );
+    return lines;
+  };
   const summaries = INFO_TIERS.filter((t) => !isExpanded(t))
-    .map((t) => {
+    .flatMap((t) => {
       const items = byTier(t);
-      return items.length ? summaryFor(t, items) : null;
+      if (items.length === 0) return [];
+      if (t === 'skipped') return skippedSummaryFor(items);
+      return [summaryFor(t, items)];
     })
     .filter((s): s is string => s !== null);
   // R96: the folded nested-unrecorded count joins the info: footer (--show-all lists them).

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -860,3 +860,57 @@ describe('map-valued declared drift shows a per-KEY delta (not a key-order-confu
     expect(out).not.toContain('~ a.b'); // unchanged
   });
 });
+
+describe('#883 — --pre-deploy footer renders pending-creation skips as their own group', () => {
+  // A `skipped: no physical id` finding is a not-yet-deployed LOCAL resource under
+  // --pre-deploy (the same predicate check.ts's #727 fix uses).
+  const skip = (note: string, resourceType = 'AWS::X::Y'): Finding => ({
+    tier: 'skipped',
+    logicalId: 'L',
+    resourceType,
+    path: '',
+    note,
+  });
+
+  it('WITHOUT preDeploy, a "no physical id" skip stays branded coverage-incomplete (unchanged)', () => {
+    const { text } = run([skip('no physical id')]);
+    expect(text).toContain('NOT checked (coverage incomplete: no physical id 1)');
+    expect(text).not.toContain('pending creation');
+  });
+
+  it('WITH preDeploy, a "no physical id" skip is a pending-creation group, NOT coverage incomplete', () => {
+    const { text } = run([skip('no physical id')], { preDeploy: true });
+    // the contradiction the issue reports must be gone: no "coverage incomplete" for it
+    expect(text).not.toContain('coverage incomplete');
+    expect(text).toContain(
+      'pending creation=1 (not yet deployed — the next deploy will create them, not a coverage gap)'
+    );
+  });
+
+  it('WITH preDeploy, a GENUINE gap (custom resource) still reads coverage incomplete', () => {
+    const { text } = run([skip('custom resource — no cloud-side model to read', 'Custom::Foo')], {
+      preDeploy: true,
+    });
+    expect(text).toContain('NOT checked (coverage incomplete: custom resource 1)');
+    expect(text).not.toContain('pending creation');
+  });
+
+  it('WITH preDeploy, mixed skips split into a coverage-incomplete line AND a pending-creation line', () => {
+    const { text } = run(
+      [
+        skip('no physical id'),
+        skip('custom resource — no cloud-side model to read', 'Custom::Foo'),
+      ],
+      { preDeploy: true }
+    );
+    const lines = text.split('\n');
+    const infoIdx = lines.indexOf('info:');
+    expect(infoIdx).toBeGreaterThan(-1);
+    // the genuine gap keeps the "coverage incomplete" framing …
+    expect(text).toMatch(/skipped=1 — NOT checked \(coverage incomplete: custom resource 1\)/);
+    // … and the not-yet-deployed resource is its own pending-creation line, not a gap
+    expect(text).toContain(
+      'pending creation=1 (not yet deployed — the next deploy will create them, not a coverage gap)'
+    );
+  });
+});

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -6,11 +6,12 @@ import {
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
 import { mockClient } from 'aws-sdk-client-mock';
-import { describe, expect, it } from 'vite-plus/test';
+import { describe, expect, it, vi } from 'vite-plus/test';
 import {
   buildResolverContext,
   collectClustersWithSiblingCapacityProviders,
   collectPrincipalsWithSiblingPolicies,
+  deletedResourceInfo,
   loadDesired,
   parseTemplateBody,
 } from '../src/desired/template-adapter.js';
@@ -356,6 +357,102 @@ describe('loadDesired templateOverride (--pre-deploy)', () => {
     expect(desired.resources[0]!.declared).toEqual({ BucketName: 'from-synth' });
     expect(desired.resources[0]!.physicalId).toBe('b-phys'); // physId still from live stack
     expect(desired.accountId).toBe('111122223333');
+  });
+});
+
+describe('#883 — deletedResourceInfo (deploy-will-DELETE surface under --pre-deploy)', () => {
+  it('lists deployed logical ids absent from the local template (a rename tears down the old one)', () => {
+    // Rename X -> Y: the live stack still has OldBucket; the local template declares NewBucket.
+    const physIds = { OldBucket: 'old-phys', Keep: 'keep-phys' };
+    const template = {
+      Resources: { NewBucket: { Type: 'AWS::S3::Bucket' }, Keep: { Type: 'AWS::S3::Bucket' } },
+    };
+    const line = deletedResourceInfo(physIds, template, 'S');
+    expect(line).toBe(
+      'info: S: 1 deployed resource(s) absent from the local template — the next deploy will DELETE them: OldBucket'
+    );
+  });
+
+  it('returns null when every deployed resource is still in the template (nothing to delete)', () => {
+    const physIds = { A: 'a', B: 'b' };
+    const template = {
+      Resources: { A: { Type: 'AWS::S3::Bucket' }, B: { Type: 'AWS::S3::Bucket' } },
+    };
+    expect(deletedResourceInfo(physIds, template, 'S')).toBeNull();
+  });
+
+  it('caps the listed ids at 10 with an overflow count', () => {
+    const physIds: Record<string, string> = {};
+    for (let i = 0; i < 12; i++) physIds[`R${String(i).padStart(2, '0')}`] = `p${i}`;
+    const line = deletedResourceInfo(physIds, { Resources: {} }, 'S');
+    expect(line).toContain('12 deployed resource(s) absent');
+    expect(line).toContain('…(+2 more)');
+  });
+});
+
+describe('#883 — loadDesired emits the deploy-will-DELETE note ONLY under --pre-deploy', () => {
+  function stack(cfn: ReturnType<typeof mockClient>): void {
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'OldBucket',
+          PhysicalResourceId: 'old-phys',
+          ResourceType: 'AWS::S3::Bucket',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+  }
+
+  it('under --pre-deploy, a deployed resource absent from the synth template is warned to stderr', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).rejects(new Error('GetTemplate must NOT be called in pre-deploy'));
+    stack(cfn);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let msg = '';
+    try {
+      // synth template renamed OldBucket -> NewBucket
+      await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', {
+        Resources: { NewBucket: { Type: 'AWS::S3::Bucket' } },
+      });
+      // read BEFORE mockRestore(): mockRestore() resets .mock.calls.
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    expect(msg).toContain('the next deploy will DELETE them: OldBucket');
+  });
+
+  it('on the NON-pre-deploy (deployed) path the note never fires (id sets always match)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Resources: { NewBucket: { Type: 'AWS::S3::Bucket', Properties: {} } },
+      }),
+    });
+    stack(cfn);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let msg = '';
+    try {
+      // no templateOverride => deployed path
+      await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1');
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    expect(msg).not.toContain('the next deploy will DELETE');
   });
 });
 


### PR DESCRIPTION
Closes #883.

Two `--pre-deploy` report-UX gaps.

## 1. Text footer branded pending-creation resources "coverage incomplete"

`src/report/report.ts` rendered `skipped=N — NOT checked (coverage incomplete: no physical id N)` for a not-yet-deployed local resource, contradicting `check.ts`'s #727 stderr note (`info: N resource(s) not yet deployed — ... not a coverage gap`). The JSON path (`coverageWarning`) already got a `preDeploy` parameter; the text footer did not.

**Fix:** add `preDeploy?: boolean` to `ReportOptions`. When set, the footer peels `skipped` findings whose `note === 'no physical id'` (the same predicate `check.ts`'s #727 fix uses) out of the "coverage incomplete" bucket and renders them as their own `pending creation=N (not yet deployed — the next deploy will create them, not a coverage gap)` line. Genuine gaps (CC-unsupported, read errors) still read "coverage incomplete". Non-pre-deploy runs and pre-deploy runs with only genuine gaps are byte-identical to before.

## 2. Resources REMOVED from the local template were invisible

`template-adapter.ts`'s `loadDesired` iterates only local-template `Resources`, so deployed-only logical ids (a rename X->Y, or a construct removed from the app) were never surfaced — the report showed the new resource as pending creation but said NOTHING about the one the next deploy will DELETE.

**Fix:** new pure exported `deletedResourceInfo(physIds, template, stackName)` computes `physIds` keys minus template ids (zero extra AWS calls) and returns `info: <stack>: N deployed resource(s) absent from the local template — the next deploy will DELETE them: <ids>`. `loadDesired` emits it to stderr (keeps `--json` stdout clean, mirrors the #727 note) ONLY under `--pre-deploy` (`templateOverride` set) — on the deployed path the id sets always match.

## Tests

- `tests/report.test.ts`: pending-creation group renders under `preDeploy`, NOT "coverage incomplete"; genuine gaps still coverage-incomplete; mixed skips split into two lines; non-pre-deploy unchanged.
- `tests/template-adapter.test.ts`: `deletedResourceInfo` lists deployed-only ids / returns null when none / caps at 10; `loadDesired` emits the note under `--pre-deploy` and never on the deployed path.

## Note on Part 1 wiring (check.ts, out of scope)

The report renderer now accepts `preDeploy`, but the `--pre-deploy` `report(...)` call site is in `check.ts` (owned by the parallel #948 lane, which this PR stays file-disjoint from). Activating Part 1 in production needs a one-line change at that call site — passing `preDeploy: true` into the report options (mirroring how `coverageWarning` already receives `a.preDeploy`). Left to the check.ts lane / integration to keep files disjoint. Part 2 (the deleted-resource note) is fully wired and active — it emits directly from `loadDesired`.

Gates: typecheck / `vp run check` (0 errors) / build / full test suite (3593 passing) all green from the worktree.
