### PR TITLE
fix(read): fail safe on an UNRESOLVED child-identity prop in three enumerators (#1089)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -362,6 +362,10 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
   const declaredValidatorIds: string[] = [];
   // Declared gateway responses of THIS api, matched by ResponseType.
   const declaredResponseTypes: string[] = [];
+  // Fail-safe: a declared GatewayResponse whose IDENTITY (ResponseType) is UNRESOLVED can't be
+  // matched against the live responses — suppress gateway-response added-reporting for this api
+  // rather than false-flag a live DEFAULT_4XX/5XX as `added` with a DeleteResource offer (#1089).
+  let gatewayResponseTypeUnresolved = false;
   // Declared stages of THIS api. An AWS::ApiGateway::Stage's Ref/physical id IS its StageName.
   const declaredStageNames: string[] = [];
   for (const r of desired.resources) {
@@ -385,10 +389,13 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
       declaredValidatorIds.push(r.physicalId);
     } else if (
       r.resourceType === 'AWS::ApiGateway::GatewayResponse' &&
-      parentRefMatches(r.declared.RestApiId, apiId) &&
-      typeof r.declared.ResponseType === 'string'
+      parentRefMatches(r.declared.RestApiId, apiId)
     ) {
-      declaredResponseTypes.push(r.declared.ResponseType);
+      if (r.declared.ResponseType === UNRESOLVED || hasUnresolved(r.declared.ResponseType)) {
+        gatewayResponseTypeUnresolved = true;
+      } else if (typeof r.declared.ResponseType === 'string') {
+        declaredResponseTypes.push(r.declared.ResponseType);
+      }
     } else if (
       r.resourceType === 'AWS::ApiGateway::Stage' &&
       parentRefMatches(r.declared.RestApiId, apiId)
@@ -464,6 +471,7 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     apiId,
     declaredResponseTypes,
     liveResponseTypes,
+    hasUnresolvedDeclaredResponseType: gatewayResponseTypeUnresolved,
   });
 
   // Stages — the V2 enumerator (enumerateHttpApiChildren) already sweeps + diffs Stages; the
