### PR TITLE
fix(check): perFinding state bugs — cancelled revert mis-reported + record ran with stale config (#761)

### DIFF
--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -528,24 +528,15 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
   if (groups.record.length + groups.ignore.length + groups.revert.length === 0)
     return { exit: p.code, awsMutated: false };
 
-  // record: the picker already chose which undeclared values — recordStack records
-  // exactly those (preselectedKeys) while still auto-keeping the existing baseline.
-  if (groups.record.length > 0) {
-    const preselectedKeys = new Set(buildRecorded(groups.record).map(recordedKey));
-    await recordStack({
-      stackName: p.stackName,
-      region: p.region,
-      desired: p.desired,
-      findings: applyIgnores(
-        p.findings,
-        { stackName: p.stackName, accountId: p.desired.accountId, region: p.region },
-        p.config
-      ),
-      yes: p.yes,
-      interactive: true,
-      preselectedKeys,
-    });
-  }
+  // ignore FIRST, then record (#761): record snapshots completeness against the
+  // ignore-filtered findings, so it must see the ignore rules THIS pass writes. If record
+  // ran first with the pre-pass `p.config`, a to-be-ignored finding would still read as an
+  // unrecorded `undeclared` value and BLOCK the resource from being marked snapshot-complete
+  // (computeCompleteResources) — a future value there would then read `unrecorded` (inventory)
+  // instead of "appeared since record" (drift), weakening detection until the next record.
+  // The bulk-chain path stays clean because it reloads config between actions; we mirror that
+  // by ordering the write before the read AND reloading the config for the record call below.
+  //
   // ignore: write rules for exactly the chosen findings (yes:true skips ignoreStack's
   // own multiselect — the picker IS the selection). addIgnoreRules unions, no data loss.
   if (groups.ignore.length > 0) {
@@ -558,10 +549,37 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
       region: p.region,
     });
   }
+  // record: the picker already chose which undeclared values — recordStack records
+  // exactly those (preselectedKeys) while still auto-keeping the existing baseline.
+  if (groups.record.length > 0) {
+    const preselectedKeys = new Set(buildRecorded(groups.record).map(recordedKey));
+    // Reload the config so record sees the ignore rules just written above (#761) — mirrors
+    // how the top-level chain loop reloads config between non-AWS actions. Only ignore writes
+    // config here, so skip the reload when nothing was ignored (no change to observe).
+    const recordConfig = groups.ignore.length > 0 ? await loadConfig() : p.config;
+    await recordStack({
+      stackName: p.stackName,
+      region: p.region,
+      desired: p.desired,
+      findings: applyIgnores(
+        p.findings,
+        { stackName: p.stackName, accountId: p.desired.accountId, region: p.region },
+        recordConfig
+      ),
+      yes: p.yes,
+      interactive: true,
+      preselectedKeys,
+    });
+  }
   // revert (AWS, last): pass ONLY the chosen findings; autoSelectAll skips the op
   // multiselect (already chosen) but keeps the AWS-write confirm.
   let revertResolved = new Set<string>();
   let revertExit = 0;
+  // #761: track whether the revert actually wrote. A CANCELLED confirm (outcome.aborted)
+  // mutates nothing, so it must NOT make the pass terminal (awsMutated) nor be reported as
+  // "applied" in the closing note — else the user answers No at the AWS-write confirm yet
+  // the summary claims the revert happened and the menu never re-shows to re-address it.
+  let revertAborted = false;
   if (groups.revert.length > 0) {
     const revertKeys = new Set(groups.revert.map(keyOf));
     const outcome = await revertStack({
@@ -586,18 +604,26 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
       interactive: true,
       autoSelectAll: true,
     });
+    revertAborted = outcome.aborted;
     if (!outcome.aborted) {
       revertResolved = revertKeys; // converged-or-attempted; outcome.exit folds in non-convergence
       revertExit = outcome.exit;
     }
   }
