### PR TITLE
fix(noise): fold EKS first-run defaults (ServiceIpv4Cidr / Version / AddonVersion) (#979)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -70,6 +70,7 @@ import {
   IDENTITY_KEYED_DEFAULT_ELEMENTS,
   isEpochHourEqual,
   KNOWN_DEFAULT_ONE_OF,
+  KNOWN_DEFAULT_ONE_OF_PATHS,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
   ORDER_SIGNIFICANT_ARRAY_KEYS,
@@ -1724,6 +1725,13 @@ export function classifyResource(
       (schemaPath in schema.defaultPaths &&
         matchesKnownDefault(value, schema.defaultPaths[schemaPath])) ||
       (schemaPath in knownDefPaths && matchesKnownDefault(value, knownDefPaths[schemaPath])) ||
+      // #979: a nested undeclared value equal to ONE OF a small closed set of stable-constant
+      // AWS defaults (the EKS ServiceIpv4Cidr's two documented CIDRs) — the nested twin of the
+      // top-level KNOWN_DEFAULT_ONE_OF, still equality-gated (a value outside the set surfaces).
+      (KNOWN_DEFAULT_ONE_OF_PATHS[resourceType]?.[schemaPath]?.some((d) =>
+        matchesKnownDefault(value, d)
+      ) ??
+        false) ||
       // #627: a GSI's undeclared WarmThroughput echoing that GSI's effective capacity
       // (on-demand constant or its own ProvisionedThroughput) — a per-GSI derived default.
       dynamoGsiWarmThroughputAtDefault(resourceType, path, value, live);

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -323,10 +323,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     },
   },
   // A fresh EKS cluster reads back several whole-object service defaults the template never
-  // declares. Constants (equality-gated) — an out-of-band change to any surfaces. The
-  // per-deploy-variable bits (KubernetesNetworkConfig.ServiceIpv4Cidr is 10.100 OR 172.20,
-  // Version tracks the service default) are deliberately NOT folded — they stay record-worthy.
-  // Observed live (hunt 2026-07-03 round E).
+  // declares. Constants (equality-gated) — an out-of-band change to any surfaces. Observed
+  // live (hunt 2026-07-03 round E). The two per-deploy-variable bits DO fold (#979, per the
+  // zero-first-run invariant): KubernetesNetworkConfig.ServiceIpv4Cidr is one of two
+  // documented constants (10.100.0.0/16 / 172.20.0.0/16) → KNOWN_DEFAULT_ONE_OF_PATHS below;
+  // the undeclared Version is the moving service-default Kubernetes GA → value-independent.
   'AWS::EKS::Cluster': {
     ControlPlaneScalingConfig: { Tier: 'standard' },
     UpgradePolicy: { SupportType: 'EXTENDED' },
@@ -336,7 +337,9 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     AccessConfig: { AuthenticationMode: 'CONFIG_MAP' },
   },
   // A vpc-cni (and other) addon reads back the kube-system namespace it installs into when
-  // the template declares no NamespaceConfig. AddonVersion is per-cluster-version → record-worthy.
+  // the template declares no NamespaceConfig. (An undeclared AddonVersion — the default
+  // compatible version EKS picks, which moves per cluster version and over time — folds
+  // value-independent, #979.)
   'AWS::EKS::Addon': { NamespaceConfig: { Namespace: 'kube-system' } },
   // A WebACL that declares no on-source DDoS protection reads back AWS's default
   // OnSourceDDoSProtectionConfig — ALBLowReputationMode=ACTIVE_UNDER_DDOS (the first
@@ -1538,6 +1541,24 @@ export const KNOWN_DEFAULT_ONE_OF: Record<string, Record<string, readonly unknow
   // are folded as PEERS here — neither masks the other, and neither masks a custom value.
   'AWS::ApiGatewayV2::Integration': {
     TimeoutInMillis: [29000, 30000],
+  },
+};
+
+// The NESTED-path twin of KNOWN_DEFAULT_ONE_OF (#979): a nested undeclared value whose AWS
+// default is one of a small, stable, closed set of constants (the discriminator is off the
+// resource's own model). Keyed BY DOTTED PATH with `*` for array elements — the same shape
+// the classify nested loop (`emitNested`) computes and `schema.defaultPaths` /
+// KNOWN_DEFAULT_PATHS use. A live value that deep-equals ANY listed constant folds to
+// `atDefault`; a declared value or anything outside the set still surfaces (equality-gated,
+// tier-1 — NOT a value-independent blanket fold).
+export const KNOWN_DEFAULT_ONE_OF_PATHS: Record<string, Record<string, readonly unknown[]>> = {
+  // An EKS cluster that declares no ServiceIpv4Cidr has EKS pick ONE OF TWO documented
+  // constants for the Kubernetes service CIDR — 10.100.0.0/16 or 172.20.0.0/16 (chosen to
+  // avoid overlapping the VPC CIDR). Both are stable constants and the value is create-only
+  // (never drifts out of band), so folding the SET keeps every clean cluster at zero
+  // first-run drift while an out-of-band value outside the set still surfaces.
+  'AWS::EKS::Cluster': {
+    'KubernetesNetworkConfig.ServiceIpv4Cidr': ['10.100.0.0/16', '172.20.0.0/16'],
   },
 };
 
