### PR TITLE
fix: ACM Certificate folds (#1090) + #845 sibling-shape folds (#1094)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1464,14 +1464,17 @@ export function classifyResource(
       if (name) knownDefPaths = { ...knownDefPaths, 'Registry.Name': name };
     }
   }
-  // #845: a CodeBuild Project's undeclared `Artifacts.Name` echoes the declared project
-  // `Name` (AWS default-fills the artifact name to the project name when the template's
-  // Artifacts block declares no Name). Derive it from the declared top-level `Name` and
-  // equality-gate it (fold tier 2): an out-of-band change of the artifact name still surfaces.
+  // #845/#1094: a CodeBuild Project's undeclared `Artifacts.Name` echoes the project name —
+  // the declared top-level `Name` when the template declares one, else the AWS-GENERATED
+  // project name (= the physical id) when the template declares NO Name (the default CDK
+  // `codebuild.Project` without an explicit projectName). Derive from `Name` and fall back to
+  // `physicalId`, then equality-gate it (fold tier 2): an out-of-band change of the artifact
+  // name away from the project name still surfaces.
   if (resourceType === 'AWS::CodeBuild::Project') {
     const name = declared['Name'];
-    if (typeof name === 'string') {
-      knownDefPaths = { ...knownDefPaths, 'Artifacts.Name': name };
+    const artifactName = typeof name === 'string' ? name : physicalId;
+    if (typeof artifactName === 'string') {
+      knownDefPaths = { ...knownDefPaths, 'Artifacts.Name': artifactName };
     }
   }
   // #845: a SecretsManager RotationSchedule declaring `RotationRules.ScheduleExpression`
@@ -1490,15 +1493,21 @@ export function classifyResource(
       };
     }
   }
-  // #845: an AmazonMQ ACTIVEMQ broker that declares no `StorageType` reads back the AWS
-  // default `EFS` (ActiveMQ brokers default to EFS storage; RabbitMQ supports only EBS).
-  // Derive the default from the declared `EngineType` and equality-gate it (fold tier 2):
-  // an ActiveMQ broker pinned to EBS declares StorageType and is compared, and an out-of-band
-  // change away from the derived default still surfaces.
+  // #845/#1094: an AmazonMQ broker that declares no `StorageType` reads back the AWS default
+  // for its engine — ActiveMQ defaults to `EFS`; RabbitMQ supports ONLY `EBS` (DescribeBroker
+  // returns storageType unconditionally). Derive the default from the declared `EngineType`
+  // and equality-gate it (fold tier 2): a broker that pins a non-default StorageType declares
+  // it and is compared, and an out-of-band change away from the derived default still surfaces.
   if (resourceType === 'AWS::AmazonMQ::Broker') {
     const engineType = declared['EngineType'];
-    if (typeof engineType === 'string' && engineType.toUpperCase() === 'ACTIVEMQ') {
-      knownDef = { ...knownDef, StorageType: 'EFS' };
+    const engineStorageDefault: Record<string, string> = {
+      ACTIVEMQ: 'EFS',
+      RABBITMQ: 'EBS',
+    };
+    const storageDefault =
+      typeof engineType === 'string' ? engineStorageDefault[engineType.toUpperCase()] : undefined;
+    if (storageDefault !== undefined) {
+      knownDef = { ...knownDef, StorageType: storageDefault };
     }
   }
   // #701: an EventSourceMapping's default BatchSize depends on the source service — 10 for

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -19,6 +19,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // exactly like Role/kin above. Equality-gated, so an out-of-band UpdateServerCertificate
   // path move still surfaces. Live-confirmed (#910).
   'AWS::IAM::ServerCertificate': { Path: '/' },
+  // An ACM Certificate declared without a KeyAlgorithm reads back "RSA_2048" (the ACM
+  // default) from DescribeCertificate, which the #974 SDK reader returns unconditionally.
+  // Equality-gated, so a user who declares a different algorithm (e.g. EC_prime256v1) pushes
+  // the property out of the undeclared tier and still surfaces any divergence (#1090).
+  'AWS::CertificateManager::Certificate': { KeyAlgorithm: 'RSA_2048' },
   // An App Runner service that declares neither HealthCheckConfiguration nor
   // NetworkConfiguration reads both back fully materialized with AWS's constant
   // first-run defaults — a TCP health check and a public IPV4 DEFAULT-egress network.
@@ -4492,6 +4497,15 @@ export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
   // `SSESpecification` — the SSE config is reflected via other readOnly props, not echoed verbatim.
   'AWS::DynamoDB::GlobalTable': new Set(['SSESpecification']),
   'AWS::DynamoDB::Table': new Set(['SSESpecification']),
+  // `DomainValidationOptions` — a createOnly write-time INPUT collection
+  // ({DomainName, ValidationDomain, HostedZoneId}) that DescribeCertificate does NOT echo
+  // back verbatim; it returns resolved runtime `DomainValidation` records instead (CNAME/
+  // status), so the SDK reader deliberately never projects it (overrides.ts readAcmCertificate,
+  // "stays a readGap"). The live registry schema has no writeOnlyProperties, so schema-strip
+  // keeps it in the declared model → classify's removed-collection branch would false-flag
+  // every DNS-validated cert. It is a true readGap: AWS genuinely never returns the input
+  // shape (#1090).
+  'AWS::CertificateManager::Certificate': new Set(['DomainValidationOptions']),
 };
 
 // SCALAR_RETURNED_WHEN_SET is the ALLOWLIST inverse of the collection default in the

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -2125,11 +2125,29 @@ const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region
   if (str(cert.KeyAlgorithm)) model.KeyAlgorithm = cert.KeyAlgorithm;
   // SANs only when declared — AWS always folds DomainName in as an implied SAN, so an
   // undeclared live list would false-flag every single-domain cert (see note above).
