### PR TITLE
fix(noise): fold RedshiftServerless (#958) + MSK::Cluster (#977) first-run defaults

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1275,6 +1275,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::RedshiftServerless::Namespace': {
     AdminUsername: 'admin',
     KmsKeyId: 'AWS_OWNED_KMS_KEY',
+    // A namespace that declares no DbName reads back the service-hardcoded initial database
+    // "dev" (observed live 2026-07-09, us-east-1; #958). A stable constant, equality-gated —
+    // a namespace that pins its own DbName reads a non-matching value and surfaces.
+    DbName: 'dev',
   },
   'AWS::RedshiftServerless::Workgroup': {
     Port: 5439,
@@ -1953,6 +1957,33 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   'AWS::MSK::Cluster': {
     // Brokers spread across AZs read back the DEFAULT distribution when unspecified.
     'BrokerNodeGroupInfo.BrokerAZDistribution': 'DEFAULT',
+    // A cluster that declares no ConnectivityInfo reads back AWS's whole default connectivity
+    // block: IPV4, every VPC-connectivity auth mechanism off, public access DISABLED (#977).
+    // Every leaf is the documented stable constant, so pin the whole object — matchesKnownDefault
+    // is recursively subset-tolerant, so a newer AWS shape carrying extra sub-keys still folds,
+    // while an out-of-band enable (e.g. PublicAccess.Type -> SERVICE_PROVIDED_EIPS, a real
+    // security-relevant change, or a Sasl/Iam enable) breaks the match and surfaces.
+    'BrokerNodeGroupInfo.ConnectivityInfo': {
+      NetworkType: 'IPV4',
+      VpcConnectivity: {
+        ClientAuthentication: {
+          Sasl: { Iam: { Enabled: false }, Scram: { Enabled: false } },
+          Tls: { Enabled: false },
+        },
+      },
+      PublicAccess: { Type: 'DISABLED' },
+    },
+    // A cluster that declares no EncryptionInfo reads back the documented in-transit defaults:
+    // TLS client-broker + in-cluster true (#977). The EncryptionInfo object is descended
+    // leaf-by-leaf (DESCEND_UNDECLARED_OBJECT_PATHS above), so this pins the EncryptionInTransit
+    // sub-block as a stable constant — an out-of-band downgrade (ClientBroker -> PLAINTEXT /
+    // TLS_PLAINTEXT, or InCluster -> false) breaks the match and surfaces. (The sibling
+    // EncryptionAtRest holds only the per-account alias/aws/kafka key ARN, folded value-
+    // independent via GENERATED_NESTED_PATHS below.)
+    'EncryptionInfo.EncryptionInTransit': {
+      ClientBroker: 'TLS',
+      InCluster: true,
+    },
   },
   'AWS::Batch::JobDefinition': {
     // A Fargate job definition reads back the documented runtime-platform defaults
@@ -2381,6 +2412,14 @@ export const DESCEND_UNDECLARED_OBJECT_PATHS: Record<string, ReadonlySet<string>
   // folds via schema.defaultPaths and only a non-default residue (a WARM tier set out of band)
   // would surface. Live, hunt 2026-07-08 round E (#624).
   'AWS::KinesisVideo::Stream': new Set(['StreamStorageConfiguration']),
+  // An MSK cluster that declares no EncryptionInfo reads back AWS's whole default object on
+  // every clean first check (#977). Descend it so its two sub-blocks fold independently:
+  // `EncryptionInTransit` is a stable constant ({ClientBroker:"TLS",InCluster:true}, folded via
+  // KNOWN_DEFAULT_PATHS below), while `EncryptionAtRest.DataVolumeKMSKeyId` is the account's
+  // AWS-managed alias/aws/kafka key ARN (a per-account AWS-assigned id — folded value-
+  // independent via GENERATED_NESTED_PATHS below). A single whole-object KNOWN_DEFAULTS entry
+  // can't cover both (the per-account KMS ARN can't be pinned), so descend + split.
+  'AWS::MSK::Cluster': new Set(['EncryptionInfo']),
 };
 
 // Value-DEPENDENT generated-name fold, scoped by type + top-level path. Folds a live value
@@ -2482,6 +2521,23 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   // AWS-assigned identifier, never user intent when undeclared. Fold value-independent. Live,
   // hunt 2026-07-08 #639.
   'AWS::AutoScaling::AutoScalingGroup': new Set(['LaunchTemplate.LaunchTemplateName']),
+  // An MSK cluster that declares no EncryptionInfo reads back EncryptionAtRest holding the
+  // account's AWS-managed `alias/aws/kafka` key ARN (a per-account AWS-assigned key id embedding
+  // a GUID — never a constant, never user intent when undeclared, the RDS/DynamoDB KmsKeyId echo
+  // class). The EncryptionInfo object is descended (DESCEND_UNDECLARED_OBJECT_PATHS), so the
+  // whole EncryptionAtRest sub-object (which only ever carries DataVolumeKMSKeyId) is emitted
+  // here and folded value-independent — a user who wants a customer-managed CMK DECLARES
+  // EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyId, which is then compared in the declared
+  // loop. (kmsAliasTargets is empty here because the stack declares no alias/aws/* to resolve;
+  // an equality-gated alias-resolution fold would need that map populated, so value-independent
+  // is the right tier for the undeclared case.)
+  // A cluster that declares no SecurityGroups gets the VPC's DEFAULT security group attached
+  // (["sg-…"], AWS-assigned per-account id) — the AmazonMQ / ELBv2 default-SG value-independent
+  // class, nested under the declared BrokerNodeGroupInfo. #977.
+  'AWS::MSK::Cluster': new Set([
+    'EncryptionInfo.EncryptionAtRest',
+    'BrokerNodeGroupInfo.SecurityGroups',
+  ]),
 };
 
 // Elastic Beanstalk ConfigurationTemplate `OptionSettings` first-run default fold. A template
