### PR TITLE
fix(baseline): reject unknown top-level + per-entry keys at load, require entry value (#1048)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -63,6 +63,26 @@ export interface BaselineFile {
   recordedPhysicalIds?: Record<string, string>;
 }
 
+// #1048: the known top-level keys of a baseline file (the `BaselineFile` fields). Used to
+// reject an unknown/typo'd top-level key at load. `accepted` is the legacy alias migrated to
+// `recorded` (and deleted) BEFORE this check runs, so it is intentionally NOT listed here.
+const KNOWN_BASELINE_KEYS = new Set<string>([
+  'schemaVersion',
+  'stackName',
+  'region',
+  'accountId',
+  'capturedAt',
+  'templateHash',
+  'recorded',
+  'completeResources',
+  'recordedPhysicalIds',
+]);
+// #1048: the known keys of a `recorded` array element. A typo'd key (`Value`, `vaule`) whose
+// intended `value` is then ABSENT reads as recorded `undefined` — a confirmed-drift false
+// positive that survives `check`. So per entry, unknown keys are rejected AND `value` must be
+// PRESENT (an intentional recorded `null` is expressible as `null`).
+const KNOWN_RECORDED_ENTRY_KEYS = new Set<string>(['logicalId', 'resourceType', 'path', 'value']);
+
 export function baselinePath(stackName: string, accountId: string, region: string): string {
   return `.cdkrd/baselines/${stackName}.${accountId}.${region}.json`;
 }
@@ -139,6 +159,17 @@ export async function loadBaseline(
     );
   if (!Array.isArray(parsed.recorded))
     throw new Error(`baseline file ${path} is malformed: \`recorded\` is missing or not an array`);
+  // #1048: reject UNKNOWN top-level keys, naming the offender — a baseline is a git-committed,
+  // hand-editable artifact, and a typo'd optional key (`completeResource`, `recordedPhysicalId`)
+  // otherwise slips through SILENTLY and turns a whole detection mechanism off (R62 completeness,
+  // #674 replacement voiding). Mirrors config-file.ts's top-level unknown-key rejection. Only
+  // PRESENT strangers are rejected — ABSENT optional keys (old files) still load fine, and a
+  // future schemaVersion's new keys are refused earlier by the `> 2` guard above.
+  const unknownTop = Object.keys(parsed).filter((k) => !KNOWN_BASELINE_KEYS.has(k));
+  if (unknownTop.length > 0)
+    throw new Error(
+      `baseline file ${path}: unknown key(s) ${unknownTop.map((k) => `"${k}"`).join(', ')} — known keys: ${[...KNOWN_BASELINE_KEYS].map((k) => `"${k}"`).join(', ')} (a typo silently disables detection; correct or remove it)`
+    );
   // Element-level validation (#794): the container shape passing is not enough — a
   // baseline is git-committed, hand-editable, and merge-conflictable, so a malformed
   // ELEMENT (a `null` entry from a bad merge, a scalar where an array/map is expected)
@@ -171,6 +202,20 @@ function validateRecordedEntry(entry: unknown, index: number, path: string): voi
   for (const k of ['logicalId', 'resourceType', 'path'] as const)
     if (typeof obj[k] !== 'string')
       throw new Error(`${at}: "${k}" is required and must be a string`);
