### PR TITLE
fix(read): CodeBuild deleted-project -> deleted tier + ACM tag-read degrade (#1083, #1086)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -1631,14 +1631,20 @@ const readSchedulerSchedule: OverrideReader = async ({ physicalId, declared, reg
 // Maps the camelCase SDK Project back to the CFn PascalCase shape, projecting
 // ONLY CFn-modeled props (Arn / Created / LastModified / Badge URL are
 // AWS-managed noise). The declared compare is subset-based, so nested fields the
-// template never set are ignored; an absent project returns undefined (-> skip).
+// template never set are ignored. BatchGetProjects NEVER throws for a missing
+// project — it returns success with the name in `projectsNotFound` and an empty
+// `projects`. Since the CFn physical id IS the exact project name (an authoritative
+// exact-key lookup), an empty `projects` is a DEFINITIVE out-of-band deletion, so
+// throw ResourceGoneError (in NOT_FOUND_ERROR_NAMES → router maps `deleted`) rather
+// than returning undefined (which would hide the deletion as `skipped`). Mirrors the
+// sibling readCodeBuildReportGroup (#1083).
 const readCodeBuildProject: OverrideReader = async ({ physicalId, declared, region }) => {
   const name = str(physicalId) ?? str(declared.Name);
   if (!name) return undefined;
   const c = new CodeBuildClient({ region, ...READ_RETRY });
   const r = await c.send(new BatchGetProjectsCommand({ names: [name] }));
   const p = r.projects?.[0];
-  if (!p) return undefined;
+  if (!p) throw new ResourceGoneError(`CodeBuild Project ${name} absent`);
   const model: Record<string, unknown> = { Name: p.name };
   if (p.serviceRole !== undefined) model.ServiceRole = p.serviceRole;
   if (p.description !== undefined) model.Description = p.description;
@@ -2195,10 +2201,28 @@ const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region
       .filter((tag) => str(tag.Key) !== undefined)
       .map((tag) => ({ Key: tag.Key as string, Value: tag.Value ?? '' }));
     if (tags.length > 0) model.Tags = tags;
-  } catch {
+  } catch (err) {
     // A ListTagsForCertificate failure (a narrow acm:ListTagsForCertificate permission gap
     // or a transient throttle) must not drop the whole cert read to skipped — keep the
-    // certificate model without Tags rather than losing the DomainName/Options coverage.
+    // DomainName/Options coverage. But silently OMITTING Tags would then read-back as
+    // Tags=undefined, which false-flags a `declared`-tier drift against any declared
+    // non-empty Tags (and revert would offer to re-write them). #964-compliant degrade:
+    // MIRROR the declared Tags into the live model so the compare is equal (no FP), and
+    // emit a one-line stderr warning so the omission is not silent (matching the router's
+    // supplement-read warn style). Only mirror a declared non-empty Tags array, shaped like
+    // the success path ([{Key, Value}, ...]).
+    const declaredTags = Array.isArray(declared.Tags)
+      ? declared.Tags.filter(
+          (t): t is Record<string, unknown> => typeof t === 'object' && t !== null
+        )
+          .filter((t) => str(t.Key) !== undefined)
+          .map((t) => ({ Key: t.Key as string, Value: str(t.Value) ?? '' }))
+      : [];
+    if (declaredTags.length > 0) model.Tags = declaredTags;
+    const call = (err as Error)?.name || 'unknown error';
+    process.stderr.write(
+      `[cdkrd] warning: ACM ListTagsForCertificate for ${arn} failed (${call}) — mirroring declared Tags to avoid a false drift; grant acm:ListTagsForCertificate to detect out-of-band tag changes\n`
+    );
   }
   return model;
 };

--- a/tests/acm-certificate-reader-974.test.ts
+++ b/tests/acm-certificate-reader-974.test.ts
@@ -4,7 +4,7 @@ import {
   ListTagsForCertificateCommand,
 } from '@aws-sdk/client-acm';
 import { mockClient } from 'aws-sdk-client-mock';
-import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { SDK_OVERRIDES } from '../src/read/overrides.js';
 
 const acm = mockClient(ACMClient);
@@ -101,7 +101,7 @@ describe('AWS::CertificateManager::Certificate SDK override', () => {
     await expect(read(ctx(ARN))).rejects.toThrow('cert gone');
   });
 
