### PR TITLE
fix(baseline): fold a promoted-to-code NESTED recorded path, not just top-level (#1079)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -745,10 +745,19 @@ export function selectRecorded(findings: Finding[], selectedKeys: Set<string>): 
 }
 
 export interface ApplyBaselineOptions {
-  // logicalId -> set of currently-declared top-level keys. An recorded entry whose
-  // path is now DECLARED in the template is the recommended "promote undeclared
-  // drift into code" workflow, NOT a removal — suppress the false removal finding.
-  declaredByLogical?: Map<string, Set<string>>;
+  // logicalId -> the resource's CURRENT declared model (the template's `Properties`
+  // object). A recorded entry whose path is now DECLARED in the template is the
+  // recommended "promote undeclared drift into code" workflow, NOT a removal — folded
+  // into a nudge, not a false removal finding. #749 fixed the nested-REMOVAL FN by
+  // gating the fold on a TOP-LEVEL path only, which left #1079's twin FP: a NESTED
+  // recorded path that the user later declares still surfaced as a false "removed since
+  // record" (and revert offered to overwrite the freshly-declared value with the stale
+  // snapshot). Carrying the whole declared model — not just its top-level key SET — lets
+  // the fold RESOLVE a recorded path (top-level OR nested) against the declared tree:
+  // promoted iff the path resolves in the model (see `declaredPathIsPromoted`). An
+  // out-of-band nested removal still surfaces because its path does NOT resolve unless
+  // the user declared it — in which case the declared-dimension compare owns it.
+  declaredByLogical?: Map<string, Record<string, unknown>>;
   // logicalId -> CDK construct path. Used to restore constructPath onto the synthetic
   // "baseline value removed since record" finding so a constructPath-form ignore rule
   // matches it (a RecordedEntry carries no constructPath of its own).
@@ -770,17 +779,65 @@ export interface ApplyBaselineOptions {
   warn?: (s: string) => void; // stderr note channel for the promotion case
 }
 
-// A recorded path is TOP-LEVEL when it is a bare template key — no nested descent
-// separator (`.` object step or `[` array/identity step). `declaredByLogical` carries
-// only top-level declared KEYS (Object.keys(declared)), so the "promoted into the
-// template" test can only be answered for a top-level path: a nested path's top segment
-// is ALWAYS a declared key by construction (collectNestedUndeclared descends only where
-// the parent key is declared), so testing that segment would fold EVERY nested recorded
-// value into `promotedStale` and never surface a legitimate removal (#749). A nested
-// value is "promoted" only if its DECLARED parent now declares that exact nested value —
-// which `declaredByLogical` cannot express — so a nested recorded path can never qualify
-// here and must fall through to the "removed since record" drift.
-const isTopLevelPath = (p: string): boolean => !p.includes('.') && !p.includes('[');
+// Split a recorded path into its ordered segments in the SAME grammar
+// `collectNestedUndeclared` builds them: object steps joined by `.` and array/identity
+// steps as `[<id>]`. `Foo.Bar` -> ['Foo','Bar']; `Foo.Bar[id].Baz` -> ['Foo','Bar','id','Baz'].
+// The bracket id is used verbatim as a lookup key (matches classify keying elements by their
+// identity FIELD value, e.g. a policy statement's StatusCode) and, for a plain declared
+// array, tolerated as a fall-through (see `descendDeclared`).
+function pathSegments(path: string): string[] {
+  return path
+    .replace(/\[([^\]]*)\]/g, '.$1')
+    .split('.')
+    .filter((s) => s.length > 0);
+}
+
+// Descend one segment into a declared node. Object: index by key. Array: index by the
+// element's identity-field value (the `[<id>]` grammar) when an element carries a matching
+// identity field, else fall back to a numeric index. Returns undefined when the segment
+// does not resolve — the signal that the recorded path is NOT declared here.
+function descendDeclared(node: unknown, seg: string): unknown {
+  if (node === null || typeof node !== 'object') return undefined;
+  if (Array.isArray(node)) {
+    for (const el of node) {
+      if (el !== null && typeof el === 'object' && !Array.isArray(el)) {
+        for (const idf of DELTA_IDENTITY_FIELDS) {
+          if (String((el as Record<string, unknown>)[idf]) === seg) return el;
+        }
+      }
+    }
+    const idx = Number(seg);
+    return Number.isInteger(idx) && idx >= 0 && idx < node.length ? node[idx] : undefined;
+  }
+  return (node as Record<string, unknown>)[seg];
+}
+
+// #1079: is the recorded path (top-level OR nested) now DECLARED in the resource's current
+// template model — i.e. the "promote undeclared drift into code" workflow, not a removal?
+// Walk `declared` along the recorded path's segments: promoted iff the walk RESOLVES to a
+// defined node at the full path, OR reaches a declared LEAF (a non-container value) at an
+// intermediate segment — declaring `Foo: <leaf>` OR `Foo: { Bar: … }` moves the whole `Foo`
+// subtree to the declared dimension, so the recorded `Foo.Bar` is now redundant intent, not
+// a vanished undeclared value. An out-of-band nested REMOVAL (#749's FN) still surfaces: the
+// removed value's path does NOT resolve unless the user declared it, and if declared, the
+// live≠declared mismatch is the declared tier's job — so we never both swallow it here AND
+// miss it there.
+function declaredPathIsPromoted(
+  declared: Record<string, unknown> | undefined,
+  path: string
+): boolean {
+  if (declared === undefined) return false;
+  let node: unknown = declared;
+  for (const seg of pathSegments(path)) {
+    // A declared leaf reached before the path ends: the whole subtree below it is declared
+    // intent, so the deeper recorded path is promoted.
+    if (node === null || typeof node !== 'object') return true;
+    const next = descendDeclared(node, seg);
+    if (next === undefined) return false; // segment absent from the declared model
+    node = next;
+  }
+  return true; // the full path resolved in the declared model
+}
 
 /**
  * Reconcile undeclared findings against the recorded baseline (per ENTRY, R62):
@@ -1043,10 +1100,13 @@ export function applyBaseline(
       continue;
     }
     // promoted into the template since record → not a removal, just stale baseline.
-    // #749: gate on the FULL path (only meaningful for a top-level path), NOT its top
-    // segment — otherwise every nested recorded value, whose top segment is a declared
-    // key by construction, would be swallowed here and never surface as a removal.
-    if (isTopLevelPath(a.path) && opts.declaredByLogical?.get(a.logicalId)?.has(a.path)) {
+    // #749 originally gated this on a TOP-LEVEL path only (declaredByLogical carried just
+    // the top-level key set), which left #1079: a NESTED recorded path the user later
+    // DECLARES kept surfacing as a false "removed since record" (+ a stale-value revert
+    // offer). declaredByLogical now carries the whole declared MODEL, so RESOLVE the
+    // recorded path (top-level OR nested) against it — promoted iff it resolves. A genuine
+    // out-of-band nested REMOVAL still surfaces: its path does not resolve unless declared.
+    if (declaredPathIsPromoted(opts.declaredByLogical?.get(a.logicalId), a.path)) {
       promotedStale.push(`${a.logicalId}.${a.path}`);
       continue;
     }
@@ -1127,11 +1187,18 @@ export function formatTypeMismatchStaleNote(paths: string[]): string {
   return `note: ${subject} recorded against a resource whose logicalId now has a DIFFERENT type — re-run \`cdkrd record\`.`;
 }
 
-/** logicalId -> set of declared top-level keys, for applyBaseline's promotion check. */
+/**
+ * logicalId -> the resource's declared model, for applyBaseline's promotion check.
+ * #1079: carries the WHOLE declared object (not just its top-level key set) so a NESTED
+ * recorded path the user later declares is RESOLVED against the declared tree and folded
+ * as promoted-to-code, rather than surfacing a false "removed since record". The map
+ * feeds ApplyBaselineOptions.declaredByLogical; `applyBaseline` walks it per recorded path
+ * via `declaredPathIsPromoted`.
+ */
 export function declaredKeysByLogical(
   resources: { logicalId: string; declared: Record<string, unknown> }[]
-): Map<string, Set<string>> {
-  return new Map(resources.map((r) => [r.logicalId, new Set(Object.keys(r.declared))]));
+): Map<string, Record<string, unknown>> {
+  return new Map(resources.map((r) => [r.logicalId, r.declared]));
 }
 
 // logicalId -> construct path, for resources that carry one. Feeds

