### PR TITLE
fix(revert): poll ProgressEvent to completion in writeCloudControlIndexNested (#1065)

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -46,6 +46,8 @@ import {
 import {
   CloudControlClient,
   GetResourceCommand,
+  GetResourceRequestStatusCommand,
+  type ProgressEvent,
   UpdateResourceCommand,
 } from '@aws-sdk/client-cloudcontrol';
 import {
@@ -214,6 +216,7 @@ import {
 } from '../read/overrides.js';
 import { applyOps } from './apply-ops.js';
 import type { PatchOp } from './plan.js';
+import { classifyTransient, errorText } from './transient.js';
 
 export type SdkWriter = (ctx: OverrideCtx, ops: PatchOp[]) => Promise<void>;
 
@@ -2709,6 +2712,83 @@ function reindexNestedPointer(
   return `/${out.join('/')}`;
 }
 
+// Poll a Cloud Control UpdateResource ProgressEvent to a terminal state. Cloud Control
+// ACCEPTS the request synchronously and runs the resource-handler asynchronously — the
+// initial ProgressEvent is IN_PROGRESS, so returning here would print a false `reverted:`
+// while the operation may still FAIL (async validation / downstream throttle / handler
+// AccessDenied). The FAILED event's StatusMessage is the ONLY place the reason exists
+// (#1065). Mirror the generic CC path's pollToCompletion (src/revert/apply.ts): poll via
+// GetResourceRequestStatus on the RequestToken until SUCCESS / FAILED / CANCEL_COMPLETE,
+// throwing on FAILED with the StatusMessage so the stack-actions.ts writer wrapper
+// classifies/retries it exactly like every other writer failure. That private helper lives
+// in apply.ts (not importable without touching a peer-owned file), so the poll is inlined
+// here reusing the shared transient classifier (classifyTransient) to avoid re-sending the
+// mutation on a transient POLL-read failure (#1064).
+const NESTED_POLL_INTERVAL_MS = 2000;
+// Generous ceiling — a Secrets Manager replica change takes tens of seconds, a Backup plan
+// version a few. pollToCompletion returns as soon as the op is terminal, so a high ceiling
+// never slows the common case; it only bounds a never-terminating op.
+const NESTED_POLL_TIMEOUT_MS = 15 * 60 * 1000;
+// Bound consecutive TRANSIENT poll-read failures so a persistent poll outage still
+// terminates. Each throw here follows the SDK's own internal retries.
+const NESTED_MAX_POLL_READ_FAILURES = 10;
+
+const nestedSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Injectable clock/sleep so tests exercise the poll loop without real 2s waits.
+export interface NestedPollOptions {
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+// Poll to a terminal ProgressEvent; throw on FAILED / CANCEL_COMPLETE / timeout carrying the
+// StatusMessage (or the reason). Resolves on SUCCESS. Exported for unit tests.
+export async function pollNestedToCompletion(
+  cc: CloudControlClient,
+  first: ProgressEvent | undefined,
+  poll: NestedPollOptions = {}
+): Promise<void> {
+  const doSleep = poll.sleep ?? nestedSleep;
+  const clock = poll.now ?? Date.now;
+  let event = first;
+  const token = event?.RequestToken;
+  if (!token) throw new Error('Cloud Control UpdateResource returned no request token');
+  const deadline = clock() + NESTED_POLL_TIMEOUT_MS;
+  let pollFailures = 0;
+  while (clock() < deadline) {
+    const status = event?.OperationStatus;
+    if (status === 'SUCCESS') return;
+    if (status === 'FAILED' || status === 'CANCEL_COMPLETE') {
+      // StatusMessage carries the service code (e.g. RSLVR-00705); ErrorCode is a coarser
+      // CC enum, appended when present. This is the ONLY place the async-failure reason lives.
+      const msg = event?.StatusMessage ?? status;
+      const code = event?.ErrorCode;
+      throw new Error(code && !msg.includes(code) ? `${code}: ${msg}` : msg);
+    }
+    await doSleep(NESTED_POLL_INTERVAL_MS);
+    try {
+      const polled = await cc.send(new GetResourceRequestStatusCommand({ RequestToken: token }));
+      event = polled.ProgressEvent;
+      pollFailures = 0;
+    } catch (e) {
+      // A poll-READ error, NOT an operation failure — the mutation is still in flight. A
+      // terminal poll error (e.g. an invalid/expired RequestToken) cannot be resolved by
+      // re-reading, so surface it. Keep polling the SAME token only for transient poll errors.
+      const text = errorText(e);
+      if (!classifyTransient(text).transient) throw new Error(text);
+      if (++pollFailures >= NESTED_MAX_POLL_READ_FAILURES) {
+        // Persistent poll outage: do NOT let this bubble as a mutation failure that would be
+        // re-sent — report a terminal failure whose wording omits the transient keyword.
+        throw new Error(
+          `unable to confirm Cloud Control request status after ${NESTED_MAX_POLL_READ_FAILURES} poll attempts`
+        );
+      }
+      // else: re-poll the same request token (event unchanged → still non-terminal).
+    }
+  }
+  throw new Error('timed out waiting for Cloud Control request');
+}
+
 // Revert an array-element nested value (e.g. Backup BackupPlanRule[<RuleName>].window,
 // Route53Resolver FirewallRules[<Priority>].setting) via Cloud Control: GetResource for the
 // live model, re-point each op's identity-bracket to the live-array index (reindexNestedPointer),
@@ -2728,13 +2808,17 @@ const writeCloudControlIndexNested: SdkWriter = async (ctx, ops) => {
     const path = reindexNestedPointer(op.path, live, type);
     return op.op === 'remove' ? { op: op.op, path } : { op: op.op, path, value: op.value };
   });
-  await cc.send(
+  const res = await cc.send(
     new UpdateResourceCommand({
       TypeName: type,
       Identifier: identifier,
       PatchDocument: JSON.stringify(patch),
     })
   );
+  // Cloud Control ACCEPTED the request but the handler runs ASYNCHRONOUSLY — poll the
+  // ProgressEvent to a terminal state before returning, so a later async FAILURE surfaces
+  // as a genuine writer error (carrying the StatusMessage) instead of a false `reverted:`.
+  await pollNestedToCompletion(cc, res.ProgressEvent);
 };
 
 // SDK writers for NESTED finding paths (a sub-key inside a declared object — dotted or

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -126,6 +126,7 @@ import {
 import {
   CloudControlClient,
   GetResourceCommand,
+  GetResourceRequestStatusCommand,
   UpdateResourceCommand,
 } from '@aws-sdk/client-cloudcontrol';
 import { KafkaClient, UpdateConfigurationCommand } from '@aws-sdk/client-kafka';
@@ -184,7 +185,12 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import type { OverrideCtx } from '../src/read/overrides.js';
 import type { PatchOp } from '../src/revert/plan.js';
-import { resolveSdkWriter, SDK_NESTED_WRITERS, SDK_WRITERS } from '../src/revert/writers.js';
+import {
+  pollNestedToCompletion,
+  resolveSdkWriter,
+  SDK_NESTED_WRITERS,
+  SDK_WRITERS,
+} from '../src/revert/writers.js';
 
 const iam = mockClient(IAMClient);
 const elb = mockClient(ElasticLoadBalancingV2Client);
@@ -2871,7 +2877,9 @@ describe('Cloud Control index-revert writer (array-element nested values)', () =
         }),
       },
     });
