### PR TITLE
fix(normalize): fold an EMBEDDED {{resolve:...}} dynamic reference to UNRESOLVED, not only a whole-string token (#722)

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -20,18 +20,40 @@ export function isDynamicReference(v: string): boolean {
   return DYNAMIC_REFERENCE_RE.test(v);
 }
 
+// A dynamic reference EMBEDDED inside a larger string. CloudFormation also resolves a
+// `{{resolve:<service>:…}}` token that appears WITHIN a longer literal (the classic
+// connection-string pattern, e.g.
+// `"postgres://admin:{{resolve:secretsmanager:MySecret:SecretString:password}}@host:5432/db"`):
+// embedded dynamic references in a larger string are an explicitly supported CFn feature,
+// resolved at deploy time. So a declared string that merely CONTAINS a well-formed token is
+// just as deploy-time-transformed — its final live value is unknowable to cdkrd and it must
+// fold to UNRESOLVED exactly like the whole-string case. The anchored isDynamicReference above
+// misses this, so the raw token would leak out as a declared value → a false positive on every
+// clean deploy that (worse) prints the resolved secret plaintext and, on revert, writes the
+// literal `{{resolve:…}}` back into the live resource. Keep the service allow-list + a closing
+// `}}` so a malformed/partial fragment (a bare `{{resolve`, or `{{resolve:unknownsvc:x}}`) is
+// NOT swallowed — only a genuine, well-formed dynamic reference is muted. The `?` makes the
+// scan non-greedy up to the FIRST closing `}}`. A whole-string match is a subset of this, so
+// the internal muting sites use this contains-form. See #722.
+const CONTAINS_DYNAMIC_REFERENCE_RE = /\{\{resolve:(ssm|ssm-secure|secretsmanager):[\s\S]*?\}\}/;
+export function containsDynamicReference(v: string): boolean {
+  return CONTAINS_DYNAMIC_REFERENCE_RE.test(v);
+}
+
 // Re-check a resolved value that an intrinsic PRODUCED (a Ref-to-parameter value,
 // an Fn::FindInMap lookup, an Fn::Select element, an Fn::ImportValue export) for a
-// whole-string dynamic reference. The literal-string guard at the top of `resolve`
+// dynamic reference. The literal-string guard at the top of `resolve`
 // only sees a `{{resolve:…}}` token that appears DIRECTLY in the template tree; when
 // the same token arrives INDIRECTLY as the result of resolving one of these
 // intrinsics, that guard never runs, so the raw token would leak out as a declared
 // value (a false positive that also prints the secret plaintext and, on revert,
 // writes the literal `{{resolve:…}}` back). Fold it to UNRESOLVED here — the same
 // post-resolution re-check Fn::Join and Fn::Sub already do on their assembled result.
+// Use the contains-form so an EMBEDDED token in a larger produced string is muted too
+// (see #722); a whole-string token is a subset of it.
 // See #1073 (the indirect siblings of the direct-literal guard #722).
 function checkResolvedDynamicRef(r: unknown): unknown {
-  return typeof r === 'string' && isDynamicReference(r) ? UNRESOLVED : r;
+  return typeof r === 'string' && containsDynamicReference(r) ? UNRESOLVED : r;
 }
 
 // A value safe to interpolate into a joined / substituted STRING: a primitive
@@ -64,8 +86,11 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
   // RDS MasterUsername declared as `{{resolve:secretsmanager:…:username::}}` reads
   // back as `admin`). cdkrd cannot — and must not — fetch the secret to resolve it,
   // so the declared side is unknowable: mark UNRESOLVED so the path is skipped, the
-  // same fail-closed treatment as Fn::GetAtt, never reported as false drift.
-  if (typeof node === 'string' && isDynamicReference(node)) return UNRESOLVED;
+  // same fail-closed treatment as Fn::GetAtt, never reported as false drift. Use the
+  // contains-form so an EMBEDDED token in a larger literal string (a connection string
+  // like `"postgres://admin:{{resolve:secretsmanager:…}}@host/db"`) is muted too, not
+  // only a whole-string token. See #722.
+  if (typeof node === 'string' && containsDynamicReference(node)) return UNRESOLVED;
   if (node === null || typeof node !== 'object') return node;
   const obj = node as Record<string, unknown>;
   const keys = Object.keys(obj);
@@ -119,8 +144,10 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
         // CDK frequently ASSEMBLES a dynamic reference with Fn::Join (e.g. an RDS
         // MasterUsername = Join("", ["{{resolve:secretsmanager:", Ref(secret),
         // ":SecretString:username::}}"])); once joined the result is a deploy-time
-        // dynamic reference cdkrd cannot resolve — UNRESOLVED, never false drift.
-        return isDynamicReference(joined) ? UNRESOLVED : joined;
+        // dynamic reference cdkrd cannot resolve — UNRESOLVED, never false drift. The
+        // contains-form also catches a token joined into surrounding literal text (a
+        // connection string). See #722.
+        return containsDynamicReference(joined) ? UNRESOLVED : joined;
       }
       case 'Fn::Select': {
         if (!Array.isArray(v)) return UNRESOLVED;
@@ -533,8 +560,10 @@ export function resolveSub(v: unknown, ctx: ResolverContext): unknown {
   });
   if (unresolved) return UNRESOLVED;
   // an Fn::Sub may also ASSEMBLE a dynamic reference (`{{resolve:…}}`) — the
