### PR TITLE
fix(read): API Gateway custom-domain mappings silently skipped (#855)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,6 +100,13 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    and the CHILD-first `[<child>, RestApiId]` (`${physicalId}|${RestApiId}`) cases
    ApiGateway::Deployment (R129) and ApiGateway::DocumentationPart — all verified
    live (skipped 7→0; DocumentationPart found by the cognito/apigw-rest-subres hunt);
+   plus the custom-domain MAPPINGS (#855): ApiGateway::BasePathMapping, whose
+   parent-first `[DomainName, BasePath]` composite is built from TWO declared props
+   (the CFn physical id is only the DomainName; an absent BasePath, the "(none)"
+   root mapping, yields an empty second segment — exact CC shape unverified-live),
+   and ApiGatewayV2::ApiMapping, whose CHILD-first `[ApiMappingId, DomainName]`
+   composite is `${physicalId}|${DomainName}` (the bare ApiMappingId otherwise
+   ValidationException-skips);
    note
    ApiGateway::Method needs NO adapter, its CFn physical id is already the full
    `RestApiId|ResourceId|HttpMethod`; plus

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -85,6 +85,22 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   // read; the reverse orders return not-found.
   'AWS::ApiGatewayV2::Model': compositeWith('ApiId'),
   'AWS::ApiGatewayV2::Deployment': compositeWith('ApiId'),
+  // ApiGatewayV2::ApiMapping primaryIdentifier is [ApiMappingId, DomainName] — CHILD
+  // first (the ApiMappingId, then the custom DomainName), the REVERSE of the parent-first
+  // v2 siblings. The CFn Ref / physical id is the bare ApiMappingId; DomainName is a
+  // declared createOnly prop (the custom domain the mapping is attached to). Without the
+  // composite the bare ApiMappingId CC GetResource ValidationException-skips it (#855
+  // read-gap), so re-pointing a mapping to a different stage / changing its api-mapping key
+  // is invisible. Composite order follows the documented CC primaryIdentifier; built from
+  // physicalId (ApiMappingId) + declared.DomainName, joined with the map's `|` separator.
+  // Not `compositeWith` (parent-first); child-first like ApiGatewayV2::Authorizer.
+  'AWS::ApiGatewayV2::ApiMapping': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const domainName = declared.DomainName;
+    return typeof domainName === 'string' && domainName.length > 0
+      ? `${pid}|${domainName}`
+      : undefined;
+  },
   // ApiGatewayV2::Authorizer primaryIdentifier is [AuthorizerId, ApiId] — CHILD
   // first, the REVERSE of its v2 siblings (Stage/Route/Integration are [ApiId,
   // <child>] parent-first). The CFn physical id is the bare AuthorizerId; ApiId comes
@@ -213,6 +229,23 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
     return typeof restApiId === 'string' && restApiId.length > 0
       ? `${pid}|${restApiId}`
       : undefined;
+  },
+  // ApiGateway::BasePathMapping primaryIdentifier is [DomainName, BasePath] —
+  // parent-first (the custom DomainName, then the BasePath key), and BOTH segments are
+  // declared createOnly props (the CFn physical id is only the DomainName). Without the
+  // composite the bare DomainName CC GetResource ValidationException-skips it (#855
+  // read-gap), so a base-path change or a stage re-point on the mapping is invisible.
+  // Composite order follows the documented CC primaryIdentifier; built directly from
+  // declared.DomainName + declared.BasePath, joined with the map's `|` separator.
+  // The "(none)" / root mapping declares no BasePath — the exact CC identifier shape for
+  // that empty-BasePath case is NOT live-confirmed here and may need adjustment; use an
+  // empty second segment (`<DomainName>|`) as the best-effort form when BasePath is absent.
+  'AWS::ApiGateway::BasePathMapping': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const domainName = declared.DomainName;
+    if (typeof domainName !== 'string' || domainName.length === 0) return undefined;
+    const basePath = typeof declared.BasePath === 'string' ? declared.BasePath : '';
+    return `${domainName}|${basePath}`;
   },
   // ApplicationAutoScaling ScalingPolicy: primaryIdentifier is [Arn,
   // ScalableDimension]. The CFn physical id IS the PolicyARN, but ScalableDimension

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1013,6 +1013,82 @@ describe('readLive (CC identifier adapters, R74)', () => {
     );
     expect(sent()).toBe('arn:x');
   });
