### PR TITLE
fix(noise): fold Valkey ReplicationGroup first-run defaults (#818)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2242,6 +2242,18 @@ export const ENGINE_DEFAULTS: Record<string, Record<string, (engine: string) => 
   'AWS::ElastiCache::CacheCluster': {
     Port: (e) => (/memcached/i.test(e) ? 11211 : /redis|valkey/i.test(e) ? 6379 : undefined),
   },
+  // A ReplicationGroup (the only node-based Valkey form) that declares no Port / no
+  // AtRestEncryptionEnabled reads back the engine defaults (#818): the same 6379 listener
+  // port (RGs are redis/valkey only, never memcached), and at-rest encryption which AWS
+  // enables BY DEFAULT for valkey (true) but not redis (false — an explicit equality gate
+  // rather than the accidental trivial-false drop). Both engine-derived from the live
+  // Engine and equality-gated, so an out-of-band port change or an encryption DISABLE still
+  // surfaces. (EngineVersion moves per GA release → value-independent, see below.)
+  'AWS::ElastiCache::ReplicationGroup': {
+    Port: (e) => (/redis|valkey/i.test(e) ? 6379 : undefined),
+    AtRestEncryptionEnabled: (e) =>
+      /valkey/i.test(e) ? true : /redis/i.test(e) ? false : undefined,
+  },
 };
 
 // RDS engine-family default listener port. Only families with a single well-known default
@@ -2891,7 +2903,17 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'SnapshotWindow',
     'PreferredAvailabilityZones',
   ]),
-  'AWS::ElastiCache::ReplicationGroup': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
+  //   AWS::ElastiCache::ReplicationGroup.EngineVersion — a RG that declares no EngineVersion
+  //   reads back the current GA patch AWS assigned (valkey "9.1.0" today), which AWS moves
+  //   over time as it ships new GA versions — not a constant we can pin. Undeclared → whatever
+  //   GA AWS assigned is its default, never user intent; a user who pins a version DECLARES it
+  //   and it is then compared (VERSION_PREFIX_PATHS tolerates the declared partial-vs-concrete
+  //   echo). Undeclared-only, like the sibling GA-version folds (#818).
+  'AWS::ElastiCache::ReplicationGroup': new Set([
+    'PreferredMaintenanceWindow',
+    'SnapshotWindow',
+    'EngineVersion',
+  ]),
   'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime']),
   'AWS::MemoryDB::Cluster': new Set(['MaintenanceWindow', 'SnapshotWindow']),
   //   AWS::Redshift::Cluster.AvailabilityZone — AWS places an undeclared cluster in an AZ it picks

--- a/tests/noise-valkey-rg-818.test.ts
+++ b/tests/noise-valkey-rg-818.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #818 — a fresh, un-mutated Valkey AWS::ElastiCache::ReplicationGroup violated the
+// zero-first-run invariant with 3 potential-drift FPs (undeclared Port=6379,
+// AtRestEncryptionEnabled=true (valkey-only), EngineVersion="9.1.0"). Port +
+// AtRestEncryptionEnabled are now engine-derived (equality-gated) folds; the undeclared GA
+// EngineVersion is value-independent. Detection preserved: an out-of-band port change or an
+// at-rest-encryption DISABLE still surfaces.
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string): string[] =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'ValkeyRg',
+  resourceType: 'AWS::ElastiCache::ReplicationGroup',
+  physicalId: 'valkey-rg',
+  declared,
+});
+const declaredMinimal = {
+  Engine: 'valkey',
+  CacheNodeType: 'cache.t4g.micro',
+  NumCacheClusters: 1,
+  AutomaticFailoverEnabled: false,
+  TransitEncryptionEnabled: false,
+  ReplicationGroupDescription: 'v',
+};
+
+describe('#818 Valkey ReplicationGroup first-run folds', () => {
+  it('folds undeclared Port / AtRestEncryptionEnabled / EngineVersion to atDefault (zero FP)', () => {
+    const f = classifyResource(
+      mk(declaredMinimal),
+      { ...declaredMinimal, Port: 6379, AtRestEncryptionEnabled: true, EngineVersion: '9.1.0' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['AtRestEncryptionEnabled', 'EngineVersion', 'Port'])
+    );
+    for (const p of ['Port', 'AtRestEncryptionEnabled', 'EngineVersion'])
+      expect(tier(f, 'undeclared')).not.toContain(p);
+  });
+
+  it('a redis RG folds AtRestEncryptionEnabled=false (its engine default)', () => {
+    const redis = { ...declaredMinimal, Engine: 'redis' };
+    const f = classifyResource(
+      mk(redis),
+      { ...redis, Port: 6379, AtRestEncryptionEnabled: false },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['AtRestEncryptionEnabled', 'Port'])
+    );
+  });
+
+  it('detection preserved: an out-of-band Port change surfaces (equality-gated, not blind)', () => {
+    // Port is engine-derived + equality-gated, so a divergence from the 6379 default is
+    // still real undeclared drift — the fold only quiets the exact default.
+    const f = classifyResource(
+      mk(declaredMinimal),
+      { ...declaredMinimal, Port: 6380, AtRestEncryptionEnabled: true, EngineVersion: '9.1.0' },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('Port');
+  });
+  // (AtRestEncryptionEnabled is a create-only property on ElastiCache — it can only be set
+  // at creation and never flips out of band — so the engine-derived equality-gate fold loses
+  // no detection; there is no OOB-disable scenario to catch.)
+});


### PR DESCRIPTION
Closes #818

## Problem
A fresh, un-mutated **Valkey** `AWS::ElastiCache::ReplicationGroup` (the only node-based Valkey form) violated the zero-first-run invariant with 3 `[Potential Drift]` FPs on the first `check` (LIVE-confirmed): undeclared `Port=6379`, `AtRestEncryptionEnabled=true` (valkey-only), `EngineVersion="9.1.0"`.

## Fix (`noise.ts` only, per the fold decision order)
- **`Port`** → tier-2 engine-derived: added an `ENGINE_DEFAULTS` entry for `ReplicationGroup` (redis/valkey → 6379; RGs are never memcached). Equality-gated — an out-of-band port change still surfaces.
- **`AtRestEncryptionEnabled`** → tier-2 engine-derived from the live `Engine` (valkey → true, redis → false, making redis's default an explicit equality fold rather than an accidental trivial-false drop). It is a **create-only** ElastiCache property (can only be set at creation, never flips out of band), so the fold loses no detection.
- **`EngineVersion`** (undeclared) → tier-3 value-independent: AWS assigns the current GA patch (`9.1.0` today) and moves it over time. A DECLARED version is still compared via the existing `VERSION_PREFIX_PATHS`.

## Tests
`tests/noise-valkey-rg-818.test.ts`: the 3 undeclared props fold to `atDefault` on a clean valkey RG (zero FP), a redis RG folds `AtRestEncryptionEnabled=false`, and an out-of-band `Port` change still surfaces (equality gate, not blind). Full suite green (3632).

Live evidence: the issue carries the live repro (hunt round 2026-07-08s, exact undeclared values); the classifyResource unit test reproduces the fold on that model — no fresh AWS deploy (offline fold fix).