### PR TITLE
fix(check): pin the current account in the deleted-out-of-band baseline probe (#1046)

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,10 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `DescribeType`; `DescribeStackResources` (the sibling-ownership check for the
   `added` tier — see the `added`-tier entry below); `ListExports` (only for
   templates using `Fn::ImportValue`)
+- `sts:GetCallerIdentity` (resolves the current account so `check` can tell a stack
+  never deployed in THIS account from one deleted out of band, under the
+  multi-account baseline pattern — allowed for any valid credentials, so no policy
+  statement is normally required)
 - `cloudcontrol:GetResource`: Cloud Control invokes each type's own read handler,
   so it needs that type's read permissions (this is why `ReadOnlyAccess` is the
   simple answer). `revert` additionally uses `cloudcontrol:UpdateResource` /

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@aws-sdk/client-sns": "^3.1065.0",
     "@aws-sdk/client-sqs": "^3.1065.0",
     "@aws-sdk/client-ssm": "^3.1075.0",
+    "@aws-sdk/client-sts": "^3.1065.0",
     "@aws-sdk/client-wafv2": "^3.1073.0",
     "@clack/core": "^1.4.1",
     "@clack/prompts": "^1.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@aws-sdk/client-ssm':
         specifier: ^3.1075.0
         version: 3.1075.0
+      '@aws-sdk/client-sts':
+        specifier: ^3.1065.0
+        version: 3.1066.0
       '@aws-sdk/client-wafv2':
         specifier: ^3.1073.0
         version: 3.1073.0