-  // assembled token is deploy-time-resolved and unknowable, so UNRESOLVED.
-  return isDynamicReference(out) ? UNRESOLVED : out;
+  // assembled token is deploy-time-resolved and unknowable, so UNRESOLVED. The
+  // contains-form also catches a token embedded in surrounding literal text of the
+  // substituted string (a connection string). See #722.
+  return containsDynamicReference(out) ? UNRESOLVED : out;
 }
 
 export function hasUnresolved(v: unknown): boolean {

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  containsDynamicReference,
   hasUnresolved,
   isDynamicReference,
   NOVALUE,
@@ -607,5 +608,92 @@ describe('intrinsic resolver', () => {
     expect(isDynamicReference('prefix-{{resolve:ssm:/p:1}}')).toBe(false);
     expect(isDynamicReference('{{resolve:ssm:/p:1}}-suffix')).toBe(false);
     expect(isDynamicReference('')).toBe(false);
+  });
+
+  it('#722: containsDynamicReference matches an EMBEDDED well-formed token', () => {
+    // whole-string (subset of contains) still matches
+    expect(containsDynamicReference('{{resolve:secretsmanager:s:SecretString:pw::}}')).toBe(true);
+    expect(containsDynamicReference('{{resolve:ssm:/p:1}}')).toBe(true);
+    expect(containsDynamicReference('{{resolve:ssm-secure:/p:1}}')).toBe(true);
+    // embedded in a larger literal (the connection-string pattern)
+    expect(
+      containsDynamicReference(
+        'postgres://admin:{{resolve:secretsmanager:MySecret:SecretString:password}}@host:5432/db'
+      )
+    ).toBe(true);
+    expect(containsDynamicReference('prefix-{{resolve:ssm:/p:1}}')).toBe(true);
+    expect(containsDynamicReference('{{resolve:ssm:/p:1}}-suffix')).toBe(true);
+    // NEGATIVE: no valid service + closing `}}` completion → not muted
+    expect(containsDynamicReference('admin')).toBe(false);
+    expect(containsDynamicReference('see {{resolve later}}')).toBe(false);
+    expect(containsDynamicReference('{{resolve:unknownsvc:x}}')).toBe(false);
+    expect(containsDynamicReference('a bare {{resolve fragment')).toBe(false);
+    expect(containsDynamicReference('')).toBe(false);
+  });
+
+  it('#722: an EMBEDDED dynamic reference in a larger literal string → UNRESOLVED', () => {
+    // connection-string pattern: a declared literal carrying an embedded token is
+    // deploy-time-transformed, so its final value is unknowable → UNRESOLVED (not a
+    // literal declared value that would falsely diverge from the resolved live value).
+    expect(
+      resolve(
+        'postgres://admin:{{resolve:secretsmanager:MySecret:SecretString:password}}@host:5432/db',
+        ctx()
+      )
+    ).toBe(UNRESOLVED);
+    // whole-string still UNRESOLVED (no regression).
+    expect(resolve('{{resolve:secretsmanager:MySecret:SecretString:password}}', ctx())).toBe(
+      UNRESOLVED
+    );
+    // a nested property carrying an embedded token folds to UNRESOLVED at that leaf.
+    expect(
+      resolve(
+        { ConnStr: 'redis://{{resolve:ssm-secure:/db/pw:1}}@r.example.com', Port: 6379 },
+        ctx()
+      )
+    ).toEqual({ ConnStr: UNRESOLVED, Port: 6379 });
+  });
+
+  it('#722: a dynamic reference EMBEDDED via Fn::Join → UNRESOLVED', () => {
+    // Join assembles a token INTO surrounding literal text (a connection string) — the
+    // assembled result is a deploy-time dynamic reference → UNRESOLVED.
+    expect(
+      resolve(
+        {
+          'Fn::Join': [
+            '',
+            [
+              'postgres://admin:',
+              '{{resolve:secretsmanager:MySecret:SecretString:password}}',
+              '@host:5432/db',
+            ],
+          ],
+        },
+        ctx()
+      )
+    ).toBe(UNRESOLVED);
+  });
+
+  it('#722: a dynamic reference EMBEDDED via Fn::Sub → UNRESOLVED', () => {
+    // Sub interpolates around an embedded token in a larger literal → UNRESOLVED.
+    expect(
+      resolve(
+        {
+          'Fn::Sub': [
+            'postgres://admin:{{resolve:secretsmanager:MySecret:SecretString:password}}@${Host}/db',
+            { Host: 'db.example.com' },
+          ],
+        },
+        ctx()
+      )
+    ).toBe(UNRESOLVED);
+  });
+
+  it('#722 NEGATIVE: a literal that merely contains `{{resolve` without a valid token is NOT muted', () => {
+    // no valid <service> + closing `}}` completion → stays a literal declared value.
+    expect(resolve('see {{resolve later}}', ctx())).toBe('see {{resolve later}}');
+    expect(resolve('{{resolve:unknownsvc:x}}', ctx())).toBe('{{resolve:unknownsvc:x}}');
+    // a plain literal with no token is unchanged.
+    expect(resolve('just-a-plain-value', ctx())).toBe('just-a-plain-value');
   });
 });


