### PR TITLE
fix(desired): restrict YAML 1.1 int/float tags so octal/hex/sexagesimal/float-special scalars stay strings

### DIFF
--- a/src/desired/yaml-cfn.ts
+++ b/src/desired/yaml-cfn.ts
@@ -123,10 +123,30 @@ const CUSTOM_TAGS = buildCustomTags();
 const TRUE_BOOL_TEST = /^(?:[Yy]es|YES|[Tt]rue|TRUE|[Oo]n|ON)$/;
 const FALSE_BOOL_TEST = /^(?:[Nn]o|NO|[Ff]alse|FALSE|[Oo]ff|OFF)$/;
 const BOOL_TAG = 'tag:yaml.org,2002:bool';
-// The `Date`-producing tag. The sexagesimal `intTime`/`floatTime` tags share the
-// int/float tag URIs (they yield NUMBERS like `1:30` -> 90, which #785 needs), so
-// only THIS tag URI is neutralized — the sexagesimal number resolution is preserved.
 const TIMESTAMP_TAG = 'tag:yaml.org,2002:timestamp';
+const INT_TAG = 'tag:yaml.org,2002:int';
+const FLOAT_TAG = 'tag:yaml.org,2002:float';
+
+// CloudFormation only treats PLAIN JSON-style numbers as numbers; the YAML-1.1-only
+// integer/float spellings (octal `0755`, hex `0x1A2B`, binary `0b…`, sexagesimal
+// `1:30`, float specials `.inf`/`.nan`, underscore digit-groups, leading-zero
+// decimals) it keeps as STRINGS (#1053). yaml@2's YAML-1.1 schema DOES resolve every
+// one of them to a number (or `Infinity`) — a declared-tier false positive that
+// survives `record` and, worse, makes `revert` write the corrupted number (a garbage
+// account id from an octal-parsed `012345670123`, or `null` from `Infinity`). So the
+// `int` and `float` tags are RESTRICTED to only the CFn-numeric plain forms; anything
+// else falls through to the string tag, matching what CFn deployed. The exotic-form
+// tags carry a `format` (`OCT`/`HEX`/`BIN`/`TIME`) or are `floatNaN` (no `format` but
+// matches only `.inf`/`.nan`), so they are droppable by that discriminant; the plain
+// `int`/`float`/`floatExp` tags (no exotic `format`) are kept but their `test` regexes
+// are narrowed to reject leading zeros and `_` grouping — leaving `5` / `-3.5` / `5e3`
+// resolving as numbers exactly as the stringly folds and known-defaults rely on.
+const EXOTIC_NUMBER_FORMATS = new Set(['OCT', 'HEX', 'BIN', 'TIME']);
+// Plain decimal integer, no leading zero (except a lone `0`), no `_` grouping.
+const CFN_INT_TEST = /^[-+]?(?:0|[1-9][0-9]*)$/;
+// Standard / scientific float, no leading zero, no `_` grouping. Covers `1.5`, `-3.5`,
+// `0.5`, `5e3`, `1.2E-4`, `.5` (a bare-fraction JSON-ish float CFn accepts numerically).
+const CFN_FLOAT_TEST = /^[-+]?(?:(?:0|[1-9][0-9]*)(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?$/;
 
 // Take the resolved YAML-1.1 core tags and (a) neutralize the `timestamp` tag so a
 // date-like scalar stays a string, and (b) swap the two `bool` tags for copies whose
@@ -156,6 +176,29 @@ function restrictYaml11Tags(baseTags: Tags): Tags {
         ...scalar,
         resolve: (value: string) => value,
       } as ScalarTag);
+      continue;
+    }
+    if (tag.tag === INT_TAG) {
+      const scalar = tag as ScalarTag;
+      // Drop the YAML-1.1-only integer spellings (octal / hex / binary / sexagesimal
+      // TIME) — they fall through to the string tag, matching CFn. The plain decimal
+      // `int` tag (no exotic `format`) is kept but re-tested to reject a leading zero
+      // (`0755`, `012345670123`) or `_` grouping, both of which CFn keeps as strings.
+      if (scalar.format && EXOTIC_NUMBER_FORMATS.has(scalar.format)) continue;
+      restricted.push({ ...scalar, test: CFN_INT_TEST } as ScalarTag);
+      continue;
+    }
+    if (tag.tag === FLOAT_TAG) {
+      const scalar = tag as ScalarTag;
+      // Drop the sexagesimal `floatTime` (format TIME) and the `floatNaN` special
+      // (`.inf`/`.nan`, identified by its test matching `.inf` — it carries no exotic
+      // `format`). The plain `float`/`floatExp` tags are kept but re-tested to the
+      // CFn-numeric form (no leading zero, no `_`); a `.inf`/`.nan` scalar then falls
+      // through to the string tag, matching CFn (and avoiding the `Infinity` -> null
+      // that `revert` would otherwise write).
+      const isNaNTag = scalar.test instanceof RegExp && scalar.test.test('.inf');
+      if ((scalar.format && EXOTIC_NUMBER_FORMATS.has(scalar.format)) || isNaNTag) continue;
+      restricted.push({ ...scalar, test: CFN_FLOAT_TEST } as ScalarTag);
       continue;
     }
     if (tag.tag === BOOL_TAG) {
@@ -198,16 +241,21 @@ export function parseCfnTemplate(text: string): Record<string, unknown> {
     parsed = JSON.parse(body);
   } else {
     // CloudFormation's service-side YAML parser resolves the YAML 1.1 schema, not
-    // yaml@2's default 1.2 core schema. Under 1.2 `yes`/`no`/`on`/`off` stay strings
-    // and `0755` parses as decimal 755 — diverging from what CFn actually deployed
-    // (1.1 folds those to boolean / octal 493, and `1:30` to sexagesimal 90),
-    // producing first-run declared false positives and silent revert corruption
-    // (#785). But the STOCK 1.1 schema also over-resolves plain date-like scalars to
-    // `Date` and single-letter `Y/N` to boolean, which CFn does NOT do (#850) — so we
-    // use a RESTRICTED yaml-1.1 schema (`restrictYaml11Tags`): 1.1 semantics minus
-    // timestamps (implicit AND explicit) minus single-letter bools, composed with the CFn short
-    // forms. The YAML-1.1 `!!binary`/... tags only fire on explicit `!!` markers a
-    // CFn template never carries, so no regression.
+    // yaml@2's default 1.2 core schema. Under 1.2 `yes`/`no`/`on`/`off` stay strings —
+    // diverging from what CFn actually deploys (1.1 folds those multi-letter forms to
+    // boolean), producing first-run declared false positives and silent revert
+    // corruption (#785). But the STOCK 1.1 schema goes the OTHER way for several plain
+    // scalars CFn keeps as STRINGS: it resolves date-like scalars to `Date` and
+    // single-letter `Y/N` to boolean (#850/#909), and it coerces the YAML-1.1-only
+    // NUMBER spellings — octal `0755`, hex `0x1A2B`, binary `0b…`, sexagesimal `1:30`,
+    // float specials `.inf`/`.nan`, underscore digit-groups, and leading-zero decimals
+    // (e.g. an account id `012345670123`) — to numbers / `Infinity`, which CFn does NOT
+    // (#1053). So we use a RESTRICTED yaml-1.1 schema (`restrictYaml11Tags`): 1.1
+    // semantics minus timestamps (implicit AND explicit), minus single-letter bools,
+    // and with `int`/`float` narrowed to only the plain JSON-style numbers CFn treats
+    // numerically (`5`, `-3.5`, `5e3`) — composed with the CFn short forms. The
+    // YAML-1.1 `!!binary`/... tags only fire on explicit `!!` markers a CFn template
+    // never carries, so no regression.
     parsed = yamlParse(body, CFN_YAML_PARSE_OPTIONS);
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/tests/yaml-cfn.test.ts
+++ b/tests/yaml-cfn.test.ts
@@ -29,10 +29,12 @@ describe('yaml-cfn parse', () => {
     expect(p.Cond).toEqual({ 'Fn::If': ['C', 'a', 'b'] });
   });
 
-  it('resolves implicit scalars with the YAML 1.1 schema, matching CloudFormation (#785)', () => {
+  it('resolves multi-letter YAML 1.1 booleans, matching CloudFormation (#785)', () => {
     // CloudFormation's service-side parser resolves YAML 1.1, not yaml@2's default
-    // 1.2 core schema. Under 1.2 these would FAIL: `yes`/`off` stay strings, `0755`
-    // is decimal 755, `1:30` stays a string. cdkrd must match what CFn deployed.
+    // 1.2 core schema. Under 1.2 `yes`/`no`/`on`/`off` stay strings; CFn folds the
+    // multi-letter forms to boolean, and cdkrd must match what CFn deployed. (The
+    // YAML-1.1-only NUMBER spellings `0755`/`1:30` are NOT numbers to CFn — it keeps
+    // them as strings; see the octal/hex/float-special/sexagesimal test below, #1053.)
     const t = parseCfnTemplate(`Resources:
   R:
     Type: AWS::Fake::Type
@@ -40,23 +42,20 @@ describe('yaml-cfn parse', () => {
       YesVal: yes
       NoVal: no
       OnVal: on
-      OffVal: off
-      Mode: 0755
-      Sexagesimal: 1:30`);
+      OffVal: off`);
     const p = (t as any).Resources.R.Properties;
     expect(p.YesVal).toBe(true); // 1.2 -> "yes"
     expect(p.NoVal).toBe(false); // 1.2 -> "no"
     expect(p.OnVal).toBe(true); // 1.2 -> "on"
     expect(p.OffVal).toBe(false); // 1.2 -> "off"
-    expect(p.Mode).toBe(493); // octal 0755; 1.2 -> 755
-    expect(p.Sexagesimal).toBe(90); // 60*1 + 30; 1.2 -> "1:30"
   });
 
   it('keeps a quoted leading-zero account id a string (no revert corruption, #785)', () => {
     // The common shape for an account id in a template is a quoted string, which stays
-    // a string under both schemas. A BARE `012345678901` is octal-invalid (digits 8/9)
-    // so YAML 1.1 falls back to decimal — same as CFn — but the quoted form is what
-    // must never silently lose its leading zero on parse -> revert round-trip.
+    // a string under both schemas. The BARE form is covered by the #1053 test below
+    // (the restricted `int` tag no longer coerces a leading-zero scalar to a number);
+    // the quoted form is what must never silently lose its leading zero on parse ->
+    // revert round-trip regardless.
     const t = parseCfnTemplate(`Resources:
   R:
     Type: AWS::Fake::Type
@@ -130,10 +129,11 @@ describe('yaml-cfn parse', () => {
     expect(p.AttrLowerY).toBe('y');
   });
 
-  it('still resolves yes/no/on/off and octal/sexagesimal under the restricted 1.1 schema (#785 preserved)', () => {
-    // The #850 restriction (drop implicit timestamps, exclude single-letter bools) must
-    // NOT regress the #785 fix: multi-letter YAML 1.1 booleans and octal/sexagesimal
-    // integers must still resolve exactly as CloudFormation's 1.1 parser produces them.
+  it('still resolves multi-letter booleans and plain numbers under the restricted 1.1 schema (#785 preserved)', () => {
+    // The #850/#909/#1053 restrictions (drop implicit/explicit timestamps, exclude
+    // single-letter bools, restrict int/float to plain JSON numbers) must NOT regress
+    // the #785 fix: multi-letter YAML 1.1 booleans and plain decimal / float / scientific
+    // numbers must still resolve exactly as CloudFormation produces them.
     const t = parseCfnTemplate(`Resources:
   R:
     Type: AWS::Fake::Type
@@ -144,8 +144,10 @@ describe('yaml-cfn parse', () => {
       OffVal: off
       TrueVal: true
       FalseVal: false
-      Mode: 0755
-      Sexagesimal: 1:30`);
+      Int: 12345
+      NegInt: -7
+      Float: -3.5
+      Sci: 5e3`);
     const p = (t as any).Resources.R.Properties;
     expect(p.YesVal).toBe(true);
     expect(p.NoVal).toBe(false);
@@ -153,8 +155,53 @@ describe('yaml-cfn parse', () => {
     expect(p.OffVal).toBe(false);
     expect(p.TrueVal).toBe(true);
     expect(p.FalseVal).toBe(false);
-    expect(p.Mode).toBe(493); // octal 0755
-    expect(p.Sexagesimal).toBe(90); // 60*1 + 30
+    expect(p.Int).toBe(12345);
+    expect(p.NegInt).toBe(-7);
+    expect(p.Float).toBe(-3.5);
+    expect(p.Sci).toBe(5000);
+  });
+
+  it('keeps octal/hex/binary/sexagesimal/float-special/leading-zero scalars strings, not coerced numbers (#1053)', () => {
+    // yaml@2's YAML-1.1 `int`/`float` tags resolve these plain scalars to numbers (or
+    // Infinity), but CloudFormation keeps them as STRINGS. Coercing them is a declared
+    // false positive that survives `record`, and `revert` then writes the corrupted
+    // number back — a garbage account id from octal `012345670123` -> 1402433619, or
+    // `null` from `.inf` -> Infinity. Each must stay the exact source string.
+    const t = parseCfnTemplate(`Resources:
+  R:
+    Type: AWS::Fake::Type
+    Properties:
+      OctalAccount: 012345670123
+      Mode: 0777
+      Hex: 0x1A2B
+      Binary: 0b1010
+      Sexagesimal: 1:30
+      Inf: .inf
+      NegInf: -.inf
+      NaN: .nan
+      Underscored: 1_000
+      LeadingZero: 000123456789`);
+    const p = (t as any).Resources.R.Properties;
+    expect(p.OctalAccount).toBe('012345670123'); // NOT 1402433619
+    expect(typeof p.OctalAccount).toBe('string');
+    expect(p.Mode).toBe('0777'); // NOT 511
+    expect(p.Hex).toBe('0x1A2B'); // NOT 6699
+    expect(p.Binary).toBe('0b1010'); // NOT 10
+    expect(p.Sexagesimal).toBe('1:30'); // NOT 90
+    expect(p.Inf).toBe('.inf'); // NOT Infinity (JSON.stringify -> null)
+    expect(Number.isFinite(p.Inf)).toBe(false);
+    expect(typeof p.Inf).toBe('string');
+    expect(p.NegInf).toBe('-.inf'); // NOT -Infinity
+    expect(typeof p.NegInf).toBe('string');
+    expect(p.NaN).toBe('.nan'); // NOT NaN
+    expect(typeof p.NaN).toBe('string');
+    expect(p.Underscored).toBe('1_000'); // NOT 1000
+    expect(typeof p.Underscored).toBe('string');
+    expect(p.LeadingZero).toBe('000123456789'); // NOT 123456789
+    expect(typeof p.LeadingZero).toBe('string');
+    // JSON-serializable: a coerced Infinity/NaN would become null, corrupting revert.
+    expect(() => JSON.parse(JSON.stringify(p))).not.toThrow();
+    expect(JSON.parse(JSON.stringify(p)).Inf).toBe('.inf');
   });
 
   it('rejects a non-object root', () => {


### PR DESCRIPTION
Closes #1053

## Problem
`restrictYaml11Tags` neutralized only the timestamp tag (#909) and swapped the bool tags (#850/#860), leaving the YAML 1.1 `int` tag (octal/hex/binary/underscore/leading-zero) and `float` tag (`.inf`/`.nan`, overflow-to-Infinity, sexagesimal `h:m:s`) fully active. A deployed YAML template with such a plain scalar had its DECLARED value coerced to a JS number while live CC returns the original string — a declared-tier FP that survives `record`, and `revert` wrote the corrupted number/null back to AWS (`012345670123` → a garbage account id, `.inf` → null).

## Fix
CloudFormation keeps all these as strings (only plain JSON-style numbers are numeric). Drop the exotic int/float format variants (OCT/HEX/BIN/TIME + `.inf`/`.nan`) and narrow the plain int/float `test` to CFn-numeric forms, so the exotic scalars fall through to the string tag. Plain decimal/float/scientific still resolve numerically (no regression).

## Tests
`tests/yaml-cfn.test.ts`: `012345670123` / `0777` / `0x1A2B` / `0b1010` / `1:30` / `.inf` / `.nan` all stay their exact source strings and the result is JSON-serializable; plain decimals still parse as numbers. Two pre-existing #785 tests that asserted octal/sexagesimal coercion are corrected — #1053 explicitly overturns that claim. Confirmed FAILS without the fix.

Gates green: typecheck / lint+fmt / build / 3753 tests.