### PR TITLE
feat(report): show recorded → live for a changed undeclared value (#758 follow-up)

### DIFF
--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -173,7 +173,19 @@ export function formatFinding(f: Finding, stackName = ''): string {
     // R128: a recorded identity-keyed array changed — show the element delta, not the
     // whole array dump (the property stays recorded; this is the WHICH-element view).
     s += formatArrayDelta(f.arrayDelta);
-  else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
+  else if (f.tier === 'undeclared' && f.desired !== undefined) {
+    // #758 follow-up: a RECORDED undeclared value that CHANGED out of band since record —
+    // applyBaseline (baseline-file.ts) threads the recorded baseline value onto `f.desired`
+    // (mirroring the `added` tier). Show the recorded-vs-live delta so the user sees WHAT the
+    // value changed FROM, not just the (possibly attacker-set) live value. Same `baseline`-vs-
+    // `actual` wording as the recorded `added` tier: a per-key delta for maps (both objects),
+    // stacked `baseline=`/`actual  =` lines for scalars.
+    if (isRecord(f.desired) && isRecord(f.actual)) s += formatMapDelta(f.desired, f.actual, true);
+    else {
+      const { a: base, b: act } = jPair(f.desired, f.actual);
+      s += `\n      baseline=${style.desired(base)}\n      actual  =${style.actual(act)}`;
+    }
+  } else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
     // Put the live value on its OWN indented line, aligned with declared's `actual =`
     // column — a long ARN/JSON list crammed inline after the id was unreadable, and it read
     // inconsistently next to a declared drift's stacked desired/actual. An undeclared value

--- a/tests/report-undeclared-recorded-live-758.test.ts
+++ b/tests/report-undeclared-recorded-live-758.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { formatFinding } from '../src/report/report.js';
+import type { Finding } from '../src/types.js';
+
+// #758 follow-up: applyBaseline threads a CHANGED recorded undeclared value's OLD baseline
+// value onto `f.desired`, so the check report should render a `recorded → live` delta
+// (baseline-vs-actual, mirroring the `added` tier) instead of only the live value — a user
+// reading `check` output must see WHAT the value changed FROM, not just the (possibly
+// attacker-set) live side.
+describe('#758 fu: a CHANGED recorded undeclared finding renders recorded-vs-live, not just actual', () => {
+  it('a changed undeclared SCALAR (desired=old, actual=new) shows BOTH the recorded and the live value', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'L',
+      resourceType: 'AWS::S3::Bucket',
+      path: 'OwnershipControls.Rules[0].ObjectOwnership',
+      desired: 'BucketOwnerEnforced',
+      actual: 'ObjectWriter',
+      note: 'changed since record',
+    };
+    const out = formatFinding(f);
+    // both sides are visible — the OLD recorded value AND the live value
+    expect(out).toContain('baseline=');
+    expect(out).toContain('actual  =');
+    expect(out).toContain('BucketOwnerEnforced');
+    expect(out).toContain('ObjectWriter');
+    // NOT the single bare `actual =` line (that would hide what it changed from)
+    expect(out).not.toContain('\n      actual =');
+  });
+
+  it('a changed undeclared MAP (both objects) renders a per-KEY delta', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'L',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Tags',
+      desired: { Env: 'prod', Owner: 'team' },
+      actual: { Env: 'staging', Owner: 'team' },
+      note: 'changed since record',
+    };
+    const out = formatFinding(f);
+    // per-key delta: only the diverging key (Env) is shown, with baseline/actual sides
+    expect(out).toContain('~ Env');
+    expect(out).toContain('baseline=');
+    expect(out).toContain('actual  =');
+    expect(out).toContain('prod');
+    expect(out).toContain('staging');
+    // the unchanged key (Owner) is not surfaced
+    expect(out).not.toContain('~ Owner');
+  });
+
+  it('regression: a NEW undeclared value (no desired) keeps the single `actual =` line, no spurious recorded line', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'L',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Layers',
+      actual: ['arn:aws:lambda:us-east-1:1234:layer:x:1'],
+    };
+    const out = formatFinding(f);
+    expect(out).toContain('\n      actual =');
+    expect(out).not.toContain('baseline=');
+    expect(out).not.toContain('recorded=');
+  });
+
+  it('regression: an undeclared finding with arrayDelta still renders the array delta (unchanged, takes precedence over desired)', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'L',
+      resourceType: 'AWS::X::Y',
+      path: 'Arr',
+      // even with a desired present, arrayDelta must win (it is the WHICH-element view)
+      desired: [{ Name: 'a', v: 1 }],
+      actual: [{ Name: 'a', v: 2 }],
+      arrayDelta: {
+        identityField: 'Name',
+        added: [],
+        changed: [{ id: 'a', recorded: { Name: 'a', v: 1 }, actual: { Name: 'a', v: 2 } }],
+        removed: [],
+      },
+    };
+    const out = formatFinding(f);
+    expect(out).toContain('Name-keyed element(s) changed');
+    expect(out).toContain('~ [a]');
+  });
+
+  it('regression: atDefault / generated tiers are unaffected (single actual = line, no recorded side)', () => {
+    for (const tier of ['atDefault', 'generated'] as const) {
+      const f: Finding = {
+        tier,
+        logicalId: 'L',
+        resourceType: 'AWS::X::Y',
+        path: 'P',
+        actual: 'v',
+      };
+      const out = formatFinding(f);
+      expect(out).toContain('\n      actual =');
+      expect(out).not.toContain('baseline=');
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #758 (merged).

#758 threaded the recorded baseline value onto a CHANGED undeclared finding's `desired` (applyBaseline), and the record picker shows `recorded → live`. But the check REPORT still rendered only `actual =<live>` for the `undeclared` tier — a user reading `check` output saw only the (possibly attacker-set) live value, not what it changed FROM.

`report.ts` now renders a recorded-vs-live delta for an undeclared finding carrying `desired`: a per-key delta for maps (`formatMapDelta(…, true)`), stacked `baseline=`/`actual  =` lines for scalars — a **byte-for-byte mirror of the recorded `added` tier's wording** (report.ts ~155-163), so the report vocabulary stays consistent.

Fires ONLY for `f.tier === 'undeclared' && !f.arrayDelta && f.desired !== undefined`, so:
- a brand-new undeclared value (no `desired`) → unchanged single `actual =` line
- an identity-array delta (R128 `arrayDelta`) → unchanged (earlier branch, takes precedence)
- `atDefault`/`generated` (never carry `desired`) → unchanged

## Tests
`tests/report-undeclared-recorded-live-758.test.ts` (5): changed-scalar shows both values, changed-map per-key delta, + 3 regressions (new-undeclared / arrayDelta / atDefault unchanged). The scalar + map tests fail without the fix.

File: `src/report/report.ts`.