### PR TITLE
fix(gather): degrade schema-unavailable resources to skipped, not an unstripped diff (#858)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -427,15 +427,35 @@ async function classifyRead(
   // resource of this type on the degraded EMPTY (no readOnly strip → first-run noise; no
   // writeOnly readGap → false declared drift; and it poisons revert: writeOnlyReincludeOps
   // drops declared write-only props, createOnly bars lost) even after the throttle clears
-  // (#1067). Leave the map unset on failure so the next resource of the type re-fetches; the
-  // EMPTY still classifies THIS resource (degraded, no strip — unchanged behavior).
-  let schema = schemas.get(r.resourceType);
-  if (!schema) {
+  // (#1067). Leave the map unset on failure so the next resource of the type re-fetches.
+  //
+  // Beyond not caching it, we must NOT diff THIS resource against the EMPTY schema either
+  // (#858): an un-schema'd compare is wrong in BOTH directions — readOnly live attrs (Arn,
+  // ids, timestamps) are not stripped → flood `[Potential Drift]` (first-run-noise invariant
+  // violated); declared writeOnly props are not routed to readGap → compared against an absent
+  // live value → red `[CFn-Declared Drift]` (`--fail` exits 1 on an untouched stack). Surfacing
+  // a known-wrong diff is worse than admitting the coverage gap, so DEGRADE to a single `skipped`
+  // finding (coverage-incomplete, `--strict`-visible) — mirroring the not-readable branch above.
+  // Only when the schema was FETCHED THIS CALL and FAILED: a cache HIT is a prior SUCCESS (a real
+  // schema), so classify normally. Key off `res.failed`, not `schema` being empty.
+  const cachedSchema = schemas.get(r.resourceType);
+  if (!cachedSchema) {
     const res = await getSchemaInfoResult(cfn, r.resourceType);
-    schema = res.info;
-    if (!res.failed) schemas.set(r.resourceType, schema);
+    if (res.failed) {
+      return [
+        {
+          tier: 'skipped',
+          logicalId: r.logicalId,
+          resourceType: r.resourceType,
+          path: '',
+          note: 'schema unavailable (DescribeType failed) — coverage incomplete',
+        },
+      ];
+    }
+    schemas.set(r.resourceType, res.info);
+    return classifyResource(r, read.live, res.info, classifyOpts);
   }
-  return classifyResource(r, read.live, schema, classifyOpts);
+  return classifyResource(r, read.live, cachedSchema, classifyOpts);
 }
 
 export async function gatherFindings(

--- a/tests/schema-cache-failure-1067.test.ts
+++ b/tests/schema-cache-failure-1067.test.ts
@@ -121,10 +121,21 @@ describe('gather does not cache a DescribeType failure in the per-run schemas ma
     // Before the fix the poisoned EMPTY short-circuited Q2 and this was 1.
     expect(describeType).toHaveBeenCalledTimes(2);
 
-    // Q1 saw the EMPTY (failed fetch) → its readOnly attr is NOT stripped → surfaces undeclared.
+    // Q1 saw the EMPTY (failed fetch). #858 degrades it to a `skipped` coverage finding
+    // instead of diffing against the unstripped model, so the readOnly attr does NOT
+    // false-surface as undeclared (before #858 it surfaced `undeclared` — the known-wrong
+    // un-schema'd diff this degrade replaces).
     expect(
       findings.some(
         (f) => f.logicalId === 'Q1' && f.tier === 'undeclared' && f.path === 'ReadOnlyAttr'
+      )
+    ).toBe(false);
+    expect(
+      findings.some(
+        (f) =>
+          f.logicalId === 'Q1' &&
+          f.tier === 'skipped' &&
+          f.note === 'schema unavailable (DescribeType failed) — coverage incomplete'
       )
     ).toBe(true);
     // Q2 re-fetched the REAL schema → its readOnly attr IS stripped → no undeclared finding.

--- a/tests/schema-unavailable-degrade-858.test.ts
+++ b/tests/schema-unavailable-degrade-858.test.ts
@@ -1,0 +1,157 @@
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  DescribeTypeCommand,
+  GetTemplateCommand,
+  ListStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { gatherFindings } from '../src/commands/gather.js';
+
+// #858 (the deferred half of #1067): when the schema for a resource type is UNAVAILABLE
+// (DescribeType failed — throttle/deny), gather returns an EMPTY degraded schema (#751).
+// Diffing a resource against that EMPTY is wrong in BOTH directions:
+//   1. readOnly live attrs (Arn/ids/timestamps) are not stripped → flood `[Potential Drift]`
+//      (the first-run-noise invariant is violated).
+//   2. declared writeOnly props are not routed to readGap → compared against an absent live
+//      value → red `[CFn-Declared Drift]` → `--fail` exits 1 on an untouched stack.
+// Surfacing a known-wrong diff is worse than admitting the coverage gap, so gather now DEGRADES
+// the resource to a single `skipped` finding (coverage-incomplete) instead of classifying it.
+//
+// NOTE: schema-strip.ts keeps a PROCESS-level schema cache keyed on `${region}\0${type}`, so a
+// SUCCESSFUL fetch of a type in a prior test would let a later test find it cached (no DescribeType
+// call → no degrade). Each test therefore uses a UNIQUE resource type to stay isolated.
+
+const DEGRADE_NOTE = 'schema unavailable (DescribeType failed) — coverage incomplete';
+
+// A schema marking the live-only `Arn` readOnly — so with the REAL schema Arn is stripped
+// (folded), but under the EMPTY (failed fetch) it would false-surface as undeclared drift.
+const okSchema = JSON.stringify({
+  properties: { QueueName: { type: 'string' }, Arn: { type: 'string' } },
+  readOnlyProperties: ['/properties/Arn'],
+});
+
+function baseStack(cfn: ReturnType<typeof mockClient>, resourceType: string, ids: string[]) {
+  cfn.on(GetTemplateCommand).resolves({
+    TemplateBody: JSON.stringify({
+      Resources: Object.fromEntries(
+        ids.map((id) => [id, { Type: resourceType, Properties: { QueueName: `${id}-q` } }])
+      ),
+    }),
+  });
+  cfn.on(ListStackResourcesCommand).resolves({
+    StackResourceSummaries: ids.map((id) => ({
+      LogicalResourceId: id,
+      PhysicalResourceId: `${id}-phys`,
+      ResourceType: resourceType,
+      LastUpdatedTimestamp: new Date(0),
+      ResourceStatus: 'CREATE_COMPLETE' as const,
+    })),
+  });
+  cfn.on(DescribeStacksCommand).resolves({
+    Stacks: [
+      {
+        StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+        StackName: 'S',
+        CreationTime: new Date(0),
+        StackStatus: 'CREATE_COMPLETE',
+        Parameters: [],
+      },
+    ],
+  });
+}
+
+// Both queues read back the declared QueueName PLUS a live-only `Arn` — which, under the EMPTY
+// schema, is NOT stripped → would false-surface as undeclared drift.
+function stubLiveReads(cc: ReturnType<typeof mockClient>) {
+  cc.on(GetResourceCommand).callsFake((input: { Identifier: string }) => {
+    const id = String(input.Identifier).replace('-phys', '');
+    return Promise.resolve({
+      ResourceDescription: {
+        Identifier: input.Identifier,
+        Properties: JSON.stringify({
+          QueueName: `${id}-q`,
+          Arn: `arn:aws:sqs:us-east-1:111122223333:${id}-q`,
+        }),
+      },
+    });
+  });
+}
+
+describe('gather degrades to skipped when the schema is unavailable (#858)', () => {
+  it('emits a skipped coverage finding instead of diffing against the EMPTY schema', async () => {
+    const resourceType = 'AWS::Test858::Fail';
+    const cfn = mockClient(CloudFormationClient);
+    baseStack(cfn, resourceType, ['Q1']);
+    // DescribeType FAILS — schema-strip returns the EMPTY degraded schema with failed:true.
+    cfn.on(DescribeTypeCommand).rejects(new Error('ThrottlingException'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const cc = mockClient(CloudControlClient);
+    stubLiveReads(cc);
+
+    const { findings } = await gatherFindings('S', 'us-east-1');
+    const q1 = findings.filter((f) => f.logicalId === 'Q1');
+
+    // The resource is a single `skipped` coverage-gap finding — NOT a diff against the EMPTY.
+    expect(q1).toHaveLength(1);
+    expect(q1[0]).toMatchObject({
+      tier: 'skipped',
+      logicalId: 'Q1',
+      resourceType,
+      path: '',
+      note: DEGRADE_NOTE,
+    });
+
+    // NOT surfaced as undeclared/declared drift against the unstripped model (the #858 bug).
+    expect(q1.some((f) => f.tier === 'undeclared' || f.tier === 'declared')).toBe(false);
+    expect(findings.some((f) => f.tier === 'undeclared' && f.path === 'Arn')).toBe(false);
+  });
+
+  it('classifies normally when the schema fetch SUCCEEDS (regression guard)', async () => {
+    const resourceType = 'AWS::Test858::Ok';
+    const cfn = mockClient(CloudFormationClient);
+    baseStack(cfn, resourceType, ['Q1']);
+    // DescribeType SUCCEEDS with a schema marking `Arn` readOnly (so it is stripped, folded).
+    cfn.on(DescribeTypeCommand).resolves({ Schema: okSchema });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const cc = mockClient(CloudControlClient);
+    stubLiveReads(cc);
+
+    const { findings } = await gatherFindings('S', 'us-east-1');
+    // A real schema classifies normally: no degrade finding, and the readOnly Arn is stripped.
+    expect(findings.some((f) => f.logicalId === 'Q1' && f.note === DEGRADE_NOTE)).toBe(false);
+    expect(
+      findings.some((f) => f.logicalId === 'Q1' && f.tier === 'undeclared' && f.path === 'Arn')
+    ).toBe(false);
+  });
+
+  it('re-fetches for a later resource of the same type after an earlier fetch failed (#1067)', async () => {
+    const resourceType = 'AWS::Test858::Refetch';
+    const cfn = mockClient(CloudFormationClient);
+    baseStack(cfn, resourceType, ['Q1', 'Q2']);
+    // FIRST DescribeType throws (Q1 degrades to skipped); SECOND succeeds (Q2 classifies clean).
+    const describeType = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ThrottlingException'))
+      .mockResolvedValue({ Schema: okSchema });
+    cfn.on(DescribeTypeCommand).callsFake(describeType);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const cc = mockClient(CloudControlClient);
+    stubLiveReads(cc);
+
+    const { findings } = await gatherFindings('S', 'us-east-1');
+
+    // The failure was NOT cached (#751/#1067), so Q2 re-fetched: DescribeType ran TWICE.
+    expect(describeType).toHaveBeenCalledTimes(2);
+    // Q1 (failed fetch) degraded to the skipped coverage finding — NOT a diff against EMPTY.
+    expect(findings.some((f) => f.logicalId === 'Q1' && f.note === DEGRADE_NOTE)).toBe(true);
+    expect(findings.some((f) => f.logicalId === 'Q1' && f.tier === 'undeclared')).toBe(false);
+    // Q2 re-fetched the REAL schema → classified normally: no degrade finding, Arn stripped.
+    expect(findings.some((f) => f.logicalId === 'Q2' && f.note === DEGRADE_NOTE)).toBe(false);
+    expect(
+      findings.some((f) => f.logicalId === 'Q2' && f.tier === 'undeclared' && f.path === 'Arn')
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #858 (deferred half of #1067)

## Problem
When `cloudformation:DescribeType` fails (throttle/deny), `getSchemaInfoResult` returns an EMPTY degraded schema. #1067 stopped *caching* that EMPTY, but `classifyRead` still **diffed the resource against it** — an un-schema'd compare that is known-wrong in BOTH directions:
- readOnly live attrs (Arn/ids/timestamps) not stripped → first-run `[Potential Drift]` flood (core-invariant violation)
- declared writeOnly props not routed to readGap → false `[CFn-Declared Drift]` → `--fail` exits 1 on an untouched stack

## Fix
`classifyRead` now DEGRADES a schema-unavailable resource to a single `skipped` coverage finding (`--strict`-visible), mirroring the existing not-readable branch, instead of surfacing the known-wrong diff. Keyed off the `getSchemaInfoResult` failure signal (a cache HIT is a prior success → classify normally); #1067's no-cache-on-failure re-fetch is preserved. `readAddedModel` (added-children) is left unchanged — out of scope.

## Tests
- `tests/schema-unavailable-degrade-858.test.ts` (new, 3): DescribeType fails → resource is `skipped` (Arn does NOT false-surface); success → classifies normally; #1067 re-fetch still holds. Verified to fail without the fix.
- Updates `tests/schema-cache-failure-1067.test.ts`: its assertion pinned the old known-wrong undeclared surface — Q1 now correctly degrades to `skipped`.

File: `src/commands/gather.ts` (+ my own #1067 test). Note: the new test's `mockClient` param typing was corrected to the repo's `ReturnType<typeof mockClient>` pattern (oxc's type-aware lint flagged the generic form that tsgo missed).