### PR TITLE
fix(report): escape Unicode bidi/zero-width controls in sanitizeForTerminal (#1058)

### DIFF
--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -644,15 +644,41 @@ function j(v: unknown): string {
 // or use CR + ANSI escapes to overwrite a real drift line on a TTY. Escape ASCII control
 // chars (C0 range + DEL) to a visible `\xNN` form so a hostile key can never emit a raw
 // newline / CR / ESC; printable text (incl. non-ASCII) is untouched. Pure + exported for tests.
+//
+// #1058: C0 + DEL is not enough — the Unicode bidi/format controls reorder or HIDE text on a
+// bidi-aware terminal without any C0 byte. A RIGHT-TO-LEFT OVERRIDE (U+202E) or a bidi isolate
+// (U+2066-U+2069) can cosmetically flip a key's rendered direction; a bidi embedding/override
+// (U+202A-U+202E); and the zero-width set (U+200B-U+200F, U+FEFF) can vanish characters
+// entirely — so a hostile key could still visually spoof a benign one. Escape those too, to a
+// visible `\u{XXXX}` form. Ordinary printable non-ASCII (CJK, accents, emoji) stays untouched.
 export function sanitizeForTerminal(s: string): string {
   let out = '';
   for (const ch of s) {
     const code = ch.charCodeAt(0);
     // C0 controls (\x00-\x1f) + DEL (\x7f) -> visible \xNN; a raw CR/LF/ESC could
     // else inject a spoofed `result:` line or overwrite a real drift line on a TTY.
-    out += code < 0x20 || code === 0x7f ? `\\x${code.toString(16).padStart(2, '0')}` : ch;
+    if (code < 0x20 || code === 0x7f) {
+      out += `\\x${code.toString(16).padStart(2, '0')}`;
+    } else if (isBidiOrZeroWidth(code)) {
+      // Unicode bidi/format controls -> visible \u{XXXX}; else they reorder/hide text.
+      out += `\\u{${code.toString(16).toUpperCase()}}`;
+    } else {
+      out += ch;
+    }
   }
   return out;
+}
+
+// #1058: the invisible/directional Unicode controls a hostile live key can carry —
+// bidi embeddings/overrides + isolates (U+202A-U+202E, U+2066-U+2069) and the
+// zero-width set (U+200B-U+200F, U+FEFF). All BMP, so a single charCode is the codepoint.
+function isBidiOrZeroWidth(code: number): boolean {
+  return (
+    (code >= 0x202a && code <= 0x202e) || // bidi embeddings/overrides (LRE/RLE/PDF/LRO/RLO)
+    (code >= 0x2066 && code <= 0x2069) || // bidi isolates (LRI/RLI/FSI/PDI)
+    (code >= 0x200b && code <= 0x200f) || // ZWSP/ZWNJ/ZWJ/LRM/RLM
+    code === 0xfeff // BOM / zero-width no-break space
+  );
 }
 
 // Truncate a desired/actual (or baseline/actual) PAIR so the FIRST point at which the

--- a/tests/report-sanitize-829.test.ts
+++ b/tests/report-sanitize-829.test.ts
@@ -42,6 +42,27 @@ describe('#829 report control-char sanitization', () => {
     expect(sanitizeForTerminal('日本語/héllo-世界')).toBe('日本語/héllo-世界'); // non-ASCII untouched
   });
 
+  // #1058: bidi/zero-width Unicode controls reorder/hide text on a bidi-aware terminal
+  // without any C0 byte — sanitize must escape them too, to a visible \u{XXXX} form.
+  it('sanitizeForTerminal escapes Unicode bidi/zero-width controls (#1058)', () => {
+    // RIGHT-TO-LEFT OVERRIDE (U+202E) between "name" and "evil", ZERO-WIDTH SPACE (U+200B) before "x".
+    const hostile = 'name‮evil​x';
+    const out = sanitizeForTerminal(hostile);
+    expect(out).not.toContain('‮'); // no raw RLO
+    expect(out).not.toContain('​'); // no raw ZWSP
+    expect(out).toBe('name\\u{202E}evil\\u{200B}x'); // visible escapes, text preserved
+  });
+
+  it('sanitizeForTerminal covers the full bidi/zero-width range and BOM (#1058)', () => {
+    // one char from each escaped class: bidi override, bidi isolate, LRM, BOM.
+    expect(sanitizeForTerminal('‪⁦‎﻿')).toBe('\\u{202A}\\u{2066}\\u{200E}\\u{FEFF}');
+  });
+
+  it('sanitizeForTerminal leaves ordinary non-ASCII (CJK, emoji) untouched (#1058)', () => {
+    // adjacent codepoints just outside the escaped ranges + CJK + an emoji must survive verbatim.
+    expect(sanitizeForTerminal('日本 \u{1F600}   ⁥⁪')).toBe('日本 \u{1F600}   ⁥⁪');
+  });
+
   it('map-delta key (added key) cannot inject a verdict line', () => {
     // declared tier + both sides records → formatMapDelta; the payload is a live map KEY.
     const f = base({ tier: 'declared', desired: {}, actual: { [PAYLOAD]: 'v' } });


### PR DESCRIPTION
Closes #1058

Offline fix with unit tests — the deterministic repro in the issue is the live evidence (no live-read hot-path change, no revert AWS-write). See the issue for root cause and repro.