### PR TITLE
fix(diff): gate DynamoDB/OpenSearch managed-key fold so an out-of-band CMK swap surfaces (#704)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -14,6 +14,7 @@ import { READ_RETRY } from '../read/client-config.js';
 import {
   fetchManagedAliasTargets,
   kmsWarnDecision,
+  typeNeedsManagedKeyResolution,
   usesManagedKmsAlias,
 } from '../read/kms-aliases.js';
 import { type AddedChild, CHILD_ENUMERATORS } from '../read/child-enumerators.js';
@@ -600,8 +601,17 @@ export async function gatherFindings(
   // a customer-managed key swapped in out of band. Missing kms:ListAliases -> empty +
   // denied (the classifier falls back to the conservative shape-based match) — and we
   // WARN once per region, because that fallback is BLIND to a customer-key swap (R115).
+  // The type check also fires for resource types whose UNDECLARED managed-key path
+  // (e.g. DynamoDB SSESpecification.KMSMasterKeyId, OpenSearch EncryptionAtRestOptions.KmsKeyId)
+  // must be gated against the AWS-managed key ARN even when the template declares no
+  // `alias/aws/*` — otherwise classify's managed-key gate always fails open and an
+  // out-of-band CMK swap stays invisible (#704).
   let kmsAliasTargets: Record<string, string> = {};
-  if (desired.resources.some((r) => usesManagedKmsAlias(r.declared))) {
+  if (
+    desired.resources.some(
+      (r) => usesManagedKmsAlias(r.declared) || typeNeedsManagedKeyResolution(r.resourceType)
+    )
+  ) {
     const resolved = await fetchManagedAliasTargets(region);
     kmsAliasTargets = resolved.targets;
     // A denied read is either a genuine IAM denial (permanent — grant kms:ListAliases) or
@@ -697,7 +707,9 @@ export async function regatherTouched(
   }
   // Re-check path (revert convergence): reuse the cached targets; the denial warning,
   // if any, already fired in the primary gather, so just take the resolved map.
-  const kmsAliasTargets = targets.some((r) => usesManagedKmsAlias(r.declared))
+  const kmsAliasTargets = targets.some(
+    (r) => usesManagedKmsAlias(r.declared) || typeNeedsManagedKeyResolution(r.resourceType)
+  )
     ? (await fetchManagedAliasTargets(region)).targets
     : {};
   // Built from desired.ctx.liveAttrs (populated by the original gather), so the OAI

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -95,6 +95,7 @@ import {
   VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS,
   VERSION_PREFIX_PATHS,
 } from '../normalize/noise.js';
+import { MANAGED_KEY_ALIAS_PATHS, shouldFoldManagedServiceKey } from '../read/kms-aliases.js';
 import { deepStripPaths } from '../normalize/path-strip.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
 import { canonicalizePolicy, rewriteOaiPrincipalsDeep } from '../normalize/policy-canonical.js';
@@ -1914,7 +1915,15 @@ export function classifyResource(
           // LoggingConfig.LogGroup, derived above): the gate already folded the AWS-default
           // value via `atDefault`, so a value reaching here is a real custom one that must
           // surface, not be value-independent-folded.
-          (generatedNestedPaths?.has(schemaPath) && !(schemaPath in knownDefPaths))
+          // #704: a managed-service-KEY nested path (DynamoDB SSESpecification.KMSMasterKeyId,
+          // OpenSearch EncryptionAtRestOptions.KmsKeyId) is value-independent ONLY for the
+          // account/region AWS-managed key (`alias/aws/<service>`); a CMK swapped in out of
+          // band (a MUTABLE, security-relevant change) must surface. Gate the fold against the
+          // resolved managed key — fail OPEN (keep folding) when the alias can't be resolved.
+          (generatedNestedPaths?.has(schemaPath) &&
+            !(schemaPath in knownDefPaths) &&
+            (!(schemaPath in (MANAGED_KEY_ALIAS_PATHS[resourceType] ?? {})) ||
+              shouldFoldManagedServiceKey(resourceType, schemaPath, value, opts.kmsAliasTargets)))
         ? 'generated'
         : 'undeclared';
     // A free-form map key surfaces (not folded), but only when it is a real undeclared

--- a/src/read/kms-aliases.ts
+++ b/src/read/kms-aliases.ts
@@ -130,6 +130,71 @@ export function kmsWarnDecision(
   };
 }
 
+// #704: some resource types read back an UNDECLARED encryption-key property whose default
+// is the account/region AWS-managed service key (`alias/aws/<service>`), stored by AWS as a
+// full key ARN. These are folded value-independent (GENERATED_NESTED_PATHS) — which HID an
+// out-of-band swap to a customer-managed key (a security-relevant, MUTABLE change: DynamoDB
+// SSE is changeable via `UpdateTable --sse-specification`, unlike RDS's create-only KmsKeyId).
+// This table maps each such (resourceType, nested schema path) to the AWS-managed alias whose
+// resolved key ARN is the fold-eligible default. The classifier gates the value-independent
+// fold against the resolved managed key: it folds ONLY when the live key IS that managed key,
+// and SURFACES any other value (a CMK). Fail OPEN (keep folding) when the alias can't be
+// resolved (no ListAliases / denied / transient) — biased to noise, never a new false positive.
+export const MANAGED_KEY_ALIAS_PATHS: Record<string, Record<string, string>> = {
+  // A DynamoDB table with `SSESpecification.SSEEnabled: true` and no explicit KMS key reads
+  // back `SSESpecification.KMSMasterKeyId` = the account's AWS-managed `alias/aws/dynamodb`
+  // key ARN. Only that managed key is the default to fold; a CMK swapped in surfaces.
+  'AWS::DynamoDB::Table': { 'SSESpecification.KMSMasterKeyId': 'alias/aws/dynamodb' },
+  // GlobalTable's per-replica twin (same managed key, nested under Replicas.*).
+  'AWS::DynamoDB::GlobalTable': {
+    'Replicas.*.SSESpecification.KMSMasterKeyId': 'alias/aws/dynamodb',
+  },
+  // An OpenSearch domain with encryption-at-rest enabled and no explicit KMS key reads back
+  // `EncryptionAtRestOptions.KmsKeyId` = the account's AWS-managed `alias/aws/es` key.
+  'AWS::OpenSearchService::Domain': { 'EncryptionAtRestOptions.KmsKeyId': 'alias/aws/es' },
+};
+
+// Match live key values to a managed-key ARN: the live value is a full key ARN
+// (`arn:aws:kms:...:key/<id>`); the alias TargetKeyId from ListAliases is a bare key id.
+// Compare on the trailing key-id segment so both forms line up.
+const keyIdOf = (s: string): string => s.slice(s.lastIndexOf('/') + 1);
+
+/** #704 fold decision for an UNDECLARED managed-service-key nested path (DynamoDB SSE,
+ *  OpenSearch EncryptionAtRest). Returns whether the value-independent fold should still
+ *  apply for this live value:
+ *   - `true`  → FOLD (atDefault): the live key IS the account/region AWS-managed key, OR the
+ *               alias could not be resolved (fail OPEN — no ListAliases / denied / transient).
+ *   - `false` → SURFACE (undeclared): the live key is some OTHER key (a customer-managed key
+ *               swapped in out of band — a real, security-relevant drift).
+ *  Pure; `aliasTargets` is the resolved alias-name -> target-key-id map (empty when unresolved).*/
+export function shouldFoldManagedServiceKey(
+  resourceType: string,
+  schemaPath: string,
+  liveValue: unknown,
+  aliasTargets?: Record<string, string>
+): boolean {
+  const alias = MANAGED_KEY_ALIAS_PATHS[resourceType]?.[schemaPath];
+  if (!alias) return false; // not a managed-key path — caller shouldn't gate it here
+  const target = aliasTargets?.[alias];
+  // Fail OPEN: alias unresolved (no ListAliases / denied / transient / not in this account) →
+  // keep folding, preserving today's value-independent behavior (no new false positive).
+  if (!target) return true;
+  // A non-string live value can't be compared to a key ARN → fold (unchanged behavior).
+  if (typeof liveValue !== 'string') return true;
+  // Strict: fold ONLY when the live key resolves to the SAME managed key; any other key surfaces.
+  return keyIdOf(liveValue) === keyIdOf(target);
+}
+
+/** #704: True when a resource TYPE has an UNDECLARED managed-service-key nested path
+ *  (DynamoDB SSE, OpenSearch EncryptionAtRest) whose value-independent fold must be gated
+ *  against the resolved AWS-managed key — so a ListAliases prefetch is worth doing even when
+ *  NO `alias/aws/*` is DECLARED. gather.ts's prefetch trigger should OR this in alongside the
+ *  declared-alias check (`usesManagedKmsAlias`) so the LIVE-only managed-key path is resolvable.
+ */
+export function typeNeedsManagedKeyResolution(resourceType: string): boolean {
+  return resourceType in MANAGED_KEY_ALIAS_PATHS;
+}
+
 /** True when any resolved declared value in the stack references an AWS-managed KMS
  *  alias, i.e. a ListAliases prefetch is worth doing. */
 export function usesManagedKmsAlias(v: unknown): boolean {

--- a/tests/classify-ddb-sse-704.test.ts
+++ b/tests/classify-ddb-sse-704.test.ts
@@ -1,0 +1,145 @@
+// #704 — an UNDECLARED managed-service-KEY nested path (DynamoDB
+// SSESpecification.KMSMasterKeyId, GlobalTable per-replica twin, OpenSearch
+// EncryptionAtRestOptions.KmsKeyId) is folded value-independent (GENERATED_NESTED_PATHS),
+// which HID an out-of-band swap from the AWS-managed key to a customer-managed key — a
+// MUTABLE, security-relevant change (DynamoDB SSE is changeable via `UpdateTable
+// --sse-specification`, unlike RDS's create-only KmsKeyId). Fix: gate the fold against the
+// resolved account/region AWS-managed key ARN — fold ONLY the managed key, surface any CMK.
+// KMS resolution failure/denial → fail OPEN (fold), so no new first-run false positive.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import {
+  shouldFoldManagedServiceKey,
+  typeNeedsManagedKeyResolution,
+} from '../src/read/kms-aliases.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const paths = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({ logicalId: 'R', resourceType, physicalId, declared });
+
+// The account's AWS-managed alias/aws/dynamodb key: ListAliases yields the bare key id;
+// the live model carries the full key ARN whose trailing segment is that key id.
+const MANAGED_KEY_ID = '11111111-2222-3333-4444-555555555555';
+const MANAGED_KEY_ARN = `arn:aws:kms:us-east-1:123456789012:key/${MANAGED_KEY_ID}`;
+const CMK_ARN = 'arn:aws:kms:us-east-1:123456789012:key/99999999-8888-7777-6666-000000000000';
+const ddbAliasTargets = { 'alias/aws/dynamodb': MANAGED_KEY_ID };
+
+describe('#704 DynamoDB SSESpecification.KMSMasterKeyId managed-key gate', () => {
+  const declared = { TableName: 't', SSESpecification: { SSEEnabled: true } };
+
+  it('folds (atDefault) when the live key IS the account AWS-managed alias/aws/dynamodb key', () => {
+    const f = classifyResource(
+      mk('AWS::DynamoDB::Table', declared),
+      {
+        TableName: 't',
+        SSESpecification: { SSEEnabled: true, SSEType: 'KMS', KMSMasterKeyId: MANAGED_KEY_ARN },
+      },
+      emptySchema,
+      { kmsAliasTargets: ddbAliasTargets }
+    );
+    expect(paths(f, 'undeclared')).not.toContain('SSESpecification.KMSMasterKeyId');
+    // it must fold — as `generated` (the value-independent tier), never surfaced
+    expect(paths(f, 'generated')).toContain('SSESpecification.KMSMasterKeyId');
+  });
+
+  it('SURFACES (undeclared) when the live key is a customer-managed key (CMK) swapped in', () => {
+    const f = classifyResource(
+      mk('AWS::DynamoDB::Table', declared),
+      {
+        TableName: 't',
+        SSESpecification: { SSEEnabled: true, SSEType: 'KMS', KMSMasterKeyId: CMK_ARN },
+      },
+      emptySchema,
+      { kmsAliasTargets: ddbAliasTargets }
+    );
+    expect(paths(f, 'undeclared')).toContain('SSESpecification.KMSMasterKeyId');
+    expect(paths(f, 'generated')).not.toContain('SSESpecification.KMSMasterKeyId');
+  });
+
+  it('fails OPEN (folds) when KMS alias resolution is unavailable (no targets / denied)', () => {
+    const f = classifyResource(
+      mk('AWS::DynamoDB::Table', declared),
+      {
+        TableName: 't',
+        SSESpecification: { SSEEnabled: true, SSEType: 'KMS', KMSMasterKeyId: CMK_ARN },
+      },
+      emptySchema,
+      { kmsAliasTargets: {} } // ListAliases denied/transient → empty map → fail open
+    );
+    expect(paths(f, 'undeclared')).not.toContain('SSESpecification.KMSMasterKeyId');
+    expect(paths(f, 'generated')).toContain('SSESpecification.KMSMasterKeyId');
+  });
+});
+
+describe('#704 OpenSearch EncryptionAtRestOptions.KmsKeyId rides the same gate', () => {
+  const declared = { DomainName: 'd', EncryptionAtRestOptions: { Enabled: true } };
+  const esKeyId = '77777777-6666-5555-4444-333333333333';
+  const esManagedArn = `arn:aws:kms:us-east-1:123456789012:key/${esKeyId}`;
+  const esAliasTargets = { 'alias/aws/es': esKeyId };
+  const esCmk = 'arn:aws:kms:us-east-1:123456789012:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+  it('folds the AWS-managed alias/aws/es key, surfaces a CMK', () => {
+    const managed = classifyResource(
+      mk('AWS::OpenSearchService::Domain', declared),
+      { DomainName: 'd', EncryptionAtRestOptions: { Enabled: true, KmsKeyId: esManagedArn } },
+      emptySchema,
+      { kmsAliasTargets: esAliasTargets }
+    );
+    expect(paths(managed, 'undeclared')).not.toContain('EncryptionAtRestOptions.KmsKeyId');
+
+    const cmk = classifyResource(
+      mk('AWS::OpenSearchService::Domain', declared),
+      { DomainName: 'd', EncryptionAtRestOptions: { Enabled: true, KmsKeyId: esCmk } },
+      emptySchema,
+      { kmsAliasTargets: esAliasTargets }
+    );
+    expect(paths(cmk, 'undeclared')).toContain('EncryptionAtRestOptions.KmsKeyId');
+  });
+});
+
+describe('#704 shouldFoldManagedServiceKey predicate', () => {
+  it('folds the managed key, surfaces a CMK, fails open when unresolved', () => {
+    const p = 'SSESpecification.KMSMasterKeyId';
+    // managed key → fold
+    expect(
+      shouldFoldManagedServiceKey('AWS::DynamoDB::Table', p, MANAGED_KEY_ARN, ddbAliasTargets)
+    ).toBe(true);
+    // CMK → surface (don't fold)
+    expect(shouldFoldManagedServiceKey('AWS::DynamoDB::Table', p, CMK_ARN, ddbAliasTargets)).toBe(
+      false
+    );
+    // unresolved alias (empty targets) → fail open (fold)
+    expect(shouldFoldManagedServiceKey('AWS::DynamoDB::Table', p, CMK_ARN, {})).toBe(true);
+    // non-managed path → false (caller must not gate it here)
+    expect(shouldFoldManagedServiceKey('AWS::DynamoDB::Table', 'Other.Path', CMK_ARN, {})).toBe(
+      false
+    );
+  });
+
+  it('typeNeedsManagedKeyResolution flags the managed-key types (gather prefetch trigger)', () => {
+    expect(typeNeedsManagedKeyResolution('AWS::DynamoDB::Table')).toBe(true);
+    expect(typeNeedsManagedKeyResolution('AWS::DynamoDB::GlobalTable')).toBe(true);
+    expect(typeNeedsManagedKeyResolution('AWS::OpenSearchService::Domain')).toBe(true);
+    expect(typeNeedsManagedKeyResolution('AWS::S3::Bucket')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`SSESpecification.KMSMasterKeyId` (DynamoDB `Table` + `GlobalTable` replicas) and `EncryptionAtRestOptions.KmsKeyId` (OpenSearch `Domain`) were folded **value-independent**, so an out-of-band swap from the AWS-managed key to any CMK read CLEAN and survived `record` — a live-proven FN (#704). Unlike RDS `KmsKeyId` (create-only, physically cannot drift), DynamoDB SSE is **mutable** (`UpdateTable --sse-specification`).

## Fix

Fold **only the AWS-managed key**. `src/read/kms-aliases.ts` gains a self-contained `MANAGED_KEY_ALIAS_PATHS` table (type to schemaPath to alias) plus `shouldFoldManagedServiceKey()` (fold when the live key ARN key-id matches the resolved managed-key id, fail OPEN when unresolvable). `src/diff/classify.ts` gates the value-independent nested fold on that predicate — a CMK falls through to `undeclared` and surfaces. `src/commands/gather.ts` now fires the managed-alias prefetch for these types even when the template declares no `alias/aws/*`, so the gate is effective end-to-end (without it the resolver always failed open).

Detection preserved: AWS-managed default still folds; any CMK is recordable if intended.

## Tests

`tests/classify-ddb-sse-704.test.ts` (6): managed-key to folded; CMK surfaced; KMS-unavailable fails open; OpenSearch generic-path proof; predicate + type-trigger units.

Closes #704
