### PR TITLE
fix(revert): carry dry-run plan counts + refused reason in the --json element (#1096)

### DIFF
--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -111,6 +111,14 @@ export async function runRevert(args: string[]): Promise<number> {
           failed: outcome.failed ?? 0,
           aborted: outcome.aborted,
           exit: outcome.exit,
+          // #1096: a --dry-run element carries the would-apply counts, and a refusal element
+          // its reason — otherwise a would-apply-N-ops preview is indistinguishable from a
+          // clean no-op. Omitted (not `0`/empty) when not applicable.
+          ...(outcome.plannedOps !== undefined && { plannedOps: outcome.plannedOps }),
+          ...(outcome.plannedResources !== undefined && {
+            plannedResources: outcome.plannedResources,
+          }),
+          ...(outcome.refusedReason !== undefined && { refusedReason: outcome.refusedReason }),
         });
     } catch (e) {
       if (isStackNotDeployed(e)) {

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -750,6 +750,16 @@ export interface RevertOutcome {
   aborted: boolean;
   reverted?: number; // #868: resources successfully reverted (for --json); absent = 0
   failed?: number; // #868: resources whose revert op failed (for --json); absent = 0
+  // #1096: under --dry-run the human "(dry-run) would apply N op(s) to M resource(s)"
+  // summary is silenced (out() is a no-op under --json), so a scripted consumer could not
+  // tell a would-apply-N-ops preview from a clean no-op. Carry the SAME counts the human
+  // summary computes so the --json element is self-describing. Present only on --dry-run.
+  plannedOps?: number; // ops a real revert would apply (Σ item.ops.length)
+  plannedResources?: number; // resources those ops touch (plan.items.length)
+  // #1096: why the revert refused to plan/apply anything — the "nothing revertable" reason
+  // (drift/unrecorded remains) or the non-interactive "pass --yes" refusal. Present only on a
+  // refusal so a scripted consumer sees WHY an exit-1/exit-2 element carries no reverted ops.
+  refusedReason?: string;
 }
 
 /**
@@ -857,8 +867,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       ...(dc > 0 ? [`${dc} drift(s)`] : []),
       ...(uc > 0 ? [`${uc} unrecorded value(s)`] : []),
     ];
-    out('\n' + style.drift(`nothing revertable — ${parts.join(' + ')} remain.`));
-    return { exit: 1, aborted: false };
+    const reason = `nothing revertable — ${parts.join(' + ')} remain.`;
+    out('\n' + style.drift(reason));
+    return { exit: 1, aborted: false, refusedReason: reason };
   }
 
   if (dryRun) {
@@ -866,14 +877,16 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     out(
       `\n(dry-run) would apply ${opCount} op(s) to ${plan.items.length} resource(s). No changes made.`
     );
-    return { exit: 0, aborted: false };
+    // #1096: the human line above is silenced under --json — carry the same counts so the
+    // JSON element is not mistaken for a clean no-op.
+    return { exit: 0, aborted: false, plannedOps: opCount, plannedResources: plan.items.length };
   }
   if (!yes) {
     if (!interactive) {
-      console.error(
-        `\nrefusing to write to AWS non-interactively — pass --yes to apply (or --dry-run to preview).`
-      );
-      return { exit: 2, aborted: false };
+      const reason =
+        'refusing to write to AWS non-interactively — pass --yes to apply (or --dry-run to preview).';
+      console.error('\n' + reason);
+      return { exit: 2, aborted: false, refusedReason: reason };
     }
     // R57: pick WHICH op(s) to write — symmetric with record's multiselect.
     // RESTORE ops are pre-selected; REMOVE ops start unselected (an explicit

--- a/src/commands/verb-json.ts
+++ b/src/commands/verb-json.ts
@@ -30,6 +30,9 @@ export interface RevertJson {
   failed: number; // resources whose revert op failed
   aborted: boolean; // the confirm prompt was cancelled (no AWS write)
   exit: number; // this stack's exit contribution (0 clean / 1 drift remains / 2 failure)
+  plannedOps?: number; // #1096: --dry-run only — ops a real revert would apply
+  plannedResources?: number; // #1096: --dry-run only — resources those ops touch
+  refusedReason?: string; // #1096: why the revert refused (nothing revertable / needs --yes)
   error?: string; // set only on a pre-revert failure / skip
 }
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -496,7 +496,12 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
 
   it('drift exists but nothing revertable (deleted-only) -> summary + exit 1', async () => {
     const { outcome, logs } = await captured([deleted()]);
-    expect(outcome).toEqual({ exit: 1, aborted: false });
+    // #1096: the refusal reason is carried on the outcome (for the --json element)
+    expect(outcome).toEqual({
+      exit: 1,
+      aborted: false,
+      refusedReason: 'nothing revertable — 1 drift(s) remain.',
+    });
     const out = logs.join('\n');
     expect(out).toContain('NOT revertable: 1 (deleted — recreate via cdk deploy)');
     expect(out).toContain('nothing revertable — 1 drift(s) remain.');
@@ -505,7 +510,7 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
   it('unrecorded values (no baseline) -> unrecorded guidance + exit 1, named as unrecorded not drift', async () => {
     // revertStack's own applyBaseline tags the no-baseline findings as unrecorded
     const { outcome, logs } = await captured([undeclared()]);
-    expect(outcome).toEqual({ exit: 1, aborted: false });
+    expect(outcome).toMatchObject({ exit: 1, aborted: false });
     const out = logs.join('\n');
     expect(out).toContain(
       'note: s has unrecorded value(s) — never recorded, so there is no recorded state to restore.'
@@ -521,7 +526,14 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
       removeUnrecorded: true,
       dryRun: true,
     });
-    expect(outcome).toEqual({ exit: 0, aborted: false });
+    // #1096: the dry-run outcome carries the would-apply counts (1 op on 1 resource) so the
+    // --json element is not mistaken for a clean no-op.
+    expect(outcome).toEqual({
+      exit: 0,
+      aborted: false,
+      plannedOps: 1,
+      plannedResources: 1,
+    });
     const out = logs.join('\n');
     expect(out).not.toContain('has unrecorded value(s) — never recorded');
     expect(out).toContain('remove (undeclared, not in baseline)'); // a real revert item is planned
@@ -545,8 +557,78 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     const { outcome, logs } = await captured([undeclared()], {
       config: { ignore: [{ path: 'B.AccelerateConfiguration', account: '999999999999' }] },
     });
-    expect(outcome).toEqual({ exit: 1, aborted: false }); // still unrecorded drift, not ignored
+    expect(outcome).toMatchObject({ exit: 1, aborted: false }); // still unrecorded drift, not ignored
     expect(logs.join('\n')).toContain('unrecorded value(s) remain.');
+  });
+});
+
+describe('revertStack --json plan-info carriage (#1096 — dry-run counts + refused reason)', () => {
+  // A revertable DECLARED drift so the plan has real items (1 op on 1 resource): the bucket
+  // has a live template resource whose declared VersioningConfiguration diverged.
+  const gathered = () =>
+    ({
+      desired: {
+        accountId: '111122223333',
+        resources: [
+          {
+            logicalId: 'B',
+            resourceType: 'AWS::S3::Bucket',
+            physicalId: 'b-phys',
+            declared: { VersioningConfiguration: { Status: 'Enabled' } },
+          },
+        ],
+        rawTemplate: '',
+      },
+      findings: [declared()],
+      schemas: NO_SCHEMAS,
+    }) as unknown as GatherResult;
+
+  const params = (over: Partial<{ dryRun: boolean; yes: boolean; interactive: boolean }> = {}) => ({
+    stackName: 's',
+    region: 'r',
+    gathered: gathered(),
+    baseline: undefined,
+    config: { ignore: [] },
+    dryRun: over.dryRun ?? false,
+    yes: over.yes ?? true,
+    removeUnrecorded: false,
+    verbose: false,
+    interactive: over.interactive ?? true,
+  });
+
+  const run = async (over: Parameters<typeof params>[0] = {}) => {
+    const logs: string[] = [];
+    const errs: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = (s: unknown) => logs.push(String(s));
+    console.error = (s: unknown) => errs.push(String(s));
+    try {
+      return { outcome: await revertStack(params(over)), logs, errs };
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  };
+
+  it('--dry-run carries plannedOps + plannedResources (not a no-op-looking element)', async () => {
+    const { outcome, logs } = await run({ dryRun: true });
+    expect(outcome).toEqual({
+      exit: 0,
+      aborted: false,
+      plannedOps: 1,
+      plannedResources: 1,
+    });
+    // the human summary reports the SAME counts
+    expect(logs.join('\n')).toContain('(dry-run) would apply 1 op(s) to 1 resource(s).');
+  });
+
+  it('a non-interactive refusal (no --yes) carries refusedReason', async () => {
+    const { outcome, errs } = await run({ yes: false, interactive: false });
+    expect(outcome.exit).toBe(2);
+    expect(outcome.refusedReason).toContain('refusing to write to AWS non-interactively');
+    // reason still surfaces on stderr for a human
+    expect(errs.join('\n')).toContain('refusing to write to AWS non-interactively');
   });
 });
 

--- a/tests/verb-json-868.test.ts
+++ b/tests/verb-json-868.test.ts
@@ -1,5 +1,40 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
-import { emitJsonArray, stackLabel } from '../src/commands/verb-json.js';
+import { emitJsonArray, type RevertJson, stackLabel } from '../src/commands/verb-json.js';
+
+// #1096: a revert --json element must carry the dry-run plan counts / the refused reason so a
+// scripted consumer can tell a would-apply-N-ops preview (or a refusal) from a clean no-op.
+// The interface's new fields are OPTIONAL, so a non-dry-run / non-refused element omits them.
+describe('RevertJson dry-run plan-info + refused reason (#1096)', () => {
+  it('a --dry-run element carries plannedOps / plannedResources', () => {
+    const el: RevertJson = {
+      stack: 'A (us-east-1)',
+      reverted: 0,
+      failed: 0,
+      aborted: false,
+      exit: 0,
+      plannedOps: 3,
+      plannedResources: 2,
+    };
+    expect(JSON.parse(JSON.stringify(el))).toMatchObject({ plannedOps: 3, plannedResources: 2 });
+  });
+
+  it('a refused element carries refusedReason; a clean element omits all three fields', () => {
+    const refused: RevertJson = {
+      stack: 'A (us-east-1)',
+      reverted: 0,
+      failed: 0,
+      aborted: false,
+      exit: 1,
+      refusedReason: 'nothing revertable — 1 drift(s) remain.',
+    };
+    expect(refused.refusedReason).toContain('nothing revertable');
+    const clean: RevertJson = { stack: 'A', reverted: 0, failed: 0, aborted: false, exit: 0 };
+    const keys = Object.keys(JSON.parse(JSON.stringify(clean)));
+    expect(keys).not.toContain('plannedOps');
+    expect(keys).not.toContain('plannedResources');
+    expect(keys).not.toContain('refusedReason');
+  });
+});
 
 // #868: record / ignore / revert now honor --json — one top-level JSON array, one element
 // per stack, symmetric with check. These tests pin the helpers + the top-level-error


### PR DESCRIPTION
Closes #1096

Offline fix with unit tests. revert --dry-run --json carried zero plan info (out() is a noop under --json), so a would-apply-N-ops preview was indistinguishable from a clean no-op. The RevertJson element now carries plannedOps / plannedResources on a dry-run and refusedReason on a refusal (RevertOutcome→verb-json RevertJson→revert.ts element, fields omitted when not applicable). Human output unchanged.