@@ -2851,6 +2872,16 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   when undeclared — a user who sets a custom Username declares it (compared in the declared
   //   loop). Fold value-independent. Observed live first-run (hunt 2026-07-03 round E).
   'AWS::EKS::AccessEntry': new Set(['Username']),
+  //   AWS::EKS::Cluster.Version — a cluster that declares no Version is provisioned at the
+  //   CURRENT default Kubernetes version (the canonical moving-GA-version tier-3 case), which
+  //   also MOVES afterward under EKS auto-upgrade — so a recorded baseline value re-drifts and
+  //   record never converges long-term. Undeclared → whatever GA EKS provisioned/upgraded to
+  //   is its default, not user intent; a pinned Version is compared in the declared loop. (#979)
+  'AWS::EKS::Cluster': new Set(['Version']),
+  //   AWS::EKS::Addon.AddonVersion — an addon that declares no version reads back the default
+  //   compatible version EKS picks, which moves per cluster version AND over time (auto-minor
+  //   bumps). Same moving-versioned-default tier-3 shape as Cluster.Version. (#979)
+  'AWS::EKS::Addon': new Set(['AddonVersion']),
   //   AWS::Glue::Job.MaxCapacity / .AllocatedCapacity — a job that sizes itself with the modern
   //   `WorkerType` + `NumberOfWorkers` pair (a glueetl / gluestreaming job on Glue 2.0+) declares
   //   NEITHER capacity field; AWS DERIVES both from the worker sizing and reads them back

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -10319,14 +10319,17 @@ describe('#531 EKS + Athena first-run default folds', () => {
       // #555: KubernetesNetworkConfig is fully undeclared but DESCENDED — its constant IpFamily
       // folds here (ElasticLoadBalancing {Enabled:false} drops as trivially-empty).
       'KubernetesNetworkConfig.IpFamily',
+      // #979: ServiceIpv4Cidr is one of two documented constants (KNOWN_DEFAULT_ONE_OF_PATHS).
+      'KubernetesNetworkConfig.ServiceIpv4Cidr',
       'ResourcesVpcConfig.ControlPlaneEgressMode',
       'ResourcesVpcConfig.EndpointPublicAccess',
       'ResourcesVpcConfig.PublicAccessCidrs',
       'UpgradePolicy',
+      // #979: the undeclared Version is the moving service-default GA (value-independent).
+      'Version',
     ]);
-    // The per-deploy-variable bits are deliberately still surfaced (record-worthy). #555:
-    // only the residue ServiceIpv4Cidr surfaces now, not the whole KubernetesNetworkConfig.
-    expect(t.undeclared).toEqual(['KubernetesNetworkConfig.ServiceIpv4Cidr', 'Version']);
+    // #979: both per-deploy-variable bits now fold per the zero-first-run invariant.
+    expect(t.undeclared).toEqual([]);
   });
 
   it('EKS Cluster: an out-of-band-narrowed PublicAccessCidrs still surfaces (equality-gated)', () => {
@@ -10347,7 +10350,7 @@ describe('#531 EKS + Athena first-run default folds', () => {
     expect(t.atDefault).toEqual([]);
   });
 
-  it('EKS Addon: kube-system NamespaceConfig folds; AddonVersion stays record-worthy', () => {
+  it('EKS Addon: kube-system NamespaceConfig folds; AddonVersion folds value-independent (#979)', () => {
     const res: DesiredResource = {
       logicalId: 'Addon',
       resourceType: 'AWS::EKS::Addon',
@@ -10366,8 +10369,8 @@ describe('#531 EKS + Athena first-run default folds', () => {
         emptySchema
       )
     );
-    expect(t.atDefault).toEqual(['NamespaceConfig']);
-    expect(t.undeclared).toEqual(['AddonVersion']);
+    expect(t.atDefault).toEqual(['AddonVersion', 'NamespaceConfig']);
+    expect(t.undeclared).toEqual([]);
   });
 
   it('EKS AccessEntry: derived Username folds value-independent; a declared Username is compared', () => {
@@ -10635,7 +10638,7 @@ describe('#555: descend a fully-undeclared object (DESCEND_UNDECLARED_OBJECT_PAT
     declared: {},
   });
 
-  it('EKS KubernetesNetworkConfig: fold IpFamily default + drop empty ELB, surface only the CIDR residue', () => {
+  it('EKS KubernetesNetworkConfig: fold IpFamily + ServiceIpv4Cidr defaults, drop empty ELB (#979)', () => {
     const t = tiers(
       classifyResource(
         bare('AWS::EKS::Cluster'),
@@ -10649,12 +10652,16 @@ describe('#555: descend a fully-undeclared object (DESCEND_UNDECLARED_OBJECT_PAT
         emptySchema
       )
     );
-    // the whole object is NO LONGER one undeclared finding — it is split leaf-by-leaf
-    expect(t.undeclared).toEqual(['KubernetesNetworkConfig.ServiceIpv4Cidr']);
-    expect(t.atDefault).toEqual(['KubernetesNetworkConfig.IpFamily']);
+    // #979: the whole object is split leaf-by-leaf; both the IpFamily constant AND the
+    // ServiceIpv4Cidr two-constant default now fold (zero first-run residue).
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault).toEqual([
+      'KubernetesNetworkConfig.IpFamily',
+      'KubernetesNetworkConfig.ServiceIpv4Cidr',
+    ]);
   });
 
-  it('equality-gated: a non-default IpFamily (ipv6) surfaces as undeclared, not folded', () => {
+  it('equality-gated: a non-default IpFamily (ipv6) surfaces; the CIDR still folds (#979)', () => {
     const t = tiers(
       classifyResource(
         bare('AWS::EKS::Cluster'),
@@ -10662,11 +10669,9 @@ describe('#555: descend a fully-undeclared object (DESCEND_UNDECLARED_OBJECT_PAT
         emptySchema
       )
     );
-    expect(t.undeclared.sort()).toEqual([
-      'KubernetesNetworkConfig.IpFamily',
-      'KubernetesNetworkConfig.ServiceIpv4Cidr',
-    ]);
-    expect(t.atDefault).toEqual([]);
+    // ipv6 is a real opt-in (surfaces); the CIDR 10.100.0.0/16 is one of the two folded constants.
+    expect(t.undeclared).toEqual(['KubernetesNetworkConfig.IpFamily']);
+    expect(t.atDefault).toEqual(['KubernetesNetworkConfig.ServiceIpv4Cidr']);
   });
 
   it('a fully-undeclared object NOT in the allowlist stays ONE whole undeclared finding (no fragmentation)', () => {

--- a/tests/corpus/AWS__EKS__Addon.AddonEksRich.json
+++ b/tests/corpus/AWS__EKS__Addon.AddonEksRich.json
@@ -77,7 +77,7 @@
       "constructPath": "CdkRealDriftIntegEksRich/Addon"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Addon",
       "resourceType": "AWS::EKS::Addon",
       "path": "AddonVersion",

--- a/tests/corpus/AWS__EKS__Cluster.Cluster.json
+++ b/tests/corpus/AWS__EKS__Cluster.Cluster.json
@@ -147,7 +147,7 @@
       "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "KubernetesNetworkConfig.ServiceIpv4Cidr",

--- a/tests/corpus/AWS__EKS__Cluster.ClusterEksRich.json
+++ b/tests/corpus/AWS__EKS__Cluster.ClusterEksRich.json
@@ -173,7 +173,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "KubernetesNetworkConfig.ServiceIpv4Cidr",
@@ -204,7 +204,7 @@
       "constructPath": "CdkRealDriftIntegEksRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "Version",

--- a/tests/noise-eks-firstrun-979.test.ts
+++ b/tests/noise-eks-firstrun-979.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #979 — three EKS values AWS assigns at creation surfaced as undeclared [Potential Drift]
+// on a clean first check, with code comments rationalizing them as "record-worthy". Each
+// fits a fold tier: Cluster.KubernetesNetworkConfig.ServiceIpv4Cidr is one of two documented
+// constants (nested KNOWN_DEFAULT_ONE_OF_PATHS), Cluster.Version + Addon.AddonVersion are
+// moving GA versions (value-independent). Detection preserved where meaningful.
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string): string[] =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const undeclared = (fs: Finding[]): string[] => tier(fs, 'undeclared');
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+describe('#979 EKS Cluster first-run folds', () => {
+  const declared = {
+    Name: 'c',
+    RoleArn: 'arn:aws:iam::111122223333:role/eks',
+    ResourcesVpcConfig: { SubnetIds: ['subnet-1'] },
+  };
+
+  for (const cidr of ['10.100.0.0/16', '172.20.0.0/16']) {
+    it(`folds ServiceIpv4Cidr=${cidr} (one of the two documented constants)`, () => {
+      const f = classifyResource(
+        mk('AWS::EKS::Cluster', declared),
+        {
+          ...declared,
+          KubernetesNetworkConfig: { ServiceIpv4Cidr: cidr, IpFamily: 'ipv4' },
+          Version: '1.36',
+        },
+        emptySchema
+      );
+      expect(undeclared(f)).not.toContain('KubernetesNetworkConfig.ServiceIpv4Cidr');
+      expect(undeclared(f)).not.toContain('Version');
+    });
+  }
+
+  it('surfaces a ServiceIpv4Cidr OUTSIDE the two-constant set (equality-gated)', () => {
+    const f = classifyResource(
+      mk('AWS::EKS::Cluster', declared),
+      {
+        ...declared,
+        KubernetesNetworkConfig: { ServiceIpv4Cidr: '192.168.0.0/16', IpFamily: 'ipv4' },
+      },
+      emptySchema
+    );
+    expect(undeclared(f)).toContain('KubernetesNetworkConfig.ServiceIpv4Cidr');
+  });
+
+  it('folds an undeclared Version regardless of the concrete GA value (value-independent)', () => {
+    const f = classifyResource(
+      mk('AWS::EKS::Cluster', declared),
+      { ...declared, Version: '1.99' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('Version');
+    expect(undeclared(f)).not.toContain('Version');
+  });
+});
+
+describe('#979 EKS Addon AddonVersion fold', () => {
+  it('folds an undeclared AddonVersion (moving default) value-independent', () => {
+    const declared = { ClusterName: 'c', AddonName: 'vpc-cni' };
+    const f = classifyResource(
+      mk('AWS::EKS::Addon', declared),
+      { ...declared, AddonVersion: 'v1.21.2-eksbuild.2' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('AddonVersion');
+    expect(undeclared(f)).not.toContain('AddonVersion');
+  });
+});


### PR DESCRIPTION
Closes #979

## Problem
Three EKS values AWS assigns at creation surfaced as undeclared `[Potential Drift]` on a clean first `check`, with code comments rationalizing them as "record-worthy" — exactly the rationalization the zero-first-run invariant (CLAUDE.md) forbids. Each fits an existing fold tier:

- **`Cluster.KubernetesNetworkConfig.ServiceIpv4Cidr`** — EKS picks ONE OF TWO documented constants (`10.100.0.0/16` / `172.20.0.0/16`). New nested **`KNOWN_DEFAULT_ONE_OF_PATHS`** table (the nested twin of the top-level `KNOWN_DEFAULT_ONE_OF`), wired into `emitNested`'s atDefault gate — equality-gated, so a CIDR outside the set still surfaces; create-only, so it never drifts.
- **`Cluster.Version`** — the moving service-default Kubernetes GA (also moves under auto-upgrade, so `record` never converges long-term) → tier-3 value-independent.
- **`Addon.AddonVersion`** — the default compatible version, moving per cluster version and over time → tier-3 value-independent.

## Changes
- `noise.ts`: new `KNOWN_DEFAULT_ONE_OF_PATHS` (EKS ServiceIpv4Cidr set); `Cluster.Version` + `Addon.AddonVersion` added to `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`; the misleading "deliberately NOT folded / record-worthy" comments corrected.
- `classify.ts`: `emitNested` consults `KNOWN_DEFAULT_ONE_OF_PATHS`.
- Tests: new `tests/noise-eks-firstrun-979.test.ts` (folds + the outside-the-set CIDR still surfaces); the \#531/\#555 classify assertions updated to the new folding; 3 EKS corpus `expected` re-tiered undeclared→atDefault (only the 4 affected findings changed, reviewed).

Full suite green (3637). Live evidence: the issue carries the live repro (exact values 172.20.0.0/16, 1.36, v1.21.2-eksbuild.2) and the classifyResource unit tests + corpus replay reproduce the fold — offline fold fix, no fresh AWS deploy.