### PR TITLE
fix(desired): honor --pre-deploy contract (type-change REPLACE, stack-state gate, SSM-typed new param) (#882)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -57,6 +57,52 @@ export function deletedResourceInfo(
   return `info: ${stackName}: ${deleted.length} deployed resource(s) absent from the local template — the next deploy will DELETE them: ${shown.join(', ')}${more}`;
 }
 
+// #882: under --pre-deploy the declared type at a logical id comes from the LOCAL synth
+// template, while physIds + deployedTypeOf come from the deployed stack. Swapping a construct
+// at the SAME construct path (`new sqs.Queue(this,'X')` -> `new sns.Topic(this,'X')`) keeps
+// the logical id but changes the Type. Attaching the deployed QUEUE's physical id to a
+// DesiredResource of the new TOPIC type makes the live read do
+// GetResource(TypeName=<new>, Identifier=<old-queue-id>) -> not-found -> a FALSE "resource
+// deleted out of band". In reality the next deploy will REPLACE the resource (delete the old,
+// create the new). Detect it (template type != deployed type at the same logical id) so the
+// caller can (a) withhold the stale physical id and (b) surface a "will REPLACE" note instead
+// of a false deletion. Returns the changed logical ids (sorted) — pure + exported for tests.
+export function typeChangedResources(
+  templateResources: Record<string, { Type?: string }>,
+  deployedTypeOf: Record<string, string>
+): string[] {
+  return Object.entries(templateResources)
+    .filter(([lid, res]) => {
+      const declaredType = res?.Type;
+      const deployedType = deployedTypeOf[lid];
+      // both types must be known AND differ; an unknown deployed type (id not in the live
+      // stack — a brand-new resource) is a normal creation, not a type change.
+      return (
+        typeof declaredType === 'string' &&
+        typeof deployedType === 'string' &&
+        declaredType !== deployedType
+      );
+    })
+    .map(([lid]) => lid)
+    .sort();
+}
+
+// Build the human-facing "this deploy will REPLACE" note for type-changed logical ids under
+// --pre-deploy. Returns null when none changed. Pure + exported for unit tests.
+export function typeChangeReplaceInfo(
+  changed: string[],
+  templateResources: Record<string, { Type?: string }>,
+  deployedTypeOf: Record<string, string>,
+  stackName: string
+): string | null {
+  if (changed.length === 0) return null;
+  const shown = changed
+    .slice(0, 10)
+    .map((lid) => `${lid} (${deployedTypeOf[lid]} -> ${templateResources[lid]?.Type})`);
+  const more = changed.length > shown.length ? `, …(+${changed.length - shown.length} more)` : '';
+  return `info: ${stackName}: ${changed.length} resource(s) changed Type at the same logical id — the next deploy will REPLACE them (old resource deleted, new created): ${shown.join(', ')}${more}`;
+}
+
 // The AWS::Partition / AWS::URLSuffix pseudo-parameters are a deterministic function of the
 // region, NOT a commercial-partition constant. CDK env-agnostic stacks emit ${AWS::Partition}
 // inside nearly every Sub/Join-built ARN, so hard-coding `aws` / `amazonaws.com` mis-resolves
@@ -122,6 +168,16 @@ export function buildResolverContext(
     // Default too and let the param resolve UNRESOLVED (property skipped, conditions
     // fail-closed) — the same safe treatment as the masked deployed value (#744).
     if (def?.NoEcho === true || def?.NoEcho === 'true') continue;
+    // An SSM-typed parameter (Type: AWS::SSM::Parameter::Value<...>) carries the SSM
+    // parameter NAME/KEY in its Default, NOT the dereferenced value AWS will resolve at
+    // deploy time. The deployed ResolvedValue (set below from DescribeStacks) is the real
+    // value and overrides — but a parameter that is NEW in the LOCAL --pre-deploy template
+    // has no deployed value yet, so seeding its Default would make Ref resolve to the KEY
+    // string (`/golden/ami`) rather than the live value (`ami-0abc…`): a fabricated declared
+    // FP, and the wrong literal fed into any Condition/Fn::If over it. Skip the Default and
+    // let it resolve UNRESOLVED (property skipped, conditions fail-closed) — the same safe
+    // treatment as a masked/unresolvable value; a deployed ResolvedValue still wins (#882).
+    if ((def?.Type ?? '').includes('::Parameter::Value<')) continue;
     if (def && 'Default' in def) params[k] = toParam(k, String(def.Default));
   }
   for (const [k, v] of Object.entries(stackParams)) params[k] = toParam(k, v); // deployed values win
