### PR TITLE
fix(revert): writeDaxParameterGroup throws on an un-expressible remove op instead of false success

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -1622,24 +1622,57 @@ const writeDaxCluster: SdkWriter = async (ctx, ops) => {
 const writeDaxParameterGroup: SdkWriter = async (ctx, ops) => {
   const name = str(ctx.physicalId) ?? str(ctx.declared['ParameterGroupName']);
   if (!name) throw new Error('cannot resolve DAX parameter-group name for revert');
-  const desired = await desiredModel('AWS::DAX::ParameterGroup', ctx, ops);
+  // Read the LIVE model directly (not just the post-ops desired): a whole-map `remove` op leaves
+  // `desired.ParameterNameValues` empty, so the keys it would (fail to) clear are only knowable
+  // from the live map. `desiredModel` = `applyOps(live, ops)`; DAX carries no PolicyDocument, so
+  // its canonicalization is a no-op here and applying the ops locally is equivalent.
+  const reader = SDK_OVERRIDES['AWS::DAX::ParameterGroup'];
+  const live = (reader && (await reader(ctx))) ?? {};
+  const liveValues = (live.ParameterNameValues as Record<string, unknown> | undefined) ?? {};
+  const desired = applyOps(live, ops);
   const desiredValues = (desired.ParameterNameValues as Record<string, unknown> | undefined) ?? {};
   // Collect the parameter keys the revert ops touch (path `/ParameterNameValues/<key>`), plus a
   // whole-map op (`/ParameterNameValues`). Re-send each from the desired map.
+  //
+  // A `remove` op reverts an out-of-band-ADDED parameter back to unset. DAX has NO
+  // ResetParameterGroup API (unlike ElastiCache/MemoryDB whose writers reset removed keys) —
+  // UpdateParameterGroup can only re-assert a value, never clear one — so a `remove` is
+  // UN-EXPRESSIBLE. Collect those keys and THROW once (the #928/#1002/#1102 pattern) rather than
+  // silently dropping the op and reporting a false `reverted:` (the parameter would never clear).
+  // Expressible add/set ops are applied FIRST so a convergeable sibling still lands even alongside
+  // an un-expressible remove.
   const keys = new Set<string>();
+  const unExpressible = new Set<string>();
   for (const op of ops) {
     const segs = op.path.replace(/^\//, '').split('/');
     if (segs[0] !== 'ParameterNameValues') continue;
-    if (segs[1] !== undefined) keys.add(segs[1].replace(/~1/g, '/').replace(/~0/g, '~'));
-    else for (const k of Object.keys(desiredValues)) keys.add(k);
+    if (segs[1] !== undefined) {
+      const key = segs[1].replace(/~1/g, '/').replace(/~0/g, '~');
+      if (op.op === 'remove') unExpressible.add(key);
+      else keys.add(key);
+    } else if (op.op === 'remove') {
+      // A whole-map remove clears every currently-set parameter — equally un-expressible. The
+      // keys live in the LIVE map (`desiredValues` is already empty post-remove). If the live map
+      // is empty there is nothing to clear, so it stays a genuine no-op (no throw).
+      for (const k of Object.keys(liveValues)) unExpressible.add(k);
+    } else for (const k of Object.keys(desiredValues)) keys.add(k);
   }
   const values = [...keys]
     .filter((k) => typeof desiredValues[k] === 'string')
     .map((k) => ({ ParameterName: k, ParameterValue: desiredValues[k] as string }));
-  if (values.length === 0) return;
-  await new DAXClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
-    new UpdateDaxParameterGroupCommand({ ParameterGroupName: name, ParameterNameValues: values })
-  );
+  if (values.length > 0)
+    await new DAXClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+      new UpdateDaxParameterGroupCommand({ ParameterGroupName: name, ParameterNameValues: values })
+    );
+  if (unExpressible.size > 0) {
+    const names = [...unExpressible].join(', ');
+    throw new Error(
+      `DAX ParameterGroup parameter ${names} cannot be cleared via UpdateParameterGroup ` +
+        `(DAX has no ResetParameterGroup API, so an out-of-band-added parameter's unset state is not expressible)` +
+        `${values.length > 0 ? '; the other revert op(s) were applied' : ''}; ` +
+        `update ${unExpressible.size > 1 ? 'them' : 'it'} manually`
+    );
+  }
 };
 
 // AWS::ElastiCache::ParameterGroup — read via an SDK override (describe-cache-parameters

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -1880,6 +1880,86 @@ describe('DAX ParameterGroup writer (NON_PROVISIONABLE; UpdateParameterGroup, is
     ]);
     expect(dax.commandCalls(UpdateDaxParameterGroupCommand)).toHaveLength(0);
   });
