### PR TITLE
fix(revert): retry a Cloud Control status-poll failure without re-sending the mutation (#1064)

### DIFF
--- a/src/revert/apply.ts
+++ b/src/revert/apply.ts
@@ -9,7 +9,7 @@ import {
   UpdateResourceCommand,
 } from '@aws-sdk/client-cloudcontrol';
 import { type RevertItem, toPatchDocument } from './plan.js';
-import { errorText, type RetryOptions, retryTransient } from './transient.js';
+import { classifyTransient, errorText, type RetryOptions, retryTransient } from './transient.js';
 
 export interface ApplyResult {
   ok: boolean;
@@ -26,6 +26,14 @@ const POLL_INTERVAL_MS = 2000;
 // as soon as the operation reaches a terminal state, so a high ceiling never slows the
 // common case — it only bounds how long we wait on an operation that never terminates.
 const TIMEOUT_MS = 15 * 60 * 1000;
+// A GetResourceRequestStatus poll-read can fail TRANSIENTLY (throttling / network / 5xx)
+// while the UpdateResource/DeleteResource it is observing is still running server-side.
+// That poll failure is NOT an operation failure — retry the POLL with the SAME request
+// token rather than letting it bubble to retryTransient, which would RE-SEND the whole
+// mutation while the first op is still in flight (#1064). Bound the consecutive poll
+// failures so a PERSISTENT poll outage still terminates (the mutating client already
+// retries each send internally, so each throw here follows several SDK attempts).
+const MAX_POLL_READ_FAILURES = 10;
 
 // A DELETE whose target is ALREADY absent is the goal state, not a failure. Two ways
 // this happens for an `added`-resource revert: (1) deleting an API Gateway Resource
@@ -45,16 +53,22 @@ export function isAlreadyGone(e: unknown): boolean {
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
-// Poll a Cloud Control ProgressEvent (Update or Delete) to a terminal state.
+// Poll a Cloud Control ProgressEvent (Update or Delete) to a terminal state. `sleep`/`now`
+// are injectable so tests exercise the poll loop without real 2s waits.
 async function pollToCompletion(
   cc: CloudControlClient,
-  first: ProgressEvent | undefined
+  first: ProgressEvent | undefined,
+  poll: Pick<RetryOptions, 'sleep' | 'now'> = {}
 ): Promise<ApplyResult> {
+  const doSleep = poll.sleep ?? sleep;
+  const clock = poll.now ?? Date.now;
   let event = first;
   const token = event?.RequestToken;
   if (!token) return { ok: false, error: 'no request token returned' };
-  const deadline = Date.now() + TIMEOUT_MS;
-  while (Date.now() < deadline) {
+  const deadline = clock() + TIMEOUT_MS;
+  // Consecutive transient poll-read failures (reset on any successful read).
+  let pollFailures = 0;
+  while (clock() < deadline) {
     const status = event?.OperationStatus;
     if (status === 'SUCCESS') return { ok: true };
     if (status === 'FAILED' || status === 'CANCEL_COMPLETE') {
@@ -64,9 +78,32 @@ async function pollToCompletion(
       const code = event?.ErrorCode;
       return { ok: false, error: code && !msg.includes(code) ? `${code}: ${msg}` : msg };
     }
-    await sleep(POLL_INTERVAL_MS);
-    const polled = await cc.send(new GetResourceRequestStatusCommand({ RequestToken: token }));
-    event = polled.ProgressEvent;
+    await doSleep(POLL_INTERVAL_MS);
+    try {
+      const polled = await cc.send(new GetResourceRequestStatusCommand({ RequestToken: token }));
+      event = polled.ProgressEvent;
+      pollFailures = 0;
+    } catch (e) {
+      // A poll-read error, NOT an operation failure — the mutation is still in flight.
+      const text = errorText(e);
+      // A terminal poll error (e.g. an invalid/expired RequestToken) cannot be resolved
+      // by re-reading: return it as a NON-transient failure so retryTransient does not
+      // re-send the mutation. Keep polling the SAME token only for transient poll errors.
+      if (!classifyTransient(text).transient) return { ok: false, error: text };
+      if (++pollFailures >= MAX_POLL_READ_FAILURES) {
+        // Persistent poll outage: the operation likely converged (or is still running) —
+        // do NOT re-send it. Report a NON-transient failure — the message deliberately
+        // omits the raw poll error's transient keyword (e.g. "Throttling") so retryTransient
+        // classifies it terminal and does NOT re-send the mutation; the next `check`
+        // re-reads the true state. #1064: better a stale FAILED than a duplicate AWS
+        // mutation racing the in-flight op.
+        return {
+          ok: false,
+          error: `unable to confirm Cloud Control request status after ${MAX_POLL_READ_FAILURES} poll attempts (mutation NOT resent, to avoid a duplicate write)`,
+        };
+      }
+      // else: re-poll the same request token (event unchanged → still non-terminal).
+    }
   }
   return { ok: false, error: 'timed out waiting for Cloud Control request' };
 }
@@ -93,7 +130,7 @@ export async function applyRevertItem(
           PatchDocument: toPatchDocument(item),
         })
       );
-      return await pollToCompletion(cc, res.ProgressEvent);
+      return await pollToCompletion(cc, res.ProgressEvent, retry);
     } catch (e) {
       return { ok: false, error: errorText(e) };
     }
@@ -174,7 +211,7 @@ export async function applyRevertDelete(
       const res = await cc.send(
         new DeleteResourceCommand({ TypeName: item.resourceType, Identifier: identifier })
       );
-      const result = await pollToCompletion(cc, res.ProgressEvent);
+      const result = await pollToCompletion(cc, res.ProgressEvent, retry);
       // already-gone surfaced as a FAILED event (vs a thrown error, handled below)
       if (!result.ok && isAlreadyGone({ message: result.error })) return { ok: true };
       return result;

--- a/tests/apply.test.ts
+++ b/tests/apply.test.ts
@@ -1,6 +1,7 @@
 import {
   CloudControlClient,
   DeleteResourceCommand,
+  GetResourceRequestStatusCommand,
   UpdateResourceCommand,
 } from '@aws-sdk/client-cloudcontrol';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -154,6 +155,72 @@ describe('applyRevertItem — transient retry then hint (issue #467)', () => {
     expect(r.ok).toBe(false);
     expect(r.error).toContain('Throttling');
     expect(r.transient).toBe(true);
+  });
+});
+
+describe('pollToCompletion — a status-poll failure must NOT re-send the mutation (issue #1064)', () => {
+  const THROTTLE = Object.assign(new Error('Rate exceeded'), { name: 'ThrottlingException' });
+
+  it('retries a throttled status-poll on the SAME request token, sends UpdateResource exactly ONCE', async () => {
+    // One UpdateResource send → IN_PROGRESS. The first status-poll is throttled (a poll
+    // read, NOT an op failure); the second poll returns SUCCESS. The mutation must be sent
+    // once, never re-sent, and the item converges.
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { RequestToken: 't1', OperationStatus: 'IN_PROGRESS' },
+    });
+    cc.on(GetResourceRequestStatusCommand)
+      .rejectsOnce(THROTTLE)
+      .resolves({ ProgressEvent: { RequestToken: 't1', OperationStatus: 'SUCCESS' } });
+
+    const r = await applyRevertItem(cc as unknown as CloudControlClient, updateItem(), undefined, {
+      now: () => 0, // freeze the clock so the poll loop never hits the 15-min deadline
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(r.ok).toBe(true);
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(1); // NOT re-sent
+    expect(cc.commandCalls(GetResourceRequestStatusCommand).length).toBe(2); // throttled + success
+    // Every status poll used the original request token — polling the in-flight op, not a new one.
+    for (const call of cc.commandCalls(GetResourceRequestStatusCommand)) {
+      expect((call.args[0].input as { RequestToken?: string }).RequestToken).toBe('t1');
+    }
+  });
+
+  it('a persistent status-poll outage returns a terminal failure that does NOT re-send the mutation', async () => {
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { RequestToken: 't1', OperationStatus: 'IN_PROGRESS' },
+    });
+    cc.on(GetResourceRequestStatusCommand).rejects(THROTTLE);
+
+    const r = await applyRevertItem(cc as unknown as CloudControlClient, updateItem(), undefined, {
+      now: () => 0,
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.transient).toBeUndefined(); // terminal — retryTransient must not re-send
+    expect(r.error).toContain('NOT resent');
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(1); // sent ONCE, never duplicated
+  });
+
+  it('a terminal status-poll error (bad token) is returned without re-sending', async () => {
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { RequestToken: 't1', OperationStatus: 'IN_PROGRESS' },
+    });
+    cc.on(GetResourceRequestStatusCommand).rejects(
+      Object.assign(new Error('RequestToken t1 not found'), {
+        name: 'RequestTokenNotFoundException',
+      })
+    );
+
+    const r = await applyRevertItem(cc as unknown as CloudControlClient, updateItem(), undefined, {
+      now: () => 0,
+      sleep: () => Promise.resolve(),
+    });
+
+    expect(r.ok).toBe(false);
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(1); // one poll failure, no re-send
+    expect(cc.commandCalls(GetResourceRequestStatusCommand).length).toBe(1);
   });
 });
 


