### PR TITLE
fix(synth): surface silent context lookups + cdk.context.json write (#906)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,16 @@ from `--app`: a command (`--app "node bin/app.js"`) or a pre-synthesized assembl
 comparison still reads each stack's **deployed** template + live state from AWS;
 synth only tells cdkrd which stacks to look at.
 
+**Context lookups.** Resolving a CDK app that uses `fromLookup`
+(`Vpc.fromLookup`, `HostedZone.fromLookup`, …) runs the same live AWS context
+lookups as `cdk synth` and caches the results in `cdk.context.json` in your app
+directory — so an app with uncached lookups will make read-only AWS calls and
+create/update that file (a `git status` change is expected; the cache makes
+subsequent checks reproducible). cdkrd prints a one-liner when it does so. This
+matches `cdk synth` semantics and is the only file `check` writes; it never writes
+to AWS. If every lookup fails (leaving only an empty `{}`), cdkrd removes the file
+it just created rather than leave that noise in your tree.
+
 ## Commands & options
 
 | command                     | does                                                                   |

--- a/src/synth/io-host.ts
+++ b/src/synth/io-host.ts
@@ -44,7 +44,20 @@ const APP_STDERR = 'CDK_ASSEMBLY_E1002';
 // WARN: a yellow wrap matches the yellow WARNING label, like every other cdkrd warning.
 const VALIDATION_REPORT = 'CDK_TOOLKIT_E9600';
 
-export type IoPlan = { action: 'drop' } | { action: 'emit'; level: Level };
+// Context-lookup lifecycle codes (toolkit-lib context-aware-source.ts). For an app with
+// `Vpc.fromLookup` / `HostedZone.fromLookup` / … and no cached `cdk.context.json`, synth
+// performs LIVE AWS lookups (I0241) and PERSISTS the results into `cdk.context.json`
+// (I0042), matching `cdk synth`. Both are registered at DEBUG level, so QuietIoHost would
+// otherwise drop them — leaving `check` (a read-only verb) to silently hit AWS and dirty
+// the user's git tree with zero output. We surface each as a concise info-level one-liner
+// to stderr so the side effect is visible (#906).
+const CONTEXT_FETCHING = 'CDK_ASSEMBLY_I0241';
+const CONTEXT_WRITING = 'CDK_ASSEMBLY_I0042';
+
+export type IoPlan =
+  | { action: 'drop' }
+  | { action: 'emit'; level: Level }
+  | { action: 'note'; level: Level; text: string };
 
 /**
  * Decide what QuietIoHost does with a message (pure, so it is unit-testable):
@@ -53,12 +66,29 @@ export type IoPlan = { action: 'drop' } | { action: 'emit'; level: Level };
  *  - the construct-annotation validation report -> emit at WARN so the whole block is
  *    yellow (matching its WARNING label) instead of the misleading ERROR-level red
  *    wrap; per-severity labels still survive (see file header);
+ *  - the context-lookup fetch / write codes -> `note` a fixed one-liner (replacing
+ *    toolkit-lib's verbose debug text) so the otherwise-silent live lookup + the
+ *    cdk.context.json write are visible (#906);
  *  - a real toolkit warning / error -> emit unchanged (still yellow / red);
  *  - everything else (toolkit info/debug/trace chatter) -> drop.
  */
 export function planIoMessage(msg: Pick<IoMessage<unknown>, 'code' | 'level'>): IoPlan {
   if (msg.code === APP_STDOUT || msg.code === APP_STDERR) return { action: 'emit', level: 'info' };
   if (msg.code === VALIDATION_REPORT) return { action: 'emit', level: 'warn' };
+  if (msg.code === CONTEXT_FETCHING) {
+    return {
+      action: 'note',
+      level: 'info',
+      text: 'performing context lookups (Vpc.fromLookup, …)…',
+    };
+  }
+  if (msg.code === CONTEXT_WRITING) {
+    return {
+      action: 'note',
+      level: 'info',
+      text: 'wrote cdk.context.json (cached context lookups)',
+    };
+  }
   if (msg.level === 'warn' || msg.level === 'error') return { action: 'emit', level: msg.level };
   return { action: 'drop' };
 }
@@ -77,9 +107,22 @@ export class QuietIoHost extends NonInteractiveIoHost {
     super({ isCI: false });
   }
 
+  // De-dupe the context-lookup notes: I0241 (fetching) can fire once per resolution round,
+  // so a single "performing context lookups…" line is enough — subsequent identical notes
+  // in the same synth are suppressed (#906).
+  private readonly seenNotes = new Set<string>();
+
   override async notify(msg: IoMessage<unknown>): Promise<void> {
     const plan = planIoMessage(msg);
     if (plan.action === 'drop') return;
+    if (plan.action === 'note') {
+      if (this.seenNotes.has(plan.text)) return;
+      this.seenNotes.add(plan.text);
+      // Replace toolkit-lib's verbose debug body with our concise one-liner (the caller's
+      // `notify` renders `message`), re-tagged to the plan's level so it prints like a
+      // normal cdkrd info line to stderr.
+      return super.notify({ ...msg, level: plan.level, message: `info: ${plan.text}` });
+    }
     return super.notify(plan.level === msg.level ? msg : { ...msg, level: plan.level });
   }
 }

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -2,7 +2,7 @@
 // uses) to discover stacks. Records a CDK app COMMAND (`node app.js`) or a
 // pre-synthesized cloud-assembly DIRECTORY (`cdk.out`). Drift detection itself
 // does not need this — it is used for stack auto-discovery (and later clobber).
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { BaseCredentials, CdkAppMultiContext, Toolkit } from '@aws-cdk/toolkit-lib';
 import { QuietIoHost } from './io-host.js';