### PR DESCRIPTION
Closes #722

The anchored DYNAMIC_REFERENCE_RE (^...$) only folded a WHOLE-STRING {{resolve:...}} token to UNRESOLVED. A dynamic reference EMBEDDED in a larger literal string (the classic connection-string pattern, e.g. postgres://admin:{{resolve:secretsmanager:MySecret:SecretString:password}}@host/db) slipped through as a literal declared value, producing a three-stage kill chain on a CLEAN deploy: (1) declared-tier false positive that survives record; (2) the resolved SECRET PLAINTEXT printed in check output / --json as the actual value; (3) revert writes the LITERAL {{resolve:...}} token into the live resource (Cloud Control does not process dynamic references) and then reports 'CLEAN after revert'.

CloudFormation DOES resolve an embedded {{resolve:<service>:...}} token at deploy time (embedded dynamic references are an explicitly supported CFn feature), so a declared string containing a well-formed token is deploy-time-transformed and unknowable to cdkrd — it must fold to UNRESOLVED exactly like the whole-string case, which skips the comparison and closes all three facets at once.

Fix: add a non-anchored, service-allow-listed containsDynamicReference() (/\{\{resolve:(ssm|ssm-secure|secretsmanager):[\s\S]*?\}\}/, non-greedy to the first closing }}) and rewire the 4 internal muting sites (the literal-string guard in resolve(), the #1073 checkResolvedDynamicRef indirect re-check, and the Fn::Join / Fn::Sub post-assembly checks) to use it. A whole-string match is a subset of the contains-match; the strict whole-string isDynamicReference export stays intact. A bare {{resolve fragment or {{resolve:unknownsvc:x}} is NOT muted (service allow-list + closing }} required).

Unit tests: embedded token in a larger literal string / via Fn::Join / via Fn::Sub -> UNRESOLVED; whole-string still UNRESOLVED (no regression); negatives ('see {{resolve later}}', '{{resolve:unknownsvc:x}}', plain literal) not muted. Fails without the fix.

Verification: offline normalize-logic fix — the resolve() pipeline is pure, so unit tests are the live evidence (a live repro would need a Secrets Manager secret + a resource with an embedded-ref connection string, faithfully modeled by the tests). No fresh deploy; core suite deferred.