### PR TITLE
fix(revert): pair REVERT_SET_DEFAULT_PATHS entries with grown KNOWN_DEFAULTS folds so omit-ignored props converge

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -84,6 +84,13 @@ const CC_REVERTABLE_DESPITE_READ_OVERRIDE = new Set<string>([
 //     `add /Description ""`) clears it. Both behaviours proven live.
 const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   'AWS::IAM::Role\0MaxSessionDuration',
+  // IAM UpdateRole ignores an omitted Description the same way it ignores an omitted
+  // MaxSessionDuration (both are UpdateRole params) — a `remove` revert of an out-of-band
+  // description is a silent no-op, so write the empty-string default (from KNOWN_DEFAULTS)
+  // back explicitly. Precedent: AWS::Lambda::Alias Description below (UpdateAlias ignores an
+  // omitted description → an explicit "" write is needed). (Role Path is create-only → not
+  // reachable as undeclared drift, correctly barred and NOT listed here.)
+  'AWS::IAM::Role\0Description',
   'AWS::Lambda::Alias\0Description',
   // Cognito UpdateIdentityPool ignores an omitted AllowClassicFlow (live-observed: a
   // `remove` revert of an out-of-band `true` is a silent no-op), so write the `false`
@@ -94,6 +101,17 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // value persists), so write the default policy (TransferSecurityPolicy-2018-11) back
   // explicitly. The value comes from KNOWN_DEFAULTS.
   'AWS::Transfer::Server\0SecurityPolicyName',
+  // Same UpdateServer omit-ignored behavior for the other mutable server-config props that
+  // KNOWN_DEFAULTS folds — all set via the same UpdateServer call proven to keep an omitted
+  // property. Write their KNOWN_DEFAULTS defaults back explicitly so an out-of-band change
+  // reverts as a set-to-default rather than a silent `remove` no-op. IpAddressType ("IPV4")
+  // is a scalar; ProtocolDetails ({PassiveIp:'AUTO', SetStatOption:'DEFAULT',
+  // TlsSessionResumptionMode:'ENFORCED'}) and S3StorageOptions
+  // ({DirectoryListingOptimization:'DISABLED'}) are whole-object defaults. (Domain is
+  // create-only → barred and NOT listed here.)
+  'AWS::Transfer::Server\0IpAddressType',
+  'AWS::Transfer::Server\0ProtocolDetails',
+  'AWS::Transfer::Server\0S3StorageOptions',
   // App Runner UpdateService IGNORES an omitted top-level config object (live-observed:
   // a `remove` revert of an out-of-band HealthCheckConfiguration reports SUCCESS yet the
   // live value persists — mutated Interval 5->10 survived the revert). Write the whole
@@ -108,12 +126,21 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // SUCCESS yet the live value stayed AccuracyBased — "1 drift remain"). Write the
   // "TimeBased" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
   'AWS::Location::Tracker\0PositionFiltering',
+  // UpdateTracker likewise ignores an omitted PricingPlan (same omit-ignored provider
+  // behavior) — write the "RequestBasedUsage" default (from KNOWN_DEFAULTS) back explicitly.
+  // (Deprecated field, near-zero drift; listed for completeness so a `remove` no-op cannot
+  // leave a non-converging revert.)
+  'AWS::Location::Tracker\0PricingPlan',
   // Amazon Location UpdatePlaceIndex likewise IGNORES an omitted DataSourceConfiguration
   // (live-observed 2026-07-07: a `remove` revert of an out-of-band IntendedUse=Storage
   // reported SUCCESS yet the live value stayed Storage — "1 drift remain"). Write the whole
   // {IntendedUse:"SingleUse"} default object back explicitly (2nd object-valued entry after
   // AppRunner) so revert converges.
   'AWS::Location::PlaceIndex\0DataSourceConfiguration',
+  // UpdatePlaceIndex likewise ignores an omitted PricingPlan — write the "RequestBasedUsage"
+  // default (from KNOWN_DEFAULTS) back explicitly (deprecated field, twin of the Tracker
+  // PricingPlan entry above; listed for completeness).
+  'AWS::Location::PlaceIndex\0PricingPlan',
   // EventBridge UpdateApiDestination IGNORES an omitted InvocationRateLimitPerSecond
   // (live-observed on events-apidest-rich 2026-07-08: a `remove` revert of an out-of-band
   // 50 reported SUCCESS yet the live value stayed 50 — "1 drift remain"). Write the 300

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -574,6 +574,117 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#1080: undeclared Transfer::Server IpAddressType -> add op writing the IPV4 default, not a no-op remove', () => {
+    // AWS::Transfer::Server IpAddressType folds atDefault from KNOWN_DEFAULTS. UpdateServer is
+    // the same call proven (SecurityPolicyName) to IGNORE an omitted property, so a bare
+    // `remove` of an out-of-band change is a silent no-op — revert never converges. Revert
+    // must write the "IPV4" default explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Transfer::Server',
+      path: 'IpAddressType',
+      actual: 'DUAL_STACK',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/IpAddressType',
+      value: 'IPV4',
+      prior: 'DUAL_STACK',
+    });
+    expect(plan.items[0]!.ops[0]).not.toMatchObject({ op: 'remove' });
+  });
+
+  it('#1080: undeclared Transfer::Server ProtocolDetails -> add op writing the whole KNOWN_DEFAULTS default object', () => {
+    // Same UpdateServer omit-ignored behavior; ProtocolDetails is a whole-object default.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Transfer::Server',
+      path: 'ProtocolDetails',
+      actual: { PassiveIp: '1.2.3.4' },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ProtocolDetails',
+      value: {
+        PassiveIp: 'AUTO',
+        SetStatOption: 'DEFAULT',
+        TlsSessionResumptionMode: 'ENFORCED',
+      },
+      prior: { PassiveIp: '1.2.3.4' },
+    });
+  });
+
+  it('#1080: undeclared Transfer::Server S3StorageOptions -> add op writing the DISABLED default object', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Transfer::Server',
+      path: 'S3StorageOptions',
+      actual: { DirectoryListingOptimization: 'ENABLED' },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/S3StorageOptions',
+      value: { DirectoryListingOptimization: 'DISABLED' },
+      prior: { DirectoryListingOptimization: 'ENABLED' },
+    });
+  });
+
+  it('#1080: undeclared IAM::Role Description -> add op writing the empty-string default, not a no-op remove', () => {
+    // AWS::IAM::Role Description folds atDefault (empty string) from KNOWN_DEFAULTS. UpdateRole
+    // IGNORES an omitted Description the same way it ignores an omitted MaxSessionDuration, so a
+    // bare `remove` of an out-of-band description is a silent no-op. Revert must write "".
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Description',
+      actual: 'set out of band',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Description',
+      value: '',
+      prior: 'set out of band',
+    });
+    expect(plan.items[0]!.ops[0]).not.toMatchObject({ op: 'remove' });
+  });
+
+  it('#1080: undeclared Location::Tracker PricingPlan -> add op writing the RequestBasedUsage default', () => {
+    // UpdateTracker ignores an omitted PricingPlan (deprecated field); revert must set-to-default.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Location::Tracker',
+      path: 'PricingPlan',
+      actual: 'MobileAssetTracking',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/PricingPlan',
+      value: 'RequestBasedUsage',
+      prior: 'MobileAssetTracking',
+    });
+  });
+
+  it('#1080: undeclared Location::PlaceIndex PricingPlan -> add op writing the RequestBasedUsage default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Location::PlaceIndex',
+      path: 'PricingPlan',
+      actual: 'MobileAssetTracking',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/PricingPlan',
+      value: 'RequestBasedUsage',
+      prior: 'MobileAssetTracking',
+    });
+  });
+
   it('#912: undeclared DocDB DBInstance CACertificateIdentifier -> add op writing the default CA, not a no-op remove', () => {
     // AWS::DocDB::DBInstance CACertificateIdentifier is inside the ModifyDBInstance writer
     // allowlist: a `remove` empties the desired model, the writer sends nothing — a silent


### PR DESCRIPTION
Closes #1080

## Problem
For a type whose provider is proven to IGNORE an omitted property on update, every KNOWN_DEFAULTS-folded property needs a paired `REVERT_SET_DEFAULT_PATHS` entry — else an out-of-band change reverts as a bare `{op:'remove'}` the provider silently keeps, so the revert never converges (#631 flags 'removal was a no-op' forever). KNOWN_DEFAULTS grew on these types but the pairing was never added.

## Fix
Add the missing RSDP entries:
- `Transfer::Server` IpAddressType / ProtocolDetails / S3StorageOptions (same `UpdateServer` omit-ignored call proven for SecurityPolicyName)
- `IAM::Role` Description (`UpdateRole` ignores omitted Description; Lambda::Alias precedent)
- `Location::Tracker` / `Location::PlaceIndex` PricingPlan (deprecated, completeness)

`revertOp` already sources the value from KNOWN_DEFAULTS gated by RSDP membership, so only the RSDP keys were added — no value table needed. Create-only Domain/Path stay barred.

## Tests
`tests/revert-plan.test.ts`: each drifted prop plans a set-to-default `add` with the correct default value, NOT a bare `remove`. All 6 confirmed FAIL without the fix.

Gates green: typecheck / lint+fmt / build / 3758 tests.