### PR TITLE
fix(synth): align raw-SDK client credential precedence with toolkit-lib (#954)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@aws-sdk/client-ssm": "^3.1075.0",
     "@aws-sdk/client-sts": "^3.1065.0",
     "@aws-sdk/client-wafv2": "^3.1073.0",
+    "@aws-sdk/credential-providers": "^3.1065.0",
     "@clack/core": "^1.4.1",
     "@clack/prompts": "^1.5.1",
     "jsonata": "^1.8.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@aws-sdk/client-wafv2':
         specifier: ^3.1073.0
         version: 3.1073.0
+      '@aws-sdk/credential-providers':
+        specifier: ^3.1065.0
+        version: 3.1066.0
       '@clack/core':
         specifier: ^1.4.1
         version: 1.4.1
@@ -574,10 +577,6 @@ packages:
     resolution: {integrity: sha512-4L/REssieLON1hVsTzZucP1p2u5jmPNejyh/9BCGZXr93IalBbhRPCrtKIKwMTu9yRGr/bcKzhrQocByKLSzLQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.46':
-    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-env@3.972.53':
     resolution: {integrity: sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==}
     engines: {node: '>=20.0.0'}
@@ -592,10 +591,6 @@ packages:
 
   '@aws-sdk/credential-provider-env@3.972.57':
     resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.55':
@@ -614,10 +609,6 @@ packages:
     resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-ini@3.972.60':
     resolution: {integrity: sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==}
     engines: {node: '>=20.0.0'}
@@ -632,10 +623,6 @@ packages:
 
   '@aws-sdk/credential-provider-ini@3.973.1':
     resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.52':
-    resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.59':
@@ -694,10 +681,6 @@ packages:
     resolution: {integrity: sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.46':
-    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-process@3.972.53':
     resolution: {integrity: sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==}
     engines: {node: '>=20.0.0'}
@@ -714,10 +697,6 @@ packages:
     resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.59':
     resolution: {integrity: sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==}
     engines: {node: '>=20.0.0'}
@@ -732,10 +711,6 @@ packages:
 
   '@aws-sdk/credential-provider-sso@3.973.1':
     resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.59':
@@ -800,10 +775,6 @@ packages:
     resolution: {integrity: sha512-PVAj7VgWK/ZxCXnkgC4B7cdJyUN99Nsr7IEduHt4A1GieuB+ZnU5bSifHwapbr17wrFkmdxfSh+aA0Lj+Ads6w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.20':
-    resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.997.27':
     resolution: {integrity: sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==}
     engines: {node: '>=20.0.0'}
@@ -834,10 +805,6 @@ packages:
 
   '@aws-sdk/signature-v4-multi-region@3.996.39':
     resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1066.0':
-    resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1079.0':
@@ -1602,10 +1569,6 @@ packages:
 
   '@smithy/core@3.29.2':
     resolution: {integrity: sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/credential-provider-imds@4.3.8':
-    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.4.5':
@@ -4142,12 +4105,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/credential-provider-node': 3.972.62
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/fetch-http-handler': 5.6.2
-      '@smithy/node-http-handler': 4.9.2
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4748,17 +4711,9 @@ snapshots:
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     dependencies:
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4791,16 +4746,6 @@ snapshots:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/fetch-http-handler': 5.6.2
-      '@smithy/node-http-handler': 4.9.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4841,22 +4786,6 @@ snapshots:
       '@smithy/core': 3.29.2
       '@smithy/fetch-http-handler': 5.6.4
       '@smithy/node-http-handler': 4.9.4
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/credential-provider-env': 3.972.53
-      '@aws-sdk/credential-provider-http': 3.972.55
-      '@aws-sdk/credential-provider-login': 3.972.52
-      '@aws-sdk/credential-provider-process': 3.972.53
-      '@aws-sdk/credential-provider-sso': 3.972.59
-      '@aws-sdk/credential-provider-web-identity': 3.972.59
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/credential-provider-imds': 4.4.5
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4921,15 +4850,6 @@ snapshots:
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
       '@smithy/credential-provider-imds': 4.4.7
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5109,14 +5029,6 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.972.53':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -5146,16 +5058,6 @@ snapshots:
       '@aws-sdk/core': 3.975.1
       '@aws-sdk/types': 3.974.0
       '@smithy/core': 3.29.2
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/token-providers': 3.1066.0
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5199,15 +5101,6 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-web-identity@3.972.59':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -5247,20 +5140,20 @@ snapshots:
   '@aws-sdk/credential-providers@3.1066.0':
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.1066.0
-      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/core': 3.975.1
       '@aws-sdk/credential-provider-cognito-identity': 3.972.45
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-ini': 3.972.53
-      '@aws-sdk/credential-provider-login': 3.972.52
-      '@aws-sdk/credential-provider-node': 3.972.62
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/credential-provider-imds': 4.3.8
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-ini': 3.973.1
+      '@aws-sdk/credential-provider-login': 3.972.63
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/credential-provider-imds': 4.4.7
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5343,19 +5236,6 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.20':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
-      '@smithy/fetch-http-handler': 5.6.2
-      '@smithy/node-http-handler': 4.9.2
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/nested-clients@3.997.27':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -5425,15 +5305,6 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.974.0
       '@smithy/signature-v4': 5.6.3
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1066.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.27
-      '@aws-sdk/nested-clients': 3.997.27
-      '@aws-sdk/types': 3.973.15
-      '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -6099,12 +5970,6 @@ snapshots:
 
   '@smithy/core@3.29.2':
     dependencies:
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@smithy/credential-provider-imds@4.3.8':
-    dependencies:
-      '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -225,6 +225,14 @@ export function parseCommonArgs(args: string[], verb?: Verb): CommonArgs {
   if (scopes.length > 1) {
     throw new Error(`${scopes.join(' and ')} are mutually exclusive — see cdkrd --help`);
   }
+
+  // #954: mark an EXPLICIT `--profile` (as opposed to an inherited $AWS_PROFILE) so the raw
+  // SDK clients' credential chain (read/client-config `shouldPrioritizeEnv`) mirrors
+  // toolkit-lib: an explicit `--profile` uses that profile EXCLUSIVELY (env creds do NOT
+  // win), whereas a bare $AWS_PROFILE + env creds prioritizes env. The verb entry points
+  // also export the resolved profile as $AWS_PROFILE; this marker is the "was it explicit?"
+  // bit that export loses. Set only when `--profile` is actually present.
+  if (values['--profile'] !== undefined) process.env.CDKRD_EXPLICIT_PROFILE = '1';
   return {
     stackNames,
     all: has('--all'),

--- a/src/read/client-config.ts
+++ b/src/read/client-config.ts
@@ -19,7 +19,61 @@
 // object, which every AWS v3 client accepts and wraps. Applied to the READ clients via
 // READ_RETRY below and spread directly into the revert WRITE clients (which must NOT inherit
 // the read-path adaptive retry — a write is not idempotent).
+import {
+  createCredentialChain,
+  fromEnv,
+  fromNodeProviderChain,
+} from '@aws-sdk/credential-providers';
+
+// #954: align the raw SDK clients' credential precedence with toolkit-lib / the AWS CLI.
+//
+// The split-brain: when BOTH static env credentials (AWS_ACCESS_KEY_ID +
+// AWS_SECRET_ACCESS_KEY) AND AWS_PROFILE are set — and no explicit `--profile` — the two
+// SDK stacks inside one cdkrd process pick OPPOSITE identities. toolkit-lib (synth /
+// discovery / context) prepends `fromEnv()` to its chain (`shouldPrioritizeEnv()` in
+// awscli-compatible.ts), so the ENV creds win over AWS_PROFILE. But the raw AWS SDK v3
+// default provider does the reverse: when `AWS_PROFILE` is set it SKIPS `fromEnv` and uses
+// the PROFILE creds. Result: discovery under account A, every live read / baseline / revert
+// write under account B — silent cross-account divergence.
+//
+// Fix: give every raw client the SAME chain toolkit-lib uses. `shouldPrioritizeEnv()` below
+// is a faithful port of toolkit-lib's function (same env vars + AMAZON_* backward-compat
+// aliases). When env creds + AWS_PROFILE are both present, the chain is
+// `createCredentialChain(fromEnv(), fromNodeProviderChain())` so ENV wins — exactly the
+// toolkit-lib branch. Otherwise the chain is a plain `fromNodeProviderChain()`, which is
+// the SDK's own default behavior, so single-source (env-only or profile-only) is unchanged.
+//
+// EXPLICIT `--profile`: toolkit-lib uses `fromIni({ profile })` EXCLUSIVELY (env does NOT
+// win). `parseCommonArgs` (cli-args.ts) sets `CDKRD_EXPLICIT_PROFILE=1` when `--profile` is
+// present, and the verb entry points export the resolved profile as `process.env.AWS_PROFILE`.
+// We honor that marker by NOT prioritizing env in the explicit-profile case, so
+// `fromNodeProviderChain` resolves the profile — matching toolkit-lib (both halves pick the
+// profile, never env).
+//
+// The provider is a LAZY function: the SDK calls it at first-request time, AFTER the verb
+// entry point has exported AWS_PROFILE / CDKRD_EXPLICIT_PROFILE, so the decision reads the
+// final environment (not the module-load snapshot).
+
+/** Port of toolkit-lib awscli-compatible `shouldPrioritizeEnv()` (env creds win over profile). */
+export function shouldPrioritizeEnv(): boolean {
+  // An explicit `--profile` means `fromIni(profile)` exclusively in toolkit-lib — env must
+  // NOT win. The verb entry points mark this so both SDK stacks agree on the profile.
+  if (process.env.CDKRD_EXPLICIT_PROFILE) return false;
+  const id = process.env.AWS_ACCESS_KEY_ID || process.env.AMAZON_ACCESS_KEY_ID;
+  const key = process.env.AWS_SECRET_ACCESS_KEY || process.env.AMAZON_SECRET_ACCESS_KEY;
+  return !!id && !!key;
+}
+
+// The shared credential provider spread into EVERY raw SDK client (via CLIENT_TIMEOUTS /
+// READ_RETRY). A single function reference is reused across all clients; it decides env-vs-
+// profile precedence lazily on each resolution (see shouldPrioritizeEnv).
+export const CLIENT_CREDENTIALS = (awsIdentityProperties?: Record<string, unknown>) =>
+  (shouldPrioritizeEnv()
+    ? createCredentialChain(fromEnv(), fromNodeProviderChain())
+    : fromNodeProviderChain())(awsIdentityProperties);
+
 export const CLIENT_TIMEOUTS = {
+  credentials: CLIENT_CREDENTIALS,
   requestHandler: {
     connectionTimeout: 6_000, // 6s to establish the TCP connection (aborts the connect attempt)
     requestTimeout: 60_000, // 60s for a single request attempt (retries add their own budget)

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -59,6 +59,28 @@ describe('parseCommonArgs', () => {
     }
   });
 
+  it('#954: sets CDKRD_EXPLICIT_PROFILE only for an EXPLICIT --profile, not inherited $AWS_PROFILE', () => {
+    const saved = { p: process.env.AWS_PROFILE, x: process.env.CDKRD_EXPLICIT_PROFILE };
+    try {
+      // Inherited $AWS_PROFILE (no --profile) must NOT mark explicit — env creds should still
+      // win over that profile (the toolkit-lib rule the raw clients now mirror).
+      delete process.env.CDKRD_EXPLICIT_PROFILE;
+      process.env.AWS_PROFILE = 'dev';
+      parseCommonArgs(['S']);
+      expect(process.env.CDKRD_EXPLICIT_PROFILE).toBeUndefined();
+
+      // An explicit --profile marks it, so client-config's shouldPrioritizeEnv defers to the
+      // profile (fromIni) — matching toolkit-lib's explicit-profile branch.
+      parseCommonArgs(['S', '--profile', 'explicit']);
+      expect(process.env.CDKRD_EXPLICIT_PROFILE).toBe('1');
+    } finally {
+      if (saved.p !== undefined) process.env.AWS_PROFILE = saved.p;
+      else delete process.env.AWS_PROFILE;
+      if (saved.x !== undefined) process.env.CDKRD_EXPLICIT_PROFILE = saved.x;
+      else delete process.env.CDKRD_EXPLICIT_PROFILE;
+    }
+  });
+
   it('recognizes --show-all, --yes/-y, --pre-deploy', () => {
     expect(parseCommonArgs(['S', '--show-all']).showAll).toBe(true);
     expect(parseCommonArgs(['S', '-y']).yes).toBe(true);

--- a/tests/client-config-cred-precedence-954.test.ts
+++ b/tests/client-config-cred-precedence-954.test.ts
@@ -1,0 +1,98 @@
+// #954: the raw SDK clients' credential precedence must match toolkit-lib / the AWS CLI.
+//
+// The split-brain the issue reports: when BOTH static env creds (AWS_ACCESS_KEY_ID +
+// AWS_SECRET_ACCESS_KEY) AND AWS_PROFILE are set, with no explicit `--profile`, toolkit-lib
+// (synth/discovery) prioritizes the ENV creds (`shouldPrioritizeEnv()` returns true), while
+// the raw SDK v3 default provider SKIPS fromEnv when AWS_PROFILE is set and uses the PROFILE
+// creds. These tests assert cdkrd's shared `shouldPrioritizeEnv` picks the SAME winner as
+// toolkit-lib (env), and that `CLIENT_CREDENTIALS` actually resolves the env identity in
+// that case — so every raw client (which spreads CLIENT_TIMEOUTS / READ_RETRY) agrees with
+// discovery on ONE identity.
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { CLIENT_CREDENTIALS, shouldPrioritizeEnv } from '../src/read/client-config.js';
+
+// The exact env vars toolkit-lib's shouldPrioritizeEnv() + our port read.
+const CRED_ENV_KEYS = [
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AMAZON_ACCESS_KEY_ID',
+  'AMAZON_SECRET_ACCESS_KEY',
+  'AMAZON_SESSION_TOKEN',
+  'AWS_PROFILE',
+  'AWS_DEFAULT_PROFILE',
+  'CDKRD_EXPLICIT_PROFILE',
+] as const;
+
+describe('#954 raw-client credential precedence (matches toolkit-lib)', () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    // Snapshot + clear every relevant var so the ambient dev environment (a real AWS_PROFILE
+    // / exported creds) never leaks into the assertions.
+    saved = {};
+    for (const k of CRED_ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of CRED_ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('prioritizes env when BOTH env creds and AWS_PROFILE are set (no --profile) — toolkit-lib winner', () => {
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAENV';
+    process.env.AWS_SECRET_ACCESS_KEY = 'secretenv';
+    process.env.AWS_PROFILE = 'dev';
+    // This is the split-brain case: toolkit-lib returns true here, so the raw clients MUST too.
+    expect(shouldPrioritizeEnv()).toBe(true);
+  });
+
+  it('resolves the ENV identity (not the profile) in the double-source case', async () => {
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAENV';
+    process.env.AWS_SECRET_ACCESS_KEY = 'secretenv';
+    process.env.AWS_SESSION_TOKEN = 'tokenenv';
+    process.env.AWS_PROFILE = 'dev'; // a profile that would win under the raw SDK default chain
+    const creds = await CLIENT_CREDENTIALS();
+    expect(creds.accessKeyId).toBe('AKIAENV');
+    expect(creds.secretAccessKey).toBe('secretenv');
+    expect(creds.sessionToken).toBe('tokenenv');
+  });
+
+  it('does NOT prioritize env when only AWS_PROFILE is set (no env creds) — profile-only, unchanged', () => {
+    process.env.AWS_PROFILE = 'dev';
+    expect(shouldPrioritizeEnv()).toBe(false);
+  });
+
+  it('prioritizes env when only env creds are set (no profile) — same as toolkit-lib; a no-op in practice', () => {
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAENV';
+    process.env.AWS_SECRET_ACCESS_KEY = 'secretenv';
+    // toolkit-lib's shouldPrioritizeEnv() only checks env creds, so it is true here too — our
+    // port matches. With no profile this is a no-op in effect (both fromEnv and the default
+    // chain resolve the same env identity), so single-source behavior is unchanged.
+    expect(shouldPrioritizeEnv()).toBe(true);
+  });
+
+  it('does NOT prioritize env when --profile is EXPLICIT (CDKRD_EXPLICIT_PROFILE) — toolkit-lib uses fromIni exclusively', () => {
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAENV';
+    process.env.AWS_SECRET_ACCESS_KEY = 'secretenv';
+    process.env.AWS_PROFILE = 'cliprofile'; // exported by the verb entry from --profile
+    process.env.CDKRD_EXPLICIT_PROFILE = '1'; // the "was explicit" marker cli-args sets
+    // An explicit --profile means the chosen profile wins in toolkit-lib (fromIni), so env
+    // must NOT be prioritized — otherwise we'd RE-INTRODUCE the split-brain in the other
+    // direction (toolkit uses profile, raw uses env).
+    expect(shouldPrioritizeEnv()).toBe(false);
+  });
+
+  it('honors AWS_DEFAULT_PROFILE and the AMAZON_* env aliases like toolkit-lib', () => {
+    process.env.AMAZON_ACCESS_KEY_ID = 'AKIAAMZ';
+    process.env.AMAZON_SECRET_ACCESS_KEY = 'secretamz';
+    process.env.AWS_DEFAULT_PROFILE = 'dev';
+    // toolkit-lib's shouldPrioritizeEnv reads the AMAZON_* aliases; AWS_DEFAULT_PROFILE is
+    // the sibling profile source (#953). Double-source still prioritizes env.
+    expect(shouldPrioritizeEnv()).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #954

When BOTH `AWS_PROFILE` and static env credentials are set (no `--profile`), toolkit-lib (synth/discovery/context) prefers the ENV creds while cdkrd's raw SDK v3 clients used the PROFILE (v3 default provider skips `fromEnv` when `AWS_PROFILE` is set) — a split-brain identity: discovery under account A, every live read / baseline / revert-write under account B.

Fix at the single shared client-config seam (`src/read/client-config.ts`): a shared `CLIENT_CREDENTIALS` provider + a faithful port of toolkit-lib's `shouldPrioritizeEnv()`. When env creds + an inherited profile are both set, clients use `createCredentialChain(fromEnv(), fromNodeProviderChain())` so ENV wins (toolkit-lib's branch); otherwise the plain default chain (unchanged). `--profile` explicitly passed → profile-only (via `CDKRD_EXPLICIT_PROFILE`, set in cli-args), matching toolkit-lib and not re-introducing the split. Wired through `CLIENT_TIMEOUTS`/`READ_RETRY` so all raw clients inherit it; no forbidden files touched.

Tests: `shouldPrioritizeEnv`/`CLIENT_CREDENTIALS` pick ENV in the double-source case and profile in the explicit-`--profile`/single-source cases; cli-args sets `CDKRD_EXPLICIT_PROFILE` only for explicit `--profile`.

⚠️ **Design decision for your review**: this adds a runtime dep `@aws-sdk/credential-providers` (already transitively present; the same package CDK uses, so precedence stays identical across versions). The dependency-free alternative is a static `credentials` object built from the env vars in the prioritize branch — same outcome for the split-brain case but without reusing CDK's exact chain-fallback semantics. Happy to switch to the zero-new-dep form if you prefer.