### PR TITLE
fix(normalize): nested unordered-array sort missing from the live normalizer (#808)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1069,10 +1069,50 @@ const PATH_UNSAFE_KEY = /[.[\]]/;
 // Cognito OAuth list, re-read by AWS in a different order, false-flagged as "changed since
 // record" (baselineValueMatches re-canonicalizes without this step). Sorting them here, in
 // the shared live-model normalizer, makes every downstream consumer see one stable order.
+// Sort a scalar array (string/number/boolean multiset) into a stable canonical order.
+// Non-scalar / non-array values are returned untouched, so a caller can apply this
+// blindly to whatever it finds at a path. Order matches the DECLARED loop's
+// `isEqualUnorderedScalarSet` comparison intent: same multiset, canonical order.
+function sortScalarSet(v: unknown): unknown {
+  if (
+    Array.isArray(v) &&
+    v.every((e) => typeof e === 'string' || typeof e === 'number' || typeof e === 'boolean')
+  )
+    return [...v].sort((a, b) =>
+      `${typeof a}:${String(a)}` < `${typeof b}:${String(b)}` ? -1 : 1
+    );
+  return v;
+}
+
+// Walk `model` along a dotted path TEMPLATE (segments separated by `.`) and apply
+// `sort` to the array found at each matching leaf, IN PLACE. A `*` segment matches
+// EVERY element of an array OR every value of a plain object at that position — the
+// same wildcard the DECLARED loop normalizes numeric drift-path segments to before its
+// `UNORDERED_ARRAY_PROPS` lookup (`Triggers.0.…Push.0.…Includes` → `Triggers.*.…Push.*.…`).
+// A concrete segment descends into that object key. Anything that doesn't match the
+// shape (a missing key, a scalar where an object/array is expected) is skipped, so an
+// absent nested config is a no-op. Used for the nested/dotted UNORDERED_ARRAY_PROPS +
+// schema `unorderedScalarPaths` entries the top-level loop cannot reach.
+function sortScalarSetAtNestedPath(model: unknown, segs: readonly string[]): void {
+  if (segs.length === 0 || model === null || typeof model !== 'object') return;
+  const [head, ...rest] = segs;
+  if (head === '*') {
+    const children = Array.isArray(model) ? model : Object.values(model);
+    for (const child of children) sortScalarSetAtNestedPath(child, rest);
+    return;
+  }
+  if (Array.isArray(model)) return; // a concrete key can't index an array
+  const obj = model as Record<string, unknown>;
+  if (!(head! in obj)) return;
+  if (rest.length === 0) obj[head!] = sortScalarSet(obj[head!]);
+  else sortScalarSetAtNestedPath(obj[head!], rest);
+}
+
 function sortUnorderedSetProps(
   model: Record<string, unknown>,
   resourceType: string,
-  schemaObjectArrayKeys: readonly string[] = []
+  schemaObjectArrayKeys: readonly string[] = [],
+  schemaScalarPaths: readonly string[] = []
 ): void {
   const objKeys = new Set([
     ...(UNORDERED_OBJECT_ARRAY_PROPS[resourceType] ?? []),
@@ -1084,15 +1124,20 @@ function sortUnorderedSetProps(
   const orderSig = ORDER_SIGNIFICANT_ARRAY_KEYS[resourceType];
   for (const k of objKeys)
     if (!orderSig?.has(k) && Array.isArray(model[k])) model[k] = sortUnorderedObjectArray(model[k]);
-  for (const k of UNORDERED_ARRAY_PROPS[resourceType] ?? []) {
-    const v = model[k];
-    if (
-      Array.isArray(v) &&
-      v.every((e) => typeof e === 'string' || typeof e === 'number' || typeof e === 'boolean')
-    )
-      model[k] = [...v].sort((a, b) =>
-        `${typeof a}:${String(a)}` < `${typeof b}:${String(b)}` ? -1 : 1
-      );
+  // Scalar unordered-set paths from BOTH sources (per-type table + schema insertionOrder:false).
+  // A TOP-LEVEL path is a plain key; a NESTED/dotted path (`DistributionConfig.Restrictions.
+  // GeoRestriction.Locations`, CodeDeploy `AutoRollbackConfiguration.Events`, CodePipeline
+  // `Triggers.*.…Includes`) is walked into. Before #808 only top-level keys were sorted here,
+  // so a recorded baseline stored a nested set RAW while the DECLARED loop tolerated its
+  // reorder at compare time — an asymmetry that false-flagged a nested set AWS re-ordered as
+  // "changed since record". Sorting nested paths here too makes the live normalizer's output
+  // symmetric with the declared-compare tolerance.
+  for (const path of [...(UNORDERED_ARRAY_PROPS[resourceType] ?? []), ...schemaScalarPaths]) {
+    if (path.includes('.')) sortScalarSetAtNestedPath(model, path.split('.'));
+    // Guard on presence — assigning `model[path]` for an absent top-level key would
+    // MATERIALIZE it as `undefined`, injecting a phantom key into the live model that
+    // reads as a false undeclared finding.
+    else if (path in model) model[path] = sortScalarSet(model[path]);
   }
 }
 
@@ -1112,9 +1157,13 @@ export function normalizeLiveModel(
     sortUnorderedSetProps(
       live,
       opts.resourceType,
-      // top-level keys only — nested (dotted) schema paths are handled per-key in the
-      // declared loop, and the undeclared loop's nested inventory is emitted per-path.
-      (schema.unorderedObjectArrayPaths ?? []).filter((p) => !p.includes('.'))
+      // OBJECT arrays: top-level keys only — nested (dotted) object-array paths are handled
+      // per-key in the declared compare loop (identity alignment + per-element sort), which
+      // the shared normalizer cannot replicate; the undeclared loop emits nested inventory
+      // per-path. SCALAR sets, however, ARE nested-walked below so the baseline/live compare
+      // is symmetric with the declared-loop reorder tolerance (#808).
+      (schema.unorderedObjectArrayPaths ?? []).filter((p) => !p.includes('.')),
+      schema.unorderedScalarPaths ?? []
     );
   return live;
 }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6878,6 +6878,152 @@ describe('normalizeLiveModel (PR4 — the shared live-model normalizer used for 
     normalizeLiveModel(input, schema);
     expect(input).toEqual({ AuthorizationType: 'NONE', MethodId: 'x' });
   });
+
+  // #808: the live normalizer must sort NESTED (dotted) unordered scalar-set paths, not
+  // only top-level keys — otherwise a recorded baseline stores a nested set RAW while the
+  // declared-compare loop tolerates its reorder, so a re-read in AWS's canonical order
+  // false-flags as "changed since record". Sorting nested paths here makes the recorded-vs-
+  // live compare reflexive.
+  describe('#808 nested unordered scalar-set paths (symmetry with declared-compare)', () => {
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+
+    it('sorts a nested UNORDERED_ARRAY_PROPS path (CloudFront GeoRestriction.Locations)', () => {
+      // recorded order vs AWS-reordered live — both must normalize IDENTICALLY.
+      const recorded = normalizeLiveModel(
+        {
+          DistributionConfig: {
+            Restrictions: {
+              GeoRestriction: { RestrictionType: 'whitelist', Locations: ['CA', 'GB', 'US'] },
+            },
+          },
+        },
+        emptySchema,
+        { resourceType: 'AWS::CloudFront::Distribution' }
+      );
+      const live = normalizeLiveModel(
+        {
+          DistributionConfig: {
+            Restrictions: {
+              GeoRestriction: { RestrictionType: 'whitelist', Locations: ['US', 'GB', 'CA'] },
+            },
+          },
+        },
+        emptySchema,
+        { resourceType: 'AWS::CloudFront::Distribution' }
+      );
+      const locs = (m: Record<string, unknown>): unknown =>
+        (
+          (
+            (m.DistributionConfig as Record<string, unknown>).Restrictions as Record<
+              string,
+              unknown
+            >
+          ).GeoRestriction as Record<string, unknown>
+        ).Locations;
+      expect(locs(live)).toEqual(['CA', 'GB', 'US']);
+      // reflexive: recorded and reordered-live are now byte-identical.
+      expect(live).toEqual(recorded);
+    });
+
+    it('sorts a nested CodeDeploy AutoRollbackConfiguration.Events set', () => {
+      const out = normalizeLiveModel(
+        {
+          AutoRollbackConfiguration: {
+            Enabled: true,
+            Events: ['DEPLOYMENT_STOP_ON_ALARM', 'DEPLOYMENT_FAILURE'],
+          },
+        },
+        emptySchema,
+        { resourceType: 'AWS::CodeDeploy::DeploymentGroup' }
+      );
+      expect((out.AutoRollbackConfiguration as Record<string, unknown>).Events).toEqual([
+        'DEPLOYMENT_FAILURE',
+        'DEPLOYMENT_STOP_ON_ALARM',
+      ]);
+    });
+
+    it('sorts a WILDCARD nested path across array indices (CodePipeline Triggers)', () => {
+      const out = normalizeLiveModel(
+        {
+          Triggers: [
+            {
+              GitConfiguration: {
+                Push: [{ Branches: { Includes: ['release/*', 'main', 'develop'] } }],
+              },
+            },
+          ],
+        },
+        emptySchema,
+        { resourceType: 'AWS::CodePipeline::Pipeline' }
+      );
+      const includes = (
+        (
+          ((out.Triggers as unknown[])[0] as Record<string, unknown>).GitConfiguration as Record<
+            string,
+            unknown
+          >
+        ).Push as unknown[]
+      )[0] as Record<string, unknown>;
+      expect((includes.Branches as Record<string, unknown>).Includes).toEqual([
+        'develop',
+        'main',
+        'release/*',
+      ]);
+    });
+
+    it('still sorts a TOP-LEVEL unordered prop (regression)', () => {
+      const out = normalizeLiveModel(
+        { AllowedOAuthFlows: ['implicit', 'code', 'client_credentials'] },
+        emptySchema,
+        { resourceType: 'AWS::Cognito::UserPoolClient' }
+      );
+      expect(out.AllowedOAuthFlows).toEqual(['client_credentials', 'code', 'implicit']);
+    });
+
+    it('sorts a schema-driven NESTED unorderedScalarPaths entry', () => {
+      const schemaWithNested: SchemaInfo = {
+        ...emptySchema,
+        unorderedScalarPaths: ['Config.Regions'],
+      };
+      const out = normalizeLiveModel(
+        { Config: { Regions: ['us-west-2', 'eu-west-1', 'ap-south-1'] } },
+        schemaWithNested,
+        { resourceType: 'AWS::Some::Type' }
+      );
+      expect((out.Config as Record<string, unknown>).Regions).toEqual([
+        'ap-south-1',
+        'eu-west-1',
+        'us-west-2',
+      ]);
+    });
+
+    it('does NOT reorder an ORDERED nested path (only listed unordered-set paths sort)', () => {
+      // GeoRestriction.Locations is the ONLY nested CloudFront set folded — a sibling
+      // ordered field must be left in place.
+      const out = normalizeLiveModel(
+        {
+          DistributionConfig: {
+            CacheBehaviors: [{ PathPattern: '/b' }, { PathPattern: '/a' }],
+          },
+        },
+        emptySchema,
+        { resourceType: 'AWS::CloudFront::Distribution' }
+      );
+      expect((out.DistributionConfig as Record<string, unknown>).CacheBehaviors).toEqual([
+        { PathPattern: '/b' },
+        { PathPattern: '/a' },
+      ]);
+    });
+  });
 });
 
 // A live-only sub-key ADDED to a declared IAM policy STATEMENT out of band (e.g. a


### PR DESCRIPTION
Closes #808.

## Root cause
The shared live normalizer `sortUnorderedSetProps` (`src/diff/classify.ts`) sorted **top-level keys only** — its schema feed was explicitly filtered to non-dotted paths (`!p.includes('.')`), and `schema.unorderedScalarPaths` was never passed in at all.

But the fold tables carry **nested/dotted** unordered scalar-set entries:
- `UNORDERED_ARRAY_PROPS` — `AWS::CloudFront::Distribution` `DistributionConfig.Restrictions.GeoRestriction.Locations`, `AWS::CodeDeploy::DeploymentGroup` `AutoRollbackConfiguration.Events`, `AWS::CodePipeline::Pipeline` `Triggers.*.GitConfiguration...Includes/Excludes` (wildcard).
- `schema.unorderedScalarPaths` — any-depth insertionOrder:false scalar arrays.

The **declared-compare** loop tolerates a reorder at those nested paths at compare time (`isEqualUnorderedScalarSet`, with numeric segments normalized to `*`). The live normalizer did not — so a recorded baseline stored a nested set in **raw** order while AWS returned it **reordered**, and the recorded-vs-live compare false-flagged it as "changed since record". Asymmetry between the two sides.

## Fix
Extend `sortUnorderedSetProps` (and its schema feed) to walk **nested/dotted** scalar-set paths, matching the declared-compare tolerance:
- New `sortScalarSetAtNestedPath` walks a dotted path template where `*` matches every array element / object value at that segment (same wildcard the declared loop normalizes numeric segments to), sorting the scalar array at each matching leaf in place.
- `normalizeLiveModel` now passes `schema.unorderedScalarPaths` through. OBJECT arrays stay top-level-filtered (their nested handling — identity alignment + per-element sort — lives in the declared-compare loop and the shared normalizer cannot replicate it).
- Top-level presence guard (`path in model`) so an absent key is never materialized as `undefined` (which would inject a phantom undeclared finding).

Recorded and reordered-live now normalize identically → reflexive compare, no false "changed since record".

Only `src/diff/classify.ts` touched (the table entries in `noise.ts` were already correct — the bug was the normalizer ignoring them).

## Tests
`tests/classify.test.ts` (`#808 nested unordered scalar-set paths`): nested `GeoRestriction.Locations` (recorded vs reordered-live → reflexive), CodeDeploy `AutoRollbackConfiguration.Events`, wildcard CodePipeline `Triggers`, schema-driven nested `unorderedScalarPaths`, plus regressions — a top-level prop still sorts and an ORDERED nested sibling is NOT reordered. The 4 nested/wildcard cases fail without the fix.

Full suite: **3706 passed**. `vp run check`: **Found 0 errors**.
