### PR TITLE
fix(config): surface YAML parse diagnostics instead of a bare 'not valid YAML'

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -100,11 +100,31 @@ export async function loadConfig(): Promise<CdkrdConfig> {
   // them explicitly to fail fast. YAML is a JSON superset, so this also reads a legacy
   // all-JSON ignore.yaml.
   const doc = parseDocument(raw, { prettyErrors: true });
-  if (doc.errors.length > 0) throw new Error(`${CONFIG_PATH} is not valid YAML`);
+  const [firstError] = doc.errors;
+  if (firstError !== undefined) {
+    // `prettyErrors` renders each `doc.errors[i].message` with a line/column and a code
+    // (e.g. `MULTILINE_IMPLICIT_KEY`, `DUPLICATE_KEY`). Surfacing the FIRST diagnostic —
+    // not just the bare "is not valid YAML" — is the whole actionability fix (#1049): the
+    // #1 real-world damage to this shared merge-magnet file is an unresolved git conflict
+    // marker (`<<<<<<< HEAD`), which yields "Implicit keys need to be on a single line at
+    // line N, column M". Without the line/column the user can't find the damage. Append a
+    // count when there is more than one so they know the first is not the only one.
+    const more = doc.errors.length > 1 ? ` (+${doc.errors.length - 1} more)` : '';
+    throw new Error(`${CONFIG_PATH} is not valid YAML: ${firstError.message}${more}`);
+  }
   try {
     parsed = doc.toJS();
-  } catch {
-    throw new Error(`${CONFIG_PATH} is not valid YAML`);
+  } catch (e) {
+    // A file can collect ZERO `doc.errors` yet still fail here — the classic case is an
+    // unquoted glob whose first char is a YAML sigil: `- path: *.DesiredCount` parses the
+    // `*` as an ALIAS reference, so `toJS()` throws "Unresolved alias ...". Surface the
+    // message (was swallowed) and, for the alias/anchor case, add the documented remedy:
+    // quote a `path` that starts with `*` / `?` so it is a literal glob, not YAML syntax.
+    const msg = (e as Error).message;
+    const hint = /alias|anchor/i.test(msg)
+      ? ' — a glob path starting with "*" or "?" must be quoted (e.g. `path: "*.DesiredCount"`) so it is read as a literal, not YAML alias/anchor syntax'
+      : '';
+    throw new Error(`${CONFIG_PATH} is not valid YAML: ${msg}${hint}`);
   }
   // A file that is empty or only comments parses to null/undefined — an empty config,
   // not an error (the `ignore` verb writes a header-comment-only file before any rule).

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -595,6 +595,46 @@ describe('loadConfig', () => {
     await expect(loadConfig()).rejects.toThrow(/not valid YAML/);
   });
 
+  it('an unresolved git merge-conflict marker → error carries the line/column diagnostic (#1049)', async () => {
+    // The #1 real-world damage to this shared merge-magnet file: a conflict marker left
+    // by a botched merge. The bare "is not valid YAML" gives the user nowhere to look;
+    // the fix appends the prettyErrors diagnostic, which pins the exact line + column.
+    await write(
+      [
+        'ignore:',
+        '<<<<<<< HEAD',
+        '  - path: A.x',
+        '=======',
+        '  - path: B.x',
+        '>>>>>>> branch',
+      ].join('\n')
+    );
+    let msg = '';
+    try {
+      await loadConfig();
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).toMatch(/not valid YAML/); // prefix preserved for continuity
+    expect(msg).toMatch(/line \d+, column \d+/); // actionable location, not the bare string
+  });
+
+  it('an unquoted "*"-glob path parses as a YAML alias → error surfaces the alias diagnostic + quote hint (#1049)', async () => {
+    // `- path: *.DesiredCount` collects ZERO doc.errors, then toJS() throws on the `*`
+    // alias. The old catch swallowed the message; the fix surfaces it AND adds the
+    // documented remedy (quote a glob that starts with `*` / `?`).
+    await write('ignore:\n  - path: *.DesiredCount\n');
+    let msg = '';
+    try {
+      await loadConfig();
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).toMatch(/not valid YAML/); // prefix preserved for continuity
+    expect(msg).toMatch(/alias/i); // the swallowed diagnostic is now surfaced
+    expect(msg).toMatch(/quoted/); // the actionable quote-glob hint
+  });
+
   it('ignore not a sequence → throws', async () => {
     await write('ignore:\n  path: x\n');
     await expect(loadConfig()).rejects.toThrow(/"ignore" must be an array/);


### PR DESCRIPTION
Closes #1049 (YAML half; baseline JSON half deferred — see below)

## Problem
When `.cdkrd/ignore.yaml` fails to parse, `loadConfig` discarded everything actionable: the `doc.errors` throw dropped `doc.errors[0].message` (pretty-printed with line/column + a code like `DUPLICATE_KEY`), and the `toJS()` catch swallowed its message. The single most likely real-world damage — an unresolved git merge-conflict marker in the shared merge-magnet `ignore.yaml` — surfaced only as `is not valid YAML` with no location.

## Fix
- Append the first diagnostic (with a `(+N more)` count when several) to the `doc.errors` throw.
- Include the `toJS()` error message; when it mentions alias/anchor, add a hint to quote a glob `path` starting with `*`/`?` (the documented quote-glob rule, which trips the YAML alias parser).
- Exit-2 behavior preserved; pure actionability, no FP/FN change.

## Scope note
This lane fixes only the **YAML/ignore.yaml half**. The baseline-JSON position-drop half (`baseline-file.ts:88-92`) is intentionally deferred to avoid collision with #1047, in flight on that file — it can be a fast follow-up once #1047 lands.

## Tests
`tests/config-file.test.ts`: merge-conflict marker → error carries `line N, column M`; unquoted `*`-glob → error surfaces the alias diagnostic + quote hint. Both confirmed FAIL without the fix.

Gates green: typecheck / lint+fmt / build / 3751 tests.