### PR TITLE
fix(baseline): make baselineValueMatches reflexive for identity-less object arrays (#767)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -27,6 +27,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { deepEqual } from '../diff/drift-calculator.js';
+import { sortUnorderedObjectArray } from '../normalize/noise.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
 import type { ArrayDelta, Finding } from '../types.js';
 
@@ -628,15 +629,51 @@ export function carryForwardUnreadable(
  * cleanly with #767's identity-sort case). Idempotency of the pipeline means an
  * already-canonical live value is unchanged, so this never weakens real change
  * detection: two values that differ after canonicalization still compare unequal.
+ *
+ * #767: `canonicalizeForCompare` only IDENTITY-sorts object arrays (by
+ * Key/Id/Name/…), but the live model reaches a DIFFERENT total order — classify's
+ * `sortUnorderedSetProps` runs `sortUnorderedObjectArray` (a full CANONICAL-JSON
+ * sort) over unordered object-array props, and for an IDENTITY-LESS array the
+ * identity-sort is a no-op, so the live `f.actual` lands in canonical-JSON order
+ * while the recorded raw baseline stays in template order. `deepEqual` is
+ * positional, so those two never converge — a permanent "changed since record" that
+ * re-recording can't clear. Re-applying the SAME canonical-JSON sort (deeply) to
+ * BOTH sides here drives them to one total order, restoring reflexivity
+ * (`baselineValueMatches(v, v)` is true for identity-less arrays too). It is
+ * SYMMETRIC and only REORDERS (never merges/drops elements), so two genuinely
+ * different values still differ — change detection is preserved. Baseline compare is
+ * type-agnostic over UNDECLARED snapshot fragments, which never carry an
+ * order-significant declared array, so an order-insensitive sort is safe here.
  */
 export function baselineValueMatches(
   baselineValue: unknown,
   currentCanonicalValue: unknown
 ): boolean {
   return deepEqual(
-    canonicalizeForCompare(baselineValue),
-    canonicalizeForCompare(currentCanonicalValue)
+    sortObjectArraysDeep(canonicalizeForCompare(baselineValue)),
+    sortObjectArraysDeep(canonicalizeForCompare(currentCanonicalValue))
   );
+}
+
+// Deeply apply the SAME canonical-JSON total order the live side reaches (classify's
+// `sortUnorderedObjectArray`) to every plain-object array, so both compare sides of
+// `baselineValueMatches` converge on one order (#767). `sortUnorderedObjectArray`
+// only reorders a single array level and leaves non-arrays untouched, so this walk
+// recurses into every element / object value and sorts each object array it finds.
+// Applied to BOTH sides symmetrically, so it can never make two different values
+// compare equal — it only removes an ordering-only difference.
+function sortObjectArraysDeep(v: unknown): unknown {
+  if (Array.isArray(v)) {
+    const mapped = v.map(sortObjectArraysDeep);
+    return sortUnorderedObjectArray(mapped);
+  }
+  if (v && typeof v === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>))
+      out[k] = sortObjectArraysDeep(val);
+    return out;
+  }
+  return v;
 }
 
 // Identity fields for the ELEMENT-LEVEL DELTA display only (R128) — deliberately

