### PR TITLE
fix(diff): surface out-of-band IAM Condition operators — gate emitNested's aws:* map drop (#863)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1700,7 +1700,20 @@ export function classifyResource(
   const underFreeFormMap = (schemaPath: string): boolean =>
     freeFormMapPaths.some((ff) => schemaPath.startsWith(`${ff}.`));
   const emitNested = (path: string, value: unknown): void => {
-    if (isAllAwsTags(value) || isTrivialEmpty(value)) return;
+    if (isTrivialEmpty(value)) return;
+    // #863: `isAllAwsTags` matches two shapes — an ARRAY of `{Key:'aws:*'}` (an unambiguous
+    // tag LIST: AWS-managed system tags, always safe to drop) and an OBJECT whose keys are
+    // all `aws:*` (a MAP-shaped tag, e.g. UserPoolTags — BUT ALSO an IAM policy Condition
+    // OPERATOR map like `{aws:SourceAccount: ...}`). Dropping the object form unconditionally
+    // (no parent-key gate — the R69 confusion `stripAwsTagsDeep` already fixed) hid an
+    // out-of-band Condition operator added under a declared statement: a security FN that
+    // survived `record`. Gate the object form on the parent key being a tag property
+    // (`*Tags`); the array form still drops unconditionally.
+    if (isAllAwsTags(value)) {
+      const isObjectForm = value !== null && typeof value === 'object' && !Array.isArray(value);
+      const parentKey = (path.split('.').pop() ?? '').replace(/\[.*$/, '');
+      if (!isObjectForm || /tags$/i.test(parentKey)) return;
+    }
     const schemaPath = path.replace(/\[[^\]]*\]/g, '.*');
     // Same subset-tolerant default match as the top-level atDefault compare: an
     // OBJECT-valued nested default (CloudFront GeoRestriction, Scheduler RetryPolicy,

--- a/tests/emitnested-awsmap-863.test.ts
+++ b/tests/emitnested-awsmap-863.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #863 — `emitNested` dropped ANY live-only map whose keys are all `aws:*`. That matches an
+// IAM policy Condition OPERATOR map (`{aws:SourceAccount: ...}`) as perfectly as a
+// MAP-shaped tag, so an out-of-band Condition operator added under a DECLARED statement was
+// silently dropped and survived `record` — a security FN. The drop is now gated on the
+// parent key being a tag property (`*Tags`); the array-of-`{Key:'aws:*'}` tag list (real
+// AWS-managed system tags) still drops unconditionally.
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const undeclaredPaths = (fs: Finding[]): string[] =>
+  fs
+    .filter((f) => f.tier === 'undeclared')
+    .map((f) => f.path)
+    .sort();
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+describe('#863 out-of-band IAM Condition operator surfaces (aws:* map no longer dropped)', () => {
+  const declaredPolicy = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: { Service: 'sns.amazonaws.com' },
+        Action: 'sqs:SendMessage',
+        Resource: 'arn:aws:sqs:us-east-1:111122223333:q',
+        Condition: { ArnEquals: { 'aws:SourceArn': 'arn:aws:sns:us-east-1:111122223333:t' } },
+      },
+    ],
+  };
+
+  it('a live-only Condition operator keyed by aws:* is undeclared drift, not dropped', () => {
+    const res = mk('AWS::SQS::QueuePolicy', {
+      Queues: ['https://sqs.us-east-1.amazonaws.com/111122223333/q'],
+      PolicyDocument: declaredPolicy,
+    });
+    const live = {
+      Queues: ['https://sqs.us-east-1.amazonaws.com/111122223333/q'],
+      PolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { Service: 'sns.amazonaws.com' },
+            Action: 'sqs:SendMessage',
+            Resource: 'arn:aws:sqs:us-east-1:111122223333:q',
+            Condition: {
+              ArnEquals: { 'aws:SourceArn': 'arn:aws:sns:us-east-1:111122223333:t' },
+              // added out of band — an access WIDENING that used to be invisible
+              StringEquals: { 'aws:SourceAccount': '222233334444' },
+            },
+          },
+        ],
+      },
+    };
+    const f = classifyResource(res, live, emptySchema);
+    // SOMETHING under the added operator must surface (the operator or its aws:* sub-key)
+    const surfaced = undeclaredPaths(f).some((p) => /StringEquals|aws:SourceAccount/.test(p));
+    expect(surfaced).toBe(true);
+  });
+
+  it('an identical live policy (no out-of-band change) stays clean', () => {
+    const res = mk('AWS::SQS::QueuePolicy', {
+      Queues: ['https://sqs.us-east-1.amazonaws.com/111122223333/q'],
+      PolicyDocument: declaredPolicy,
+    });
+    const live = {
+      Queues: ['https://sqs.us-east-1.amazonaws.com/111122223333/q'],
+      PolicyDocument: declaredPolicy,
+    };
+    const f = classifyResource(res, live, emptySchema);
+    expect(undeclaredPaths(f)).toEqual([]);
+  });
+
+  it('AWS-managed system tags (array of {Key:aws:*}) still fold — no first-run FP', () => {
+    const res = mk('AWS::SNS::Topic', { TopicName: 't' });
+    const live = {
+      TopicName: 't',
+      // the array-of-Key tag list form: always AWS-managed, must still be dropped
+      Tags: [{ Key: 'aws:cloudformation:stack-name', Value: 'MyStack' }],
+    };
+    const f = classifyResource(res, live, emptySchema);
+    expect(undeclaredPaths(f)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #863

## Problem (security FN)
`emitNested` (`classify.ts`) dropped ANY live-only value whose map keys are all `aws:*`. That matches an IAM policy **Condition operator map** (`{aws:SourceAccount: ...}`) as perfectly as a map-shaped tag — the exact aws:*-condition-keys-vs-tags confusion the R69 fix already corrected for `stripAwsTagsDeep`, but never applied here. So an out-of-band operator added under a **declared** statement (e.g. a `StringEquals: {aws:SourceAccount}` access widening on an SQS/SNS/S3 resource policy) was silently dropped and **survived `record`** — the access change never surfaced.

## Fix (`classify.ts` only)
`isAllAwsTags` matches two shapes: an ARRAY of `{Key:'aws:*'}` (an unambiguous tag LIST — real AWS-managed system tags, always safe to drop) and an OBJECT keyed all `aws:*` (a map-shaped tag OR a Condition operator). The array form still drops unconditionally; the **object form** now drops only when the parent key is a tag property (`*Tags`). A Condition operator (`.Condition.StringEquals`) has a non-`Tags` parent → surfaces as undeclared drift.

No new first-run FP: a map-shaped `{aws:*}` only occurs under a `*Tags` property (still folded) or a policy Condition (which exists only when the user DECLARED the policy — not undeclared first-run noise). Full suite green (3629).

## Tests
`tests/emitnested-awsmap-863.test.ts`: the out-of-band Condition operator now surfaces (verified RED without the gate), an identical live policy stays clean, and array-form AWS system tags still fold (no first-run FP).

Live-test: offline detection-correctness fix; the classifyResource unit test on the exact repro shape (proven RED→GREEN) is the authoritative evidence — no fresh AWS deploy.