### PR TITLE
fix(baseline): sanitize Windows reserved DOS device stack names in baseline path (#1077)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -83,8 +83,47 @@ const KNOWN_BASELINE_KEYS = new Set<string>([
 // PRESENT (an intentional recorded `null` is expressible as `null`).
 const KNOWN_RECORDED_ENTRY_KEYS = new Set<string>(['logicalId', 'resourceType', 'path', 'value']);
 
+// #1077: Windows reserved DOS device names. On the Win32 namespace, ANY final path
+// component whose BASE NAME (the part before the FIRST dot, case-insensitively) equals
+// one of these resolves to a DEVICE, not a file — `nul.111.us-east-1.json` IS `\\.\NUL`.
+// So `record Nul` writes the baseline JSON into the NUL device (silent data loss with a
+// success exit code), `con.*` blocks/hangs, and a committed `con.<acct>.<region>.json`
+// breaks Windows teammates' `git clone`/checkout (git-for-Windows refuses reserved
+// names, bricking the whole clone). All of these ARE valid CloudFormation stack names.
+// The accountId (digits) and region are safe; only the stack-name component can collide.
+const RESERVED_DOS_DEVICE_NAMES = new Set<string>([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  ...Array.from({ length: 9 }, (_, i) => `COM${i + 1}`), // COM1..COM9
+  ...Array.from({ length: 9 }, (_, i) => `LPT${i + 1}`), // LPT1..LPT9
+]);
+
+// #1077: sanitize the stack-name component so it can never resolve to a Windows DOS
+// device. Only names whose base name (before the first dot, case-insensitively) IS a
+// reserved device are transformed — we append a single `_` right after the base name
+// (`nul` -> `nul_`, `con.foo` -> `con_.foo`, `NUL` -> `NUL_`). Every other stack name is
+// returned UNCHANGED (no migration for the 99.9% case).
+//
+// INJECTIVITY: a valid CloudFormation stack name is `[A-Za-z][-A-Za-z0-9]*` — letters,
+// digits, and hyphens ONLY, never an underscore. The transform inserts an `_`, so a
+// transformed reserved name (`nul_`, `con_`, `com1_`, …) can NEVER equal any real
+// (untransformed, `_`-free) stack name. Two distinct stack names therefore never map to
+// the same on-disk filename: reserved names get a `_`-bearing base name that no plain
+// name can produce, and every plain name maps to itself. The mapping is also stable and
+// deterministic (same input -> same output) and reversible enough that every caller of
+// `baselinePath` (read in loadBaseline, write in writeBaselineFile) computes the SAME path.
+export function sanitizeStackNameComponent(stackName: string): string {
+  const firstDot = stackName.indexOf('.');
+  const base = firstDot === -1 ? stackName : stackName.slice(0, firstDot);
+  const rest = firstDot === -1 ? '' : stackName.slice(firstDot); // includes the leading '.'
+  if (RESERVED_DOS_DEVICE_NAMES.has(base.toUpperCase())) return `${base}_${rest}`;
+  return stackName;
+}
+
 export function baselinePath(stackName: string, accountId: string, region: string): string {
-  return `.cdkrd/baselines/${stackName}.${accountId}.${region}.json`;
+  return `.cdkrd/baselines/${sanitizeStackNameComponent(stackName)}.${accountId}.${region}.json`;
 }
 
 export function hashTemplate(rawTemplate: string): string {

--- a/tests/baseline-winname-1077.test.ts
+++ b/tests/baseline-winname-1077.test.ts
@@ -1,0 +1,124 @@
+import { basename } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import { baselinePath, sanitizeStackNameComponent } from '../src/baseline/baseline-file.js';
+
+// #1077: a stack named exactly a Windows reserved DOS device name (`nul`, `con`, `aux`,
+// `prn`, `com1`-`com9`, `lpt1`-`lpt9` — all valid CloudFormation stack names) must NOT map
+// its baseline filename to a Win32 device. The base name (before the FIRST dot,
+// case-insensitively) must never equal a reserved device after sanitization.
+
+const RESERVED = [
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+];
+
+// The Win32 rule: the base name is the substring before the first dot, matched
+// case-insensitively. Extract it from a baseline filename to assert it is not a device.
+function baseNameOfFile(file: string): string {
+  const name = basename(file);
+  const firstDot = name.indexOf('.');
+  return (firstDot === -1 ? name : name.slice(0, firstDot)).toUpperCase();
+}
+
+const RESERVED_UPPER = new Set(RESERVED.map((r) => r.toUpperCase()));
+
+describe('#1077 Windows reserved DOS device stack names', () => {
+  it('every reserved device name (any case) no longer yields a device base name', () => {
+    for (const name of [
+      ...RESERVED,
+      ...RESERVED.map((r) => r.toUpperCase()),
+      'Nul',
+      'CON',
+      'CoM1',
+    ]) {
+      const p = baselinePath(name, '111122223333', 'us-east-1');
+      expect(RESERVED_UPPER.has(baseNameOfFile(p))).toBe(false);
+    }
+  });
+
+  it('sanitizes reserved names by appending an underscore to the base name only', () => {
+    expect(sanitizeStackNameComponent('nul')).toBe('nul_');
+    expect(sanitizeStackNameComponent('con')).toBe('con_');
+    expect(sanitizeStackNameComponent('aux')).toBe('aux_');
+    expect(sanitizeStackNameComponent('com1')).toBe('com1_');
+    expect(sanitizeStackNameComponent('lpt9')).toBe('lpt9_');
+    // case is preserved on the original base, only the reserved-ness is case-insensitive
+    expect(sanitizeStackNameComponent('Nul')).toBe('Nul_');
+    expect(sanitizeStackNameComponent('CON')).toBe('CON_');
+  });
+
+  it('a reserved base name followed by an extension is still sanitized (Win32 matches base only)', () => {
+    // The Win32 device rule uses the part BEFORE the first dot — so `nul.foo` is also NUL.
+    // (A CFn stack name cannot contain a dot, but defend the device rule at the base name.)
+    expect(sanitizeStackNameComponent('nul.foo')).toBe('nul_.foo');
+    expect(baseNameOfFile(baselinePath('nul.foo', '111122223333', 'us-east-1'))).not.toBe('NUL');
+  });
+
+  it('leaves a normal (non-reserved) stack name UNCHANGED', () => {
+    for (const name of [
+      'MyStack',
+      'console',
+      'nuller',
+      'com',
+      'com10',
+      'lpt',
+      'prod-api',
+      'aux-service',
+    ]) {
+      expect(sanitizeStackNameComponent(name)).toBe(name);
+      expect(baselinePath(name, '111122223333', 'us-east-1')).toBe(
+        `.cdkrd/baselines/${name}.111122223333.us-east-1.json`
+      );
+    }
+  });
+
+  it('is injective over the VALID CFn stack-name domain: distinct names never collide', () => {
+    // A valid CFn stack name is [A-Za-z][-A-Za-z0-9]* — letters, digits, hyphens ONLY, NEVER
+    // an underscore. The transform inserts an `_`, so a transformed reserved name (nul_) can
+    // never equal any plain (underscore-free) name — injectivity holds precisely BECAUSE the
+    // domain excludes underscores. Check the reserved set plus near-miss plain names (which a
+    // real stack CAN be named — `console`, `nuller`, `com`, `com10`) all map to DISTINCT
+    // filenames. (`nul_` is NOT a valid CFn stack name, so it is intentionally excluded.)
+    const names = [...RESERVED, 'MyStack', 'nuller', 'console', 'com', 'com10', 'lpt', 'aux-x'];
+    const paths = names.map((n) => baselinePath(n, '111122223333', 'us-east-1'));
+    expect(new Set(paths).size).toBe(paths.length);
+    // and every reserved name maps to a DIFFERENT path than every other reserved name
+    const reservedPaths = RESERVED.map((n) => baselinePath(n, '111122223333', 'us-east-1'));
+    expect(new Set(reservedPaths).size).toBe(RESERVED.length);
+  });
+
+  it('is stable and deterministic: same input yields the same output', () => {
+    for (const name of [...RESERVED, 'MyStack', 'Nul']) {
+      const a = baselinePath(name, '111122223333', 'us-east-1');
+      const b = baselinePath(name, '111122223333', 'us-east-1');
+      expect(a).toBe(b);
+      expect(sanitizeStackNameComponent(name)).toBe(sanitizeStackNameComponent(name));
+    }
+  });
+
+  it('keeps accountId and region in the filename intact', () => {
+    expect(baselinePath('nul', '111122223333', 'us-east-1')).toBe(
+      '.cdkrd/baselines/nul_.111122223333.us-east-1.json'
+    );
+  });
+});


### PR DESCRIPTION
Closes #1077

Offline fix with unit tests. A stack named exactly a DOS device (nul/con/aux/prn/com1-9/lpt1-9 — all valid CFn names) mapped its baseline filename to a Windows device (silent data loss on record; broke Windows teammates' git clone). baselinePath now routes the stack-name component through sanitizeStackNameComponent, appending _ after a reserved base name (nul -> nul_); injective because valid CFn names never contain _. Normal names unchanged (no migration).