### PR TITLE
fix(noise): fold Chatbot GuardrailPolicies per-partition via array-valued CONTEXT_ARN_DEFAULTS

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -2726,19 +2726,22 @@ export function classifyResource(
     // Equality-gated (a view scoped elsewhere still surfaces); with no resolved account/region
     // it falls through to plain `undeclared` (recordable), never a wrong fold.
     const ctxArnTemplate = CONTEXT_ARN_DEFAULTS[resourceType]?.[k];
-    if (
-      ctxArnTemplate !== undefined &&
-      opts.region !== undefined &&
-      opts.accountId !== undefined &&
-      typeof v === 'string'
-    ) {
+    if (ctxArnTemplate !== undefined && opts.region !== undefined && opts.accountId !== undefined) {
       // Canonical partition helper (#945): folds ISO partitions too. region is defined here.
       const partition = partitionForRegion(opts.region).partition;
-      const ctxArnDefault = ctxArnTemplate
-        .replace('{partition}', partition)
-        .replace('{region}', opts.region)
-        .replace('{accountId}', opts.accountId);
-      if (v === ctxArnDefault) {
+      const region = opts.region;
+      const accountId = opts.accountId;
+      const substitute = (t: string): string =>
+        t
+          .replace('{partition}', partition)
+          .replace('{region}', region)
+          .replace('{accountId}', accountId);
+      // A scalar template folds a single ARN string; an ARRAY template (a list-valued default
+      // like Chatbot's GuardrailPolicies, #1071) folds the whole live array element-for-element.
+      const matches = Array.isArray(ctxArnTemplate)
+        ? deepEqual(v, ctxArnTemplate.map(substitute))
+        : typeof v === 'string' && v === substitute(ctxArnTemplate);
+      if (matches) {
         findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
         continue;
       }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -373,11 +373,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     EncryptionOptions: { UseAwsOwnedKey: true },
     DataReplicationMode: 'NONE',
   },
-  // Chatbot applies the AdministratorAccess guardrail when none is declared
-  // (verified live on a default-config SlackChannelConfiguration).
-  'AWS::Chatbot::SlackChannelConfiguration': {
-    GuardrailPolicies: ['arn:aws:iam::aws:policy/AdministratorAccess'],
-  },
+  // (Chatbot's undeclared AdministratorAccess guardrail default lives in
+  // CONTEXT_ARN_DEFAULTS below — the AWS-managed policy ARN is partition-scoped, so a
+  // hardcoded commercial `arn:aws:` literal here false-positived aws-us-gov / aws-cn
+  // first runs, #1071.)
   // CloudTrail materializes the default management-events selector when the
   // template declares EventSelectors [] or omits it (observed live on the
   // harvest3 fixture, R74 — CDK's Trail construct synthesizes `EventSelectors:
@@ -2210,8 +2209,10 @@ export const CONTEXT_DEFAULTS: Record<string, Record<string, 'region' | 'regionL
 // gated against the live value: a resource that points the property at a DIFFERENT scope / key
 // still surfaces as real undeclared drift (detection preserved, unlike a value-independent
 // fold). With no resolved account/region the substitution is skipped and the value stays
-// `undeclared` (recordable), never a wrong fold.
-export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string>> = {
+// `undeclared` (recordable), never a wrong fold. A value may be a single templated ARN string
+// or an ARRAY of them (a list-valued default like Chatbot's GuardrailPolicies, #1071) — each
+// element is substituted and the whole list is equality-gated against the live array.
+export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string[]>> = {
   // A ResourceExplorer2 View that declares no Scope reads back the account-root ARN — the
   // whole-account default scope. createOnly (never drifts), but derived rather than value-
   // independent per the fold-strategy order. Live, hunt 2026-07-08 round F (#626).
@@ -2241,6 +2242,16 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string>> = {
   // account id; equality-gated, so an AccessPoint pointed at a cross-account bucket owner still
   // surfaces. Live-confirmed on a fresh s3objectlambda-rich AccessPoint (#919).
   'AWS::S3::AccessPoint': { BucketAccountId: '{accountId}' },
+  // A SlackChannelConfiguration that declares no GuardrailPolicies reads back the single
+  // AWS-managed `AdministratorAccess` policy ARN — the service default guardrail. The
+  // AWS-managed policy ARN is PARTITION-scoped (`arn:aws-cn:…` in China, `arn:aws-us-gov:…`
+  // in GovCloud), so a KNOWN_DEFAULTS constant `arn:aws:…` literal false-positived every
+  // non-commercial first run (#1071). Array-valued (one templated ARN), equality-gated: a
+  // config that scopes to a narrower/custom guardrail policy still surfaces. Verified live
+  // on a default-config SlackChannelConfiguration (commercial partition).
+  'AWS::Chatbot::SlackChannelConfiguration': {
+    GuardrailPolicies: ['arn:{partition}:iam::aws:policy/AdministratorAccess'],
+  },
 };
 
 // Top-level UNDECLARED keys whose service default VALUE is derived from the resource's own

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1112,6 +1112,48 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(t({ Scope: 'arn:aws:iam::111111111111:root' }).undeclared).toEqual(['Scope']);
   });
 
+  it('#1071: Chatbot GuardrailPolicies undeclared default folds per-partition via the ARRAY context-ARN default', () => {
+    const t = (live: Record<string, unknown>, opts?: Parameters<typeof classifyResource>[3]) =>
+      tiers(
+        classifyResource(bare('AWS::Chatbot::SlackChannelConfiguration'), live, emptySchema, opts)
+      );
+    const opts = { accountId: '111111111111', region: 'us-east-1' };
+    // commercial partition: the AWS-managed AdministratorAccess guardrail folds atDefault
+    expect(
+      t({ GuardrailPolicies: ['arn:aws:iam::aws:policy/AdministratorAccess'] }, opts).atDefault
+    ).toEqual(['GuardrailPolicies']);
+    // GovCloud (aws-us-gov): the partition-scoped ARN read-back FAILS with a hardcoded
+    // commercial `arn:aws:` literal — the #1071 first-run FP — and now folds via {partition}
+    expect(
+      t(
+        { GuardrailPolicies: ['arn:aws-us-gov:iam::aws:policy/AdministratorAccess'] },
+        {
+          ...opts,
+          region: 'us-gov-west-1',
+        }
+      ).atDefault
+    ).toEqual(['GuardrailPolicies']);
+    // China (aws-cn) folds too
+    expect(
+      t(
+        { GuardrailPolicies: ['arn:aws-cn:iam::aws:policy/AdministratorAccess'] },
+        {
+          ...opts,
+          region: 'cn-north-1',
+        }
+      ).atDefault
+    ).toEqual(['GuardrailPolicies']);
+    // a NARROWER / custom guardrail (ReadOnlyAccess) is NOT the default and still surfaces
+    // (the array is equality-gated element-for-element)
+    expect(
+      t({ GuardrailPolicies: ['arn:aws:iam::aws:policy/ReadOnlyAccess'] }, opts).undeclared
+    ).toEqual(['GuardrailPolicies']);
+    // with no resolved account/region the substitution is skipped → stays undeclared, recordable
+    expect(
+      t({ GuardrailPolicies: ['arn:aws:iam::aws:policy/AdministratorAccess'] }).undeclared
+    ).toEqual(['GuardrailPolicies']);
+  });
+
   it('#676: RestApi resource-policy execute-api:/* shorthand folds against the echoed full ARN', () => {
     const apiId = 'wmvd2s08ng';
     const opts = { accountId: '111111111111', region: 'us-east-1' };

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -817,6 +817,41 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('Chatbot GuardrailPolicies default is an ARRAY-valued context-ARN default, not a KNOWN_DEFAULTS literal (#1071)', () => {
+    // The AWS-managed AdministratorAccess policy ARN is PARTITION-scoped, so a KNOWN_DEFAULTS
+    // constant `arn:aws:` literal false-positived non-commercial first runs. It lives in
+    // CONTEXT_ARN_DEFAULTS as a single-element array templated on {partition} (exercised
+    // end-to-end by the classify #1071 fold test).
+    expect(CONTEXT_ARN_DEFAULTS['AWS::Chatbot::SlackChannelConfiguration']).toEqual({
+      GuardrailPolicies: ['arn:{partition}:iam::aws:policy/AdministratorAccess'],
+    });
+    // It must NOT linger in KNOWN_DEFAULTS (where the partition-hardcoded literal was the bug).
+    expect(KNOWN_DEFAULTS['AWS::Chatbot::SlackChannelConfiguration']).toBeUndefined();
+  });
+
+  it('no KNOWN_DEFAULTS / KNOWN_DEFAULT_PATHS value pins a partition-hardcoded `arn:aws:` literal (#1071 class guard)', () => {
+    // A default whose VALUE is an ARN must template `arn:{partition}:…` (CONTEXT_ARN_DEFAULTS),
+    // never a hardcoded `arn:aws:…` literal that FPs aws-us-gov / aws-cn / aws-iso partitions.
+    // Whitelist: the CodeStarConnections HostArn all-zeros sentinel (noise.ts ~1522) is a
+    // documented service "no host" placeholder proven region-invariant by corpus; its partition
+    // segment is not yet partition-proven, so it stays a literal until then (#1071 leaves as-is).
+    const WHITELIST = new Set(['AWS::CodeStarConnections::Connection']);
+    const hasArnAwsLiteral = (val: unknown): boolean => {
+      if (typeof val === 'string') return /(^|["\s])arn:aws:/.test(val);
+      if (Array.isArray(val)) return val.some(hasArnAwsLiteral);
+      if (val && typeof val === 'object') return Object.values(val).some(hasArnAwsLiteral);
+      return false;
+    };
+    for (const [type, defaults] of Object.entries(KNOWN_DEFAULTS)) {
+      if (WHITELIST.has(type)) continue;
+      expect(hasArnAwsLiteral(defaults), `KNOWN_DEFAULTS[${type}]`).toBe(false);
+    }
+    for (const [type, defaults] of Object.entries(KNOWN_DEFAULT_PATHS)) {
+      if (WHITELIST.has(type)) continue;
+      expect(hasArnAwsLiteral(defaults), `KNOWN_DEFAULT_PATHS[${type}]`).toBe(false);
+    }
+  });
+
   it('KinesisVideo Stream/SignalingChannel first-run defaults fold (#624)', () => {
     // Tier-1 constants (auto-exercised by the generic KNOWN_DEFAULTS atDefault test + corpus).
     expect(KNOWN_DEFAULTS['AWS::KinesisVideo::Stream']).toEqual({ DataRetentionInHours: 0 });


### PR DESCRIPTION
Closes #1071

## Problem
`AWS::Chatbot::SlackChannelConfiguration.GuardrailPolicies` was pinned in `KNOWN_DEFAULTS` as a partition-hardcoded `['arn:aws:iam::aws:policy/AdministratorAccess']` literal. In aws-us-gov / aws-cn the live read-back ARN never equals the commercial literal → the fold never matches → first-run false positive on every non-commercial account.

## Fix
- Move the entry to `CONTEXT_ARN_DEFAULTS` as `arn:{partition}:iam::aws:policy/AdministratorAccess` (the dedicated partition-templating mechanism, tier-2 derived).
- Extend `CONTEXT_ARN_DEFAULTS` values to `string | string[]`; the consumer in `classify.ts` folds a scalar template as before and an **array** template element-for-element (equality-gated — a narrower/custom guardrail policy still surfaces).
- Class-guard test asserting no `KNOWN_DEFAULTS` value pins an `arn:aws:` literal (whitelisting the region-invariant CodeStarConnections HostArn sentinel).

## Tests
- `tests/classify.test.ts`: commercial / GovCloud / China all fold to `atDefault`; a `ReadOnlyAccess` policy still surfaces `undeclared`. Confirmed FAILS without the fix.
- `tests/noise-and-strip.test.ts`: entry moved out of KNOWN_DEFAULTS; the arn:aws: class guard.

Gates green: typecheck / lint+fmt / build / 3752 tests.