### PR TITLE
fix(read): re-fold declared CognitoEvents to a readGap when GetCognitoEvents fails (#1085)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -151,6 +151,7 @@ import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { ResourceGoneError } from '../aws-errors.js';
 import { READ_RETRY } from './client-config.js';
+import { isDefinitiveDenial } from './kms-aliases.js';
 import { hashCaBundle } from './pem.js';
 
 export interface OverrideCtx {
@@ -2001,7 +2002,24 @@ const readAppSyncApiKey: OverrideReader = async ({ physicalId, declared, region 
 // stay writeOnly readGaps — they are not projected, so they can never false-positive.
 // (CognitoEvents is exempted from the writeOnly strip via OVERRIDE_READABLE_WRITEONLY so
 // the projected value is actually compared.)
-const readCognitoIdentityPool: OverrideReader = async ({ physicalId, region }) => {
+//
+// GetCognitoEvents failure handling (#1085): the ORIGINAL unconditional `catch {}` swallowed
+// EVERY failure identically — an AccessDenied (missing `cognito-sync:GetCognitoEvents`) or a
+// throttle silently dropped CognitoEvents from the live model. Because CognitoEvents is exempt
+// from the writeOnly strip, a DECLARED value then compared against an ABSENT live value and
+// FALSE-flagged as declared-tier drift ("removed out of band"), which `revert` would try to
+// re-write — the exact #752/#964 failure mode, but on the OVERRIDE path (so the router's
+// restoreSupplementReadGaps degrade never fires for it). Distinguish the failure kinds:
+//   - genuine region-unavailability (cognito-sync is a deprecated service absent in most
+//     regions → the endpoint won't resolve): degrade QUIETLY. Nothing to warn about; the
+//     service simply cannot exist there.
+//   - AccessDenied / throttling / any other transient failure: degrade LOUDLY (warn on
+//     stderr) — this is a real coverage gap the user can fix (grant the permission / retry).
+// In BOTH cases, re-fold the DECLARED CognitoEvents to a readGap by mirroring the declared
+// value into the live model (declared == live → no drift surfaced, the readGap semantic), so
+// the value is NEVER silently dropped into a false declared-tier finding. This mirrors the
+// router's restoreSupplementReadGaps, done inline because this is an override (not a supplement).
+const readCognitoIdentityPool: OverrideReader = async ({ physicalId, declared, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const cc = new CloudControlClient({ region, ...READ_RETRY });
@@ -2017,11 +2035,46 @@ const readCognitoIdentityPool: OverrideReader = async ({ physicalId, region }) =
     // Only project a NON-EMPTY event map: a pool with no Sync trigger reads back `{}`,
     // which must stay absent (declared) so a clean pool never reports false drift.
     if (ev.Events && Object.keys(ev.Events).length > 0) model.CognitoEvents = ev.Events;
-  } catch {
-    /* cognito-sync unavailable/disabled in the region -> leave CognitoEvents a readGap */
+  } catch (e) {
+    // Re-fold a DECLARED CognitoEvents to a readGap (mirror declared -> live) so it never
+    // false-flags as declared drift against the (now unread) live value. An UNDECLARED
+    // CognitoEvents has nothing to compare, so nothing is mirrored — a clean pool stays clean.
+    if ('CognitoEvents' in declared && !('CognitoEvents' in model))
+      model.CognitoEvents = declared.CognitoEvents;
+    // Only a genuine region-unavailability is silent; a permission/throttle/other transient
+    // failure is a fixable coverage gap and warns LOUDLY on stderr.
+    if (!isCognitoSyncRegionUnavailable(e)) {
+      const call = (e as Error)?.name || 'unknown error';
+      const gap =
+        'CognitoEvents' in declared
+          ? ' — treating CognitoEvents as an unverifiable read-gap (declared value assumed unchanged; grant cognito-sync:GetCognitoEvents to detect out-of-band drift on it)'
+          : '';
+      process.stderr.write(
+        `[cdkrd] warning: cognito-sync:GetCognitoEvents for ${id} failed (${call})${gap}\n`
+      );
+    }
   }
   return model;
 };
+
+// True only for a GENUINE region-unavailability of the (deprecated) cognito-sync service:
+// the SDK cannot resolve/reach an endpoint in this region, so the service literally cannot
+// exist here. Matches endpoint-resolution / DNS failures by error name or the underlying
+// ENOTFOUND system error code. Everything ELSE — an AccessDenied (isDefinitiveDenial), a
+// throttle, a 5xx, a timeout — is NOT region-unavailability: it is a fixable coverage gap
+// that must warn, so it is deliberately excluded here (isDefinitiveDenial-matched errors are
+// rejected explicitly, in case an endpoint field ever coincides).
+function isCognitoSyncRegionUnavailable(err: unknown): boolean {
+  if (isDefinitiveDenial(err)) return false;
+  const e = err as
+    | { name?: string; code?: string; cause?: { code?: string; errno?: string } }
+    | undefined;
+  if (!e) return false;
+  const regionUnavailable = /^(UnknownEndpoint|EndpointError|InvalidEndpoint)$/;
+  if (e.name && regionUnavailable.test(e.name)) return true;
+  if (e.code && (regionUnavailable.test(e.code) || e.code === 'ENOTFOUND')) return true;
+  return e.cause?.code === 'ENOTFOUND' || e.cause?.errno === 'ENOTFOUND';
+}
 
 // The SES inbound receipt-rule family (ReceiptRuleSet / ReceiptRule / ReceiptFilter)
 // has NO Cloud Control handlers (GetResource throws UnsupportedActionException), so each

--- a/tests/cognito-identity-pool-events-1085.test.ts
+++ b/tests/cognito-identity-pool-events-1085.test.ts
@@ -1,0 +1,133 @@
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { CognitoSyncClient, GetCognitoEventsCommand } from '@aws-sdk/client-cognito-sync';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+const cc = mockClient(CloudControlClient);
+const sync = mockClient(CognitoSyncClient);
+
+const POOL_ID = 'us-east-1:12345678-1234-1234-1234-123456789012';
+const DECLARED_EVENTS = { SyncTrigger: 'arn:aws:lambda:us-east-1:123456789012:function:MyTrigger' };
+
+const ctx = (
+  physicalId: string,
+  declared: Record<string, unknown> = {},
+  region = 'us-east-1',
+  accountId = '123456789012'
+) => ({ physicalId, declared, region, accountId });
+
+const read = (c: ReturnType<typeof ctx>) => SDK_OVERRIDES['AWS::Cognito::IdentityPool'](c);
+
+// The CC base-model GetResource that always succeeds (a live pool). CognitoEvents is a
+// writeOnly prop that Cloud Control never echoes, so it is absent from the CC model.
+const okBaseModel = () =>
+  cc.on(GetResourceCommand).resolves({
+    ResourceDescription: {
+      Identifier: POOL_ID,
+      Properties: JSON.stringify({
+        IdentityPoolName: 'mypool',
+        AllowUnauthenticatedIdentities: false,
+      }),
+    },
+  });
+
+beforeEach(() => {
+  cc.reset();
+  sync.reset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AWS::Cognito::IdentityPool GetCognitoEvents failure handling (#1085)', () => {
+  it('projects a NON-EMPTY live CognitoEvents map onto the base model', async () => {
+    okBaseModel();
+    sync.on(GetCognitoEventsCommand).resolves({ Events: DECLARED_EVENTS });
+
+    const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
+    expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
+  });
+
+  it('keeps a clean pool clean: empty live event map stays absent, no CognitoEvents projected', async () => {
+    okBaseModel();
+    sync.on(GetCognitoEventsCommand).resolves({ Events: {} });
+
+    const out = await read(ctx(POOL_ID, {}));
+    expect(out).not.toHaveProperty('CognitoEvents');
+  });
+
+  // The core #1085 regression: an AccessDenied (missing cognito-sync:GetCognitoEvents)
+  // must NOT silently drop a DECLARED CognitoEvents. Before the fix, the reader returned a
+  // model with CognitoEvents omitted -> the exempted-from-writeOnly-strip prop compared
+  // against absent live -> a FALSE declared-tier "removed out of band" finding.
+  it('does NOT drop a DECLARED CognitoEvents on AccessDenied — mirrors it to a readGap + warns', async () => {
+    okBaseModel();
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    sync
+      .on(GetCognitoEventsCommand)
+      .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+
+    const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
+    // The declared value is mirrored into live (declared == live -> no false drift).
+    expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
+    // AND it warns LOUDLY on stderr — a fixable coverage gap, not a silent drop.
+    expect(warn).toHaveBeenCalled();
+    const msg = warn.mock.calls.map((c) => String(c[0])).join('');
+    expect(msg).toContain('cognito-sync:GetCognitoEvents');
+    expect(msg).toContain('AccessDeniedException');
+  });
+
+  it('does NOT drop a DECLARED CognitoEvents on throttling — mirrors it to a readGap + warns', async () => {
+    okBaseModel();
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    sync
+      .on(GetCognitoEventsCommand)
+      .rejects(Object.assign(new Error('rate exceeded'), { name: 'ThrottlingException' }));
+
+    const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
+    expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls.map((c) => String(c[0])).join('')).toContain('ThrottlingException');
+  });
+
+  it('an UNDECLARED CognitoEvents stays absent on AccessDenied (nothing to false-flag) but still warns', async () => {
+    okBaseModel();
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    sync
+      .on(GetCognitoEventsCommand)
+      .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+
+    const out = await read(ctx(POOL_ID, {}));
+    // No declared CognitoEvents -> nothing to mirror -> stays absent (a clean pool).
+    expect(out).not.toHaveProperty('CognitoEvents');
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('genuine region-unavailability (UnknownEndpoint) degrades QUIETLY — mirrors declared, no warning', async () => {
+    okBaseModel();
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    sync
+      .on(GetCognitoEventsCommand)
+      .rejects(Object.assign(new Error('endpoint not resolvable'), { name: 'UnknownEndpoint' }));
+
+    const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
+    // Still no false declared-tier drift: the declared value is folded to a readGap.
+    expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
+    // But it is SILENT — the deprecated cognito-sync service simply cannot exist there.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('region-unavailability via an ENOTFOUND DNS cause is also silent', async () => {
+    okBaseModel();
+    const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    sync
+      .on(GetCognitoEventsCommand)
+      .rejects(Object.assign(new Error('getaddrinfo ENOTFOUND'), { cause: { code: 'ENOTFOUND' } }));
+
+    const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
+    expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1085

readCognitoIdentityPool swallowed EVERY GetCognitoEvents failure identically — an AccessDenied (missing cognito-sync:GetCognitoEvents) or a throttle silently dropped CognitoEvents from the live model. Because CognitoEvents is exempt from the writeOnly strip (OVERRIDE_READABLE_WRITEONLY), a DECLARED value then compared against an absent live value and false-flagged as declared-tier 'removed out of band' drift, which revert would try to re-write. This is the #752/#964 failure mode on the OVERRIDE path, where the router's restoreSupplementReadGaps degrade never fires.

Fix: on any GetCognitoEvents failure, re-fold a DECLARED CognitoEvents to a readGap by mirroring the declared value into the live model (declared == live -> no false drift). Distinguish genuine region-unavailability (cognito-sync is deprecated/absent in most regions -> endpoint won't resolve) which degrades QUIETLY, from AccessDenied/throttle/other transient failures which degrade LOUDLY with a stderr warning naming cognito-sync:GetCognitoEvents. Reuses the existing isDefinitiveDenial classifier (#789). An UNDECLARED CognitoEvents has nothing to mirror, so a clean pool stays clean.

Unit test: mocks CC GetResource OK + GetCognitoEvents AccessDenied / throttling / UnknownEndpoint / ENOTFOUND, asserts no false declared FP (declared mirrored) and correct warn/silent behavior. Fails without the fix (5/7 fail on the old unconditional catch).