### PR TITLE
fix(baseline): reject duplicate recorded identity keys at load (#1047)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -148,6 +148,7 @@ export async function loadBaseline(
   // turning completeness quietly off). Same loud-vs-silent principle the ignore.yaml
   // validation applies (config-file.ts validateIgnoreEntry).
   parsed.recorded.forEach((entry, i) => validateRecordedEntry(entry, i, path));
+  validateRecordedUniqueness(parsed.recorded, path);
   validateCompleteResources(parsed.completeResources, path);
   validateRecordedPhysicalIds(parsed.recordedPhysicalIds, path);
   return parsed;
@@ -170,6 +171,39 @@ function validateRecordedEntry(entry: unknown, index: number, path: string): voi
   for (const k of ['logicalId', 'resourceType', 'path'] as const)
     if (typeof obj[k] !== 'string')
       throw new Error(`${at}: "${k}" is required and must be a string`);
+}
+
+/**
+ * #1047: reject duplicate `recorded` identity keys at load. The baseline is git-committed,
+ * hand-editable, and merge-conflictable, so a bad merge / hand-edit can leave TWO entries
+ * sharing the SAME identity — `(logicalId, path, resourceType)` — with DIFFERENT values. The
+ * #794 shape validation above proves each element is well-FORMED but never cross-checks
+ * identity, so such a file loads cleanly and then misbehaves: every match site
+ * (`recorded.find(...)` in applyBaseline / splitRecordedByBaseline) silently first-wins — so
+ * if LIVE equals the SECOND duplicate the finding is NOT suppressed and false-surfaces as
+ * confirmed drift — AND the removed-since-record loop iterates ALL entries, emitting TWO
+ * identical "baseline value removed since record" findings for the one path (an inflated
+ * drift count). The identity here is exactly the one the match sites compare on (see
+ * `entryMatches` / splitRecordedByBaseline's `.find`), so a collision is genuinely
+ * ambiguous — the file is corrupt. Fail LOUDLY (naming the duplicated identity) rather than
+ * silently pick the first, mirroring #794's loud-vs-silent principle. Entries are all
+ * shape-validated by this point, so `logicalId`/`resourceType`/`path` are known strings.
+ */
+function validateRecordedUniqueness(recorded: RecordedEntry[], path: string): void {
+  const seen = new Set<string>();
+  recorded.forEach((entry, i) => {
+    // key on the SAME three axes the match sites compare (logicalId + path + resourceType);
+    // JSON.stringify a tuple to keep the delimiter unambiguous across arbitrary field values.
+    const key = JSON.stringify([entry.logicalId, entry.path, entry.resourceType]);
+    if (seen.has(key))
+      throw new Error(
+        `baseline file ${path}: \`recorded\`[${i}] is a duplicate of an earlier entry with the same ` +
+          `identity (logicalId=${JSON.stringify(entry.logicalId)}, path=${JSON.stringify(entry.path)}, ` +
+          `resourceType=${JSON.stringify(entry.resourceType)}). Two recorded entries with the same identity ` +
+          'are ambiguous (a bad merge or hand-edit) — remove the stale one, or restore the correct file from git.'
+      );
+    seen.add(key);
+  });
 }
 
 /**

--- a/tests/baseline-validate-794.test.ts
+++ b/tests/baseline-validate-794.test.ts
@@ -125,3 +125,87 @@ describe('#794 loadBaseline element-level validation', () => {
     expect(loaded?.recorded).toHaveLength(1);
   });
 });
+
+// #1047: two `recorded` entries sharing the SAME (logicalId, path, resourceType) identity but
+// DIFFERENT values (a bad merge / hand-edit) must be REJECTED LOUDLY at load — the match sites
+// (`recorded.find`) silently first-win, so a live value equal to the SECOND duplicate would
+// false-surface as drift, and the removed-since-record loop would double-count. Fail rather
+// than silently pick the first.
+describe('#1047 loadBaseline duplicate-identity rejection', () => {
+  let cwd: string;
+  let dir: string;
+  beforeEach(async () => {
+    cwd = process.cwd();
+    dir = await mkdtemp(join(tmpdir(), 'cdkrd-baseline-1047-'));
+    process.chdir(dir);
+  });
+  afterEach(async () => {
+    process.chdir(cwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const base = (recorded: unknown[]): string =>
+    JSON.stringify({
+      schemaVersion: 2,
+      stackName: STACK,
+      region: REGION,
+      accountId: ACCOUNT,
+      capturedAt: '',
+      templateHash: '',
+      recorded,
+    });
+
+  it('two entries with the same identity but different values are rejected, naming the identity', async () => {
+    await expect(
+      loadRaw(
+        base([
+          { logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P', value: 1 },
+          { logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P', value: 2 },
+        ])
+      )
+    ).rejects.toThrow(
+      /baseline file .*`recorded`\[1\] is a duplicate of an earlier entry with the same identity \(logicalId="L", path="P", resourceType="AWS::X::Y"\)/
+    );
+  });
+
+  it('two entries with the same identity and IDENTICAL values are still rejected (still ambiguous / corrupt)', async () => {
+    await expect(
+      loadRaw(
+        base([
+          { logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P', value: 1 },
+          { logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P', value: 1 },
+        ])
+      )
+    ).rejects.toThrow(/`recorded`\[1\] is a duplicate of an earlier entry/);
+  });
+
+  it('same logicalId+resourceType but DIFFERENT path still loads (distinct identities)', async () => {
+    const loaded = await loadRaw(
+      base([
+        { logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P1', value: 1 },
+        { logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P2', value: 2 },
+      ])
+    );
+    expect(loaded?.recorded).toHaveLength(2);
+  });
+
+  it('same logicalId+path but DIFFERENT resourceType still loads (id recycled across a refactor, #793)', async () => {
+    const loaded = await loadRaw(
+      base([
+        { logicalId: 'L', resourceType: 'AWS::SQS::Queue', path: 'P', value: 1 },
+        { logicalId: 'L', resourceType: 'AWS::SNS::Topic', path: 'P', value: 2 },
+      ])
+    );
+    expect(loaded?.recorded).toHaveLength(2);
+  });
+
+  it('two `added` entries (empty path) for DIFFERENT child logicalIds still load', async () => {
+    const loaded = await loadRaw(
+      base([
+        { logicalId: 'ChildA', resourceType: 'AWS::ApiGateway::Stage', path: '', value: {} },
+        { logicalId: 'ChildB', resourceType: 'AWS::ApiGateway::Stage', path: '', value: {} },
+      ])
+    );
+    expect(loaded?.recorded).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #1047

Offline fix with unit tests — the deterministic repro in the issue is the live evidence (no live-read hot-path change, no revert AWS-write). See the issue for root cause and repro.