@@ -681,11 +689,15 @@ export interface ApiGatewayGatewayResponseInput {
   apiId: string;
   declaredResponseTypes: string[]; // ResponseTypes of AWS::ApiGateway::GatewayResponse on this api
   liveResponseTypes: { type: string; label?: string | undefined }[];
+  // Fail-safe (#1089): a declared GatewayResponse's identity (ResponseType) was UNRESOLVED, so it
+  // could not be matched against the live responses — suppress ALL added for this api.
+  hasUnresolvedDeclaredResponseType?: boolean;
 }
 
 export function diffApiGatewayGatewayResponses(
   input: ApiGatewayGatewayResponseInput
 ): AddedChild[] {
+  if (input.hasUnresolvedDeclaredResponseType) return [];
   const { apiId, declaredResponseTypes, liveResponseTypes } = input;
   const declared = new Set(declaredResponseTypes);
   const added: AddedChild[] = [];
@@ -1634,9 +1646,14 @@ async function enumerateUserPoolChildren(ctx: EnumeratorContext): Promise<AddedC
 export interface GraphQLApiChildInput {
   declaredDataSourceNames: string[]; // Names of AWS::AppSync::DataSource declared on this api
   liveDataSources: { name: string; arn: string; label?: string | undefined }[];
+  // Fail-safe (#1089): a declared datasource's identity (Name) was UNRESOLVED, so it could not
+  // be matched against the live datasources — suppress ALL added for this api (a `revert
+  // --remove-unrecorded` would otherwise DeleteResource a declared datasource).
+  hasUnresolvedDeclaredDataSource?: boolean;
 }
 
 export function diffGraphQLApiChildren(input: GraphQLApiChildInput): AddedChild[] {
+  if (input.hasUnresolvedDeclaredDataSource) return [];
   const declared = new Set(input.declaredDataSourceNames);
   const added: AddedChild[] = [];
   for (const ds of input.liveDataSources) {
@@ -1669,9 +1686,13 @@ async function pageDataSources(client: AppSyncClient, apiId: string): Promise<Ap
 export interface GraphQLApiResolverInput {
   declaredResolverKeys: string[]; // `${typeName}|${fieldName}` of declared AWS::AppSync::Resolver
   liveResolvers: { key: string; arn: string; label?: string | undefined }[];
+  // Fail-safe (#1089): a declared resolver's identity (TypeName/FieldName) was UNRESOLVED, so it
+  // could not be matched against the live resolvers — suppress ALL added for this api.
+  hasUnresolvedDeclaredResolver?: boolean;
 }
 
 export function diffGraphQLApiResolvers(input: GraphQLApiResolverInput): AddedChild[] {
+  if (input.hasUnresolvedDeclaredResolver) return [];
   const declared = new Set(input.declaredResolverKeys);
   const added: AddedChild[] = [];
   for (const r of input.liveResolvers) {
@@ -1770,16 +1791,24 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
   // DataSource's ApiId (Fn::GetAtt ApiId, resolved by gather) is the bare api id; tolerate
   // an ARN form too in case gather resolved it differently.
   const declaredDataSourceNames: string[] = [];
+  // Fail-safe: a declared datasource whose IDENTITY (Name) is UNRESOLVED can't be matched
+  // against the live datasources by name — suppress datasource added-reporting for this api
+  // rather than false-flag every live datasource as `added` with a DeleteResource offer
+  // (#1089, the identity-prop half of #962; #1016 covered only the parent ApiId ref).
+  let datasourceNameUnresolved = false;
   for (const r of desired.resources) {
-    if (r.resourceType !== 'AWS::AppSync::DataSource' || typeof r.declared.Name !== 'string') {
-      continue;
-    }
+    if (r.resourceType !== 'AWS::AppSync::DataSource') continue;
     // Fail-safe: an UNRESOLVED ApiId (dynamic ref / no-default Param / degraded ImportValue)
     // must not exclude a declared datasource (#962); only a RESOLVED, non-matching id does.
     const declaredApiId = r.declared.ApiId;
     if (declaredApiId !== UNRESOLVED && !hasUnresolved(declaredApiId)) {
       if (typeof declaredApiId !== 'string' || bareApiId(declaredApiId) !== apiId) continue;
     }
+    if (r.declared.Name === UNRESOLVED || hasUnresolved(r.declared.Name)) {
+      datasourceNameUnresolved = true;
+      continue;
+    }
+    if (typeof r.declared.Name !== 'string') continue;
     declaredDataSourceNames.push(r.declared.Name);
   }
 
@@ -1788,6 +1817,9 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
   // unreliable). A declared Resolver's ApiId (Fn::GetAtt ApiId) is the bare api id;
   // tolerate an ARN form too in case gather resolved it differently.
   const declaredResolverKeys: string[] = [];
+  // Fail-safe: a declared resolver whose IDENTITY (TypeName/FieldName) is UNRESOLVED can't be
+  // matched against the live resolvers — suppress resolver added-reporting for this api (#1089).
+  let resolverKeyUnresolved = false;
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::AppSync::Resolver') continue;
     // Fail-safe: an UNRESOLVED ApiId must not exclude a declared resolver (#962).
@@ -1796,6 +1828,15 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
       if (typeof declaredApiId !== 'string' || bareApiId(declaredApiId) !== apiId) continue;
     }
     const { TypeName, FieldName } = r.declared;
+    if (
+      TypeName === UNRESOLVED ||
+      hasUnresolved(TypeName) ||
+      FieldName === UNRESOLVED ||
+      hasUnresolved(FieldName)
+    ) {
+      resolverKeyUnresolved = true;
+      continue;
+    }
     if (typeof TypeName !== 'string' || typeof FieldName !== 'string') continue;
     declaredResolverKeys.push(`${TypeName}|${FieldName}`);
   }
@@ -1827,7 +1868,11 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
       arn: ds.dataSourceArn,
       label: ds.type ? `${ds.type} ${ds.name}` : ds.name,
     }));
