### PR TITLE
fix(read): route enumerator fails safe on UNRESOLVED DestinationCidrBlock (#1082)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -2267,10 +2267,21 @@ export interface RouteTableChildInput {
   routeTableId: string;
   declaredCidrs: string[]; // DestinationCidrBlocks of AWS::EC2::Route declared on this table
   liveRoutes: { cidr: string }[];
+  // Fail-safe (#1082): at least one declared route on this table has an UNRESOLVED
+  // DestinationCidrBlock (a `{{resolve:ssm:...}}` dynamic ref, a degraded Fn::ImportValue,
+  // or a no-default NoEcho Ref → the UNRESOLVED symbol). The route's identity is matched
+  // ONLY through its DestinationCidrBlock (the CFn physical id is a generated token), so an
+  // UNRESOLVED cidr cannot be matched to any live route. Reporting a live route as `added`
+  // then risks a destructive `revert --remove-unrecorded` DeleteResource against a route the
+  // template DECLARES. When true, suppress `added` for THIS table's routes entirely.
+  hasUnresolvedDeclaredRoute?: boolean;
 }
 
 export function diffRouteTableChildren(input: RouteTableChildInput): AddedChild[] {
-  const { routeTableId, declaredCidrs, liveRoutes } = input;
+  const { routeTableId, declaredCidrs, liveRoutes, hasUnresolvedDeclaredRoute } = input;
+  // A declared route with an UNRESOLVED DestinationCidrBlock could be ANY of the live
+  // routes — we can't tell which — so we cannot safely call any live route `added`.
+  if (hasUnresolvedDeclaredRoute) return [];
   const declared = new Set(declaredCidrs);
   const added: AddedChild[] = [];
   for (const route of liveRoutes) {
@@ -2318,13 +2329,24 @@ async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<Adde
   // physical id by gather). A route's CFn physical id is a generated token, so MATCH
   // declared routes by DestinationCidrBlock (the route's identity within the table).
   const declaredCidrs: string[] = [];
+  let hasUnresolvedDeclaredRoute = false;
   for (const r of desired.resources) {
     if (
-      r.resourceType === 'AWS::EC2::Route' &&
-      parentRefMatches(r.declared.RouteTableId, routeTableId) &&
-      typeof r.declared.DestinationCidrBlock === 'string'
+      r.resourceType !== 'AWS::EC2::Route' ||
+      !parentRefMatches(r.declared.RouteTableId, routeTableId)
     ) {
-      declaredCidrs.push(r.declared.DestinationCidrBlock);
+      continue;
+    }
+    const cidr = r.declared.DestinationCidrBlock;
+    if (typeof cidr === 'string') {
+      declaredCidrs.push(cidr);
+    } else if (cidr === UNRESOLVED || hasUnresolved(cidr)) {
+      // Fail-safe (#1082): an UNRESOLVED DestinationCidrBlock (dynamic ref / degraded
+      // ImportValue / no-default NoEcho Ref) is this route's ONLY identity handle, so its
+      // live counterpart cannot be matched. Suppress `added` for this table's routes rather
+      // than offer a destructive delete of a route the template declares. Mirrors the
+      // parentRefMatches / #962 fail-safe, applied to the child IDENTITY property.
+      hasUnresolvedDeclaredRoute = true;
     }
   }
 
@@ -2334,7 +2356,12 @@ async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<Adde
     .filter(isEnumerableRoute)
     .map((route) => ({ cidr: route.DestinationCidrBlock }));
 
-  return diffRouteTableChildren({ routeTableId, declaredCidrs, liveRoutes });
+  return diffRouteTableChildren({
+    routeTableId,
+    declaredCidrs,
+    liveRoutes,
+    hasUnresolvedDeclaredRoute,
+  });
 }
 
 // ── ECS ──────────────────────────────────────────────────────────────────────

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1594,6 +1594,37 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
     ).toEqual([]);
   });
 
+  // #1082: a declared AWS::EC2::Route's identity is matched ONLY through its
+  // DestinationCidrBlock (the CFn physical id is a generated token). When that cidr is
+  // UNRESOLVED (a `{{resolve:ssm:...}}` dynamic ref, a degraded Fn::ImportValue, or a
+  // no-default NoEcho Ref → the UNRESOLVED symbol) the enumerator sets
+  // `hasUnresolvedDeclaredRoute`, and the diff must FAIL SAFE: it cannot match the declared
+  // route to any live cidr, so it must NOT flag any live route `added` (a `revert
+  // --remove-unrecorded` would then destructively DeleteResource a route the template
+  // declares).
+  it('fails safe: an UNRESOLVED declared cidr suppresses ALL added for this table (#1082)', () => {
+    expect(
+      diffRouteTableChildren({
+        routeTableId: RT,
+        // The declared cidr was UNRESOLVED, so it never made it into declaredCidrs; the
+        // enumerator instead raised the fail-safe flag.
+        declaredCidrs: [],
+        liveRoutes: [{ cidr: '10.99.0.0/16' }],
+        hasUnresolvedDeclaredRoute: true,
+      })
+    ).toEqual([]);
+  });
+
+  it('with no UNRESOLVED declared route, a genuinely out-of-band route is STILL added (no regression, #1082)', () => {
+    const added = diffRouteTableChildren({
+      routeTableId: RT,
+      declaredCidrs: ['0.0.0.0/0'],
+      liveRoutes: [{ cidr: '0.0.0.0/0' }, { cidr: '10.99.0.0/16' }],
+      hasUnresolvedDeclaredRoute: false,
+    });
+    expect(added.map((a) => a.identifier)).toEqual([`${RT}|10.99.0.0/16`]);
+  });
+
   describe('isEnumerableRoute', () => {
     it('keeps a user-declarable route (manual CreateRoute with a real CIDR)', () => {
       expect(


### PR DESCRIPTION
Closes #1082

Offline fix with unit tests — the deterministic repro in the issue is the live evidence (no live-read hot-path change, no revert AWS-write). See the issue for root cause and repro.