-    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    cloudcontrol
+      .on(UpdateResourceCommand)
+      .resolves({ ProgressEvent: { RequestToken: 'tok', OperationStatus: 'SUCCESS' } });
     const ops: PatchOp[] = [
       {
         op: 'add',
@@ -2905,7 +2913,9 @@ describe('Cloud Control index-revert writer (array-element nested values)', () =
         }),
       },
     });
-    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    cloudcontrol
+      .on(UpdateResourceCommand)
+      .resolves({ ProgressEvent: { RequestToken: 'tok', OperationStatus: 'SUCCESS' } });
     const ops: PatchOp[] = [
       {
         op: 'add',
@@ -2938,7 +2948,9 @@ describe('Cloud Control index-revert writer (array-element nested values)', () =
         }),
       },
     });
-    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    cloudcontrol
+      .on(UpdateResourceCommand)
+      .resolves({ ProgressEvent: { RequestToken: 'tok', OperationStatus: 'SUCCESS' } });
     const ops: PatchOp[] = [
       {
         op: 'add',
@@ -2970,7 +2982,9 @@ describe('Cloud Control index-revert writer (array-element nested values)', () =
         }),
       },
     });
-    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    cloudcontrol
+      .on(UpdateResourceCommand)
+      .resolves({ ProgressEvent: { RequestToken: 'tok', OperationStatus: 'SUCCESS' } });
     const ops: PatchOp[] = [
       { op: 'add', path: '/MethodSettings[*]/CacheTtlInSeconds', value: 300, human: 'x' },
     ];