@@ -2986,6 +3042,29 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   folded as an equality-gated tier-1 KNOWN_DEFAULTS entry instead — a real out-of-band EndTime
   //   timestamp then surfaces rather than folding to any value (#946). Live, hunt 2026-07-09 (#847).
   'AWS::AutoScaling::ScheduledAction': new Set(['StartTime']),
+  //   AWS::RedshiftServerless::Workgroup.SecurityGroupIds / .SubnetIds — a workgroup that
+  //   declares neither is placed by the service into the account's DEFAULT VPC: it reads back
+  //   the default VPC's default security group (["sg-…"]) and ALL of that VPC's subnets
+  //   (["subnet-…", …]). These are per-account AWS-assigned ids, not constants and not
+  //   derivable from the workgroup's own declared inputs. Undeclared → whatever placement AWS
+  //   chose is its default, never user intent; a user who cares about network placement
+  //   DECLARES SecurityGroupIds/SubnetIds, which is then compared in the declared loop.
+  //   AWS::RedshiftServerless::Workgroup.ConfigParameters — a workgroup that declares no
+  //   ConfigParameters reads back AWS's full default effective-parameter set
+  //   ([{ParameterKey:"auto_mv",ParameterValue:"true"},{ParameterKey:"datestyle",…}, …]). The
+  //   documented default set is not fully enumerated in the evidence and AWS extends it over
+  //   time (a pinned whole-array constant would rot into a false positive the moment AWS adds a
+  //   parameter — the #653 recursive-subset lesson). A per-element equality gate (keyed by
+  //   ParameterKey) would preserve out-of-band-parameter detection but needs an
+  //   IDENTITY_KEYED_SUBSET_ARRAYS registration in classify.ts; until that follow-up lands, fold
+  //   value-independent: undeclared, so the whole AWS default parameter set is its choice, not
+  //   user intent (a user who pins a parameter DECLARES ConfigParameters, compared in the
+  //   declared loop). Live-confirmed on a fresh minimal workgroup (2026-07-09, us-east-1; #958).
+  'AWS::RedshiftServerless::Workgroup': new Set([
+    'ConfigParameters',
+    'SecurityGroupIds',
+    'SubnetIds',
+  ]),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/corpus/AWS__MSK__Cluster.Cluster.json
+++ b/tests/corpus/AWS__MSK__Cluster.Cluster.json
@@ -128,19 +128,27 @@
       "constructPath": "CdkRealDriftIntegMskCluster/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Cluster",
       "resourceType": "AWS::MSK::Cluster",