+  // Word the revert group by what actually happened (#761): "cancelled" when the AWS-write
+  // confirm was declined (nothing written), "applied" otherwise. record/ignore always apply.
+  const revertSummary = revertAborted
+    ? summarizeChoices(chosen.map((a) => (a === 'revert' ? 'skip' : a)))
+    : summarizeChoices(chosen);
+  const cancelledNote = revertAborted ? ` (${groups.revert.length} revert cancelled)` : '';
   console.error(
-    `note: ${p.stackName}: per-finding decisions applied (${summarizeChoices(chosen)}).`
+    `note: ${p.stackName}: per-finding decisions applied (${revertSummary})${cancelledNote}.`
   );
   return {
     exit: Math.max(await recomputeExit(p, revertResolved), revertExit),
-    // per-finding is terminal only if it actually wrote to AWS (a revert ran); a
-    // record/ignore-only per-finding pass is re-derivable, so the menu re-shows.
-    awsMutated: groups.revert.length > 0,
+    // per-finding is terminal only if it actually wrote to AWS (a revert that was NOT
+    // cancelled); a record/ignore-only pass, or a CANCELLED revert (#761), is re-derivable,
+    // so the menu re-shows to re-address the still-standing drift.
+    awsMutated: groups.revert.length > 0 && !revertAborted,
   };
 }

