### PR TITLE
fix(noise): fold default SLR / AWS-managed KMS ARNs via CONTEXT_ARN_DEFAULTS (#846)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2232,6 +2232,30 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string
     ServiceLinkedRoleARN:
       'arn:{partition}:iam::{accountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling',
   },
+  // A Batch ComputeEnvironment that declares no ServiceRole reads back the account's
+  // AWS-managed Batch service-linked role ARN — f(partition, accountId) (IAM ARNs carry no
+  // region). Verbatim twin of the ASG ServiceLinkedRoleARN SLR fold: a user who passes a
+  // CUSTOM service role declares it and it is compared in the declared loop (detection
+  // preserved). Corpus baked FP (#846).
+  'AWS::Batch::ComputeEnvironment': {
+    ServiceRole:
+      'arn:{partition}:iam::{accountId}:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch',
+  },
+  // A CodeBuild Project that declares no EncryptionKey reads back the AWS-managed
+  // `alias/aws/s3` KMS key ARN — the documented CodeBuild default CMK, f(partition, region,
+  // accountId). Same shape as the KinesisVideo `alias/aws/kinesisvideo` entry; equality-gated,
+  // so a project switched to a customer CMK still surfaces. Corpus baked FP (#846).
+  'AWS::CodeBuild::Project': {
+    EncryptionKey: 'arn:{partition}:kms:{region}:{accountId}:alias/aws/s3',
+  },
+  // An SSM MaintenanceWindowTask that declares no ServiceRoleArn reads back the account's
+  // AWS-managed SSM service-linked role ARN — f(partition, accountId). Twin of the ASG / Batch
+  // SLR folds; equality-gated, so a task pointed at a custom role still surfaces. Live-confirmed
+  // (hunt-v, us-east-1, #846).
+  'AWS::SSM::MaintenanceWindowTask': {
+    ServiceRoleArn:
+      'arn:{partition}:iam::{accountId}:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM',
+  },
   // A LakeFormation Tag that declares no CatalogId reads back the deploying account id — the
   // default (own-account) Data Catalog. The bare `{accountId}` placeholder substitutes to the
   // account id; equality-gated, so a Tag pointed at another account's catalog still surfaces.

--- a/tests/corpus/AWS__Batch__ComputeEnvironment.FargateCE1DBBBD09.json
+++ b/tests/corpus/AWS__Batch__ComputeEnvironment.FargateCE1DBBBD09.json
@@ -105,7 +105,7 @@
       "constructPath": "CdkRealDriftIntegBatchRich/FargateCE"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FargateCE1DBBBD09",
       "resourceType": "AWS::Batch::ComputeEnvironment",
       "path": "ServiceRole",

--- a/tests/corpus/AWS__CodeBuild__Project.Build.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build.json
@@ -79,7 +79,7 @@
       "constructPath": "CdkrdIntegHarvest6/Build"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Build",
       "resourceType": "AWS::CodeBuild::Project",
       "path": "EncryptionKey",

--- a/tests/noise-arndefaults-846.test.ts
+++ b/tests/noise-arndefaults-846.test.ts
@@ -1,0 +1,124 @@
+// #846: three derived CONTEXT_ARN_DEFAULTS entries — the AWS-managed service-linked-role /
+// AWS-managed-KMS ARNs AWS attaches when the property is UNDECLARED. Each is
+// f(partition, region, accountId), equality-gated: the exact default folds to atDefault, but a
+// value pointed at a DIFFERENT role / key still surfaces as real undeclared drift (detection
+// preserved). Batch ServiceRole + CodeBuild EncryptionKey are corpus baked FPs; SSM
+// MaintenanceWindowTask ServiceRoleArn is a live-confirmed instance (hunt-v, us-east-1).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const opts = { accountId: '111111111111', region: 'us-east-1' };
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#846 Batch ComputeEnvironment ServiceRole default SLR', () => {
+  const res: DesiredResource = {
+    logicalId: 'FargateCE',
+    resourceType: 'AWS::Batch::ComputeEnvironment',
+    physicalId: 'arn:aws:batch:us-east-1:111111111111:compute-environment/FargateCE',
+    declared: { Type: 'MANAGED' },
+  };
+  it('folds the AWS-managed Batch SLR ARN to atDefault', () => {
+    const f = classifyResource(
+      res,
+      {
+        ServiceRole:
+          'arn:aws:iam::111111111111:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch',
+      },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('ServiceRole');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('ServiceRole');
+  });
+  it('surfaces a custom service role as undeclared', () => {
+    const f = classifyResource(
+      res,
+      { ServiceRole: 'arn:aws:iam::111111111111:role/my-custom-batch-role' },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('ServiceRole');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('ServiceRole');
+  });
+});
+
+describe('#846 CodeBuild Project EncryptionKey default alias/aws/s3', () => {
+  const res: DesiredResource = {
+    logicalId: 'Build',
+    resourceType: 'AWS::CodeBuild::Project',
+    physicalId: 'my-build',
+    declared: { Name: 'my-build' },
+  };
+  it('folds the AWS-managed alias/aws/s3 key ARN to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { EncryptionKey: 'arn:aws:kms:us-east-1:111111111111:alias/aws/s3' },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('EncryptionKey');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('EncryptionKey');
+  });
+  it('surfaces a customer CMK as undeclared', () => {
+    const f = classifyResource(
+      res,
+      {
+        EncryptionKey:
+          'arn:aws:kms:us-east-1:111111111111:key/12345678-1234-1234-1234-123456789012',
+      },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('EncryptionKey');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('EncryptionKey');
+  });
+});
+
+describe('#846 SSM MaintenanceWindowTask ServiceRoleArn default SLR', () => {
+  const res: DesiredResource = {
+    logicalId: 'MaintTask',
+    resourceType: 'AWS::SSM::MaintenanceWindowTask',
+    physicalId: 'task-id',
+    declared: { WindowId: 'mw-123', TaskType: 'RUN_COMMAND' },
+  };
+  it('folds the AWS-managed SSM SLR ARN to atDefault', () => {
+    const f = classifyResource(
+      res,
+      {
+        ServiceRoleArn:
+          'arn:aws:iam::111111111111:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM',
+      },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('ServiceRoleArn');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('ServiceRoleArn');
+  });
+  it('surfaces a custom service role as undeclared', () => {
+    const f = classifyResource(
+      res,
+      { ServiceRoleArn: 'arn:aws:iam::111111111111:role/my-custom-ssm-role' },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('ServiceRoleArn');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('ServiceRoleArn');
+  });
+});


### PR DESCRIPTION
Closes #846

Adds three derived `CONTEXT_ARN_DEFAULTS` entries (each `f(partition, region, accountId)`, equality-gated so an out-of-band swap still surfaces):

1. `AWS::Batch::ComputeEnvironment` `ServiceRole` → `arn:{partition}:iam::{accountId}:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch`
2. `AWS::CodeBuild::Project` `EncryptionKey` → `arn:{partition}:kms:{region}:{accountId}:alias/aws/s3`
3. `AWS::SSM::MaintenanceWindowTask` `ServiceRoleArn` → `arn:{partition}:iam::{accountId}:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM` (LIVE-confirmed instance in the issue comment)

Corpus `expected` updated for the two baked FPs (`undeclared` → `atDefault`). New test `tests/noise-arndefaults-846.test.ts` asserts each ARN folds and a different role/key still surfaces.

Live evidence: corpus-replay (the FPs were live-harvested in their originating hunt).