-  const datasourceAdded = diffGraphQLApiChildren({ declaredDataSourceNames, liveDataSources });
+  const datasourceAdded = diffGraphQLApiChildren({
+    declaredDataSourceNames,
+    liveDataSources,
+    hasUnresolvedDeclaredDataSource: datasourceNameUnresolved,
+  });
 
   // Resolvers are scoped per type: list all types, then list resolvers per type.
   const types = await pageTypes(client, apiId);
@@ -1843,7 +1888,11 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
       });
     }
   }
-  const resolverAdded = diffGraphQLApiResolvers({ declaredResolverKeys, liveResolvers });
+  const resolverAdded = diffGraphQLApiResolvers({
+    declaredResolverKeys,
+    liveResolvers,
+    hasUnresolvedDeclaredResolver: resolverKeyUnresolved,
+  });
 
   // Functions are listed per api (not per type).
   const functions = await pageAppSyncFunctions(client, apiId);

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -406,6 +406,31 @@ describe('diffApiGatewayGatewayResponses (REST API gateway responses)', () => {
     });
     expect(added).toEqual([]);
   });
+
+  // #1089: a declared GatewayResponse is matched ONLY by ResponseType. When that identity is
+  // UNRESOLVED (dynamic ref / no-default Param / degraded ImportValue), the enumerator raises
+  // hasUnresolvedDeclaredResponseType — the diff must FAIL SAFE (no live DEFAULT_4XX/5XX flagged
+  // added, since a `revert --remove-unrecorded` would DeleteResource a declared response).
+  it('fails safe: an UNRESOLVED declared ResponseType suppresses ALL added for this api (#1089)', () => {
+    expect(
+      diffApiGatewayGatewayResponses({
+        apiId: API,
+        declaredResponseTypes: [], // the UNRESOLVED ResponseType never reached the list
+        liveResponseTypes: [{ type: 'DEFAULT_4XX' }],
+        hasUnresolvedDeclaredResponseType: true,
+      })
+    ).toEqual([]);
+  });
+
+  it('with no UNRESOLVED declared ResponseType, a genuine out-of-band response is STILL added (#1089)', () => {
+    const added = diffApiGatewayGatewayResponses({
+      apiId: API,
+      declaredResponseTypes: ['DEFAULT_4XX'],
+      liveResponseTypes: [{ type: 'DEFAULT_4XX' }, { type: 'DEFAULT_5XX' }],
+      hasUnresolvedDeclaredResponseType: false,
+    });
+    expect(added.map((a) => a.identifier)).toEqual([`${API}:DEFAULT_5XX`]);
+  });
 });
 
 describe('diffApiGatewayV2Children (HTTP / WebSocket API)', () => {
@@ -1169,6 +1194,31 @@ describe('diffGraphQLApiChildren (AppSync data sources)', () => {
       })
     ).toEqual([]);
   });
+
+  // #1089: a declared DataSource is matched ONLY by Name. When that identity is UNRESOLVED,
+  // the enumerator raises hasUnresolvedDeclaredDataSource — the diff must FAIL SAFE (no live
+  // datasource flagged added, since a `revert --remove-unrecorded` would DeleteResource it).
+  it('fails safe: an UNRESOLVED declared Name suppresses ALL added for this api (#1089)', () => {
+    expect(
+      diffGraphQLApiChildren({
+        declaredDataSourceNames: [], // the UNRESOLVED Name never reached the list
+        liveDataSources: [{ name: 'console', arn: DS('console') }],
+        hasUnresolvedDeclaredDataSource: true,
+      })
+    ).toEqual([]);
+  });
+
+  it('with no UNRESOLVED declared Name, a genuine out-of-band data source is STILL added (#1089)', () => {
+    const added = diffGraphQLApiChildren({
+      declaredDataSourceNames: ['declared'],
+      liveDataSources: [
+        { name: 'declared', arn: DS('declared') },
+        { name: 'console', arn: DS('console') },
+      ],
+      hasUnresolvedDeclaredDataSource: false,
+    });
+    expect(added.map((a) => a.identifier)).toEqual([DS('console')]);
+  });
 });
 
 describe('diffGraphQLApiResolvers (AppSync resolvers)', () => {
@@ -1211,6 +1261,31 @@ describe('diffGraphQLApiResolvers (AppSync resolvers)', () => {
         ],
       })
     ).toEqual([]);
