### PR TITLE
fix(normalize): re-check intrinsic-resolved strings for dynamic references (Ref/FindInMap/Select/ImportValue) (#1073)

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -20,6 +20,20 @@ export function isDynamicReference(v: string): boolean {
   return DYNAMIC_REFERENCE_RE.test(v);
 }
 
+// Re-check a resolved value that an intrinsic PRODUCED (a Ref-to-parameter value,
+// an Fn::FindInMap lookup, an Fn::Select element, an Fn::ImportValue export) for a
+// whole-string dynamic reference. The literal-string guard at the top of `resolve`
+// only sees a `{{resolve:…}}` token that appears DIRECTLY in the template tree; when
+// the same token arrives INDIRECTLY as the result of resolving one of these
+// intrinsics, that guard never runs, so the raw token would leak out as a declared
+// value (a false positive that also prints the secret plaintext and, on revert,
+// writes the literal `{{resolve:…}}` back). Fold it to UNRESOLVED here — the same
+// post-resolution re-check Fn::Join and Fn::Sub already do on their assembled result.
+// See #1073 (the indirect siblings of the direct-literal guard #722).
+function checkResolvedDynamicRef(r: unknown): unknown {
+  return typeof r === 'string' && isDynamicReference(r) ? UNRESOLVED : r;
+}
+
 // A value safe to interpolate into a joined / substituted STRING: a primitive
 // (string / number / boolean). A symbol (UNRESOLVED / NOVALUE) or an object / array
 // means resolution was incomplete (a deep GetAtt) or the template is malformed —
@@ -60,7 +74,7 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
     const v = obj[k];
     switch (k) {
       case 'Ref':
-        return resolveRef(String(v), ctx);
+        return checkResolvedDynamicRef(resolveRef(String(v), ctx));
       case 'Fn::Sub':
         return resolveSub(v, ctx);
       case 'Fn::Base64': {
@@ -124,7 +138,7 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
         // element itself being UNRESOLVED also propagates.
         if (!Number.isInteger(i) || i < 0 || i >= arr.length) return UNRESOLVED;
         const sel = arr[i];
-        return sel === UNRESOLVED ? UNRESOLVED : sel;
+        return sel === UNRESOLVED ? UNRESOLVED : checkResolvedDynamicRef(sel);
       }
       case 'Fn::FindInMap': {
         if (!Array.isArray(v) || v.length < 3) return UNRESOLVED;
@@ -149,7 +163,7 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
         )
           return UNRESOLVED;
         const val = ctx.mappings?.[mapName]?.[topKey]?.[secondKey];
-        if (val !== undefined) return val;
+        if (val !== undefined) return checkResolvedDynamicRef(val);
         // CFn supports an optional 4th argument — { DefaultValue: ... } — returned when
         // the map path is absent. Honor it so a declared default is still compared (else
         // a knowable declared value is silently dropped to UNRESOLVED = missed drift).
@@ -161,7 +175,7 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
           'DefaultValue' in fourth
         ) {
           const def = resolve((fourth as Record<string, unknown>).DefaultValue, ctx);
-          return def === UNRESOLVED ? UNRESOLVED : def;
+          return def === UNRESOLVED ? UNRESOLVED : checkResolvedDynamicRef(def);
         }
         return UNRESOLVED;
       }
@@ -194,7 +208,7 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
         const name = resolve(v, ctx);
         if (typeof name !== 'string') return UNRESOLVED;
         // Prefetched exports (see loadDesired); absent name -> fail-closed.
-        return name in ctx.exports ? ctx.exports[name] : UNRESOLVED;
+        return name in ctx.exports ? checkResolvedDynamicRef(ctx.exports[name]) : UNRESOLVED;
       }
       case 'Fn::GetAtt':
         return resolveGetAtt(v, ctx);

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -428,6 +428,54 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::Join': ['-', ['a', { Ref: 'Env' }]] }, ctx())).toBe('a-prod');
   });
 
+  // #1073: a whole-string dynamic reference that arrives INDIRECTLY — produced by
+  // resolving a Ref-to-parameter / Fn::FindInMap / Fn::Select / Fn::ImportValue rather
+  // than as a direct string literal in the tree — must ALSO fold to UNRESOLVED. The
+  // literal-string guard only sees a token that appears directly in the template; the
+  // #722 fix guarded the direct case, this covers its indirect siblings. Leaking the
+  // raw `{{resolve:…}}` here is a declared FP that prints the secret and, on revert,
+  // writes the literal token back.
+  it('R130 #1073: a dynamic reference resolved via Ref/FindInMap/Select/ImportValue → UNRESOLVED', () => {
+    const secret =
+      '{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:111111111111:secret:Db-abc:SecretString:username::}}';
+    const ssm = '{{resolve:ssm-secure:/my/secure:5}}';
+
+    // (a) Ref to a parameter whose value IS the dynamic-ref string.
+    expect(resolve({ Ref: 'SecretRef' }, ctx({ params: { SecretRef: secret } }))).toBe(UNRESOLVED);
+
+    // (b) Fn::FindInMap looked-up value is a dynamic-ref string.
+    const mapCtx = ctx({ mappings: { M: { top: { key: ssm } } } });
+    expect(resolve({ 'Fn::FindInMap': ['M', 'top', 'key'] }, mapCtx)).toBe(UNRESOLVED);
+    // ...and via the FindInMap DefaultValue (map path absent) resolving to one.
+    expect(
+      resolve(
+        { 'Fn::FindInMap': ['M', 'nope', 'nope', { DefaultValue: { Ref: 'SecretRef' } }] },
+        ctx({ mappings: { M: {} }, params: { SecretRef: secret } })
+      )
+    ).toBe(UNRESOLVED);
+
+    // (c) Fn::Select of a list containing the dynamic-ref string.
+    expect(resolve({ 'Fn::Select': [1, ['a', secret, 'c']] }, ctx())).toBe(UNRESOLVED);
+
+    // (d) Fn::ImportValue resolving to a dynamic-ref export.
+    expect(
+      resolve({ 'Fn::ImportValue': 'SecretExport' }, ctx({ exports: { SecretExport: ssm } }))
+    ).toBe(UNRESOLVED);
+
+    // no-regression: an ordinary (non-dynamic-ref) resolved string still resolves normally.
+    expect(resolve({ Ref: 'Env' }, ctx())).toBe('prod');
+    expect(
+      resolve(
+        { 'Fn::FindInMap': ['M', 'top', 'key'] },
+        ctx({ mappings: { M: { top: { key: 'plain' } } } })
+      )
+    ).toBe('plain');
+    expect(resolve({ 'Fn::Select': [0, ['first', 'second']] }, ctx())).toBe('first');
+    expect(
+      resolve({ 'Fn::ImportValue': 'PlainExport' }, ctx({ exports: { PlainExport: 'plain-val' } }))
+    ).toBe('plain-val');
+  });
+
   // #851: a malformed Fn::Sub argument (non-string / non-`[string, map]` array) must
   // fail closed to UNRESOLVED, never throw a TypeError on `.replace` of a non-string
   // template. Every branch of the resolver is fail-closed; these shapes were the gap.


### PR DESCRIPTION
Closes #1073

Offline fix with unit tests. A whole-string {{resolve:...}} dynamic reference arriving via Ref/Fn::FindInMap/Fn::Select/Fn::ImportValue bypassed the UNRESOLVED guard (a declared FP + secret plaintext print + revert writing the literal token) — #722's untouched sibling entry points. Each intrinsic now re-checks its resolved string against the dynamic-reference detector (as Fn::Join/Fn::Sub already did) and returns UNRESOLVED.