### PR TITLE
fix(schema): resolve $ref top-level defaults and descend oneOf/anyOf/allOf in schema collectors

### DIFF
--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -270,9 +270,14 @@ function pointerToDotted(p: string): string {
 // path — array `items` contribute a `*` segment, matching the readOnlyPaths
 // convention and the `[id]`->`*`-normalized live finding paths. The per-branch
 // `seen` ref-set breaks recursive definitions (a $ref cannot expand inside its
-// own descent). Best-effort: only `properties` + `items` are descended (not
-// oneOf/anyOf/allOf), so a missed default just stays `undeclared` — never a false
-// positive.
+// own descent). `properties` + `items` are descended, PLUS the `oneOf`/`anyOf`/
+// `allOf` combinator branches (#1069): each branch is an alternative schema node
+// at the SAME path (a combinator adds no path segment), so we recurse into every
+// branch and union what each finds — otherwise a `default` (or an
+// `insertionOrder:false` array, or a free-form map) that lives only inside a
+// variant is lost across ~30 registry types (Bedrock Flow LoopController, CFn
+// Hooks, VerifiedPermissions, DataBrew Recipe, SES MailManager). Still
+// best-effort: a missed fact just stays `undeclared` — never a false positive.
 type SchemaNode = {
   $ref?: string;
   default?: unknown;
@@ -283,7 +288,18 @@ type SchemaNode = {
   items?: SchemaNode;
   patternProperties?: Record<string, SchemaNode>;
   additionalProperties?: boolean | SchemaNode;
+  oneOf?: SchemaNode[];
+  anyOf?: SchemaNode[];
+  allOf?: SchemaNode[];
 };
+
+// The `oneOf`/`anyOf`/`allOf` branches of a node, flattened into a single list.
+// Each element is an alternative schema at the CURRENT path (a combinator does not
+// add a path segment), so a collector recurses into each branch at the SAME path
+// and merges (unions) what each finds. Shared by all three collectors (#1069).
+function combinatorBranches(node: SchemaNode): SchemaNode[] {
+  return [...(node.oneOf ?? []), ...(node.anyOf ?? []), ...(node.allOf ?? [])];
+}
 function collectDefaultPaths(
   definitions: Record<string, SchemaNode>,
   properties: Record<string, SchemaNode>
@@ -302,6 +318,9 @@ function collectDefaultPaths(
       for (const [k, child] of Object.entries(node.properties))
         walk(child, path ? `${path}.${k}` : k, seen);
     if (node.items) walk(node.items, path ? `${path}.*` : '*', seen);
+    // A `default` may live inside a oneOf/anyOf/allOf variant — recurse each
+    // branch at the SAME path (a combinator adds no path segment). #1069.
+    for (const branch of combinatorBranches(node)) walk(branch, path, seen);
   };
   for (const [k, child] of Object.entries(properties)) walk(child, k, new Set());
   return out;
@@ -375,6 +394,9 @@ function collectUnorderedArrayPaths(
     if (n.properties)
       for (const [k, child] of Object.entries(n.properties))
         walk(child, path ? `${path}.${k}` : k, nextSeen);
+    // An `insertionOrder:false` array may sit inside a oneOf/anyOf/allOf variant —
+    // recurse each branch at the SAME path (a combinator adds no path segment). #1069.
+    for (const branch of combinatorBranches(n)) walk(branch, path, nextSeen);
   };
   for (const [k, child] of Object.entries(properties)) walk(child, k, new Set());
   return { scalar: [...new Set(scalar)].sort(), object: [...new Set(object)].sort() };
@@ -432,6 +454,9 @@ function collectFreeFormMapPaths(
       for (const [k, child] of Object.entries(node.properties))
         walk(child, path ? `${path}.${k}` : k, seen);
     if (node.items) walk(node.items, path ? `${path}.*` : '*', seen);
+    // A free-form map may live inside a oneOf/anyOf/allOf variant — recurse each
+    // branch at the SAME path (a combinator adds no path segment). #1069.
+    for (const branch of combinatorBranches(node)) walk(branch, path, seen);
   };
   for (const [k, child] of Object.entries(properties)) walk(child, k, new Set());
   return [...new Set(out)].sort();
@@ -464,19 +489,34 @@ export function parseSchema(schemaJson: string): SchemaInfo {
   // rejects it cleanly (it never silently replaces) — an honest failure beats a silent
   // bar. (Live-confirmed on AWS::RDS::DBInstance BackupRetentionPeriod.)
   const createOnlyPaths = dotted(schema.createOnlyProperties);
+  const definitions = schema.definitions ?? {};
+  // Follow a chain of local `#/definitions/...` refs to the concrete node, guarding
+  // against a recursive definition. A top-level property written as
+  // `{ "$ref": "#/definitions/X" }` carries its `default` inside definition X, so
+  // resolve it before reading `default` — else the top-level fold (classify's
+  // `k in schema.defaults`) misses it and a freshly deployed value that IS the
+  // schema default surfaces as first-run [Potential Drift] (#1068). Reuses the same
+  // ref-resolution shape as collectUnorderedArrayPaths.
+  const resolveRef = (node: SchemaNode | undefined): SchemaNode | undefined => {
+    let n = node;
+    const seen = new Set<string>();
+    while (n?.$ref) {
+      const name = n.$ref.replace('#/definitions/', '');
+      if (seen.has(name)) return undefined; // recursive — stop
+      seen.add(name);
+      n = definitions[name];
+    }
+    return n;
+  };
   const defaults: Record<string, unknown> = {};
   for (const [k, def] of Object.entries(schema.properties ?? {})) {
-    if (def && typeof def === 'object' && 'default' in def) defaults[k] = def.default;
+    const resolved = resolveRef(def);
+    if (resolved && typeof resolved === 'object' && 'default' in resolved)
+      defaults[k] = resolved.default;
   }
-  const defaultPaths = collectDefaultPaths(schema.definitions ?? {}, schema.properties ?? {});
-  const unorderedArrayPaths = collectUnorderedArrayPaths(
-    schema.definitions ?? {},
-    schema.properties ?? {}
-  );
-  const freeFormMapPaths = collectFreeFormMapPaths(
-    schema.definitions ?? {},
-    schema.properties ?? {}
-  );
+  const defaultPaths = collectDefaultPaths(definitions, schema.properties ?? {});
+  const unorderedArrayPaths = collectUnorderedArrayPaths(definitions, schema.properties ?? {});
+  const freeFormMapPaths = collectFreeFormMapPaths(definitions, schema.properties ?? {});
   // A type is `updatable` when its schema's `handlers` block declares an `update` handler.
   // ONLY decide when handlers are PRESENT: an absent handlers block is unknown updatability
   // (leave `updatable` undefined), so revert never bars on a schema-unavailable degradation.

--- a/tests/schema-collectors-1068-1069.test.ts
+++ b/tests/schema-collectors-1068-1069.test.ts
@@ -1,0 +1,173 @@
+// #1068 — parseSchema builds the TOP-LEVEL `defaults` map from a property's `default`
+// annotation EVEN when that property is written as `{ "$ref": "#/definitions/X" }` and the
+// `default` lives inside definition X. Before the fix, the top-level loop only read a DIRECT
+// `default` key on the property node, so a `$ref` property's default was skipped — a freshly
+// deployed value that IS the schema default surfaced as first-run [Potential Drift]
+// (IoTFleetWise DecoderManifest Status=DRAFT, HealthLake SseConfiguration, Deadline Queue
+// DefaultBudgetAction, BedrockAgentCore Policy EnforcementMode).
+//
+// #1069 — the three schema collectors (collectDefaultPaths, collectUnorderedArrayPaths,
+// collectFreeFormMapPaths) now descend `oneOf`/`anyOf`/`allOf` combinators. A combinator adds
+// no path segment, so a fact under a variant branch is collected at the SAME path. Before the
+// fix these facts were lost across ~30 registry types (Bedrock Flow LoopController default,
+// CFn Hooks, VerifiedPermissions, DataBrew Recipe, SES MailManager).
+import { describe, expect, it } from 'vite-plus/test';
+import { parseSchema } from '../src/schema/schema-strip.js';
+
+describe('#1068 top-level defaults resolve a $ref property', () => {
+  it('pulls a `default` living inside the referenced definition into `defaults[k]`', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::RefDefault',
+        properties: {
+          // A top-level property written as a bare $ref — its `default` is in definition Status.
+          Status: { $ref: '#/definitions/Status' },
+          // A direct default still works (regression guard).
+          Mode: { type: 'string', default: 'STANDARD' },
+        },
+        definitions: {
+          Status: { type: 'string', enum: ['ACTIVE', 'DRAFT'], default: 'DRAFT' },
+        },
+      })
+    );
+    expect(info.defaults).toEqual({ Status: 'DRAFT', Mode: 'STANDARD' });
+  });
+
+  it('follows a chain of $refs and does not loop on a recursive definition', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::RefChain',
+        properties: {
+          A: { $ref: '#/definitions/A' },
+          Loop: { $ref: '#/definitions/Loop' },
+        },
+        definitions: {
+          A: { $ref: '#/definitions/B' },
+          B: { type: 'string', default: 'chained' },
+          // Self-referential: must not hang; contributes no default.
+          Loop: { $ref: '#/definitions/Loop' },
+        },
+      })
+    );
+    expect(info.defaults).toEqual({ A: 'chained' });
+  });
+
+  it('leaves `defaults` empty when a $ref property has no default in its definition', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::RefNoDefault',
+        properties: { X: { $ref: '#/definitions/X' } },
+        definitions: { X: { type: 'string' } },
+      })
+    );
+    expect(info.defaults).toEqual({});
+  });
+});
+
+describe('#1069 collectors descend oneOf/anyOf/allOf combinators', () => {
+  it('collects a `default` under a oneOf branch into defaultPaths (same path)', () => {
+    // Mirrors Bedrock Flow: Definition.Nodes.*.Configuration is a oneOf; one branch is a
+    // LoopController whose MaxIterations has default 10.
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::OneOfDefault',
+        properties: {
+          Configuration: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  LoopController: {
+                    type: 'object',
+                    properties: { MaxIterations: { type: 'integer', default: 10 } },
+                  },
+                },
+              },
+              { type: 'object', properties: { Other: { type: 'string' } } },
+            ],
+          },
+        },
+      })
+    );
+    expect(info.defaultPaths['Configuration.LoopController.MaxIterations']).toBe(10);
+  });
+
+  it('collects a `default` under an allOf branch into defaultPaths', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::AllOfDefault',
+        properties: {
+          Settings: {
+            allOf: [
+              { type: 'object', properties: { Enabled: { type: 'boolean', default: false } } },
+            ],
+          },
+        },
+      })
+    );
+    expect(info.defaultPaths['Settings.Enabled']).toBe(false);
+  });
+
+  it('collects an insertionOrder:false scalar array under a oneOf branch (unorderedScalarPaths)', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::OneOfUnordered',
+        properties: {
+          Variant: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  Ids: { type: 'array', insertionOrder: false, items: { type: 'string' } },
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+    expect(info.unorderedScalarPaths).toContain('Variant.Ids');
+  });
+
+  it('collects a free-form map under an anyOf branch (freeFormMapPaths)', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::AnyOfMap',
+        properties: {
+          Config: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: {
+                  Params: {
+                    type: 'object',
+                    additionalProperties: { type: 'string' },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      })
+    );
+    expect(info.freeFormMapPaths).toContain('Config.Params');
+  });
+
+  it('unions facts across MULTIPLE combinator branches', () => {
+    // Each branch contributes a distinct default at a distinct path — all must be collected.
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::Test::MultiBranch',
+        properties: {
+          Node: {
+            oneOf: [
+              { type: 'object', properties: { A: { type: 'string', default: 'a' } } },
+              { type: 'object', properties: { B: { type: 'string', default: 'b' } } },
+            ],
+          },
+        },
+      })
+    );
+    expect(info.defaultPaths).toMatchObject({ 'Node.A': 'a', 'Node.B': 'b' });
+  });
+});


