### PR TITLE
fix(diff): skip execute-api Policy expansion when declared Policy is UNRESOLVED (#839)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1720,7 +1720,20 @@ export function classifyResource(
     // service echoes back, so a clean private (or any) api with the documented shorthand policy
     // does not false-drift on every statement. Re-canonicalize so the expanded Resource arrays
     // sort identically to the live side. Needs the api id (physicalId) + account + region.
-    if (physicalId && opts.accountId !== undefined && declared['Policy']) {
+    // #839: only expand a RESOLVED policy. When declared['Policy'] is the UNRESOLVED symbol
+    // (an unresolved Fn::If / Fn::Sub / {{resolve:...}} dynamic reference) — or an object still
+    // carrying it — it is truthy but NOT a real policy. Running canonicalizePolicy on it spreads
+    // the symbol away (`{...symbol}` → `{ Statement: [null] }`), destroying the UNRESOLVED marker
+    // and manufacturing a false `declared` Policy.Statement drift (desired:[null]) plus a false
+    // `undeclared` Policy.Version — and a revert would write `[null]` to the live policy. Skip the
+    // expansion so the normal path yields the single benign `unresolved`-tier Policy finding.
+    if (
+      physicalId &&
+      opts.accountId !== undefined &&
+      declared['Policy'] &&
+      declared['Policy'] !== UNRESOLVED &&
+      !hasUnresolved(declared['Policy'])
+    ) {
       // Canonical partition helper (#945): folds ISO partitions too. Unknown region → `aws`.
       const partition =
         opts.region !== undefined ? partitionForRegion(opts.region).partition : 'aws';

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1234,6 +1234,49 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     }
   });
 
+  it('#839: an UNRESOLVED RestApi Policy is NOT run through the execute-api expansion (no [null] corruption)', () => {
+    // A declared resource Policy provided via an intrinsic cdkrd cannot resolve at compare time
+    // (unresolved Fn::If / Fn::Sub / {{resolve:ssm:...}} dynamic reference) arrives as the
+    // UNRESOLVED symbol. Before the fix the expansion still ran (physicalId + accountId + truthy
+    // Policy), and canonicalizePolicy(`{...symbol}`) silently spread the marker away into
+    // `{ Statement: [null] }` → a false `declared` Policy.Statement drift with desired:[null]
+    // plus a false `undeclared` Policy.Version — and a revert would then write `[null]` live.
+    const apiId = 'abc123';
+    const opts = { accountId: '111111111111', region: 'us-east-1' };
+    const res: DesiredResource = {
+      logicalId: 'PrivApi',
+      resourceType: 'AWS::ApiGateway::RestApi',
+      physicalId: apiId,
+      declared: { Policy: UNRESOLVED },
+    };
+    const live = {
+      Policy: JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [
+          { Effect: 'Allow', Principal: '*', Action: 'execute-api:Invoke', Resource: ['*'] },
+        ],
+      }),
+    };
+    const t = tiers(classifyResource(res, live, emptySchema, opts));
+    // The whole finding set is the single benign `unresolved`-tier Policy — matching the CONTROL
+    // (no physicalId → expansion skipped) in the issue.
+    expect(t.unresolved).toEqual(['Policy']);
+    expect(t.declared).toEqual([]);
+    expect(t.undeclared).toEqual([]);
+
+    // CONTROL: with no physicalId (expansion path unreachable) the output is identical — proving
+    // the guard makes the WITH-physicalId path behave like the always-safe no-physicalId path.
+    const noPhys: DesiredResource = { ...res, physicalId: undefined };
+    const tControl = tiers(classifyResource(noPhys, live, emptySchema, opts));
+    expect(tControl.unresolved).toEqual(['Policy']);
+    expect(tControl.declared).toEqual([]);
+    expect(tControl.undeclared).toEqual([]);
+
+    // The full findings never carry a `[null]` desired for Policy.Statement.
+    const all = classifyResource(res, live, emptySchema, opts);
+    expect(all.some((f) => f.path.startsWith('Policy.') && f.tier === 'declared')).toBe(false);
+  });
+
   it('#705: Classic ELB Policies folds ONLY the default SSL policy; a downgrade / added policy surfaces', () => {
     const t = (policies: unknown[]) =>
       tiers(


### PR DESCRIPTION
Closes #839

The #676 execute-api shorthand expansion for an `AWS::ApiGateway::RestApi` resource policy ran whenever `physicalId && opts.accountId !== undefined && declared['Policy']` was truthy — WITHOUT checking that `declared['Policy']` actually resolved. When it is the UNRESOLVED symbol (an unresolved Fn::If / {{resolve:...}} / Fn::Sub), the `{...symbol}` spread inside `canonicalizePolicy(expandExecuteApiResources(...))` destroyed the marker → `{ Statement: [null] }`, producing a false `declared` drift (`desired:[null]`) + false `undeclared` drift, and a revert would write `Statement:[null]` to the live policy.

Fix: guard the expansion with `declared['Policy'] !== UNRESOLVED && !hasUnresolved(declared['Policy'])` (both already imported from intrinsic-resolver). When unresolved, control falls through to the normal path yielding the single benign `unresolved`-tier finding.

Test (`tests/classify.test.ts`): drives real `classifyResource` with `declared:{Policy:UNRESOLVED}` + physicalId, asserts the single `unresolved` finding (matches the issue CONTROL) and never a `Policy.Statement` declared drift; the #676 positive case (resolved shorthand still expands) is unchanged.