@@ -57,6 +57,53 @@ export function contextIgnoredWarning(
   );
 }
 
+/**
+ * Decide whether to remove a `cdk.context.json` that synth may have written (#906).
+ *
+ * For an app with context lookups but no cached context, toolkit-lib's default
+ * `CdkAppMultiContext` persists the resolved lookups into `<cwd>/cdk.context.json` — even
+ * when EVERY lookup FAILED, in which case it writes an empty `{}`. That empty file dirties
+ * the user's git tree for no benefit (it caches nothing). We remove it, but ONLY when it is
+ * safe: the file must NOT have pre-existed (so we never touch a user's committed context),
+ * AND it must be empty (`{}` / whitespace-only) now (so we never delete a file that captured
+ * real lookup results). Returns true iff the file at `file` should be deleted.
+ */
+export function shouldRemoveEmptyContextFile(existedBefore: boolean, existsNow: boolean): boolean {
+  return !existedBefore && existsNow;
+}
+
+/** An object with no own enumerable keys — a persisted `{}` context (an all-failed lookup). */
+function isEmptyContextJson(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === '{}') return true;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      Object.keys(parsed).length === 0
+    );
+  } catch {
+    // Not valid JSON — leave it alone (never our empty-write; do not delete).
+    return false;
+  }
+}
+
+/**
+ * Remove a `cdk.context.json` at `file` iff synth JUST created it AND it is empty (an
+ * all-failed lookup that persisted `{}`). Guarded so a pre-existing or non-empty user file
+ * is NEVER touched (#906). No-op on any read/remove error — cleanup is best-effort.
+ */
+function cleanupEmptyContextFile(file: string, existedBefore: boolean): void {
+  if (!shouldRemoveEmptyContextFile(existedBefore, existsSync(file))) return;
+  try {
+    if (isEmptyContextJson(readFileSync(file, 'utf-8'))) rmSync(file);
+  } catch {
+    // best-effort: never fail a check because we could not tidy an empty context file.
+  }
+}
+
 export async function synthApp(app: string, opts: SynthOptions = {}): Promise<SynthStack[]> {
   const { region, profile, context = {} } = opts;
   const toolkit = new Toolkit({
@@ -71,6 +118,12 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
 
   const p = resolve(app);
   const isDir = existsSync(p) && statSync(p).isDirectory();
+  // toolkit-lib's default CdkAppMultiContext persists resolved lookups into
+  // <cwd>/cdk.context.json on the fromCdkApp path (the dir path uses MemoryContext, no
+  // write). Snapshot whether that file already exists so we only ever clean up one WE
+  // caused, and only when it is empty (an all-failed `{}` lookup) (#906).
+  const contextFile = resolve(process.cwd(), 'cdk.context.json');
+  const contextFileExistedBefore = !isDir && existsSync(contextFile);
   let source;
   if (isDir) {
     // pre-synthesized assembly: no subprocess to feed region/profile/context to. Any
@@ -97,6 +150,10 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
   }
 
   const cached = await toolkit.synth(source);
+  // Best-effort: if synth just created an EMPTY cdk.context.json (every lookup failed → `{}`),
+  // remove it so a read-only `check` does not dirty the user's git tree with a useless file.
+  // Guarded to never touch a pre-existing or non-empty file (#906). Skipped on the dir path.
+  if (!isDir) cleanupEmptyContextFile(contextFile, contextFileExistedBefore);
   try {
     // A CDK app whose context lookups are unresolved still synthesizes — CDK fills every
     // gap with a well-known DUMMY value (`vpc-12345`, ...) and records the gap in the

--- a/tests/io-host.test.ts
+++ b/tests/io-host.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { IoMessage } from '@aws-cdk/toolkit-lib';
 import { planIoMessage, QuietIoHost } from '../src/synth/io-host.js';
 
 describe('planIoMessage (QuietIoHost routing)', () => {
@@ -44,6 +45,22 @@ describe('planIoMessage (QuietIoHost routing)', () => {
     });
   });
 
+  it('surfaces the context-lookup FETCH (I0241, debug) as an info one-liner (#906)', () => {
+    // toolkit-lib registers I0241 at DEBUG, so it would otherwise be dropped, leaving the
+    // read-only `check` to hit AWS silently. Note it as a concise info line.
+    expect(planIoMessage({ code: 'CDK_ASSEMBLY_I0241', level: 'debug' })).toMatchObject({
+      action: 'note',
+      level: 'info',
+    });
+  });
+
+  it('surfaces the cdk.context.json WRITE (I0042, debug) as an info one-liner (#906)', () => {
+    expect(planIoMessage({ code: 'CDK_ASSEMBLY_I0042', level: 'debug' })).toMatchObject({
+      action: 'note',
+      level: 'info',
+    });
+  });
+
   it('drops toolkit info / debug / trace chatter', () => {
     expect(planIoMessage({ code: 'CDK_ASSEMBLY_I0010', level: 'info' })).toEqual({
       action: 'drop',
@@ -52,6 +69,80 @@ describe('planIoMessage (QuietIoHost routing)', () => {
       action: 'drop',
     });
     expect(planIoMessage({ code: undefined, level: 'trace' })).toEqual({ action: 'drop' });
+  });
+});
+
+describe('QuietIoHost surfaces context-lookup + cdk.context.json write (#906)', () => {
+  // Build a minimal IoMessage. code/level are the only fields planIoMessage inspects;
+  // message is what the base host renders.
+  const msg = (
+    code: string | undefined,
+    level: string,
+    message = 'toolkit body'
+  ): IoMessage<unknown> =>
+    ({
+      code,
+      level,
+      message,
+      time: new Date(),
+    }) as unknown as IoMessage<unknown>;
+
+  it('emits ONE info line to stderr for I0241 (fetching), de-duped across repeats', async () => {
+    const host = new QuietIoHost();
+    const writes: string[] = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    try {
+      await host.notify(msg('CDK_ASSEMBLY_I0241', 'debug'));
+      // fires again in a later resolution round — must NOT print a second line
+      await host.notify(msg('CDK_ASSEMBLY_I0241', 'debug'));
+    } finally {
+      spy.mockRestore();
+    }
+    const lines = writes.join('').trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('context lookups');
+    expect(lines[0]).not.toContain('toolkit body'); // our concise text, not the verbose debug body
+  });
+
+  it('emits an info line to stderr for I0042 (cdk.context.json write)', async () => {
+    const host = new QuietIoHost();
+    const writes: string[] = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    try {
+      await host.notify(msg('CDK_ASSEMBLY_I0042', 'debug'));
+    } finally {
+      spy.mockRestore();
+    }
+    expect(writes.join('')).toContain('cdk.context.json');
+  });
+
+  it('still DROPS a below-warn message with a different code (no stderr write)', async () => {
+    const host = new QuietIoHost();
+    const stderrWrites: string[] = [];
+    const stdoutWrites: string[] = [];
+    const eSpy = vi.spyOn(process.stderr, 'write').mockImplementation((c: unknown) => {
+      stderrWrites.push(String(c));
+      return true;
+    });
+    const oSpy = vi.spyOn(process.stdout, 'write').mockImplementation((c: unknown) => {
+      stdoutWrites.push(String(c));
+      return true;
+    });
+    try {
+      await host.notify(msg('CDK_ASSEMBLY_I0010', 'debug'));
+      await host.notify(msg('CDK_TOOLKIT_I0001', 'info'));
+    } finally {
+      eSpy.mockRestore();
+      oSpy.mockRestore();
+    }
+    expect(stderrWrites.join('')).toBe('');
+    expect(stdoutWrites.join('')).toBe('');
   });
 });
 

--- a/tests/synth-empty-context-906.test.ts
+++ b/tests/synth-empty-context-906.test.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { shouldRemoveEmptyContextFile } from '../src/synth/synth.js';
+
+// The empty-file guard for #906: a read-only `check` must never leave an empty `{}`
+// cdk.context.json (an all-failed lookup) in the user's tree, but must NEVER delete a
+// pre-existing or non-empty file. shouldRemoveEmptyContextFile encodes the existence half
+// of that guard; the emptiness check is exercised against a real file below.
+
+describe('shouldRemoveEmptyContextFile (#906)', () => {
+  it('removes only a file synth JUST created (did not exist before, exists now)', () => {
+    expect(shouldRemoveEmptyContextFile(false, true)).toBe(true);
+  });
+
+  it('never touches a file that pre-existed the synth', () => {
+    // a user's committed cdk.context.json — even if we later saw it, we did not create it
+    expect(shouldRemoveEmptyContextFile(true, true)).toBe(false);
+  });
+
+  it('is a no-op when no file exists after synth', () => {
+    expect(shouldRemoveEmptyContextFile(false, false)).toBe(false);
+    expect(shouldRemoveEmptyContextFile(true, false)).toBe(false);
+  });
+});
+
+// Model the full cleanup contract (create-check + emptiness) against a real temp dir, so
+// the guard against clobbering a user's real context file is covered end to end.
+describe('empty-context cleanup contract (#906)', () => {
+  const dirs: string[] = [];
+  const mk = (): string => {
+    const d = mkdtempSync(join(tmpdir(), 'cdkrd-ctx-'));
+    dirs.push(d);
+    return d;
+  };
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  // Mirror of the private cleanup logic in synth.ts, kept in sync via the exported guard.
+  const isEmpty = (raw: string): boolean => {
+    const t = raw.trim();
+    if (t === '' || t === '{}') return true;
+    try {
+      const p: unknown = JSON.parse(t);
+      return (
+        typeof p === 'object' && p !== null && !Array.isArray(p) && Object.keys(p).length === 0
+      );
+    } catch {
+      return false;
+    }
+  };
+  const cleanup = (file: string, existedBefore: boolean): void => {
+    if (!shouldRemoveEmptyContextFile(existedBefore, existsSync(file))) return;
+    if (isEmpty(readFileSync(file, 'utf-8'))) rmSync(file);
+  };
+
+  it('deletes a newly-created empty {} file', () => {
+    const dir = mk();
+    const file = join(dir, 'cdk.context.json');
+    const existedBefore = existsSync(file); // false
+    writeFileSync(file, '{}\n');
+    cleanup(file, existedBefore);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it('KEEPS a newly-created file that captured real lookup results', () => {
+    const dir = mk();
+    const file = join(dir, 'cdk.context.json');
+    const existedBefore = existsSync(file); // false
+    writeFileSync(file, JSON.stringify({ 'vpc-provider:account=1': { vpcId: 'vpc-abc' } }));
+    cleanup(file, existedBefore);
+    expect(existsSync(file)).toBe(true);
+  });
+
+  it('NEVER deletes a pre-existing user file, even if it is empty {}', () => {
+    const dir = mk();
+    const file = join(dir, 'cdk.context.json');
+    writeFileSync(file, '{}');
+    const existedBefore = existsSync(file); // true — user committed it
+    cleanup(file, existedBefore);
+    expect(existsSync(file)).toBe(true);
+  });
+
+  it('NEVER deletes a pre-existing non-empty user file', () => {
+    const dir = mk();
+    const file = join(dir, 'cdk.context.json');
+    writeFileSync(file, JSON.stringify({ 'hosted-zone:account=1': { Id: 'Z123' } }));
+    const existedBefore = existsSync(file); // true
+    cleanup(file, existedBefore);
+    expect(existsSync(file)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #906.

`check` (a read-only verb) silently ran live AWS context lookups for apps using `fromLookup` and silently wrote `cdk.context.json` into the user's app dir, with zero output. Three parts:

**1. Surface the lookup / write as info one-liners.** toolkit-lib emits `CDK_ASSEMBLY_I0241` (fetching context) and `I0042` (writing `cdk.context.json`) at DEBUG level, which `QuietIoHost` dropped. `planIoMessage` now maps those two codes to a new `note` action that replaces the verbose debug body with a concise `info:` one-liner to stderr ("performing context lookups" / "wrote cdk.context.json (cached context lookups)"). `QuietIoHost.notify` de-dupes the notes (I0241 can fire once per resolution round, so a single line). All other sub-warn chatter is still dropped, and the stderr-under-CI pinning (#867) is unaffected.

**2. Skip the empty `{}` write.** The write itself lives entirely inside toolkit-lib's default `CdkAppMultiContext.update` (writes to `<cwd>/cdk.context.json` on the `fromCdkApp` path; the `--app cdk.out` dir path uses `MemoryContext`, no write) — there is no clean hook to suppress it. So, per the issue's fallback direction, `synthApp` snapshots whether `cdk.context.json` existed BEFORE synth, and after synth removes it ONLY if it did NOT pre-exist AND is now empty (`{}` / all-failed lookup). Guarded via the exported, unit-tested `shouldRemoveEmptyContextFile` plus an emptiness check so a pre-existing OR non-empty user file is NEVER deleted. Best-effort (never fails a check on a read/remove error).

**3. README.** Added a "Context lookups" note under "Selecting stacks": `check` runs the same live lookups as `cdk synth` and creates/updates `cdk.context.json` (expected `git status` change; cache makes subsequent checks reproducible; the only file `check` writes; empty `{}` is removed).

Tests: extended `tests/io-host.test.ts` (I0241/I0042 to info line on stderr, de-dupe, a different-code below-warn message still dropped) and added `tests/synth-empty-context-906.test.ts` (empty-file guard never deletes a pre-existing/non-empty file). Full suite: 3605 passing; `vp run check` -> 0 errors.

Notes: #905's `StackSelector` change is separately deferred (not touched here). A full live-test needs an app with `fromLookup` and no cached context — the unit tests plus the issue's live repro are the evidence; maintainer can live-verify.
