### PR TITLE
fix(revert)+fix(noise): ClientVpnEndpoint revert-op isolation (F2) + TagSpecifications readGap (F3) (#1102)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -4512,6 +4512,13 @@ export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
   // every DNS-validated cert. It is a true readGap: AWS genuinely never returns the input
   // shape (#1090).
   'AWS::CertificateManager::Certificate': new Set(['DomainValidationOptions']),
+  // `TagSpecifications` — the EC2 create-time tag INPUT shape ([{ResourceType, Tags}]). The live
+  // resource carries its tags under `Tags` (where the Cloud Control read returns them); the
+  // `TagSpecifications` input wrapper is NEVER echoed back, so classify's removed-collection
+  // branch would false-flag `[CFn-Declared Drift] TagSpecifications` on every tagged endpoint
+  // (live-observed on a clean ClientVpnEndpoint, us-east-1, 2026-07-10; #1102 F3). A true readGap:
+  // the declared input shape is simply not part of the live model.
+  'AWS::EC2::ClientVpnEndpoint': new Set(['TagSpecifications']),
 };
 
 // SCALAR_RETURNED_WHEN_SET is the ALLOWLIST inverse of the collection default in the

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -1764,6 +1764,13 @@ const writeEc2ClientVpnEndpoint: SdkWriter = async (ctx, ops) => {
   const desired = await desiredModel('AWS::EC2::ClientVpnEndpoint', ctx, ops);
   const input: { ClientVpnEndpointId: string; [k: string]: unknown } = { ClientVpnEndpointId: id };
   let any = false;
+  // Un-expressible clears (a `remove` whose unset state ModifyClientVpnEndpoint cannot express)
+  // are COLLECTED here rather than thrown inline: a single un-expressible op must NOT abort the
+  // whole batch and drop the CONVERGEABLE sibling ops (#1102 — a `SessionTimeoutHours` remove was
+  // aborting the #912 VpnPort set-default that WOULD converge). We apply every expressible op
+  // first, then throw ONCE naming what could not be reverted (its live value stays, surfaced by
+  // the post-revert convergence re-read).
+  const unExpressible: string[] = [];
   const tops = new Set(ops.map((op) => op.path.replace(/^\//, '').split('/')[0] ?? ''));
   // A `remove` op (revert of an OOB-added value back to unset) must send an EXPLICIT clearing value
   // — ModifyClientVpnEndpoint is a selective modify, so an omitted field keeps the live value and
@@ -1778,24 +1785,23 @@ const writeEc2ClientVpnEndpoint: SdkWriter = async (ctx, ops) => {
       } else if (removed(top)) {
         // ModifyClientVpnEndpoint expresses a clear for Description ('') and the booleans
         // (SplitTunnel=false, DisconnectOnSessionTimeout=false); VpnPort / SessionTimeoutHours are
-        // numbers with NO expressible unset, so bar them honestly.
-        if (top === 'Description') input.Description = '';
-        else if (top === 'SplitTunnel') input.SplitTunnel = false;
-        else if (top === 'DisconnectOnSessionTimeout') input.DisconnectOnSessionTimeout = false;
-        else
-          throw new Error(
-            `EC2 ClientVpnEndpoint ${top} cannot be cleared via ModifyClientVpnEndpoint (its unset state is not expressible in a selective modify); update it manually`
-          );
-        any = true;
+        // numbers with NO expressible unset, so bar them honestly (isolated, not batch-aborting).
+        if (top === 'Description') {
+          input.Description = '';
+          any = true;
+        } else if (top === 'SplitTunnel') {
+          input.SplitTunnel = false;
+          any = true;
+        } else if (top === 'DisconnectOnSessionTimeout') {
+          input.DisconnectOnSessionTimeout = false;
+          any = true;
+        } else unExpressible.push(top);
       }
     } else if (top === 'ConnectionLogOptions') {
       if (desired.ConnectionLogOptions !== undefined) {
         input.ConnectionLogOptions = desired.ConnectionLogOptions;
         any = true;
-      } else if (removed('ConnectionLogOptions'))
-        throw new Error(
-          'EC2 ClientVpnEndpoint ConnectionLogOptions cannot be cleared via ModifyClientVpnEndpoint (its unset state is not expressible in a selective modify); update it manually'
-        );
+      } else if (removed('ConnectionLogOptions')) unExpressible.push('ConnectionLogOptions');
     } else if (top === 'DnsServers') {
       const list = desired.DnsServers as string[] | undefined;
       // An empty/absent desired list is itself an expressible clear ({Enabled:false}), so a
@@ -1812,16 +1818,21 @@ const writeEc2ClientVpnEndpoint: SdkWriter = async (ctx, ops) => {
         input.SecurityGroupIds = list;
         input.VpcId = vpcId;
         any = true;
-      } else if (removed('SecurityGroupIds'))
-        throw new Error(
-          'EC2 ClientVpnEndpoint SecurityGroupIds cannot be cleared via ModifyClientVpnEndpoint (an endpoint cannot revert to no security group in a selective modify); update it manually'
-        );
+      } else if (removed('SecurityGroupIds')) unExpressible.push('SecurityGroupIds');
     }
   }
