### PR TITLE
fix(check): match hasBaselineForStack on the sanitized stack-name component (#1077 follow-up)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -20,6 +20,7 @@ import {
   declaredKeysByLogical,
   loadBaseline,
   physicalIdsByLogical,
+  sanitizeStackNameComponent,
   warnBaselineSchemaV1,
   warnTemplateHashDrift,
 } from '../baseline/baseline-file.js';
@@ -270,7 +271,14 @@ export function hasBaselineForStack(
   // Stack names are alphanumeric/hyphen (no dots) and an accountId is digits, so
   // `${stackName}.${accountId}.` is an unambiguous prefix. Without a known account the
   // account segment stays wildcarded (region-only pin, today's behavior).
-  const prefix = (accountId ? `${stackName}.${accountId}.` : `${stackName}.`).toLowerCase();
+  // #1077: match on the SANITIZED stack-name component `baselinePath` actually writes — a
+  // Windows-reserved DOS device name (`nul`/`con`/…) is stored as `nul_.<acct>.<region>.json`,
+  // so probing the raw `nul.` prefix would MISS its file and falsely report the deleted stack
+  // as never-deployed. sanitizeStackNameComponent is identity for every normal name.
+  const stackComponent = sanitizeStackNameComponent(stackName);
+  const prefix = (
+    accountId ? `${stackComponent}.${accountId}.` : `${stackComponent}.`
+  ).toLowerCase();
   const suffix = `.${region}.json`.toLowerCase();
   return entries.some((f) => {
     const lower = f.toLowerCase();

--- a/tests/deleted-stack-781.test.ts
+++ b/tests/deleted-stack-781.test.ts
@@ -121,6 +121,18 @@ describe('#781 deleted-out-of-band stack surfaces as drift, not a skip', () => {
       expect(hasBaselineForStack(STACK, REGION)).toBe(false);
     });
 
+    it('#1077: finds the SANITIZED baseline of a Windows-reserved DOS device stack name', async () => {
+      // A stack literally named `nul` (a valid CFn name) has its baseline written by
+      // `baselinePath` as `nul_.<acct>.<region>.json` (sanitizeStackNameComponent avoids the
+      // Win32 device collision). The probe must match on that SAME sanitized component — a raw
+      // `nul.` prefix would miss the file and falsely downgrade a truly deleted `nul` stack to
+      // a benign never-deployed skip.
+      await writeBaseline('nul', ACCOUNT, REGION); // → nul_.<acct>.<region>.json on disk
+      expect(hasBaselineForStack('nul', REGION)).toBe(true);
+      expect(hasBaselineForStack('nul', REGION, ACCOUNT)).toBe(true); // account-pinned too
+      expect(hasBaselineForStack('Con', REGION)).toBe(false); // a different (absent) reserved name
+    });
+
     it('does not false-match a stack name that is a prefix of a different stack', async () => {
       // `MyStackExtra.<...>.json` must NOT satisfy hasBaselineForStack('MyStack') — the
       // `<stackName>.` separator guards against a bare-prefix collision.


### PR DESCRIPTION
Refs #1077

Follow-up completing the #1077 / #1145 Windows-reserved-name fix. #1145 made baselinePath write a reserved DOS device stack name (nul/con/aux/...) as `nul_.<acct>.<region>.json`, but the deleted-out-of-band probe hasBaselineForStack (check.ts) re-derived its own raw `nul.` prefix — so it MISSED the sanitized file and would falsely downgrade a genuinely deleted `nul` stack to a benign never-deployed skip. Now probes on sanitizeStackNameComponent(stackName). Identity for every normal name. Unit test added (tests/deleted-stack-781.test.ts, #1077 case).