### PR TITLE
fix(desired): parse a duplicate-map-key YAML template last-wins instead of throwing (#1074)

### DIFF
--- a/src/desired/yaml-cfn.ts
+++ b/src/desired/yaml-cfn.ts
@@ -223,6 +223,14 @@ function restrictYaml11Tags(baseTags: Tags): Tags {
 const CFN_YAML_PARSE_OPTIONS: ParseOptions & SchemaOptions = {
   schema: 'yaml-1.1',
   customTags: restrictYaml11Tags,
+  // CloudFormation ACCEPTS a duplicate map key and deploys LAST-wins (proven via
+  // validate-template + get-template-summary: a duplicated Parameter Default resolves to
+  // the last occurrence, for YAML and JSON alike). yaml@2 defaults to `uniqueKeys: true`,
+  // which makes a duplicate key a hard parse ERROR — so a hand-written template CFn happily
+  // deployed (a copy-pasted property, two `Tags:` blocks, a duplicated logicalId) made the
+  // ENTIRE stack uncheckable (YAMLParseError → exit 2). Mirror CFn's last-wins semantics
+  // instead of throwing (#1074). JSON is already last-wins via JSON.parse — no gap there.
+  uniqueKeys: false,
 };
 
 export function detectTemplateFormat(text: string): TemplateFormat {

--- a/tests/yaml-cfn.test.ts
+++ b/tests/yaml-cfn.test.ts
@@ -208,6 +208,35 @@ describe('yaml-cfn parse', () => {
     expect(() => parseCfnTemplate('[1,2]')).toThrow();
   });
 
+  // #1074: CloudFormation ACCEPTS a duplicate map key and deploys last-wins; yaml@2's
+  // default uniqueKeys:true would throw YAMLParseError and make the whole stack uncheckable.
+  it('a duplicated Properties key parses last-wins (does not throw)', () => {
+    const t = parseCfnTemplate(`Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: firstwins
+      BucketName: lastwins`);
+    expect((t as any).Resources.B.Properties.BucketName).toBe('lastwins');
+  });
+
+  it('a duplicated logicalId parses last-wins (does not throw)', () => {
+    const t = parseCfnTemplate(`Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: first
+  B:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: second`);
+    // Last occurrence wins for the duplicated key, matching CFn deploy semantics.
+    expect((t as any).Resources.B).toEqual({
+      Type: 'AWS::SNS::Topic',
+      Properties: { TopicName: 'second' },
+    });
+  });
+
   it('degrades a dot-less !GetAtt to a 1-element array instead of crashing the whole parse', () => {
     // A custom-tag resolve() that throws aborts the ENTIRE yaml parse — one malformed
     // !GetAtt would crash the whole stack check. It must degrade to UNRESOLVED-able


### PR DESCRIPTION
Closes #1074.

## Problem
CloudFormation **accepts** a duplicated map key and deploys **last-wins** (verified read-only against CFn: `validate-template` accepts a duplicated Properties key and a duplicated logicalId; `get-template-summary` on a template with a duplicated Parameter `Default` returns the last value — for YAML and JSON alike). But `yaml@2` defaults to `uniqueKeys: true`, so `parseCfnTemplate` threw `YAMLParseError: Map keys must be unique`. One accidental duplicate anywhere (a copy-pasted property, two `Tags:` blocks, a duplicated logicalId) made the **entire stack uncheckable** — per-stack error, exit 2, on every verb that loads desired state (check/record/revert) — for a template CFn had happily deployed.

## Fix
Add `uniqueKeys: false` to `CFN_YAML_PARSE_OPTIONS` (`src/desired/yaml-cfn.ts`), so a duplicate key resolves last-wins, matching CFn's proven deploy semantics. JSON was already last-wins via `JSON.parse` — no gap there.

## Tests
Two new cases in `tests/yaml-cfn.test.ts`: a duplicated `Properties` key and a duplicated logicalId parse to the last occurrence and no longer throw. Full suite green (3793).

Offline/deterministic (parser behavior) — unit tests are the evidence, no live deploy. Branched off current main (carries #1053/#1125).