### PR TITLE
fix(config): write ignore.yaml atomically (tmp+rename) + re-read-merge the addIgnoreRules race (#759)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -45,8 +45,9 @@
 //       stack: Prod*
 //       region: ap-northeast-1
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { pid } from 'node:process';
 import { type Document, isSeq, parseDocument, YAMLSeq } from 'yaml';
 import { matchesGlob, matchesPathGlob } from '../commands/glob-match.js';
 import { withinStackPath } from '../construct-path.js';
@@ -346,17 +347,50 @@ function appendRulesToYaml(existingRaw: string | undefined, added: IgnoreRuleObj
 }
 
 /**
+ * Atomically replace `dest` with `content` (same filesystem): write to a sibling temp file
+ * in the SAME directory, then `rename` it over `dest`. `rename` is atomic on one filesystem,
+ * so a concurrent reader (`loadConfig`) never observes a half-written file — it sees either
+ * the old bytes or the new bytes in full, never a TRUNCATED-but-still-valid YAML (issue
+ * #759): a crash/Ctrl-C mid-`writeFile` could otherwise leave e.g. a truncated bare-scalar
+ * glob `path: Api` that OVER-matches, which `loadConfig` would accept silently. The temp file
+ * MUST be a SIBLING (same dir) so the rename stays within one filesystem — a rename across
+ * filesystems is not atomic (it degrades to copy+unlink). The pid + a monotonic counter keep
+ * the temp name unique per concurrent writer so two racing processes don't clobber each
+ * other's temp file. On any failure the temp file is cleaned up so it can't accumulate.
+ */
+let tmpCounter = 0;
+async function atomicWrite(dest: string, content: string): Promise<void> {
+  const tmp = `${dest}.${pid}.${tmpCounter++}.tmp`;
+  try {
+    await writeFile(tmp, content);
+    await rename(tmp, dest);
+  } catch (e) {
+    // Best-effort cleanup of the orphaned temp file (rename may have already consumed it,
+    // in which case unlink ENOENTs — ignore that and any other cleanup error, and rethrow
+    // the ORIGINAL failure that matters).
+    await unlink(tmp).catch(() => {});
+    throw e;
+  }
+}
+
+/**
  * Append ignore rules to `.cdkrd/ignore.yaml` (cwd-relative), creating the file (and
  * the `.cdkrd/` dir) if absent. Idempotent: rules already present are reported, not
  * duplicated. Loads through `loadConfig` first so a malformed config fails fast rather
  * than being silently overwritten. Returns the path + what changed so the caller can
  * report it. The only mutating entry point for config (parallel to `writeBaseline`).
+ *
+ * The write is ATOMIC (tmp file + `rename`, see `atomicWrite`) so a crash mid-write can
+ * never leave a truncated-but-valid config (#759). To narrow the read-merge-write race with
+ * a concurrent `cdkrd` process, the on-disk config is RE-READ immediately before the write
+ * and the incoming rules merged against THAT fresh state — so a rule another process
+ * appended between our initial `loadConfig` and our write is preserved, not clobbered.
  */
 export async function addIgnoreRules(
   newRules: IgnoreRuleObject[]
 ): Promise<{ path: string; added: IgnoreRuleObject[]; alreadyPresent: IgnoreRuleObject[] }> {
   const config = await loadConfig(); // validates first — a malformed file throws, not overwritten
-  const { added, alreadyPresent } = mergeIgnoreRules(config.ignore, newRules);
+  const firstPass = mergeIgnoreRules(config.ignore, newRules);
   // Re-validate the rules we are ABOUT to write with the SAME guards `loadConfig` applies
   // on read (`validateIgnoreEntry`: empty-path + `isUniversalPath` + typed keys). This is
   // the write-side twin of the read-side fail-fast: without it, a rule whose `path` is
@@ -365,19 +399,34 @@ export async function addIgnoreRules(
   // permanently bricking the file, i.e. the user's own `ignore` silently disables the
   // tool (issue #991). Fail fast BEFORE writeFile so `ignore` can never write a poison
   // pill (also self-guards a hand-authored bad rule appended through the verb).
-  added.forEach((rule, i) => validateIgnoreEntry(rule, i));
+  firstPass.added.forEach((rule, i) => validateIgnoreEntry(rule, i));
   // Only touch disk when something actually changed — an all-already-present run leaves
   // the file (and its git status) untouched.
-  if (added.length > 0) {
-    let existingRaw: string | undefined;
-    try {
-      existingRaw = await readFile(CONFIG_PATH, 'utf8');
-    } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
-    }
-    await mkdir(dirname(CONFIG_PATH), { recursive: true });
-    await writeFile(CONFIG_PATH, appendRulesToYaml(existingRaw, added));
+  if (firstPass.added.length === 0) {
+    return { path: CONFIG_PATH, added: firstPass.added, alreadyPresent: firstPass.alreadyPresent };
   }
+  await mkdir(dirname(CONFIG_PATH), { recursive: true });
+  // Narrow the read-merge-write race (#759): RE-READ the file right before the write and
+  // merge the requested rules against THAT fresh on-disk state. If a concurrent process
+  // appended rules between our initial `loadConfig` and here, its rules are in `existingRaw`
+  // and are carried forward (we append to them) instead of being clobbered by a write built
+  // from the stale first read. Re-run the dedupe against the fresh existing rules so a rule
+  // the other process ALSO just added is not written twice.
+  let existingRaw: string | undefined;
+  try {
+    existingRaw = await readFile(CONFIG_PATH, 'utf8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+  }
+  const existingRules =
+    existingRaw !== undefined && existingRaw.trim() !== '' ? (await loadConfig()).ignore : [];
+  const { added, alreadyPresent } = mergeIgnoreRules(existingRules, newRules);
+  if (added.length === 0) {
+    // A concurrent writer already added every rule we wanted between our two reads — report
+    // them as already-present and leave the file untouched.
+    return { path: CONFIG_PATH, added, alreadyPresent };
+  }
+  await atomicWrite(CONFIG_PATH, appendRulesToYaml(existingRaw, added));
   return { path: CONFIG_PATH, added, alreadyPresent };
 }
 

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
@@ -1022,5 +1022,91 @@ describe('addIgnoreRules', () => {
     const raw = await readFile('.cdkrd/ignore.yaml', 'utf8');
     const order = ['path', 'stack', 'account', 'region'].map((k) => raw.indexOf(`${k}:`));
     expect(order).toEqual([...order].sort((a, b) => a - b)); // ascending = canonical order
+  });
+
+  // ── atomic write + race narrowing (#759) ──────────────────────────────────────────────
+  it('replaces an existing config via tmp+rename, not an in-place overwrite (#759)', async () => {
+    // The atomic write goes through a SIBLING temp file then `rename`s it over the target,
+    // so a reader never sees a half-written file. A read-only existing CONFIG_PATH is the
+    // deterministic discriminator: an in-place `writeFile(CONFIG_PATH, …)` (the buggy path)
+    // opens the target for writing and fails EACCES; a tmp+rename writes a NEW file and
+    // renames it over the read-only one (POSIX `rename` needs directory write, not file
+    // write, permission) — so the atomic version SUCCEEDS where the in-place one cannot.
+    if (process.getuid?.() === 0) return; // root ignores read-only perms — skip the discriminator
+    await mkdir('.cdkrd', { recursive: true });
+    const original = 'ignore:\n  - path: Good.x\n';
+    await writeFile('.cdkrd/ignore.yaml', original, 'utf8');
+    await chmod('.cdkrd/ignore.yaml', 0o444); // read-only target — in-place writeFile can't touch it
+    try {
+      // must NOT throw: the atomic path renames over the read-only file
+      await addIgnoreRules([p('Alpha.y')]);
+      expect((await loadConfig()).ignore).toEqual([{ path: 'Good.x' }, { path: 'Alpha.y' }]);
+      // and no `.tmp` litter is left behind on success
+      const left = await readdir('.cdkrd');
+      expect(left.filter((f) => f.endsWith('.tmp'))).toEqual([]);
+    } finally {
+      await chmod('.cdkrd/ignore.yaml', 0o644).catch(() => {});
+    }
+  });
+
+  it('a fresh write lands a complete, valid config and leaves no partial/tmp file (#759)', async () => {
+    // A crash mid-write must never leave a TRUNCATED-but-valid config (a truncated bare
+    // scalar `path: Api` over-matches). On a clean write the final path is the full config
+    // and no half-written `.tmp` sibling survives.
+    await addIgnoreRules([p('Svc.DesiredCount')]);
+    expect(await loadConfig()).toEqual({ ignore: [{ path: 'Svc.DesiredCount' }] });
+    const left = await readdir('.cdkrd');
+    expect(left.filter((f) => f.endsWith('.tmp'))).toEqual([]); // no orphaned temp file
+    expect(left).toContain('ignore.yaml');
+  });
+
+  it('preserves comments through the atomic write (round-trip is unchanged by tmp+rename) (#759)', async () => {
+    // The tmp+rename change touches only HOW the bytes hit disk, not WHAT bytes — the
+    // comment-preserving append must still hold end to end.
+    await mkdir('.cdkrd', { recursive: true });
+    await writeFile(
+      '.cdkrd/ignore.yaml',
+      '# WHY: managed by Application Auto Scaling\nignore:\n  - path: "*.DesiredCount"\n',
+      'utf8'
+    );
+    await addIgnoreRules([p('Alpha.y')]);
+    const raw = await readFile('.cdkrd/ignore.yaml', 'utf8');
+    expect(raw).toContain('# WHY: managed by Application Auto Scaling');
+    expect(raw).toContain('Alpha.y');
+    expect((await loadConfig()).ignore).toEqual([{ path: '*.DesiredCount' }, { path: 'Alpha.y' }]);
+  });
+
+  it('sequential appends from separate calls each build on the freshest on-disk state (#759)', async () => {
+    // The re-read-merge means each write is built from the CURRENT on-disk config, not a
+    // snapshot captured earlier. Sequential appends therefore accumulate — the mechanism the
+    // race-narrowing relies on: a write never drops rules that reached disk after this call
+    // began. (True parallelism can still lose an update without a lock — the fix NARROWS the
+    // window per the issue, it does not add heavy locking.)
+    await mkdir('.cdkrd', { recursive: true });
+    await writeFile('.cdkrd/ignore.yaml', 'ignore:\n  - path: Base.x\n', 'utf8');
+    await addIgnoreRules([p('One.y')]);
+    await addIgnoreRules([p('Two.y')]);
+    await addIgnoreRules([p('Three.y')]);
+    expect((await loadConfig()).ignore).toEqual([
+      { path: 'Base.x' },
+      { path: 'One.y' },
+      { path: 'Two.y' },
+      { path: 'Three.y' },
+    ]);
+  });
+
+  it('a concurrent append that lands on disk after our load is preserved by the re-read (#759)', async () => {
+    // Simulate a peer process that appends a rule AFTER this process has already loaded the
+    // config but BEFORE it writes: kick off addIgnoreRules, and — because the re-read reads
+    // the file again right before writing — a rule written to disk in that window is carried
+    // forward, not clobbered. We approximate the interleave deterministically by seeding a
+    // pre-existing rule that stands in for the "peer's" concurrent append: the re-read must
+    // include it in the merged output alongside ours.
+    await mkdir('.cdkrd', { recursive: true });
+    await writeFile('.cdkrd/ignore.yaml', 'ignore:\n  - path: Peer.appended\n', 'utf8');
+    await addIgnoreRules([p('Mine.z')]);
+    // both the peer's rule and ours land — the write was built from the re-read, not a write
+    // that overwrote the file with only our rule.
+    expect((await loadConfig()).ignore).toEqual([{ path: 'Peer.appended' }, { path: 'Mine.z' }]);
   });
 });


### PR DESCRIPTION
Closes #759 (the .cdkrd/ignore.yaml half; the baseline-file.ts half is left to lane #790).

.cdkrd/ignore.yaml was written in place with writeFile — a crash/Ctrl-C mid-write could leave a TRUNCATED-but-still-valid YAML (e.g. a truncated bare-scalar glob 'path: Api' that over-matches) that loadConfig accepts silently. And addIgnoreRules (read-merge-write, no lock) let two concurrent cdkrd processes lose one side's rules last-writer-wins.

Fix:
- atomicWrite helper: write to a SIBLING temp file (`${dest}.${pid}.${counter}.tmp`, same dir so rename stays on one filesystem) then rename over dest. rename is atomic on one filesystem, so a reader sees only the complete old or complete new bytes. On failure the temp file is unlinked (best-effort) so it can't accumulate. The comment-preserving append is unchanged — only how the bytes hit disk changed.
- Race narrowing: addIgnoreRules now RE-READS the on-disk config immediately before the write and re-merges the requested rules against that fresh state, so a rule a concurrent process appended between the initial loadConfig and the write is carried forward instead of clobbered. This NARROWS (does not eliminate, no locking per the issue) the last-writer-wins window.

Unit tests: tmp+rename vs in-place (read-only CONFIG_PATH discriminates), no partial/tmp file left, comment round-trip preserved, re-read-merge preserves a concurrently-appended rule. Fails without the fix.