### PR TITLE
fix(cli): gate interactivity on both stdin AND stdout being a TTY (#869)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,12 @@ the line) are errors (exit `2`): a typo'd flag never silently becomes a stack na
 Every option runs exactly the same code as the standalone commands. Prompts are
 skipped under `--json`, `--show-all`, `--pre-deploy`, and `--fail`. A non-TTY run
 never prompts: a required write decision without `--yes` errors with exit 2 (the
-safe side); `--yes` in a TTY skips the write confirmation AND each verb's selection
+safe side). "Interactive" requires **both** a TTY stdin and a TTY stdout — so
+**redirecting or piping the output** (`cdkrd check > report.txt`, `| tee`) is also
+treated as non-interactive: the report is written cleanly with no prompt (which
+would otherwise deadlock, waiting on stdin for a prompt written into the file) and
+no spinner frames leaking into the text. `--yes` in a TTY skips the write
+confirmation AND each verb's selection
 multiselect — `record` records ALL, `ignore` ignores ALL, `revert` applies the full
 plan. Only `check`'s action menu (Record / Revert / Ignore / …) still shows under
 `--yes`.

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -114,9 +114,18 @@ export interface CommonArgs {
  * non-TTY (real CI/cron/pipes). The single source of truth — command code threads this
  * in rather than reading `process.stdin.isTTY` directly. Optional prompts skip when
  * false; required-decision prompts error (exit 2) when false.
+ *
+ * #869: gate on BOTH stdin AND stdout being a TTY — the interactive UI (the @clack
+ * spinner + resolve prompt) WRITES to stdout, so `cdkrd check > out.txt` (or `| tee`)
+ * from a terminal has a TTY stdin but a redirected stdout: gating on stdin alone RAN the
+ * prompt into the file, deadlocking the run on a prompt the user cannot see, and leaked
+ * the spinner's ANSI erase-frames into the text report (polluting the `^result:` grep
+ * contract). Requiring stdout too matches the color gate (`style.ts`, `process.stdout.isTTY`)
+ * so the two interactivity axes are consistent: a redirected/piped stdout is report-only,
+ * never prompts, never hangs.
  */
 export function isInteractive(): boolean {
-  return Boolean(process.stdin.isTTY);
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
 export function parseCommonArgs(args: string[], verb?: Verb): CommonArgs {

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -188,23 +188,42 @@ describe('parseCommonArgs', () => {
   });
 });
 
-describe('isInteractive (non-interactive simply means non-TTY, R58)', () => {
-  // Stub process.stdin.isTTY; restore in finally so other tests
-  // (and the real terminal) are unaffected.
-  const withTTY = (tty: boolean, fn: () => void) => {
-    const saved = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
-    Object.defineProperty(process.stdin, 'isTTY', { value: tty, configurable: true });
+describe('isInteractive (non-interactive simply means non-TTY, R58; #869 both axes)', () => {
+  // Stub BOTH process.stdin.isTTY and process.stdout.isTTY; restore in finally so other
+  // tests (and the real terminal) are unaffected. #869: the interactive UI writes to
+  // stdout, so interactivity must require stdout to be a TTY too — a redirected stdout
+  // (`check > file`) is report-only, never prompts.
+  const stub = (stream: NodeJS.ReadStream | NodeJS.WriteStream, tty: boolean): (() => void) => {
+    const saved = Object.getOwnPropertyDescriptor(stream, 'isTTY');
+    Object.defineProperty(stream, 'isTTY', { value: tty, configurable: true });
+    return () => {
+      if (saved) Object.defineProperty(stream, 'isTTY', saved);
+      else delete (stream as { isTTY?: boolean }).isTTY;
+    };
+  };
+  const withTTY = (stdinTty: boolean, stdoutTty: boolean, fn: () => void) => {
+    const restoreIn = stub(process.stdin, stdinTty);
+    const restoreOut = stub(process.stdout, stdoutTty);
     try {
       fn();
     } finally {
-      if (saved) Object.defineProperty(process.stdin, 'isTTY', saved);
-      else delete (process.stdin as { isTTY?: boolean }).isTTY;
+      restoreOut();
+      restoreIn();
     }
   };
 
-  it('true exactly when stdin is a TTY', () => {
-    withTTY(true, () => expect(isInteractive()).toBe(true));
-    withTTY(false, () => expect(isInteractive()).toBe(false));
+  it('true only when BOTH stdin and stdout are a TTY', () => {
+    withTTY(true, true, () => expect(isInteractive()).toBe(true));
+    withTTY(false, true, () => expect(isInteractive()).toBe(false));
+  });
+
+  it('#869: a TTY stdin with a redirected stdout (`check > file`) is NOT interactive', () => {
+    // The regression: gating on stdin alone RAN the prompt into the file, deadlocking.
+    withTTY(true, false, () => expect(isInteractive()).toBe(false));
+  });
+
+  it('a fully non-TTY run (CI/pipe) is not interactive', () => {
+    withTTY(false, false, () => expect(isInteractive()).toBe(false));
   });
 });
 


### PR DESCRIPTION
Closes #869

## Problem
`isInteractive()` gated on `process.stdin.isTTY` alone, but the interactive UI (the @clack spinner + resolve prompt) WRITES to **stdout**. So `cdkrd check > out.txt` (or `| tee`) from a terminal — TTY stdin, redirected stdout — RAN the prompt, sending its UI into the file and **deadlocking** the run on a prompt the user cannot see, and leaked the spinner's ANSI erase-frames into the text report (polluting the README `^result:` grep contract). Colors already correctly gate on `process.stdout.isTTY` (`style.ts`) — the two axes were inconsistent.

## Fix
`isInteractive()` now requires **both** `process.stdin.isTTY && process.stdout.isTTY`, matching the color gate. A redirected/piped stdout is report-only: no prompt (no hang), no spinner frames. It is the single source of truth threaded into `showProgress` and the resolve prompt, so every interactive path is fixed at once.

## Tests
`tests/cli-args.test.ts` — `isInteractive` truth table extended to both axes: true only when BOTH are a TTY; the regression case (TTY stdin + redirected stdout → NOT interactive); fully non-TTY → not interactive. Full suite green (3593). Docs: README "Interactive prompts" section now states redirect/pipe is non-interactive.

Live evidence: the change is a pure gate function (the single source of truth for `showProgress` + the prompt); its unit truth-table IS the authoritative evidence, so no fresh AWS deploy (CLI-contract fix, no read/revert hot path).