### PR TITLE
fix(commands): region in per-finding decision prompts (#1097)

### DIFF
--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -149,15 +149,30 @@ export function buildScopeOptions(
  * to be prompted, so it gets the full set, matching the pre-gate `--yes` behaviour). The
  * `--yes` case never reaches the AWS-mutating revert through here (revert has no gate).
  */
+// #1097: the scope-select and per-finding action-picker headers, pure + exported so
+// their wording is unit-tested. Both label with `Name (region)` (the #1023 `stackLabel`) —
+// after #899 exact-name selection targets EVERY same-named region instance, so a bare
+// stackName in these DECISION prompts is indistinguishable across regions right where the
+// user decides (chooseScope) or assigns per-finding record/ignore/REVERT (the picker),
+// while the menu/multiselects already name the region.
+export function scopeMessage(stackName: string, region: string, foldedCount: number): string {
+  return `${stackLabel(stackName, region)}: the report folded ${foldedCount} undeclared value(s) — which to decide on?`;
+}
+
+export function perFindingActionMessage(stackName: string, region: string): string {
+  return `${stackLabel(stackName, region)}: assign an action to each finding`;
+}
+
 async function chooseScope(
   stackName: string,
+  region: string,
   shownCount: number,
   foldedCount: number,
   yes: boolean
 ): Promise<'shown' | 'all' | null> {
   if (yes || foldedCount === 0 || shownCount === 0) return 'all';
   const choice = await select({
-    message: `${stackName}: the report folded ${foldedCount} undeclared value(s) — which to decide on?`,
+    message: scopeMessage(stackName, region, foldedCount),
     options: buildScopeOptions(shownCount, foldedCount),
     initialValue: 'shown',
   });
@@ -437,7 +452,13 @@ async function ignoreAll(p: ResolveParams): Promise<SubResult | null> {
     (f) => f.tier === 'declared' || f.tier === 'undeclared' || f.tier === 'added'
   );
   const foldedCount = ignorable.filter((f) => isFoldedFinding(f, p.verbose)).length;
-  const scope = await chooseScope(p.stackName, ignorable.length - foldedCount, foldedCount, p.yes);
+  const scope = await chooseScope(
+    p.stackName,
+    p.region,
+    ignorable.length - foldedCount,
+    foldedCount,
+    p.yes
+  );
   if (scope === null) return null; // scope prompt cancelled → back to the menu
   const findings =
     scope === 'all' ? ignorable : ignorable.filter((f) => !isFoldedFinding(f, p.verbose));
@@ -487,7 +508,13 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
   // Gate the folded undeclared inventory the same way ignore does: default the picker to
   // the report's SHOWN findings, ask before pulling the folded nested values in.
   const foldedCount = decidable.filter((f) => isFoldedFinding(f, p.verbose)).length;
-  const scope = await chooseScope(p.stackName, decidable.length - foldedCount, foldedCount, p.yes);
+  const scope = await chooseScope(
+    p.stackName,
+    p.region,
+    decidable.length - foldedCount,
+    foldedCount,
+    p.yes
+  );
   if (scope === null) return null; // scope prompt cancelled → back to the menu
   const scoped =
     scope === 'all' ? decidable : decidable.filter((f) => !isFoldedFinding(f, p.verbose));
@@ -495,7 +522,7 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
     label: pickerLabel(f, p.stackName),
     applicable: applicableActions(f),
   }));
-  const chosen = await actionPicker(`${p.stackName}: assign an action to each finding`, rows);
+  const chosen = await actionPicker(perFindingActionMessage(p.stackName, p.region), rows);
   if (chosen === undefined) return null; // picker cancelled (Esc) → back to the menu
   const groups = groupByAction(scoped, chosen);
   if (groups.record.length + groups.ignore.length + groups.revert.length === 0)

