### PR TITLE
fix(report): defend --json output against a nested UNRESOLVED symbol (#1059 --json residue)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -35,6 +35,7 @@ import {
   stackSeparator,
 } from '../report/report.js';
 import { style } from '../report/style.js';
+import { UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import { CLIENT_TIMEOUTS } from '../read/client-config.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
@@ -316,6 +317,15 @@ export function safeStringifyJson(value: unknown): string {
   const seen = new WeakSet<object>();
   const replacer = (_key: string, v: unknown): unknown => {
     if (typeof v === 'bigint') return v.toString();
+    // #1059 (--json residue; the render-side twin of #839, complementing #1142 which
+    // defended the TEXT render): a nested UNRESOLVED symbol reaching a finding value
+    // would otherwise be SILENTLY dropped by JSON.stringify (an object property whose
+    // VALUE is a symbol vanishes; a symbol array element becomes `null`), emitting a
+    // value-stripped object that misrepresents the diff / machine contract. Substitute
+    // a visible marker so `--json` shows the unresolved position instead of dropping the
+    // key — `⟨unresolved⟩` matches the marker report.ts's text render uses for UNRESOLVED.
+    if (typeof v === 'symbol')
+      return v === UNRESOLVED ? '⟨unresolved⟩' : `⟨${v.description ?? 'symbol'}⟩`;
     if (typeof v === 'object' && v !== null) {
       if (seen.has(v)) return '[Circular]';
       seen.add(v);

--- a/tests/json-safe-stringify-1060.test.ts
+++ b/tests/json-safe-stringify-1060.test.ts
@@ -7,6 +7,7 @@
 // and a valid-JSON `[]` fallback if even the guarded pass throws.
 import { describe, expect, it, vi } from 'vite-plus/test';
 import { safeStringifyJson } from '../src/commands/check.js';
+import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 
 describe('safeStringifyJson (#1060 — non-serializable --json values must not crash)', () => {
   it('coerces a BigInt to a string instead of throwing', () => {
@@ -55,5 +56,35 @@ describe('safeStringifyJson (#1060 — non-serializable --json values must not c
   it('passes an ordinary serializable value through unchanged', () => {
     const reports = [{ stack: 's (us-east-1)', drifted: 0, findings: [], error: 'skipped' }];
     expect(JSON.parse(safeStringifyJson(reports))).toEqual(reports);
+  });
+
+  // #1059 (--json residue) — a nested UNRESOLVED symbol in a finding value would otherwise be
+  // SILENTLY dropped by JSON.stringify (a value-stripped object that misrepresents the diff),
+  // producing a phantom "key appeared in live". #1142 defended the TEXT render; this defends
+  // the `--json` machine contract. safeStringifyJson must substitute the visible marker.
+  describe('#1059 — a nested UNRESOLVED symbol renders as a marker, never a dropped key', () => {
+    it('keeps an object property whose VALUE is UNRESOLVED (would else be dropped)', () => {
+      const parsed = JSON.parse(safeStringifyJson({ A: UNRESOLVED, B: 1 }));
+      expect('A' in parsed).toBe(true);
+      expect(parsed.A).toBe('⟨unresolved⟩');
+      expect(parsed.B).toBe(1);
+    });
+
+    it('substitutes a NESTED UNRESOLVED value inside an object/array', () => {
+      const parsed = JSON.parse(
+        safeStringifyJson({ Statement: [{ Resource: UNRESOLVED, Action: '*' }] })
+      );
+      expect(parsed.Statement[0].Resource).toBe('⟨unresolved⟩');
+      expect(parsed.Statement[0].Action).toBe('*');
+    });
+
+    it('substitutes a symbol ARRAY ELEMENT (JSON.stringify would emit a phantom null)', () => {
+      expect(JSON.parse(safeStringifyJson([UNRESOLVED, 1]))).toEqual(['⟨unresolved⟩', 1]);
+    });
+
+    it('falls back to the description marker for a non-UNRESOLVED symbol', () => {
+      const parsed = JSON.parse(safeStringifyJson({ K: Symbol('mystery') }));
+      expect(parsed.K).toBe('⟨mystery⟩');
+    });
   });
 });


### PR DESCRIPTION
Follow-up / residue of #1059 (which #1142 closed by fixing only the TEXT render).

#1142 made report.ts `j()`/`jPair()` symbol-aware, but the `--json` path — `safeStringifyJson` in `src/commands/check.ts` — was left unguarded, so a nested `UNRESOLVED` symbol in a finding value is still SILENTLY dropped by `JSON.stringify` (an object property whose value is a symbol vanishes; a symbol array element becomes `null`), emitting a value-stripped object that misrepresents the diff / machine contract.

This adds a symbol branch to `safeStringifyJson`'s existing replacer that substitutes `⟨unresolved⟩` for `UNRESOLVED` (matching the marker #1142 uses in the text render) and `⟨<description>⟩` for any other symbol. Self-contained (imports only `UNRESOLVED`); disjoint from #1142 (report.ts). Unit tests cover the object-property, nested, array-element, and non-UNRESOLVED-symbol cases.

Refs #1059.
