### PR TITLE
fix(revert): assert RFC6902 test precondition against the RAW live model (#853)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -346,6 +346,12 @@ export interface RevertItem {
   // delete = Cloud Control DeleteResource (revert of an `added` out-of-band resource).
   kind: 'cc' | 'sdk' | 'delete';
   ops: PatchOp[]; // for `delete`: a single pseudo-op carrying the human label (never serialized)
+  // #853: the RAW live model (read.live, pre-normalize) for this resource, attached to cc-kind
+  // items so toPatchDocument sources an index-bearing `test` op's value from the raw domain CC
+  // evaluates against — NOT the canonicalized `op.prior` (= f.actual), which mismatches CC's raw
+  // model whenever normalization transformed the tested subtree (sorted id arrays, canonicalized
+  // policy docs, base64-decoded WAF SearchString). Never serialized to Cloud Control.
+  liveRaw?: Record<string, unknown>;
 }
 
 export interface NotRevertable {
@@ -887,6 +893,9 @@ export function buildRevertPlan(
       if (item.kind !== 'cc') continue;
       const live = opts.liveByLogical.get(item.logicalId);
       if (!live) continue;
+      // #853: carry the raw live model onto the item so toPatchDocument can source an
+      // index-bearing `test` op's value from the RAW domain (not canonicalized `op.prior`).
+      item.liveRaw = live;
       const huskOps = nullHuskRemovalOps(live);
       if (huskOps.length > 0) item.ops.unshift(...huskOps);
     }
@@ -1261,27 +1270,79 @@ function hasArrayIndexSegment(pointer: string): boolean {
   return pointer.split('/').some((seg) => /^\d+$/.test(seg));
 }
 
+// Resolve the value at a concrete (wildcard-free) RFC6902 JSON pointer against a model,
+// returning a sentinel when the pointer does not resolve — so a genuine `null` value is
+// distinguished from an ABSENT one. Unlike expandPointer (which walks `*` wildcards and only
+// descends OBJECT keys), this walks LITERAL numeric array-index segments too, as an
+// index-bearing revert pointer (`/Rules/0/GroupSet`) requires. Each pointer segment is
+// RFC6901-unescaped (`~1` -> `/`, `~0` -> `~`).
+const POINTER_ABSENT = Symbol('pointer-absent');
+function rawValueAtPointer(model: Record<string, unknown>, pointer: string): unknown {
+  let node: unknown = model;
+  for (const rawSeg of pointer.split('/').slice(1)) {
+    const seg = rawSeg.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (Array.isArray(node)) {
+      if (!/^\d+$/.test(seg)) return POINTER_ABSENT;
+      const idx = Number(seg);
+      if (idx >= node.length) return POINTER_ABSENT;
+      node = node[idx];
+    } else if (node !== null && typeof node === 'object') {
+      if (!Object.hasOwn(node as Record<string, unknown>, seg)) return POINTER_ABSENT;
+      node = (node as Record<string, unknown>)[seg];
+    } else {
+      return POINTER_ABSENT;
+    }
+  }
+  return node;
+}
+
 /**
  * Serialize a RevertItem's ops to an RFC6902 PatchDocument string for Cloud Control.
  *
  * #762: the Cloud Control path had no analogue of the SDK-writer guard (writers.ts
  * `desiredModel` re-reads + re-canonicalizes the live model so an indexed op lands on the
  * SAME element classify diffed). For an INDEX-BEARING pointer we emit a preceding RFC6902
- * `test` precondition asserting the addressed location still equals the value classify saw
- * (`op.prior` = the finding's live `actual`). Cloud Control accepts standard RFC6902 and
- * evaluates `test` atomically before the mutation, so a shifted index makes it REJECT the
- * whole patch instead of writing the wrong element — fail-closed, the same intent as the
- * writer-path re-read. Scalar non-indexed pointers carry no aliasing risk (a named property
- * is stable regardless of array order), so they get NO `test` op — the patch stays minimal.
+ * `test` precondition asserting the addressed location still equals the value classify saw.
+ * Cloud Control accepts standard RFC6902 and evaluates `test` atomically before the mutation,
+ * so a shifted index makes it REJECT the whole patch instead of writing the wrong element —
+ * fail-closed, the same intent as the writer-path re-read. Scalar non-indexed pointers carry
+ * no aliasing risk (a named property is stable regardless of array order), so they get NO
+ * `test` op — the patch stays minimal.
+ *
+ * #853: the `test` value must come from the RAW live model, NOT `op.prior` (= the finding's
+ * canonicalized `f.actual`). Findings are built from `normalizeLiveModel` output — aws:* tags
+ * stripped, readOnly/writeOnly paths stripped, `canonicalizeIdArraysDeep` sorts sg-/subnet-id
+ * arrays, policy documents canonicalized, WAF `SearchString` base64-decoded. Cloud Control,
+ * however, evaluates `test` against its RAW resource model. Whenever normalization transformed
+ * the value at (or under) the tested pointer, asserting the canonical value against the raw
+ * model fails though nothing raced (LIVE-confirmed on AWS::ECR::RegistryPolicy: the Action
+ * array is canonicalize-SORTED vs the raw model's append-last order) → the whole patch is
+ * rejected → revert of genuine drift always fails. So resolve the test value from the raw
+ * live model passed by the apply path (the same UN-stripped `liveByLogical` model the
+ * tag-preserving / empty-husk-strip paths already use). Fall back to `op.prior` only when the
+ * raw model is unavailable (offline / no gather) or the pointer does not resolve against it
+ * (then the index has genuinely shifted and the guard should still fire and fail-close).
  */
-export function toPatchDocument(item: RevertItem): string {
+export function toPatchDocument(
+  item: RevertItem,
+  // The RAW live model for this resource. Defaults to the model carried on the item by
+  // buildRevertPlan (from `opts.liveByLogical`), so the apply path calls `toPatchDocument(item)`
+  // unchanged; an explicit arg is only for tests / callers without a built plan.
+  liveRaw: Record<string, unknown> | undefined = item.liveRaw
+): string {
   const doc: { op: string; path: string; value?: unknown }[] = [];
   for (const { op, path, value, prior } of item.ops) {
     // Guard only index-bearing pointers, and only when we know the value classify diffed
     // against (`prior` = f.actual). A `test` with an `undefined` value is meaningless
     // (RFC6902 has no "undefined"): skip it rather than assert an absent value.
     if (hasArrayIndexSegment(path) && prior !== undefined) {
-      doc.push({ op: 'test', path, value: prior });
+      // Prefer the RAW value at the pointer; the canonicalized `prior` mismatches CC's raw
+      // model whenever normalization transformed the subtree (#853). If the raw model is
+      // absent, or the pointer doesn't resolve (index shifted away), keep `prior` so the
+      // precondition still fails-closed rather than silently dropping the guard.
+      const rawValue = liveRaw ? rawValueAtPointer(liveRaw, path) : POINTER_ABSENT;
+      const testValue = rawValue === POINTER_ABSENT ? prior : rawValue;
+      doc.push({ op: 'test', path, value: testValue });
     }
     doc.push(op === 'remove' ? { op, path } : { op, path, value });
   }

--- a/tests/cc-patch-test-raw-value-853.test.ts
+++ b/tests/cc-patch-test-raw-value-853.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { type RevertItem, toPatchDocument } from '../src/revert/plan.js';
+
+// #853: the RFC6902 `test` precondition (#762) asserts the addressed location still equals
+// what classify diffed against — but `op.prior` = the finding's CANONICALIZED `f.actual`
+// (aws:* tags stripped, readOnly/writeOnly stripped, `canonicalizeIdArraysDeep` SORTS sg-/
+// subnet-id arrays, policy documents canonicalized, WAF `SearchString` base64-DECODED). Cloud
+// Control evaluates `test` against its RAW resource model. Whenever normalization transformed
+// the value at (or under) the tested pointer, the canonical `prior` mismatches the raw model
+// and CC rejects the WHOLE patch though nothing raced — revert of genuine drift always fails
+// (LIVE-confirmed on AWS::ECR::RegistryPolicy: the Action array is canonicalize-SORTED vs the
+// raw model's append-last order). The fix sources the `test` VALUE from the RAW live model.
+
+const item = (ops: RevertItem['ops'], liveRaw?: Record<string, unknown>): RevertItem => ({
+  logicalId: 'R',
+  displayId: 'R',
+  resourceType: 'AWS::Test::Resource',
+  physicalId: 'PID',
+  kind: 'cc',
+  ops,
+  ...(liveRaw !== undefined && { liveRaw }),
+});
+
+describe('#853 CC index `test` value comes from the RAW live model, not canonical prior', () => {
+  it('ECR RegistryPolicy Action array: `test` asserts the RAW (append-last) order, not the sorted prior', () => {
+    // The live raw model appends the rogue action LAST; classify SORTS it into `prior`.
+    const rawActions = ['ecr:ReplicateImage', 'ecr:BatchImportUpstreamImage'];
+    const sortedPrior = ['ecr:BatchImportUpstreamImage', 'ecr:ReplicateImage'];
+    const liveRaw = {
+      PolicyText: { Statement: [{ Action: rawActions }] },
+    };
+    const doc = JSON.parse(
+      toPatchDocument(
+        item(
+          [
+            {
+              op: 'add',
+              path: '/PolicyText/Statement/0/Action',
+              value: ['ecr:ReplicateImage'], // deployed-template intent
+              prior: sortedPrior, // canonicalize-SORTED f.actual
+              human: 'PolicyText.Statement[0].Action -> deployed-template value',
+            },
+          ],
+          liveRaw
+        )
+      )
+    );
+    expect(doc).toEqual([
+      // the `test` value is the RAW (unsorted) array, so CC's own raw model matches it
+      { op: 'test', path: '/PolicyText/Statement/0/Action', value: rawActions },
+      { op: 'add', path: '/PolicyText/Statement/0/Action', value: ['ecr:ReplicateImage'] },
+    ]);
+    // regression guard: it must NOT be the sorted canonical value
+    expect(doc[0].value).not.toEqual(sortedPrior);
+  });
+
+  it('sorted sg-id array under an indexed pointer: `test` uses the RAW (AWS-order) list', () => {
+    const rawGroups = ['sg-333', 'sg-111', 'sg-222']; // AWS order in the raw model
+    const sortedPrior = ['sg-111', 'sg-222', 'sg-333']; // canonicalizeIdArraysDeep sorted
+    const liveRaw = {
+      NetworkInterfaces: [{ GroupSet: rawGroups }],
+    };
+    const doc = JSON.parse(
+      toPatchDocument(
+        item(
+          [
+            {
+              op: 'add',
+              path: '/NetworkInterfaces/0/GroupSet',
+              value: ['sg-111'],
+              prior: sortedPrior,
+              human: 'NetworkInterfaces[0].GroupSet -> deployed-template value',
+            },
+          ],
+          liveRaw
+        )
+      )
+    );
+    expect(doc).toEqual([
+      { op: 'test', path: '/NetworkInterfaces/0/GroupSet', value: rawGroups },
+      { op: 'add', path: '/NetworkInterfaces/0/GroupSet', value: ['sg-111'] },
+    ]);
+  });
+
+  it('WAF SearchString: `test` uses the RAW base64 value, not the decoded prior', () => {
+    const rawSearch = 'YmFkc3RyaW5n'; // base64 in the raw CC model
+    const decodedPrior = 'badstring'; // classify base64-DECODES SearchString
+    const liveRaw = {
+      Rules: [
+        {
+          Statement: { ByteMatchStatement: { SearchString: rawSearch } },
+        },
+      ],
+    };
+    const doc = JSON.parse(
+      toPatchDocument(
+        item(
+          [
+            {
+              op: 'add',
+              path: '/Rules/0/Statement/ByteMatchStatement/SearchString',
+              value: 'good',
+              prior: decodedPrior,
+              human: 'Rules[0]…SearchString -> deployed-template value',
+            },
+          ],
+          liveRaw
+        )
+      )
+    );
+    expect(doc[0]).toEqual({
+      op: 'test',
+      path: '/Rules/0/Statement/ByteMatchStatement/SearchString',
+      value: rawSearch,
+    });
+    expect(doc[0].value).not.toEqual(decodedPrior);
+  });
+
+  it('the raw live model carried ON the item (item.liveRaw) is used when no explicit arg', () => {
+    const rawGroups = ['sg-b', 'sg-a'];
+    const doc = JSON.parse(
+      toPatchDocument(
+        item(
+          [
+            {
+              op: 'add',
+              path: '/NetworkInterfaces/0/GroupSet',
+              value: ['sg-a'],
+              prior: ['sg-a', 'sg-b'], // sorted
+              human: 'x',
+            },
+          ],
+          rawGroups.length ? { NetworkInterfaces: [{ GroupSet: rawGroups }] } : undefined
+        )
+      )
+      // NOTE: no second arg — liveRaw defaults to item.liveRaw
+    );
+    expect(doc[0].value).toEqual(rawGroups);
+  });
+
+  it('falls back to `prior` when NO raw model is available (offline / no gather)', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([
+          {
+            op: 'add',
+            path: '/CacheBehaviors/0/ViewerProtocolPolicy',
+            value: 'https-only',
+            prior: 'allow-all',
+            human: 'x',
+          },
+        ])
+        // no liveRaw on the item, no explicit arg
+      )
+    );
+    expect(doc).toEqual([
+      { op: 'test', path: '/CacheBehaviors/0/ViewerProtocolPolicy', value: 'allow-all' },
+      { op: 'add', path: '/CacheBehaviors/0/ViewerProtocolPolicy', value: 'https-only' },
+    ]);
+  });
+
+  it('falls back to `prior` (fails-closed) when the pointer does NOT resolve — the index shifted away', () => {
+    // The raw model has only ONE element, so `/Rules/2/...` is absent → keep the #762 guard
+    // firing on the canonical prior (a shift should still REJECT the patch, not silently drop).
+    const liveRaw = { Rules: [{ Statement: {} }] };
+    const doc = JSON.parse(
+      toPatchDocument(
+        item(
+          [
+            {
+              op: 'remove',
+              path: '/Rules/2/Statement/ByteMatchStatement/SearchString',
+              prior: 'canonical',
+              human: 'x',
+            },
+          ],
+          liveRaw
+        )
+      )
+    );
+    expect(doc).toEqual([
+      {
+        op: 'test',
+        path: '/Rules/2/Statement/ByteMatchStatement/SearchString',
+        value: 'canonical',
+      },
+      { op: 'remove', path: '/Rules/2/Statement/ByteMatchStatement/SearchString' },
+    ]);
+  });
+
+  it('a RAW value of `null` at the pointer is a real value (not "absent"), so `test` asserts null', () => {
+    const liveRaw = { Rules: [{ Setting: null }] };
+    const doc = JSON.parse(
+      toPatchDocument(
+        item(
+          [
+            {
+              op: 'add',
+              path: '/Rules/0/Setting',
+              value: 'x',
+              prior: 'canonical-nonnull',
+              human: 'x',
+            },
+          ],
+          liveRaw
+        )
+      )
+    );
+    // raw is null → test asserts null (matching CC's raw model), NOT the canonical prior
+    expect(doc[0]).toEqual({ op: 'test', path: '/Rules/0/Setting', value: null });
+  });
+
+  it('a non-indexed scalar op still gets NO `test`, even with a raw model present', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([{ op: 'add', path: '/Comment', value: 'intended', prior: 'drifted', human: 'x' }], {
+          Comment: 'raw-drifted',
+        })
+      )
+    );
+    expect(doc).toEqual([{ op: 'add', path: '/Comment', value: 'intended' }]);
+  });
+});