--- a/tests/perfinding-flow-761.test.ts
+++ b/tests/perfinding-flow-761.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// #761: two state bugs in interactive-resolve.ts's `perFinding` flow.
+//  A — a CANCELLED revert confirm was still treated as "applied" + terminal.
+//  B — record ran before ignore with a STALE config → completeness under-marked.
+//
+// The top menu `select` returns 'per-finding'; the action-picker returns the per-row
+// action assignment; the AWS/local writers are spied.
+
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, select: vi.fn(), isCancel: () => false };
+});
+
+// Replace the per-finding action picker with a spy so a test can dictate the action
+// assigned to each decidable row (the real one drives a TTY).
+vi.mock('../src/commands/action-picker.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, actionPicker: vi.fn() };
+});
+
+// Keep the real availableActions/applicableActions/groupByAction, but spy the writers so
+// we can assert HOW perFinding calls them (revert's aborted outcome, record's findings).
+vi.mock('../src/commands/stack-actions.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    revertStack: vi.fn().mockResolvedValue({ exit: 0, aborted: false }),
+    ignoreStack: vi.fn().mockResolvedValue({ wrote: true, refused: false, added: 1 }),
+    recordStack: vi.fn().mockResolvedValue({ wrote: true, refused: false }),
+  };
+});
+
+// Spy loadConfig + applyIgnores (config-file) so Bug B can assert the record call re-reads
+// the config AFTER ignore wrote its rules. applyIgnores stays a real pass-through wrapper
+// so we can capture which config object it was handed on each call.
+vi.mock('../src/config/config-file.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    loadConfig: vi.fn(),
+    applyIgnores: vi.fn(),
+  };
+});
+
+import { select } from '@clack/prompts';
+import { actionPicker } from '../src/commands/action-picker.js';
+import { ignoreStack, recordStack, revertStack } from '../src/commands/stack-actions.js';
+import { applyIgnores, loadConfig } from '../src/config/config-file.js';
+import { resolveInteractively } from '../src/commands/interactive-resolve.js';
+import type { Finding } from '../src/types.js';
+
+const undeclaredDrift: Finding = {
+  tier: 'undeclared',
+  logicalId: 'R',
+  physicalId: 'r-phys',
+  resourceType: 'AWS::S3::Bucket',
+  path: 'OwnershipControls',
+  actual: 'x',
+};
+const declaredDrift: Finding = {
+  tier: 'declared',
+  logicalId: 'B',
+  physicalId: 'b-phys',
+  resourceType: 'AWS::S3::Bucket',
+  path: 'VersioningConfiguration.Status',
+  desired: 'Enabled',
+  actual: 'Suspended',
+};
+
+// The initial config passed into resolveInteractively (pre-ignore); a fresh reload returns
+// a DIFFERENT object so a test can tell which one the record call was handed.
+const preConfig = { version: 1, ignore: [] } as const;
+const postConfig = { version: 1, ignore: [{ path: 'R.OwnershipControls' }] } as const;
+
+const params = (findings: Finding[]) =>
+  ({
+    stackName: 'S',
+    region: 'us-east-1',
+    desired: {
+      accountId: '111122223333',
+      resources: [
+        { logicalId: 'R', resourceType: 'AWS::S3::Bucket', declared: {} },
+        { logicalId: 'B', resourceType: 'AWS::S3::Bucket', declared: {} },
+      ],
+    },
+    findings,
+    reconciled: findings,
+    baseline: { schemaVersion: 1, recorded: [] },
+    schemas: new Map(),
+    liveByLogical: new Map(),
+    config: preConfig,
+    code: 1,
+    yes: false,
+    removeUnrecorded: false,
+    verbose: false,
+  }) as unknown as Parameters<typeof resolveInteractively>[0];
+
+// Capture what console.error emitted (the closing note) for the current test.
+let notes: string[];
+const errSpy = vi.spyOn(console, 'error');
+
+beforeEach(() => {
+  vi.mocked(select).mockReset();
+  vi.mocked(actionPicker).mockReset();
+  vi.mocked(revertStack).mockClear();
+  vi.mocked(recordStack).mockClear();
+  vi.mocked(ignoreStack).mockClear();
+  vi.mocked(revertStack).mockResolvedValue({ exit: 0, aborted: false });
+  vi.mocked(recordStack).mockResolvedValue({ wrote: true, refused: false });
+  vi.mocked(ignoreStack).mockResolvedValue({ wrote: true, refused: false, added: 1 });
+  // applyIgnores: identity pass-through (returns the findings unchanged) so reconciliation
+  // works; loadConfig: return the post-ignore config so a reload is observable.
+  vi.mocked(applyIgnores).mockImplementation(
+    (findings: Finding[]) => findings as unknown as ReturnType<typeof applyIgnores>
+  );
+  vi.mocked(loadConfig).mockResolvedValue(
+    postConfig as unknown as Awaited<ReturnType<typeof loadConfig>>
+  );
+  notes = [];
+  errSpy.mockClear();
+  errSpy.mockImplementation((...a: unknown[]) => {
+    notes.push(a.join(' '));
+  });
+});
+
+describe('#761 Bug A — a CANCELLED per-finding revert is not "applied" nor terminal', () => {
+  it('cancelled revert (outcome.aborted) → awsMutated false (menu re-shows) + note says "cancelled"', async () => {
+    // per-finding needs >1 decidable finding to appear in the menu; assign revert to both.
+    vi.mocked(select)
+      .mockResolvedValueOnce('per-finding') // top menu
+      .mockResolvedValueOnce('nothing'); // re-shown menu (revert cancelled, drift stands) → exit
+    vi.mocked(actionPicker).mockResolvedValueOnce(['revert', 'revert']);
+    // The AWS-write confirm is DECLINED → nothing written.
+    vi.mocked(revertStack).mockResolvedValueOnce({ exit: 0, aborted: true });
+
+    await resolveInteractively(params([undeclaredDrift, declaredDrift]));
+
+    // The menu was re-shown (a second `select` call) — proof the pass was NOT terminal.
+    expect(vi.mocked(select)).toHaveBeenCalledTimes(2);
+    // The closing note flags the revert as cancelled, not applied.
+    const note = notes.find((n) => n.includes('per-finding decisions applied'));
+    expect(note).toBeDefined();
+    expect(note!).toContain('2 revert cancelled');
+    // the APPLIED-summary segment (before the "(… cancelled)" tail) must NOT claim a revert
+    // ran — with only a cancelled revert it degrades to "nothing selected".
+    const appliedSegment = note!.slice(0, note!.indexOf(' (2 revert cancelled)'));
+    expect(appliedSegment).not.toMatch(/revert/);
+    expect(appliedSegment).toContain('nothing selected');
+  });
+
+  it('applied revert (not aborted) → awsMutated true (terminal, menu NOT re-shown) + note says the revert', async () => {
+    vi.mocked(select).mockResolvedValueOnce('per-finding'); // top menu ONLY — terminal after write
+    vi.mocked(actionPicker).mockResolvedValueOnce(['revert', 'revert']);
+    vi.mocked(revertStack).mockResolvedValueOnce({ exit: 0, aborted: false });
+
+    await resolveInteractively(params([undeclaredDrift, declaredDrift]));
+
+    // Terminal: only the ONE top-menu select fired (no re-show).
+    expect(vi.mocked(select)).toHaveBeenCalledTimes(1);
+    const note = notes.find((n) => n.includes('per-finding decisions applied'));
+    expect(note).toBeDefined();
+    expect(note!).not.toContain('cancelled');
+    expect(note!).toContain('2 revert'); // applied summary counts the revert
+  });
+});
+
+describe('#761 Bug B — record sees the ignore rules written earlier in the same pass', () => {
+  it('ignore X + record Y → record runs AFTER ignore with a RELOADED (post-ignore) config', async () => {
+    // Two undeclared findings on distinct resources: X ignored, Y recorded.
+    const ignoreMe: Finding = { ...undeclaredDrift, logicalId: 'R', path: 'OwnershipControls' };
+    const recordMe: Finding = { ...undeclaredDrift, logicalId: 'B', path: 'ObjectLockEnabled' };
+    vi.mocked(select).mockResolvedValueOnce('per-finding').mockResolvedValueOnce('nothing'); // re-shown menu → exit (no AWS write in this pass)
+    // row 0 (X) → ignore, row 1 (Y) → record
+    vi.mocked(actionPicker).mockResolvedValueOnce(['ignore', 'record']);
+
+    await resolveInteractively(params([ignoreMe, recordMe]));
+
+    // ignore ran, then record ran.
+    expect(ignoreStack).toHaveBeenCalledTimes(1);
+    expect(recordStack).toHaveBeenCalledTimes(1);
+    // The config was RELOADED (loadConfig re-read) so record sees the just-written rule.
+    // Without the fix, record used p.config (preConfig) and loadConfig would only be called
+    // in the post-action recomputeExit — never BEFORE recordStack.
+    const recordOrder = vi.mocked(recordStack).mock.invocationCallOrder[0]!;
+    const ignoreOrder = vi.mocked(ignoreStack).mock.invocationCallOrder[0]!;
+    expect(ignoreOrder).toBeLessThan(recordOrder); // ignore BEFORE record
+
+    // The applyIgnores call that built record's findings received the POST-ignore config,
+    // not the stale preConfig. Find the applyIgnores call whose config is postConfig and
+    // assert it happened before recordStack.
+    const postIgnoreCall = vi
+      .mocked(applyIgnores)
+      .mock.calls.find((c) => c[2] === (postConfig as unknown));
+    expect(postIgnoreCall).toBeDefined();
+  });
+
+  it('record with NO ignore in the same pass does NOT force a config reload before record', async () => {
+    // Only a record action → no ignore rule to reload for; p.config is fresh enough.
+    const recordMe: Finding = { ...undeclaredDrift, logicalId: 'B', path: 'ObjectLockEnabled' };
+    const other: Finding = { ...undeclaredDrift, logicalId: 'R', path: 'OwnershipControls' };
+    vi.mocked(select).mockResolvedValueOnce('per-finding').mockResolvedValueOnce('nothing');
+    vi.mocked(actionPicker).mockResolvedValueOnce(['record', 'skip']);
+
+    await resolveInteractively(params([recordMe, other]));
+
+    expect(ignoreStack).not.toHaveBeenCalled();
+    expect(recordStack).toHaveBeenCalledTimes(1);
+    // record's findings were built with the ORIGINAL preConfig (no reload needed).
+    const recordFindingsCall = vi
+      .mocked(applyIgnores)
+      .mock.calls.find((c) => c[2] === (preConfig as unknown));
+    expect(recordFindingsCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #761 — two state bugs in the `perFinding` flow (`interactive-resolve.ts`).

## Bug A — a CANCELLED revert confirm treated as applied + terminal
`awsMutated` was `groups.revert.length > 0` regardless of `outcome.aborted`. So when the user answered **No** at the "this WRITES to AWS" confirm, nothing was written yet the pass went terminal (menu never re-shown → drift can't be re-addressed this run) and the closing note claimed the revert was applied.
**Fix:** `awsMutated = groups.revert.length > 0 && !revertAborted`; the closing note now words the revert group `(N revert cancelled)` vs applied. (Exit code was already correct — `revertResolved` stayed empty.)

## Bug B — record ran before ignore with a stale config
`record` ran FIRST using the pre-pass `p.config`, so a to-be-ignored `undeclared` finding still read as unrecorded and BLOCKED its resource from being marked snapshot-complete (`computeCompleteResources`) — a future value there then read `unrecorded` (inventory) instead of "appeared since record" (drift), weakening detection until the next record.
**Fix:** write the **ignore** group FIRST, then `record` with a **reloaded** config (`groups.ignore.length > 0 ? await loadConfig() : p.config`) — mirroring how the top-level chain loop reloads config between non-AWS actions. Revert stays AWS-last, unchanged.

## Tests
`tests/perfinding-flow-761.test.ts` (4): Bug A cancelled (awsMutated false + "cancelled" note, menu re-shows) / applied guard; Bug B reload (ignore precedes record, record gets post-ignore config) / no-ignore guard. The 2 primary tests fail without the fix.

File: `src/commands/interactive-resolve.ts`.