--- a/tests/baseline-nested-removal-749.test.ts
+++ b/tests/baseline-nested-removal-749.test.ts
@@ -4,12 +4,14 @@ import { applyBaseline, type BaselineFile } from '../src/baseline/baseline-file.
 // #749: the "baseline value removed since record" drift never fired for NESTED recorded
 // values. Every nested undeclared path is built as `<TopLevelKey>.<...>` and is only ever
 // collected where its parent key is DECLARED (collectNestedUndeclared descends only into
-// `k in declaredVal`). The old promotion check tested `topSegment(path)` — the top-level
-// key — against `declaredByLogical`, so for EVERY nested recorded value that top segment
-// was a declared key and the vanished value was misclassified `promotedStale` (folded into
-// the "now declared in the template — re-run record" nudge) instead of surfacing as a real
-// removal. The fix gates the promotion check on the FULL path AND requires the path to be
-// top-level, since `declaredByLogical` only carries top-level declared keys.
+// `k in declaredVal`). The old promotion check tested the top-level key against
+// declaredByLogical's key set, so for EVERY nested recorded value that top segment was a
+// declared key and the vanished value was misclassified `promotedStale` instead of
+// surfacing as a real removal. #1079 replaced that with a WALK of the whole declared MODEL
+// along the recorded path: a nested value is promoted only if the path RESOLVES in the
+// model, so an out-of-band nested REMOVAL — a path present under a declared parent but NOT
+// itself declared — still surfaces. These tests declare the PARENT (an object with other
+// keys) but NOT the recorded nested leaf, so the removal must still fire.
 
 function baseline(recorded: BaselineFile['recorded']): BaselineFile {
   return {
@@ -35,10 +37,11 @@ describe('#749 nested recorded value removed since record', () => {
       },
     ]);
     const warnings: string[] = [];
-    // `Environment` is declared (top-level key present), but the nested value FOO is NOT in
-    // the template — the recorded value disappeared out of band → a genuine removal.
+    // `Environment` is declared, but the nested value FOO is NOT in the template (the
+    // declared Environment.Variables holds a DIFFERENT key) — the recorded value disappeared
+    // out of band → a genuine removal, and the path must NOT resolve in the declared model.
     const out = applyBaseline([], b, {
-      declaredByLogical: new Map([['Fn', new Set(['Environment'])]]),
+      declaredByLogical: new Map([['Fn', { Environment: { Variables: { OTHER: 'y' } } }]]),
       warn: (m) => warnings.push(m),
     });
     expect(out).toHaveLength(1);
@@ -65,8 +68,9 @@ describe('#749 nested recorded value removed since record', () => {
       },
     ]);
     const warnings: string[] = [];
