### PR TITLE
fix(revert): gate revert on a mid-operation stack + surface stackStatusWarning in record/ignore/revert (#786)

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,14 @@ mode: a `record` / `ignore` that would need the selection prompt refuses without
 
 After publication this shape is a backward-compatible API.
 
+`revert` also **refuses to write (exit 2) when the target stack is mid-operation**
+(`*_IN_PROGRESS`): it re-reads the stack status immediately before applying, so a
+revert can never fight an in-flight `cdk deploy` / update by writing stale values
+onto an updating stack — wait for the stack to settle, then re-run. And
+`record` / `ignore` / `revert` now surface the same stack-status warning `check`
+prints when a stack is mid-operation or in a failed state (a `record` mid-update
+would otherwise snapshot transient values into the committed baseline).
+
 ## IAM permissions
 
 `check` / `record` are **read-only**: the AWS managed `ReadOnlyAccess` policy

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -17,7 +17,7 @@ import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
-import { ignoreStack } from './stack-actions.js';
+import { ignoreStack, warnStackStatus } from './stack-actions.js';
 import { emitJsonArray, type IgnoreJson, stackLabel } from './verb-json.js';
 
 export async function runIgnore(args: string[]): Promise<number> {
@@ -67,6 +67,10 @@ export async function runIgnore(args: string[]): Promise<number> {
         progressLabel(idx, stacks.length, stackName, region),
         () => gatherFindings(stackName, region, undefined, template)
       );
+      // #786: surface the mid-operation / failed-state warning the same way check does —
+      // an in-flux stack's drift may be transient, so ignoring it could bake in a rule for
+      // a value that settles on its own once the deploy completes.
+      warnStackStatus(stackName, desired.stackStatusWarning);
       // Reconcile exactly as check does so the offered drift matches what the user saw:
       // suppress already-recorded baseline entries, then re-tag config-ignored findings
       // out (they are already `ignored`, so ignoreStack never re-offers them).

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -8,7 +8,7 @@ import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
-import { recordStack } from './stack-actions.js';
+import { recordStack, warnStackStatus } from './stack-actions.js';
 import { emitJsonArray, type RecordJson, stackLabel } from './verb-json.js';
 
 export async function runRecord(args: string[]): Promise<number> {
@@ -68,6 +68,10 @@ export async function runRecord(args: string[]): Promise<number> {
         progressLabel(idx, stacks.length, stackName, region),
         () => gatherFindings(stackName, region, undefined, template)
       );
+      // #786: warn loudly when the stack is mid-operation / failed — recording now would
+      // snapshot TRANSIENT live values into the git-committed baseline. Same wording/stderr
+      // routing check uses; a --yes run still records (just warned), matching check's behavior.
+      warnStackStatus(stackName, desired.stackStatusWarning);
       // ignore rules re-tag matching undeclared findings out of the record set, so an
       // externally-managed property is never recorded (and never re-detected).
       const result = await recordStack({

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -16,7 +16,7 @@ import { loadConfig } from '../config/config-file.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
 import { resolveStacks } from './resolve-stacks.js';
-import { revertStack } from './stack-actions.js';
+import { revertStack, warnStackStatus } from './stack-actions.js';
 import { emitJsonArray, type RevertJson, stackLabel } from './verb-json.js';
 
 export async function runRevert(args: string[]): Promise<number> {
@@ -85,6 +85,10 @@ export async function runRevert(args: string[]): Promise<number> {
         region
       );
       if (baseline) checkBaselineAccount(baseline, gathered.desired.accountId, stackName);
+      // #786: surface the mid-operation / failed-state warning the same way check does —
+      // a revert on an in-flux stack is risky (revertStack additionally re-reads the state
+      // right before the write and refuses on a mid-operation stack).
+      warnStackStatus(stackName, gathered.desired.stackStatusWarning);
       // standalone revert: an aborted confirm means nothing changed → exit 0 (the
       // outcome's `exit` already encodes that; `aborted` is only consulted by check).
       const outcome = await revertStack({

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -3,6 +3,7 @@
 // the interactive flow and the single-verb commands behaviourally identical: both go
 // through exactly the same record / plan / apply / converge code.
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { confirm, isCancel } from '@clack/prompts';
 import {
   recordedKey,
@@ -70,6 +71,51 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
  */
 export function stackLabel(stackName: string, region: string): string {
   return `${stackName} (${region})`;
+}
+
+/**
+ * Print the stack-state warning (#786) — a stack that is mid-operation (`*_IN_PROGRESS`)
+ * or in a failed state (`*_FAILED`) carries a `stackStatusWarning` from `loadDesired`
+ * (via `classifyStackStatus`). `check` prints it (`check.ts`), but the standalone
+ * `record` / `ignore` / `revert` verbs never consumed it — so a `record` mid-`cdk deploy`
+ * would snapshot transient values into the git baseline, and a `revert` would fight the
+ * in-flight deploy, all silently. This centralizes the SAME wording/stderr routing check
+ * uses so every verb surfaces the warning identically. No-op when the stack is stable.
+ */
+export function warnStackStatus(stackName: string, warning: string | undefined): void {
+  if (warning) console.error(`warning: ${stackName}: ${warning}`);
+}
+
+/**
+ * TOCTOU guard (#786): re-read the stack's live `StackStatus` immediately before a
+ * revert's Cloud Control / SDK write and REFUSE when it is mid-operation
+ * (`*_IN_PROGRESS`). A stack stable at gather time can enter a `cdk deploy` while the
+ * revert confirm prompt sits open — writing OLD values onto an updating stack fights the
+ * deploy. `revert` is the one AWS-mutating verb, so the gate must be right before the
+ * write, not only at gather time. Returns a refusal reason string when the write must be
+ * refused, or `undefined` when it is safe to proceed. A DescribeStacks read error is NOT
+ * treated as a refusal (fail-open: the gather already succeeded, so a transient re-read
+ * failure should not block a legitimate revert) — only a confirmed in-progress state does.
+ */
+export async function stackInProgressRefusal(
+  stackName: string,
+  region: string
+): Promise<string | undefined> {
+  let status: string | undefined;
+  try {
+    const cfn = new CloudFormationClient({ region, ...CLIENT_TIMEOUTS });
+    const res = await cfn.send(new DescribeStacksCommand({ StackName: stackName }));
+    status = res.Stacks?.[0]?.StackStatus;
+  } catch {
+    // Fail-open: the gather already read this stack successfully, so a transient
+    // re-read failure must not block a legitimate revert. Only a CONFIRMED in-progress
+    // state refuses.
+    return undefined;
+  }
+  if (status?.endsWith('_IN_PROGRESS')) {
+    return `refusing to write to AWS — ${stackName} is mid-operation (${status}). A revert now would fight the in-flight deploy/update. Wait for the stack to settle, then re-run.`;
+  }
+  return undefined;
 }
 
 /**
@@ -919,6 +965,17 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       out(style.note('aborted.'));
       return { exit: 0, aborted: true };
     }
+  }
+
+  // TOCTOU gate (#786): the stack was stable at gather time, but it may have entered a
+  // `cdk deploy` while the confirm prompt sat open. Re-read StackStatus RIGHT before the
+  // write and REFUSE when it is mid-operation — a revert now would fight the in-flight
+  // deploy, writing OLD values onto an updating stack. No override flag: this is the one
+  // AWS-mutating verb, so it fails CLOSED rather than risk a racing write.
+  const inProgress = await stackInProgressRefusal(stackName, region);
+  if (inProgress) {
+    console.error('\n' + inProgress);
+    return { exit: 2, aborted: false, refusedReason: inProgress };
   }
 
   const cc = new CloudControlClient({ region, ...CLIENT_TIMEOUTS });

--- a/tests/ignore-footer-949.test.ts
+++ b/tests/ignore-footer-949.test.ts
@@ -48,6 +48,7 @@ vi.mock('../src/cli-args.js', () => ({
 const ignoreStack = vi.fn();
 vi.mock('../src/commands/stack-actions.js', () => ({
   ignoreStack: (...a: unknown[]) => ignoreStack(...a),
+  warnStackStatus: () => {}, // #786: ignore.ts imports this; no-op in these footer tests
 }));
 
 import { runIgnore } from '../src/commands/ignore.js';

--- a/tests/record-footer-799.test.ts
+++ b/tests/record-footer-799.test.ts
@@ -43,6 +43,7 @@ vi.mock('../src/cli-args.js', () => ({
 const recordStack = vi.fn();
 vi.mock('../src/commands/stack-actions.js', () => ({
   recordStack: (...a: unknown[]) => recordStack(...a),
+  warnStackStatus: () => {}, // #786: record.ts imports this; no-op in these footer tests
 }));
 
 import { runRecord } from '../src/commands/record.js';

--- a/tests/record-footer-949.test.ts
+++ b/tests/record-footer-949.test.ts
@@ -39,6 +39,7 @@ vi.mock('../src/cli-args.js', () => ({
 const recordStack = vi.fn();
 vi.mock('../src/commands/stack-actions.js', () => ({
   recordStack: (...a: unknown[]) => recordStack(...a),
+  warnStackStatus: () => {}, // #786: record.ts imports this; no-op in these footer tests
 }));
 
 import { runRecord } from '../src/commands/record.js';

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -7,6 +7,7 @@ import {
   GetResourceCommand,
   UpdateResourceCommand,
 } from '@aws-sdk/client-cloudcontrol';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { mockClient } from 'aws-sdk-client-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { BaselineFile } from '../src/baseline/baseline-file.js';
@@ -35,6 +36,7 @@ import {
   revertStack,
   stackLabel,
   summarizeRevertResults,
+  warnStackStatus,
 } from '../src/commands/stack-actions.js';
 
 describe('includeUnrecordedRemovals (R113 — surface undeclared REMOVE in a gated prompt)', () => {
@@ -633,6 +635,18 @@ describe('revertStack --json plan-info carriage (#1096 — dry-run counts + refu
 });
 
 describe('revertStack convergence re-check (R44 — scoped to touched resources)', () => {
+  // #786: revertStack now re-reads StackStatus right before the write (the TOCTOU gate).
+  // Mock CloudFormation to a stable state so these convergence tests exercise the apply path
+  // (the gate itself is covered by its own describe block below).
+  let cfnMock: ReturnType<typeof mockClient>;
+  beforeEach(() => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' } as never] });
+  });
+  afterEach(() => cfnMock.restore());
+
   const EMPTY_SCHEMA = {
     readOnly: new Set<string>(),
     writeOnly: new Set<string>(),
@@ -923,6 +937,16 @@ describe('revertStack custom-bus Events::Rule identifier (#1088 — revert must 
   // `?? item.physicalId` fallback sent the raw `myBus|myRule` composite to UpdateResource →
   // ValidationException → exit 2. The fix threads region + gathered.desired.accountId into
   // both revert call sites so the region/account branch fires and the ARN is built.
+  // #786: stub the pre-write StackStatus re-read to a stable state (see gate below).
+  let cfnMock: ReturnType<typeof mockClient>;
+  beforeEach(() => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' } as never] });
+  });
+  afterEach(() => cfnMock.restore());
+
   const EMPTY_SCHEMA = {
     readOnly: new Set<string>(),
     writeOnly: new Set<string>(),
@@ -1022,6 +1046,180 @@ describe('revertStack custom-bus Events::Rule identifier (#1088 — revert must 
     // → ValidationException. WITH the fix it is the full rule ARN.
     expect(ident).toBe('arn:aws:events:us-east-1:111111111111:rule/myBus/myRule');
     expect(ident).not.toBe('myBus|myRule');
+  });
+});
+
+describe('revertStack stack-stability gate (#786 — refuse a write onto a mid-operation stack)', () => {
+  const EMPTY_SCHEMA = {
+    readOnly: new Set<string>(),
+    writeOnly: new Set<string>(),
+    createOnly: new Set<string>(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  } as SchemaInfo;
+
+  // A declared VersioningConfiguration drift on one bucket — a real revertable item, so the
+  // run reaches the pre-apply StackStatus gate (dry-run / nothing-revertable return earlier).
+  const gathered = (): GatherResult =>
+    ({
+      desired: {
+        stackName: 's',
+        region: 'r',
+        accountId: '111122223333',
+        resources: [
+          {
+            logicalId: 'B',
+            resourceType: 'AWS::S3::Bucket',
+            physicalId: 'b-phys',
+            declared: { VersioningConfiguration: { Status: 'Enabled' } },
+          },
+        ],
+        rawTemplate: '{}',
+        ctx: {
+          params: {},
+          pseudo: {},
+          conditions: {},
+          physIds: {},
+          liveAttrs: {},
+          mappings: {},
+          exports: {},
+          condCache: new Map(),
+        },
+      },
+      findings: [declared()],
+      schemas: new Map([['AWS::S3::Bucket', EMPTY_SCHEMA]]),
+      liveByLogical: new Map(),
+    }) as GatherResult;
+
+  const params = () => ({
+    stackName: 's',
+    region: 'r',
+    gathered: gathered(),
+    baseline: undefined,
+    config: { ignore: [] },
+    dryRun: false,
+    yes: true,
+    removeUnrecorded: false,
+    verbose: false,
+    interactive: false,
+    convergeRetryDelayMs: 0,
+  });
+
+  const run = async () => {
+    const logs: string[] = [];
+    const errs: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = (s: unknown) => logs.push(String(s));
+    console.error = (s: unknown) => errs.push(String(s));
+    try {
+      const outcome = await revertStack(params());
+      return { outcome, logs: logs.join('\n'), errs: errs.join('\n') };
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  };
+
+  let cfnMock: ReturnType<typeof mockClient>;
+  afterEach(() => cfnMock?.restore());
+
+  it('REFUSES (exit 2, NO Cloud Control write) when the pre-apply StackStatus is UPDATE_IN_PROGRESS', async () => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'UPDATE_IN_PROGRESS' } as never] });
+    const cc = mockClient(CloudControlClient);
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' },
+    });
+
+    const { outcome, errs } = await run();
+    expect(outcome.exit).toBe(2);
+    expect(outcome.aborted).toBe(false);
+    expect(outcome.refusedReason).toContain('mid-operation (UPDATE_IN_PROGRESS)');
+    expect(errs).toContain('mid-operation (UPDATE_IN_PROGRESS)');
+    // the write must NOT have been issued — the whole point of the TOCTOU gate
+    expect(cc.commandCalls(UpdateResourceCommand)).toHaveLength(0);
+    cc.restore();
+  });
+
+  it('PROCEEDS with the write when the pre-apply StackStatus is a stable *_COMPLETE', async () => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'UPDATE_COMPLETE' } as never] });
+    const cc = mockClient(CloudControlClient);
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' },
+    });
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Identifier: 'b-phys',
+        Properties: JSON.stringify({ VersioningConfiguration: { Status: 'Enabled' } }),
+      },
+    });
+
+    const { outcome } = await run();
+    expect(outcome.exit).toBe(0);
+    // the write WAS issued (the stable state let it through)
+    expect(cc.commandCalls(UpdateResourceCommand)).toHaveLength(1);
+    cc.restore();
+  });
+
+  it('FAILS OPEN on a DescribeStacks re-read error — a legitimate revert is not blocked by a transient re-read failure', async () => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock.on(DescribeStacksCommand).rejects(new Error('ThrottlingException'));
+    const cc = mockClient(CloudControlClient);
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' },
+    });
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Identifier: 'b-phys',
+        Properties: JSON.stringify({ VersioningConfiguration: { Status: 'Enabled' } }),
+      },
+    });
+
+    const { outcome } = await run();
+    // not refused: the gather already succeeded, so a transient re-read failure must not block
+    expect(outcome.exit).toBe(0);
+    expect(cc.commandCalls(UpdateResourceCommand)).toHaveLength(1);
+    cc.restore();
+  });
+});
+
+describe('warnStackStatus (#786 — record / ignore / revert surface the mid-operation warning like check)', () => {
+  const capture = (fn: () => void): string => {
+    const errs: string[] = [];
+    const orig = console.error;
+    console.error = (s: unknown) => errs.push(String(s));
+    try {
+      fn();
+    } finally {
+      console.error = orig;
+    }
+    return errs.join('\n');
+  };
+
+  it('prints the warning to stderr, matching check.ts wording, when a warning is present', () => {
+    const out = capture(() =>
+      warnStackStatus(
+        'MyStack',
+        'stack is mid-operation (UPDATE_IN_PROGRESS) — live state is in flux'
+      )
+    );
+    expect(out).toBe(
+      'warning: MyStack: stack is mid-operation (UPDATE_IN_PROGRESS) — live state is in flux'
+    );
+  });
+
+  it('is a no-op when the stack is stable (no warning)', () => {
+    const out = capture(() => warnStackStatus('MyStack', undefined));
+    expect(out).toBe('');
   });
 });
 


### PR DESCRIPTION
Closes #786

Before this, the stack-stability warning classifyStackStatus produces (for every *_IN_PROGRESS / *_FAILED state, carried as Desired.stackStatusWarning) was consumed ONLY by check — record/ignore/revert never printed it, and the revert path did NO stack-state validation before the Cloud Control write. So revert --yes could write OLD values onto a stack mid-cdk-deploy (fighting the update), and record could snapshot transient in-transition values into the git baseline, all silently.

Fix:
- warnStackStatus(): record/ignore/revert now print the stackStatusWarning right after gather, mirroring check's exact wording/stderr routing.
- stackInProgressRefusal() TOCTOU gate: revertStack re-reads DescribeStacks immediately before the Cloud Control/SDK write and REFUSES (exit 2, no write) when StackStatus is *_IN_PROGRESS — closing the window where a stack stable at gather time enters a deploy while the confirm prompt sits open. Fails OPEN on a DescribeStacks read error (the gather already succeeded; a transient re-read failure must not block a legitimate revert); only a confirmed in-progress state refuses. No override flag (fails closed on the one AWS-mutating verb); a --force flag can be a follow-up (would need cli-args.ts).

Unit tests (tests/stack-actions.test.ts): revert refuses with exit 2 and ZERO UpdateResource writes on UPDATE_IN_PROGRESS; proceeds on UPDATE_COMPLETE; fails open (writes) on a DescribeStacks throw; warnStackStatus wording matches check. Fails without the fix.