-  it('keeps the certificate model when ListTagsForCertificate fails (no whole-read drop)', async () => {
+  it('keeps the certificate model (no whole-read drop) and omits Tags when none were declared and ListTagsForCertificate fails', async () => {
     acm.on(DescribeCertificateCommand).resolves({
       Certificate: { CertificateArn: ARN, DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' },
     });
@@ -109,6 +109,39 @@ describe('AWS::CertificateManager::Certificate SDK override', () => {
 
     const out = await read(ctx(ARN, { DomainName: 'example.com' }));
     expect(out).toEqual({ DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' });
+  });
+
+  it('#1086: mirrors declared Tags when ListTagsForCertificate fails (no false declared-Tags drift)', async () => {
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: { CertificateArn: ARN, DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' },
+    });
+    const denied = Object.assign(new Error('not authorized'), { name: 'AccessDeniedException' });
+    acm.on(ListTagsForCertificateCommand).rejects(denied);
+
+    // Template DECLARES a non-empty Tags list. Without the fix the live model omits Tags
+    // (Tags=undefined) → a false `declared` drift. The degrade mirrors declared Tags so the
+    // compare is equal, and warns on stderr so the omission is not silent.
+    const out = await read(
+      ctx(ARN, {
+        DomainName: 'example.com',
+        Tags: [
+          { Key: 'team', Value: 'ci' },
+          { Key: 'env', Value: 'prod' },
+        ],
+      })
+    );
+    expect(out).toEqual({
+      DomainName: 'example.com',
+      KeyAlgorithm: 'RSA_2048',
+      Tags: [
+        { Key: 'team', Value: 'ci' },
+        { Key: 'env', Value: 'prod' },
+      ],
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('ACM ListTagsForCertificate');
+    warn.mockRestore();
   });
 
   it('returns undefined when the physical id is not an ARN (target not resolvable)', async () => {

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -2018,9 +2018,13 @@ describe('SDK overrides', () => {
       expect(KNOWN_DEFAULTS['AWS::CodeBuild::Project'].Cache).toEqual({ Type: 'NO_CACHE' });
     });
 
-    it('undefined when the project is absent (-> stays skipped)', async () => {
-      codebuild.on(BatchGetProjectsCommand).resolves({ projects: [] });
-      expect(await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'missing'))).toBeUndefined();
+    it('#1083: a deleted project (empty projects, name in projectsNotFound) throws ResourceGoneError → router maps to deleted (not skipped)', async () => {
+      codebuild
+        .on(BatchGetProjectsCommand)
+        .resolves({ projects: [], projectsNotFound: ['missing'] });
+      await expect(
+        SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'missing'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
     });
 
     it('undefined when no name is resolvable', async () => {


### PR DESCRIPTION
Closes #1083
Closes #1086

Two reader-degrade fixes in `src/read/overrides.ts`, same class:

- **#1083** `readCodeBuildProject`: `BatchGetProjects` never throws for a missing project (empty `projects`, name in `projectsNotFound`). The CFn physical id IS the exact project name, so an empty result is a DEFINITIVE out-of-band deletion. Now throws `ResourceGoneError` (in `NOT_FOUND_ERROR_NAMES` -> router maps `deleted`) instead of returning `undefined` (which hid the deletion as `skipped`), mirroring the sibling `readCodeBuildReportGroup`.
- **#1086** `readAcmCertificate`: on a `ListTagsForCertificate` AccessDenied/throttle the Tags were silently omitted, false-flagging a `declared`-tier drift against a declared non-empty Tags list (and revert would offer to re-write them). The catch now MIRRORS the declared Tags into the live model (shaped `[{Key,Value}]`, only when declared non-empty) so the compare is equal, and emits a one-line stderr warning so the omission is not silent. DomainName/Options coverage is unchanged.

Tests (fail without the fix, pass with it):
- `tests/overrides.test.ts`: `#1083: a deleted project (empty projects, name in projectsNotFound) throws ResourceGoneError -> router maps to deleted (not skipped)`
- `tests/acm-certificate-reader-974.test.ts`: `#1086: mirrors declared Tags when ListTagsForCertificate fails (no false declared-Tags drift)`

`vp test run`: 114 files / 3822 tests passed.