### PR TITLE
fix(report): render unrecorded added live model + defend nested UNRESOLVED symbol in value rendering (#1057, #1059)

### DIFF
--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -22,6 +22,7 @@
 import { withinStackPath } from '../construct-path.js';
 import { deepEqual } from '../diff/drift-calculator.js';
 import { annotateHints } from '../diff/hints.js';
+import { UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import type { ArrayDelta, Finding, Tier } from '../types.js';
 import { style } from './style.js';
 
@@ -160,6 +161,14 @@ export function formatFinding(f: Finding, stackName = ''): string {
       const { a: base, b: act } = jPair(f.desired, f.actual);
       s += `\n      baseline=${style.desired(base)}\n      actual  =${style.actual(act)}`;
     }
+  } else if (f.tier === 'added' && f.actual !== undefined) {
+    // #1057: an UNRECORDED `added` resource (no baseline `desired`) — there is no delta to
+    // show, so render its LIVE model (`f.actual`, the full out-of-band-created content) on
+    // its own indented line, so the text report reveals WHAT the rogue resource is instead
+    // of a bare id+type line (the live model was previously only visible under --json). The
+    // `f.actual !== undefined` guard keeps a degraded read (identity-only, no model) rendering
+    // as its bare id+type line rather than a stray `actual =undefined`.
+    s += `\n      actual =${style.actual(j(f.actual))}`;
   } else if (f.tier === 'undeclared' && f.arrayDelta)
     // R128: a recorded identity-keyed array changed — show the element delta, not the
     // whole array dump (the property stays recorded; this is the WHICH-element view).
@@ -630,8 +639,29 @@ export function safeSlice(s: string, start: number, end: number): string {
   return out;
 }
 
+// #1059: JSON.stringify SILENTLY drops an object property whose VALUE is a symbol and
+// turns a symbol ARRAY ELEMENT into `null` — so a nested UNRESOLVED symbol (the
+// intrinsic-resolver marker a declared value may carry) VANISHES from a rendered diff,
+// producing a phantom "key appeared in live" / a wrong delta. Stringify through a replacer
+// that maps a symbol to a VISIBLE marker so it renders instead of being dropped. UNRESOLVED
+// gets its own `⟨unresolved⟩` label (matching how the footer names an unresolved intrinsic);
+// any other symbol falls back to its description. The replacer only sees object-property /
+// array-element values; a TOP-LEVEL symbol (`JSON.stringify(sym)` → undefined) is handled
+// by symbolMarker before the stringify.
+function symbolMarker(v: symbol): string {
+  return v === UNRESOLVED ? '⟨unresolved⟩' : `⟨${v.description ?? 'symbol'}⟩`;
+}
+const symbolReplacer = (_k: string, value: unknown): unknown =>
+  typeof value === 'symbol' ? symbolMarker(value) : value;
+// JSON.stringify with symbol defense: a top-level symbol stringifies to `undefined`, so
+// substitute its marker directly; nested symbols are caught by the replacer.
+function stringifySymbolSafe(v: unknown): string | undefined {
+  if (typeof v === 'symbol') return JSON.stringify(symbolMarker(v));
+  return JSON.stringify(v, symbolReplacer);
+}
+
 function j(v: unknown): string {
-  const s = JSON.stringify(v);
+  const s = stringifySymbolSafe(v);
   return s && s.length > VALUE_CAP ? safeSlice(s, 0, VALUE_CAP) + '…' : (s ?? String(v));
 }
 
@@ -688,8 +718,8 @@ function isBidiOrZeroWidth(code: number): boolean {
 // identical blobs, hiding the very change the report exists to show (common for long
 // inline-policy / bucket-policy documents). Pure + exported for tests.
 export function jPair(a: unknown, b: unknown): { a: string; b: string } {
-  const as = JSON.stringify(a) ?? String(a);
-  const bs = JSON.stringify(b) ?? String(b);
+  const as = stringifySymbolSafe(a) ?? String(a);
+  const bs = stringifySymbolSafe(b) ?? String(b);
   if (as.length <= VALUE_CAP && bs.length <= VALUE_CAP) return { a: as, b: bs };
   let i = 0;
   const min = Math.min(as.length, bs.length);

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
+import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 import { formatFinding, jPair, report, safeSlice, stackSeparator } from '../src/report/report.js';
 import type { Finding } from '../src/types.js';
 
@@ -266,6 +267,58 @@ describe('report', () => {
     expect(text).toContain('actual  =');
     expect(text).toContain('NONE');
     expect(text).toContain('AWS_IAM');
+  });
+
+  it('#1057: an UNRECORDED added resource (no baseline desired) renders its LIVE model, not a bare id+type line', () => {
+    const f: Finding = {
+      tier: 'added',
+      logicalId: 'Api/abc|root|ANY',
+      physicalId: 'abc|root|ANY',
+      constructPath: 'Stack/Api ▸ ANY /',
+      resourceType: 'AWS::ApiGateway::Method',
+      path: '',
+      unrecorded: true,
+      actual: { AuthorizationType: 'AWS_IAM', HttpMethod: 'ANY' },
+      note: 'created out of band — not in your CloudFormation template',
+    };
+    const out = formatFinding(f);
+    // the live model is visible in the text report (previously only under --json)
+    expect(out).toContain('actual =');
+    expect(out).toContain('AWS_IAM');
+    expect(out).toContain('AuthorizationType');
+    // it is NOT rendered as just its id+type line
+    expect(out.split('\n').length).toBeGreaterThan(1);
+  });
+
+  it('#1057: a degraded added read (no actual model) still renders as a bare id+type line, no stray actual=undefined', () => {
+    const f: Finding = {
+      tier: 'added',
+      logicalId: 'Api/x',
+      constructPath: 'Stack/Api ▸ /x',
+      resourceType: 'AWS::ApiGateway::Resource',
+      path: '',
+      modelReadFailed: true,
+      note: 'created out of band — live model unreadable this run',
+    };
+    const out = formatFinding(f);
+    expect(out).not.toContain('actual =undefined');
+    expect(out).not.toContain('actual =');
+  });
+
+  it('#1057: a RECORDED added (has desired) still shows its baseline-vs-actual delta (no regression)', () => {
+    const f: Finding = {
+      tier: 'added',
+      logicalId: 'Api/abc',
+      constructPath: 'Stack/Api ▸ ANY /',
+      resourceType: 'AWS::ApiGateway::Method',
+      path: '',
+      desired: { AuthorizationType: 'NONE' },
+      actual: { AuthorizationType: 'AWS_IAM' },
+      note: 'changed since record',
+    };
+    const out = formatFinding(f);
+    expect(out).toContain('NONE');
+    expect(out).toContain('AWS_IAM');
   });
 
   it('the Added section sorts AFTER declared/undeclared (sections + result line)', () => {
@@ -754,6 +807,50 @@ describe('jPair (pair-aware truncation keeps the divergence visible)', () => {
   it('a long value vs a short one still shows where they diverge', () => {
     const { a, b } = jPair('z'.repeat(250), 'z'.repeat(10));
     expect(a).not.toBe(b);
+  });
+});
+
+describe('#1059: nested UNRESOLVED symbol is rendered VISIBLY, never silently dropped', () => {
+  it('a symbol OBJECT-PROPERTY value renders the ⟨unresolved⟩ marker (JSON.stringify would drop the key)', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'L',
+      resourceType: 'AWS::X::Y',
+      path: 'P',
+      desired: { Foo: UNRESOLVED, Bar: 'ok' },
+      actual: { Foo: 'live', Bar: 'ok' },
+    };
+    const out = formatFinding(f);
+    // the key is NOT dropped — the unresolved marker is visible
+    expect(out).toContain('⟨unresolved⟩');
+    // and it is NOT a phantom "Foo missing on the desired side"
+    expect(out).toContain('Foo');
+  });
+
+  it('a symbol ARRAY ELEMENT renders the marker, not a phantom null', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'L',
+      resourceType: 'AWS::X::Y',
+      path: 'P',
+      desired: { Items: ['a', UNRESOLVED, 'c'] },
+      actual: { Items: ['a', 'b', 'c'] },
+    };
+    const out = formatFinding(f);
+    expect(out).toContain('⟨unresolved⟩');
+    // JSON.stringify turns a symbol array element into `null` — that phantom must be gone
+    expect(out).not.toContain('null');
+  });
+
+  it('jPair defends a top-level UNRESOLVED symbol (would stringify to undefined otherwise)', () => {
+    const { a, b } = jPair(UNRESOLVED, 'live');
+    expect(a).toContain('⟨unresolved⟩');
+    expect(b).toBe('"live"');
+  });
+
+  it('an unknown symbol falls back to its description marker (symbols generally)', () => {
+    const { a } = jPair(Symbol('mystery'), 'x');
+    expect(a).toContain('⟨mystery⟩');
   });
 });
 


### PR DESCRIPTION
Closes #1057
Closes #1059

Offline fix with unit tests. formatFinding now renders an unrecorded added resource's live model (was a bare id+type line, only visible under --json). j()/jPair() stringify through a symbol-defending replacer so a nested UNRESOLVED symbol renders as ⟨unresolved⟩ instead of being silently dropped by JSON.stringify (which caused phantom "key appeared in live").