### PR TITLE
fix(revert): bar cc-kind revert on a handler-less CFn-legacy type (#1091)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -807,17 +807,29 @@ export function buildRevertPlan(
       });
       continue;
     }
-    // A resource type whose CFn schema declares a `handlers` block but NO `update` handler
-    // (create/read/delete only — e.g. AWS::CloudFront::MonitoringSubscription) can never be
-    // patched via Cloud Control UpdateResource: the apply fails with a raw
-    // UnsupportedActionException (#908). Bar the doomed cc-kind revert here with a clear
-    // reason instead of emitting a patch that always fails. EXEMPT: a type with a
-    // type-specific SDK writer (SDK_WRITERS / prop- / nested-scoped) reverts via its own API,
-    // and a `delete`-kind out-of-band-added item already `continue`d far above. `updatable`
-    // is `false` ONLY when handlers ARE present and `update` is absent — an `undefined`
-    // (schema unavailable / no handlers block) is NOT barred (that degradation is #858).
+    // A resource type that can never be patched via Cloud Control UpdateResource — the apply
+    // fails with a raw UnsupportedActionException — must bar the doomed cc-kind revert here
+    // with a clear reason instead of emitting a patch that always fails. Two cases:
+    //   (a) #908: the schema declares a `handlers` block but NO `update` handler (create/read/
+    //       delete only — e.g. AWS::CloudFront::MonitoringSubscription) → `updatable === false`.
+    //   (b) #1091: a CFn-legacy type read via SDK_OVERRIDES whose registry schema has NO
+    //       `handlers` block AT ALL (ACM Certificate's shape) → `hasHandlers === false`. Here
+    //       `updatable` is `undefined`, but that undefined means "handlers legitimately absent",
+    //       NOT "schema unavailable" — so the #858 undefined-degrade skip (which leaves a
+    //       genuinely schema-unavailable type UNBARRED, `hasHandlers` undefined) must not swallow
+    //       it. The SDK_OVERRIDES guard confines this to types we KNOW are read via an SDK
+    //       override (a pure CC-read type has a handlers block by construction). NOTE: most such
+    //       types (ACM included) are ALSO caught by the broader SDK_OVERRIDES-not-in-
+    //       CC_REVERTABLE_DESPITE_READ_OVERRIDE bar earlier in this loop; this is the narrower
+    //       safety net for a handler-less type that IS on that allowlist (so it falls through the
+    //       broader bar) yet can never take a CC UpdateResource.
+    // EXEMPT (both cases): a type with a type-specific SDK writer (SDK_WRITERS / prop- / nested-
+    // scoped) reverts via its own API, and a `delete`-kind out-of-band-added item already
+    // `continue`d far above.
+    const noUpdateHandler = schema?.updatable === false;
+    const legacyNoHandlers = schema?.hasHandlers === false && !!SDK_OVERRIDES[f.resourceType];
     if (
-      schema?.updatable === false &&
+      (noUpdateHandler || legacyNoHandlers) &&
       !SDK_WRITERS[f.resourceType] &&
       !propScoped &&
       !nestedScoped
@@ -826,7 +838,9 @@ export function buildRevertPlan(
         displayId,
         resourceType: f.resourceType,
         path: f.path,
-        reason: 'type has no update handler — detect/record only',
+        reason: legacyNoHandlers
+          ? 'CFn-legacy type has no update handler block — detect/record only'
+          : 'type has no update handler — detect/record only',
       });
       continue;
     }

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -546,6 +546,11 @@ export function parseSchema(schemaJson: string): SchemaInfo {
   // (leave `updatable` undefined), so revert never bars on a schema-unavailable degradation.
   const updatable =
     schema.handlers === undefined ? undefined : Object.hasOwn(schema.handlers, 'update');
+  // Whether a `handlers` block exists AT ALL. `false` here (schema present, no handlers)
+  // is a CFn-legacy type (ACM Certificate et al.) that can never be CC-UpdateResource'd —
+  // distinct from a schema-unavailable degradation (EMPTY leaves this undefined). The
+  // #908/#1091 revert bar uses this to tell the two apart. (#1091)
+  const hasHandlers = schema.handlers !== undefined;
   // `propertyTransform` maps a JSON-pointer property path to a JSONata expression describing how
   // the SERVICE transforms a declared value before storing it (so the live read differs from the
   // template value without any real drift). Key it by the same dotted path convention as the other
@@ -570,5 +575,6 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     freeFormMapPaths,
     ...(Object.keys(propertyTransforms).length > 0 && { propertyTransforms }),
     updatable,
+    hasHandlers,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,6 +154,16 @@ export interface SchemaInfo {
   // failure returning EMPTY): revert must NOT bar on unknown, to avoid regressing on
   // schema-unavailable degradation (#858 handles that separately). Optional like the above.
   updatable?: boolean | undefined;
+  // True when the CFn resource schema carries a `handlers` block AT ALL (regardless of which
+  // handlers it declares); false when the schema is present but has NO `handlers` block — a
+  // CFn-legacy type (e.g. AWS::CertificateManager::Certificate) whose auto-generated registry
+  // schema predates the handler model, so Cloud Control UpdateResource always fails at apply
+  // with a raw UnsupportedActionException. UNDEFINED when the schema itself is unavailable
+  // (DescribeType failure → EMPTY): unlike `hasHandlers === false`, that degradation must NOT
+  // bar a revert (#858). Lets the #908/#1091 revert bar tell "handlers legitimately absent"
+  // apart from "schema unavailable" instead of overloading `updatable === undefined` for both.
+  // Optional like the above (set by parseSchema; test/corpus fixtures may omit it). (#1091)
+  hasHandlers?: boolean | undefined;
 }
 
 export interface ResolverContext {

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1818,6 +1818,93 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  // #1091 — a CFn-legacy type read via SDK_OVERRIDES whose registry schema has NO `handlers`
+  // block AT ALL (ACM Certificate's shape). Cloud Control UpdateResource always fails at apply
+  // with a raw UnsupportedActionException, so buildRevertPlan must never emit a cc-kind item for
+  // it. `updatable` is `undefined` (no handlers block), which the #908 guard deliberately does
+  // NOT bar (that undefined can also mean "schema unavailable" — #858). The new discriminator is
+  // `hasHandlers === false` (schema present, no handlers block) gated on the type being
+  // SDK_OVERRIDES-read; a schema-unavailable degradation leaves `hasHandlers` undefined and stays
+  // revertable. NOTE: for ACM the doomed patch is ALSO (and first) prevented by the broader
+  // SDK_OVERRIDES-not-in-CC_REVERTABLE bar earlier in buildRevertPlan; this new guard is the
+  // narrower safety net for a type that IS on the CC_REVERTABLE_DESPITE_READ_OVERRIDE allowlist
+  // (falls through that broader bar) yet turns out handler-less — exercised below with
+  // AWS::Scheduler::Schedule (SDK_OVERRIDES + allowlisted, no SDK writer).
+  describe('CFn-legacy no-handlers-block guard (SDK_OVERRIDES-read, #1091)', () => {
+    const ACM = 'AWS::CertificateManager::Certificate';
+    // AWS::Scheduler::Schedule is SDK_OVERRIDES-read AND on CC_REVERTABLE_DESPITE_READ_OVERRIDE
+    // (so it falls through the broader SDK_OVERRIDES bar and reaches the cc-kind path) with no
+    // SDK writer — the one existing type shape that actually exercises the new guard.
+    const SCHED = 'AWS::Scheduler::Schedule';
+    // A registry schema with real props but NO `handlers` block — ACM's / a CFn-legacy shape.
+    const noHandlersSchema = (type: string): Map<string, SchemaInfo> =>
+      new Map([
+        [
+          type,
+          parseSchema(
+            JSON.stringify({
+              properties: { Options: { type: 'object' }, Tags: { type: 'array' } },
+              readOnlyProperties: ['/properties/Id'],
+            })
+          ),
+        ],
+      ]);
+    // A DECLARED drift (desired/actual) isolates the handler bar from the undeclared/
+    // unrecorded path.
+    const drift = (type: string, path: string): Finding =>
+      F({ tier: 'declared', resourceType: type, path, desired: 'a', actual: 'b', physicalId: 'p' });
+
+    it('parseSchema.hasHandlers: false when the schema has no handlers block, true when present', () => {
+      expect(parseSchema(JSON.stringify({ properties: { Foo: {} } })).hasHandlers).toBe(false);
+      expect(parseSchema(JSON.stringify({ handlers: { read: {} } })).hasHandlers).toBe(true);
+      // updatable stays undefined for a handler-less schema (unchanged) — the two flags differ.
+      expect(parseSchema(JSON.stringify({ properties: { Foo: {} } })).updatable).toBeUndefined();
+    });
+
+    it('an ACM cc revert is NOT offered — no doomed CC UpdateResource patch reaches apply (#1091 symptom)', () => {
+      // The user-visible guarantee: whatever the reason, revert is barred and no cc item is
+      // built. (For ACM this is enforced by the broader SDK_OVERRIDES-not-in-CC_REVERTABLE bar.)
+      const plan = buildRevertPlan(
+        [drift(ACM, 'Options.CertificateTransparencyLoggingPreference')],
+        undefined,
+        { schemas: noHandlersSchema(ACM) }
+      );
+      expect(plan.items).toHaveLength(0);
+      expect(plan.notRevertable).toHaveLength(1);
+    });
+
+    it('BARS a cc revert on a CC_REVERTABLE-allowlisted SDK_OVERRIDES type that is handler-less, with the CFn-legacy reason (the new #1091 guard)', () => {
+      const plan = buildRevertPlan([drift(SCHED, 'ScheduleExpression')], undefined, {
+        schemas: noHandlersSchema(SCHED),
+      });
+      expect(plan.items).toHaveLength(0);
+      expect(plan.notRevertable).toHaveLength(1);
+      expect(plan.notRevertable[0]!.reason).toContain('CFn-legacy');
+      expect(plan.notRevertable[0]!.reason).toContain('no update handler block');
+    });
+
+    it('the SAME allowlisted type WITH a handlers block still produces the cc item (no regression)', () => {
+      const schemas = new Map([
+        [SCHED, parseSchema(JSON.stringify({ handlers: { create: {}, update: {}, read: {} } }))],
+      ]);
+      const plan = buildRevertPlan([drift(SCHED, 'ScheduleExpression')], undefined, { schemas });
+      expect(plan.notRevertable).toHaveLength(0);
+      expect(plan.items[0]!.kind).toBe('cc');
+    });
+
+    it('a NON-SDK_OVERRIDES type with no handlers block is NOT barred — schema-unavailable degradation stays revertable (#858 preserved)', () => {
+      // Same handler-less schema shape, but a type that is NOT SDK_OVERRIDES-read: the #1091
+      // guard must not fire (updatable === undefined alone, which #908 deliberately skips).
+      const type = 'AWS::Some::CcReadType';
+      const schemas = new Map([
+        [type, parseSchema(JSON.stringify({ properties: { Foo: { type: 'string' } } }))],
+      ]);
+      const plan = buildRevertPlan([drift(type, 'Foo')], undefined, { schemas });
+      expect(plan.notRevertable).toHaveLength(0);
+      expect(plan.items[0]!.kind).toBe('cc');
+    });
+  });
+
   it('a NESTED create-only path (parent mutable) is notRevertable, not a doomed in-place patch', () => {
     // ECR EncryptionConfiguration is mutable but EncryptionConfiguration.KmsKey is
     // create-only; the top-level-only check missed it and built a patch AWS rejects at


### PR DESCRIPTION
Closes #1091

## Problem
A CFn-legacy type read via `SDK_OVERRIDES` (e.g. `AWS::CertificateManager::Certificate`) has a registry schema with **no `handlers` block at all**, so `schema-strip` leaves `updatable = undefined`. The #908 revert bar only bars `updatable === false` (handlers present, no `update`) and deliberately does **not** bar `undefined` (which it reads as "schema unavailable" degradation, #858). That conflation lets a doomed Cloud Control `UpdateResource` patch through for a handler-less type — it fails raw at apply with `UnsupportedActionException`.

## Fix
Thread a new `hasHandlers` flag out of `schema-strip` (`SchemaInfo.hasHandlers`): `false` when the schema is present but carries no `handlers` block (a CFn-legacy type), `undefined` when the schema itself is unavailable (`DescribeType` → EMPTY). The #908 bar now also bars a cc-kind revert when `schema.hasHandlers === false && SDK_OVERRIDES[type]` — distinguishing "handlers legitimately absent" from "schema unavailable", so #858's degradation path stays unbarred and revertable.

### Finding: the concrete ACM symptom is already prevented today
While implementing, I confirmed the literal ACM symptom does **not** reproduce on `main`: a broader earlier bar (`SDK_OVERRIDES && !SDK_WRITERS && !CC_REVERTABLE_DESPITE_READ_OVERRIDE`, predates this issue) already marks every ACM finding `notRevertable` before it can reach the cc-kind path. So this `hasHandlers` change is **defense-in-depth for the CLASS the issue calls out** — the narrower safety net for a handler-less type that IS on the `CC_REVERTABLE_DESPITE_READ_OVERRIDE` allowlist (thus falls through the broad bar) yet can never take a CC `UpdateResource`. No behavior change for any type on `main` today; it prevents a future SDK_OVERRIDES reader added for a handler-less legacy type from emitting a doomed patch.

## Tests
`tests/revert-plan.test.ts` › "CFn-legacy no-handlers-block guard (SDK_OVERRIDES-read, #1091)":
- `parseSchema.hasHandlers` is `false` with no handlers block, `true` with one (and `updatable` stays `undefined` — the two flags differ).
- The new guard bars a `CC_REVERTABLE`-allowlisted SDK_OVERRIDES type given a handler-less schema (fails-without / passes-with).
- The same type **with** a handlers block still produces the cc item (no regression).
- A non-SDK_OVERRIDES type with no handlers block is **not** barred — #858 schema-unavailable degradation preserved.
- The user-visible guarantee: an ACM cc revert is not offered.

Gates: typecheck / lint+format / build / **3826 unit tests** all green.
