### PR TITLE
fix(synth): decode cdk.json BOM/UTF-16 and surface a parse error instead of the misleading 'no CDK app' (#1076)

### DIFF
--- a/src/synth/resolve-app.ts
+++ b/src/synth/resolve-app.ts
@@ -2,15 +2,46 @@
 // cli-args) → cdk.json "app". Mirrors cdk-local's resolveApp precedence.
 import { existsSync, readFileSync } from 'node:fs';
 
+// Decode a cdk.json buffer the way the real `cdk` CLI does (via fs-extra/jsonfile, which
+// strips a BOM before JSON.parse) PLUS the UTF-16 cases Windows tooling produces (#1076):
+// a UTF-8 BOM (EF BB BF — Notepad / PowerShell 5.1 `Out-File -Encoding utf8`), UTF-16 LE
+// (FF FE — PowerShell 5.1's DEFAULT for `> cdk.json`), or UTF-16 BE (FE FF). A default
+// TextDecoder consumes the BOM (`ignoreBOM` defaults to false), so the decoded text is
+// clean JSON. Node's own `readFileSync(…, 'utf8')` does neither — it leaves the BOM as a
+// leading U+FEFF and turns UTF-16 into mojibake, both of which then throw in JSON.parse.
+function decodeCdkJson(buf: Buffer): string {
+  const encoding =
+    buf[0] === 0xff && buf[1] === 0xfe
+      ? 'utf-16le'
+      : buf[0] === 0xfe && buf[1] === 0xff
+        ? 'utf-16be'
+        : 'utf-8';
+  return new TextDecoder(encoding).decode(buf);
+}
+
 export function resolveApp(explicit: string | undefined): string | undefined {
   if (explicit) return explicit;
+  // No cdk.json at all → genuinely no app here (the caller's "run in a directory with
+  // cdk.json / pass --app" message is correct). Only a cdk.json that EXISTS but can't be
+  // read/parsed is turned into a SPECIFIC error below, instead of being swallowed into the
+  // misleading "there is no CDK app here" (#1076 — a Windows user whose cdk.json `cdk`
+  // itself accepts was sent hunting for a missing file / flag).
+  if (!existsSync('cdk.json')) return undefined;
+  let text: string;
   try {
-    if (existsSync('cdk.json')) {
-      const json = JSON.parse(readFileSync('cdk.json', 'utf8')) as { app?: unknown };
-      if (typeof json.app === 'string' && json.app.length > 0) return json.app;
-    }
-  } catch {
-    /* unreadable cdk.json → no app */
+    text = decodeCdkJson(readFileSync('cdk.json'));
+  } catch (e) {
+    throw new Error(`cdk.json exists but could not be read: ${(e as Error).message}`);
   }
-  return undefined;
+  let json: { app?: unknown };
+  try {
+    json = JSON.parse(text) as { app?: unknown };
+  } catch (e) {
+    throw new Error(
+      `cdk.json exists but is not valid JSON (an unsupported encoding or a syntax error?): ${(e as Error).message}`
+    );
+  }
+  // A parseable cdk.json with no `app` is a valid case (the app may come from --app /
+  // $CDKRD_APP) — return undefined, not an error.
+  return typeof json.app === 'string' && json.app.length > 0 ? json.app : undefined;
 }

--- a/tests/resolve-app-1076.test.ts
+++ b/tests/resolve-app-1076.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { resolveApp } from '../src/synth/resolve-app.js';
+
+// #1076 — resolveApp used a bare `readFileSync('cdk.json','utf8')` + `JSON.parse` inside a
+// swallow-all `catch {}`, so a cdk.json with a UTF-8 BOM / UTF-16 encoding (common Windows
+// tooling output that the real `cdk` accepts) or a syntax error returned `undefined`, which
+// callers reported as the misleading "there is no CDK app here". Now the BOM/UTF-16 cases
+// decode correctly and a genuinely-unparseable EXISTING cdk.json throws a specific error.
+const APP = 'npx ts-node bin/app.ts';
+const cdkJson = (app: string = APP): string => JSON.stringify({ app, context: {} });
+
+describe('resolveApp (#1076 encoding + error surfacing)', () => {
+  let dir: string;
+  let prev: string;
+
+  beforeEach(() => {
+    prev = process.cwd();
+    dir = mkdtempSync(join(tmpdir(), 'cdkrd-app-'));
+    process.chdir(dir);
+  });
+  afterEach(() => {
+    process.chdir(prev);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('an explicit value short-circuits (no cdk.json read)', () => {
+    expect(resolveApp('node app.js')).toBe('node app.js');
+  });
+
+  it('reads a plain UTF-8 cdk.json', () => {
+    writeFileSync('cdk.json', cdkJson());
+    expect(resolveApp(undefined)).toBe(APP);
+  });
+
+  it('reads a UTF-8 BOM cdk.json (Notepad / PowerShell utf8)', () => {
+    writeFileSync(
+      'cdk.json',
+      Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(cdkJson())])
+    );
+    expect(resolveApp(undefined)).toBe(APP);
+  });
+
+  it('reads a UTF-16 LE cdk.json (PowerShell 5.1 `> cdk.json` default)', () => {
+    writeFileSync('cdk.json', Buffer.from(`﻿${cdkJson()}`, 'utf16le'));
+    expect(resolveApp(undefined)).toBe(APP);
+  });
+
+  it('reads a UTF-16 BE cdk.json', () => {
+    const le = Buffer.from(`﻿${cdkJson()}`, 'utf16le');
+    const be = Buffer.alloc(le.length);
+    for (let i = 0; i < le.length; i += 2) {
+      be[i] = le[i + 1]!;
+      be[i + 1] = le[i]!;
+    }
+    writeFileSync('cdk.json', be);
+    expect(resolveApp(undefined)).toBe(APP);
+  });
+
+  it('returns undefined when no cdk.json exists (genuinely no app here)', () => {
+    expect(resolveApp(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for a parseable cdk.json with no `app` (app may come from --app)', () => {
+    writeFileSync('cdk.json', JSON.stringify({ context: {} }));
+    expect(resolveApp(undefined)).toBeUndefined();
+  });
+
+  it('THROWS a specific error for an existing but unparseable cdk.json (not the "no app" lie)', () => {
+    writeFileSync('cdk.json', '{ "app": "x", }'); // trailing comma
+    expect(() => resolveApp(undefined)).toThrow(/cdk\.json exists but is not valid JSON/);
+  });
+});


### PR DESCRIPTION
Closes #1076

## Problem (Windows users blocked from every verb)
`resolveApp` used a bare `readFileSync('cdk.json','utf8')` + `JSON.parse` inside a swallow-all `catch {}`. So a `cdk.json` that the real `cdk` CLI accepts every day — but that is **not** parseable by a bare `JSON.parse` — returned `undefined`, which the callers reported as the misleading `cdkrd needs a CDK app: run in a directory with cdk.json…` (exit 2). The user is sent hunting for a missing file / `--app` flag instead of at the real problem. Triggers:
- **UTF-8 BOM** (Notepad, PowerShell 5.1 `Out-File -Encoding utf8`) — Node's `utf8` read leaves a leading U+FEFF that throws in `JSON.parse`; the real `cdk` strips it (fs-extra/jsonfile `stripBom`).
- **UTF-16 LE** — PowerShell 5.1's *default* for `> cdk.json` — decodes to mojibake under `utf8`.
- a plain **JSON syntax error**.

## Fix (`resolve-app.ts` only)
- `decodeCdkJson` reads the file as a buffer and decodes by BOM (`FF FE`→utf-16le, `FE FF`→utf-16be, else utf-8) via `TextDecoder`, which consumes the BOM — matching `cdk`.
- When `cdk.json` **exists but can't be read/parsed**, throw a SPECIFIC error (`cdk.json exists but is not valid JSON (an unsupported encoding or a syntax error?)…`) instead of swallowing to `undefined`. The callers already propagate it to cli.ts's error lane (exit 2 with the real reason).
- **No cdk.json** → still `undefined` (the "no app here" message is correct); a **parseable cdk.json with no `app`** → still `undefined` (app may come from `--app`/`$CDKRD_APP`).

## Tests
`tests/resolve-app-1076.test.ts`: UTF-8 BOM, UTF-16 LE, UTF-16 BE, plain UTF-8 all resolve the app; explicit short-circuit; no-cdk.json and no-`app` return undefined; an unparseable existing cdk.json throws the specific error. Full suite green (3745).

Live: pure file-decode/error-surfacing fix (no AWS); the unit suite over the real encodings IS the evidence.