### PR TITLE
fix(config): ignore rule for a '/'-bearing CC identifier no longer swallows a '/'-extended sibling (#1061)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -420,17 +420,32 @@ export function parseIgnoreRule(entry: IgnoreRuleObject): IgnoreRule {
  *
  * `wholeResource` marks an atomic, whole-resource target (an `added` finding — empty property
  * path, so the target is just `<parentLogicalId>/<CC-identifier>`). Such a target has NO
- * property subtree: the `.` / `[` inside it are DATA within the CC identifier
- * (`example.com`, an ARN, `a[0]`), never property separators. Trimming there would walk into
- * a DIFFERENT sibling resource whose identifier is this one extended by `.` / `[`
- * (`MyApi/a` wrongly swallowing `MyApi/a.b`, `MyApi/a[0]`) — a silent over-suppression of the
- * `added` out-of-band feature (issue #990). So in this mode the ancestor walk trims ONLY at
- * `/` boundaries, which alone mark a resource boundary: a bare PARENT-resource rule (`MyLb`)
- * still covers its added children across `/` (e.g. a listener child whose id is an ARN full
- * of `/`, issue #903), while a rule for one whole resource can no longer reach a sibling.
+ * property subtree: everything after the FIRST `/` is the OPAQUE CC identifier — and it may
+ * itself contain `.`, `[`, `|`, OR `/` (a Cognito ResourceServer URI identifier
+ * `https://api.example.com/v2`, an ARN, a log-group name). None of those are property or
+ * resource separators; they are DATA inside one atomic id, so the segment-bounded ancestor
+ * walk below MUST NOT run — an intermediate `.` / `[` / `/`-prefix is a truncation of the
+ * identifier that reaches a DIFFERENT sibling (`MyApi/a` swallowing `MyApi/a.b` or
+ * `MyApi/a[0]` — #990; a LITERAL rule `.../api.example.com` swallowing the extended sibling
+ * `.../api.example.com/v2` — #1061). Instead we test exactly two things, both with the
+ * identifier treated ATOMICALLY (the UNBOUNDED `matchesGlob`, whose `*` / `?` span `/`, since
+ * a `/` inside the identifier is data, not a boundary):
+ *   1. the FULL target — a LITERAL rule (what `ignoreRuleFor` writes, metachars escaped) then
+ *      matches ONLY its own exact id, never a `/`-extended sibling; a user-authored parent
+ *      glob (`MyLb/*`) still spans the whole atomic identifier of a child; and
+ *   2. the BARE PARENT logical id — the single segment BEFORE the first `/` — so a bare
+ *      parent-RESOURCE rule (`MyLb`, issue #903) still covers a child whose id is an ARN full
+ *      of `/`.
  */
 function pathMatches(pattern: string, target: string, wholeResource = false): boolean {
   if (matchesPathGlob(pattern, target)) return true;
+  if (wholeResource) {
+    // Identifier is atomic — test the full target and the bare-parent prefix with the
+    // unbounded glob (no walk into the identifier). See the doc comment (#903 / #990 / #1061).
+    if (matchesGlob(pattern, target)) return true;
+    const firstSlash = target.indexOf('/');
+    return firstSlash > 0 && matchesGlob(pattern, target.slice(0, firstSlash));
+  }
   // A rule on a PARENT property ignores its whole subtree — including array / identity-
   // keyed children whose path glues the index to its key inside ONE dot-segment
   // (`Policies[MyPol].PolicyName`, `Statement[0].Condition`, `Tags[env]`) AND deeper
@@ -439,13 +454,10 @@ function pathMatches(pattern: string, target: string, wholeResource = false): bo
   // each `.`, `[`, OR `/` boundary, so a rule `X.Policies` covers `X.Policies[MyPol].Name`,
   // `X.Statement` covers `X.Statement[0].Condition`, and `MyApi/Res` covers its `/`-subtree
   // — symmetric with the `.` case (the dot/bracket-only split silently failed across `/`).
-  // For a whole-resource (`added`) target the identifier is atomic, so trim ONLY at `/`
-  // (parent-RESOURCE coverage) — never at `.` / `[`, which would reach a sibling (#990).
+  // (A whole-resource `added` target returns above; this walk is property-subtree only.)
   let t = target;
   while (true) {
-    const cut = wholeResource
-      ? t.lastIndexOf('/')
-      : Math.max(t.lastIndexOf('.'), t.lastIndexOf('['), t.lastIndexOf('/'));
+    const cut = Math.max(t.lastIndexOf('.'), t.lastIndexOf('['), t.lastIndexOf('/'));
     if (cut <= 0) break;
     t = t.slice(0, cut);
     if (matchesPathGlob(pattern, t)) return true;

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -341,6 +341,40 @@ describe('applyIgnores', () => {
     expect(ign([added('CDN', 'example.com')], 'S', cfg([cdnRule]))[0]?.tier).toBe('added');
   });
 
+  it('an `added` rule for a `/`-bearing CC identifier never swallows a `/`-extended sibling (#1061)', () => {
+    // #990 residue: the identifier itself can contain `/` (a Cognito ResourceServer URI
+    // identifier `https://api.example.com` vs `https://api.example.com/v2`), and the old
+    // wholeResource walk trimmed at EVERY `/` — so a rule for one added resource silently
+    // over-suppressed a DIFFERENT sibling whose id is the first extended by `/…`.
+    const added = (parent: string, id: string): Finding => ({
+      tier: 'added',
+      logicalId: `${parent}/${id}`,
+      constructPath: `MyStack/${parent} ▸ ${id}`,
+      resourceType: 'AWS::Cognito::UserPoolResourceServer',
+      path: '',
+    });
+    const a = added('Pool', 'us-east-1_ABC|https://api.example.com');
+    const b = added('Pool', 'us-east-1_ABC|https://api.example.com/v2');
+    // rule written by the verb for `a` is the full literal identifier (no glob metachars)
+    const rule = ignoreRuleFor(a, 'MyStack');
+    expect(rule.path).toBe('Pool/us-east-1_ABC|https://api.example.com');
+    // applying it over BOTH siblings ignores exactly `a`, leaving the extended sibling `b`
+    const out = ign([a, b], 'MyStack', cfg([rule]));
+    expect(out[0]?.tier).toBe('ignored');
+    expect(out[1]?.tier).toBe('added'); // BUG on main: wrongly 'ignored'
+    // symmetric: a rule for the LONGER `b` must not swallow the shorter `a` either (already
+    // correct, but the full-target-only match must stay exact)
+    const ruleB = ignoreRuleFor(b, 'MyStack');
+    const out2 = ign([a, b], 'MyStack', cfg([ruleB]));
+    expect(out2[0]?.tier).toBe('added');
+    expect(out2[1]?.tier).toBe('ignored');
+    // #903 preserved: the bare PARENT rule `Pool` still covers a child whose id has `/`
+    expect(ign([b], 'MyStack', cfg([p('Pool')]))[0]?.tier).toBe('ignored');
+    // #990 preserved: a `.`-extended sibling of `a`'s identifier is still not swallowed
+    const dotSibling = added('Pool', 'us-east-1_ABC|https://api.example.com.bak');
+    expect(ign([dotSibling], 'MyStack', cfg([rule]))[0]?.tier).toBe('added');
+  });
+
   it('a bare PARENT-resource rule still covers its added children across `/` (#903 not regressed)', () => {
     // The `/`-boundary walk (parent-RESOURCE coverage) survives the #990 fix — only the
     // `.`/`[` within-identifier trim is dropped. A rule on the parent `MyLb` still ignores an


### PR DESCRIPTION
Closes #1061

## Problem
An `added`-tier ignore rule targets an atomic whole-resource id `<parentLogicalId>/<CC-identifier>`. The #990 fix stopped the ancestor walk from trimming inside the identifier at `.`/`[`, but kept trimming at every `/` (for #903's bare-parent coverage). A CC identifier can itself contain `/` (Cognito ResourceServer URI identifiers `https://api.example.com` vs `https://api.example.com/v2`), so ignoring one resource silently re-tagged a `/`-extended sibling `ignored` too — a detection hole in the `added` out-of-band feature, identical in kind to #990.

## Fix
In `pathMatches` `wholeResource` mode, the identifier after the first `/` is now treated **atomically**: it tests only (1) the full target and (2) the bare-parent prefix (segment before the first `/`), using the unbounded `matchesGlob`. A **literal** rule (what the `ignore` verb writes — metachars escaped) becomes an exact compare, so it can never reach a `/`-extended sibling, while a user-authored parent glob (`MyLb`, `MyLb/*`) still spans a child's whole slashful identifier.

- Fixes #1061 (literal rule no longer swallows `.../x/v2` sibling of `.../x`).
- Preserves #990 (no trimming into `.`/`[`-extended siblings).
- Preserves #903 (both bare `MyLb` and `MyLb/*` still cover a slashful child) — the two pre-existing #903 tests pass unchanged.

## Tests
Added `tests/config-file.test.ts` › "an 'added' rule for a '/'-bearing CC identifier never swallows a '/'-extended sibling (#1061)" — the issue's Cognito ResourceServer case, plus reverse-direction exactness and #903/#990 preservation assertions. Fails without the fix, passes with it.

Gates: typecheck / lint+format / build / **3822 unit tests** all green.