--- a/tests/baseline-reflexive-767.test.ts
+++ b/tests/baseline-reflexive-767.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { baselineValueMatches } from '../src/baseline/baseline-file.js';
+import { sortUnorderedObjectArray } from '../src/normalize/noise.js';
+import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
+
+// #767: `baselineValueMatches` must be REFLEXIVE for identity-keyed / object-array
+// values too. `canonicalizeForCompare` only IDENTITY-sorts object arrays (Key/Id/
+// Name/…), but the live model reaches a DIFFERENT total order — classify's
+// `sortUnorderedSetProps` runs a full CANONICAL-JSON `sortUnorderedObjectArray` over
+// unordered object-array props. For an array whose elements share NO identity field
+// the identity-sort is a no-op, so the live `f.actual` lands in canonical-JSON order
+// while the recorded raw baseline stays in template order — `deepEqual` is positional,
+// so the two never converge and `record` -> `check` is a permanent "changed since
+// record" that re-recording can't clear. The fix re-applies the SAME canonical-JSON
+// sort (deeply) to BOTH sides so they converge on one order.
+describe('#767 baselineValueMatches reflexivity for reordered object arrays', () => {
+  // The exact shape from the issue: identity-keyed (`Name`) elements whose
+  // identity-sort order differs from their canonical-JSON order.
+  it('(reflexive) identity-keyed array where identity order != canonical-JSON order', () => {
+    const v = [
+      { A: 1, Name: 'n2' },
+      { Name: 'n1', Z: 2 },
+    ];
+    expect(baselineValueMatches(v, v)).toBe(true);
+  });
+
+  // The residual #767 case #807 did NOT cover: an IDENTITY-LESS object array. Here
+  // `canonicalizeForCompare`'s identity-sort is a no-op, so only the deep
+  // canonical-JSON sort makes a live-reordered array converge with the raw baseline.
+  it('(reflexive) identity-less object array (raw baseline vs canon-JSON-reordered live)', () => {
+    const raw = [{ Zeta: 1 }, { Alpha: 2 }];
+    // Emulate the live model's ordering (classify's sortUnorderedObjectArray).
+    const live = sortUnorderedObjectArray(canonicalizeForCompare(raw));
+    // The live model reordered the array relative to the raw template order...
+    expect(JSON.stringify(live)).not.toBe(JSON.stringify(canonicalizeForCompare(raw)));
+    // ...yet the recorded raw baseline still matches it.
+    expect(baselineValueMatches(raw, live)).toBe(true);
+    // And it is reflexive with itself.
+    expect(baselineValueMatches(raw, raw)).toBe(true);
+  });
+
+  it('(reflexive) nested object array inside an object still converges', () => {
+    const rules = [
+      { Effect: 'Deny', SortKey: 'z' },
+      { SortKey: 'a', Effect: 'Allow' },
+    ];
+    const v = { Rules: rules };
+    // Emulate the live model reordering the nested array (classify sorts it in place).
+    const live = { Rules: sortUnorderedObjectArray(canonicalizeForCompare(rules)) };
+    expect(baselineValueMatches(v, v)).toBe(true);
+    expect(baselineValueMatches(v, live)).toBe(true);
+  });
+
+  it('(reflexive) deeply nested object array (array of objects holding arrays)', () => {
+    const v = [
+      { Group: 'g2', Items: [{ B: 2 }, { A: 1 }] },
+      { Group: 'g1', Items: [{ D: 4 }, { C: 3 }] },
+    ];
+    expect(baselineValueMatches(v, v)).toBe(true);
+  });
+
+  // NEGATIVE guard: the symmetric sort only REORDERS — it must NOT loosen the
+  // predicate into matching genuinely-different values.
+  it('(negative) a changed element value still returns false', () => {
+    const recorded = [{ Zeta: 1 }, { Alpha: 2 }];
+    const changed = [{ Zeta: 1 }, { Alpha: 999 }];
+    expect(baselineValueMatches(recorded, changed)).toBe(false);
+  });
+
+  it('(negative) a changed identity-keyed element still returns false', () => {
+    const recorded = [
+      { Name: 'n1', Value: 'a' },
+      { Name: 'n2', Value: 'b' },
+    ];
+    const changed = [
+      { Name: 'n1', Value: 'a' },
+      { Name: 'n2', Value: 'CHANGED' },
+    ];
+    expect(baselineValueMatches(recorded, changed)).toBe(false);
+  });
+
+  it('(negative) an added element still returns false', () => {
+    const recorded = [{ Zeta: 1 }, { Alpha: 2 }];
+    const changed = [{ Zeta: 1 }, { Alpha: 2 }, { Extra: 3 }];
+    expect(baselineValueMatches(recorded, changed)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #767

## Problem
`baselineValueMatches` — the single-source-of-truth predicate for "recorded == live" — is not reflexive: `baselineValueMatches(v, v)` can return `false`. When it fires, `record` → `check` can never go clean (permanent "changed since record"), and re-recording doesn't help.

Root cause: two sorts that disagree, only one re-applied at compare time.
- Live side (`classify.ts`): `canonicalizeForCompare` identity-sorts object arrays, then `sortUnorderedSetProps` canonical-JSON-sorts unordered object-array props. For an **identity-less** array the identity-sort is a no-op, so the live `f.actual` lands in canonical-JSON order.
- Compare side (`baseline-file.ts`): only `canonicalizeForCompare` (identity sort) is re-applied, so the recorded raw baseline stays in template order. `deepEqual` is positional → mismatch.

Unit repro: `baselineValueMatches([{A:1,Name:'n2'},{Name:'n1',Z:2}], <same value>)` returned `false`.

## Fix
Apply the same canonical-JSON object-array sort (`sortUnorderedObjectArray`, already exported from `noise.ts`) **deeply to BOTH compare sides**, so they converge on one total order — restoring reflexivity. Symmetric and reorder-only, so two genuinely different values still differ.

### Tradeoff (please review)
This sorts *every* object array, which is **broader than the live side's schema-gated set**. An out-of-band reorder of an *order-significant UNDECLARED* array would therefore fold (the #880 class — undeclared-only, and no such corpus case exists today; full corpus-replay stays green). The narrower schema-gated alternative from the issue needs `resourceType`/`schema` plumbed into `baselineValueMatches` at every call site; I took the self-contained route. Happy to switch to the plumbed variant if you prefer.

## Test
`tests/baseline-reflexive-767.test.ts` — reflexivity over identity-keyed / identity-less / nested shapes (the issue's exact shape) + 3 negative guards (changed value / changed element / added element still return false).

File: `src/baseline/baseline-file.ts`.