### PR TITLE
fix(normalize): content-gate the AWSLogDelivery policy-statement subtraction (#715)

### DIFF
--- a/src/normalize/policy-canonical.ts
+++ b/src/normalize/policy-canonical.ts
@@ -116,10 +116,36 @@ function canonicalizeStatement(s: unknown): unknown {
 // logging v2, VPC flow logs, etc.) — Sid `AWSLogDeliveryWrite`/`AWSLogDeliveryAclCheck`.
 // It is AWS-managed and never in the template, so it fires a false declared drift on the
 // bucket policy's Statement array (an extra live-only statement). Recognized by the
-// `AWSLogDelivery` Sid prefix AND the delivery-logs service principal (both required, so a
-// user statement is never dropped), it is subtracted before compare — same philosophy as
+// `AWSLogDelivery` Sid prefix AND the delivery-logs service principal AND a KNOWN-SAFE
+// content shape (see below), it is subtracted before compare — same philosophy as
 // stripping AWS-managed fields / aws:* tags. Symmetric: a user who declared the identical
 // statement still compares equal (both sides drop it).
+//
+// #715 (security-relevant FALSE NEGATIVE): matching on ONLY the Sid prefix + principal is
+// content-blind. A rogue statement that carries the `AWSLogDelivery*` Sid + delivery-logs
+// principal but ARBITRARY grants (e.g. `Action: s3:*` to a foreign account) was silently
+// subtracted on BOTH sides → the policy widening read CLEAN (invisible). So the subtraction
+// is now equality-gated to the DOCUMENTED safe shape: `Effect` must be `Allow`, and every
+// `Action` must be in the vended allow-set — the exact actions AWS grants the delivery-logs
+// principal per DESTINATION type (S3: `s3:PutObject`/`s3:GetBucketAcl`; CloudWatch Logs:
+// `logs:CreateLogStream`/`logs:PutLogEvents`; Firehose: `firehose:PutRecord`/`PutRecordBatch`).
+// Anything broader — a wildcard or foreign Action (`s3:*`, `s3:DeleteObject`, `logs:*`, …) —
+// is NOT subtracted, so it SURFACES as drift. Conservative by design: only the exact known-safe
+// Action shapes are dropped; a deviation keeps the statement (no false negative). Genuine AWS
+// statements (S3 bucket policy, Logs LogGroup resource policy, Firehose) still fold (no false
+// positive). We deliberately do NOT additionally gate on Resource/Condition equality — the
+// destination ARN / owning account vary per deployment and are not knowable here, and Action
+// is the axis that actually widens access; the Action gate alone closes the reported hole
+// (an `s3:*` / `logs:*` grant no longer folds) without risking a false positive on the legit
+// shape. Actions per https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html
+const AWS_LOG_DELIVERY_ALLOWED_ACTIONS = new Set([
+  's3:PutObject',
+  's3:GetBucketAcl',
+  'logs:CreateLogStream',
+  'logs:PutLogEvents',
+  'firehose:PutRecord',
+  'firehose:PutRecordBatch',
+]);
 function isAwsManagedLogDeliveryStatement(s: unknown): boolean {
   if (!isObj(s)) return false;
   const sid = s.Sid;
@@ -128,7 +154,14 @@ function isAwsManagedLogDeliveryStatement(s: unknown): boolean {
   if (!isObj(principal)) return false;
   const svc = principal.Service;
   const services = Array.isArray(svc) ? svc : [svc];
-  return services.includes('delivery.logs.amazonaws.com');
+  if (!services.includes('delivery.logs.amazonaws.com')) return false;
+  // Content gate: only fold the DOCUMENTED safe shape. `Effect` must be `Allow` and every
+  // `Action` must be in the vended allow-set — a broader/foreign grant surfaces (#715).
+  if (s.Effect !== 'Allow') return false;
+  const actionRaw = s.Action;
+  const actions = Array.isArray(actionRaw) ? actionRaw : [actionRaw];
+  if (actions.length === 0) return false;
+  return actions.every((a) => typeof a === 'string' && AWS_LOG_DELIVERY_ALLOWED_ACTIONS.has(a));
 }
 function canonicalizePrincipal(v: unknown): unknown {
   if (isObj(v)) {

--- a/tests/policy-canonical-logdelivery-715.test.ts
+++ b/tests/policy-canonical-logdelivery-715.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { canonicalizePolicy } from '../src/normalize/policy-canonical.js';
+
+// #715: the AWSLogDelivery statement subtraction was content-blind (matched on ONLY the
+// Sid prefix + delivery-logs principal, ignoring Action/Resource/Condition). A rogue
+// statement carrying the AWSLogDelivery Sid + principal but ARBITRARY grants (Action:
+// s3:*) was silently subtracted on both sides → a policy widening read CLEAN (invisible).
+// The subtraction is now equality-gated to the documented safe Action shape.
+
+function stmtCount(doc: Record<string, unknown>): number {
+  return Array.isArray(doc.Statement) ? doc.Statement.length : 0;
+}
+
+describe('#715: AWSLogDelivery subtraction is content-gated (Action must be safe)', () => {
+  const deliveryPrincipal = { Service: 'delivery.logs.amazonaws.com' } as const;
+
+  it('does NOT drop a rogue AWSLogDelivery statement granting a broader Action (s3:*)', () => {
+    // The rogue statement from the issue: AWSLogDelivery* Sid + delivery-logs principal,
+    // but a wide `s3:*` grant to a foreign source account. It must SURFACE (not fold).
+    const rogue = {
+      Sid: 'AWSLogDeliveryWriteRogue',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: 's3:*',
+      Resource: 'arn:aws:s3:::bucket/*',
+      Condition: { StringEquals: { 'aws:SourceAccount': '999999999999' } },
+    };
+    const doc = canonicalizePolicy({ Statement: [rogue] });
+    expect(stmtCount(doc)).toBe(1); // kept — a widening grant is visible drift
+  });
+
+  it('does NOT drop an AWSLogDelivery statement carrying an extra broad Action in an array', () => {
+    const rogue = {
+      Sid: 'AWSLogDeliveryWrite',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: ['s3:PutObject', 's3:DeleteObject'],
+      Resource: 'arn:aws:s3:::bucket/AWSLogs/*',
+    };
+    const doc = canonicalizePolicy({ Statement: [rogue] });
+    expect(stmtCount(doc)).toBe(1); // the extra s3:DeleteObject keeps the statement visible
+  });
+
+  it('does NOT drop an AWSLogDelivery statement flipped to Deny', () => {
+    const rogue = {
+      Sid: 'AWSLogDeliveryWrite',
+      Effect: 'Deny',
+      Principal: deliveryPrincipal,
+      Action: 's3:PutObject',
+      Resource: 'arn:aws:s3:::bucket/AWSLogs/*',
+    };
+    const doc = canonicalizePolicy({ Statement: [rogue] });
+    expect(stmtCount(doc)).toBe(1);
+  });
+
+  it('STILL drops the genuine AWSLogDeliveryWrite statement (Action s3:PutObject + acl condition)', () => {
+    const genuineWrite = {
+      Sid: 'AWSLogDeliveryWrite',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: 's3:PutObject',
+      Resource: 'arn:aws:s3:::bucket/AWSLogs/123456789012/*',
+      Condition: {
+        StringEquals: {
+          's3:x-amz-acl': 'bucket-owner-full-control',
+          'aws:SourceAccount': '123456789012',
+        },
+      },
+    };
+    const doc = canonicalizePolicy({ Statement: [genuineWrite] });
+    expect(stmtCount(doc)).toBe(0); // legit vended statement still folds (no false positive)
+  });
+
+  it('STILL drops the genuine AWSLogDeliveryAclCheck statement (Action s3:GetBucketAcl)', () => {
+    const genuineAclCheck = {
+      Sid: 'AWSLogDeliveryAclCheck',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: 's3:GetBucketAcl',
+      Resource: 'arn:aws:s3:::bucket',
+      Condition: { StringEquals: { 'aws:SourceAccount': '123456789012' } },
+    };
+    const doc = canonicalizePolicy({ Statement: [genuineAclCheck] });
+    expect(stmtCount(doc)).toBe(0);
+  });
+
+  it('STILL drops the genuine CloudWatch Logs vended statement (logs:CreateLogStream/PutLogEvents)', () => {
+    // A Logs::LogGroup resource policy vends this statement — a different destination than
+    // S3, with logs:* actions. It must still fold (this shape appears in the corpus).
+    const genuineLogs = {
+      Sid: 'AWSLogDeliveryWrite1',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+      Resource: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/vendedlogs/x:log-stream:*',
+      Condition: {
+        StringEquals: { 'aws:SourceAccount': '111111111111' },
+        ArnLike: { 'aws:SourceArn': 'arn:aws:logs:us-east-1:111111111111:*' },
+      },
+    };
+    const doc = canonicalizePolicy({ Statement: [genuineLogs] });
+    expect(stmtCount(doc)).toBe(0);
+  });
+
+  it('STILL drops the genuine Firehose vended statement (firehose:PutRecord/PutRecordBatch)', () => {
+    const genuineFirehose = {
+      Sid: 'AWSLogDeliveryWrite',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: ['firehose:PutRecord', 'firehose:PutRecordBatch'],
+      Resource: 'arn:aws:firehose:us-east-1:111111111111:deliverystream/x',
+    };
+    const doc = canonicalizePolicy({ Statement: [genuineFirehose] });
+    expect(stmtCount(doc)).toBe(0);
+  });
+
+  it('does NOT drop an AWSLogDelivery statement with a wildcard logs:* action', () => {
+    const rogue = {
+      Sid: 'AWSLogDeliveryWrite1',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: 'logs:*',
+      Resource: 'arn:aws:logs:us-east-1:111111111111:log-group:*',
+    };
+    const doc = canonicalizePolicy({ Statement: [rogue] });
+    expect(stmtCount(doc)).toBe(1);
+  });
+
+  it('drops both genuine vended statements but keeps a co-located rogue one', () => {
+    const genuineWrite = {
+      Sid: 'AWSLogDeliveryWrite',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: 's3:PutObject',
+      Resource: 'arn:aws:s3:::bucket/AWSLogs/*',
+      Condition: { StringEquals: { 's3:x-amz-acl': 'bucket-owner-full-control' } },
+    };
+    const genuineAclCheck = {
+      Sid: 'AWSLogDeliveryAclCheck',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: 's3:GetBucketAcl',
+      Resource: 'arn:aws:s3:::bucket',
+    };
+    const rogue = {
+      Sid: 'AWSLogDeliveryWriteRogue',
+      Effect: 'Allow',
+      Principal: deliveryPrincipal,
+      Action: 's3:*',
+      Resource: 'arn:aws:s3:::bucket/*',
+    };
+    const doc = canonicalizePolicy({ Statement: [genuineWrite, genuineAclCheck, rogue] });
+    expect(stmtCount(doc)).toBe(1); // only the rogue statement survives
+    const surviving = (doc.Statement as Record<string, unknown>[])[0];
+    expect(surviving.Sid).toBe('AWSLogDeliveryWriteRogue');
+  });
+});


### PR DESCRIPTION
Closes #715 (security-relevant false negative, live-confirmed)

## Problem
cdkrd subtracts AWS-vended-log-delivery statements from a resource policy before diffing. The subtraction (`isAwsManagedLogDeliveryStatement`) matched on ONLY the `^AWSLogDelivery` Sid prefix + the `delivery.logs.amazonaws.com` service principal — ignoring Action/Resource/Condition. So a rogue statement carrying that Sid + principal but ARBITRARY grants (e.g. `Action: s3:*` to a foreign account) was silently subtracted on both sides → the policy widening read `CLEAN` (invisible).

## Fix
Equality-gate the subtraction to the documented safe shape: `Effect` must be `Allow` and every `Action` must be in the vended allow-set — the exact actions AWS grants the delivery-logs principal per destination:
- S3: `s3:PutObject`, `s3:GetBucketAcl`
- CloudWatch Logs: `logs:CreateLogStream`, `logs:PutLogEvents`
- Firehose: `firehose:PutRecord`, `firehose:PutRecordBatch`

Anything broader (`s3:*`, `logs:*`, a `Deny`, a foreign action) is NOT subtracted → surfaces as drift. Resource/Condition are deliberately not gated (destination ARN / owning account vary per deployment; Action is the axis that widens access). The corpus contains a genuine **CloudWatch Logs** vended statement, not just S3 — the allow-set covers all three destinations so the legit statements still fold (no false positive).

## Test
`tests/policy-canonical-logdelivery-715.test.ts` — 9 tests: the rogue `s3:*`/`logs:*`/`Deny` cases must surface; the genuine S3 Write/AclCheck + CloudWatch Logs + Firehose statements must still fold. (5/9 fail without the fix.)

File: `src/normalize/policy-canonical.ts`.