### PR TITLE
fix(read): project Tags in readCodeBuildProject so a declared-tags Project is not a false drift (#1056)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -1775,6 +1775,14 @@ const readCodeBuildProject: OverrideReader = async ({ physicalId, declared, regi
       ...(cache.location !== undefined && { Location: cache.location }),
       ...(cache.modes?.length && { Modes: cache.modes }),
     };
+  // Tags — BatchGetProjects returns the project's `tags` ([{key, value}]), but the
+  // projection omitted them, so a project that DECLARES Tags (a CDK app almost always
+  // stamps app/stack-level `Tags.of(app).add(...)` onto every Project) read back
+  // `Tags: undefined` → a false CFn-declared drift (desired=[...] actual=undefined) that
+  // SURVIVES record. Mirror the sibling `readCodeBuildReportGroup` mapping (#1056); guarded
+  // on non-empty so an untagged project emits no `Tags` and stays clean.
+  if (Array.isArray(p.tags) && p.tags.length > 0)
+    model.Tags = p.tags.map((t) => ({ Key: t.key, Value: t.value }));
   return model;
 };
 

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -1712,6 +1712,53 @@ describe('SDK overrides', () => {
       expect(out.Visibility).toBe('PRIVATE');
     });
 
+    it('projects Tags so a declared-tags project is not a false declared drift (#1056)', async () => {
+      // A CDK app almost always stamps app/stack-level tags onto every Project; the reader
+      // omitted `tags`, so a declared `Tags` read back `undefined` → a declared-tier FP that
+      // survived record. Mirror the ReportGroup mapping ({key,value} -> {Key,Value}).
+      codebuild.on(BatchGetProjectsCommand).resolves({
+        projects: [
+          {
+            name: 'p',
+            source: { type: 'NO_SOURCE' },
+            artifacts: { type: 'NO_ARTIFACTS' },
+            projectVisibility: 'PRIVATE',
+            tags: [
+              { key: 'cdkrd:ephemeral', value: '1' },
+              { key: 'team', value: 'platform' },
+            ],
+          },
+        ],
+      });
+      const out = (await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'p'))) as Record<
+        string,
+        unknown
+      >;
+      expect(out.Tags).toEqual([
+        { Key: 'cdkrd:ephemeral', Value: '1' },
+        { Key: 'team', Value: 'platform' },
+      ]);
+    });
+
+    it('omits Tags for an untagged project (no empty Tags noise)', async () => {
+      codebuild.on(BatchGetProjectsCommand).resolves({
+        projects: [
+          {
+            name: 'p',
+            source: { type: 'NO_SOURCE' },
+            artifacts: { type: 'NO_ARTIFACTS' },
+            projectVisibility: 'PRIVATE',
+            tags: [],
+          },
+        ],
+      });
+      const out = (await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'p'))) as Record<
+        string,
+        unknown
+      >;
+      expect(out.Tags).toBeUndefined();
+    });
+
     it('projects LogsConfig + BadgeEnabled — an out-of-band logging/badge change is no longer invisible', async () => {
       codebuild.on(BatchGetProjectsCommand).resolves({
         projects: [


### PR DESCRIPTION
Closes #1056

## Problem (declared-tier FP surviving record — the most user-damaging class)
`readCodeBuildProject` (the SDK override reader — CC `GetResource` throws `UnsupportedActionException`, so CodeBuild is read via `BatchGetProjects`) projected the whole CFn surface but **never mapped `p.tags` to `model.Tags`**. `BatchGetProjects` DOES return the project's `tags` (`[{key, value}]`). A CDK app almost always stamps app/stack-level tags (`Tags.of(app).add(...)`) onto every Project, so a declared `Tags` read back `undefined`:

```
[CFn-Declared Drift: 1]
  Proj.Tags (AWS::CodeBuild::Project)  desired=[{"Key":"..."}]  actual=undefined
```

— a false declared drift on the FIRST `check` that **survives `record`** (the declared dimension is not snapshotted). Violates the zero-drift invariant.

## Fix (`overrides.ts` only)
Project `Tags` in `readCodeBuildProject`, mirroring the sibling `readCodeBuildReportGroup` (same file) exactly: `if (Array.isArray(p.tags) && p.tags.length > 0) model.Tags = p.tags.map((t) => ({ Key: t.key, Value: t.value }))`. Guarded on non-empty, so an untagged project emits no `Tags` and stays clean.

## Tests
`tests/overrides.test.ts` (aws-sdk-client-mock): a tagged project projects `Tags` `{key,value}`→`{Key,Value}`; an untagged project omits `Tags`. Full suite green (3702).

## Live evidence
The issue is LIVE-CONFIRMED (0.4.1, `CdkrdHuntXReadFn` — a bare `codebuild.Project` with an app-level tag reproduced the drift). The fix is a direct mirror of the live-proven ReportGroup reader, and the mock test drives the exact `BatchGetProjects` response shape. Fresh deploy deferred (issue's real repro + proven-sibling mirror + exact-shape mock stand in — no new AWS resource created).