-      "path": "EncryptionInfo",
+      "path": "EncryptionInfo.EncryptionAtRest",
       "actual": {
-        "EncryptionAtRest": {
-          "DataVolumeKMSKeyId": "arn:aws:kms:ap-northeast-1:111111111111:key/a2715ad0-2ae0-410e-8c6f-09e3de34ff91"
-        },
-        "EncryptionInTransit": {
-          "ClientBroker": "TLS",
-          "InCluster": true
-        }
+        "DataVolumeKMSKeyId": "arn:aws:kms:ap-northeast-1:111111111111:key/a2715ad0-2ae0-410e-8c6f-09e3de34ff91"
       },
+      "nested": true,
+      "physicalId": "arn:aws:kafka:ap-northeast-1:111111111111:cluster/cdkrd-fp-msk/0067ab24-fb2f-4477-b169-3e1f61139875-4",
+      "constructPath": "CdkRealDriftIntegMskCluster/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MSK::Cluster",
+      "path": "EncryptionInfo.EncryptionInTransit",
+      "actual": {
+        "ClientBroker": "TLS",
+        "InCluster": true
+      },
+      "nested": true,
       "physicalId": "arn:aws:kafka:ap-northeast-1:111111111111:cluster/cdkrd-fp-msk/0067ab24-fb2f-4477-b169-3e1f61139875-4",
       "constructPath": "CdkRealDriftIntegMskCluster/Cluster"
     },
@@ -154,7 +162,7 @@
       "constructPath": "CdkRealDriftIntegMskCluster/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Cluster",
       "resourceType": "AWS::MSK::Cluster",
       "path": "BrokerNodeGroupInfo.SecurityGroups",
@@ -164,7 +172,7 @@
       "constructPath": "CdkRealDriftIntegMskCluster/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::MSK::Cluster",
       "path": "BrokerNodeGroupInfo.ConnectivityInfo",

