### PR TITLE
fix(read): surface a counted readGap for scalar exempted props on supplement-read failure (#849)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -461,12 +461,28 @@ function compositeWith(
 // A supplement read failed, so its props (exempted from the writeOnly/readGap strip by
 // OVERRIDE_READABLE_WRITEONLY on the assumption the supplement provides the live value)
 // would false-flag as declared drift against an absent live value (#752). Restore the
-// readGap for the props the user DECLARED — mirror the declared value into the live model
-// so declared == live folds to no drift (the readGap outcome) — and warn on stderr naming
-// the failed supplement call, so a permission gap degrades LOUDLY to coverage-incomplete
-// instead of silently to false declared drift. Only exempted TOP-LEVEL props that are (a)
-// declared and (b) NOT already present in the live model are mirrored (an undeclared prop
-// has nothing to compare, and a prop the CC read already echoed is genuinely readable).
+// readGap for the props the user DECLARED, and warn on stderr naming the failed supplement
+// call, so a permission gap degrades LOUDLY to coverage-incomplete instead of silently to
+// false declared drift.
+//
+// HOW the readGap is restored depends on the DECLARED value shape (#849), because classify's
+// "declared key absent from live" branch (diff/classify.ts) treats the two shapes oppositely:
+//   - a SCALAR (or an empty collection) absent from live → classify emits a genuine
+//     `readGap`-tier finding on its own. So we LEAVE the scalar ABSENT: the readGap now
+//     surfaces in the report's `info:` read-gap count (footer) AND blocks snapshot-
+//     completeness (#795) for the failed-supplement resource — closing the gap between the
+//     stderr-only warning and the reported coverage. Since the value is absent, there is no
+//     declared==live compare, so no false declared drift either.
+//   - a NON-EMPTY COLLECTION absent from live → classify treats it as a real removal and
+//     emits a `declared`-tier finding (the #752 false positive). classify's collection
+//     read-gap denylist (READGAP_COLLECTION_PATHS) is not aware of the supplement-failure
+//     context, so leaving a collection absent would REGRESS #752. For collections we keep the
+//     original declared→live MIRROR (declared == live → folds to no drift). Surfacing a
+//     counted readGap for the collection-shaped exempted props too would require plumbing a
+//     supplement-failure signal into classify.ts — deferred (out of this router-only scope).
+// Only exempted TOP-LEVEL props that are (a) declared and (b) NOT already present in the live
+// model are handled (an undeclared prop has nothing to compare/surface; a prop the CC read
+// already echoed is genuinely readable).
 function restoreSupplementReadGaps(
   resourceType: string,
   declared: Record<string, unknown>,
@@ -477,13 +493,20 @@ function restoreSupplementReadGaps(
   const restored: string[] = [];
   for (const path of exempt ?? []) {
     if (path in declared && !(path in live)) {
-      live[path] = declared[path];
+      const value = declared[path];
+      // A NON-EMPTY collection would false-flag as a `declared`-tier removal in classify
+      // (#752) — mirror it so declared == live folds to no drift. A SCALAR / empty
+      // collection is left ABSENT so classify emits a genuine, COUNTED readGap for it (#849).
+      const isNonEmptyCollection =
+        (Array.isArray(value) && value.length > 0) ||
+        (value !== null && typeof value === 'object' && Object.keys(value as object).length > 0);
+      if (isNonEmptyCollection) live[path] = value;
       restored.push(path);
     }
   }
   const call = (error as Error)?.name || 'unknown error';
   const gap = restored.length
-    ? ` — treating ${restored.join(', ')} as an unverifiable read-gap (declared value assumed unchanged; grant the missing read permission to detect out-of-band drift on it)`
+    ? ` — treating ${restored.join(', ')} as an unverifiable read-gap (grant the missing read permission to detect out-of-band drift on it)`
     : '';
   process.stderr.write(
     `[cdkrd] warning: supplement read for ${resourceType} failed (${call})${gap}\n`

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1487,11 +1487,18 @@ describe('readLive (SDK supplement path — ECS Service ServiceConnectConfigurat
   });
 });
 
-describe('readLive (supplement failure re-folds exempted props to a readGap, #752)', () => {
+describe('readLive (supplement failure re-folds exempted props to a readGap, #752/#849)', () => {
   // When a supplement read fails (missing narrow IAM permission / throttle), a DECLARED
   // exempted prop (OVERRIDE_READABLE_WRITEONLY) must NOT false-flag as declared drift
-  // against an absent live value — it must degrade to a readGap (declared value mirrored
-  // into live so it folds to no drift) plus a LOUD stderr warning naming the failed call.
+  // against an absent live value — it must degrade to a readGap plus a LOUD stderr warning
+  // naming the failed call.
+  //
+  // #849 refines HOW the readGap is restored, by the declared value shape:
+  //   - a SCALAR is left ABSENT from live so classify emits a genuine, COUNTED `readGap`
+  //     finding (surfaced in the report's read-gap footer; blocks #795 completeness).
+  //   - a NON-EMPTY COLLECTION is still MIRRORED (declared==live folds to no drift), because
+  //     classify would otherwise treat an absent declared collection as a `declared`-tier
+  //     removal — the #752 false positive.
   let warnings: string[] = [];
   beforeEach(() => {
     warnings = [];
@@ -1505,10 +1512,15 @@ describe('readLive (supplement failure re-folds exempted props to a readGap, #75
   const ecUser = (declared: Record<string, unknown>): DesiredResource =>
     res({ resourceType: 'AWS::ElastiCache::User', physicalId: 'reader', declared });
 
-  it('mirrors the DECLARED exempted prop into live (declared==live -> no drift, a readGap)', async () => {
+  const svc = (declared: Record<string, unknown>): DesiredResource =>
+    res({ resourceType: 'AWS::ECS::Service', physicalId: 'arn:svc', declared });
+
+  it('leaves a DECLARED SCALAR exempted prop ABSENT from live so classify emits a counted readGap (#849)', async () => {
     // CC never echoes AccessString (writeOnly); the user DECLARED it. When
-    // elasticache:DescribeUsers is denied, without the fix AccessString stays absent from
-    // live and false-flags declared drift; with the fix it is mirrored from declared.
+    // elasticache:DescribeUsers is denied, the SCALAR AccessString is left ABSENT so
+    // classify's "declared key absent from live" branch emits a genuine readGap for it
+    // (counted in the report footer + blocks snapshot-completeness), NOT a mirror that
+    // hides it. It is a scalar, so it can never false-flag as a `declared` removal.
     cc.on(GetResourceCommand).resolves({
       ResourceDescription: {
         Properties: '{"UserId":"reader","UserName":"reader","Engine":"redis","Status":"active"}',
@@ -1526,10 +1538,52 @@ describe('readLive (supplement failure re-folds exempted props to a readGap, #75
       'us-east-1',
       '1'
     );
-    // The declared AccessString is mirrored onto live so declared == live -> readGap, NOT
-    // a `desired="…" actual=undefined` declared-tier drift.
-    expect(r.live?.AccessString).toBe('on ~app:* -@all +@read');
+    // The scalar is NOT mirrored — it stays absent so classify surfaces the readGap.
+    expect('AccessString' in (r.live ?? {})).toBe(false);
     expect(r.skippedReason).toBeUndefined();
+  });
+
+  it('still MIRRORS a DECLARED NON-EMPTY COLLECTION exempted prop (no false declared removal, #752)', async () => {
+    // ServiceConnectConfiguration is a writeOnly OBJECT the supplement reconstructs. When the
+    // supplement (ecs:DescribeServices) fails, an absent declared collection would false-flag
+    // as a `declared`-tier removal in classify (#752), so it is mirrored declared->live to
+    // fold to no drift — a readGap outcome preserved for the collection shape.
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: { Properties: '{"ServiceName":"svc","Cluster":"c"}' },
+    });
+    ecs.on(DescribeServicesCommand).rejects(named('AccessDeniedException'));
+    const config = { Enabled: true, Namespace: 'ns' };
+    const r = await readLive(
+      cc as unknown as CloudControlClient,
+      svc({ ServiceName: 'svc', Cluster: 'c', ServiceConnectConfiguration: config }),
+      'us-east-1',
+      '1'
+    );
+    // The non-empty collection IS mirrored so declared == live -> no false declared removal.
+    expect(r.live?.ServiceConnectConfiguration).toEqual(config);
+    expect(r.skippedReason).toBeUndefined();
+    // Confirm the supplement-FAILURE path was actually taken (loud warning names the prop).
+    expect(warnings.join('')).toContain('ServiceConnectConfiguration');
+  });
+
+  it('leaves an EMPTY-collection declared exempted prop ABSENT (declared {}/[] vs absent is not drift, #849)', async () => {
+    // An empty declared collection is not a real removal (classify exempts it), and it is
+    // never real drift — so it is left absent (classify then treats it as a readGap), not
+    // mirrored. Mirroring an empty collection would add a meaningless live={} entry.
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: { Properties: '{"ServiceName":"svc","Cluster":"c"}' },
+    });
+    ecs.on(DescribeServicesCommand).rejects(named('ThrottlingException'));
+    const r = await readLive(
+      cc as unknown as CloudControlClient,
+      svc({ ServiceName: 'svc', Cluster: 'c', ServiceConnectConfiguration: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect('ServiceConnectConfiguration' in (r.live ?? {})).toBe(false);
+    expect(r.skippedReason).toBeUndefined();
+    // Confirm the supplement-FAILURE path was actually taken.
+    expect(warnings.join('')).toContain('ServiceConnectConfiguration');
   });
 
   it('emits a LOUD stderr warning naming the failed supplement call and the read-gap prop', async () => {


### PR DESCRIPTION
Addresses #849 (scalar half; collection + gap #2 deferred — see below).

#752 made the supplement-read-failure path mirror each declared exempted prop into the live model (declared==live → no false drift) + a stderr warning, but the unread prop never surfaced as a true `readGap`-tier finding (no `info:` footer line, doesn't block #795 completeness).

Root cause: the `readGap` tier is assigned in classify.ts (a declared key ABSENT from live → `readGap` for scalars/empty collections, or a false `declared` for non-empty collections). router.ts has no channel to emit a Finding, but it controls presence/absence in the live model.

Fix (router.ts-only, in `restoreSupplementReadGaps`): **stop mirroring scalars, keep mirroring non-empty collections.**
- Scalar exempted props (Description, AllowedPattern, Tier, ServerProperties, AccessString, PreferredMaintenanceWindow, NotificationTopicArn, EngineVersion) are left ABSENT → classify emits a genuine, counted `readGap` (footer + #795). Verified none are in `SCALAR_RETURNED_WHEN_SET`, so this never produces a false `declared`.
- Non-empty collection exempted props stay mirrored → #752's false-`declared` suppression preserved (zero regression).

Tests (`tests/router.test.ts`, #752/#849 block): scalar left absent → counted readGap; non-empty collection still mirrored (no false removal); empty collection left absent.

**Deferred (needs classify.ts/gather.ts — out of this router-only lane, and classify.ts is owned by PR #1156):**
1. Counted readGap for COLLECTION-shaped exempted props on supplement failure (needs a per-prop supplement-failure signal plumbed into classify).
2. Gap #2 — an UNDECLARED exempted prop's unread-ness (no declared value to compare/mirror; requires synthesizing a finding in classify/gather).
I'll file/track these as the classify.ts follow-up.