+  });
+
+  // #1089: a declared Resolver is matched ONLY by its `${TypeName}|${FieldName}` key. When
+  // either identity is UNRESOLVED the enumerator raises hasUnresolvedDeclaredResolver — the
+  // diff must FAIL SAFE (no live resolver flagged added → no destructive DeleteResource offer).
+  it('fails safe: an UNRESOLVED declared TypeName/FieldName suppresses ALL added for this api (#1089)', () => {
+    expect(
+      diffGraphQLApiResolvers({
+        declaredResolverKeys: [], // the UNRESOLVED key never reached the list
+        liveResolvers: [{ key: 'Query|ping', arn: RES('Query', 'ping') }],
+        hasUnresolvedDeclaredResolver: true,
+      })
+    ).toEqual([]);
+  });
+
+  it('with no UNRESOLVED declared resolver, a genuine out-of-band resolver is STILL added (#1089)', () => {
+    const added = diffGraphQLApiResolvers({
+      declaredResolverKeys: ['Query|ping'],
+      liveResolvers: [
+        { key: 'Query|ping', arn: RES('Query', 'ping') },
+        { key: 'Query|pong', arn: RES('Query', 'pong') },
+      ],
+      hasUnresolvedDeclaredResolver: false,
+    });
+    expect(added.map((a) => a.identifier)).toEqual([RES('Query', 'pong')]);
   });
 });
 


### PR DESCRIPTION
Closes #1089.

## Problem
#962/#1016 fail-safed each child enumerator's **parent-ref** match against the `UNRESOLVED` symbol. But three enumerators resolve a **second** declared-side value — the child's own **identity** property — and that was NOT covered. When the identity is an unresolvable intrinsic (a `{{resolve:...}}` dynamic reference, a no-default `NoEcho` `Ref`, a degraded `Fn::ImportValue`) it becomes `UNRESOLVED`, fails the `typeof === 'string'` filter, and the declared child drops out of the declared set. Its live counterpart is then reported `[Added] created out of band`, and `revert --remove-unrecorded` offers a Cloud Control **DeleteResource** against a resource the template explicitly declares.

Members (the AppSync + ApiGateway half of the class; the EC2 `Route` half was #1082/#1118):
- **AppSync DataSource** `Name`
- **AppSync Resolver** `TypeName`/`FieldName`
- **ApiGateway GatewayResponse** `ResponseType`

## Fix (`src/read/child-enumerators.ts` only)
Each enumerator now detects an `UNRESOLVED` identity (`=== UNRESOLVED || hasUnresolved(...)`) and threads a `hasUnresolvedDeclared*` flag into its pure diff — **mirroring #1082's `hasUnresolvedDeclaredRoute`**. The pure diff short-circuits to `[]` when set: an unresolvable identity cannot be matched to any live child, so no live child may be flagged `added`.

## Tests
Six new cases in `tests/child-enumerators.test.ts` (two per member): the fail-safe suppresses all `added` when the identity is `UNRESOLVED`, and — no regression — a genuine out-of-band child is **still** flagged `added` when it is not. Full suite green (3802).

Offline/deterministic (pure-diff fail-safe, same class as merged #1082) — unit tests are the evidence, no live deploy. Not re-filing the route (xtab-03/#1082).