### PR TITLE
fix(synth): sibling context-lookup failure aborts named-stack check (#905)

### DIFF
--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -133,10 +133,20 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
       'cdkrd needs a CDK app: run in a directory with cdk.json, pass --app "<cmd>" or --app <cdk.out> (a pre-synthesized assembly), or set $CDKRD_APP'
     );
   }
+  // #905: scope synth's metadata validation to the TARGET stacks. When the user named
+  // specific stacks (exact and/or glob) and did NOT pass --all, forward those patterns so a
+  // failing context lookup in an UNRELATED sibling stack does not abort the whole command —
+  // the standard multi-account CI shape (creds for account A only; app defines A+B with
+  // lookups in B). For --all or no-args discovery the user asked for EVERYTHING, so we pass
+  // no scope (undefined) and toolkit-lib validates every stack, exactly as before. Discovery
+  // still returns every stack the app defines regardless — this only narrows VALIDATION — so
+  // the exact-name-typo / no-match-glob errors below still see the full known-stack list.
+  const scopePatterns = !a.all && a.stackNames.length > 0 ? a.stackNames : undefined;
   const discovered = await discoverStacks(app, {
     region: a.region,
     profile: a.profile,
     context: a.context,
+    stackPatterns: scopePatterns,
   });
 
   // Region fallback chain for an env-agnostic stack (no `env` on the stack): an

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -4,7 +4,13 @@
 // does not need this — it is used for stack auto-discovery (and later clobber).
 import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { BaseCredentials, CdkAppMultiContext, Toolkit } from '@aws-cdk/toolkit-lib';
