### PR TITLE
fix(normalize): stringify numeric/boolean Fn::FindInMap key arguments so numeric-keyed maps resolve

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -128,7 +128,19 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
       }
       case 'Fn::FindInMap': {
         if (!Array.isArray(v) || v.length < 3) return UNRESOLVED;
-        const [mapName, topKey, secondKey] = v.slice(0, 3).map((x) => resolve(x, ctx));
+        // YAML 1.1 turns an unquoted numeric-looking map key argument
+        // (`!FindInMap [AcctMap, 123456789012, Bucket]` — account-id / port /
+        // numeric-version keyed maps) into a JS NUMBER, and `yes`/`no`/`on`/`off`
+        // into a boolean. But Mappings keys are ALWAYS strings (object keys
+        // stringify; CFn rejects non-string Mappings keys), so a resolved primitive
+        // scalar is safe to stringify for both the string-type check and the lookup —
+        // otherwise a knowable declared value is silently dropped to UNRESOLVED
+        // (missed drift + a permanent `check --strict` red). Only coerce primitive
+        // scalars; objects/arrays/UNRESOLVED args stay fail-closed.
+        const [mapName, topKey, secondKey] = v.slice(0, 3).map((x) => {
+          const r = resolve(x, ctx);
+          return typeof r === 'number' || typeof r === 'boolean' ? String(r) : r;
+        });
         // All 3 keys must resolve to strings and the path must exist; else fail-closed.
         if (
           typeof mapName !== 'string' ||

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -326,6 +326,29 @@ describe('intrinsic resolver', () => {
     ).toBe(UNRESOLVED);
   });
 
+  it('Fn::FindInMap stringifies a numeric-/boolean-literal key argument (#1075)', () => {
+    // YAML 1.1 turns `!FindInMap [AcctMap, 123456789012, Bucket]` into a JS number.
+    // Mappings keys are always strings, so the numeric key must stringify and look up
+    // the value rather than fail the string-type check (which left it UNRESOLVED).
+    const c = ctx({
+      mappings: {
+        AcctMap: { '123456789012': { Bucket: 'my-bucket' } },
+        FlagMap: { true: { Port: '443' } },
+        RegionMap: { 'us-east-1': { '80': 'http' } },
+      },
+    });
+    // numeric TopLevelKey
+    expect(resolve({ 'Fn::FindInMap': ['AcctMap', 123456789012, 'Bucket'] }, c)).toBe('my-bucket');
+    // boolean TopLevelKey (YAML 1.1 `yes`/`no`/`on`/`off`)
+    expect(resolve({ 'Fn::FindInMap': ['FlagMap', true, 'Port'] }, c)).toBe('443');
+    // numeric SecondLevelKey
+    expect(resolve({ 'Fn::FindInMap': ['RegionMap', 'us-east-1', 80] }, c)).toBe('http');
+    // a genuinely-unresolved key argument still fails closed (not stringified)
+    expect(resolve({ 'Fn::FindInMap': ['AcctMap', { Ref: 'Ghost' }, 'Bucket'] }, c)).toBe(
+      UNRESOLVED
+    );
+  });
+
   it('Fn::Split splits a resolved string, propagates UNRESOLVED', () => {
     expect(resolve({ 'Fn::Split': [',', 'a,b,c'] }, ctx())).toEqual(['a', 'b', 'c']);
     expect(resolve({ 'Fn::Split': [',', { Ref: 'Env' }] }, ctx())).toEqual(['prod']);


### PR DESCRIPTION
Closes #1075

## Problem
A raw-CFn YAML template using a numeric-looking literal as an `Fn::FindInMap` key argument — `!FindInMap [AcctMap, 123456789012, Bucket]` (account-id / port / numeric-version keyed maps) — resolved to UNRESOLVED. YAML 1.1 parses the unquoted `123456789012` as a JS number, and the resolver's three-key `typeof === 'string'` guard rejected it. The declared property was silently skipped (drift invisible) and the stack carried a permanent `unresolved=` footer keeping `check --strict` red.

## Fix
Mapping keys are ALWAYS strings (CFn rejects numeric `Mappings` keys; JS object keys stringify), so coercing a resolved primitive scalar (number/boolean) key argument to `String()` before the lookup is always safe. Objects/arrays and the `UNRESOLVED` symbol are left untouched, preserving fail-closed behavior for genuinely-unresolved args.

## Tests
`tests/intrinsic-resolver.test.ts`: numeric TopLevelKey, boolean key (YAML 1.1 yes/no), numeric SecondLevelKey all resolve to the value; a genuinely-unresolved key still returns UNRESOLVED. Confirmed FAILS without the fix.

Gates green: typecheck / lint+fmt / build / 3750 tests.