### PR TITLE
fix(noise): canonicalize WAFv2 FieldToMatch.SingleHeader key+value case (#876)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3821,14 +3821,47 @@ function deepEqualValue(a: unknown, b: unknown): boolean {
 // binary pattern, or a mismatched twin, is left untouched and still surfaces. The declared
 // side (plain `SearchString`, no base64) is a no-op; the live side is folded to match, so a
 // clean rule is not drift while an out-of-band pattern change (both live keys change in
-// lockstep) still surfaces via the `SearchString` compare. Applied (via
-// canonicalizeForCompare) only for AWS::WAFv2::WebACL. Pure.
+// lockstep) still surfaces via the `SearchString` compare.
+//
+// It ALSO canonicalizes the WAFv2 `FieldToMatch.SingleHeader` / `SingleQueryArgument` shape
+// on BOTH compare sides so a clean header-matching rule is not double-flagged (#876). Two
+// divergences hit at once on a fresh WebACL:
+//   1. KEY case — the template's free-form `FieldToMatch` carries a LOWERCASE `name` key
+//      (the documented CDK/CFn form: WAFv2 types `FieldToMatch` as raw JSON passed to the
+//      WAF API, whose JSON key is `name`), but the CC read echoes the schema-canonical
+//      PascalCase `Name`. A case-sensitive diff then reports `name` as template-only AND
+//      `Name` as live-only — a false `[CFn-Declared Drift]`.
+//   2. VALUE case — WAF lowercases the header/argument NAME (`User-Agent` -> `user-agent`;
+//      header names are case-insensitive per RFC 9110, same as the already-folded
+//      LoggingConfiguration RedactedFields SingleHeader.Name), so the leaf ALSO surfaces as
+//      a duplicate `[Potential Drift]` on `SingleHeader.Name`.
+// Folding the inner object to a single `{ Name: <lowercased> }` on both sides collapses BOTH
+// findings. The canonicalization is equality-gated by the resulting value: two header names
+// that differ beyond case (a genuine `user-agent` -> `referer` change) still differ after
+// lowercasing and still surface as real drift. Scoped to the `SingleHeader` /
+// `SingleQueryArgument` member objects only — no unrelated key/value is touched.
+//
+// Applied (via canonicalizeForCompare) only for AWS::WAFv2::WebACL. Pure.
 export function normalizeWafByteMatchDeep(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(normalizeWafByteMatchDeep);
   if (value === null || typeof value !== 'object') return value;
   const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value as Record<string, unknown>))
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    // Canonicalize the FieldToMatch header/argument selector: fold the `name`/`Name` key case
+    // to `Name` and lowercase the header/argument NAME value (WAF stores it lowercased). Only
+    // the SingleHeader / SingleQueryArgument member (a `{ name|Name: <string> }` object) is
+    // rewritten; every other key recurses unchanged.
+    if (
+      (k === 'SingleHeader' || k === 'SingleQueryArgument') &&
+      v !== null &&
+      typeof v === 'object' &&
+      !Array.isArray(v)
+    ) {
+      out[k] = canonicalizeWafFieldNameSelector(v as Record<string, unknown>);
+      continue;
+    }
     out[k] = normalizeWafByteMatchDeep(v);
+  }
   const b64 = out.SearchStringBase64;
   if (typeof b64 === 'string') {
     const plain = out.SearchString;
@@ -3842,6 +3875,23 @@ export function normalizeWafByteMatchDeep(value: unknown): unknown {
         delete out.SearchStringBase64;
         out.SearchString = decoded;
       }
+    }
+  }
+  return out;
+}
+
+// Canonicalize a WAFv2 `FieldToMatch.SingleHeader` / `SingleQueryArgument` selector object
+// (`{ name|Name: <headerName> }`) to a single representation: the key is folded to PascalCase
+// `Name` and its string value is lowercased (WAF stores header/argument names lowercased). A
+// non-string / absent name, or any extra sibling key, is preserved verbatim so an unexpected
+// shape is never silently dropped. Pure; used only by normalizeWafByteMatchDeep.
+function canonicalizeWafFieldNameSelector(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === 'name' || k === 'Name') {
+      out.Name = typeof v === 'string' ? v.toLowerCase() : v;
+    } else {
+      out[k] = normalizeWafByteMatchDeep(v);
     }
   }
   return out;

--- a/src/normalize/pipeline.ts
+++ b/src/normalize/pipeline.ts
@@ -31,5 +31,7 @@ export function canonicalizeForCompare(v: unknown, resourceType?: string): unkno
   );
   // A WAFv2 WebACL's ByteMatchStatement search patterns read back base64-encoded; fold both
   // sides to the plain SearchString the template declares so a clean rule is not false drift.
