### PR TITLE
fix(revert): dependency-violation deletes fail fast to the pass loop, not the retry budget (#969)

### DIFF
--- a/src/revert/apply.ts
+++ b/src/revert/apply.ts
@@ -51,6 +51,32 @@ export function isAlreadyGone(e: unknown): boolean {
   return m.includes('not found') || m.includes('does not exist') || m.includes('notfound');
 }
 
+// A delete failure whose blocker is ANOTHER resource still present — the resource can
+// only be deleted after its dependent sibling is gone (#765/#969). In a delete BATCH the
+// blocker is almost always INTERNAL to the plan (a sibling `added`-delete queued later),
+// so time alone never fixes it — only the next `applyRevertDeletes` pass, once the sibling
+// is deleted, does. Such an error MUST NOT burn the per-item transient retry budget: the
+// generic transient patterns (`ConflictException`, `resource is in use`, …) classify it
+// TRANSIENT, so an in-item `retryTransient` would spin its full backoff / `--wait` deadline
+// against a blocker the pass loop is designed to clear for free (the exact #969 blowup —
+// a wrong-ordered Route→Integration pair burning a guaranteed-futile 10-minute `--wait`).
+// Deferring it to the pass loop is a NO-COST fail-fast; a genuine throttle (below) still
+// gets its in-item retry. Matches the DependencyViolation code (EC2/ELB/etc.) plus the
+// cross-service "still referenced / still in use / cannot delete because …" phrasings and
+// ApiGatewayV2's ConflictException "referenced by" form for the #765 child-delete pairs.
+export function isDependencyViolation(error: string | undefined): boolean {
+  if (!error) return false;
+  return /DependencyViolation|dependent object|still (in use|referenced|being used|depends on|contains|has (a |an |dependent |associated ))|cannot (be )?delete[d]?[^.]*because[^.]*(referenced|in use|dependent|attached|associated|member|child)|is (still )?(referenced|attached|associated|in use)/i.test(
+    error
+  );
+}
+
+// Internal sentinel: a dependency-violation delete swaps its (transient-CLASSIFIED) error
+// for this string so retryTransient sees a TERMINAL failure and returns immediately without
+// retrying/sleeping. Deliberately worded to match NONE of transient.ts's TRANSIENT_PATTERNS.
+// Never surfaced to the user — the real error is restored before applyRevertDelete returns.
+const DEP_VIOLATION_TERMINAL = 'dependency-violation deferred to delete-batch pass loop';
+
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 // Poll a Cloud Control ProgressEvent (Update or Delete) to a terminal state. `sleep`/`now`
@@ -204,9 +230,9 @@ export async function applyRevertDelete(
   identifier: string = item.physicalId,
   retry: RetryOptions = {}
 ): Promise<ApplyResult> {
-  // Same transient-retry wrapper as the update path: a DeleteResource can also hit a
-  // "resource is currently updating / in use" window and settle on a retry.
-  return retryTransient(async () => {
+  // ONE DeleteResource send + poll. Self-contained (catches its own throws) so it can be
+  // re-invoked verbatim by the transient retry — same contract retryTransient requires.
+  const oneDelete = async (): Promise<ApplyResult> => {
     try {
       const res = await cc.send(
         new DeleteResourceCommand({ TypeName: item.resourceType, Identifier: identifier })
@@ -220,5 +246,36 @@ export async function applyRevertDelete(
       if (isAlreadyGone(err)) return { ok: true };
       return { ok: false, error: errorText(e) };
     }
-  }, retry);
+  };
+
+  // A DEPENDENCY-VIOLATION failure (#969) must NOT burn the in-item transient-retry budget.
+  // In a delete BATCH the blocker is a sibling delete queued later in the SAME pass, so time
+  // (and the `--wait` deadline) can never free it — only the next applyRevertDeletes pass,
+  // after that sibling is deleted, does. It must fail FAST back to the pass loop (the pass IS
+  // the retry) rather than spin its private backoff / `--wait` deadline on a guaranteed-futile
+  // wait (the #969 blowup: a wrong-ordered Route→Integration pair burning a full 10-minute
+  // `--wait` before the Route even runs). The generic transient patterns classify a
+  // dependency error TRANSIENT (`ConflictException`, `resource is in use`, …), so we can't let
+  // retryTransient see the raw text. Wrap the op: on a dependency violation, stash the real
+  // error and hand retryTransient a TERMINAL-classified sentinel so it returns immediately
+  // (no retry, no sleep); a genuine transient (throttle / mid-update) still flows through with
+  // the full backoff / `--wait` semantics unchanged. This keeps retryTransient the single
+  // driver of backoff/deadline/onRetry — no duplicated retry math, no double send.
+  let deferredDepError: string | undefined;
+  const guardedDelete = async (): Promise<ApplyResult> => {
+    const r = await oneDelete();
+    if (!r.ok && isDependencyViolation(r.error)) {
+      deferredDepError = r.error;
+      return { ok: false, error: DEP_VIOLATION_TERMINAL };
+    }
+    return r;
+  };
+  const r = await retryTransient(guardedDelete, retry);
+  // Restore the real dependency-violation text for the caller (the pass loop folds it back).
+  // deferredDepError is always set when the sentinel appears (guardedDelete sets it in the
+  // same call that returns the sentinel); fall back defensively to the sentinel otherwise.
+  if (!r.ok && r.error === DEP_VIOLATION_TERMINAL) {
+    return { ok: false, error: deferredDepError ?? DEP_VIOLATION_TERMINAL };
+  }
+  return r;
 }

--- a/tests/apply-deleteretry-969.test.ts
+++ b/tests/apply-deleteretry-969.test.ts
@@ -1,0 +1,274 @@
+import { CloudControlClient, DeleteResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import {
+  type ApplyResult,
+  applyRevertDelete,
+  applyRevertDeletes,
+  isDependencyViolation,
+} from '../src/revert/apply.js';
+import type { RevertItem } from '../src/revert/plan.js';
+
+// #969: a delete-batch item whose failure is DEPENDENCY-VIOLATION shaped must fail FAST to
+// the applyRevertDeletes pass loop (the pass IS the retry) instead of burning its private
+// per-item transient retry / `--wait` deadline against a blocker only the next pass frees.
+
+const cc = mockClient(CloudControlClient);
+beforeEach(() => cc.reset());
+
+const deleteItem = (physicalId = 'api123|res456|ANY'): RevertItem => ({
+  logicalId: 'Child',
+  displayId: 'Api ▸ ANY /a',
+  resourceType: 'AWS::ApiGateway::Method',
+  physicalId,
+  kind: 'delete',
+  ops: [],
+});
+
+// A ConflictException "referenced by" (ApiGatewayV2 child pair) — the exact #969 example.
+const CONFLICT_REFERENCED =
+  'ConflictException: Unable to delete Integration integ-x because it is referenced by Route route-y';
+// A DependencyViolation (EC2 SG still referenced by an ENI).
+const DEP_VIOLATION =
+  'DependencyViolation: resource sg-abc has a dependent object and cannot be deleted';
+// A GENUINE transient (throttle) — must still get the in-item retry.
+const THROTTLE = 'ThrottlingException: Rate exceeded';
+
+describe('isDependencyViolation', () => {
+  it('matches DependencyViolation + "referenced by" + "still in use" phrasings', () => {
+    expect(isDependencyViolation(DEP_VIOLATION)).toBe(true);
+    expect(isDependencyViolation(CONFLICT_REFERENCED)).toBe(true);
+    expect(
+      isDependencyViolation('Cannot delete Integration because it is referenced by a Route')
+    ).toBe(true);
+    expect(isDependencyViolation('The security group is still in use')).toBe(true);
+  });
+  it('does NOT match a throttle / terminal / already-gone error', () => {
+    expect(isDependencyViolation(THROTTLE)).toBe(false);
+    expect(isDependencyViolation('AccessDeniedException: not authorized')).toBe(false);
+    expect(isDependencyViolation('Resource was not found')).toBe(false);
+    expect(isDependencyViolation(undefined)).toBe(false);
+  });
+});
+
+describe('applyRevertDelete — dependency violation fails fast, does NOT burn retry budget (#969)', () => {
+  const failedEvent = (msg: string): void => {
+    cc.on(DeleteResourceCommand).resolves({
+      ProgressEvent: { RequestToken: 't1', OperationStatus: 'FAILED', StatusMessage: msg },
+    });
+  };
+
+  it('a ConflictException "referenced by" delete sends DeleteResource EXACTLY ONCE (no retry loop)', async () => {
+    failedEvent(CONFLICT_REFERENCED);
+    let sleeps = 0;
+    const r = await applyRevertDelete(
+      cc as unknown as CloudControlClient,
+      deleteItem(),
+      undefined,
+      {
+        // A full attempt budget — if the dep-violation wrongly entered retryTransient it would
+        // send DeleteResource maxAttempts times and sleep between them.
+        maxAttempts: 5,
+        sleep: () => {
+          sleeps++;
+          return Promise.resolve();
+        },
+      }
+    );
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('referenced by');
+    // The transient wrapper was bypassed: ONE send, ZERO backoff sleeps.
+    expect(cc.commandCalls(DeleteResourceCommand).length).toBe(1);
+    expect(sleeps).toBe(0);
+    // Not annotated as a settled-transient (it did not go through the retry-exhaustion path).
+    expect(r.transient).toBeUndefined();
+  });
+
+  it('a DependencyViolation delete under `--wait` (deadlineMs) does NOT sleep against the deadline', async () => {
+    failedEvent(DEP_VIOLATION);
+    let sleeps = 0;
+    let now = 0;
+    const r = await applyRevertDelete(
+      cc as unknown as CloudControlClient,
+      deleteItem(),
+      undefined,
+      {
+        // `--wait` mode: a 10-minute deadline. Pre-fix, the dep-violation classified transient
+        // and this item would spin its whole 10-min budget against a blocker it can never free.
+        deadlineMs: 600_000,
+        now: () => now,
+        sleep: (ms) => {
+          sleeps++;
+          now += ms;
+          return Promise.resolve();
+        },
+      }
+    );
+    expect(r.ok).toBe(false);
+    expect(cc.commandCalls(DeleteResourceCommand).length).toBe(1);
+    expect(sleeps).toBe(0); // fails fast — the `--wait` deadline is never consumed
+  });
+
+  it('still retries a GENUINE transient (throttle) in-item and settles on a later attempt', async () => {
+    cc.on(DeleteResourceCommand)
+      .resolvesOnce({
+        ProgressEvent: { RequestToken: 't1', OperationStatus: 'FAILED', StatusMessage: THROTTLE },
+      })
+      .resolves({ ProgressEvent: { RequestToken: 't2', OperationStatus: 'SUCCESS' } });
+    let sleeps = 0;
+    const r = await applyRevertDelete(
+      cc as unknown as CloudControlClient,
+      deleteItem(),
+      undefined,
+      {
+        maxAttempts: 3,
+        sleep: () => {
+          sleeps++;
+          return Promise.resolve();
+        },
+      }
+    );
+    expect(r.ok).toBe(true);
+    // Throttle → the in-item retry IS engaged: first attempt + one retry = 2 sends, 1 backoff.
+    expect(cc.commandCalls(DeleteResourceCommand).length).toBe(2);
+    expect(sleeps).toBe(1);
+  });
+
+  it('a persistent throttle exhausts the in-item budget and returns a transient hint', async () => {
+    cc.on(DeleteResourceCommand).resolves({
+      ProgressEvent: { RequestToken: 't1', OperationStatus: 'FAILED', StatusMessage: THROTTLE },
+    });
+    const r = await applyRevertDelete(
+      cc as unknown as CloudControlClient,
+      deleteItem(),
+      undefined,
+      {
+        maxAttempts: 3,
+        sleep: () => Promise.resolve(),
+      }
+    );
+    expect(r.ok).toBe(false);
+    expect(r.transient).toBe(true); // throttle still uses the full retry-then-hint path
+    expect(cc.commandCalls(DeleteResourceCommand).length).toBe(3);
+  });
+
+  it('a terminal (non-transient) delete failure returns on the first attempt, no retry', async () => {
+    failedEvent('Invalid identifier for AWS::ApiGateway::Method');
+    const r = await applyRevertDelete(
+      cc as unknown as CloudControlClient,
+      deleteItem(),
+      undefined,
+      {
+        maxAttempts: 5,
+        sleep: () => Promise.resolve(),
+      }
+    );
+    expect(r.ok).toBe(false);
+    expect(cc.commandCalls(DeleteResourceCommand).length).toBe(1);
+  });
+});
+
+describe('applyRevertDeletes — the PASS LOOP resolves the dependency the fast-fail defers (#969)', () => {
+  // The real composition: two `added` deletes in wrong order [Integration, Route].
+  // Integration fails on a ConflictException "referenced by" (its Route still queued in the
+  // same pass) → fast-fails to the pass loop. The Route deletes. Pass 2 re-runs the
+  // Integration → the blocker is gone → it succeeds. TOTAL Integration attempts = 2 (one per
+  // pass), NOT maxAttempts-per-pass — proving the per-item transient budget never burned.
+  it('a wrong-ordered Integration→Route pair converges via the pass loop, not the in-item retry', async () => {
+    const integration = deleteItem('api|integ-x'); // must be deleted AFTER the Route
+    const route = deleteItem('api|route-y'); // frees the Integration once gone
+
+    let routeDeleted = false;
+    let integrationSends = 0;
+
+    // Model each DeleteResource send: Integration fails while the Route lives, then succeeds.
+    cc.on(DeleteResourceCommand).callsFake((input) => {
+      const id = (input as { Identifier?: string }).Identifier ?? '';
+      if (id === 'api|route-y') {
+        routeDeleted = true;
+        return { ProgressEvent: { RequestToken: 'r', OperationStatus: 'SUCCESS' } };
+      }
+      // Integration.
+      integrationSends++;
+      return routeDeleted
+        ? { ProgressEvent: { RequestToken: 'i', OperationStatus: 'SUCCESS' } }
+        : {
+            ProgressEvent: {
+              RequestToken: 'i',
+              OperationStatus: 'FAILED',
+              StatusMessage: CONFLICT_REFERENCED,
+            },
+          };
+    });
+
+    let sleeps = 0;
+    const client = cc as unknown as CloudControlClient;
+    const outcomes = await applyRevertDeletes(
+      [integration, route],
+      (item): Promise<ApplyResult> =>
+        applyRevertDelete(client, item, item.physicalId, {
+          // A generous in-item budget — if the Integration wrongly spun it, integrationSends
+          // would be > 2 (maxAttempts on pass 1 alone).
+          maxAttempts: 5,
+          sleep: () => {
+            sleeps++;
+            return Promise.resolve();
+          },
+        })
+    );
+
+    // Both deletes converged.
+    expect(outcomes.every((o) => o.result.ok)).toBe(true);
+    // Integration was attempted ONCE per pass (pass 1 fast-fail + pass 2 success) = 2 sends,
+    // NOT the 5-attempt in-item budget. The pass loop owned the retry.
+    expect(integrationSends).toBe(2);
+    // No backoff waiting was spent on the dependency violation.
+    expect(sleeps).toBe(0);
+  });
+
+  it('under `--wait` the batch is NOT starved: a fast-fail leaves the deadline intact for the next pass', async () => {
+    // Pre-fix, the Integration's in-item wait consumed the whole 10-min deadline before the
+    // Route even ran. Now the Integration fails fast (no sleep) → the Route runs immediately →
+    // pass 2 converges. Assert ZERO wall-clock was spent sleeping across the whole batch.
+    const integration = deleteItem('api|integ-x');
+    const route = deleteItem('api|route-y');
+    let routeDeleted = false;
+
+    cc.on(DeleteResourceCommand).callsFake((input) => {
+      const id = (input as { Identifier?: string }).Identifier ?? '';
+      if (id === 'api|route-y') {
+        routeDeleted = true;
+        return { ProgressEvent: { RequestToken: 'r', OperationStatus: 'SUCCESS' } };
+      }
+      return routeDeleted
+        ? { ProgressEvent: { RequestToken: 'i', OperationStatus: 'SUCCESS' } }
+        : {
+            ProgressEvent: {
+              RequestToken: 'i',
+              OperationStatus: 'FAILED',
+              StatusMessage: CONFLICT_REFERENCED,
+            },
+          };
+    });
+
+    let now = 0;
+    let sleeps = 0;
+    const client = cc as unknown as CloudControlClient;
+    const outcomes = await applyRevertDeletes(
+      [integration, route],
+      (item): Promise<ApplyResult> =>
+        applyRevertDelete(client, item, item.physicalId, {
+          deadlineMs: now + 600_000, // a fresh 10-min `--wait` budget (as buildRetryOpts hands it)
+          now: () => now,
+          sleep: (ms) => {
+            sleeps++;
+            now += ms;
+            return Promise.resolve();
+          },
+        })
+    );
+    expect(outcomes.every((o) => o.result.ok)).toBe(true);
+    expect(sleeps).toBe(0);
+    expect(now).toBe(0); // no time burned — the pre-fix ~10-min stall is gone
+  });
+});


### PR DESCRIPTION
Addresses #969 (headline blowup fixed; a narrow --wait residual deferred — see below).

#765's `applyRevertDeletes` runs delete-kind items in PASSES so a delete blocked by a sibling queued later succeeds next pass. But the per-item `retryTransient` wrapper INSIDE each delete classified the dependency-violation error as TRANSIENT, so each delete burned its FULL in-item retry budget (with backoff, and `--wait` re-armed a 10-min deadline) BEFORE returning to the pass loop that resolves it for free — turning a seconds-long convergent revert into multi-10-minute stalls on exactly the multi-delete plans #765 targets.

Fix (apply.ts-only):
- New `isDependencyViolation(error)` — detects the dependency/conflict class (DependencyViolation, ApiGatewayV2 ConflictException '… referenced by …', 'still in use / still referenced / cannot delete because …').
- `applyRevertDelete` now runs the single delete via a `guardedDelete` wrapper: on a dependency violation it stashes the real error and hands `retryTransient` a terminal-classified sentinel (`DEP_VIOLATION_TERMINAL`, verified to match none of transient.ts's patterns) → `retryTransient` returns immediately with ZERO retries and ZERO backoff/`--wait` sleeps; the real error is restored before returning. A genuine transient (throttle) still flows through `retryTransient` unchanged. No duplicated retry math, no double sends; `TRANSIENT_PATTERNS`/`retryTransient` unmodified.

The guaranteed-futile in-item `--wait` on dependency-violation deletes is gone, so the pass loop (which frees the sibling) is never starved — the batch converges immediately.

Tests (`tests/apply-deleteretry-969.test.ts`, 9): dep-violation delete sends DeleteResource exactly once, zero sleeps, does not consume the `--wait` deadline; genuine throttle still retries; terminal returns first attempt; the real [Integration, Route] wrong-order pair converges via the pass loop (Integration attempted once per pass, 2 total not the 5-budget) with zero wall-clock slept under a 10-min `--wait`.

**Deferred (needs stack-actions.ts, peer-owned):** the residual `--wait` deadline re-arm for a GENUINE persistent throttle spanning multiple passes — `deadlineMs = clock() + waitMs` is computed per-item per-pass in `buildRetryOpts` (stack-actions.ts:948-949). Fully fixing it means hoisting the deadline out of the per-item closure (one deadline per revert run). Recommend a follow-up PR in stack-actions.ts.