### PR TITLE
fix(baseline): recorded added-resource lifecycle — surface OOB deletion + carry-forward under throttled parent (#791)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -604,9 +604,19 @@ export function carryForwardUnreadable(
   );
   if (unreadable.size === 0) return recorded;
   const present = new Set(recorded.map(recordedKey));
-  const preserved = prior.filter(
-    (e) => unreadable.has(e.logicalId) && !present.has(recordedKey(e))
-  );
+  // #791: a recorded `added` child entry is keyed on the synthesized child id
+  // `${parent.logicalId}/${identifier}` (baseline-file.ts / gather.ts), but an enumeration
+  // failure emits its `skipped` finding on the PARENT logicalId — so `unreadable.has(id)`
+  // never matches the child directly and ALL prior added entries under a throttled parent
+  // would be silently DROPPED from the full-replace write (defeating this function for the
+  // added tier). Match the child too when its PARENT is unreadable: the child could not be
+  // enumerated, so it is unread this run, not gone — carry it forward.
+  const isUnread = (e: RecordedEntry): boolean => {
+    if (unreadable.has(e.logicalId)) return true;
+    const parent = addedChildParentLogicalId(e.logicalId);
+    return parent !== undefined && unreadable.has(parent);
+  };
+  const preserved = prior.filter((e) => isUnread(e) && !present.has(recordedKey(e)));
   return preserved.length === 0 ? recorded : [...recorded, ...preserved];
 }
 
@@ -910,6 +920,17 @@ function pathSegments(path: string): string[] {
     .filter((s) => s.length > 0);
 }
 
+// #791: the PARENT logicalId of an out-of-band `added` child entry. gather.ts synthesizes
+// the child's logicalId as `${parent.logicalId}/${identifier}` (an added child is not in the
+// template, so it has no logicalId of its own) — the CC identifier may be composite (e.g.
+// `RestApiId|ResourceId|HttpMethod`, pipe-joined, never `/`), and a CloudFormation logical id
+// is alphanumeric (never `/`), so the parent is the segment BEFORE the FIRST `/`. Returns
+// undefined for an id without a `/` (a top-level property entry, not an added child).
+function addedChildParentLogicalId(logicalId: string): string | undefined {
+  const slash = logicalId.indexOf('/');
+  return slash < 0 ? undefined : logicalId.slice(0, slash);
+}
+
 // Descend one segment into a declared node. Object: index by key. Array: index by the
 // element's identity-field value (the `[<id>]` grammar) when an element carries a matching
 // identity field, else fall back to a numeric index. Returns undefined when the segment