+
+  it('THROWS on a `remove` op — DAX has no ResetParameterGroup API to clear a parameter (#1087)', async () => {
+    // Reverting an out-of-band-ADDED parameter back to unset is UN-EXPRESSIBLE: UpdateParameterGroup
+    // can only re-assert a value, never clear one. Silently returning here reported a false
+    // `reverted:` while the parameter never cleared — throw loudly instead (#928/#1002/#1102 class).
+    stubRead({ 'record-ttl-millis': '10000' });
+    dax.on(UpdateDaxParameterGroupCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::DAX::ParameterGroup'](ctx({ physicalId: PGN }), [
+        {
+          op: 'remove',
+          path: '/ParameterNameValues/record-ttl-millis',
+          human: 'ParameterNameValues.record-ttl-millis -> unset (OOB-added)',
+        },
+      ])
+    ).rejects.toThrow(/cannot be cleared via UpdateParameterGroup/);
+    // and it must NOT have silently "succeeded" via an UpdateParameterGroup call for the remove
+    expect(dax.commandCalls(UpdateDaxParameterGroupCommand)).toHaveLength(0);
+  });
+
+  it('THROWS on the mixed [remove k1, add k2] case rather than partially applying k2 and lying (#1087)', async () => {
+    // The remove makes the whole item un-convergent; the convergeable add IS applied, but the
+    // writer must still throw so the un-expressible remove is not reported as reverted.
+    stubRead({ 'query-ttl-millis': '5000' });
+    dax.on(UpdateDaxParameterGroupCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::DAX::ParameterGroup'](ctx({ physicalId: PGN }), [
+        {
+          op: 'remove',
+          path: '/ParameterNameValues/record-ttl-millis',
+          human: 'ParameterNameValues.record-ttl-millis -> unset (OOB-added)',
+        },
+        {
+          op: 'add',
+          path: '/ParameterNameValues/query-ttl-millis',
+          value: '5000',
+          human: 'ParameterNameValues.query-ttl-millis -> deployed-template value',
+        },
+      ])
+    ).rejects.toThrow(/record-ttl-millis/);
+    // the expressible add IS applied first (so the convergeable sibling still lands) ...
+    const calls = dax.commandCalls(UpdateDaxParameterGroupCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({
+      ParameterGroupName: PGN,
+      ParameterNameValues: [{ ParameterName: 'query-ttl-millis', ParameterValue: '5000' }],
+    });
+  });
+
+  it('THROWS on a whole-map `remove /ParameterNameValues` (--remove-unrecorded) — keys sourced from the LIVE map (#1087)', async () => {
+    // An undeclared, unrecorded ParameterNameValues reverted with --remove-unrecorded plans a
+    // WHOLE-PROPERTY remove. After applyOps the desired map is EMPTY, so the keys to (fail to)
+    // clear are only knowable from the LIVE model. The CdkrdDaxVerify live-test caught the writer
+    // silently no-op'ing here (false `reverted:`, only the #631 post-hoc detector flagged it)
+    // because it enumerated the post-remove desired map. It must throw, naming the live keys.
+    stubRead({ 'query-ttl-millis': '75000', 'record-ttl-millis': '300000' });
+    dax.on(UpdateDaxParameterGroupCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::DAX::ParameterGroup'](ctx({ physicalId: PGN }), [
+        {
+          op: 'remove',
+          path: '/ParameterNameValues',
+          human: 'ParameterNameValues -> unset (undeclared, --remove-unrecorded)',
+        },
+      ])
+    ).rejects.toThrow(/query-ttl-millis/);
+    expect(dax.commandCalls(UpdateDaxParameterGroupCommand)).toHaveLength(0);
+  });
+
+  it('a whole-map `remove` when the live map is already EMPTY is a genuine no-op, not a throw (#1087)', async () => {
+    // Nothing is set live, so "clear everything" clears nothing — must succeed silently.
+    stubRead({});
+    dax.on(UpdateDaxParameterGroupCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::DAX::ParameterGroup'](ctx({ physicalId: PGN }), [
+        { op: 'remove', path: '/ParameterNameValues', human: 'ParameterNameValues -> unset' },
+      ])
+    ).resolves.toBeUndefined();
+    expect(dax.commandCalls(UpdateDaxParameterGroupCommand)).toHaveLength(0);
+  });
 });
 
 describe('ElastiCache ParameterGroup writer (source=user reader; Modify/Reset)', () => {


### PR DESCRIPTION
Closes #1087

## Problem
`writeDaxParameterGroup` silently dropped a `remove /ParameterNameValues/<key>` op — the writer returned with no API call while stack-actions printed `reverted:` success. DAX has no ResetParameterGroup API, so the parameter never clears and the revert can NEVER converge. Mixed `[remove k1, add k2]` sent only k2, reporting the whole item reverted. This is the last unfiled in-allowlist remove-drop of the #984/#913 class.

## Fix
Match the #928/#1002/#1102 pattern (`writeEc2ClientVpnEndpoint`): apply the expressible add/set ops first (a convergeable sibling still lands), then throw ONCE naming the un-clearable parameter(s). An un-expressible remove now fails loudly instead of lying.

## Tests
`tests/writers.test.ts`: throws on a `remove` op (zero UpdateParameterGroup calls) and on the mixed remove+add case (the add IS sent, then throws); pure add/set still succeeds. Confirmed FAILS without the fix.

Gates green: typecheck / lint+fmt / build / 3754 tests.