### PR TITLE
fix(diff): fold derivable tier-3 policy residue (#894)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1647,6 +1647,47 @@ export function classifyResource(
       knownDef = { ...knownDef, SecondaryPrivateIpAddressCount: Math.max(0, ips.length - 1) };
     }
   }
+  // #894: a Stage that declares a CanarySetting reads back an undeclared
+  // `CanarySetting.DeploymentId` AWS materializes at creation — the canary starts pointed at the
+  // stage's CURRENT deployment, so it EQUALS the stage's own `DeploymentId` (declared, or the live
+  // value when omitted). Previously folded value-INDEPENDENT via GENERATED_NESTED_PATHS, which hid
+  // an out-of-band canary re-point (`update-stage /canarySettings/deploymentId`) — re-aiming the
+  // canary at an old/vulnerable deployment serves that code to the canary % of prod traffic,
+  // invisibly. Promote to a tier-2 derived equality gate against the stage's own DeploymentId
+  // (declared wins; else the live top-level value). The value-independent GENERATED_NESTED_PATHS
+  // branch in emitNested is suppressed for any nested path that has a knownDefPaths gate this run,
+  // so a re-pointed canary now surfaces while a clean deploy stays atDefault.
+  if (resourceType === 'AWS::ApiGateway::Stage') {
+    const stageDeploymentId = declared['DeploymentId'] ?? live['DeploymentId'];
+    if (typeof stageDeploymentId === 'string') {
+      knownDefPaths = { ...knownDefPaths, 'CanarySetting.DeploymentId': stageDeploymentId };
+    }
+  }
+  // #894: a VPCEndpoint that declares no `DnsOptions` reads back an AWS-assigned default object
+  // whose `DnsRecordIpType` is a DETERMINISTIC function of the declared `VpcEndpointType`
+  // ("ipv4" for an Interface endpoint, "service-defined" for a Gateway one); the other sub-keys
+  // are stable constants. Previously folded value-INDEPENDENT (whole object) via
+  // VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS, which hid an out-of-band `ModifyVpcEndpoint` edit of
+  // any sub-key. Derive the full default object from VpcEndpointType and equality-gate it (fold
+  // tier 2, subset-tolerant): a clean deploy stays atDefault, an out-of-band change to any sub-key
+  // (e.g. a DnsRecordIpType flip) surfaces. A user who configures DNS DECLARES DnsOptions and is
+  // compared in the declared loop, never reaching here.
+  if (resourceType === 'AWS::EC2::VPCEndpoint') {
+    const epType = declared['VpcEndpointType'];
+    const dnsRecordIpType =
+      epType === 'Interface' ? 'ipv4' : epType === 'Gateway' ? 'service-defined' : undefined;
+    if (dnsRecordIpType !== undefined) {
+      knownDef = {
+        ...knownDef,
+        DnsOptions: {
+          DnsRecordIpType: dnsRecordIpType,
+          PrivateDnsOnlyForInboundResolverEndpoint: 'NotSpecified',
+          PrivateDnsSpecifiedDomains: ['*'],
+          PrivateDnsPreference: 'VERIFIED_DOMAINS_ONLY',
+        },
+      };
+    }
+  }
   // R140: nested paths that are always an AWS-assigned generated id (value-independent),
   // folded as `generated` like the top-level isGeneratedName/GENERATED_DEFAULTS cases.
   const generatedPaths = GENERATED_PATHS[resourceType] ?? [];
@@ -2473,8 +2514,13 @@ export function classifyResource(
       // AWS's choice, not user intent. A trivially-empty value ([] / "" / {}) is NOT an
       // AWS-assigned default — it is just absent — so let it fall through to the shared
       // trivial-empty drop rather than surfacing a spurious atDefault (e.g. an NLB's empty
-      // SecurityGroups []).
-      (VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k) && !isTrivialEmpty(v)) ||
+      // SecurityGroups []). But NOT when the key has a knownDef equality gate this run
+      // (#894 VPCEndpoint DnsOptions, derived from VpcEndpointType above): the gate already
+      // folded the AWS-default value via the `k in knownDef` branch, so a value reaching here
+      // is a real out-of-band change that must surface, not be value-independent-folded.
+      (VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k) &&
+        !isTrivialEmpty(v) &&
+        !(k in knownDef)) ||
       // #705: a Classic ELB's undeclared Policies folds atDefault ONLY when it is exactly the
       // AWS default SSL negotiation policy (by PolicyName); a downgrade / added policy surfaces.
       clbDefaultSslPoliciesAtDefault(resourceType, k, v)

