### PR TITLE
fix(baseline): surface JSON.parse position + conflict/recovery hint on a corrupt baseline

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -107,8 +107,20 @@ export async function loadBaseline(
   let parsed: BaselineFile & { accepted?: RecordedEntry[] };
   try {
     parsed = JSON.parse(raw) as BaselineFile & { accepted?: RecordedEntry[] };
-  } catch {
-    throw new Error(`baseline file ${path} is not valid JSON (corrupt or partially written)`);
+  } catch (e) {
+    // Surface JSON.parse's own diagnostic (it names the offending token + position, e.g.
+    // `Unexpected token '<', "<<<<<<< HEAD"... is not valid JSON`) — the bare message dropped
+    // it, leaving the user no location. An unresolved git merge-conflict marker is the #1 way
+    // this committed file breaks; recognize it and point at the recovery (#1137, the deferred
+    // JSON half of #1049 — mirrors the ignore.yaml diagnostic in config-file.ts).
+    const detail = (e as Error).message;
+    const conflict = /^(<{7}|={7}|>{7})/m.test(raw)
+      ? ' — looks like an unresolved git merge conflict (resolve the <<<<<<< / ======= / >>>>>>> markers)'
+      : '';
+    throw new Error(
+      `baseline file ${path} is not valid JSON (corrupt or partially written): ${detail}${conflict} ` +
+        `(delete or \`git restore\` the file to reset, then re-run \`cdkrd record\`)`
+    );
   }
   if (parsed === null || typeof parsed !== 'object')
     throw new Error(`baseline file ${path} is malformed: root is not an object`);

--- a/tests/baseline-validate-794.test.ts
+++ b/tests/baseline-validate-794.test.ts
@@ -283,3 +283,36 @@ describe('#1048 loadBaseline unknown-key rejection', () => {
     ]);
   });
 });
+
+// #1137: loadBaseline JSON.parse diagnostics (the deferred JSON half of #1049). A corrupt /
+// merge-conflicted baseline must surface JSON.parse's position + a conflict/recovery hint, not
+// a bare "is not valid JSON".
+describe('#1137 loadBaseline JSON.parse diagnostics', () => {
+  let cwd: string;
+  let dir: string;
+  beforeEach(async () => {
+    cwd = process.cwd();
+    dir = await mkdtemp(join(tmpdir(), 'cdkrd-baseline-1137-'));
+    process.chdir(dir);
+  });
+  afterEach(async () => {
+    process.chdir(cwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('an unresolved git merge-conflict marker surfaces the conflict hint + JSON.parse detail', async () => {
+    const raw =
+      '{\n<<<<<<< HEAD\n  "schemaVersion": 2,\n=======\n  "schemaVersion": 3,\n>>>>>>> branch\n}\n';
+    await expect(loadRaw(raw)).rejects.toThrow(/unresolved git merge conflict/);
+    // and it still carries JSON.parse's own diagnostic (not just the bare message)
+    await expect(loadRaw(raw)).rejects.toThrow(/is not valid JSON.*:/);
+  });
+
+  it('a trailing-comma corruption surfaces JSON.parse position + recovery hint', async () => {
+    const raw = '{ "schemaVersion": 2, "recorded": [], }';
+    await expect(loadRaw(raw)).rejects.toThrow(
+      /is not valid JSON \(corrupt or partially written\): .+/
+    );
+    await expect(loadRaw(raw)).rejects.toThrow(/git restore/);
+  });
+});


### PR DESCRIPTION
Closes #1137 (the deferred JSON half of #1049)

## Problem
`loadBaseline`'s catch threw a bare `baseline file … is not valid JSON (corrupt or partially written)` and **discarded `(e as Error).message`** — which for a real corruption names the offending token + position (e.g. `Unexpected token '<', "<<<<<<< HEAD"… is not valid JSON`). An unresolved git merge-conflict marker is the #1 way this git-committed file breaks, and `record` gave no recovery path (loadBaseline runs before the rewrite).

## Fix
Append JSON.parse's diagnostic, detect `<<<<<<< / ======= / >>>>>>>` markers with a targeted hint, and point at the recovery (`delete` / `git restore`, then re-`record`). Mirrors the ignore.yaml diagnostic in `config-file.ts` (#1049). Pure actionability, no FP/FN change.

## Tests
`tests/baseline-validate-794.test.ts` (#1137 block): a merge-conflict marker surfaces the conflict hint + JSON.parse detail; a trailing-comma corruption surfaces the position + `git restore` hint. Both confirmed FAIL without the fix; full suite 3823 pass.

The #1047/#1048 baseline-file.ts lanes that forced this deferral in #1049 have since merged, freeing the file.