--- a/tests/noise-958-977-folds.test.ts
+++ b/tests/noise-958-977-folds.test.ts
@@ -1,0 +1,162 @@
+// #958 RedshiftServerless Namespace/Workgroup first-run FP batch + #977 MSK::Cluster
+// first-run FP trio. Each fold is asserted BOTH ways: the undeclared AWS creation default
+// folds (atDefault / generated) so a clean first check is zero-drift, and — for the
+// equality-gated (tier-1) ones — a value CHANGED away from the default still surfaces
+// (out-of-band detection preserved). The value-independent (tier-3) folds preserve no
+// detection by design (the value is undeclared per-account/AWS-assigned), so they are
+// asserted only in the fold direction.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({ logicalId: 'R', resourceType, physicalId, declared });
+
+describe('#958 RedshiftServerless Namespace DbName default', () => {
+  const ns = mk('AWS::RedshiftServerless::Namespace', { NamespaceName: 'ns' });
+  it('folds the undeclared DbName "dev" to atDefault (tier 1)', () => {
+    const f = classifyResource(ns, { DbName: 'dev' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('DbName');
+    expect(tier(f, 'undeclared')).not.toContain('DbName');
+  });
+  it('surfaces a namespace that pins a non-default DbName (detection preserved)', () => {
+    const f = classifyResource(ns, { DbName: 'analytics' }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('DbName');
+  });
+});
+
+describe('#958 RedshiftServerless Workgroup placement + config parameters', () => {
+  const wg = mk('AWS::RedshiftServerless::Workgroup', { WorkgroupName: 'wg' });
+  it('folds undeclared default-VPC SecurityGroupIds/SubnetIds value-independent (tier 3)', () => {
+    const f = classifyResource(
+      wg,
+      {
+        SecurityGroupIds: ['sg-0a26e23e2310ee0c9'],
+        SubnetIds: ['subnet-00c21350a74a112b8', 'subnet-11c21350a74a112b8'],
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(expect.arrayContaining(['SecurityGroupIds', 'SubnetIds']));
+    expect(tier(f, 'undeclared')).not.toContain('SecurityGroupIds');
+    expect(tier(f, 'undeclared')).not.toContain('SubnetIds');
+  });
+  it('folds the undeclared default ConfigParameters set value-independent (tier 3)', () => {
+    const f = classifyResource(
+      wg,
+      {
+        ConfigParameters: [
+          { ParameterKey: 'auto_mv', ParameterValue: 'true' },
+          { ParameterKey: 'datestyle', ParameterValue: 'ISO, MDY' },
+          { ParameterKey: 'enable_case_sensitive_identifier', ParameterValue: 'false' },
+        ],
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('ConfigParameters');
+    expect(tier(f, 'undeclared')).not.toContain('ConfigParameters');
+  });
+});
+
+describe('#977 MSK::Cluster first-run FP trio', () => {
+  const declaredBroker = {
+    ClientSubnets: ['subnet-a', 'subnet-b'],
+    InstanceType: 'kafka.t3.small',
+    StorageInfo: { EBSStorageInfo: { VolumeSize: 10 } },
+  };
+  const mkMsk = (broker: Record<string, unknown>) =>
+    mk('AWS::MSK::Cluster', {
+      ClusterName: 'c',
+      KafkaVersion: '3.6.0',
+      NumberOfBrokerNodes: 2,
+      BrokerNodeGroupInfo: broker,
+    });
+  const cleanLive = {
+    BrokerNodeGroupInfo: {
+      ...declaredBroker,
+      SecurityGroups: ['sg-059dd37aa34acef10'],
+      ConnectivityInfo: {
+        NetworkType: 'IPV4',
+        VpcConnectivity: {
+          ClientAuthentication: {
+            Sasl: { Iam: { Enabled: false }, Scram: { Enabled: false } },
+            Tls: { Enabled: false },
+          },
+        },
+        PublicAccess: { Type: 'DISABLED' },
+      },
+    },
+    EncryptionInfo: {
+      EncryptionAtRest: {
+        DataVolumeKMSKeyId: 'arn:aws:kms:us-east-1:111111111111:key/uuid',
+      },
+      EncryptionInTransit: { ClientBroker: 'TLS', InCluster: true },
+    },
+  };
+
+  it('a clean minimal cluster produces ZERO undeclared/declared drift', () => {
+    const f = classifyResource(mkMsk(declaredBroker), structuredClone(cleanLive), emptySchema);
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'declared')).toEqual([]);
+  });
+
+  it('folds EncryptionInfo.EncryptionInTransit constant to atDefault (tier 1)', () => {
+    const f = classifyResource(mkMsk(declaredBroker), structuredClone(cleanLive), emptySchema);
+    expect(tier(f, 'atDefault')).toContain('EncryptionInfo.EncryptionInTransit');
+  });
+
+  it('folds EncryptionInfo.EncryptionAtRest per-account KMS value-independent (tier 3)', () => {
+    const f = classifyResource(mkMsk(declaredBroker), structuredClone(cleanLive), emptySchema);
+    expect(tier(f, 'generated')).toContain('EncryptionInfo.EncryptionAtRest');
+  });
+
+  it('folds BrokerNodeGroupInfo.ConnectivityInfo constant to atDefault (tier 1)', () => {
+    const f = classifyResource(mkMsk(declaredBroker), structuredClone(cleanLive), emptySchema);
+    expect(tier(f, 'atDefault')).toContain('BrokerNodeGroupInfo.ConnectivityInfo');
+  });
+
+  it('folds default-VPC BrokerNodeGroupInfo.SecurityGroups value-independent (tier 3)', () => {
+    const f = classifyResource(mkMsk(declaredBroker), structuredClone(cleanLive), emptySchema);
+    expect(tier(f, 'generated')).toContain('BrokerNodeGroupInfo.SecurityGroups');
+  });
+
+  it('surfaces an out-of-band in-transit downgrade (ClientBroker -> PLAINTEXT)', () => {
+    const live = structuredClone(cleanLive);
+    live.EncryptionInfo.EncryptionInTransit.ClientBroker = 'PLAINTEXT';
+    const f = classifyResource(mkMsk(declaredBroker), live, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('EncryptionInfo.EncryptionInTransit');
+    expect(tier(f, 'atDefault')).not.toContain('EncryptionInfo.EncryptionInTransit');
+  });
+
+  it('surfaces an out-of-band public-access enable (PublicAccess.Type)', () => {
+    const live = structuredClone(cleanLive);
+    live.BrokerNodeGroupInfo.ConnectivityInfo.PublicAccess.Type = 'SERVICE_PROVIDED_EIPS';
+    const f = classifyResource(mkMsk(declaredBroker), live, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('BrokerNodeGroupInfo.ConnectivityInfo');
+    expect(tier(f, 'atDefault')).not.toContain('BrokerNodeGroupInfo.ConnectivityInfo');
+  });
+
+  it('surfaces an out-of-band VPC-connectivity Sasl/Iam enable', () => {
+    const live = structuredClone(cleanLive);
+    live.BrokerNodeGroupInfo.ConnectivityInfo.VpcConnectivity.ClientAuthentication.Sasl.Iam.Enabled = true;
+    const f = classifyResource(mkMsk(declaredBroker), live, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('BrokerNodeGroupInfo.ConnectivityInfo');
+  });
+});


### PR DESCRIPTION
Closes #958
Closes #977

Two first-run false-positive batches folded in `src/normalize/noise.ts` so a clean, un-mutated deploy of a RedshiftServerless pair / minimal MSK cluster produces ZERO `[Potential Drift]` on the first check (core invariant), while out-of-band changes still surface where the value is meaningful.

## #958 RedshiftServerless Namespace/Workgroup

| Property | Tier | Table |
| --- | --- | --- |
| `Namespace.DbName = "dev"` | 1 (equality-gated constant) | `KNOWN_DEFAULTS` — a namespace pinning a non-default DbName still surfaces |
| `Workgroup.SecurityGroupIds` / `SubnetIds` | 3 (value-independent) | `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` — default-VPC placement, per-account AWS-assigned sg-/subnet- ids |
| `Workgroup.ConfigParameters` | 3 (value-independent) | `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` |

**Note (ConfigParameters):** the issue prefers a per-element equality gate (keyed by `ParameterKey`) to keep out-of-band-parameter detection, but that requires an `IDENTITY_KEYED_SUBSET_ARRAYS` registration in `classify.ts` (outside this PR allowed-file scope), and the full stable default parameter set is not enumerated in the evidence (the list is `...` truncated) — so a whole-array constant would be both a guess and fragile (#653 recursive-subset lesson). Folded value-independent for now; a follow-up can lift it to per-element in classify.ts. Called out inline in the table comment.

## #977 MSK::Cluster

`EncryptionInfo` is a fully-undeclared object, so it is added to `DESCEND_UNDECLARED_OBJECT_PATHS` and descended leaf-by-leaf; the two sub-blocks fold independently:

| Property | Tier | Table |
| --- | --- | --- |
| `EncryptionInfo.EncryptionInTransit` `{ClientBroker:TLS, InCluster:true}` | 1 (constant, whole-object) | `KNOWN_DEFAULT_PATHS` — an out-of-band downgrade (PLAINTEXT / InCluster:false) surfaces |
| `EncryptionInfo.EncryptionAtRest` (per-account `alias/aws/kafka` key ARN) | 3 (value-independent) | `GENERATED_NESTED_PATHS` — `kmsAliasTargets` is empty for an undeclared key, so no equality-gated alias resolution applies; per-account AWS-assigned id, RDS/DynamoDB KmsKeyId class |
| `BrokerNodeGroupInfo.ConnectivityInfo` (all-off VPC connectivity, public DISABLED, IPV4) | 1 (constant, whole-object) | `KNOWN_DEFAULT_PATHS` — equality-gated whole-object (recursively subset-tolerant), so a PublicAccess enable / Sasl/Iam enable surfaces (no reliance on trivial-empty) |
| `BrokerNodeGroupInfo.SecurityGroups` (default-VPC SG) | 3 (value-independent nested) | `GENERATED_NESTED_PATHS` |

## Tests

- New `tests/noise-958-977-folds.test.ts` (12 cases): each undeclared default folds (atDefault/generated) AND each tier-1 fold still surfaces on a changed value (DbName non-default; MSK in-transit downgrade, public-access enable, Sasl/Iam enable). A clean minimal MSK cluster asserts ZERO undeclared/declared drift.
- Updated `tests/corpus/AWS__MSK__Cluster.Cluster.json` `expected`: the three former `undeclared` findings now fold — `EncryptionInfo` splits into `EncryptionInfo.EncryptionInTransit` (atDefault) + `EncryptionInfo.EncryptionAtRest` (generated); `BrokerNodeGroupInfo.ConnectivityInfo` → atDefault; `BrokerNodeGroupInfo.SecurityGroups` → generated. Live input (`actual`/`liveRaw`) untouched.

All gates green: typecheck / lint+format / build / 3596 unit tests + 678 corpus-replay cases.