+    // `Tags` is declared with a different entry; the recorded `Owner` tag is not declared.
     const out = applyBaseline([], b, {
-      declaredByLogical: new Map([['Bkt', new Set(['Tags'])]]),
+      declaredByLogical: new Map([['Bkt', { Tags: [{ Key: 'Env', Value: 'prod' }] }]]),
       warn: (m) => warnings.push(m),
     });
     expect(out).toHaveLength(1);
@@ -87,8 +91,19 @@ describe('#749 nested recorded value removed since record', () => {
         value: { StringEquals: { 'aws:username': 'x' } },
       },
     ]);
+    // The declared statement[0] has NO Condition — the recorded one was added then removed
+    // out of band, so `PolicyDocument.Statement[0].Condition` must NOT resolve.
     const out = applyBaseline([], b, {
-      declaredByLogical: new Map([['Pol', new Set(['PolicyDocument'])]]),
+      declaredByLogical: new Map([
+        [
+          'Pol',
+          {
+            PolicyDocument: {
+              Statement: [{ Effect: 'Allow', Action: 's3:*', Resource: '*' }],
+            },
+          },
+        ],
+      ]),
     });
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({
@@ -103,7 +118,7 @@ describe('#749 nested recorded value removed since record', () => {
     ]);
     const warnings: string[] = [];
     const out = applyBaseline([], b, {
-      declaredByLogical: new Map([['A', new Set(['ReservedConcurrentExecutions'])]]),
+      declaredByLogical: new Map([['A', { ReservedConcurrentExecutions: 5 }]]),
       warn: (m) => warnings.push(m),
     });
     expect(out).toHaveLength(0); // no false "removed" finding for a real promotion

--- a/tests/baseline-promote-nested-1079.test.ts
+++ b/tests/baseline-promote-nested-1079.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyBaseline,
+  type BaselineFile,
+  declaredKeysByLogical,
+} from '../src/baseline/baseline-file.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+
+// #1079: promoting a NESTED recorded value into the template (the recommended
+// "promote undeclared drift into code" workflow) surfaced a FALSE confirmed "baseline
+// value removed since record" drift — and revert then offered to overwrite the
+// freshly-declared value with the STALE recorded one. #749 folded only TOP-LEVEL promoted
+// paths (declaredByLogical carried just the top-level key set); a nested recorded path the
+// user later declared was invisible to that gate. The fix walks the whole declared MODEL
+// along the recorded path: promoted iff the path resolves. #749's nested-REMOVAL FN still
+// surfaces because a removed value's path does NOT resolve unless the user declared it.
+
+function baseline(recorded: BaselineFile['recorded']): BaselineFile {
+  return {
+    schemaVersion: 1,
+    stackName: 's',
+    region: 'r',
+    accountId: '111122223333',
+    capturedAt: '',
+    templateHash: '',
+    recorded,
+  };
+}
+
+describe('#1079 promoted-to-code NESTED recorded path folds (not "removed since record")', () => {
+  it('folds a NESTED recorded path whose value is now DECLARED (the repro from the issue)', () => {
+    // recorded live-only `LoggingConfig.LogFormat = 'Text'`, then the user declares
+    // LoggingConfig (incl. LogFormat) in the template and deploys → nothing drifted.
+    const b = baseline([
+      {
+        logicalId: 'Fn',
+        resourceType: 'AWS::Lambda::Function',
+        path: 'LoggingConfig.LogFormat',
+        value: 'Text',
+      },
+    ]);
+    const warnings: string[] = [];
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([
+        ['Fn', { LoggingConfig: { LogFormat: 'JSON', ApplicationLogLevel: 'INFO' } }],
+      ]),
+      physicalIdByLogical: new Map([['Fn', 'my-fn']]),
+      warn: (m) => warnings.push(m),
+    });
+    // NO false "removed since record" finding — it was promoted, not removed.
+    expect(out).toHaveLength(0);
+    expect(warnings.some((w) => w.includes('now declared in the template'))).toBe(true);
+  });
+
+  it('does NOT offer a stale-value revert for the promoted nested path', () => {
+    const b = baseline([
+      {
+        logicalId: 'Fn',
+        resourceType: 'AWS::Lambda::Function',
+        path: 'LoggingConfig.LogFormat',
+        value: 'Text',
+      },
+    ]);
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['Fn', { LoggingConfig: { LogFormat: 'JSON' } }]]),
+      physicalIdByLogical: new Map([['Fn', 'my-fn']]),
+    });
+    const plan = buildRevertPlan(out, b, { schemas: new Map() });
+    // no synthesized finding survived → no revert op that would clobber the declared 'JSON'.
+    expect(plan.items).toHaveLength(0);
+  });
+
+  it('folds a bracketed nested path (Foo[0].Baz) when the element is now declared', () => {
+    const b = baseline([
+      {
+        logicalId: 'Pol',
+        resourceType: 'AWS::IAM::Policy',
+        path: 'PolicyDocument.Statement[0].Condition',
+        value: { StringEquals: { 'aws:username': 'x' } },
+      },
+    ]);
+    const warnings: string[] = [];
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([
+        [
+          'Pol',
+          {
+            PolicyDocument: {
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Action: 's3:*',
+                  Resource: '*',
+                  Condition: { StringEquals: { 'aws:username': 'x' } },
+                },
+              ],
+            },
+          },
+        ],
+      ]),
+      warn: (m) => warnings.push(m),
+    });
+    expect(out).toHaveLength(0);
+    expect(warnings.some((w) => w.includes('now declared in the template'))).toBe(true);
+  });
+
+  it('folds a bracketed nested path keyed by an IDENTITY field value when now declared', () => {
+    // an identity-keyed object-array element — classify keys the bracket by the element's
+    // identity FIELD value (here `Name`), not a numeric index. The walk must resolve the
+    // element by that same identity value.
+    const b = baseline([
+      {
+        logicalId: 'Ev',
+        resourceType: 'AWS::Events::Rule',
+        path: 'Targets[my-target].RetryPolicy',
+        value: { MaximumRetryAttempts: 3 },
+      },
+    ]);
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([
+        [
+          'Ev',
+          {
+            Targets: [
+              {
+                Name: 'my-target',
+                Arn: 'arn:aws:x',
+                RetryPolicy: { MaximumRetryAttempts: 3 },
+              },
+            ],
+          },
+        ],
+      ]),
+    });
+    expect(out).toHaveLength(0);
+  });
+
+  it('does NOT over-fold: a nested path whose top-level parent is NOT declared still surfaces', () => {
+    // `Config` is entirely absent from the declared model → not promoted, a real removal.
+    const b = baseline([
+      {
+        logicalId: 'Fn',
+        resourceType: 'AWS::Lambda::Function',
+        path: 'Config.Nested.Value',
+        value: 42,
+      },
+    ]);
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['Fn', { Code: { ZipFile: 'x' }, Role: 'arn' }]]),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      path: 'Config.Nested.Value',
+      note: 'baseline value removed since record',
+    });
+  });
+
+  it('does NOT over-fold: parent declared but the exact nested leaf NOT declared → still a removal', () => {
+    // `LoggingConfig` is declared, but only ApplicationLogLevel — the recorded LogFormat was
+    // an out-of-band nested value that vanished (the #749 FN we must keep detecting).
+    const b = baseline([
+      {
+        logicalId: 'Fn',
+        resourceType: 'AWS::Lambda::Function',
+        path: 'LoggingConfig.LogFormat',
+        value: 'Text',
+      },
+    ]);
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['Fn', { LoggingConfig: { ApplicationLogLevel: 'INFO' } }]]),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      path: 'LoggingConfig.LogFormat',
+      note: 'baseline value removed since record',
+    });
+  });
+
+  it('folds the whole subtree when the parent is declared as a LEAF (Foo declared, Foo.Bar promoted)', () => {
+    // declaring `Environment` at all moves its whole subtree to the declared dimension; the
+    // recorded `Environment.Variables.FOO` is now redundant intent, not a vanished value.
+    const b = baseline([
+      {
+        logicalId: 'Fn',
+        resourceType: 'AWS::Lambda::Function',
+        path: 'Environment.Variables.FOO',
+        value: 'bar',
+      },
+    ]);
+    const warnings: string[] = [];
+    // `Environment` declared as a leaf-ish value (an unresolved token placeholder) — the
+    // walk hits a non-container before the path ends → the subtree is declared intent.
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['Fn', { Environment: 'DECLARED_TOKEN' }]]),
+      warn: (m) => warnings.push(m),
+    });
+    expect(out).toHaveLength(0);
+    expect(warnings.some((w) => w.includes('now declared in the template'))).toBe(true);
+  });
+
+  it('declaredKeysByLogical carries the full declared model (not just top-level keys)', () => {
+    const m = declaredKeysByLogical([
+      { logicalId: 'Fn', declared: { LoggingConfig: { LogFormat: 'JSON' }, Role: 'arn' } },
+    ]);
+    expect(m.get('Fn')).toEqual({ LoggingConfig: { LogFormat: 'JSON' }, Role: 'arn' });
+  });
+});

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -874,7 +874,7 @@ describe('baseline', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     const warnings: string[] = [];
     const out = applyBaseline([], b, {
-      declaredByLogical: new Map([['A', new Set(['P'])]]), // P is now declared
+      declaredByLogical: new Map([['A', { P: ['x'] }]]), // P is now declared
       warn: (m) => warnings.push(m),
     });
     expect(out).toHaveLength(0); // no false "removed" finding
@@ -890,9 +890,9 @@ describe('baseline', () => {
     ]);
     const warnings: string[] = [];
     const out = applyBaseline([], b, {
-      declaredByLogical: new Map([
-        ['A', new Set(['P1', 'P2'])],
-        ['B', new Set(['Q'])],
+      declaredByLogical: new Map<string, Record<string, unknown>>([
+        ['A', { P1: ['x'], P2: ['y'] }],
+        ['B', { Q: ['z'] }],
       ]),
       warn: (m) => warnings.push(m),
     });
@@ -919,7 +919,9 @@ describe('baseline', () => {
 
   it('still reports a removal when the recorded path is genuinely gone (not declared)', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
-    const out = applyBaseline([], b, { declaredByLogical: new Map([['A', new Set(['Other'])]]) });
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['A', { Other: true }]]),
+    });
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({ note: 'baseline value removed since record' });
   });


### PR DESCRIPTION
Closes #1079

Offline fix with unit tests. Promoting a NESTED recorded value into the template (record undeclared, then declare it) surfaced false "baseline value removed since record" drift + a stale-value revert offer (#749's residue — the gate only handled top-level promoted paths). declaredByLogical now carries the whole declared model per logicalId and a path-walker recognizes a nested recorded path as promoted when it resolves in (or is subtree-covered by) the declared model; a genuine nested OOB removal still surfaces (no over-fold). 9 new tests.