### PR DESCRIPTION
Closes #1068, Closes #1069

## #1068 — top-level `default` behind a `$ref`
`parseSchema` built the top-level `defaults` map only from a DIRECT `default` key, so a property written as `{ $ref: '#/definitions/X' }` whose default lives in X was skipped — the schema's own default surfaced as first-run `[Potential Drift]` (IoTFleetWise Status=DRAFT, HealthLake SseConfiguration, Deadline Queue DefaultBudgetAction, BedrockAgentCore Policy EnforcementMode). Now resolve a top-level `$ref` before reading `default` so it lands in `schema.defaults` and classify's existing top-level fold picks it up (**classify.ts untouched** — collision-free).

## #1069 — collectors never descended combinators
`collectDefaultPaths` / `collectUnorderedArrayPaths` / `collectFreeFormMapPaths` never descended `oneOf`/`anyOf`/`allOf`, so defaults (first-run FP), `insertionOrder:false` arrays (reorder FP), and free-form maps (picker blind-record) under a variant branch were lost across ~30 registry types (Bedrock Flow, CFn Hooks, VerifiedPermissions, DataBrew Recipe, SES MailManager). A shared `combinatorBranches` helper recurses each branch at the SAME path (a combinator adds no segment) and unions the results. The strip-path side (`deepStripPaths`) is model-key-based and unaffected.

## Tests
`tests/schema-collectors-1068-1069.test.ts` — 8 tests ($ref default into `defaults`, chained/recursion-safe $ref; default under oneOf & allOf, unordered array under oneOf, free-form map under anyOf, multi-branch union). 7 of 8 confirmed FAIL without the fix.

Gates green: typecheck / lint+fmt / build / 3760 tests.