--- a/tests/interactive-resolve.test.ts
+++ b/tests/interactive-resolve.test.ts
@@ -23,8 +23,10 @@ import { select } from '@clack/prompts';
 import {
   buildScopeOptions,
   isFoldedFinding,
+  perFindingActionMessage,
   pickerLabel,
   resolveInteractively,
+  scopeMessage,
 } from '../src/commands/interactive-resolve.js';
 import { ignoreStack, recordStack, revertStack } from '../src/commands/stack-actions.js';
 import type { Finding } from '../src/types.js';
@@ -223,5 +225,34 @@ describe('pickerLabel — the per-finding "decide per finding" row (mirrors the 
     expect(pickerLabel(f, 'S')).toContain(
       'Edge.LoadBalancerAttributes[idle_timeout.timeout_seconds]'
     );
+  });
+});
+
+describe('per-finding DECISION prompt headers name the region (#1097 — #947 residue)', () => {
+  describe('scopeMessage — the scope-select header (chooseScope)', () => {
+    it('labels with Name (region), not a bare stackName', () => {
+      const msg = scopeMessage('Dup', 'us-east-1', 3);
+      expect(msg).toContain('Dup (us-east-1):');
+      expect(msg).toContain('folded 3 undeclared value(s)');
+    });
+
+    it('two same-named different-region invocations produce DISTINCT strings', () => {
+      expect(scopeMessage('Dup', 'us-east-1', 3)).not.toBe(scopeMessage('Dup', 'us-west-2', 3));
+    });
+  });
+
+  describe('perFindingActionMessage — the action-picker header (record/ignore/REVERT)', () => {
+    it('labels with Name (region), not a bare stackName', () => {
+      const msg = perFindingActionMessage('Dup', 'eu-west-1');
+      expect(msg).toBe('Dup (eu-west-1): assign an action to each finding');
+      // the bare form the report menu already moved away from must NOT reappear here
+      expect(msg).not.toBe('Dup: assign an action to each finding');
+    });
+
+    it('two same-named different-region invocations produce DISTINCT strings', () => {
+      expect(perFindingActionMessage('Dup', 'us-east-1')).not.toBe(
+        perFindingActionMessage('Dup', 'us-west-2')
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #1097

## What

#947 residue: PR #1023 threaded `stackLabel(stackName, region)` (`Name (region)`) into the per-stack menu + record/ignore/revert multiselects, but the TWO per-finding DECISION prompts inside the same `resolveInteractively` loop still labelled with the bare `stackName`. In a post-#899 same-named multi-region run the menu said `Dup (us-east-1)` while the very next prompts said bare `Dup:` — the operator couldn't tell which region's finding they were deciding on (including per-finding REVERT).

Threaded the region into both, matching the `Name (region)` form the menu/multiselects already use (reusing the #1023 `stackLabel` helper, unchanged):

- **`chooseScope` scope-select header** (`interactive-resolve.ts`) — gained a `region` param (it had none); both call sites (ignoreAll, perFinding) now pass `p.region`. Extracted the wording into a pure exported `scopeMessage(stackName, region, foldedCount)`.
- **`actionPicker` header** (per-finding record/ignore/**REVERT** — highest stakes) — now uses `p.region` from the already-available `ResolveParams`. Extracted into a pure exported `perFindingActionMessage(stackName, region)`.

Both helpers mirror the existing `resolveMenuMessage` / `recordSelectMessage` / `revertConfirmMessage` pure-exported pattern so their wording is unit-tested.

## Scope

Fixed ONLY the two primary DECISION prompts (where the user decides). The issue lists a batch of lower-stakes secondary notes/warnings — several live in `check.ts`, owned by the parallel #948 lane — so **the secondary-note sweep is deferred**, not done here.

## Tests

New `interactive-resolve.test.ts` block "per-finding DECISION prompt headers name the region (#1097)":
- `scopeMessage` labels `Name (region)` + two same-named different-region invocations produce DISTINCT strings.
- `perFindingActionMessage` labels `Name (region)`, is NOT the bare form, + two same-named different-region invocations produce DISTINCT strings.

Verified these 4 tests FAIL when the message helpers are reverted to bare `stackName`, and pass with the fix. Full suite: 98 files / 3641 tests green.