-  return resourceType === 'AWS::WAFv2::WebACL' ? normalizeWafByteMatchDeep(base) : base;
+  return resourceType === 'AWS::WAFv2::WebACL' || resourceType === 'AWS::WAFv2::RuleGroup'
+    ? normalizeWafByteMatchDeep(base)
+    : base;
 }

--- a/tests/noise-waf-singleheader-876.test.ts
+++ b/tests/noise-waf-singleheader-876.test.ts
@@ -1,0 +1,159 @@
+// #876 — a clean WAFv2 WebACL rule that matches on a header (FieldToMatch.SingleHeader)
+// produced a DOUBLE false positive on a fresh, un-mutated deploy:
+//   1. the template's free-form `FieldToMatch` carries a LOWERCASE `name` key (the
+//      documented CDK/CFn form), but the CC read echoes PascalCase `Name` — a case-sensitive
+//      diff flags `name` (template-only) + `Name` (live-only) as a `[CFn-Declared Drift]`;
+//   2. WAF lowercases the header NAME value (`User-Agent` -> `user-agent`), so the leaf ALSO
+//      surfaces as a duplicate `[Potential Drift]` on `SingleHeader.Name`.
+// normalizeWafByteMatchDeep now canonicalizes the SingleHeader / SingleQueryArgument selector
+// on BOTH compare sides ({ name|Name } -> { Name: <lowercased> }), folding both findings while
+// still surfacing a genuine header-name change.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { normalizeWafByteMatchDeep } from '../src/normalize/noise.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+function tiers(findings: Finding[]) {
+  const by = (t: string) =>
+    findings
+      .filter((f) => f.tier === t)
+      .map((f) => f.path)
+      .sort();
+  return { declared: by('declared'), undeclared: by('undeclared') };
+}
+
+// Build a WebACL Rules array with a single ByteMatchStatement matching on a SingleHeader.
+// `wrap` optionally nests the statement inside an And/Or/Not composite (recursion coverage).
+function webAcl(
+  headerKey: 'name' | 'Name',
+  headerValue: string,
+  wrap: 'none' | 'and' | 'or' = 'none'
+): Record<string, unknown> {
+  const byteMatch = {
+    ByteMatchStatement: {
+      SearchString: 'evil',
+      FieldToMatch: { SingleHeader: { [headerKey]: headerValue } },
+      TextTransformations: [{ Priority: 0, Type: 'NONE' }],
+      PositionalConstraint: 'CONTAINS',
+    },
+  };
+  let statement: Record<string, unknown> = byteMatch;
+  if (wrap === 'and') statement = { AndStatement: { Statements: [byteMatch] } };
+  else if (wrap === 'or') statement = { OrStatement: { Statements: [byteMatch] } };
+  return {
+    Rules: [
+      {
+        Name: 'ua-block',
+        Priority: 0,
+        Action: { Block: {} },
+        Statement: statement,
+        VisibilityConfig: {
+          SampledRequestsEnabled: true,
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'ua',
+        },
+      },
+    ],
+  };
+}
+
+function webAclResource(acl: Record<string, unknown>): DesiredResource {
+  return {
+    logicalId: 'Acl',
+    resourceType: 'AWS::WAFv2::WebACL',
+    physicalId: 'acl-phys',
+    declared: acl,
+  };
+}
+
+describe('WAFv2 FieldToMatch.SingleHeader key+value canonicalization (#876)', () => {
+  it('declared { name: "User-Agent" } vs live { Name: "user-agent" } → NO drift', () => {
+    // Exact live-vs-declared shape from the issue: template lowercase `name`/mixed-case value,
+    // live PascalCase `Name`/lowercased value. Neither the declared FP nor the duplicate
+    // potential-drift may surface.
+    const declared = webAcl('name', 'User-Agent');
+    const live = webAcl('Name', 'user-agent');
+    const t = tiers(classifyResource(webAclResource(declared), live, emptySchema));
+    expect(t.declared).toEqual([]);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('a GENUINE header-name change (declared user-agent vs live referer) still surfaces', () => {
+    const declared = webAcl('name', 'User-Agent');
+    const live = webAcl('Name', 'referer');
+    const findings = classifyResource(webAclResource(declared), live, emptySchema);
+    // A real divergence must still be caught — the fold is equality-gated by the lowercased value.
+    const t = tiers(findings);
+    expect(t.declared.length + t.undeclared.length).toBeGreaterThan(0);
+  });
+
+  it('SingleHeader nested inside an AndStatement folds (recursion)', () => {
+    const declared = webAcl('name', 'User-Agent', 'and');
+    const live = webAcl('Name', 'user-agent', 'and');
+    const t = tiers(classifyResource(webAclResource(declared), live, emptySchema));
+    expect(t.declared).toEqual([]);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('SingleHeader nested inside an OrStatement folds (recursion)', () => {
+    const declared = webAcl('name', 'X-Custom', 'or');
+    const live = webAcl('Name', 'x-custom', 'or');
+    const t = tiers(classifyResource(webAclResource(declared), live, emptySchema));
+    expect(t.declared).toEqual([]);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('AWS::WAFv2::RuleGroup routes through the same SingleHeader canonicalization', () => {
+    // A RuleGroup carries the identical Rules/Statement shape and the same case divergence;
+    // the pipeline gate now folds it too (issue fix-shape explicitly lists RuleGroup).
+    const declared = webAcl('name', 'User-Agent');
+    const live = webAcl('Name', 'user-agent');
+    const ruleGroupResource: DesiredResource = {
+      logicalId: 'Rg',
+      resourceType: 'AWS::WAFv2::RuleGroup',
+      physicalId: 'rg-phys',
+      declared,
+    };
+    const t = tiers(classifyResource(ruleGroupResource, live, emptySchema));
+    expect(t.declared).toEqual([]);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('SingleQueryArgument selector is canonicalized the same way', () => {
+    const declared = { FieldToMatch: { SingleQueryArgument: { name: 'MyArg' } } };
+    const live = { FieldToMatch: { SingleQueryArgument: { Name: 'myarg' } } };
+    expect(normalizeWafByteMatchDeep(declared)).toEqual(normalizeWafByteMatchDeep(live));
+  });
+
+  it('normalizeWafByteMatchDeep folds { name } and { Name } to one { Name: lowercased } form', () => {
+    const declared = { FieldToMatch: { SingleHeader: { name: 'User-Agent' } } };
+    const live = { FieldToMatch: { SingleHeader: { Name: 'user-agent' } } };
+    const canonical = { FieldToMatch: { SingleHeader: { Name: 'user-agent' } } };
+    expect(normalizeWafByteMatchDeep(declared)).toEqual(canonical);
+    expect(normalizeWafByteMatchDeep(live)).toEqual(canonical);
+  });
+
+  it('genuine header-name difference is NOT folded by the deep normalizer', () => {
+    const a = { SingleHeader: { name: 'User-Agent' } };
+    const b = { SingleHeader: { Name: 'referer' } };
+    expect(normalizeWafByteMatchDeep(a)).not.toEqual(normalizeWafByteMatchDeep(b));
+  });
+
+  it('a non-string / extra-key SingleHeader shape is preserved (no silent drop)', () => {
+    const weird = { SingleHeader: { Name: 123, Extra: 'keep' } };
+    expect(normalizeWafByteMatchDeep(weird)).toEqual({
+      SingleHeader: { Name: 123, Extra: 'keep' },
+    });
+  });
+});


### PR DESCRIPTION
Closes #876

LIVE-CONFIRMED double false positive on a clean WAFv2 WebACL header-matching rule: `FieldToMatch.SingleHeader` diverges in BOTH the property KEY case (template lowercase `name` — the documented CDK/CFn form — vs live PascalCase `Name`) and the header-name VALUE case (WAF lowercases `User-Agent` → `user-agent`), producing a false `[CFn-Declared Drift]` plus a duplicate `[Potential Drift]`.

Fix: `normalizeWafByteMatchDeep` now also canonicalizes the `SingleHeader`/`SingleQueryArgument` selector on BOTH compare sides (`{ name|Name } → { Name: <lowercased> }`, via new pure helper `canonicalizeWafFieldNameSelector`), scoped to exactly that selector key — recursing through And/Or/Not composites. Equality-gated by the lowercased value, so a genuine header-name change still surfaces. The revert HARD-FAIL noted in the issue becomes moot: the finding was a normalization FP and simply disappears. Also extended the pipeline gate to route `AWS::WAFv2::RuleGroup` (same Rules/Statement shape) through the normalizer, per the issue's fix shape.

9 unit tests (WebACL key+value fold, genuine-change still surfaces, And/Or recursion, SingleQueryArgument, non-string/extra-key preserved, RuleGroup routing). Live evidence: the issue's harvested clean-deploy repro (stack CdkrdHuntUCase, us-east-1).