### PR TITLE
fix(cli): route swallowed signals/rejections to real exit codes (SIGTERM 143, unhandled error 2) (#951)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,10 +333,13 @@ CI (with `--yes`).
   is always surfaced regardless (as the `skipped=N` footer line or a loud
   `warning:`); `--strict` only decides whether it fails the build.
 - Errors always exit `2`; `revert` exits `1` when drift remains after it.
-- Interrupting a run with **Ctrl-C** (or **ESC**) during the gather/read phase
-  exits `130` (128 + SIGINT) for every verb — never `0`, so an aborted
-  `check --fail` can never be mistaken for "no drift" and an aborted `record` is
-  never a false "written".
+- Interrupting a run with **Ctrl-C** (or **ESC** / SIGINT) during the gather/read
+  phase exits `130` (128 + SIGINT) for every verb, and a **SIGTERM** (CI
+  cancellation, `timeout`, a supervisor) exits `143` promptly on the first signal
+  — never `0`, so an aborted `check --fail` can never be mistaken for "no drift"
+  and an aborted `record` is never a false "written". An unhandled internal error
+  (a stray promise rejection / uncaught exception) always exits `2` (the error
+  code), never `0` or `1`.
 
 ```yaml
 - run: npm ci # cdkrd resolves the CDK app, so its deps must be installed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,7 +85,7 @@ EXIT CODES
   record: 0 = written   2 = error/refused
   ignore: 0 = rule(s) written / nothing to ignore   2 = error/refused
   revert: 0 = converged/aborted   1 = drift remains   2 = error/apply failure
-  all:    130 = interrupted (Ctrl-C / ESC) during the gather/read phase — never mistaken for clean
+  all:    130 = interrupted (Ctrl-C / ESC / SIGINT)   143 = terminated (SIGTERM) — never mistaken for clean; an unhandled error always exits 2
 
 The baseline lives at .cdkrd/baselines/<stack>.<accountId>.<region>.json — commit it; review
 its diff in PRs. Ignore rules live in .cdkrd/ignore.yaml — also git-committed.`;

--- a/src/interrupt.ts
+++ b/src/interrupt.ts
@@ -11,8 +11,14 @@
 // exit-0 to 130 (128 + SIGINT, the conventional interrupt code) via a thin process.exit
 // wrapper, and install real SIGINT/SIGTERM handlers for the phases where stdin is NOT in
 // raw mode (synth/discovery, the interactive prompt gap) so those interrupts also land on
-// 130 with the cursor restored. Outside the gather window the wrapper is a pass-through,
+// 130/143 with the cursor restored. Outside the gather window the wrapper is a pass-through,
 // so a clean 0 / drift 1 / error 2 exit is unaffected.
+//
+// #951 extends the same central handlers to the OTHER process-level listeners @clack also
+// registers-and-swallows while the spinner is active: a SIGTERM (or signal-delivered SIGINT)
+// no longer just prints "Canceled" and continues (it exits 143/130), and a stray unhandled
+// rejection / uncaught exception exits 2 (the error code) instead of being swallowed to a
+// clean exit 0 in the spinner window or defaulting to exit 1 (the drift code) outside it.
 
 let gatherActive = false;
 
@@ -44,13 +50,35 @@ export function installInterruptGuard(): void {
   const realExit = process.exit.bind(process) as (code?: number) => never;
   (process as unknown as { exit: (code?: number) => never }).exit = (code?: number): never =>
     realExit(interruptExitCode(code, gatherActive));
-  const onSignal = (): never => {
-    // Restore the cursor the spinner may have hidden, then exit with the interrupt code.
-    // (Overrides Node's default SIGINT handler, which would exit 130 anyway but without
-    // the cursor-restore.) Bypass the wrapper — this is unambiguously an interrupt.
+  const onSignal = (code: number) => (): never => {
+    // Restore the cursor the spinner may have hidden, then exit with the conventional
+    // 128+signal code. (Overrides Node's default handler — which would exit with the same
+    // code but without the cursor-restore — AND neutralizes @clack's spinner listener,
+    // which otherwise just prints "Canceled" and lets the run CONTINUE, so a CI
+    // cancellation / `timeout` / supervisor kill needed a SECOND signal to terminate,
+    // #951.) Bypass the exit wrapper — this is unambiguously an interrupt.
     process.stderr.write('\x1B[?25h');
-    return realExit(130);
+    return realExit(code);
   };
-  process.on('SIGINT', onSignal);
-  process.on('SIGTERM', onSignal);
+  process.on('SIGINT', onSignal(130)); // 128 + SIGINT(2)
+  process.on('SIGTERM', onSignal(143)); // 128 + SIGTERM(15)
+  // #951: a stray unhandled rejection / uncaught exception is an ERROR — exit 2 per the
+  // documented contract ("errors always 2"), in AND out of the gather-spinner window. While
+  // the spinner is active @clack registers its own unhandledRejection /
+  // uncaughtExceptionMonitor listeners that only stop the spinner and CONTINUE (swallowing a
+  // real dependency failure into a clean exit 0); OUTSIDE it, Node's default kills with exit
+  // 1 — which collides with `check --fail`'s "drift found" code. Registered here at startup
+  // (before any spinner), cdkrd's handler coexists with clack's transient one and performs
+  // the real exit. cli.ts's own `main().catch` still handles main's rejection (also exit 2);
+  // this covers the STRAY ones that never flow through main's promise.
+  const onFatal =
+    (kind: string) =>
+    (err: unknown): void => {
+      process.stderr.write('\x1B[?25h');
+      const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      console.error(`error: ${kind}: ${detail}`);
+      realExit(2);
+    };
+  process.on('unhandledRejection', onFatal('unhandled rejection'));
+  process.on('uncaughtException', onFatal('uncaught exception'));
 }

--- a/tests/interrupt-fatal-951.test.ts
+++ b/tests/interrupt-fatal-951.test.ts
@@ -1,0 +1,76 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+// #951 — while the gather spinner is active @clack registers its own
+// SIGINT/SIGTERM/unhandledRejection/uncaughtException listeners that only stop the spinner
+// and CONTINUE (swallowing the failure), and cdkrd itself registered none for the
+// error/signal lanes. Building on #950's guard, a stray unhandled rejection / uncaught
+// exception now exits 2 (the error code) and SIGTERM exits 143.
+//
+// Everything is verified in a CHILD process: installInterruptGuard() hijacks process.exit
+// and installs process-global unhandledRejection/uncaughtException handlers, so calling it
+// inside the vitest process would make a stray rejection anywhere tear the runner down.
+// interrupt.ts has no relative imports, so node's type-stripping imports it directly.
+const here = dirname(fileURLToPath(import.meta.url));
+const interruptTs = join(here, '..', 'src', 'interrupt.ts');
+const runChild = (body: string): ReturnType<typeof spawnSync> => {
+  const script = `const { installInterruptGuard } = await import(${JSON.stringify(interruptTs)});\n${body}`;
+  return spawnSync(process.execPath, ['--input-type=module', '--experimental-strip-types', '-'], {
+    input: script,
+    encoding: 'utf8',
+  });
+};
+
+describe('#951 fatal/interrupt lanes (child-process, end to end)', () => {
+  it('a stray unhandled rejection exits 2 with error on stderr (not swallowed to 0, not the drift 1)', () => {
+    const r = runChild(`
+      installInterruptGuard();
+      Promise.reject(new Error('stray rejection during gather'));
+      setTimeout(() => { console.log('SHOULD NOT PRINT'); }, 300);
+    `);
+    expect(r.status).toBe(2);
+    expect(`${r.stdout}`).not.toContain('SHOULD NOT PRINT');
+    expect(`${r.stderr}`).toMatch(/error: unhandled rejection: .*stray rejection/);
+  });
+
+  it('a stray uncaught exception exits 2', () => {
+    const r = runChild(`
+      installInterruptGuard();
+      setTimeout(() => { throw new Error('boom uncaught'); }, 10);
+    `);
+    expect(r.status).toBe(2);
+    expect(`${r.stderr}`).toMatch(/error: uncaught exception: .*boom uncaught/);
+  });
+
+  it('registers the fatal + signal handlers, idempotently', () => {
+    const r = runChild(`
+      installInterruptGuard();
+      installInterruptGuard(); // second call must not stack more listeners
+      const c = {
+        rej: process.listenerCount('unhandledRejection'),
+        exc: process.listenerCount('uncaughtException'),
+        int: process.listenerCount('SIGINT'),
+        term: process.listenerCount('SIGTERM'),
+      };
+      process.stdout.write(JSON.stringify(c));
+      process.exit(0);
+    `);
+    const c = JSON.parse(`${r.stdout}`) as Record<string, number>;
+    expect(c.rej).toBe(1);
+    expect(c.exc).toBe(1);
+    expect(c.int).toBe(1);
+    expect(c.term).toBe(1);
+  });
+
+  it('a clean run is unaffected — exit 0 passes through the guard', () => {
+    const r = runChild(`
+      installInterruptGuard();
+      console.log('clean');
+      process.exit(0);
+    `);
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}`).toContain('clean');
+  });
+});


### PR DESCRIPTION
Closes #951 (follow-up to #950)

## Problem
While the gather spinner is active, `@clack/prompts` registers its own `SIGINT`/`SIGTERM`/`unhandledRejection`/`uncaughtExceptionMonitor` listeners that only stop the spinner and **return** — cdkrd registered none for the error/signal lanes. #950 fixed the Ctrl-C-keypress→exit-0 and added SIGINT/SIGTERM handlers; this closes the remaining two holes:

1. **A single SIGTERM (CI cancellation / `timeout` / supervisor) was swallowed** — clack printed `■ Canceled` and the run CONTINUED (a second signal was needed to terminate), and for `revert` it kept mutating AWS through later stacks.
2. **A stray unhandled rejection / uncaught exception** was swallowed to a clean **exit 0** inside the spinner window, or defaulted to Node's **exit 1** outside it — colliding with `check --fail`'s "drift found" code. The contract is "errors always 2".

## Fix (`interrupt.ts` + docs)
Extends #950's central guard:
- SIGINT→**130**, SIGTERM→**143** (128+signal), cursor restored, terminating on the FIRST signal (neutralizing clack's swallow).
- New `unhandledRejection` + `uncaughtException` handlers → restore cursor, `error: <kind>: <detail>` on stderr, **exit 2** — in AND out of the spinner window. Registered at startup so they coexist with clack's transient listeners and perform the real exit; `main().catch` still covers main's own rejection.

HELP + README `EXIT CODES` document 143 and the always-2 error lane.

## Tests
`tests/interrupt-fatal-951.test.ts` — child-process end-to-end (interrupt.ts has no relative imports → type-strip-imported directly): a stray rejection → exit 2 + stderr; an uncaught exception → exit 2; handlers registered idempotently (rej/exc/int/term = 1); a clean run still exits 0. Full suite green (3641).

Live: a single `kill -TERM` on a guard-installed process terminated **promptly with the cursor restored** (`[?25h`), where the bare clack spinner needs a second signal.