### PR TITLE
fix(record): stop silently pruning/blessing recorded drift on re-record (#790, #758)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,9 +418,16 @@ Nothing` (see [The model](#the-model-one-verb-you-run-three-it-offers)). Each
   each write. REMOVE ops (deleting a live value not in your template) are labeled
   `(REMOVE)`. **space** toggles · **→** selects all · **←** clears all · **enter**
   confirms. `--yes` applies the full plan.
-- **`record`** shows a multiselect of only the **delta** from the existing baseline
-  (new + changed values, pre-selected); already-recorded unchanged values are
-  auto-kept. Deselect a suspicious one and it stays reported by `check`. Nested
+- **`record`** shows a multiselect of only the **delta** from the existing
+  baseline; already-recorded unchanged values are auto-kept. **New** undeclared
+  values are pre-selected; a value that **changed since record** (a recorded value
+  altered out of band) is shown as `recorded → live` and default **UNSELECTED**,
+  so one Enter never silently blesses a changed value. A recorded value that
+  **reverted to its AWS default or was removed** since record is offered as a
+  separate default-unselected "drop from baseline?" row — leaving it keeps the
+  watch (it stays reported by `check`); a `--yes` record preserves it and echoes
+  what it accepted. Deselect a suspicious one and it stays reported by `check`.
+  Nested
   undeclared sub-keys (a value inside an object you _did_ declare) are listed in
   full alongside the top-level ones — a non-default one is a real out-of-band
   setting, so it is surfaced, not hidden. `record` writes only undeclared + added

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -775,6 +775,87 @@ export function splitRecordedByBaseline(
   return { unchanged, changed };
 }
 
+/**
+ * #758: for a `changed` recorded entry (a path already in the baseline whose value differs
+ * this run), return the OLD recorded value so the record picker can show a `recorded → live`
+ * diff and the user can see WHAT they are blessing. Matches on the same three identity axes as
+ * `splitRecordedByBaseline` (#793). Returns `undefined` for a genuinely NEW path (no baseline
+ * entry) — the caller then renders a plain "new" row. A sentinel `{ hasRecorded: boolean }` is
+ * used rather than a bare `undefined` return so an intentional recorded value of `undefined`/
+ * `null` is still distinguishable from "no baseline entry".
+ */
+export function recordedValueForChanged(
+  entry: RecordedEntry,
+  baseline: BaselineFile | undefined
+): { hasRecorded: boolean; recordedValue: unknown } {
+  const baselineEntry = baseline?.recorded.find(
+    (a) =>
+      a.logicalId === entry.logicalId &&
+      a.path === entry.path &&
+      a.resourceType === entry.resourceType
+  );
+  return baselineEntry
+    ? { hasRecorded: true, recordedValue: baselineEntry.value }
+    : { hasRecorded: false, recordedValue: undefined };
+}
+
+/**
+ * #790: baseline entries that have NO counterpart in the freshly-built recorded set for a
+ * resource that was READ CLEANLY this run — i.e. a recorded value reverted to its AWS default
+ * (now classified `atDefault`/`generated`, so absent from `buildRecorded`) or a recorded
+ * property REMOVED out of band. `check`'s `applyBaseline` force-surfaces these as drift, but a
+ * naive re-`record` full-replaces the baseline with only the newly-built set, silently DROPPING
+ * these entries — accepting exactly that drift with zero output. They must instead surface in
+ * the record flow as explicit "drop this recorded watch?" rows (default UNSELECTED).
+ *
+ * An entry is a drop-candidate ONLY when its resource was genuinely OBSERVED and the value is
+ * genuinely gone — every "the recorded value is stale for a benign reason" case is EXCLUDED so
+ * it is never offered for a (misleading) drop:
+ *  - resource `skipped`/`modelReadFailed` this run → unread, not gone (carryForwardUnreadable
+ *    already preserves these; excluding them here keeps them silently preserved, not offered);
+ *  - resource `deleted`, or absent from the current template (`allLogicalIds`) → the resource
+ *    itself is gone (#675), a different story than a value reverting;
+ *  - path since PROMOTED into the template (declared) → the "clean up your baseline" nudge
+ *    (#749/#1079), not an accepted drift;
+ *  - the entry is an `added`-resource snapshot (empty path) → reconciled resource-wise, not a
+ *    property revert.
+ * The remaining entries are true "recorded value reverted-to-default / removed since record".
+ * Mirrors the exclusion set `applyBaseline`'s removed-since-record loop already applies.
+ */
+export function baselineOnlyEntries(
+  recorded: RecordedEntry[],
+  baseline: BaselineFile | undefined,
+  findings: Finding[],
+  opts: {
+    declaredByLogical?: Map<string, Record<string, unknown>> | undefined;
+    allLogicalIds?: Set<string> | string[] | undefined;
+  } = {}
+): RecordedEntry[] {
+  if (!baseline || baseline.recorded.length === 0) return [];
+  const present = new Set(recorded.map(recordedKey));
+  const skippedOrUnread = new Set(
+    findings.filter((f) => f.tier === 'skipped' || f.modelReadFailed).map((f) => f.logicalId)
+  );
+  const deletedLogical = new Set(
+    findings.filter((f) => f.tier === 'deleted').map((f) => f.logicalId)
+  );
+  const currentLogicalIds =
+    opts.allLogicalIds === undefined
+      ? undefined
+      : Array.isArray(opts.allLogicalIds)
+        ? new Set(opts.allLogicalIds)
+        : opts.allLogicalIds;
+  return baseline.recorded.filter((e) => {
+    if (e.path === '') return false; // `added`-resource snapshot, not a property revert
+    if (present.has(recordedKey(e))) return false; // still recorded this run (unchanged/changed)
+    if (skippedOrUnread.has(e.logicalId)) return false; // unread this run -> not gone
+    if (deletedLogical.has(e.logicalId)) return false; // resource deleted -> #675 story
+    if (currentLogicalIds !== undefined && !currentLogicalIds.has(e.logicalId)) return false; // #675
+    if (declaredPathIsPromoted(opts.declaredByLogical?.get(e.logicalId), e.path)) return false; // promoted
+    return true;
+  });
+}
+
 /** Selective record: build the recorded set from only the findings whose key is in
  *  `selectedKeys`. Empty set -> []; all keys -> equals buildRecorded(findings). */
 export function selectRecorded(findings: Finding[], selectedKeys: Set<string>): RecordedEntry[] {
@@ -1017,8 +1098,17 @@ export function applyBaseline(
       // drift. For an identity-keyed object array (IAM inline Policies, …) attach the
       // element-level delta so the report shows WHICH element changed (R128, display-only;
       // the finding still names the whole-array path, so record/revert are unaffected).
+      // #758: carry the RECORDED value on `desired` (mirroring the `added` tier at :976), so
+      // the recorded→live diff is available to the report / --json / a re-record picker — the
+      // user must see WHAT the out-of-band change was, not just the (possibly attacker-set)
+      // live value under a bare label.
       const delta = identityArrayDelta(canonicalizeForCompare(entry.value), f.actual);
-      kept.push({ ...f, tier: 'undeclared', ...(delta && { arrayDelta: delta }) });
+      kept.push({
+        ...f,
+        tier: 'undeclared',
+        desired: canonicalizeForCompare(entry.value),
+        ...(delta && { arrayDelta: delta }),
+      });
       continue;
     }
     if (f.tier === 'atDefault' || f.tier === 'generated') {

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -9,6 +9,7 @@ import {
   recordedKey,
   applyBaseline,
   type BaselineFile,
+  baselineOnlyEntries,
   buildRecorded,
   carryForwardUnreadable,
   checkBaselineAccount,
@@ -16,6 +17,8 @@ import {
   declaredKeysByLogical,
   loadBaseline,
   physicalIdsByLogical,
+  type RecordedEntry,
+  recordedValueForChanged,
   selectRecorded,
   splitRecordedByBaseline,
   writeBaseline,
@@ -171,6 +174,65 @@ export function recordSelectMessage(stackName: string, region: string, foldedCou
       ? `; +${foldedCount} folded sub-key(s) ALWAYS recorded too (--verbose to itemize)`
       : '';
   return `${stackLabel(stackName, region)}: select undeclared value(s) to record (unselected stay reported)${fold}`;
+}
+
+/**
+ * #790: header for the record DROP multiselect — the baseline-only entries (a recorded value
+ * reverted to its AWS default, or removed out of band). Selecting a row DROPS the recorded
+ * watch (accept the drift); leaving it UNSELECTED preserves the entry (it keeps reporting as
+ * drift). Default-unselected, so one Enter here changes nothing. Pure + exported for unit tests.
+ */
+export function recordDropMessage(stackName: string, region: string): string {
+  return `${stackLabel(stackName, region)}: recorded value(s) reverted-to-default / removed since record — select to DROP from the baseline (unselected stay watched & reported)`;
+}
+
+/**
+ * #758: a compact single-line preview of a recorded/live VALUE for a record-picker label —
+ * so a `changed since record` row can show `recorded → live` and the user can see WHAT they
+ * are blessing (instead of a bare `Res.Path`). JSON-encoded (scalars stay bare-ish), then
+ * truncated to keep the multiselect row on one line. Pure + exported for unit tests.
+ */
+export function previewValue(v: unknown, max = 40): string {
+  let s: string;
+  try {
+    s = typeof v === 'string' ? v : JSON.stringify(v);
+  } catch {
+    s = String(v);
+  }
+  if (s === undefined) s = String(v); // JSON.stringify(undefined) === undefined
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * #758: the record multiselect label for a `changed` entry — a path already in the baseline
+ * whose live value differs this run (a recorded value CHANGED out of band). Distinct from a
+ * plain new-path row: it shows `recorded → live` (or a `(changed since record)` marker when the
+ * old value could not be paired) so the user does not silently bless a possibly-attacker-changed
+ * value under a bare label. Pure + exported for unit tests.
+ */
+export function changedRecordLabel(
+  entry: { logicalId: string; path: string; value: unknown },
+  recordedValue: { hasRecorded: boolean; recordedValue: unknown }
+): string {
+  const id = entry.path
+    ? `${entry.logicalId}.${entry.path}`
+    : `${entry.logicalId} (added resource)`;
+  if (!recordedValue.hasRecorded) return id; // genuinely NEW path — plain row
+  return `${id} (changed since record: ${previewValue(recordedValue.recordedValue)} → ${previewValue(entry.value)})`;
+}
+
+/**
+ * #790: the record multiselect label for a `baseline-only` drop-candidate — a recorded value
+ * that reverted to its AWS default (now folded away) or was REMOVED out of band, so it has no
+ * current undeclared finding. Selecting the row DROPS the recorded watch (an accept-drift
+ * action, so the row is default UNSELECTED); leaving it keeps the entry in the baseline. Pure +
+ * exported for unit tests.
+ */
+export function dropRecordLabel(entry: { logicalId: string; path: string }): string {
+  const id = entry.path
+    ? `${entry.logicalId}.${entry.path}`
+    : `${entry.logicalId} (added resource)`;
+  return `${id} (reverted-to-default / removed since record — drop from baseline?)`;
 }
 
 /**
@@ -362,8 +424,40 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
   // entries for resources this run could NOT read (skipped / model-read-failed) so a
   // re-record never silently shrinks the committed baseline (writeBaseline full-replaces).
   let recorded = carryForwardUnreadable(buildRecorded(findings), existing, findings);
+  // #790: baseline entries with NO current undeclared finding for a resource read cleanly —
+  // a recorded value reverted to its AWS default (folded away) or removed out of band. A naive
+  // full-replace re-record would silently DROP these (accepting drift `check` force-surfaces).
+  // Compute them up front so they can be PRESERVED by default under every path (--yes and
+  // interactive), and surfaced as an explicit "drop?" row in the interactive picker.
+  const dropCandidates: RecordedEntry[] = baselineOnlyEntries(recorded, existing, findings, {
+    declaredByLogical: declaredKeysByLogical(desired.resources),
+    allLogicalIds: desired.resources.map((r) => r.logicalId),
+  });
+  // #790: the baseline-only entries the user chose to DROP (interactive picker only). Empty by
+  // default so an entry is always PRESERVED unless explicitly selected — a re-record must not
+  // silently accept a reverted-to-default / removed value that `check` force-surfaces as drift.
+  const droppedKeys = new Set<string>();
+  // #758: a `record --yes` (scripts/CI) accepts every current value with no prompt. Echo a
+  // summary of what it BLESSED — recorded values CHANGED out of band (a possibly attacker-
+  // changed value) and baseline-only entries PRESERVED — so the acceptance is not silent.
+  if (yes && existing) {
+    const { changed } = splitRecordedByBaseline(recorded, existing);
+    const changedExisting = changed.filter((e) => recordedValueForChanged(e, existing).hasRecorded);
+    if (changedExisting.length > 0)
+      console.error(
+        `note: ${stackName}: --yes accepted ${changedExisting.length} recorded value(s) CHANGED out of band since record (review the baseline diff): ` +
+          changedExisting.map((e) => `${e.logicalId}.${e.path}`).join(', ')
+      );
+    if (dropCandidates.length > 0)
+      console.error(
+        `note: ${stackName}: --yes PRESERVED ${dropCandidates.length} recorded watch(es) whose value reverted-to-default / was removed since record (they still report as drift; re-run interactively to drop them)`
+      );
+  }
   let refreshedOnly = false; // true when only unchanged values remained (no delta to decide)
-  if (!yes && recorded.length > 0) {
+  // #790: a decision is also required when there are baseline-only drop candidates but zero
+  // current undeclared values (the exact reverted-to-default case) — else the interactive
+  // block is skipped and the drop rows are never shown.
+  if (!yes && (recorded.length > 0 || dropCandidates.length > 0)) {
     // A decision is required (which undeclared values to record). Non-interactively
     // we refuse rather than implicitly record ALL of them (R38).
     if (!interactive) {
@@ -382,8 +476,10 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
       );
     if (changed.length === 0) {
       // Nothing new to decide — just refresh the baseline (re-snapshot the unchanged set).
+      // #790: dropCandidates still get their own picker below, so this is a refresh only when
+      // there is also nothing to drop.
       recorded = unchanged;
-      refreshedOnly = true;
+      refreshedOnly = dropCandidates.length === 0;
     } else {
       // Per-finding path: the action picker already chose the keys, so take them
       // directly (no second prompt). Otherwise show the record multiselect.
@@ -415,14 +511,18 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
         } else {
           const fromPrompt = await bulkMultiselect(
             recordSelectMessage(stackName, region, folded.length),
-            // default = all selected (→/← bulk-toggle from there)
-            standout.map((e) => ({
-              value: recordedKey(e),
-              // an `added`-resource entry (PR4) has an empty path — the whole resource is
-              // the value — so omit the trailing dot and tag it as a resource snapshot.
-              label: e.path ? `${e.logicalId}.${e.path}` : `${e.logicalId} (added resource)`,
-              selected: true,
-            }))
+            standout.map((e) => {
+              // #758: a `changed` standout that has a MATCHING baseline entry is a recorded
+              // value CHANGED out of band — show `recorded → live` and default it UNSELECTED
+              // so the (possibly attacker-changed) value is not blessed by one Enter. A
+              // genuinely NEW path stays default-selected (today's behavior).
+              const rec = recordedValueForChanged(e, existing);
+              return {
+                value: recordedKey(e),
+                label: changedRecordLabel(e, rec),
+                selected: !rec.hasRecorded,
+              };
+            })
           );
           if (fromPrompt === undefined) {
             console.error(`note: ${stackName}: record cancelled — baseline unchanged`);
@@ -434,24 +534,56 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
       }
       const selectedChanged = selectRecorded(findings, new Set(picked));
       recorded = [...unchanged, ...selectedChanged]; // auto-kept unchanged + the user's picks
-      // The FINAL written set being empty (no unchanged + nothing picked) writes an EMPTY
-      // baseline. Since R62 that no longer arms revert removal (unrecorded values stay
-      // guarded per entry) — it just records "I decided nothing", so the values keep
-      // being reported as unrecorded. Still confirm: writing a file that changes nothing
-      // is more likely a mis-keyed multiselect than an intent (R19, defanged by R62).
-      // Skipped on the per-finding path: the picker is the decision, no extra confirm.
-      if (recorded.length === 0 && !preselectedKeys) {
-        const proceed = await confirm({
-          message: `${stackLabel(stackName, region)}: record nothing? This writes an EMPTY baseline — every undeclared value stays reported as unrecorded.`,
-          initialValue: false,
-        });
-        if (isCancel(proceed) || !proceed) {
-          console.error(`note: ${stackName}: record cancelled — baseline unchanged`);
-          return { wrote: false, refused: false };
-        }
+    }
+    // #790: offer the baseline-only entries (reverted-to-default / removed since record) as an
+    // explicit DROP multiselect — default UNSELECTED, so leaving the prompt PRESERVES the watch
+    // (unselected = keep). Dropping a recorded watch is an accept-drift action, so it is opt-in.
+    // Skipped on the per-finding path (the action picker owns the decision; unrelated entries
+    // must not be dropped by it).
+    if (dropCandidates.length > 0 && !preselectedKeys) {
+      const dropPrompt = await bulkMultiselect(
+        recordDropMessage(stackName, region),
+        dropCandidates.map((e) => ({
+          value: recordedKey(e),
+          label: dropRecordLabel(e),
+          selected: false, // default keep — dropping is an explicit accept-drift opt-in
+        }))
+      );
+      if (dropPrompt === undefined) {
+        console.error(`note: ${stackName}: record cancelled — baseline unchanged`);
+        return { wrote: false, refused: false };
+      }
+      for (const key of dropPrompt) droppedKeys.add(key);
+      refreshedOnly = false;
+    }
+    // #790: re-append the baseline-only entries the user did NOT drop, so a re-record preserves
+    // watched values that reverted-to-default / were removed (they keep reporting as drift).
+    recorded = [...recorded, ...dropCandidates.filter((e) => !droppedKeys.has(recordedKey(e)))];
+    // The FINAL written set being empty (no unchanged + nothing picked) writes an EMPTY
+    // baseline. Since R62 that no longer arms revert removal (unrecorded values stay
+    // guarded per entry) — it just records "I decided nothing", so the values keep
+    // being reported as unrecorded. Still confirm: writing a file that changes nothing
+    // is more likely a mis-keyed multiselect than an intent (R19, defanged by R62).
+    // Skipped on the per-finding path: the picker is the decision, no extra confirm.
+    if (recorded.length === 0 && !preselectedKeys) {
+      const proceed = await confirm({
+        message: `${stackLabel(stackName, region)}: record nothing? This writes an EMPTY baseline — every undeclared value stays reported as unrecorded.`,
+        initialValue: false,
+      });
+      if (isCancel(proceed) || !proceed) {
+        console.error(`note: ${stackName}: record cancelled — baseline unchanged`);
+        return { wrote: false, refused: false };
       }
     }
   }
+  // #790: ensure every baseline-only entry the user did NOT explicitly drop is in the written
+  // set — under --yes / the per-finding path the interactive drop picker never ran, so append
+  // them here (deduped by key, so a re-append after the interactive merge is a no-op). Without
+  // this, `writeBaseline`'s full-replace would silently drop a reverted-to-default / removed
+  // recorded value that `check` force-surfaces as drift.
+  const presentKeys = new Set(recorded.map(recordedKey));
+  for (const e of dropCandidates)
+    if (!droppedKeys.has(recordedKey(e)) && !presentKeys.has(recordedKey(e))) recorded.push(e);
   const { path, count } = await writeBaseline(
     stackName,
     region,

--- a/tests/record-lifecycle-790-758.test.ts
+++ b/tests/record-lifecycle-790-758.test.ts
@@ -1,0 +1,393 @@
+// #790 + #758: re-record must not SILENTLY accept drift on recorded values.
+//
+// #790: a baseline entry with NO current undeclared finding (its recorded value reverted to
+//       the AWS default, or was removed out of band) must NOT be silently pruned by the
+//       full-replace write — it surfaces as an explicit "drop?" row (default UNSELECTED) and,
+//       if not dropped, stays in the written baseline.
+// #758: a recorded value CHANGED out of band gets a picker row that is default UNSELECTED and
+//       shows `recorded → live`, and applyBaseline threads the recorded value onto the finding.
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import {
+  applyBaseline,
+  type BaselineFile,
+  baselineOnlyEntries,
+  baselinePath,
+  buildRecorded,
+  recordedValueForChanged,
+} from '../src/baseline/baseline-file.js';
+import {
+  changedRecordLabel,
+  dropRecordLabel,
+  previewValue,
+  recordDropMessage,
+  recordStack,
+} from '../src/commands/stack-actions.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import type { RecordedEntry } from '../src/baseline/baseline-file.js';
+import type { Finding } from '../src/types.js';
+
+const baseline = (recorded: RecordedEntry[], complete: string[] = []): BaselineFile => ({
+  schemaVersion: 2,
+  stackName: 's',
+  region: 'r',
+  accountId: '111122223333',
+  capturedAt: '',
+  templateHash: '',
+  recorded,
+  completeResources: complete,
+});
+
+// -------------------------------------------------------------------------------------------
+// #790 — baselineOnlyEntries (the drop-candidate set)
+// -------------------------------------------------------------------------------------------
+describe('baselineOnlyEntries (#790 — recorded value reverted-to-default / removed since record)', () => {
+  const entry: RecordedEntry = {
+    logicalId: 'A',
+    resourceType: 'AWS::IAM::Role',
+    path: 'MaxSessionDuration',
+    value: 7200,
+  };
+  const b = baseline([entry]);
+
+  it('surfaces a recorded entry whose resource read CLEAN but has no current undeclared finding', () => {
+    // MaxSessionDuration=7200 reset out of band to the 3600 default → classify tags it
+    // `atDefault`, so buildRecorded emits NOTHING for it. The resource was read cleanly (an
+    // atDefault finding present, no skip/gap), so its recorded value genuinely reverted.
+    const findings: Finding[] = [
+      {
+        tier: 'atDefault',
+        logicalId: 'A',
+        resourceType: 'AWS::IAM::Role',
+        path: 'MaxSessionDuration',
+        actual: 3600,
+      },
+    ];
+    const recorded = buildRecorded(findings); // = [] (atDefault is excluded)
+    const out = baselineOnlyEntries(recorded, b, findings, { allLogicalIds: ['A'] });
+    expect(out).toEqual([entry]);
+  });
+
+  it('surfaces a recorded property REMOVED out of band (no finding of any tier for the path)', () => {
+    // The resource is still present (read cleanly, other findings) but the recorded path is gone.
+    const findings: Finding[] = [];
+    const out = baselineOnlyEntries([], b, findings, { allLogicalIds: ['A'] });
+    expect(out).toEqual([entry]);
+  });
+
+  it('EXCLUDES an entry still recorded this run (unchanged/changed — has a live finding)', () => {
+    const findings: Finding[] = [
+      {
+        tier: 'undeclared',
+        logicalId: 'A',
+        resourceType: 'AWS::IAM::Role',
+        path: 'MaxSessionDuration',
+        actual: 7200,
+      },
+    ];
+    const recorded = buildRecorded(findings);
+    expect(baselineOnlyEntries(recorded, b, findings, { allLogicalIds: ['A'] })).toEqual([]);
+  });
+
+  it('EXCLUDES a skipped/model-read-failed resource (unread ≠ gone — carried forward elsewhere)', () => {
+    const skipped: Finding[] = [
+      { tier: 'skipped', logicalId: 'A', resourceType: 'AWS::IAM::Role', path: '' },
+    ];
+    expect(baselineOnlyEntries([], b, skipped, { allLogicalIds: ['A'] })).toEqual([]);
+  });
+
+  it('EXCLUDES a deleted resource (#675 story, subsumed by the deleted finding)', () => {
+    const deleted: Finding[] = [
+      { tier: 'deleted', logicalId: 'A', resourceType: 'AWS::IAM::Role', path: '' },
+    ];
+    expect(baselineOnlyEntries([], b, deleted, { allLogicalIds: ['A'] })).toEqual([]);
+  });
+
+  it('EXCLUDES a resource no longer in the template (allLogicalIds gate, #675)', () => {
+    expect(baselineOnlyEntries([], b, [], { allLogicalIds: [] })).toEqual([]);
+  });
+
+  it('EXCLUDES a path since PROMOTED into the template (declared — the clean-up nudge)', () => {
+    const declaredByLogical = new Map([['A', { MaxSessionDuration: 3600 }]]);
+    expect(baselineOnlyEntries([], b, [], { allLogicalIds: ['A'], declaredByLogical })).toEqual([]);
+  });
+
+  it('EXCLUDES an `added`-resource snapshot (empty path — reconciled resource-wise)', () => {
+    const addedEntry = baseline([
+      { logicalId: 'Child', resourceType: 'AWS::ApiGateway::Stage', path: '', value: { x: 1 } },
+    ]);
+    expect(baselineOnlyEntries([], addedEntry, [], { allLogicalIds: ['Child'] })).toEqual([]);
+  });
+
+  it('returns [] when there is no baseline', () => {
+    expect(baselineOnlyEntries([], undefined, [], {})).toEqual([]);
+  });
+});
+
+// -------------------------------------------------------------------------------------------
+// #758 — recordedValueForChanged + labels + applyBaseline threading
+// -------------------------------------------------------------------------------------------
+describe('recordedValueForChanged (#758 — old recorded value for a changed row)', () => {
+  const b = baseline([{ logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'P', value: 'OLD' }]);
+  it('returns the recorded value for a matching baseline entry', () => {
+    const e: RecordedEntry = {
+      logicalId: 'A',
+      resourceType: 'AWS::IAM::Role',
+      path: 'P',
+      value: 'NEW',
+    };
+    expect(recordedValueForChanged(e, b)).toEqual({ hasRecorded: true, recordedValue: 'OLD' });
+  });
+  it('hasRecorded=false for a genuinely NEW path', () => {
+    const e: RecordedEntry = {
+      logicalId: 'A',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Q',
+      value: 1,
+    };
+    expect(recordedValueForChanged(e, b)).toEqual({ hasRecorded: false, recordedValue: undefined });
+  });
+  it('hasRecorded=false with no baseline', () => {
+    const e: RecordedEntry = {
+      logicalId: 'A',
+      resourceType: 'AWS::IAM::Role',
+      path: 'P',
+      value: 1,
+    };
+    expect(recordedValueForChanged(e, undefined)).toEqual({
+      hasRecorded: false,
+      recordedValue: undefined,
+    });
+  });
+});
+
+describe('record labels (#758 / #790)', () => {
+  it('previewValue truncates a long value to one line', () => {
+    expect(previewValue('short')).toBe('short');
+    expect(previewValue('x'.repeat(60), 10)).toBe(`${'x'.repeat(9)}…`);
+    expect(previewValue({ a: 1 })).toBe('{"a":1}');
+  });
+  it('changedRecordLabel shows recorded → live for a CHANGED entry', () => {
+    const label = changedRecordLabel(
+      { logicalId: 'A', path: 'P', value: 'NEW' },
+      { hasRecorded: true, recordedValue: 'OLD' }
+    );
+    expect(label).toBe('A.P (changed since record: OLD → NEW)');
+  });
+  it('changedRecordLabel is a plain row for a NEW path (no recorded value)', () => {
+    const label = changedRecordLabel(
+      { logicalId: 'A', path: 'P', value: 'NEW' },
+      { hasRecorded: false, recordedValue: undefined }
+    );
+    expect(label).toBe('A.P');
+  });
+  it('dropRecordLabel names the reverted/removed entry', () => {
+    expect(dropRecordLabel({ logicalId: 'A', path: 'MaxSessionDuration' })).toContain(
+      'A.MaxSessionDuration'
+    );
+    expect(dropRecordLabel({ logicalId: 'A', path: 'MaxSessionDuration' })).toContain(
+      'drop from baseline?'
+    );
+  });
+  it('recordDropMessage states unselected stay watched', () => {
+    expect(recordDropMessage('s', 'r')).toContain('unselected stay watched');
+  });
+});
+
+describe('applyBaseline threads the recorded value onto a CHANGED undeclared finding (#758)', () => {
+  it('a recorded value reset to the AWS default carries the recorded value on `desired`', () => {
+    const b = baseline([
+      { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'MaxSessionDuration', value: 7200 },
+    ]);
+    const out = applyBaseline(
+      [
+        {
+          tier: 'atDefault',
+          logicalId: 'A',
+          resourceType: 'AWS::IAM::Role',
+          path: 'MaxSessionDuration',
+          actual: 3600,
+        },
+      ],
+      b
+    );
+    expect(out).toHaveLength(1);
+    // #758: the recorded (7200) → live (3600) diff is now available on the finding, not just live.
+    expect(out[0]).toMatchObject({ tier: 'undeclared', desired: 7200, actual: 3600 });
+  });
+});
+
+// -------------------------------------------------------------------------------------------
+// #790 + #758 — recordStack integration (writes a real baseline file to disk)
+// -------------------------------------------------------------------------------------------
+describe('recordStack lifecycle (#790 preserve reverted/removed watches; #758 --yes summary)', () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths.splice(0)) if (existsSync(p)) rmSync(p);
+  });
+
+  function makeDesired(overrides: Partial<Desired> = {}): Desired {
+    return {
+      stackName: 'Lifecycle790',
+      region: 'lc-790-region',
+      accountId: '999988887777',
+      resources: [{ logicalId: 'A', resourceType: 'AWS::IAM::Role', declared: {} }],
+      rawTemplate: '{}',
+      ctx: {},
+      ...overrides,
+    } as unknown as Desired;
+  }
+
+  function seedBaseline(desired: Desired, recorded: RecordedEntry[]): string {
+    const p = baselinePath(desired.stackName, desired.accountId, desired.region);
+    mkdirSync(dirname(p), { recursive: true });
+    // Stamp the file's identity (stack/region/account) to match its path so loadBaseline's
+    // identity guard accepts it.
+    const b: BaselineFile = {
+      ...baseline(recorded, ['A']),
+      stackName: desired.stackName,
+      region: desired.region,
+      accountId: desired.accountId,
+    };
+    writeFileSync(p, JSON.stringify(b), 'utf8');
+    paths.push(p);
+    return p;
+  }
+
+  it('#790: a recorded value reverted-to-default is PRESERVED under --yes (not silently dropped)', async () => {
+    const desired = makeDesired();
+    const p = seedBaseline(desired, [
+      { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'MaxSessionDuration', value: 7200 },
+    ]);
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+      errs.push(String(m));
+    });
+    try {
+      // classify now reports MaxSessionDuration at the 3600 default (atDefault) → NO undeclared
+      // finding. A naive full-replace would drop the recorded 7200 entry with zero output.
+      const findings: Finding[] = [
+        {
+          tier: 'atDefault',
+          logicalId: 'A',
+          resourceType: 'AWS::IAM::Role',
+          path: 'MaxSessionDuration',
+          actual: 3600,
+        },
+      ];
+      const result = await recordStack({
+        stackName: desired.stackName,
+        region: desired.region,
+        desired,
+        findings,
+        yes: true,
+        interactive: false,
+      });
+      expect(result.wrote).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+    const written = JSON.parse(readFileSync(p, 'utf8')) as BaselineFile;
+    // the recorded watch is PRESERVED, not pruned
+    expect(written.recorded).toEqual([
+      { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'MaxSessionDuration', value: 7200 },
+    ]);
+    // and --yes is NOT silent about it
+    expect(errs.join('\n')).toContain('PRESERVED 1 recorded watch');
+  });
+
+  it('#790: a recorded property REMOVED out of band is PRESERVED under --yes', async () => {
+    const desired = makeDesired();
+    const p = seedBaseline(desired, [
+      { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'Description', value: 'my-role' },
+    ]);
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await recordStack({
+        stackName: desired.stackName,
+        region: desired.region,
+        desired,
+        findings: [], // resource read clean, path gone
+        yes: true,
+        interactive: false,
+      });
+      expect(result.wrote).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+    const written = JSON.parse(readFileSync(p, 'utf8')) as BaselineFile;
+    expect(written.recorded).toEqual([
+      { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'Description', value: 'my-role' },
+    ]);
+  });
+
+  it('#758: --yes echoes a summary when a recorded value CHANGED out of band', async () => {
+    const desired = makeDesired();
+    seedBaseline(desired, [
+      { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'MaxSessionDuration', value: 7200 },
+    ]);
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+      errs.push(String(m));
+    });
+    try {
+      // the recorded value 7200 was CHANGED to 43200 out of band (still an undeclared finding)
+      const findings: Finding[] = [
+        {
+          tier: 'undeclared',
+          logicalId: 'A',
+          resourceType: 'AWS::IAM::Role',
+          path: 'MaxSessionDuration',
+          actual: 43200,
+        },
+      ];
+      await recordStack({
+        stackName: desired.stackName,
+        region: desired.region,
+        desired,
+        findings,
+        yes: true,
+        interactive: false,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+    expect(errs.join('\n')).toContain('--yes accepted 1 recorded value(s) CHANGED out of band');
+    expect(errs.join('\n')).toContain('A.MaxSessionDuration');
+  });
+
+  it('regression: a normal NEW-undeclared record under --yes still records the value', async () => {
+    const desired = makeDesired();
+    const p = baselinePath(desired.stackName, desired.accountId, desired.region);
+    if (existsSync(p)) rmSync(p);
+    paths.push(p);
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const findings: Finding[] = [
+        {
+          tier: 'undeclared',
+          logicalId: 'A',
+          resourceType: 'AWS::IAM::Role',
+          path: 'MaxSessionDuration',
+          actual: 7200,
+        },
+      ];
+      const result = await recordStack({
+        stackName: desired.stackName,
+        region: desired.region,
+        desired,
+        findings,
+        yes: true,
+        interactive: false,
+      });
+      expect(result.wrote).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+    const written = JSON.parse(readFileSync(p, 'utf8')) as BaselineFile;
+    expect(written.recorded).toEqual([
+      { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'MaxSessionDuration', value: 7200 },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #790
Closes #758

Two re-record silent-acceptance bugs (same files).

## #790 — baseline-only entries silently PRUNED
A re-record full-replaces the baseline with only the freshly-built recorded set. A baseline entry whose value **reverted to the AWS default** (now folded `atDefault`/`generated`) or was **removed out of band** — which `check` force-surfaces as drift — had no counterpart in the new set and was silently DROPPED (drift accepted, zero output).

**Fix:** `baselineOnlyEntries()` computes these drop-candidates, EXCLUDING every benign-stale case (skipped/unread, deleted, not-in-template #675, promoted-to-declared #749/#1079, `added` snapshots — mirroring `applyBaseline`'s removed-since-record exclusion set). `recordStack` PRESERVES them by default under every path (`--yes`, per-finding, interactive) and offers an explicit **default-UNSELECTED** "drop from baseline?" multiselect. `--yes` echoes a `PRESERVED N watch(es)` note.

## #758 — changed-since-record rows pre-selected under a bare label
The record multiselect pre-selected recorded-value-**CHANGED**-out-of-band rows under a bare `Res.Path` label — one Enter blessed a possibly-attacker-set value, and the old recorded value was never shown.

**Fix:** changed rows now render `recorded → live` and default **UNSELECTED** (genuinely new paths stay pre-selected, today's behavior). `applyBaseline` threads the recorded value onto the changed undeclared finding's `desired` (mirroring the `added` tier at plan restore `value: f.desired` — so this is the correct restore-to-recorded target, verified against the revert plan contract). `--yes` echoes an accepted-changed summary.

## Review notes
- **`desired` on undeclared findings**: revert's op value for undeclared drift is `f.desired` (plan.ts:917 = restore-to-baseline). The threaded value is exactly `canonicalizeForCompare(entry.value)` (the recorded value), so it matches / improves the restore target — full suite (3934 tests) green including revert.
- **Semantics of an UNSELECTED changed row**: it is not re-recorded, so the path leaves the baseline and `check` re-reports it as unrecorded undeclared drift (still reported — not silently accepted). If you'd prefer 'unselected = keep watching the OLD value (keep flagging changed-since-record)', that's a one-spot change — flagging for your call.

## Tests
`tests/record-lifecycle-790-758.test.ts` (22): `baselineOnlyEntries` exclusion matrix (9), `recordedValueForChanged`/label helpers (8), `applyBaseline` threads desired (1), and 4 `recordStack` integration proofs (#790 reverted-to-default + removed PRESERVED under --yes; #758 --yes changed-summary; new-undeclared regression). 21/22 fail without the fix.

Files: `src/baseline/baseline-file.ts`, `src/commands/stack-actions.ts`, README.