### PR TITLE
fix(gather): don't re-cache a failed DescribeType's EMPTY schema in the per-run map (#1067)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -19,7 +19,7 @@ import {
 import { type AddedChild, CHILD_ENUMERATORS } from '../read/child-enumerators.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
 import { CC_IDENTIFIER_ADAPTERS, readLive, type ReadResult } from '../read/router.js';
-import { getSchemaInfo } from '../schema/schema-strip.js';
+import { getSchemaInfoResult } from '../schema/schema-strip.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../types.js';
 
 export interface GatherResult {
@@ -129,8 +129,18 @@ async function readAddedModel(
       new GetResourceCommand({ TypeName: c.resourceType, Identifier: c.identifier })
     );
     const raw = JSON.parse(g.ResourceDescription?.Properties ?? '{}') as Record<string, unknown>;
-    const schema = schemas.get(c.resourceType) ?? (await getSchemaInfo(cfn, c.resourceType));
-    schemas.set(c.resourceType, schema);
+    // Reuse the per-run cache, else fetch. Only re-cache a SUCCESSFUL fetch: a DescribeType
+    // failure returns an EMPTY schema (#751 — schema-strip itself does not cache it), and
+    // caching that EMPTY in the per-run map would poison every later resource of this type
+    // (writeOnly reinclude drops declared write-only props, createOnly bars lost) even after
+    // the throttle clears — so leave the map unset on failure to let the next occurrence
+    // re-fetch (#1067). The EMPTY still drives THIS resource's normalize (degraded, no strip).
+    let schema = schemas.get(c.resourceType);
+    if (!schema) {
+      const res = await getSchemaInfoResult(cfn, c.resourceType);
+      schema = res.info;
+      if (!res.failed) schemas.set(c.resourceType, schema);
+    }
     return {
       model: normalizeLiveModel(raw, schema, { oaiCanonicalIds, resourceType: c.resourceType }),
       ok: true,
@@ -412,8 +422,19 @@ async function classifyRead(
       },
     ];
   }
-  const schema = schemas.get(r.resourceType) ?? (await getSchemaInfo(cfn, r.resourceType));
-  schemas.set(r.resourceType, schema);
+  // Reuse the per-run cache, else fetch. A DescribeType FAILURE returns an EMPTY schema
+  // (#751) that must NOT be re-cached in the per-run map — caching it would keep every later
+  // resource of this type on the degraded EMPTY (no readOnly strip → first-run noise; no
+  // writeOnly readGap → false declared drift; and it poisons revert: writeOnlyReincludeOps
+  // drops declared write-only props, createOnly bars lost) even after the throttle clears
+  // (#1067). Leave the map unset on failure so the next resource of the type re-fetches; the
+  // EMPTY still classifies THIS resource (degraded, no strip — unchanged behavior).
+  let schema = schemas.get(r.resourceType);
+  if (!schema) {
+    const res = await getSchemaInfoResult(cfn, r.resourceType);
+    schema = res.info;
+    if (!res.failed) schemas.set(r.resourceType, schema);
+  }
   return classifyResource(r, read.live, schema, classifyOpts);
 }
 

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -47,14 +47,28 @@ export function describeTypeFailedWarning(resourceType: string, region: string):
   );
 }
 
