### PR TITLE
fix(noise): fold 3 clean-deploy first-run FPs — Athena Status, VPCPeering PeerOwnerId, Neptune subnet-group echo (#980)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -8,7 +8,7 @@ import {
 } from '@aws-sdk/client-cloudformation';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
-import { classifyResource, normalizeLiveModel } from '../diff/classify.js';
+import { CLUSTER_ECHO_CHILD, classifyResource, normalizeLiveModel } from '../diff/classify.js';
 import { resolveProperties } from '../normalize/intrinsic-resolver.js';
 import { READ_RETRY } from '../read/client-config.js';
 import {
@@ -322,17 +322,24 @@ export function buildBucketNotificationManaged(desired: Desired): Set<string> {
 // cannot be resolved is simply not stripped (its echoes stay a one-time visible inventory,
 // never a hidden change).
 export function buildClusterEchoModels(desired: Desired): Record<string, Record<string, unknown>> {
+  // Both the parent cluster types to harvest and the child types to resolve are sourced from
+  // CLUSTER_ECHO_CHILD — the SAME table the classify strip reads — so a new echo-child entry
+  // wires this live path automatically (a hardcoded RDS-only list here silently left Neptune's
+  // fold corpus-green but live-broken, #980). A child's parentIdKey Refs its parent's physical id;
+  // physical ids are unique across types, so one clusterByPhys map serves all parent types.
+  const parentTypes = new Set(Object.values(CLUSTER_ECHO_CHILD).map((s) => s.parentType));
   const clusterByPhys: Record<string, Record<string, unknown>> = {};
   for (const r of desired.resources) {
-    if (r.resourceType !== 'AWS::RDS::DBCluster' || !r.physicalId) continue;
+    if (!parentTypes.has(r.resourceType) || !r.physicalId) continue;
     const live = desired.ctx.liveAttrs[r.logicalId];
     if (live && typeof live === 'object')
       clusterByPhys[r.physicalId] = live as Record<string, unknown>;
   }
   const map: Record<string, Record<string, unknown>> = {};
   for (const r of desired.resources) {
-    if (r.resourceType !== 'AWS::RDS::DBInstance' || !r.physicalId) continue;
-    const clusterId = (r.declared as Record<string, unknown> | undefined)?.DBClusterIdentifier;
+    const spec = CLUSTER_ECHO_CHILD[r.resourceType];
+    if (!spec || !r.physicalId) continue;
+    const clusterId = (r.declared as Record<string, unknown> | undefined)?.[spec.parentIdKey];
     if (typeof clusterId !== 'string') continue;
     const clusterLive = clusterByPhys[clusterId];
     if (clusterLive) map[r.physicalId] = clusterLive;

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -317,19 +317,39 @@ export const NESTED_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
 // key; `aliases` maps the few keys the two APIs spell differently. The parent's own property
 // still carries detection, so no out-of-band change is hidden — and an instance value that
 // DIVERGES from the cluster (its own maintenance window, its single AZ) still surfaces.
-const CLUSTER_ECHO_CHILD: Record<string, { parentIdKey: string; aliases: Record<string, string> }> =
-  {
-    'AWS::RDS::DBInstance': {
-      parentIdKey: 'DBClusterIdentifier',
-      // The two APIs spell a few shared settings differently: an instance's VPCSecurityGroups
-      // is the cluster's VpcSecurityGroupIds; its EnablePerformanceInsights is the cluster's
-      // PerformanceInsightsEnabled (Aurora manages PI cluster-wide, so the instance mirrors it).
-      aliases: {
-        VPCSecurityGroups: 'VpcSecurityGroupIds',
-        EnablePerformanceInsights: 'PerformanceInsightsEnabled',
-      },
+// Keyed by the CHILD resource type. `parentType` is the cluster resource type whose live model
+// the child echoes — `buildClusterEchoModels` (gather.ts / corpus record.ts) reads this to know
+// which resources to harvest a parent model from, so adding an entry here wires the live path too
+// (do NOT re-hardcode the type list in gather). `parentIdKey` is the child's declared property that
+// Refs the parent's physical id; `aliases` maps a child prop name to the differently-spelled parent
+// prop name.
+export const CLUSTER_ECHO_CHILD: Record<
+  string,
+  { parentType: string; parentIdKey: string; aliases: Record<string, string> }
+> = {
+  'AWS::RDS::DBInstance': {
+    parentType: 'AWS::RDS::DBCluster',
+    parentIdKey: 'DBClusterIdentifier',
+    // The two APIs spell a few shared settings differently: an instance's VPCSecurityGroups
+    // is the cluster's VpcSecurityGroupIds; its EnablePerformanceInsights is the cluster's
+    // PerformanceInsightsEnabled (Aurora manages PI cluster-wide, so the instance mirrors it).
+    aliases: {
+      VPCSecurityGroups: 'VpcSecurityGroupIds',
+      EnablePerformanceInsights: 'PerformanceInsightsEnabled',
     },
-  };
+  },
+  // A Neptune DBInstance echoes its parent DBCluster's cluster-level DBSubnetGroupName — the
+  // CDK instance never declares it (only DBClusterIdentifier + DBInstanceClass), so it floods a
+  // first run as undeclared inventory that merely mirrors the cluster's declared value (#980).
+  // Same shape as the Aurora echo above; Neptune's instance/cluster APIs spell the shared keys
+  // identically, so no aliases are needed. Equality-gated against the parent's live model, so an
+  // instance moved to a DIFFERENT subnet group still surfaces.
+  'AWS::Neptune::DBInstance': {
+    parentType: 'AWS::Neptune::DBCluster',
+    parentIdKey: 'DBClusterIdentifier',
+    aliases: {},
+  },
+};
 
 const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>
   !!t &&

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1345,6 +1345,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::InternetMonitor::Monitor': {
     Status: 'ACTIVE',
   },
+  // An Athena DataCatalog that declares no Status reads back the steady-state "CREATE_COMPLETE"
+  // every healthy catalog materializes (observed live, corpus at 0.2.68, #980). Same class as the
+  // InternetMonitor Status: ACTIVE / WorkGroup State: ENABLED constants. Equality-gated, so a
+  // catalog stuck in CREATE_FAILED / DELETE_* still surfaces as real undeclared drift.
+  'AWS::Athena::DataCatalog': {
+    Status: 'CREATE_COMPLETE',
+  },
   // A Roles Anywhere profile that declares neither a session duration nor attribute mappings
   // reads back AWS's 3600-second default and the constant default attribute-mapping set
   // (observed live, hunt 2026-07-08, #619). DurationSeconds is a user-settable knob (equality-
@@ -2242,6 +2249,11 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string
   // account id; equality-gated, so an AccessPoint pointed at a cross-account bucket owner still
   // surfaces. Live-confirmed on a fresh s3objectlambda-rich AccessPoint (#919).
   'AWS::S3::AccessPoint': { BucketAccountId: '{accountId}' },
+  // A same-account VPC peering connection that declares no PeerOwnerId reads back the deploying
+  // (caller's) account id — the default peer owner. The bare `{accountId}` placeholder substitutes
+  // to the account id; equality-gated, so a genuine cross-account peer (which declares PeerOwnerId,
+  // compared in the declared loop) still surfaces. Live corpus at 0.2.68 (#980).
+  'AWS::EC2::VPCPeeringConnection': { PeerOwnerId: '{accountId}' },
   // A SlackChannelConfiguration that declares no GuardrailPolicies reads back the single
   // AWS-managed `AdministratorAccess` policy ARN — the service default guardrail. The
   // AWS-managed policy ARN is PARTITION-scoped (`arn:aws-cn:…` in China, `arn:aws-us-gov:…`

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -11284,3 +11284,108 @@ describe('#747 dotted live-only map key -> whole map at parent path (undeclared)
     expect(undeclared[0].path).toBe('Parameters');
   });
 });
+
+// #980: first-run undeclared false positives on clean deploys, each folded via an existing
+// mechanism. Each fold is EQUALITY-GATED, so a value that DIVERGES from the default still surfaces.
+describe('#980 clean-deploy first-run folds', () => {
+  const bareSchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+
+  it('Athena DataCatalog Status=CREATE_COMPLETE folds (constant, equality-gated)', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Cat',
+      resourceType: 'AWS::Athena::DataCatalog',
+      physicalId: 'my-catalog',
+      declared: { Name: 'my-catalog', Type: 'GLUE' },
+    };
+    const clean = tiers(
+      classifyResource(
+        resource,
+        { Name: 'my-catalog', Type: 'GLUE', Status: 'CREATE_COMPLETE' },
+        bareSchema
+      )
+    );
+    expect(clean.undeclared).toEqual([]);
+    expect(clean.atDefault).toEqual(['Status']);
+    // a catalog stuck in a non-steady state still surfaces
+    const drifted = tiers(
+      classifyResource(
+        resource,
+        { Name: 'my-catalog', Type: 'GLUE', Status: 'CREATE_FAILED' },
+        bareSchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['Status']);
+  });
+
+  it('VPCPeeringConnection PeerOwnerId=<account> folds (account-derived, equality-gated)', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Peer',
+      resourceType: 'AWS::EC2::VPCPeeringConnection',
+      physicalId: 'pcx-1',
+      declared: { VpcId: 'vpc-a', PeerVpcId: 'vpc-b' },
+    };
+    const opts = { accountId: '111111111111', region: 'us-east-1' };
+    const clean = tiers(
+      classifyResource(
+        resource,
+        { VpcId: 'vpc-a', PeerVpcId: 'vpc-b', PeerOwnerId: '111111111111' },
+        bareSchema,
+        opts
+      )
+    );
+    expect(clean.undeclared).toEqual([]);
+    expect(clean.atDefault).toEqual(['PeerOwnerId']);
+    // a cross-account peer owner (a different account) still surfaces
+    const drifted = tiers(
+      classifyResource(
+        resource,
+        { VpcId: 'vpc-a', PeerVpcId: 'vpc-b', PeerOwnerId: '222222222222' },
+        bareSchema,
+        opts
+      )
+    );
+    expect(drifted.undeclared).toEqual(['PeerOwnerId']);
+  });
+
+  it('Neptune DBInstance DBSubnetGroupName echoes its cluster and folds (equality-gated)', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Inst',
+      resourceType: 'AWS::Neptune::DBInstance',
+      physicalId: 'inst-1',
+      declared: { DBClusterIdentifier: 'clu-1', DBInstanceClass: 'db.t4g.medium' },
+    };
+    const opts = {
+      accountId: '111111111111',
+      region: 'us-east-1',
+      clusterEchoModel: { 'inst-1': { DBSubnetGroupName: 'sg-shared' } },
+    };
+    const clean = tiers(
+      classifyResource(
+        resource,
+        { DBInstanceClass: 'db.t4g.medium', DBSubnetGroupName: 'sg-shared' },
+        bareSchema,
+        opts
+      )
+    );
+    expect(clean.undeclared).toEqual([]);
+    // an instance in a DIFFERENT subnet group than its cluster still surfaces
+    const drifted = tiers(
+      classifyResource(
+        resource,
+        { DBInstanceClass: 'db.t4g.medium', DBSubnetGroupName: 'sg-other' },
+        bareSchema,
+        opts
+      )
+    );
+    expect(drifted.undeclared).toEqual(['DBSubnetGroupName']);
+  });
+});