-  const declaresSans =
-    Array.isArray(declared.SubjectAlternativeNames) && declared.SubjectAlternativeNames.length > 0;
-  const sans = (cert.SubjectAlternativeNames ?? []).filter(
-    (s): s is string => str(s) !== undefined
-  );
+  const declaredSans = Array.isArray(declared.SubjectAlternativeNames)
+    ? declared.SubjectAlternativeNames.filter((s): s is string => str(s) !== undefined)
+    : [];
+  const declaresSans = declaredSans.length > 0;
+  let sans = (cert.SubjectAlternativeNames ?? []).filter((s): s is string => str(s) !== undefined);
+  // DescribeCertificate ALWAYS includes the canonical apex DomainName as the first SAN, but
+  // CFn users declare only the ADDITIONAL names. When the declared list does NOT itself
+  // contain the DomainName, subtract that single implied apex element from the live list
+  // before compare so a clean multi-SAN cert folds to zero drift. Equality-gated: this
+  // removes ONLY the DomainName-matching element, so any OTHER extra/missing SAN still
+  // surfaces (#1090). If the user DID declare the DomainName as a SAN, keep the live list
+  // verbatim (they intend it, so it is a faithful compare).
+  const apex = str(cert.DomainName);
+  if (declaresSans && apex !== undefined && !declaredSans.includes(apex)) {
+    let dropped = false;
+    sans = sans.filter((s) => {
+      if (!dropped && s === apex) {
+        dropped = true;
+        return false;
+      }
+      return true;
+    });
+  }
   if (declaresSans && sans.length > 0) model.SubjectAlternativeNames = sans;
   // CertificateTransparencyLoggingPreference: project only when declared OR moved away from
   // the ENABLED default, so a clean undeclared cert folds to nothing (zero first-run drift)