+import type { StackSelector } from '@aws-cdk/toolkit-lib';
+import {
+  BaseCredentials,
+  CdkAppMultiContext,
+  StackSelectionStrategy,
+  Toolkit,
+} from '@aws-cdk/toolkit-lib';
 import { QuietIoHost } from './io-host.js';
 import {
   collectMissingRecursively,
@@ -21,6 +27,37 @@ export interface SynthOptions {
   // `vpc-12345` placeholders). Escalate the missing-context surface from a warning to a
   // hard refusal (throw) in that mode (#907). Discovery (default) only warns.
   preDeploy?: boolean;
+  // The requested stack name(s)/glob(s) to SCOPE synthesis validation to (#905). When the
+  // caller targets specific stacks (an exact name or a glob positional), only THOSE stacks
+  // should be metadata-validated by toolkit-lib — a failing context lookup (missing
+  // cross-account creds, a VPC-not-found, ...) in an UNRELATED sibling stack must NOT abort
+  // the whole command. `undefined`/empty means "no scope" → validate every stack (the
+  // no-args discovery / `--all` case, where the user asked for everything). See
+  // buildStackSelector for the exact StackSelector this maps to.
+  stackPatterns?: string[] | undefined;
+}
+
+/**
+ * Map the requested stack name(s)/glob(s) to the toolkit-lib `StackSelector` that scopes
+ * `toolkit.synth`'s metadata validation (#905).
+ *
+ * - No patterns (`undefined` / empty) → `undefined`: the caller wants EVERY stack (no-args
+ *   discovery or `--all`), so we pass no selector and toolkit-lib defaults to `ALL_STACKS` —
+ *   the pre-#905 behavior, unchanged. Everything is validated because the user asked for it.
+ * - One or more patterns → a `PATTERN_MATCH` selector over those patterns. toolkit-lib then
+ *   validates ONLY the matched stacks, so a sibling stack the user did NOT target can fail a
+ *   context lookup without aborting synth. `PATTERN_MATCH` (NOT `PATTERN_MUST_MATCH`) is
+ *   deliberate: it halts successfully — never throws — when the patterns match zero stacks.
+ *   The selector matches on the toolkit's HIERARCHICAL id (`Stage/Stack` for a staged stack)
+ *   via picomatch, which can differ from the deployed stackName resolveStacks filters on, so
+ *   a staged-stack pattern may legitimately match nothing here; that must not error. The
+ *   real "unknown stack / no-match glob" errors stay in resolveStacks, checked against the
+ *   FULL discovered stack list (this selector only narrows what gets VALIDATED, never what
+ *   gets discovered — the returned assembly still carries every stack).
+ */
+export function buildStackSelector(patterns: string[] | undefined): StackSelector | undefined {
+  if (!patterns || patterns.length === 0) return undefined;
+  return { strategy: StackSelectionStrategy.PATTERN_MATCH, patterns };
 }
 
 export interface SynthStack {
@@ -106,6 +143,10 @@ function cleanupEmptyContextFile(file: string, existedBefore: boolean): void {
 
 export async function synthApp(app: string, opts: SynthOptions = {}): Promise<SynthStack[]> {
   const { region, profile, context = {} } = opts;
+  // #905: scope synth's metadata validation to the TARGET stacks, so a failing context
+  // lookup in an unrelated sibling does not abort a named-stack check (undefined = validate
+  // all, the discovery / --all default).
+  const stackSelector = buildStackSelector(opts.stackPatterns);
   const toolkit = new Toolkit({
     ioHost: new QuietIoHost(),
     sdkConfig: {
@@ -149,7 +190,9 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
     });
   }
 
-  const cached = await toolkit.synth(source);
+  // Pass the selector only when scoped: an omitted `stacks` defaults to ALL_STACKS in
+  // toolkit-lib, so no-scope discovery / --all keeps the exact pre-#905 call shape.
+  const cached = await toolkit.synth(source, stackSelector ? { stacks: stackSelector } : undefined);
   // Best-effort: if synth just created an EMPTY cdk.context.json (every lookup failed → `{}`),
   // remove it so a read-only `check` does not dirty the user's git tree with a useless file.
   // Guarded to never touch a pre-existing or non-empty file (#906). Skipped on the dir path.

--- a/tests/synth-selector-905.test.ts
+++ b/tests/synth-selector-905.test.ts
@@ -1,0 +1,141 @@
+import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { buildStackSelector } from '../src/synth/synth.js';
+
+// #905: a failing context lookup in an UNRELATED sibling stack must not abort a check of an
+// explicitly-named, lookup-free stack. The fix scopes toolkit.synth's metadata validation to
+// the TARGET stacks via a StackSelector. Two units are covered here:
+//   1. buildStackSelector — the pure mapping from requested patterns to the StackSelector.
+//   2. resolveStacks — that it forwards the target patterns to discoverStacks (which threads
+//      them into synth) for named/glob targets, and forwards NOTHING (validate all) for the
+//      no-args / --all discovery modes.
+
+describe('buildStackSelector (#905) — scope synth validation to target stacks', () => {
+  it('returns undefined for no patterns (→ toolkit-lib defaults to ALL_STACKS: validate all)', () => {
+    // The no-args discovery / --all case: the user asked for everything, so no scope.
+    expect(buildStackSelector(undefined)).toBeUndefined();
+    expect(buildStackSelector([])).toBeUndefined();
+  });
+
+  it('returns a PATTERN_MATCH selector carrying the requested names/globs', () => {
+    const sel = buildStackSelector(['GoodStack']);
+    expect(sel).toEqual({
+      strategy: StackSelectionStrategy.PATTERN_MATCH,
+      patterns: ['GoodStack'],
+    });
+  });
+
+  it('uses PATTERN_MATCH (halts successfully on zero match), NOT a MUST_MATCH strategy', () => {
+    // PATTERN_MUST_MATCH throws when patterns match no stack; a staged-stack pattern can
+    // legitimately match nothing against the hierarchical id, so we must NOT throw here —
+    // resolveStacks keeps the real typo/no-match errors against the full discovered list.
+    const sel = buildStackSelector(['Stage-Nested', 'Some*']);
+    expect(sel?.strategy).toBe(StackSelectionStrategy.PATTERN_MATCH);
+    expect(sel?.strategy).not.toBe(StackSelectionStrategy.PATTERN_MUST_MATCH);
+    expect(sel?.strategy).not.toBe(StackSelectionStrategy.ALL_STACKS);
+    expect(sel?.patterns).toEqual(['Stage-Nested', 'Some*']);
+  });
+
+  it('carries multiple mixed exact + glob patterns verbatim', () => {
+    const sel = buildStackSelector(['Prod', 'Dev-*']);
+    expect(sel?.patterns).toEqual(['Prod', 'Dev-*']);
+  });
+});
+
+// resolveStacks synthesizes + discovers via discoverStacks (heavy — mocked). We assert the
+// SynthOptions it hands discoverStacks: `stackPatterns` scopes synth validation. resolveApp
+// is mocked to a truthy app so we exercise resolution in isolation.
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+
+const discovered = [
+  { stackName: 'GoodStack', region: 'us-east-1', template: {} },
+  { stackName: 'BadLookupStack', region: 'us-east-1', template: {} },
+];
+type DiscoverFn = (
+  app: string,
+  opts?: { stackPatterns?: string[] | undefined }
+) => Promise<typeof discovered>;
+const discoverStacksMock = vi.fn<DiscoverFn>(() => Promise.resolve(discovered));
+vi.mock('../src/synth/synth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/synth/synth.js')>();
+  // Reference the mock lazily (the vi.mock factory is hoisted above discoverStacksMock's
+  // definition), so we forward through an arrow rather than aliasing it directly.
+  const discoverStacks: DiscoverFn = (app, opts) => discoverStacksMock(app, opts);
+  return { ...actual, discoverStacks };
+});
+
+import type { CommonArgs } from '../src/cli-args.js';
+import { resolveStacks } from '../src/commands/resolve-stacks.js';
+
+function args(overrides: Partial<CommonArgs>): CommonArgs {
+  return {
+    stackNames: [],
+    all: false,
+    region: 'us-east-1',
+    profile: undefined,
+    app: undefined,
+    context: {},
+    json: false,
+    showAll: false,
+    yes: false,
+    preDeploy: false,
+    undeclaredOnly: false,
+    declaredOnly: false,
+    fail: false,
+    strict: false,
+    removeUnrecorded: false,
+    verbose: false,
+    waitMs: undefined,
+    ...overrides,
+  };
+}
+
+// The SynthOptions passed to discoverStacks by the most recent resolveStacks call.
+function lastSynthOpts(): { stackPatterns?: string[] | undefined } {
+  const call = discoverStacksMock.mock.calls.at(-1);
+  return call?.[1] ?? {};
+}
+
+describe('resolveStacks — forwards target patterns to scope synth validation (#905)', () => {
+  beforeEach(() => {
+    discoverStacksMock.mockClear();
+  });
+
+  it('an exact-name target scopes synth to THAT stack (sibling not validated)', async () => {
+    await resolveStacks(args({ stackNames: ['GoodStack'] }));
+    // The unrelated BadLookupStack is excluded from the selector, so its failing lookup can
+    // no longer abort the synth of GoodStack.
+    expect(lastSynthOpts().stackPatterns).toEqual(['GoodStack']);
+  });
+
+  it('a glob target scopes synth to the glob pattern', async () => {
+    await resolveStacks(args({ stackNames: ['Good*'] }));
+    expect(lastSynthOpts().stackPatterns).toEqual(['Good*']);
+  });
+
+  it('mixed exact + glob targets forward all patterns', async () => {
+    await resolveStacks(args({ stackNames: ['GoodStack', 'Other-*'] })).catch(() => {
+      // `Other-*` matches no discovered stack → resolveStacks throws (#778). We only care
+      // that the patterns were forwarded to the synth scope BEFORE that check.
+    });
+    expect(lastSynthOpts().stackPatterns).toEqual(['GoodStack', 'Other-*']);
+  });
+
+  it('no-args discovery forwards NO scope (validate every stack — unchanged behavior)', async () => {
+    await resolveStacks(args({ stackNames: [] }));
+    expect(lastSynthOpts().stackPatterns).toBeUndefined();
+  });
+
+  it('--all forwards NO scope even when positional names are present (target everything)', async () => {
+    // --all overrides positional names, so the user asked for everything → validate all.
+    await resolveStacks(args({ all: true, stackNames: ['GoodStack'] }));
+    expect(lastSynthOpts().stackPatterns).toBeUndefined();
+  });
+
+  it('still resolves only the named stack (discovery returns all; selector only narrows validation)', async () => {
+    const out = await resolveStacks(args({ stackNames: ['GoodStack'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['GoodStack']);
+  });
+});


### PR DESCRIPTION
Closes #905.

## Root cause
`src/synth/synth.ts` called `toolkit.synth(source)` with NO `StackSelector`. toolkit-lib then selects `ALL_STACKS` and `validateStacksMetadata` validates EVERY stack in the app. `src/commands/resolve-stacks.ts` always synthesizes, even for an exact-name target. So a failing context lookup (missing cross-account credentials, VPC-not-found, ...) in an UNRELATED sibling stack aborted the WHOLE command — `cdkrd check GoodStack` failed because a sibling `BadLookupStack`'s lookup could not resolve. This blocked the primary verb for the standard multi-account CI shape (creds for account A only; app defines A+B with lookups in B). The `cdk` CLI does not behave this way: it validates metadata only for SELECTED stacks.

## Fix
Thread the requested stack names/globs into a `StackSelector` on the `toolkit.synth` call so only the TARGET stacks are metadata-validated.

- New exported pure helper `buildStackSelector(patterns)` in `synth.ts`, and a new `stackPatterns?: string[]` field on `SynthOptions`, threaded into `toolkit.synth(source, { stacks })`.
- `resolveStacks` forwards `a.stackNames` as `stackPatterns` ONLY for named/glob targets that are NOT `--all`; otherwise it forwards `undefined`.

### StackSelector strategy — `PATTERN_MATCH` (and why)
- **Named / glob target(s)** → `{ strategy: StackSelectionStrategy.PATTERN_MATCH, patterns }`. toolkit-lib matches patterns against each stack's HIERARCHICAL id via picomatch (glob-aware) and validates only the matches, so an unselected sibling's failing lookup can no longer abort synth.
- `PATTERN_MATCH` (NOT `PATTERN_MUST_MATCH`) is deliberate: it *halts successfully* — never throws — when patterns match zero stacks. A staged stack's hierarchical id (`Stage/Stack`) differs from its deployed `stackName` (`Stage-Stack`), which `resolveStacks` filters on, so a staged-stack pattern can legitimately match nothing at the selector level; that must not error. The real "unknown stack / no-match glob" errors stay in `resolveStacks`, checked against the FULL discovered stack list.

### Modes preserved
- **no-args discovery / `--all`** → `resolveStacks` forwards no patterns → `buildStackSelector` returns `undefined` → `toolkit.synth(source)` is called with the exact pre-#905 shape (toolkit-lib defaults to `ALL_STACKS`, validates everything — the user asked for everything).
- The selector only narrows what gets VALIDATED; the returned `CachedCloudAssembly` still carries every stack (`stacksRecursively`), so DISCOVERY is unchanged — a name typo still errors with the full known-stack list, and `resolveStacks`' own name/glob filtering is untouched.
- The `--pre-deploy` synth path (`check.ts`) is intentionally left at `ALL_STACKS`: it uses each stack's synth template as the declared source and already refuses unresolved lookups (#907), so scoping it is out of scope for #905.

## Tests (`tests/synth-selector-905.test.ts`, 10 cases)
- `buildStackSelector`: `undefined`/`[]` → `undefined`; patterns → a `PATTERN_MATCH` selector; asserts it is NOT a `MUST_MATCH`/`ALL_STACKS` strategy; multi-pattern verbatim.
- `resolveStacks` (mocking `discoverStacks`): exact-name and glob targets forward the target patterns as `stackPatterns`; mixed exact+glob forwards all; no-args and `--all` forward NO scope; still resolves only the named stack (discovery returns all).
- Verified the tests FAIL without the fix (7/10 fail) and PASS with it.

Full suite: **106 files, 3710 tests pass**. `vp run check`: **0 errors**.

NOTE: a multi-account live-test is not available in this environment — verified by unit tests across all synth modes + full-suite regression. A multi-account live-test (creds for A only, app A+B with a lookup in B, `cdkrd check A` must succeed) is a recommended follow-up.