--- a/tests/corpus/AWS__Athena__DataCatalog.DataCatalog.json
+++ b/tests/corpus/AWS__Athena__DataCatalog.DataCatalog.json
@@ -42,7 +42,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DataCatalog",
       "resourceType": "AWS::Athena::DataCatalog",
       "path": "Status",

--- a/tests/corpus/AWS__EC2__VPCPeeringConnection.Peering.json
+++ b/tests/corpus/AWS__EC2__VPCPeeringConnection.Peering.json
@@ -73,7 +73,7 @@
       "constructPath": "CdkRealDriftIntegVpcPeering/Peering"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Peering",
       "resourceType": "AWS::EC2::VPCPeeringConnection",
       "path": "PeerOwnerId",

--- a/tests/corpus/AWS__Neptune__DBInstance.Instance.json
+++ b/tests/corpus/AWS__Neptune__DBInstance.Instance.json
@@ -69,7 +69,46 @@
     "accountId": "111111111111",
     "region": "ap-northeast-1",
     "kmsAliasTargets": {},
-    "oaiCanonicalIds": {}
+    "oaiCanonicalIds": {},
+    "clusterEchoModel": {
+      "neptunedbinstance-l2b64zeeyarj": {
+        "StorageEncrypted": false,
+        "EngineVersion": "1.3.5.0",
+        "AssociatedRoles": [],
+        "AvailabilityZones": ["ap-northeast-1c", "ap-northeast-1d", "ap-northeast-1a"],
+        "Port": "8182",
+        "DBClusterIdentifier": "neptunedbcluster-jmhbhbdjulu9",
+        "PreferredMaintenanceWindow": "sat:14:01-sat:14:31",
+        "IamAuthEnabled": false,
+        "DBSubnetGroupName": "neptunedbsubnetgroup-w5v1jnrqmuw8",
+        "DeletionProtection": false,
+        "PreferredBackupWindow": "21:15-21:45",
+        "DBPort": 8182,
+        "ClusterResourceId": "cluster-HUBGEUVUYBS2BWC2IOTHYJVVCY",
+        "Endpoint": "neptunedbcluster-jmhbhbdjulu9.cluster-c8xglnroz2jt.ap-northeast-1.neptune.amazonaws.com",
+        "VpcSecurityGroupIds": ["sg-09a4346aa4ef78d16"],
+        "NetworkType": "IPV4",
+        "ReadEndpoint": "neptunedbcluster-jmhbhbdjulu9.cluster-ro-c8xglnroz2jt.ap-northeast-1.neptune.amazonaws.com",
+        "CopyTagsToSnapshot": false,
+        "DBClusterParameterGroupName": "default.neptune1.3",
+        "BackupRetentionPeriod": 1,
+        "Tags": [
+          {
+            "Value": "Cluster",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "arn:aws:cloudformation:ap-northeast-1:111111111111:stack/CdkRealDriftIntegNeptuneRich/d4b6c970-6e1a-11f1-b5f4-061b70f4ac69",
+            "Key": "aws:cloudformation:stack-id"
+          },
+          {
+            "Value": "CdkRealDriftIntegNeptuneRich",
+            "Key": "aws:cloudformation:stack-name"
+          }
+        ],
+        "EnableCloudwatchLogsExports": []
+      }
+    }
   },
   "expected": [
     {
@@ -105,15 +144,6 @@
       "resourceType": "AWS::Neptune::DBInstance",
       "path": "AutoMinorVersionUpgrade",
       "actual": true,
-      "physicalId": "neptunedbinstance-l2b64zeeyarj",
-      "constructPath": "CdkRealDriftIntegNeptuneRich/Instance"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Instance",
-      "resourceType": "AWS::Neptune::DBInstance",
-      "path": "DBSubnetGroupName",
-      "actual": "neptunedbsubnetgroup-w5v1jnrqmuw8",
       "physicalId": "neptunedbinstance-l2b64zeeyarj",
       "constructPath": "CdkRealDriftIntegNeptuneRich/Instance"
     }

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -16,6 +16,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vite-plus/test';
 import {
   buildBucketNotificationManaged,
+  buildClusterEchoModels,
   buildSiblingSgRules,
   type GatherResult,
   gatherFindings,
@@ -739,6 +740,86 @@ describe('buildBucketNotificationManaged', () => {
       ])
     );
     expect(managed.size).toBe(0);
+  });
+});
+
+describe('buildClusterEchoModels (#980 — sources parent/child types from CLUSTER_ECHO_CHILD)', () => {
+  const desiredWith = (
+    resources: DesiredResource[],
+    liveAttrs: Record<string, Record<string, unknown>>
+  ): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources,
+      rawTemplate: '',
+      ctx: { liveAttrs } as unknown as ResolverContext,
+    }) as Desired;
+
+  it('maps a Neptune DBInstance to its Neptune DBCluster live model (the live path #980 item 3 needs)', () => {
+    const map = buildClusterEchoModels(
+      desiredWith(
+        [
+          {
+            logicalId: 'NeptuneCluster',
+            resourceType: 'AWS::Neptune::DBCluster',
+            physicalId: 'neptune-cluster-1',
+            declared: { DBSubnetGroupName: 'neptunedbsubnetgroup-w5v1jnrqmuw8' },
+          },
+          {
+            logicalId: 'NeptuneInstance',
+            resourceType: 'AWS::Neptune::DBInstance',
+            physicalId: 'neptune-inst-1',
+            declared: { DBClusterIdentifier: 'neptune-cluster-1', DBInstanceClass: 'db.r5.large' },
+          },
+        ],
+        { NeptuneCluster: { DBSubnetGroupName: 'neptunedbsubnetgroup-w5v1jnrqmuw8' } }
+      )
+    );
+    expect(map['neptune-inst-1']).toEqual({
+      DBSubnetGroupName: 'neptunedbsubnetgroup-w5v1jnrqmuw8',
+    });
+  });
+
+  it('still maps an RDS DBInstance to its RDS DBCluster live model (no regression)', () => {
+    const map = buildClusterEchoModels(
+      desiredWith(
+        [
+          {
+            logicalId: 'AuroraCluster',
+            resourceType: 'AWS::RDS::DBCluster',
+            physicalId: 'aurora-cluster-1',
+            declared: {},
+          },
+          {
+            logicalId: 'AuroraInstance',
+            resourceType: 'AWS::RDS::DBInstance',
+            physicalId: 'aurora-inst-1',
+            declared: { DBClusterIdentifier: 'aurora-cluster-1' },
+          },
+        ],
+        { AuroraCluster: { VpcSecurityGroupIds: ['sg-1'] } }
+      )
+    );
+    expect(map['aurora-inst-1']).toEqual({ VpcSecurityGroupIds: ['sg-1'] });
+  });
+
+  it('fail-open: an instance whose DBClusterIdentifier does not resolve to a harvested cluster is absent', () => {
+    const map = buildClusterEchoModels(
+      desiredWith(
+        [
+          {
+            logicalId: 'NeptuneInstance',
+            resourceType: 'AWS::Neptune::DBInstance',
+            physicalId: 'neptune-inst-1',
+            declared: { DBClusterIdentifier: 'some-other-cluster' },
+          },
+        ],
+        {}
+      )
+    );
+    expect(map['neptune-inst-1']).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #980

Three first-run `undeclared` `[Potential Drift]` findings on clean deploys, each folded via the existing mechanism the issue prescribed. Every fold is **equality-gated** — a changed value still surfaces.

## Items
1. **`AWS::Athena::DataCatalog` `Status = "CREATE_COMPLETE"`** — tier-1 constant. Added to `KNOWN_DEFAULTS`, mirroring the InternetMonitor `Status: ACTIVE` entry. A catalog stuck in `CREATE_FAILED`/`DELETE_*` still surfaces.
2. **`AWS::EC2::VPCPeeringConnection` `PeerOwnerId = <deploying account>`** — tier-2 account-derived. Added to the `{accountId}` placeholder table (`CONTEXT_ARN_DEFAULTS`), the same mechanism as the S3 AccessPoint `BucketAccountId` fold (#919). A genuine cross-account peer declares `PeerOwnerId` and is compared declared.
3. **`AWS::Neptune::DBInstance` `DBSubnetGroupName`** — echoes its parent DBCluster's declared value. Added a `CLUSTER_ECHO_CHILD` entry (parent `AWS::Neptune::DBCluster`, keyed by `DBClusterIdentifier`), equality-gated against the parent's live model.

## Live-path correctness (beyond the corpus)
Item 3's classify strip is corpus-replay-green, but the **live** path also needs the parent cluster model built during `gather`. `buildClusterEchoModels` was hardcoded to RDS types, so on a real `check` the Neptune parent model would never be built and `DBSubnetGroupName` would re-surface (corpus-green but live-broken). Fixed by sourcing both the parent-cluster types and child types from `CLUSTER_ECHO_CHILD` itself (added a `parentType` field) — so any future echo-child entry wires the live path automatically and can never silently regress this way again.

## Tests
- `tests/classify.test.ts` › "#980 clean-deploy first-run folds" — one case per item: the clean value folds AND a divergent value (CREATE_FAILED / cross-account owner / different subnet group) still surfaces as `undeclared`.
- `tests/gather.test.ts` › "buildClusterEchoModels (#980)" — Neptune instance→cluster live-model mapping, RDS regression, and fail-open.
- Corpus `expected` updated for the 3 affected cases (Athena, VPCPeering, Neptune); `golden corpus replay` covers them.

Gates: typecheck / lint+format / build / **3827 unit tests** all green.