### PR DESCRIPTION
Closes #853

The #762 fix added an RFC6902 `test` precondition before every index-bearing Cloud Control patch op, asserting the addressed location equals `op.prior` = `f.actual`. But `f.actual` is the CANONICALIZED live value (id-arrays sorted, policies canonicalized, WAF SearchString base64-decoded), while Cloud Control evaluates `test` against its RAW model — so any normalization-transformed indexed value made the revert of genuine drift always fail (maintainer LIVE-confirmed on AWS::ECR::RegistryPolicy: sorted Action array vs raw order → `ValidationException: [TEST Operation] value mismatch`).

Fix (option 2, entirely inside plan.ts): the raw pre-normalization live model is already threaded via `buildRevertPlan`'s `opts.liveByLogical`. Attach `item.liveRaw = live` on cc-kind items; `toPatchDocument` resolves each index-bearing `test` value from the RAW model (new literal-index JSON-pointer walker). Fail-closed fallback to `op.prior` when the raw model is absent (offline/dry-run) or the pointer no longer resolves — so the #762 shift guard still fires.

New test `tests/cc-patch-test-raw-value-853.test.ts`: emitted `test` value matches the RAW model for the ECR sorted-Action repro, a sorted sg-id array, a base64 WAF SearchString, plus the fallback/edge cases.