--- a/tests/acm-firstrun-folds-1090.test.ts
+++ b/tests/acm-firstrun-folds-1090.test.ts
@@ -1,0 +1,169 @@
+// #1090 — ACM Certificate first-run folds. The #974 SDK reader un-skipped
+// AWS::CertificateManager::Certificate but added no fold-table entries, so a clean
+// DNS-validated cert produced 2-3 [Potential Drift] on a first check. Three fixes, each
+// satisfying the zero-first-run invariant while PRESERVING detection:
+//   F1 DomainValidationOptions — a createOnly write-time INPUT collection AWS never echoes
+//      back verbatim → READGAP_COLLECTION_PATHS denylist (classify's removed-collection
+//      branch skips it → readGap, not declared drift).
+//   F2 KeyAlgorithm — the RSA_2048 default the reader returns unconditionally →
+//      KNOWN_DEFAULTS tier-1 pin (folds to atDefault; a declared different algorithm surfaces).
+//   F3 SubjectAlternativeNames — ACM injects the apex DomainName as an implied SAN; the
+//      reader subtracts it from the projected live list when the declared list omits it.
+import {
+  ACMClient,
+  DescribeCertificateCommand,
+  ListTagsForCertificateCommand,
+} from '@aws-sdk/client-acm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// The live ACM registry schema exposes only readOnly=/properties/Id — no writeOnly — so
+// DomainValidationOptions survives schema-strip into the declared model (the F1 condition).
+const acmSchema: SchemaInfo = {
+  readOnly: new Set(['Id']),
+  writeOnly: new Set(),
+  createOnly: new Set(['DomainName', 'SubjectAlternativeNames', 'KeyAlgorithm']),
+  readOnlyPaths: ['Id'],
+  writeOnlyPaths: [],
+  createOnlyPaths: ['DomainName', 'SubjectAlternativeNames', 'KeyAlgorithm'],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Cert',
+  resourceType: 'AWS::CertificateManager::Certificate',
+  physicalId: 'arn:aws:acm:us-east-1:123456789012:certificate/abc',
+  declared,
+});
+
+describe('#1090 F1 ACM DomainValidationOptions readGap denylist', () => {
+  it('a declared DomainValidationOptions absent from the live read stays readGap, not declared drift', () => {
+    const findings = classifyResource(
+      mk({
+        DomainName: 'example.com',
+        DomainValidationOptions: [{ DomainName: 'example.com', HostedZoneId: 'Z123' }],
+      }),
+      // the reader deliberately never projects DomainValidationOptions
+      { DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' },
+      acmSchema
+    );
+    expect(
+      findings.some((f) => f.tier === 'declared' && f.path === 'DomainValidationOptions')
+    ).toBe(false);
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'DomainValidationOptions')).toBe(
+      true
+    );
+  });
+});
+
+describe('#1090 F2 ACM KeyAlgorithm RSA_2048 default', () => {
+  it('folds the undeclared KeyAlgorithm RSA_2048 to atDefault (ZERO first-run drift)', () => {
+    const findings = classifyResource(
+      mk({ DomainName: 'example.com' }),
+      { DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' },
+      acmSchema
+    );
+    expect(tier(findings, 'atDefault')).toContain('KeyAlgorithm');
+    expect(tier(findings, 'undeclared')).not.toContain('KeyAlgorithm');
+  });
+  it('surfaces a KeyAlgorithm that diverges from the RSA_2048 default — detection preserved', () => {
+    const findings = classifyResource(
+      mk({ DomainName: 'example.com' }),
+      { DomainName: 'example.com', KeyAlgorithm: 'EC_prime256v1' },
+      acmSchema
+    );
+    expect(tier(findings, 'undeclared')).toContain('KeyAlgorithm');
+  });
+});
+
+// F3 lives in the reader: it subtracts the apex DomainName from the projected live SAN list.
+const acm = mockClient(ACMClient);
+const ARN = 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012';
+const ctx = (declared: Record<string, unknown>) => ({
+  physicalId: ARN,
+  declared,
+  region: 'us-east-1',
+  accountId: '123456789012',
+});
+const read = (c: ReturnType<typeof ctx>) =>
+  SDK_OVERRIDES['AWS::CertificateManager::Certificate'](c);
+
+describe('#1090 F3 ACM SubjectAlternativeNames apex subtraction', () => {
+  beforeEach(() => acm.reset());
+
+  it('subtracts the implied apex DomainName so a clean multi-SAN cert folds to zero drift', async () => {
+    // Template declares only the ADDITIONAL names; AWS returns the apex DomainName folded in.
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        DomainName: 'example.com',
+        SubjectAlternativeNames: ['example.com', 'www.example.com', 'api.example.com'],
+        KeyAlgorithm: 'RSA_2048',
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+
+    const out = await read(
+      ctx({
+        DomainName: 'example.com',
+        SubjectAlternativeNames: ['www.example.com', 'api.example.com'],
+      })
+    );
+    // apex 'example.com' subtracted → matches the declared list exactly (no drift).
+    expect(out).toMatchObject({
+      SubjectAlternativeNames: ['www.example.com', 'api.example.com'],
+    });
+  });
+
+  it('surfaces a genuinely extra SAN even after apex subtraction — detection preserved', async () => {
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        DomainName: 'example.com',
+        // apex + declared www + an OUT-OF-BAND extra name the template never declared
+        SubjectAlternativeNames: ['example.com', 'www.example.com', 'rogue.example.com'],
+        KeyAlgorithm: 'RSA_2048',
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+
+    const out = await read(
+      ctx({ DomainName: 'example.com', SubjectAlternativeNames: ['www.example.com'] })
+    );
+    // only the single apex is subtracted; the rogue element stays → differs from declared.
+    expect(out).toMatchObject({
+      SubjectAlternativeNames: ['www.example.com', 'rogue.example.com'],
+    });
+  });
+
+  it('keeps the live list verbatim when the declared SAN list DOES contain the apex DomainName', async () => {
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        DomainName: 'example.com',
+        SubjectAlternativeNames: ['example.com', 'www.example.com'],
+        KeyAlgorithm: 'RSA_2048',
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+
+    const out = await read(
+      ctx({
+        DomainName: 'example.com',
+        SubjectAlternativeNames: ['example.com', 'www.example.com'],
+      })
+    );
+    // the user intends the apex as a SAN → no subtraction, faithful compare.
+    expect(out).toMatchObject({
+      SubjectAlternativeNames: ['example.com', 'www.example.com'],
+    });
+  });
+});

--- a/tests/classify-1094-derived.test.ts
+++ b/tests/classify-1094-derived.test.ts
@@ -1,0 +1,106 @@
+// #1094 — the #845/#1027 derived-echo folds were case-split: they fired only for the exact
+// shapes the corpus captured, leaving sibling shapes as first-run undeclared [Potential Drift].
+//   F8 CodeBuild Artifacts.Name — the derivation gated on a declared top-level Name; the
+//      default CDK project declares NO Name and AWS generates it (= physicalId), still echoing
+//      Artifacts.Name. Fall back to physicalId when Name is undeclared.
+//   F9 AmazonMQ StorageType — the derivation folded EFS only for ACTIVEMQ; a RabbitMQ broker
+//      reads back StorageType 'EBS' (RabbitMQ supports only EBS). Add RABBITMQ → EBS.
+// Each fold stays equality-gated: a genuinely diverging value still surfaces as undeclared drift.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+describe('#1094 F8 CodeBuild Artifacts.Name echoes the generated project name (unnamed project)', () => {
+  const PHYS = 'MyStack-Build45A36621-1AB2C3';
+  it('folds Artifacts.Name to atDefault when it equals the AWS-generated project name (= physicalId)', () => {
+    const res = mk(
+      'AWS::CodeBuild::Project',
+      { Artifacts: { Type: 'CODEPIPELINE' } }, // NO declared top-level Name
+      PHYS
+    );
+    const f = classifyResource(
+      res,
+      { Artifacts: { Type: 'CODEPIPELINE', Name: PHYS } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('Artifacts.Name');
+    expect(tier(f, 'undeclared')).not.toContain('Artifacts.Name');
+  });
+  it('surfaces Artifacts.Name when it diverges from the generated project name — detection preserved', () => {
+    const res = mk('AWS::CodeBuild::Project', { Artifacts: { Type: 'CODEPIPELINE' } }, PHYS);
+    const f = classifyResource(
+      res,
+      { Artifacts: { Type: 'CODEPIPELINE', Name: 'renamed-artifact' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('Artifacts.Name');
+  });
+  it('still folds Artifacts.Name to the declared top-level Name when one is declared (regression)', () => {
+    const res = mk('AWS::CodeBuild::Project', {
+      Name: 'my-build',
+      Artifacts: { Type: 'CODEPIPELINE' },
+    });
+    const f = classifyResource(
+      res,
+      { Name: 'my-build', Artifacts: { Type: 'CODEPIPELINE', Name: 'my-build' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('Artifacts.Name');
+    expect(tier(f, 'undeclared')).not.toContain('Artifacts.Name');
+  });
+});
+
+describe('#1094 F9 AmazonMQ StorageType default per engine', () => {
+  it('folds StorageType EBS to atDefault for a RABBITMQ broker declaring no StorageType', () => {
+    const res = mk('AWS::AmazonMQ::Broker', {
+      EngineType: 'RABBITMQ',
+      DeploymentMode: 'SINGLE_INSTANCE',
+    });
+    const f = classifyResource(res, { EngineType: 'RABBITMQ', StorageType: 'EBS' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('StorageType');
+    expect(tier(f, 'undeclared')).not.toContain('StorageType');
+  });
+  it('handles mixed-case EngineType (rabbitmq) for the RabbitMQ EBS default', () => {
+    const res = mk('AWS::AmazonMQ::Broker', { EngineType: 'rabbitmq' });
+    const f = classifyResource(res, { EngineType: 'rabbitmq', StorageType: 'EBS' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('StorageType');
+    expect(tier(f, 'undeclared')).not.toContain('StorageType');
+  });
+  it('surfaces a RABBITMQ broker whose StorageType is EFS (away from the EBS default) — detection preserved', () => {
+    const res = mk('AWS::AmazonMQ::Broker', { EngineType: 'RABBITMQ' });
+    const f = classifyResource(res, { EngineType: 'RABBITMQ', StorageType: 'EFS' }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('StorageType');
+  });
+  it('still folds StorageType EFS for an ACTIVEMQ broker (regression)', () => {
+    const res = mk('AWS::AmazonMQ::Broker', { EngineType: 'ACTIVEMQ' });
+    const f = classifyResource(res, { EngineType: 'ACTIVEMQ', StorageType: 'EFS' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('StorageType');
+    expect(tier(f, 'undeclared')).not.toContain('StorageType');
+  });
+});


### PR DESCRIPTION
Closes #1090
Closes #1094

Two fold-table residue issues that both violate the core zero-first-run invariant (a clean, un-mutated deploy must produce ZERO first-run [Potential Drift]).

## #1090 — ACM Certificate got ZERO fold entries when the #974 reader un-skipped it

- **F1 DomainValidationOptions** (readGap denylist, `noise.ts`): a createOnly write-time INPUT collection DescribeCertificate never echoes back verbatim (the reader deliberately never projects it), but the live schema has no writeOnly so it survived schema-strip → classify's removed-collection branch fired a `[declared]` FP on every DNS-validated cert. Added `AWS::CertificateManager::Certificate → DomainValidationOptions` to `READGAP_COLLECTION_PATHS` → it stays an informational readGap.
- **F2 KeyAlgorithm** (tier-1 KNOWN_DEFAULTS pin, `noise.ts`): the reader returns `KeyAlgorithm` unconditionally; the undeclared default is `RSA_2048` but no fold existed → `[undeclared]`. Pinned `{ KeyAlgorithm: 'RSA_2048' }`; equality-gated, so a declared different algorithm (e.g. `EC_prime256v1`) still surfaces.
- **F3 SubjectAlternativeNames** (reader projection, `overrides.ts`): DescribeCertificate always folds the apex `DomainName` in as the first SAN, but CFn users declare only the ADDITIONAL names → `[declared]` FP. When the declared SAN list does NOT contain the cert's `DomainName`, the reader now subtracts that single implied apex element from the projected live list before compare. Equality-gated: any OTHER extra/missing SAN still surfaces; if the user DID declare the apex as a SAN, the live list is kept verbatim.

## #1094 — #845 derived-echo folds were case-split (introduced in #1027)

- **F8 CodeBuild Artifacts.Name — unnamed project** (tier-2 derived, `classify.ts`): the derivation fired only when the template declared a top-level `Name`; the default CDK project declares none and AWS generates the project name (= physicalId), still echoing `Artifacts.Name`. Now falls back to `physicalId` when `Name` is undeclared. A truly renamed artifact still surfaces.
- **F9 AmazonMQ StorageType — RabbitMQ** (tier-2 derived, `classify.ts`): the derivation folded EFS only for `EngineType==='ACTIVEMQ'`; a RabbitMQ broker reads back `StorageType:'EBS'` (RabbitMQ supports only EBS). Added `RABBITMQ → 'EBS'` (mixed-case handled). A broker pinning a non-default StorageType still surfaces.

## Tests

- `tests/acm-firstrun-folds-1090.test.ts` — F1 (readGap not declared), F2 (RSA_2048 folds / EC surfaces), F3 (apex subtracted / extra SAN surfaces / declared-apex kept verbatim).
- `tests/classify-1094-derived.test.ts` — F8 (generated-name folds / renamed surfaces / declared-Name regression), F9 (RabbitMQ EBS folds / mixed-case / EFS surfaces / ActiveMQ regression).

Verified each new test FAILS without its fix (7 failing → 0). Full suite: 3650 passing; no corpus snapshots changed.