@@ -3009,6 +3023,152 @@ describe('Cloud Control index-revert writer (array-element nested values)', () =
         ops
       )
     ).rejects.toThrow(/cannot locate/);
+  });
+
+  // #1065 — the writer must POLL the returned ProgressEvent to a terminal state before
+  // returning success; an async handler FAILURE after CC accepts the request must surface
+  // (carrying its StatusMessage) instead of a false `reverted:`.
+  const okOps: PatchOp[] = [
+    {
+      op: 'add',
+      path: '/BackupPlan/BackupPlanRule[Daily]/CompletionWindowMinutes',
+      value: 10080,
+      human: 'x',
+    },
+  ];
+  const mockGetResource = (): void => {
+    cloudcontrol.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Properties: JSON.stringify({
+          BackupPlan: { BackupPlanRule: [{ RuleName: 'Daily', CompletionWindowMinutes: 5000 }] },
+        }),
+      },
+    });
+  };
+
+  it('surfaces an async FAILED ProgressEvent (with its StatusMessage) instead of a false success', async () => {
+    mockGetResource();
+    // CC accepts the UpdateResource, but the async handler FAILS — the reason lives only on
+    // the FAILED event's StatusMessage. The writer must throw it, not resolve.
+    cloudcontrol.on(UpdateResourceCommand).resolves({
+      ProgressEvent: {
+        RequestToken: 'tok-1',
+        OperationStatus: 'FAILED',
+        ErrorCode: 'GeneralServiceException',
+        StatusMessage: 'Backup plan version limit exceeded',
+      },
+    });
+    await expect(
+      resolveSdkWriter('AWS::Backup::BackupPlan', okOps)!(
+        ctx('AWS::Backup::BackupPlan', 'plan|abc'),
+        okOps
+      )
+    ).rejects.toThrow(/Backup plan version limit exceeded/);
+    // No poll needed — the accept event was already terminal.
+    expect(cloudcontrol.commandCalls(GetResourceRequestStatusCommand)).toHaveLength(0);
+  });
+
+  it('resolves normally when the ProgressEvent reaches SUCCESS', async () => {
+    mockGetResource();
+    cloudcontrol
+      .on(UpdateResourceCommand)
+      .resolves({ ProgressEvent: { RequestToken: 'tok-2', OperationStatus: 'SUCCESS' } });
+    await expect(
+      resolveSdkWriter('AWS::Backup::BackupPlan', okOps)!(
+        ctx('AWS::Backup::BackupPlan', 'plan|abc'),
+        okOps
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws "no request token" when CC accepts without a RequestToken (cannot confirm)', async () => {
+    mockGetResource();
+    // A malformed accept with no token — the operation cannot be polled, so success is
+    // unconfirmable: throw rather than claim a false `reverted:`.
+    cloudcontrol
+      .on(UpdateResourceCommand)
+      .resolves({ ProgressEvent: { OperationStatus: 'IN_PROGRESS' } });
+    await expect(
+      resolveSdkWriter('AWS::Backup::BackupPlan', okOps)!(
+        ctx('AWS::Backup::BackupPlan', 'plan|abc'),
+        okOps
+      )
+    ).rejects.toThrow(/no request token/);
+  });
+});
+
+// #1065 — the poll loop itself: an IN_PROGRESS accept is followed by GetResourceRequestStatus
+// reads until a terminal state. Exercised directly with an injected sleep/clock so the 2s
+// poll interval never waits real time.
+describe('pollNestedToCompletion (Cloud Control ProgressEvent poll, #1065)', () => {
+  const noSleep = async (): Promise<void> => {};
+
+  it('polls IN_PROGRESS -> FAILED and throws with the StatusMessage', async () => {
+    cloudcontrol.on(GetResourceRequestStatusCommand).resolvesOnce({
+      ProgressEvent: {
+        RequestToken: 'tok',
+        OperationStatus: 'FAILED',
+        StatusMessage: 'AccessDenied invoking backup:UpdateBackupPlan',
+      },
+    });
+    await expect(
+      pollNestedToCompletion(
+        cloudcontrol as unknown as CloudControlClient,
+        { RequestToken: 'tok', OperationStatus: 'IN_PROGRESS' },
+        { sleep: noSleep }
+      )
+    ).rejects.toThrow(/AccessDenied invoking backup:UpdateBackupPlan/);
+    expect(cloudcontrol.commandCalls(GetResourceRequestStatusCommand)).toHaveLength(1);
+  });
+
+  it('polls IN_PROGRESS -> SUCCESS and resolves', async () => {
+    cloudcontrol
+      .on(GetResourceRequestStatusCommand)
+      .resolvesOnce({ ProgressEvent: { RequestToken: 'tok', OperationStatus: 'SUCCESS' } });
+    await expect(
+      pollNestedToCompletion(
+        cloudcontrol as unknown as CloudControlClient,
+        { RequestToken: 'tok', OperationStatus: 'IN_PROGRESS' },
+        { sleep: noSleep }
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it('re-polls the SAME token on a TRANSIENT poll-read failure (does NOT re-send the mutation)', async () => {
+    cloudcontrol
+      .on(GetResourceRequestStatusCommand)
+      .rejectsOnce(Object.assign(new Error('Rate exceeded'), { name: 'ThrottlingException' }))
+      .resolves({ ProgressEvent: { RequestToken: 'tok', OperationStatus: 'SUCCESS' } });
+    await expect(
+      pollNestedToCompletion(
+        cloudcontrol as unknown as CloudControlClient,
+        { RequestToken: 'tok', OperationStatus: 'IN_PROGRESS' },
+        { sleep: noSleep }
+      )
+    ).resolves.toBeUndefined();
+    // Two reads: the throttled one, then the SUCCESS. UpdateResource is NEVER re-sent here.
+    expect(cloudcontrol.commandCalls(GetResourceRequestStatusCommand)).toHaveLength(2);
+    expect(cloudcontrol.commandCalls(UpdateResourceCommand)).toHaveLength(0);
+  });
+
+  it('times out (throws) if the operation never reaches a terminal state', async () => {
+    cloudcontrol
+      .on(GetResourceRequestStatusCommand)
+      .resolves({ ProgressEvent: { RequestToken: 'tok', OperationStatus: 'IN_PROGRESS' } });
+    // Injected clock jumps past the 15-min deadline after the first poll wait.
+    let t = 0;
+    const now = (): number => {
+      const v = t;
+      t += 16 * 60 * 1000;
+      return v;
+    };
+    await expect(
+      pollNestedToCompletion(
+        cloudcontrol as unknown as CloudControlClient,
+        { RequestToken: 'tok', OperationStatus: 'IN_PROGRESS' },
+        { sleep: noSleep, now }
+      )
+    ).rejects.toThrow(/timed out/);
   });
 });
 


### PR DESCRIPTION
Closes #1065

For the four `SDK_NESTED_WRITERS` types routed to `writeCloudControlIndexNested` (ApiGateway Stage MethodSettings, Backup BackupPlan, Route53Resolver FirewallRuleGroup, SecretsManager Secret ReplicaRegions), the writer printed `reverted: <id>` the moment Cloud Control ACCEPTED the request — it never polled the returned ProgressEvent. So an async handler failure after accept (validation, throttle, handler AccessDenied) was invisible (false `reverted:`, StatusMessage lost) and the convergence re-read raced the in-flight op.

Fix (writers.ts-only): capture the `UpdateResource` response and await a new exported `pollNestedToCompletion` before returning — it mirrors apply.ts's generic-CC poll (SUCCESS/FAILED/CANCEL_COMPLETE terminal states, 2s interval, 15-min ceiling) and on FAILED throws an Error carrying StatusMessage+ErrorCode, so the stack-actions writer wrapper reports a genuine failure. It reuses the shared `classifyTransient`/`errorText` (src/revert/transient.ts) so a transient poll-READ failure re-polls the SAME RequestToken (never re-sends the mutation — the #1064 hazard). apply.ts's `pollToCompletion` is private, so the loop is re-implemented rather than exported across files.

Because the writer now blocks until terminal, the value has converged in AWS by the time the apply loop returns — so the issue's second symptom (spurious non-convergence on slow ops) is largely dissolved for the common case; the residual retry-window timing-tuning in stack-actions.ts is peer-owned and untouched.

Tests (`tests/writers.test.ts`): FAILED surfaces StatusMessage, SUCCESS resolves, IN_PROGRESS→terminal, transient poll-failure re-polls same token (no mutation resend), timeout (injected clock), no-request-token throws.

Live deploy deferred: strictly safer than status quo (turns a silent false `reverted:` into a real poll + surfaced failure); comprehensively unit-tested incl. FAILED/timeout/transient paths.