+  // #1048: reject an unknown/typo'd per-entry key (`Value`, `vaule`) — otherwise the intended
+  // `value` is ABSENT, reads as recorded `undefined`, and false-surfaces the live value as
+  // confirmed drift (invisible: the typo'd key shows nowhere). Mirrors config-file.ts's
+  // per-rule unknown-key rejection.
+  const unknown = Object.keys(obj).filter((k) => !KNOWN_RECORDED_ENTRY_KEYS.has(k));
+  if (unknown.length > 0)
+    throw new Error(
+      `${at}: unknown key(s) ${unknown.map((k) => `"${k}"`).join(', ')} — known keys: "logicalId", "resourceType", "path", "value" (a typo'd "value" false-flags confirmed drift)`
+    );
+  // `value` must be PRESENT: absence is indistinguishable from a typo and means recorded
+  // `undefined` (compares false against everything). An intentional recorded value of nothing
+  // is written as `null`.
+  if (!('value' in obj))
+    throw new Error(`${at}: "value" is required (use null for an empty value)`);
 }
 
 /**

--- a/tests/baseline-validate-794.test.ts
+++ b/tests/baseline-validate-794.test.ts
@@ -209,3 +209,77 @@ describe('#1047 loadBaseline duplicate-identity rejection', () => {
     expect(loaded?.recorded).toHaveLength(2);
   });
 });
+
+// #1048: a baseline is a git-committed, hand-editable artifact, so a typo'd key must fail
+// LOUDLY (like config-file.ts) rather than silently disable detection — a top-level typo
+// (`completeResource`/`recordedPhysicalId`) turns a whole mechanism off, a per-entry typo
+// (`Value`) drops the value to recorded `undefined` = a confirmed-drift false positive.
+describe('#1048 loadBaseline unknown-key rejection', () => {
+  let cwd: string;
+  let dir: string;
+  beforeEach(async () => {
+    cwd = process.cwd();
+    dir = await mkdtemp(join(tmpdir(), 'cdkrd-baseline-1048-'));
+    process.chdir(dir);
+  });
+  afterEach(async () => {
+    process.chdir(cwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const base = (extra: Record<string, unknown>): string =>
+    JSON.stringify({
+      schemaVersion: 2,
+      stackName: STACK,
+      region: REGION,
+      accountId: ACCOUNT,
+      capturedAt: '',
+      templateHash: '',
+      recorded: [],
+      ...extra,
+    });
+
+  it('an unknown TOP-LEVEL key throws, naming the offender (completeResource typo)', async () => {
+    await expect(loadRaw(base({ completeResource: ['Res'] }))).rejects.toThrow(
+      /baseline file .*unknown key\(s\) "completeResource"/
+    );
+  });
+
+  it('a recordedPhysicalId (missing s) typo throws instead of silently disabling #674 voiding', async () => {
+    await expect(loadRaw(base({ recordedPhysicalId: { Res: 'phys' } }))).rejects.toThrow(
+      /unknown key\(s\) "recordedPhysicalId"/
+    );
+  });
+
+  it('all known optional keys ABSENT still loads (old file — only PRESENT strangers rejected)', async () => {
+    const loaded = await loadRaw(base({}));
+    expect(loaded?.recorded).toEqual([]);
+  });
+
+  it('an unknown PER-ENTRY key throws (a capital-V `Value` typo)', async () => {
+    await expect(
+      loadRaw(
+        base({
+          recorded: [{ logicalId: 'L', resourceType: 'AWS::S3::Bucket', path: 'P', Value: 'v1' }],
+        })
+      )
+    ).rejects.toThrow(/`recorded`\[0\]: unknown key\(s\) "Value"/);
+  });
+
+  it('a per-entry with `value` ABSENT throws (undefined-by-absence is indistinguishable from a typo)', async () => {
+    await expect(
+      loadRaw(base({ recorded: [{ logicalId: 'L', resourceType: 'AWS::S3::Bucket', path: 'P' }] }))
+    ).rejects.toThrow(/`recorded`\[0\]: "value" is required/);
+  });
+
+  it('an intentional recorded null value is accepted (value PRESENT as null)', async () => {
+    const loaded = await loadRaw(
+      base({
+        recorded: [{ logicalId: 'L', resourceType: 'AWS::S3::Bucket', path: 'P', value: null }],
+      })
+    );
+    expect(loaded?.recorded).toEqual([
+      { logicalId: 'L', resourceType: 'AWS::S3::Bucket', path: 'P', value: null },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #1048.

## Problem
A baseline is a git-committed, **hand-editable** artifact, yet `loadBaseline` accepted unknown keys silently at **both** levels — the opposite of `config-file.ts`, which rejects any unknown key (top-level AND per-rule) to close exactly this typo-variant of a silent-failure mode. Realistic PR-review typos:

- A per-entry `Value` (capital V) / `vaule` passed `validateRecordedEntry` (it checked only the three string keys); `entry.value` was then `undefined`, so the live value **false-surfaced as confirmed `undeclared` drift** even when live equalled what the user wrote — the typo'd key invisible everywhere.
- `completeResource` (missing `s`) silently demoted R62 completeness; a `recordedPhysicalId` typo silently reopened the #674 replacement-voiding FP — both with zero output.

## Fix (`src/baseline/baseline-file.ts` only)
Mirror `config-file.ts`:
- Reject unknown **top-level** keys (naming the offender + listing known keys). Only PRESENT strangers are rejected, so old files with ABSENT optional keys still load; a future `schemaVersion`'s new keys are refused earlier by the `> 2` guard.
- Reject unknown **per-entry** keys, and require `value` to be PRESENT (`'value' in entry`) — absence is indistinguishable from a typo; an intentional empty value is written as `null`.

## Tests
Six new cases in `tests/baseline-validate-794.test.ts` (a #1048 describe block): unknown top-level key, `recordedPhysicalId` typo, all-optional-absent still loads, unknown per-entry `Value`, `value`-absent rejected, `value: null` accepted. Full suite green (3817).

Offline/deterministic (loader validation, same class as merged #794/#1047) — unit tests are the evidence, no live deploy.