@@ -3923,7 +3926,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -3931,7 +3934,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/types': 3.974.0
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -4610,13 +4613,13 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/credential-provider-node': 3.972.62
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/fetch-http-handler': 5.6.2
-      '@smithy/node-http-handler': 4.9.2
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -8,6 +8,7 @@
 // stacks.
 import { readdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
@@ -33,6 +34,7 @@ import {
   stackSeparator,
 } from '../report/report.js';
 import { style } from '../report/style.js';
+import { CLIENT_TIMEOUTS } from '../read/client-config.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
 import type { DesiredResource, Finding } from '../types.js';
@@ -241,10 +243,23 @@ export function finalCheckExit(code: number, fail: boolean): number {
  * A case-sensitive `readdirSync` prefix would MISS a baseline committed as `mystack.….json`
  * when checking `MyStack`, silently downgrading a genuinely deleted stack to a benign skip.
  *
+ * #1046: when the CURRENT account is known (resolved via `resolveCallerAccount`), PIN the
+ * filename's account segment too — else a same-named stack that lives in ANOTHER account
+ * (the common `env: { account: PERSONAL || SHARED }` CDK pattern, which the baseline filename
+ * design explicitly serves) but was never deployed in THIS account is falsely reported
+ * "deleted out of band" (multi-account CI goes permanently red the moment the other account's
+ * baseline is committed). The account is only wildcarded when it genuinely cannot be resolved
+ * (an STS failure), preserving today's behavior as a fallback — the account axis twin of the
+ * region pin the #942 fix applied.
+ *
  * The baselines directory is derived from `baselinePath` so the layout stays single-sourced.
  * Pure (filesystem-only, no AWS) + exported for unit tests. Missing dir → false.
  */
-export function hasBaselineForStack(stackName: string, region: string): boolean {
+export function hasBaselineForStack(
+  stackName: string,
+  region: string,
+  accountId?: string
+): boolean {
   const dir = dirname(baselinePath(stackName, 'a', 'r'));
   let entries: string[];
   try {
@@ -252,12 +267,34 @@ export function hasBaselineForStack(stackName: string, region: string): boolean 
   } catch {
     return false; // no `.cdkrd/baselines/` directory at all → nothing was ever recorded
   }
-  const prefix = `${stackName}.`.toLowerCase();
+  // Stack names are alphanumeric/hyphen (no dots) and an accountId is digits, so
+  // `${stackName}.${accountId}.` is an unambiguous prefix. Without a known account the
+  // account segment stays wildcarded (region-only pin, today's behavior).
+  const prefix = (accountId ? `${stackName}.${accountId}.` : `${stackName}.`).toLowerCase();
   const suffix = `.${region}.json`.toLowerCase();
   return entries.some((f) => {
     const lower = f.toLowerCase();
     return lower.startsWith(prefix) && lower.endsWith(suffix);
   });
+}
+
+/**
+ * #1046: resolve the CURRENT account (region-free `sts:GetCallerIdentity`, a zero-permission
+ * call) so `hasBaselineForStack` can pin the baseline filename's account segment. Returns
+ * `undefined` on ANY failure (expired creds, blocked STS, network) so the caller falls back
+ * to today's account-wildcard rather than erroring — a `check` that reached the not-deployed
+ * catch already has working creds, so the STS call almost always succeeds. `--profile` is
+ * already in `process.env.AWS_PROFILE` (set by the verb entry points), so the default
+ * credential chain resolves it. Exported for unit tests.
+ */
+export async function resolveCallerAccount(region: string): Promise<string | undefined> {
+  try {
+    const sts = new STSClient({ region, ...CLIENT_TIMEOUTS });
+    const id = await sts.send(new GetCallerIdentityCommand({}));
+    return id.Account;
+  } catch {
+    return undefined;
+  }
 }
 
 // #1060 — the top-level `--json` emit runs AFTER the per-stack loop, OUTSIDE any
@@ -406,6 +443,13 @@ export async function runCheck(args: string[]): Promise<number> {
   const separate = stackSeparator();
   // The gather-phase spinner (see gatherWithProgress) — text mode + TTY only.
   const showProgress = !a.json && isInteractive();
+  // #1046: the CURRENT account, resolved AT MOST ONCE per run (lazily, only when a
+  // not-deployed stack is hit) and cached — used to pin the deleted-out-of-band detector's
+  // baseline account segment so a shared-account baseline does not false-flag a stack never
+  // deployed in THIS account. `callerAccountResolved` guards the one-shot resolution; an
+  // `undefined` `callerAccount` afterwards means STS could not answer → wildcard fallback.
+  let callerAccount: string | undefined;
+  let callerAccountResolved = false;
   for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
       const msg =
@@ -674,7 +718,14 @@ export async function runCheck(args: string[]): Promise<number> {
         // proof the stack was once deployed, so its presence promotes this from a benign skip
         // (exit 0) to real drift: the deployed state is GONE. Without this, `check --fail`
         // (and `--strict`) exit 0 on a deleted stack, indistinguishable from never-deployed.
-        if (hasBaselineForStack(stackName, region)) {
+        // #1046: resolve the current account (once per run, cached) and pin the baseline's
+        // account segment — else another account's committed baseline false-flags a stack
+        // never deployed in THIS account as "deleted out of band" (multi-account CI red).
+        if (!callerAccountResolved) {
+          callerAccount = await resolveCallerAccount(region);
+          callerAccountResolved = true;
+        }
+        if (hasBaselineForStack(stackName, region, callerAccount)) {
           const msg = 'deployed baseline exists but the stack is gone — deleted out of band';
           const label = `${stackName} (${region})`;
           console.error(`[Drift] ${label}: ${msg}`);

--- a/tests/deleted-stack-781.test.ts
+++ b/tests/deleted-stack-781.test.ts
@@ -11,12 +11,18 @@
 // exists → keep the benign skip + exit 0. This test drives the pure `hasBaselineForStack`
 // probe (filesystem-only, no AWS) plus `finalCheckExit`, mirroring the catch's exit math.
 
+import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import { mockClient } from 'aws-sdk-client-mock';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 import { baselinePath } from '../src/baseline/baseline-file.js';
-import { finalCheckExit, hasBaselineForStack } from '../src/commands/check.js';
+import {
+  finalCheckExit,
+  hasBaselineForStack,
+  resolveCallerAccount,
+} from '../src/commands/check.js';
 
 const STACK = 'MyStack';
 const ACCOUNT = '111122223333';
@@ -128,6 +134,32 @@ describe('#781 deleted-out-of-band stack surfaces as drift, not a skip', () => {
       await writeFile(join(dirname(p), `${STACK}.note.txt`), 'x', 'utf8');
       expect(hasBaselineForStack(STACK, REGION)).toBe(false);
     });
+
+    // #1046: when the current account is KNOWN, the filename's account segment is pinned too,
+    // so ANOTHER account's committed baseline no longer false-matches a stack never deployed
+    // in THIS account (the multi-account `env: { account: PERSONAL || SHARED }` pattern).
+    const SHARED = '222222222222';
+    const PERSONAL = '111111111111';
+
+    it('a SHARED-account baseline does NOT match when checking under the PERSONAL account (#1046)', async () => {
+      await writeBaseline(STACK, SHARED, REGION);
+      expect(hasBaselineForStack(STACK, REGION, PERSONAL)).toBe(false); // pinned → no false "deleted"
+    });
+
+    it('matches when the pinned account IS the baseline account (#1046)', async () => {
+      await writeBaseline(STACK, SHARED, REGION);
+      expect(hasBaselineForStack(STACK, REGION, SHARED)).toBe(true);
+    });
+
+    it('falls back to today wildcard match when the account is UNKNOWN (STS failed, #1046)', async () => {
+      await writeBaseline(STACK, SHARED, REGION);
+      expect(hasBaselineForStack(STACK, REGION, undefined)).toBe(true); // no account → region-only pin
+    });
+
+    it('the account pin is case-insensitive-safe and still region-bounded (#1046)', async () => {
+      await writeBaseline(STACK, SHARED, 'eu-west-1');
+      expect(hasBaselineForStack(STACK, REGION, SHARED)).toBe(false); // right account, wrong region
+    });
   });
 
   describe('exit-code contract of the not-deployed catch (#781)', () => {
@@ -152,5 +184,28 @@ describe('#781 deleted-out-of-band stack surfaces as drift, not a skip', () => {
       expect(hasBaselineForStack(STACK, REGION)).toBe(false);
       expect(notDeployedExit(hasBaselineForStack(STACK, REGION), true, true)).toBe(0);
     });
+  });
+});
+
+// #1046: resolveCallerAccount is a region-free sts:GetCallerIdentity that returns the account
+// (to pin the baseline account segment) and NEVER throws — any STS failure falls back to
+// undefined so the caller keeps today's account-wildcard behavior (no regression).
+describe('#1046 resolveCallerAccount', () => {
+  const sts = mockClient(STSClient);
+  beforeEach(() => sts.reset());
+
+  it('returns the Account from GetCallerIdentity', async () => {
+    sts.on(GetCallerIdentityCommand).resolves({ Account: '111111111111' });
+    expect(await resolveCallerAccount('us-east-1')).toBe('111111111111');
+  });
+
+  it('returns undefined (wildcard fallback) when STS throws', async () => {
+    sts.on(GetCallerIdentityCommand).rejects(new Error('ExpiredToken'));
+    expect(await resolveCallerAccount('us-east-1')).toBeUndefined();
+  });
+
+  it('returns undefined when GetCallerIdentity has no Account field', async () => {
+    sts.on(GetCallerIdentityCommand).resolves({});
+    expect(await resolveCallerAccount('us-east-1')).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #1046.

## Problem
`hasBaselineForStack` matched the baseline filename `<stack>.<accountId>.<region>.json` on only **two** of its three identity axes — region (pinned by #942) and stack — leaving the **account** segment wildcarded. Under the documented multi-account pattern (`env: { account: PERSONAL || SHARED }`, which the per-account baseline filename design explicitly serves):

1. Stack `App` is deployed + recorded in the **SHARED** account (`App.222….json` committed).
2. A dev runs `cdkrd check --fail` with **PERSONAL**-account creds where `App` was never deployed.
3. The SHARED account's baseline matches (account wildcarded) → `[Drift] deleted out of band`, `drifted:1` / `stackDeleted:true`, exit 1.

A never-deployed stack in the current account is reported as the **strongest drift there is** — multi-account / staging CI goes permanently red the moment the shared baseline is committed. This is the account-axis twin of the closed region bug #942.

## Fix (`src/commands/check.ts` + `package.json`)
Resolve the current account **once per run** (lazily — only when a not-deployed stack is hit — and cached) via a region-free `sts:GetCallerIdentity` (a zero-permission call; the issue's **primary** recommended direction — the `env.account` alternative is blocked by open #740), and pass it to `hasBaselineForStack`, which pins the filename's account segment when known. **Any STS failure falls back to today's account-wildcard**, so there is no regression when the account can't be resolved. `--profile` is already in `process.env.AWS_PROFILE`, so the default credential chain resolves it. Adds `@aws-sdk/client-sts`.

## Tests
`tests/deleted-stack-781.test.ts`: the account pin (a SHARED baseline no longer matches a PERSONAL check; matches when accounts agree; wildcard fallback when the account is `undefined`; still region-bounded) + `resolveCallerAccount` (returns the Account via a mocked STS, `undefined` on STS throw / missing `Account`). Full suite green (3828). README IAM list notes `sts:GetCallerIdentity`.

Follow-up to my #1062/#1064/#1074/#1089/#1048 batch (I had deferred this as needing the account resolved). Verified offline (mocked STS + filesystem probe); the STS call itself is a trivial, well-understood API.