+
+  // #855: ApiGateway custom-domain mappings — composite CC primaryIdentifier.
+  it('ApiGateway BasePathMapping: builds the composite DomainName|BasePath identifier (#855)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGateway::BasePathMapping',
+        physicalId: 'api.example.com',
+        declared: { DomainName: 'api.example.com', BasePath: 'v1' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('api.example.com|v1');
+  });
+
+  it('ApiGateway BasePathMapping: an absent BasePath ("(none)" mapping) uses an empty second segment (#855)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGateway::BasePathMapping',
+        physicalId: 'api.example.com',
+        declared: { DomainName: 'api.example.com' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('api.example.com|');
+  });
+
+  it('ApiGateway BasePathMapping: an unresolved DomainName falls back to the raw physical id (#855)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGateway::BasePathMapping',
+        physicalId: 'api.example.com',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('api.example.com');
+  });
+
+  it('ApiGatewayV2 ApiMapping: builds the composite ApiMappingId|DomainName identifier — child FIRST (#855)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::ApiMapping',
+        physicalId: 'mapping123',
+        declared: { DomainName: 'api.example.com' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('mapping123|api.example.com');
+  });
+
+  it('ApiGatewayV2 ApiMapping: an unresolved DomainName falls back to the raw physical id (#855)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::ApiMapping',
+        physicalId: 'mapping123',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('mapping123');
+  });
 });
 
 describe('readLive (custom resources short-circuit, R26)', () => {


### PR DESCRIPTION
Closes #855.

## Root cause
API Gateway custom-domain mappings have COMPOSITE Cloud Control `primaryIdentifier`s, but cdkrd passed only the bare CFn physical id to `GetResource`. Cloud Control raised `ValidationException`, so the resource was silently `skipped=` on every `check` — a stage re-point or base-path change on the mapping was invisible (a read-gap). Two types were affected:

- `AWS::ApiGateway::BasePathMapping` — CC `primaryIdentifier: [DomainName, BasePath]`.
- `AWS::ApiGatewayV2::ApiMapping` — CC `primaryIdentifier: [ApiMappingId, DomainName]` (Ref = bare `ApiMappingId`).

## Fix
Two new `CC_IDENTIFIER_ADAPTERS` entries in `src/read/router.ts`, following the existing 10+ adapted siblings:

- **BasePathMapping** — parent-first `[DomainName, BasePath]`, BOTH declared createOnly props (the CFn physical id is only the DomainName). Built directly from `declared.DomainName` + `declared.BasePath` → `${DomainName}|${BasePath}`. The "(none)"/root mapping declares no BasePath — handled defensively with an empty second segment (`${DomainName}|`).
- **ApiMapping** — child-first `[ApiMappingId, DomainName]` (like `ApiGatewayV2::Authorizer`). `${physicalId}|${DomainName}` from `declared.DomainName`.

## Separator / order rationale
- Separator `|` — the map's standard delimiter, used by every existing composite entry and the shared `compositeWith` / `scalingPolicyComposite` helpers (grepped: all composites join with `|`, verified live per R74/R76/R77 comments).
- Composite ORDER follows the documented CC `primaryIdentifier` for each type (parent-first for BasePathMapping, child-first for ApiMapping), matching how the already-adapted v1/v2 siblings are ordered.
- Unresolved segment → return `undefined` (falls back to the bare physical id = honest skip), same defensive pattern as every sibling adapter.

## Tests
5 cases added to `tests/router.test.ts` (R74 adapter block): BasePathMapping `DomainName|BasePath`, BasePathMapping empty-BasePath `DomainName|`, ApiMapping `ApiMappingId|DomainName`, plus the two unresolved-fallback cases. Confirmed the 3 composite assertions FAIL without the entries and PASS with them.

NOTE: the exact CC identifier shape (especially the empty-BasePath "(none)" mapping) is NOT live-confirmed in this environment (needs a registered custom domain + ACM cert). The order follows the documented CC `primaryIdentifier` and the 10+ already-adapted siblings; a live `aws cloudcontrol get-resource --identifier '<a>|<b>'` confirm is a recommended follow-up (a code comment flags the unverified empty-BasePath case).
