### PR TITLE
fix(read): derive Events::Rule CC-identifier ARN partition via partitionForRegion (#1062)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -3,6 +3,7 @@
 //   GetResource → skip + log. Declared/undeclared labeling happens later.
 import { type CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
 import { isResourceNotFoundError } from '../aws-errors.js';
+import { partitionForRegion } from '../desired/template-adapter.js';
 import { OVERRIDE_READABLE_WRITEONLY } from '../schema/schema-strip.js';
 import type { DesiredResource } from '../types.js';
 import { SDK_OVERRIDES, SDK_SUPPLEMENTS } from './overrides.js';
@@ -406,11 +407,11 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
     if (typeof busArn === 'string' && busArn.includes(':event-bus/'))
       return `${busArn.replace(':event-bus/', ':rule/')}/${ruleName}`;
     if (region && account) {
-      const partition = region.startsWith('cn-')
-        ? 'aws-cn'
-        : region.startsWith('us-gov-')
-          ? 'aws-us-gov'
-          : 'aws';
+      // Derive the partition from the region (GovCloud / China / the four ISO
+      // partitions), NOT a cn-/us-gov-only inline ternary — an ISO-region rule ARN
+      // otherwise gets the commercial `aws` partition and UpdateResource rejects it
+      // (#1062, the #945 residue; same fix as #730's partitionForRegion adoption).
+      const { partition } = partitionForRegion(region);
       return `arn:${partition}:events:${region}:${account}:rule/${busName}/${ruleName}`;
     }
     return undefined;

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -278,6 +278,31 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('arn:aws-us-gov:events:us-gov-west-1:111111111111:rule/myBus/myRule');
   });
 
+  // #1062: the inline cn-/us-gov ternary fell through to the commercial `aws` partition
+  // for the four ISO partitions partitionForRegion supports — an ISO-region rule ARN was
+  // then rejected by UpdateResource. Now derived via partitionForRegion.
+  it('Events::Rule (custom bus): honors an ISO region partition (aws-iso)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::Events::Rule', physicalId: 'myBus|myRule', declared: {} }),
+      'us-iso-east-1',
+      '111111111111'
+    );
+    expect(sent()).toBe('arn:aws-iso:events:us-iso-east-1:111111111111:rule/myBus/myRule');
+  });
+
+  it('Events::Rule (custom bus): honors the China region partition (aws-cn)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::Events::Rule', physicalId: 'myBus|myRule', declared: {} }),
+      'cn-north-1',
+      '111111111111'
+    );
+    expect(sent()).toBe('arn:aws-cn:events:cn-north-1:111111111111:rule/myBus/myRule');
+  });
+
   it('Events::Rule (default bus): a bare-name physical id passes through UNCHANGED', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(


### PR DESCRIPTION
Closes #1062.

## Problem
The revert-side `AWS::Events::Rule` CC-identifier adapter (`src/read/router.ts`) rebuilt the rule ARN with an inline `cn-`/`us-gov-`-only partition ternary. A rule in any of the four ISO partitions (`aws-iso`, `aws-iso-b`, `aws-iso-f`, `aws-iso-e`) fell through to the commercial `aws` partition, so `UpdateResource` was sent a wrong-partition ARN and rejected — the #945 residue that broke the check→revert contract (#1003) on the revert half in ISO regions.

## Fix
Replace the inline ternary with `partitionForRegion(region).partition` — the #730 helper that already covers GovCloud, China, and all four ISO partitions. One-line substitution + import.

## Tests
Added ISO-region (`us-iso-east-1` → `aws-iso`) and China-region (`cn-north-1` → `aws-cn`) cases to `tests/router.test.ts`; the ISO case fails on the old ternary. Full suite green (3754).

Offline/deterministic (identifier-adapter logic) — corpus/unit tests are the evidence, no live deploy.