### PR TITLE
chore(corpus): OpenSearch Domain sibling stale createOnlyPaths (follow-up #887)

### DIFF
--- a/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
@@ -158,7 +158,7 @@
       "AdvancedSecurityOptions.SAMLOptions.MasterBackendRole",
       "AdvancedSecurityOptions.SAMLOptions.MasterUserName"
     ],
-    "createOnlyPaths": ["AdvancedSecurityOptions.Enabled", "DomainName", "EncryptionAtRestOptions"],
+    "createOnlyPaths": ["DomainName"],
     "defaults": {},
     "defaultPaths": {}
   },


### PR DESCRIPTION
Follow-up to #887/#1028. The sibling corpus fixture `Domain66AC69E0.json` carried the same stale `createOnlyPaths` (`AdvancedSecurityOptions.Enabled`, `EncryptionAtRestOptions`) the primary fixture had — artifacts of an older parser (interior `/properties/` uncollapsed + conditionalCreateOnly merged). The current parser emits only `["DomainName"]`. corpus-replay stays green (678 passed). Corpus-only, no src.