### PR TITLE
fix(noise): fold ClientVpnEndpoint SessionTimeoutHours=24 + TransportProtocol=udp first-run defaults (#1102)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1035,14 +1035,20 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::EC2::IPAM': {
     MeteredAccount: 'ipam-owner',
   },
-  // A Client VPN endpoint that declares neither VpnPort nor DisconnectOnSessionTimeout
-  // reads back the constant service defaults (port 443, disconnect-on-timeout on).
-  // Observed live on a fresh ClientVPN deploy (us-east-1, 2026-07-03; #554 from #534's
-  // live verify). Equality-gated: flip either out of band (e.g. VpnPort=1194) and the
-  // value no longer matches, so it re-surfaces as real undeclared drift.
+  // A Client VPN endpoint that declares none of VpnPort / DisconnectOnSessionTimeout /
+  // TransportProtocol / SessionTimeoutHours reads back the constant service defaults
+  // (port 443, disconnect-on-timeout on, UDP transport, 24h session timeout). Observed
+  // live on a fresh ClientVPN deploy (VpnPort/DisconnectOnSessionTimeout: us-east-1,
+  // 2026-07-03, #554; TransportProtocol='udp' + SessionTimeoutHours=24: us-east-1,
+  // 2026-07-10, #1102 — surfaced as first-run [Potential Drift] while live-verifying the
+  // #912/#1019 VpnPort set-default). Equality-gated: flip any out of band (e.g.
+  // VpnPort=1194, TransportProtocol='tcp') and the value no longer matches, so it
+  // re-surfaces as real undeclared drift.
   'AWS::EC2::ClientVpnEndpoint': {
     VpnPort: 443,
     DisconnectOnSessionTimeout: true,
+    TransportProtocol: 'udp',
+    SessionTimeoutHours: 24,
   },
   // A DAX cluster that declares no ClusterEndpointEncryptionType reads back "NONE" (the
   // constant service default; the only other value, "TLS", is an explicit opt-in).

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1268,15 +1268,31 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
   it('#554: ClientVPN + DAX first-run defaults fold; an out-of-band change surfaces', () => {
     const t = (rt: string, live: Record<string, unknown>) =>
       tiers(classifyResource(bare(rt), live, emptySchema));
-    // ClientVpnEndpoint VpnPort 443 / DisconnectOnSessionTimeout true → fold; a flipped
-    // port (1194) or disabled disconnect surfaces as real undeclared drift.
+    // ClientVpnEndpoint VpnPort 443 / DisconnectOnSessionTimeout true / TransportProtocol
+    // 'udp' / SessionTimeoutHours 24 → fold; a flipped value surfaces as real undeclared
+    // drift. TransportProtocol + SessionTimeoutHours added in #1102 (live-observed as
+    // first-run FPs while verifying the #912/#1019 VpnPort set-default).
     expect(
       t('AWS::EC2::ClientVpnEndpoint', {
         VpnPort: 443,
         DisconnectOnSessionTimeout: true,
+        TransportProtocol: 'udp',
+        SessionTimeoutHours: 24,
       }).atDefault.sort()
-    ).toEqual(['DisconnectOnSessionTimeout', 'VpnPort']);
+    ).toEqual([
+      'DisconnectOnSessionTimeout',
+      'SessionTimeoutHours',
+      'TransportProtocol',
+      'VpnPort',
+    ]);
     expect(t('AWS::EC2::ClientVpnEndpoint', { VpnPort: 1194 }).undeclared).toEqual(['VpnPort']);
+    // A flipped transport (tcp) or a non-default session timeout still surfaces.
+    expect(t('AWS::EC2::ClientVpnEndpoint', { TransportProtocol: 'tcp' }).undeclared).toEqual([
+      'TransportProtocol',
+    ]);
+    expect(t('AWS::EC2::ClientVpnEndpoint', { SessionTimeoutHours: 12 }).undeclared).toEqual([
+      'SessionTimeoutHours',
+    ]);
     // DAX ClusterEndpointEncryptionType NONE → fold; TLS (an explicit opt-in) surfaces.
     expect(t('AWS::DAX::Cluster', { ClusterEndpointEncryptionType: 'NONE' }).atDefault).toEqual([
       'ClusterEndpointEncryptionType',


### PR DESCRIPTION
Closes #1102 (F1).

## What
A clean minimal `AWS::EC2::ClientVpnEndpoint` reads back two undeclared AWS defaults that were not folded, surfacing as first-run [Potential Drift] (core-invariant violation):
- `SessionTimeoutHours` = 24
- `TransportProtocol` = 'udp'

Added both to the existing `AWS::EC2::ClientVpnEndpoint` KNOWN_DEFAULTS block (tier-1, siblings of the already-folded VpnPort=443 / DisconnectOnSessionTimeout=true). Equality-gated: a non-default transport ('tcp') or timeout still surfaces.

## Why it also mattered for #912/#1019
Because these were unfolded, `revert --remove-unrecorded` planned a `remove` for them in the SAME ModifyClientVpnEndpoint call as the #1019 VpnPort set-default; the writer threw on the un-expressible SessionTimeoutHours clear and **aborted the whole batch**, silently dropping the convergeable VpnPort revert.

## Live-verified (stack Cdkrd1019Verify, us-east-1, 2026-07-10)
- Clean deploy with the fix: SessionTimeoutHours/TransportProtocol fold to atDefault (zero first-run FP).
- OOB VpnPort 443->1194 -> `revert --remove-unrecorded --yes` -> **live VpnPort converged to 443** (the #912/#1019 set-default now applies end-to-end once the sibling gap no longer poisons the batch).

Remaining in #1102 for a follow-up: F2 (writer should isolate an un-expressible op instead of aborting the batch) + F3 (TagSpecifications createOnly readGap).