### PR TITLE
fix(check): apply the #1077 reserved-name sanitization to the hasBaselineForStack prefix scan (#1148)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -20,6 +20,7 @@ import {
   declaredKeysByLogical,
   loadBaseline,
   physicalIdsByLogical,
+  sanitizeStackNameComponent,
   warnBaselineSchemaV1,
   warnTemplateHashDrift,
 } from '../baseline/baseline-file.js';
@@ -270,7 +271,15 @@ export function hasBaselineForStack(
   // Stack names are alphanumeric/hyphen (no dots) and an accountId is digits, so
   // `${stackName}.${accountId}.` is an unambiguous prefix. Without a known account the
   // account segment stays wildcarded (region-only pin, today's behavior).
-  const prefix = (accountId ? `${stackName}.${accountId}.` : `${stackName}.`).toLowerCase();
+  // #1148: the on-disk file is named via `baselinePath`, which #1077 SANITIZES for a Windows
+  // reserved DOS device name (`nul` -> `nul_.<acct>.<region>.json`). This existence probe does
+  // its OWN prefix scan (not a `baselinePath` filename compare), so it must apply the SAME
+  // sanitization to the stack-name component — else a recorded reserved-name stack deleted out
+  // of band is silently MISSED (the raw `nul.` prefix never matches the `nul_.` file).
+  const stackComponent = sanitizeStackNameComponent(stackName);
+  const prefix = (
+    accountId ? `${stackComponent}.${accountId}.` : `${stackComponent}.`
+  ).toLowerCase();
   const suffix = `.${region}.json`.toLowerCase();
   return entries.some((f) => {
     const lower = f.toLowerCase();

--- a/tests/deleted-stack-781.test.ts
+++ b/tests/deleted-stack-781.test.ts
@@ -160,6 +160,22 @@ describe('#781 deleted-out-of-band stack surfaces as drift, not a skip', () => {
       await writeBaseline(STACK, SHARED, 'eu-west-1');
       expect(hasBaselineForStack(STACK, REGION, SHARED)).toBe(false); // right account, wrong region
     });
+
+    // #1148: #1077 sanitizes a Windows reserved DOS device stack name in the on-disk filename
+    // (`nul` -> `nul_.<acct>.<region>.json`). The existence probe must apply the SAME sanitization
+    // to its prefix scan, else a recorded reserved-name stack deleted out of band is MISSED (the
+    // raw `nul.` prefix never matches the `nul_.` file that `record`/`baselinePath` actually wrote).
+    it('finds a recorded reserved-name (`nul`) stack — prefix scan mirrors #1077 sanitization (#1148)', async () => {
+      await writeBaseline('nul', ACCOUNT, REGION); // baselinePath writes `nul_.<acct>.<region>.json`
+      expect(hasBaselineForStack('nul', REGION)).toBe(true);
+      expect(hasBaselineForStack('nul', REGION, ACCOUNT)).toBe(true); // account-pinned path too
+    });
+
+    it('a reserved-name miss is still region-bounded (#1148)', async () => {
+      await writeBaseline('con', ACCOUNT, 'eu-west-1');
+      expect(hasBaselineForStack('con', REGION)).toBe(false); // wrong region → no match
+      expect(hasBaselineForStack('con', 'eu-west-1')).toBe(true); // right region → match
+    });
   });
 
   describe('exit-code contract of the not-deployed catch (#781)', () => {


### PR DESCRIPTION
Closes #1148.

## Problem (an interaction bug between #1077 and #1046/#781)
#1077 made `baselinePath` sanitize a Windows reserved DOS device stack name in the on-disk filename via `sanitizeStackNameComponent` (`nul` → `nul_.<acct>.<region>.json`). But `hasBaselineForStack` does its **own** directory prefix scan (not a `baselinePath` filename compare) using the **raw** stack name, so its prefix `nul.<acct>.` never matches the sanitized `nul_.…` file that `record` actually wrote.

Consequence: a recorded reserved-name stack (`nul`/`con`/`aux`/`prn`/`com1..9`/`lpt1..9` — all valid CFn names) that is **deleted out of band** is silently **missed** by the #781/#942/#1046 deleted-detection — reported `not deployed yet — skipped` (exit 0) instead of drift. #1077 fixed the write path but its own issue's note to mirror the sanitization "in the read + hasBaselineForStack prefix scan" wasn't applied to the prefix.

## Fix (`src/commands/check.ts` only)
Apply `sanitizeStackNameComponent` (already exported by `baseline-file.ts`) to the stack-name component when building the prefix, so the probe matches the exact file `baselinePath` writes. One line + import.

## Tests
`tests/deleted-stack-781.test.ts`: a recorded reserved-name stack (`nul`, `con`) is now found by `hasBaselineForStack` (raw + account-pinned paths), still region-bounded. Full suite green (3848).

Found while auditing the overlap of my #1046 and the peer's #1077 (both edited the baseline identity path). Offline/deterministic (filesystem probe) — unit tests are the evidence.