### PR TITLE
fix(check): guard top-level --json stringify against non-serializable finding values (#1060)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -260,6 +260,35 @@ export function hasBaselineForStack(stackName: string, region: string): boolean 
   });
 }
 
+// #1060 — the top-level `--json` emit runs AFTER the per-stack loop, OUTSIDE any
+// try/catch, so a non-serializable finding value (a BigInt, a circular reference)
+// that survived the per-stack try detonates `JSON.stringify` and crashes the whole
+// run with partial/empty stdout — violating the #943/#1000/#1063 contract that every
+// `--json` exit path leaves stdout a single JSON.parse-able value. This wraps the
+// stringify so the user still gets their real data (BigInt→string, circular refs
+// replaced by a marker), falling back to `[]` only if even the guarded pass throws.
+export function safeStringifyJson(value: unknown): string {
+  const seen = new WeakSet<object>();
+  const replacer = (_key: string, v: unknown): unknown => {
+    if (typeof v === 'bigint') return v.toString();
+    if (typeof v === 'object' && v !== null) {
+      if (seen.has(v)) return '[Circular]';
+      seen.add(v);
+    }
+    return v;
+  };
+  try {
+    return JSON.stringify(value, replacer, 2);
+  } catch (e) {
+    // Even the guarded replacer failed (e.g. a throwing toJSON, a non-coerced type).
+    // Keep the contract: emit a valid-JSON fallback and route the diagnostic to stderr.
+    console.error(
+      `error: could not serialize --json output: ${(e as Error).message} — emitting [] instead`
+    );
+    return '[]';
+  }
+}
+
 export async function runCheck(args: string[]): Promise<number> {
   const a = parseCommonArgs(args, 'check');
   if (a.profile) process.env.AWS_PROFILE = a.profile; // honored by SDK clients + synth subprocess
@@ -695,7 +724,7 @@ export async function runCheck(args: string[]): Promise<number> {
   // value. Printed once here, after the loop, on stdout (the machine channel; all notes /
   // warnings above go to stderr). Even a single-stack run is an array of one, kept uniform
   // so a consumer's JSON.parse always yields an array.
-  if (a.json) console.log(JSON.stringify(jsonReports, null, 2));
+  if (a.json) console.log(safeStringifyJson(jsonReports));
   // Report-only mode found drift: say so, and say how to make it fail — a script
   // author piping this must discover --fail from the output, not from a surprise
   // green pipeline (R53). Suppressed under --json (machine consumers read stdout).

--- a/tests/json-safe-stringify-1060.test.ts
+++ b/tests/json-safe-stringify-1060.test.ts
@@ -1,0 +1,59 @@
+// #1060 — the top-level `--json` emit in runCheck (`console.log(safeStringifyJson(...))`)
+// runs AFTER the per-stack loop, OUTSIDE any try/catch. A non-serializable finding value
+// (a BigInt, a circular reference) that survived the per-stack try used to detonate the
+// bare `JSON.stringify` there, crashing the whole run with partial/empty stdout — a breach
+// of the #943/#1000/#1063 contract that every `--json` exit path leaves stdout a single
+// JSON.parse-able value. `safeStringifyJson` guards it: BigInt→string, circular→marker,
+// and a valid-JSON `[]` fallback if even the guarded pass throws.
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { safeStringifyJson } from '../src/commands/check.js';
+
+describe('safeStringifyJson (#1060 — non-serializable --json values must not crash)', () => {
+  it('coerces a BigInt to a string instead of throwing', () => {
+    const out = safeStringifyJson([{ stack: 's', drifted: 1, value: 10n }]);
+    const parsed = JSON.parse(out); // must not throw, must be valid JSON
+    expect(parsed).toEqual([{ stack: 's', drifted: 1, value: '10' }]);
+  });
+
+  it('replaces a circular reference with a marker instead of throwing', () => {
+    const node: Record<string, unknown> = { name: 'a' };
+    node.self = node; // circular
+    const out = safeStringifyJson([node]);
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual([{ name: 'a', self: '[Circular]' }]);
+  });
+
+  it('handles a BigInt nested inside a circular structure', () => {
+    const a: Record<string, unknown> = { size: 5n };
+    const b: Record<string, unknown> = { a };
+    a.b = b; // circular via b -> a -> b
+    const out = safeStringifyJson({ a, b });
+    const parsed = JSON.parse(out);
+    // both the BigInt coercion and the cycle break survive; only that it parsed + coerced
+    expect(JSON.stringify(parsed)).toContain('"size":"5"');
+    expect(JSON.stringify(parsed)).toContain('[Circular]');
+  });
+
+  it('emits valid-JSON "[]" fallback (not a throw) when even the guarded pass fails, logging to stderr', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // a throwing toJSON defeats the replacer (JSON.stringify calls toJSON before the replacer)
+      const hostile = {
+        toJSON() {
+          throw new Error('boom');
+        },
+      };
+      const out = safeStringifyJson([hostile]);
+      expect(out).toBe('[]');
+      expect(JSON.parse(out)).toEqual([]); // still a single JSON.parse-able value
+      expect(err).toHaveBeenCalled(); // diagnostic went to stderr, never stdout
+    } finally {
+      err.mockRestore();
+    }
+  });
+
+  it('passes an ordinary serializable value through unchanged', () => {
+    const reports = [{ stack: 's (us-east-1)', drifted: 0, findings: [], error: 'skipped' }];
+    expect(JSON.parse(safeStringifyJson(reports))).toEqual(reports);
+  });
+});


### PR DESCRIPTION
Closes #1060

Offline fix with unit tests. A BigInt / circular finding value no longer crashes the whole --json run with partial/empty stdout — safeStringifyJson coerces BigInt→string, breaks cycles, and falls back to [] (stderr diagnostic) so stdout stays a single JSON.parse-able value.