-  if (!any) return;
-  await new EC2Client({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
-    new ModifyClientVpnEndpointCommand(input)
-  );
+  // Apply the expressible ops FIRST so a convergeable op (e.g. the #912 VpnPort set-default) still
+  // lands even alongside an un-expressible sibling; only then report what could not be reverted.
+  if (any)
+    await new EC2Client({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+      new ModifyClientVpnEndpointCommand(input)
+    );
+  if (unExpressible.length > 0)
+    throw new Error(
+      `EC2 ClientVpnEndpoint ${unExpressible.join(', ')} cannot be cleared via ModifyClientVpnEndpoint ` +
+        `(unset state is not expressible in a selective modify)${any ? '; the other revert op(s) were applied' : ''}; ` +
+        `update ${unExpressible.length > 1 ? 'them' : 'it'} manually`
+    );
 };
 
 // AWS::Lex::Bot `BotLocales` is the ENTIRE conversational model (locales → intents → slots +

--- a/tests/clientvpn-f3-tagspec-1102.test.ts
+++ b/tests/clientvpn-f3-tagspec-1102.test.ts
@@ -1,0 +1,47 @@
+// #1102 F3 — AWS::EC2::ClientVpnEndpoint TagSpecifications is the EC2 create-time tag INPUT shape
+// ([{ResourceType, Tags}]). The live resource carries its tags under `Tags` (where the Cloud
+// Control read returns them); TagSpecifications is never echoed back, so without the readGap
+// denylist classify's removed-collection branch false-flags [CFn-Declared Drift] TagSpecifications
+// on every tagged endpoint (live-observed on a clean deploy, us-east-1, 2026-07-10).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+
+// No writeOnly on TagSpecifications, so it survives schema-strip into the declared model — the
+// condition under which the removed-collection branch would fire.
+const schema: SchemaInfo = {
+  readOnly: new Set(['ClientVpnEndpointId']),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: ['ClientVpnEndpointId'],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Cvpn',
+  resourceType: 'AWS::EC2::ClientVpnEndpoint',
+  physicalId: 'cvpn-endpoint-0123456789abcdef0',
+  declared,
+});
+
+describe('#1102 F3 ClientVpnEndpoint TagSpecifications readGap denylist', () => {
+  it('a declared TagSpecifications absent from the live read stays readGap, not declared drift', () => {
+    const findings = classifyResource(
+      mk({
+        ClientCidrBlock: '10.0.0.0/22',
+        TagSpecifications: [
+          { ResourceType: 'client-vpn-endpoint', Tags: [{ Key: 'team', Value: 'net' }] },
+        ],
+      }),
+      // the live model carries tags under Tags; TagSpecifications is never returned
+      { ClientCidrBlock: '10.0.0.0/22' },
+      schema
+    );
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'TagSpecifications')).toBe(
+      false
+    );
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'TagSpecifications')).toBe(true);
+  });
+});

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -2126,6 +2126,34 @@ describe('EC2 ClientVpnEndpoint writer (NON_PROVISIONABLE; ModifyClientVpnEndpoi
       ])
     ).rejects.toThrow(/endpoint id/);
   });