### PR DESCRIPTION
Closes #1064 (the core, dangerous half — see note below).

## Problem
`applyRevertItem` / `applyRevertDelete` wrapped the `UpdateResource`/`DeleteResource` **send** AND the `pollToCompletion` **poll** in one `retryTransient` body. A throttled (or otherwise transient) `GetResourceRequestStatus` poll therefore surfaced as an *operation* failure, and `retryTransient` re-invoked the whole op — **RE-SENDING the mutation while the first was still in flight**. Result: a duplicate write racing the in-flight op (or a `ConcurrentOperationException`, which matches no transient pattern → reported terminal FAILED), and a revert that actually converged reported `FAILED` + exit 2 under throttling.

## Fix (`src/revert/apply.ts` only)
`pollToCompletion` now handles a poll-read failure locally:
- **transient** poll error (throttling/network/5xx) → retry the poll on the **same `RequestToken`** (keeps observing the in-flight op), bounded by `MAX_POLL_READ_FAILURES`;
- **terminal** poll error (e.g. a bad/expired token) → return non-transient, no re-send;
- **persistent** poll outage → return a terminal failure whose message deliberately omits the transient keyword, so `retryTransient` does **not** re-send the mutation; the next `check` re-reads the true state.

`sleep`/`now` are threaded into `pollToCompletion` so tests drive the poll loop without real 2s waits.

## Tests
Three new cases in `tests/apply.test.ts`: a throttled poll retried on the same token with `UpdateResource` sent **exactly once**; a persistent poll outage that returns terminal without re-sending; a terminal (bad-token) poll error returned without re-send. Full suite green (3755).

## Scope note
Root cause #1 in the issue (the mutating client in `stack-actions.ts` uses the SDK-default `maxAttempts:3` instead of `READ_RETRY`) is **left to the lane that owns `stack-actions.ts`** — the poll-local retry here makes the weak client default non-critical for the high-volume status polls. Flagged on the issue.

Offline/deterministic (mocked Cloud Control client) — unit tests are the evidence, no live deploy.