@@ -222,7 +278,7 @@ export async function loadDesired(
 ): Promise<Desired> {
   // GetTemplate + DescribeStacks are single calls (kept in Promise.all); ListStackResources
   // is paginated separately (DescribeStackResources caps at 100, CDK stacks reach ~500).
-  const [tmplRes, stkRes, { physIds }] = await Promise.all([
+  const [tmplRes, stkRes, { physIds, typeOf: deployedTypeOf }] = await Promise.all([
     templateOverride
       ? Promise.resolve({ TemplateBody: undefined })
       : client.send(new GetTemplateCommand({ StackName: stackName })),
@@ -235,11 +291,17 @@ export async function loadDesired(
   // would otherwise blow up parseTemplateBody with "Unexpected end of JSON input". Skip
   // a stack with no meaningful deployed reality (REVIEW_IN_PROGRESS / deleting) rather
   // than silently compare live state against a never-deployed template; carry a warning
-  // for mid-operation / failed states. Skipped under --pre-deploy (the declared source
-  // is the LOCAL synth, not the deployed stack).
-  const stateClass = templateOverride
-    ? ({ kind: 'ok', message: '' } as const)
-    : classifyStackStatus(stack?.StackStatus);
+  // for mid-operation / failed states.
+  //
+  // #882: this gate runs under --pre-deploy too. The templateOverride only substitutes the
+  // DECLARED source (the local synth template replaces GetTemplate); physIds + every live
+  // read still come from the DEPLOYED stack, so the deployed stack's state is just as
+  // relevant. Skipping the gate under --pre-deploy meant a DELETE_IN_PROGRESS stack was
+  // compared against half-deleted reality (red `deleted` findings), and a mid-operation /
+  // failed stack proceeded with NO stackStatusWarning (always undefined). Keep the
+  // classification. (REVIEW_IN_PROGRESS still returns an empty GetTemplate, but that body
+  // is never parsed under --pre-deploy — it is skipped by the `skip` branch just the same.)
+  const stateClass = classifyStackStatus(stack?.StackStatus);
   if (stateClass.kind === 'skip') throw new StackNotCheckableError(stateClass.message);
   const stackStatusWarning = stateClass.kind === 'warn' ? stateClass.message : undefined;
   const template = (templateOverride ?? parseTemplateBody(tmplRes.TemplateBody ?? '{}')) as Record<
@@ -280,6 +342,27 @@ export async function loadDesired(
   if (templateOverride) {
     const deletedInfo = deletedResourceInfo(physIds, template, stackName);
     if (deletedInfo) console.error(deletedInfo);
+  }
+
+  // #882: detect logical ids whose Type changed between the deployed stack and the declared
+  // template (a same-path construct swap under --pre-deploy). On the deployed path the declared
+  // type IS the deployed type, so this set is always empty there — but compute unconditionally
+  // and use it in the resource loop below to WITHHOLD the stale physical id (a phys id from the
+  // OLD type can't be read as the NEW type → false "deleted out of band"). Under --pre-deploy,
+  // also surface a "will REPLACE" note so the type change is not silently swallowed.
+  const templateResourcesForTypeCheck = (template.Resources ?? {}) as Record<
+    string,
+    { Type?: string }
+  >;
+  const typeChanged = new Set(typeChangedResources(templateResourcesForTypeCheck, deployedTypeOf));
+  if (templateOverride && typeChanged.size > 0) {
+    const replaceInfo = typeChangeReplaceInfo(
+      [...typeChanged].sort(),
+      templateResourcesForTypeCheck,
+      deployedTypeOf,
+      stackName
+    );
+    if (replaceInfo) console.error(replaceInfo);
   }
 
   const ctx = buildResolverContext(
@@ -361,10 +444,16 @@ export async function loadDesired(
     }
     const cdkPath = res.Metadata?.['aws:cdk:path'];
     const declaredRaw = (res.Properties ?? {}) as Record<string, unknown>;
+    // #882: withhold the physical id when the Type changed at this logical id — the deployed
+    // phys id belongs to the OLD type and can't be GetResource'd as the NEW type. Leaving it
+    // undefined makes the live read find nothing to fetch (the resource does not yet exist
+    // under the new type), so classify tags it a normal pending create rather than emitting a
+    // false "resource deleted out of band" (the note above already told the user it'll REPLACE).
+    const physicalId = typeChanged.has(logicalId) ? undefined : physIds[logicalId];
     resources.push({
       logicalId,
       resourceType: res.Type as string,
-      physicalId: physIds[logicalId],
+      physicalId,
       constructPath: typeof cdkPath === 'string' ? prettyConstructPath(cdkPath) : undefined,
       // first-pass resolution (no live attrs yet → GetAtt is UNRESOLVED). gather
       // re-resolves declaredRaw once liveAttrs is populated, reducing UNRESOLVED.

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   GetTemplateCommand,
   ListExportsCommand,
   ListStackResourcesCommand,
+  type StackStatus,
 } from '@aws-sdk/client-cloudformation';
 import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it, vi } from 'vite-plus/test';
@@ -14,7 +15,10 @@ import {
   deletedResourceInfo,
   loadDesired,
   parseTemplateBody,
+  typeChangedResources,
+  typeChangeReplaceInfo,
 } from '../src/desired/template-adapter.js';
+import { StackNotCheckableError } from '../src/aws-errors.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 
 describe('collectPrincipalsWithSiblingPolicies', () => {
@@ -841,5 +845,210 @@ describe('loadDesired resource-level Condition (#689)', () => {
     const ids = desired.resources.map((r) => r.logicalId).sort();
     // ProdOnly (condition false, no physical id) is dropped; everything else survives.
     expect(ids).toEqual(['Always', 'AnomalyFalse', 'DevOnly', 'Unk']);
+  });
+});
+
+describe('#882 — typeChangedResources / typeChangeReplaceInfo (pure)', () => {
+  it('flags a logical id whose declared Type differs from the deployed Type', () => {
+    const template = { X: { Type: 'AWS::SNS::Topic' }, Keep: { Type: 'AWS::S3::Bucket' } };
+    const deployed = { X: 'AWS::SQS::Queue', Keep: 'AWS::S3::Bucket' };
+    expect(typeChangedResources(template, deployed)).toEqual(['X']); // Queue -> Topic
+  });
+
+  it('does NOT flag a brand-new logical id absent from the deployed stack (a normal create)', () => {
+    const template = { New: { Type: 'AWS::SNS::Topic' } };
+    const deployed = {}; // New not deployed yet
+    expect(typeChangedResources(template, deployed)).toEqual([]);
+  });
+
+  it('does NOT flag a logical id with the same Type on both sides', () => {
+    const template = { Same: { Type: 'AWS::S3::Bucket' } };
+    const deployed = { Same: 'AWS::S3::Bucket' };
+    expect(typeChangedResources(template, deployed)).toEqual([]);
+  });
+
+  it('builds a "will REPLACE" note showing old -> new types, capped at 10', () => {
+    const template: Record<string, { Type?: string }> = {};
+    const deployed: Record<string, string> = {};
+    for (let i = 0; i < 12; i++) {
+      template[`R${String(i).padStart(2, '0')}`] = { Type: 'AWS::SNS::Topic' };
+      deployed[`R${String(i).padStart(2, '0')}`] = 'AWS::SQS::Queue';
+    }
+    const changed = typeChangedResources(template, deployed);
+    const line = typeChangeReplaceInfo(changed, template, deployed, 'S')!;
+    expect(line).toContain('12 resource(s) changed Type');
+    expect(line).toContain('AWS::SQS::Queue -> AWS::SNS::Topic');
+    expect(line).toContain('…(+2 more)');
+  });
+
+  it('returns null when nothing changed type', () => {
+    expect(typeChangeReplaceInfo([], {}, {}, 'S')).toBeNull();
+  });
+});
+
+describe('#882 — loadDesired same-logical-id Type change under --pre-deploy', () => {
+  function typeSwapStack(cfn: ReturnType<typeof mockClient>): void {
+    // Deployed stack has X as an SQS Queue with a real physical id.
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'X',
+          PhysicalResourceId: 'https://sqs.us-east-1.amazonaws.com/111122223333/old-queue',
+          ResourceType: 'AWS::SQS::Queue',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+  }
+
+  it('withholds the deployed phys id when the local template swaps the type at the same id', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).rejects(new Error('GetTemplate must NOT be called in pre-deploy'));
+    typeSwapStack(cfn);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let msg = '';
+    let physicalId: string | undefined;
+    try {
+      // local synth swapped X from a Queue to a Topic (same logical id, new Type)
+      const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', {
+        Resources: { X: { Type: 'AWS::SNS::Topic', Properties: {} } },
+      });
+      physicalId = desired.resources.find((r) => r.logicalId === 'X')?.physicalId;
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    // The stale Queue phys id is NOT attached (would GetResource as a Topic → false deletion).
+    expect(physicalId).toBeUndefined();
+    // Instead the user is told the deploy will REPLACE it.
+    expect(msg).toContain('changed Type at the same logical id — the next deploy will REPLACE');
+    expect(msg).toContain('AWS::SQS::Queue -> AWS::SNS::Topic');
+  });
+
+  it('KEEPS the phys id when the type is unchanged (no false replace)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).rejects(new Error('GetTemplate must NOT be called in pre-deploy'));
+    typeSwapStack(cfn);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let physicalId: string | undefined;
+    let msg = '';
+    try {
+      // same type as deployed → phys id kept, no replace note
+      const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', {
+        Resources: { X: { Type: 'AWS::SQS::Queue', Properties: {} } },
+      });
+      physicalId = desired.resources.find((r) => r.logicalId === 'X')?.physicalId;
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    expect(physicalId).toBe('https://sqs.us-east-1.amazonaws.com/111122223333/old-queue');
+    expect(msg).not.toContain('changed Type');
+  });
+});
+
+describe('#882 — loadDesired stack-state gate under --pre-deploy', () => {
+  function stateStack(cfn: ReturnType<typeof mockClient>, status: StackStatus): void {
+    cfn.on(GetTemplateCommand).rejects(new Error('GetTemplate must NOT be called in pre-deploy'));
+    cfn.on(ListStackResourcesCommand).resolves({ StackResourceSummaries: [] });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: status,
+          Parameters: [],
+        },
+      ],
+    });
+  }
+
+  it('SKIPS (throws StackNotCheckableError) a DELETE_IN_PROGRESS stack even under --pre-deploy', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    stateStack(cfn, 'DELETE_IN_PROGRESS');
+    await expect(
+      loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', {
+        Resources: { B: { Type: 'AWS::S3::Bucket', Properties: {} } },
+      })
+    ).rejects.toBeInstanceOf(StackNotCheckableError);
+  });
+
+  it('WARNS (stackStatusWarning) for a mid-operation stack even under --pre-deploy', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    stateStack(cfn, 'UPDATE_IN_PROGRESS');
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', {
+      Resources: { B: { Type: 'AWS::S3::Bucket', Properties: {} } },
+    });
+    expect(desired.stackStatusWarning).toContain('mid-operation');
+  });
+
+  it('stays OK (no warning) for a stable CREATE_COMPLETE stack under --pre-deploy', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    stateStack(cfn, 'CREATE_COMPLETE');
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', {
+      Resources: { B: { Type: 'AWS::S3::Bucket', Properties: {} } },
+    });
+    expect(desired.stackStatusWarning).toBeUndefined();
+  });
+});
+
+describe('#882 — buildResolverContext does NOT seed an SSM-typed param Default (resolves UNRESOLVED)', () => {
+  it('skips the SSM KEY Default of a NEW SSM-typed param so Ref does not resolve to the key', () => {
+    // A new local `Type: AWS::SSM::Parameter::Value<String>` param with Default '/golden/ami'
+    // has no deployed ResolvedValue. Seeding its Default would make Ref resolve to the KEY
+    // string, not the live AMI id — a fabricated declared FP. It must stay out of ctx.
+    const template = {
+      Parameters: {
+        Ami: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/golden/ami' },
+        Plain: { Type: 'String', Default: 'kept' },
+      },
+    };
+    const ctx = buildResolverContext(template, {}, {}, 'us-east-1', '999', 'S', 'arn');
+    expect('Ami' in ctx.params).toBe(false); // SSM-typed Default NOT seeded (would be the key)
+    expect(ctx.params.Plain).toBe('kept'); // an ordinary Default is still seeded
+  });
+
+  it('a deployed ResolvedValue still WINS for an SSM-typed param (existing param)', () => {
+    // When the param IS deployed, the DescribeStacks ResolvedValue is passed in stackParams
+    // and overrides — the fix only withholds the KEY-string Default, never the real value.
+    const template = {
+      Parameters: { Ami: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/golden/ami' } },
+    };
+    const ctx = buildResolverContext(
+      template,
+      { Ami: 'ami-0abc123' }, // deployed ResolvedValue (loadDesired prefers ResolvedValue)
+      {},
+      'us-east-1',
+      '999',
+      'S',
+      'arn'
+    );
+    expect(ctx.params.Ami).toBe('ami-0abc123'); // real deployed value, not the key
+  });
+
+  it('an SSM LIST-typed Default is likewise withheld (would be the key, not the values)', () => {
+    const template = {
+      Parameters: {
+        Sgs: {
+          Type: 'AWS::SSM::Parameter::Value<List<AWS::EC2::SecurityGroup::Id>>',
+          Default: '/my/sgs',
+        },
+      },
+    };
+    const ctx = buildResolverContext(template, {}, {}, 'us-east-1', '999', 'S', 'arn');
+    expect('Sgs' in ctx.params).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #882

Three deterministic `--pre-deploy` contract violations, all in the pre-deploy gather path (`src/desired/template-adapter.ts`), all provable offline:

1. **Same-logical-id TYPE change → false 'resource deleted out of band'**: `loadDesired` discarded the deployed `Type`. New `typeChangedResources`/`typeChangeReplaceInfo` helpers detect a declared-vs-deployed Type mismatch at the same logical id and **withhold** the stale physical id (so no `GetResource(TypeName=new, Identifier=old)` → false deletion); under `--pre-deploy` it emits a 'will REPLACE (old → new)' note.
2. **Stack-state gate bypassed under --pre-deploy**: removed the `templateOverride ? {ok} : classifyStackStatus(...)` bypass — the gate now runs unconditionally (DELETE_IN_PROGRESS → skip; mid-op/failed → warning) since live reads still come from the deployed stack.
3. **New SSM-typed parameter Default resolving to the KEY string**: params typed `::Parameter::Value<...>` are no longer seeded from their `Default` (the SSM key, not the value) — they resolve UNRESOLVED (same safe treatment as NoEcho); a deployed `ResolvedValue` still wins.

+13 unit tests, each failing without its fix. (Note: a `StackStatus` enum type-cast in the new test was needed after rebase — caught by oxc `vp check`, not tsgo.)

Offline live evidence: all three are deterministic from code per the issue; unit tests drive the adapter directly.