+
+  it('applies the convergeable op(s) BEFORE barring an un-expressible sibling clear — no batch abort (#1102)', async () => {
+    // A VpnPort set-default (#912, expressible) alongside a SessionTimeoutHours remove
+    // (un-expressible). Previously the un-expressible clear THREW inline and aborted the whole
+    // ModifyClientVpnEndpoint call, silently dropping the convergeable VpnPort revert.
+    stubRead({ VpnPort: 1194, SessionTimeoutHours: 99 });
+    ec2.on(ModifyClientVpnEndpointCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+        { op: 'add', path: '/VpnPort', value: 443, human: 'VpnPort -> 443' },
+        { op: 'remove', path: '/SessionTimeoutHours', human: 'SessionTimeoutHours -> (none)' },
+      ])
+    ).rejects.toThrow(/SessionTimeoutHours cannot be cleared/);
+    // the VpnPort set-default was STILL sent (isolated from the un-expressible sibling)
+    const calls = ec2.commandCalls(ModifyClientVpnEndpointCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({ ClientVpnEndpointId: CVID, VpnPort: 443 });
+  });
+
+  it('bars a SessionTimeoutHours remove honestly when it is the ONLY op (nothing to send, #1102)', async () => {
+    stubRead({ SessionTimeoutHours: 99 });
+    await expect(
+      SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+        { op: 'remove', path: '/SessionTimeoutHours', human: 'SessionTimeoutHours -> (none)' },
+      ])
+    ).rejects.toThrow(/SessionTimeoutHours cannot be cleared/);
+    expect(ec2.commandCalls(ModifyClientVpnEndpointCommand)).toHaveLength(0);
+  });
 });
 
 describe('ServiceDiscovery HttpNamespace writer (CC read+write gap)', () => {


### PR DESCRIPTION
Closes #1102 (F2 + F3; F1 shipped in #1113).

## F2 — revert/writers.ts: an un-expressible clear no longer aborts the whole batch
`writeEc2ClientVpnEndpoint` threw INLINE the moment it hit a clear whose unset state ModifyClientVpnEndpoint can't express (VpnPort/SessionTimeoutHours/ConnectionLogOptions/SecurityGroupIds remove) — aborting the entire call and silently dropping CONVERGEABLE sibling ops (LIVE-observed: a SessionTimeoutHours remove killed the #912 VpnPort set-default). Now un-expressible clears are COLLECTED; every expressible op is applied first (the Modify call is sent), THEN a single error names what couldn't be reverted (its live value stays, surfaced by the post-revert convergence re-read). A lone un-expressible op still throws and sends nothing (unchanged).

## F3 — noise.ts: TagSpecifications readGap
`AWS::EC2::ClientVpnEndpoint` `TagSpecifications` (the EC2 create-time tag input shape) is never echoed by the live read (tags come back under `Tags`), so it false-flagged `[CFn-Declared Drift] TagSpecifications` on every tagged endpoint. Added to `READGAP_COLLECTION_PATHS` (same denylist #1090 used for ACM DomainValidationOptions) → stays readGap.

## Tests
writers.test.ts: mixed batch sends VpnPort AND reports the un-expressible SessionTimeoutHours (no abort); lone un-expressible op sends nothing + throws. clientvpn-f3-tagspec-1102.test.ts: declared TagSpecifications absent from live → readGap, not declared drift.

## Verification
Unit-tested (deterministic writer/classify paths). The ClientVpnEndpoint writer + VpnPort convergence were already LIVE-proven end-to-end earlier this session (#1102 F1 verification); a fresh heavyweight cert-gated ClientVPN deploy purely for these edge behaviors is disproportionate — CORE suite deferred.