@@ -1170,6 +1191,27 @@ export function applyBaseline(
   const deletedLogical = new Set(
     findings.filter((f) => f.tier === 'deleted').map((f) => f.logicalId)
   );
+  // #791: the child ids STILL enumerated as `added` this run (the whole-resource `added`
+  // findings, keyed on the synthesized `${parent}/${identifier}` id). A recorded added
+  // entry whose id is in here still exists — reconciled in the loop above (suppressed or
+  // "changed since record"), never "removed". `modelReadFailed` added findings count as
+  // present too: the resource EXISTS (only its full model was unreadable this run), so it
+  // is unread, not gone.
+  const presentAddedLogical = new Set(
+    findings.filter((f) => f.tier === 'added').map((f) => f.logicalId)
+  );
+  // #791: logicalIds POSITIVELY proven READ this run — any finding that is NOT the
+  // unread/gone signal (`skipped`/`deleted`). A parent that was gathered and classified
+  // emits at least one such finding (undeclared / atDefault / generated / declared / added
+  // child …); a parent that was UNREAD emits only a `skipped`/`deleted`. Gap 1 (surfacing
+  // an endorsed added child DELETED out of band) fires only when the child's parent is in
+  // here — POSITIVE read-proof — so the ambiguous "no signal at all for the parent" case
+  // (a degenerate/empty findings input) folds to "unread → carry forward", never a false
+  // deletion. This is the precise guard the Gap 1 / Gap 2 interaction needs: a child under a
+  // THROTTLED parent (parent `skipped`, absent here) is carried forward, not reported gone.
+  const readParentLogical = new Set(
+    findings.filter((f) => f.tier !== 'skipped' && f.tier !== 'deleted').map((f) => f.logicalId)
+  );
   // A recorded nested undeclared value whose DECLARED parent property is itself
   // drifting this run is subsumed by that `declared` finding: the parent array/object
   // changed (e.g. CloudFront `DistributionConfig.Origins` -> []), so the nested value's
@@ -1194,11 +1236,43 @@ export function applyBaseline(
   const replacedStale: string[] = []; // #674
   const typeMismatchStale: string[] = []; // #793
   for (const a of recorded) {
-    // PR4: an `added`-resource entry has an empty path (the whole resource is the value)
-    // and is reconciled in the loop above, never here. If its live resource is gone the
-    // out-of-band addition was simply removed — nothing to "restore", so skip it (a
-    // property-removal note against a synthesized child id would be meaningless).
-    if (a.path === '') continue;
+    // #791: an `added`-resource entry has an empty path (the WHOLE resource is the value)
+    // and is reconciled in the loop above when its live child is still enumerated. When it
+    // is NOT — the user RECORDED (endorsed) an out-of-band child, and it has since been
+    // DELETED out of band — "record KEEPS watching" means that deletion is drift and must
+    // surface. But only when the resource is genuinely GONE, not merely UNREAD: an added
+    // child is enumerated under its PARENT, so if the parent was SKIPPED / DELETED /
+    // model-read-failed this run the enumeration never ran (or was incomplete), and the
+    // child is unread, not removed — carryForwardUnreadable preserves it (Gap 2) and we
+    // must NOT false-report it deleted here. So surface a DETECT-ONLY finding only when the
+    // child is absent from this run's `added` findings AND its parent WAS read. It rides
+    // the `deleted` tier so it counts as drift (--fail catches it) yet is NEVER given a
+    // restore op — an added resource cannot be "restored" by writing a value; revert routes
+    // every `deleted` finding to not-revertable (revert/plan.ts).
+    if (a.path === '') {
+      if (presentAddedLogical.has(a.logicalId)) continue; // still enumerated -> reconciled above
+      const parent = addedChildParentLogicalId(a.logicalId);
+      // Fire ONLY on POSITIVE proof the parent was READ this run (a non-skipped/deleted
+      // finding on it): the child was enumerable, yet is now absent from `added` -> it was
+      // deleted out of band. When the parent is `skipped`/`deleted` (unread/gone) OR gave NO
+      // signal at all (a degenerate empty-findings input), the child is unread, not removed —
+      // carryForwardUnreadable preserves it (Gap 2), so DO NOT report a false deletion here.
+      const parentRead = parent !== undefined && readParentLogical.has(parent);
+      if (!parentRead) continue; // unread / no-signal parent -> not "removed" (Gap 2 carries it)
+      kept.push({
+        tier: 'deleted',
+        logicalId: a.logicalId,
+        resourceType: a.resourceType,
+        ...(opts.constructPathByLogical?.get(a.logicalId) !== undefined && {
+          constructPath: opts.constructPathByLogical.get(a.logicalId),
+        }),
+        path: '',
+        // no `desired`/`actual` value and no physicalId reconstruction: this is a
+        // detect-only signal, never a revert target (the `deleted` tier is not-revertable).
+        note: 'recorded added resource removed since record',
+      });
+      continue;
+    }
     // #793: the logicalId now hosts a DIFFERENT resource type (id reused across a refactor),
     // so this entry belongs to the old type. Void it: without this the synthetic "removed
     // since record" finding below would pair the entry's OLD resourceType with the new

--- a/tests/added-lifecycle-791.test.ts
+++ b/tests/added-lifecycle-791.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyBaseline,
+  type BaselineFile,
+  buildRecorded,
+  carryForwardUnreadable,
+} from '../src/baseline/baseline-file.js';
+import type { Finding } from '../src/types.js';
+
+// #791: two lifecycle gaps for RECORDED out-of-band `added` resources (baseline entries
+// with `path === ''`), which together break "record KEEPS watching" for the added tier.
+//   Gap 1 — a recorded added resource DELETED out of band (parent WAS read this run) must
+//           surface as drift (a detect-only "recorded added resource removed since record"
+//           finding), not read as CLEAN.
+//   Gap 2 — carryForwardUnreadable must NOT drop a recorded added child when the PARENT's
+//           child-enumeration was throttled (a `skipped` finding is keyed on the parent, the
+//           recorded entry on the synthesized child id) — else a transient throttle silently
+//           shrinks the committed baseline.
+//   Interaction — a child under a THROTTLED parent is CARRIED FORWARD (Gap 2), NOT reported
+//           deleted (Gap 1): Gap 1 fires only on POSITIVE proof the parent was read.
+
+const PARENT = 'Api';
+const CHILD = `${PARENT}/m1`; // gather.ts synthesizes `${parent.logicalId}/${identifier}`
+const METHOD_TYPE = 'AWS::ApiGateway::Method';
+
+function baseline(recorded: BaselineFile['recorded']): BaselineFile {
+  return {
+    schemaVersion: 2,
+    stackName: 's',
+    region: 'r',
+    accountId: '111122223333',
+    capturedAt: '',
+    templateHash: '',
+    recorded,
+    completeResources: [],
+  };
+}
+
+// A recorded `added` entry: whole-resource value, empty path, synthesized child id.
+const recordedAdded = (value: unknown): BaselineFile['recorded'][number] => ({
+  logicalId: CHILD,
+  resourceType: METHOD_TYPE,
+  path: '',
+  value,
+});
+
+// An `added` finding as gather.ts would emit for a live out-of-band child.
+const added = (value: unknown, extra: Partial<Finding> = {}): Finding => ({
+  tier: 'added',
+  logicalId: CHILD,
+  resourceType: METHOD_TYPE,
+  path: '',
+  physicalId: 'RestApiId|ResourceId|GET',
+  actual: value,
+  note: 'created out of band — not in your CloudFormation template',
+  ...extra,
+});
+
+// A finding proving the PARENT resource was READ this run (any non-skipped/deleted tier).
+const parentReadSignal = (): Finding => ({
+  tier: 'undeclared',
+  logicalId: PARENT,
+  resourceType: 'AWS::ApiGateway::RestApi',
+  path: 'ApiKeySourceType',
+  actual: 'HEADER',
+});
+
+// The parent's `skipped` finding (enumeration throttled) — keyed on the PARENT logicalId.
+const parentSkipped = (): Finding => ({
+  tier: 'skipped',
+  logicalId: PARENT,
+  resourceType: 'AWS::ApiGateway::RestApi',
+  path: '',
+  note: 'added-resource scan: ThrottlingException',
+});
+
+describe('#791 added-resource lifecycle (record KEEPS watching)', () => {
+  describe('Gap 1 — a recorded added resource DELETED out of band surfaces as drift', () => {
+    it('parent WAS read but the child is no longer enumerated -> detect-only "removed since record" finding', () => {
+      const b = baseline([recordedAdded({ AuthorizationType: 'NONE' })]);
+      // The parent was read (positive signal), yet NO `added` finding for the child: it was
+      // deleted out of band. Deleting an ENDORSED resource IS a change -> must surface.
+      const out = applyBaseline([parentReadSignal()], b, {
+        constructPathByLogical: new Map([[CHILD, 'MyStack/Api ▸ GET /']]),
+      });
+      const removed = out.find(
+        (f) => f.logicalId === CHILD && f.note === 'recorded added resource removed since record'
+      );
+      expect(removed).toBeDefined();
+      // Rides the `deleted` tier so it COUNTS as drift (--fail catches it) ...
+      expect(removed!.tier).toBe('deleted');
+      // ... yet carries NO revert target: no desired value + no physical id, so revert can
+      // never build a (malformed) restore op — an added resource cannot be "restored".
+      expect(removed!.desired).toBeUndefined();
+      expect(removed!.actual).toBeUndefined();
+      expect(removed!.physicalId).toBeUndefined();
+      // The construct path is restored for a readable report label.
+      expect(removed!.constructPath).toBe('MyStack/Api ▸ GET /');
+    });
+
+    it('counts as drift (the parent-read parentReadSignal is itself the only OTHER finding)', () => {
+      const b = baseline([recordedAdded({ AuthorizationType: 'NONE' })]);
+      const out = applyBaseline([parentReadSignal()], b);
+      // Exactly one detect-only `deleted` finding for the vanished endorsed child.
+      expect(out.filter((f) => f.tier === 'deleted' && f.logicalId === CHILD)).toHaveLength(1);
+    });
+  });
+
+  describe('regression — a recorded added resource STILL present fires neither gap', () => {
+    it('unchanged live child is suppressed (still recorded, no false "removed")', () => {
+      const b = baseline([recordedAdded({ AuthorizationType: 'NONE' })]);
+      const out = applyBaseline([parentReadSignal(), added({ AuthorizationType: 'NONE' })], b);
+      // No `deleted` "removed since record" finding: the child is present + unchanged.
+      expect(out.find((f) => f.tier === 'deleted')).toBeUndefined();
+      expect(out.find((f) => f.logicalId === CHILD)).toBeUndefined(); // suppressed
+    });
+
+    it('carryForwardUnreadable KEEPS it (nothing unread) without duplicating', () => {
+      const b = baseline([recordedAdded({ AuthorizationType: 'NONE' })]);
+      const findings = [parentReadSignal(), added({ AuthorizationType: 'NONE' })];
+      const out = carryForwardUnreadable(buildRecorded(findings), b, findings);
+      expect(out.filter((e) => e.logicalId === CHILD && e.path === '')).toHaveLength(1);
+    });
+  });
+
+  describe('Gap 2 — a throttled parent carries the recorded added child forward', () => {
+    it('carryForwardUnreadable preserves the child entry when the PARENT is `skipped`', () => {
+      const b = baseline([recordedAdded({ AuthorizationType: 'NONE' })]);
+      // Enumeration threw -> a `skipped` finding on the PARENT; buildRecorded produces NO
+      // entry for the child this run (it was never enumerated).
+      const findings = [parentSkipped()];
+      expect(buildRecorded(findings)).toHaveLength(0);
+      const out = carryForwardUnreadable(buildRecorded(findings), b, findings);
+      // The child is carried forward (prefix-match: child id starts with `${parent}/`).
+      expect(out).toContainEqual(recordedAdded({ AuthorizationType: 'NONE' }));
+    });
+
+    it('a throttled parent is NOT reported deleted by Gap 1 (interaction)', () => {
+      const b = baseline([recordedAdded({ AuthorizationType: 'NONE' })]);
+      // Parent `skipped` -> no positive read-proof -> Gap 1 must stay silent.
+      const out = applyBaseline([parentSkipped()], b);
+      expect(out.find((f) => f.tier === 'deleted' && f.logicalId === CHILD)).toBeUndefined();
+      // The only finding is the parent's own skipped coverage-gap signal.
+      expect(out).toEqual([parentSkipped()]);
+    });
+  });
+
+  describe('a degenerate empty-findings input never false-reports a deletion', () => {
+    it('no signal at all for the parent -> child folds to unread, not "removed"', () => {
+      const b = baseline([recordedAdded({ AuthorizationType: 'NONE' })]);
+      expect(applyBaseline([], b)).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #791 — two lifecycle gaps for RECORDED out-of-band `added` resources (baseline entries with `path === ''`) that break "record KEEPS watching" for the added tier.

## Gap 1 — an endorsed added resource DELETED out of band read CLEAN
The removal pass skipped every `path === ''` entry, so after a user records (endorses) an out-of-band API-GW Method and someone later DELETES it: no `added` finding (not enumerated), no `deleted` finding (not in template), entry skipped → **CLEAN**. Contradicts the core contract.
**Fix:** `applyBaseline` emits a **detect-only** `deleted`-tier finding (`recorded added resource removed since record`) when the child is absent from this run's `added` findings AND its parent was **positively read**. It carries **no** `desired`/`actual`/`physicalId` — `revert/plan.ts` routes every `deleted` finding to not-revertable, so no malformed restore op can be built; `--fail` still catches it.

## Gap 2 — carry-forward missed added entries under a throttled parent
`carryForwardUnreadable` keyed the unread check on the entry's own logicalId, but an enumeration-failure `skipped` finding is keyed on the **parent**, while added entries are keyed on the synthesized child id `${parent}/${identifier}`. A transient parent throttle at re-record thus silently DROPPED every added entry under it (defeating the function's purpose).
**Fix:** prefix-match the parent (`addedChildParentLogicalId`, split on first `/`) so the child is carried forward.

## Interaction
Gap 1 fires **only on positive parent read-proof** (a non-`skipped`/`deleted` finding on the parent). A child under a THROTTLED/unread parent — or a degenerate empty-findings input — folds to Gap 2 (carry forward), never a false deletion.

## Tests
`tests/added-lifecycle-791.test.ts` (7): Gap 1 detect-only finding + counts-as-drift; Gap 2 carry-forward-under-skipped-parent + not-reported-deleted; regression (still-enumerated child suppressed + carried without dup); degenerate no-signal folds to unread. 3 detection tests fail without the fix.

File: `src/baseline/baseline-file.ts` (gather.ts was not needed).