--- a/tests/classify-894-derived.test.ts
+++ b/tests/classify-894-derived.test.ts
@@ -1,0 +1,154 @@
+// #894 — DERIVED tier-2 folds promoting three formerly value-INDEPENDENT (tier-3) policy
+// residues to equality gates computed from declared inputs, so a clean deploy stays atDefault
+// while an out-of-band change to the value still surfaces (detection preserved):
+//   - ApiGateway Stage CanarySetting.DeploymentId derived from the stage's own DeploymentId
+//     (the canary is created pointed at the stage's current deployment). Previously folded
+//     value-INDEPENDENT via GENERATED_NESTED_PATHS, hiding a canary re-point.
+//   - EC2 VPCEndpoint DnsOptions derived from the declared VpcEndpointType (DnsRecordIpType
+//     "ipv4" for Interface, "service-defined" for Gateway). Previously folded whole-object
+//     value-INDEPENDENT via VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS.
+// (Bedrock AgentAlias RoutingConfiguration stays value-independent by design — the auto-created
+// agent version is a per-resource AWS-assigned value with no declared input to derive it from —
+// so it has no classify.ts fold and is not asserted here.)
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+describe('#894 ApiGateway Stage CanarySetting.DeploymentId derived from the stage DeploymentId', () => {
+  const declared = {
+    RestApiId: 'api1',
+    StageName: 'prod',
+    DeploymentId: 'dep-abc',
+    CanarySetting: { PercentTraffic: 10, UseStageCache: false },
+  };
+  it('folds CanarySetting.DeploymentId to atDefault when it equals the stage DeploymentId', () => {
+    const f = classifyResource(
+      mk('AWS::ApiGateway::Stage', declared, 'prod'),
+      {
+        RestApiId: 'api1',
+        StageName: 'prod',
+        DeploymentId: 'dep-abc',
+        CanarySetting: { PercentTraffic: 10, UseStageCache: false, DeploymentId: 'dep-abc' },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('CanarySetting.DeploymentId');
+    expect(tier(f, 'undeclared')).not.toContain('CanarySetting.DeploymentId');
+    expect(tier(f, 'generated')).not.toContain('CanarySetting.DeploymentId');
+  });
+  it('surfaces a canary re-pointed at a DIFFERENT deployment — detection preserved', () => {
+    const f = classifyResource(
+      mk('AWS::ApiGateway::Stage', declared, 'prod'),
+      {
+        RestApiId: 'api1',
+        StageName: 'prod',
+        DeploymentId: 'dep-abc',
+        // Out-of-band `update-stage /canarySettings/deploymentId` to an OLD deployment.
+        CanarySetting: { PercentTraffic: 10, UseStageCache: false, DeploymentId: 'dep-OLD' },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('CanarySetting.DeploymentId');
+    expect(tier(f, 'atDefault')).not.toContain('CanarySetting.DeploymentId');
+    expect(tier(f, 'generated')).not.toContain('CanarySetting.DeploymentId');
+  });
+  it('derives from the LIVE DeploymentId when the stage declares none', () => {
+    const f = classifyResource(
+      mk(
+        'AWS::ApiGateway::Stage',
+        { RestApiId: 'api1', StageName: 'prod', CanarySetting: {} },
+        'p'
+      ),
+      {
+        RestApiId: 'api1',
+        StageName: 'prod',
+        DeploymentId: 'dep-live',
+        CanarySetting: { DeploymentId: 'dep-live' },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('CanarySetting.DeploymentId');
+  });
+});
+
+describe('#894 EC2 VPCEndpoint DnsOptions derived from VpcEndpointType', () => {
+  const dnsOptions = (dnsRecordIpType: string) => ({
+    PrivateDnsOnlyForInboundResolverEndpoint: 'NotSpecified',
+    PrivateDnsSpecifiedDomains: ['*'],
+    DnsRecordIpType: dnsRecordIpType,
+    PrivateDnsPreference: 'VERIFIED_DOMAINS_ONLY',
+  });
+  it('folds an Interface endpoint DnsOptions (DnsRecordIpType ipv4) to atDefault', () => {
+    const f = classifyResource(
+      mk('AWS::EC2::VPCEndpoint', { VpcEndpointType: 'Interface', ServiceName: 'svc' }, 'vpce-1'),
+      { VpcEndpointType: 'Interface', ServiceName: 'svc', DnsOptions: dnsOptions('ipv4') },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('DnsOptions');
+    expect(tier(f, 'undeclared')).not.toContain('DnsOptions');
+  });
+  it('folds a Gateway endpoint DnsOptions (DnsRecordIpType service-defined) to atDefault', () => {
+    const f = classifyResource(
+      mk('AWS::EC2::VPCEndpoint', { VpcEndpointType: 'Gateway', ServiceName: 'svc' }, 'vpce-2'),
+      {
+        VpcEndpointType: 'Gateway',
+        ServiceName: 'svc',
+        DnsOptions: dnsOptions('service-defined'),
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('DnsOptions');
+    expect(tier(f, 'undeclared')).not.toContain('DnsOptions');
+  });
+  it('surfaces an Interface endpoint whose DnsRecordIpType is flipped out of band — detection preserved', () => {
+    const f = classifyResource(
+      mk('AWS::EC2::VPCEndpoint', { VpcEndpointType: 'Interface', ServiceName: 'svc' }, 'vpce-1'),
+      // Out-of-band ModifyVpcEndpoint flips DnsRecordIpType to dualstack.
+      { VpcEndpointType: 'Interface', ServiceName: 'svc', DnsOptions: dnsOptions('dualstack') },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('DnsOptions');
+    expect(tier(f, 'atDefault')).not.toContain('DnsOptions');
+  });
+  it('surfaces a changed non-DnsRecordIpType sub-key too (subset-tolerant equality gate)', () => {
+    const f = classifyResource(
+      mk('AWS::EC2::VPCEndpoint', { VpcEndpointType: 'Interface', ServiceName: 'svc' }, 'vpce-1'),
+      {
+        VpcEndpointType: 'Interface',
+        ServiceName: 'svc',
+        DnsOptions: {
+          ...dnsOptions('ipv4'),
+          PrivateDnsPreference: 'ALL_DOMAINS', // out-of-band change away from the default
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('DnsOptions');
+  });
+});

--- a/tests/corpus/AWS__ApiGateway__Stage.CanaryStage.json
+++ b/tests/corpus/AWS__ApiGateway__Stage.CanaryStage.json
@@ -62,7 +62,7 @@
   },
   "expected": [
     {
-      "tier": "generated",
+      "tier": "atDefault",
       "logicalId": "ApiDeploymentStageprod3EB9684E",
       "resourceType": "AWS::ApiGateway::Stage",
       "path": "CanarySetting.DeploymentId",


### PR DESCRIPTION
Closes #894

Promotes two formerly value-INDEPENDENT (tier-3) policy residues to tier-2 DERIVED equality gates in `classify.ts`, computed from declared inputs — so a clean deploy still folds `atDefault` while an out-of-band change now surfaces (detection preserved). The third (Bedrock AgentAlias RoutingConfiguration) is genuinely non-derivable and stays value-independent by design.

## 1. ApiGateway Stage `CanarySetting.DeploymentId` — tier-2 derived
The canary is created pointed at the stage's CURRENT deployment, so its `DeploymentId` EQUALS the stage's own `DeploymentId` (declared, else the live top-level value). Previously folded value-independent via `GENERATED_NESTED_PATHS`, which HID an out-of-band canary re-point (`update-stage /canarySettings/deploymentId`) — re-aiming the canary at an old/vulnerable deployment served that code to the canary % of prod traffic invisibly. Now gated against the stage's `DeploymentId`: a clean deploy stays `atDefault`, a re-point surfaces. (The value-independent `GENERATED_NESTED_PATHS` branch in `emitNested` was already suppressed for any nested path carrying a `knownDefPaths` gate this run.)

## 2. EC2 VPCEndpoint `DnsOptions` — tier-2 derived
`DnsRecordIpType` is a deterministic function of the declared `VpcEndpointType` (ipv4 for Interface, service-defined for Gateway); the other sub-keys are stable constants. Previously folded whole-object value-independent via `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`, hiding an out-of-band `ModifyVpcEndpoint` edit of any sub-key. Now the full default object is derived from `VpcEndpointType` and equality-gated (subset-tolerant): a clean deploy stays `atDefault`, an out-of-band change to any sub-key surfaces. Since `DnsOptions` remains in the noise.ts value-independent table (out of scope for this classify.ts-only lane), the top-level value-independent branch is now suppressed when a `knownDef` gate exists for the key (`!(k in knownDef)`) — mirroring the existing `emitNested` `!(schemaPath in knownDefPaths)` suppression — so a changed value defers to the equality gate instead of being folded.

## 3. Bedrock AgentAlias `RoutingConfiguration` — kept value-independent (decision)
The live value `[{"AgentVersion":"1"}]` is the AWS-assigned pointer to the auto-created agent version. The declared inputs (`AgentAliasName`, `AgentId`, `Description`) carry NO signal to derive the version number: "1" is only the first-created version, and a second alias / re-prepared agent gets a different number, so it is neither a stable constant nor a deterministic function of any declared input. Per the fold-strategy decision order this is the legitimate tier-3 case (undeclared → the user delegated version choice to AWS; a user who pins a version DECLARES routingConfiguration, compared in the declared loop). It already sits in the noise.ts value-independent table, so no classify.ts change was made.

## Tests
- `tests/classify-894-derived.test.ts` — 7 cases: each derived fold folds `atDefault` on the clean model AND surfaces `undeclared` when the value diverges from the computed default (canary re-point; DnsRecordIpType flip; a non-DnsRecordIpType DnsOptions sub-key change; canary derives from the LIVE DeploymentId when the stage declares none). 5 of 7 fail without the fix.
- Corpus `AWS__ApiGateway__Stage.CanaryStage` `CanarySetting.DeploymentId` expected tier updated `generated` → `atDefault` (now equality-gated). VPCEndpoint / AgentAlias corpus cases keep their `atDefault` tier (same value, detection now preserved).

`vp run typecheck && vp check && vp pack && vp test run` all green (3591 tests).