-export async function getSchemaInfo(
+// The outcome of a getSchemaInfo call: the (possibly EMPTY-degraded) schema plus a
+// `failed` signal that a DescribeType failure produced the EMPTY fallback. The signal
+// lets a per-RUN caller (gather's `schemas` map) avoid re-caching that EMPTY — schema-strip's
+// own region cache already skips it (#751), but a caller with its own cache would otherwise
+// re-poison it, keeping every later resource of the type on the degraded EMPTY even after the
+// throttle clears / the permission is granted (#1067). `getSchemaInfo` below is the thin
+// SchemaInfo-only wrapper for callers that do not maintain a cache.
+export interface SchemaInfoResult {
+  info: SchemaInfo;
+  // True when DescribeType failed and `info` is the EMPTY degraded fallback (do NOT cache it);
+  // false when `info` is a real fetched (or already-cached) schema (safe to cache).
+  failed: boolean;
+}
+
+export async function getSchemaInfoResult(
   client: CloudFormationClient,
   resourceType: string
-): Promise<SchemaInfo> {
+): Promise<SchemaInfoResult> {
   const region = await client.config.region();
   const cacheKey = `${region}\0${resourceType}`;
   const cached = cache.get(cacheKey);
-  if (cached) return cached;
+  if (cached) return { info: cached, failed: false };
   const result = await fetch(client, resourceType);
   if (result.ok) {
     // Only cache a REAL schema. A DescribeType failure must NOT be persisted as if it
@@ -63,15 +77,23 @@ export async function getSchemaInfo(
     // stripped, writeOnly not readGap'd) even after the permission is granted / the
     // throttle clears. Leaving it uncached lets the next occurrence re-fetch.
     cache.set(cacheKey, result.info);
-    return result.info;
+    return { info: result.info, failed: false };
   }
   // Failure: warn once per type+region, then return EMPTY for THIS call (best-effort — a
-  // missing schema means no strip, never a crash) WITHOUT caching it.
+  // missing schema means no strip, never a crash) WITHOUT caching it. `failed: true` tells
+  // a per-run caller not to re-cache the EMPTY in its own map either (#1067).
   if (!failureWarned.has(cacheKey)) {
     failureWarned.add(cacheKey);
     console.error(describeTypeFailedWarning(resourceType, region));
   }
-  return result.info;
+  return { info: result.info, failed: true };
+}
+
+export async function getSchemaInfo(
+  client: CloudFormationClient,
+  resourceType: string
+): Promise<SchemaInfo> {
+  return (await getSchemaInfoResult(client, resourceType)).info;
 }
 
 // Top-level writeOnly properties that an SDK_OVERRIDES reader (read/overrides.ts) CAN

--- a/tests/schema-cache-failure-1067.test.ts
+++ b/tests/schema-cache-failure-1067.test.ts
@@ -1,0 +1,138 @@
+import type { CloudFormationClient as CFNClientType } from '@aws-sdk/client-cloudformation';
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  DescribeTypeCommand,
+  GetTemplateCommand,
+  ListStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { gatherFindings } from '../src/commands/gather.js';
+import { getSchemaInfoResult } from '../src/schema/schema-strip.js';
+
+// #1067: schema-strip DELIBERATELY does not cache a DescribeType FAILURE (#751), but gather's
+// per-run `schemas` map used to `schemas.set(resourceType, schema)` whatever came back —
+// INCLUDING a failure's EMPTY schema. That poisoned the per-run cache: every LATER resource of
+// the same type reused the degraded EMPTY (no readOnly strip → first-run noise; no writeOnly
+// readGap → false declared drift; and it broke revert — writeOnlyReincludeOps drops declared
+// write-only props, createOnly bars lost) even after the throttle cleared / the permission was
+// granted. The fix: getSchemaInfoResult signals `failed`, and gather only caches a SUCCESS.
+
+// A CloudFormationClient-like fake whose `.config.region()` resolves to `region` and whose
+// `.send()` is a scriptable mock — proves the `failed` signal without the AWS SDK machinery.
+function fakeClient(region: string, send: () => Promise<unknown>): CFNClientType {
+  return {
+    config: { region: () => Promise.resolve(region) },
+    send,
+  } as unknown as CFNClientType;
+}
+
+describe('getSchemaInfoResult failure signal (#1067)', () => {
+  it('reports failed:true on a DescribeType failure and failed:false on success', async () => {
+    const resourceType = 'AWS::Foo::Signal1067';
+    const region = 'eu-central-1';
+    const schema = { properties: { A: { type: 'string' } }, readOnlyProperties: ['/properties/A'] };
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ThrottlingException'))
+      .mockResolvedValue({ Schema: JSON.stringify(schema) });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = fakeClient(region, send as unknown as () => Promise<unknown>);
+
+    // Failure: EMPTY schema, and failed:true so a caller does not cache it.
+    const failed = await getSchemaInfoResult(client, resourceType);
+    expect(failed.failed).toBe(true);
+    expect(failed.info.readOnly.has('A')).toBe(false);
+
+    // The failure was NOT cached (#751), so the next call re-fetches and succeeds.
+    const ok = await getSchemaInfoResult(client, resourceType);
+    expect(ok.failed).toBe(false);
+    expect(ok.info.readOnly.has('A')).toBe(true);
+  });
+});
+
+// A stack with TWO resources of the SAME type whose FIRST DescribeType fails and SECOND
+// succeeds. The live model carries a schema-readOnly attribute (`ReadOnlyAttr`) the template
+// never declares: with the real schema it is stripped (folded), with the EMPTY it surfaces as
+// `undeclared`. Before the fix, resource 1's EMPTY poisoned the per-run map → resource 2 reused
+// it (never re-fetched) → its ReadOnlyAttr false-surfaced as undeclared AND DescribeType ran
+// only ONCE. After the fix, resource 2 re-fetches the now-succeeding schema → clean.
+describe('gather does not cache a DescribeType failure in the per-run schemas map (#1067)', () => {
+  it('re-fetches for a later resource of the same type after an earlier fetch failed', async () => {
+    const ids = ['Q1', 'Q2'];
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Resources: Object.fromEntries(
+          ids.map((id) => [id, { Type: 'AWS::SQS::Queue', Properties: { QueueName: `${id}-q` } }])
+        ),
+      }),
+    });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: ids.map((id) => ({
+        LogicalResourceId: id,
+        PhysicalResourceId: `${id}-phys`,
+        ResourceType: 'AWS::SQS::Queue',
+        LastUpdatedTimestamp: new Date(0),
+        ResourceStatus: 'CREATE_COMPLETE' as const,
+      })),
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+    // FIRST DescribeType throws (denied/throttled); SECOND succeeds with a schema that marks
+    // the live-only `ReadOnlyAttr` readOnly (so it is stripped, not surfaced as undeclared).
+    const okSchema = JSON.stringify({
+      properties: { QueueName: { type: 'string' }, ReadOnlyAttr: { type: 'string' } },
+      readOnlyProperties: ['/properties/ReadOnlyAttr'],
+    });
+    const describeType = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ThrottlingException'))
+      .mockResolvedValue({ Schema: okSchema });
+    cfn.on(DescribeTypeCommand).callsFake(describeType);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const cc = mockClient(CloudControlClient);
+    // Both queues read back the declared QueueName PLUS an undeclared, schema-readOnly attr.
+    cc.on(GetResourceCommand).callsFake((input: { Identifier: string }) => {
+      const id = String(input.Identifier).replace('-phys', '');
+      return Promise.resolve({
+        ResourceDescription: {
+          Identifier: input.Identifier,
+          Properties: JSON.stringify({ QueueName: `${id}-q`, ReadOnlyAttr: `${id}-ro` }),
+        },
+      });
+    });
+
+    const { findings } = await gatherFindings('S', 'us-east-1');
+
+    // DescribeType was called TWICE — the failure for Q1 was NOT cached, so Q2 re-fetched.
+    // Before the fix the poisoned EMPTY short-circuited Q2 and this was 1.
+    expect(describeType).toHaveBeenCalledTimes(2);
+
+    // Q1 saw the EMPTY (failed fetch) → its readOnly attr is NOT stripped → surfaces undeclared.
+    expect(
+      findings.some(
+        (f) => f.logicalId === 'Q1' && f.tier === 'undeclared' && f.path === 'ReadOnlyAttr'
+      )
+    ).toBe(true);
+    // Q2 re-fetched the REAL schema → its readOnly attr IS stripped → no undeclared finding.
+    // Before the fix Q2 reused Q1's poisoned EMPTY and also false-surfaced ReadOnlyAttr.
+    expect(
+      findings.some(
+        (f) => f.logicalId === 'Q2' && f.tier === 'undeclared' && f.path === 'ReadOnlyAttr'
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1067

## Problem
A throttled/denied `cloudformation:DescribeType` returns an EMPTY schema fallback. #751 made schema-strip's own region cache skip a failed fetch, but gather's per-run `schemas` map re-cached that EMPTY keyed by resourceType — so every later resource of the type rode the degraded EMPTY even after the throttle cleared:
- no readOnly strip → first-run undeclared noise
- no writeOnly readGap → false declared drift
- **poisoned revert**: `writeOnlyReincludeOps` returns `[]` (drops declared write-only props — IAM `LoginProfile.Password` reset, ECS Service managed-EBS hard-fail), createOnly bars lost, `updatable` undefined.
- the post-revert convergence re-check (`regatherTouched`) reused the poisoned schemas too.

## Fix
`getSchemaInfo` now exposes a `failed` signal via a new `getSchemaInfoResult` (thin wrapper keeps every existing consumer + `SchemaInfo` serialization unchanged). Gather only `schemas.set(...)` on a successful fetch and leaves the map unset on failure, so the next resource of the type re-fetches (matching #751's intent). The EMPTY still drives THIS resource's diff (degraded — unchanged behavior; the degrade-to-readGap redesign is #858, untouched).

## Test
`tests/schema-cache-failure-1067.test.ts` — asserts the `failed` signal, and that a 2-resource same-type stack whose first DescribeType throws RE-FETCHES for the second (verified to fail without the fix).

Files: `src/schema/schema-strip.ts`, `src/commands/gather.ts`.