### PR TITLE
fix(revert): gate deletion of a recorded (endorsed) added resource behind --remove-unrecorded (#764)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -132,13 +132,19 @@ export function revertConfirmMessage(
   stackName: string,
   region: string,
   opCount: number,
-  notRevertableCount: number
+  notRevertableCount: number,
+  deleteCount = 0
 ): string {
   const scope =
     notRevertableCount > 0
       ? ` Only the ${opCount} selected op(s) are written — the ${notRevertableCount} NOT-revertable finding(s) are untouched.`
       : '';
-  return `Apply ${opCount} revert op(s) to ${stackLabel(stackName, region)}? This WRITES to AWS.${scope}`;
+  // #764: a `delete`-kind op DELETES a whole out-of-band resource (not a property
+  // patch), so the confirm must name how many resources will be DELETED — otherwise a
+  // user reading "revert op(s)" under --yes has no signal that a resource is destroyed.
+  const del =
+    deleteCount > 0 ? ` ${deleteCount} of these DELETE(S) a whole out-of-band resource.` : '';
+  return `Apply ${opCount} revert op(s) to ${stackLabel(stackName, region)}? This WRITES to AWS.${del}${scope}`;
 }
 
 /**
@@ -1087,8 +1093,15 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       }
     }
     const opCount = plan.items.reduce((n, i) => n + i.ops.length, 0);
+    const deleteCount = plan.items.filter((i) => i.kind === 'delete').length;
     const ok = await confirm({
-      message: revertConfirmMessage(stackName, region, opCount, plan.notRevertable.length),
+      message: revertConfirmMessage(
+        stackName,
+        region,
+        opCount,
+        plan.notRevertable.length,
+        deleteCount
+      ),
       // A destructive AWS write must NOT default to Yes — Enter/default is No (#1055),
       // matching record's empty-baseline confirm (initialValue: false above).
       initialValue: false,

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -599,6 +599,29 @@ export function buildRevertPlan(
         });
         continue;
       }
+      // #764: a RECORDED (endorsed) `added` resource that later CHANGED stays tier
+      // `added` with `unrecorded` UNSET — applyBaseline keeps it with the recorded baseline
+      // model on `desired` + a "changed since record" note (the ONLY way an added finding
+      // carries a `desired`). Reverting it still has only ONE lever — DeleteResource of the
+      // WHOLE resource — so `revert --yes` would DELETE an endorsed out-of-band
+      // DBInstance/ECS Service with no delete-specific gate (the interactive multiselect's
+      // unselected-by-default `(DELETE)` rows are the real gate, skipped under --yes). That
+      // is the destructive mirror of the undeclared asymmetry: a recorded VALUE that
+      // changed is RESTORED to the baseline, but a recorded RESOURCE that changed was being
+      // DELETED. Extend the same `--remove-unrecorded` opt-in the unrecorded branch above
+      // uses: a recorded-added delete is a DESTRUCTIVE op, so it must not be auto-applied
+      // under --yes without the explicit opt-in. (A recorded-added that did NOT change is
+      // suppressed in applyBaseline and never reaches here.)
+      if (f.desired !== undefined && !opts.removeUnrecorded) {
+        notRevertable.push({
+          displayId,
+          resourceType: f.resourceType,
+          path: f.path,
+          reason:
+            'recorded added resource changed since record — reverting DELETES the whole resource; re-record if the change is right, or --remove-unrecorded to delete it',
+        });
+        continue;
+      }
       // an out-of-band resource (not in the template) is reverted by DELETING it via
       // Cloud Control DeleteResource. f.physicalId is the CC identifier (the composite
       // `RestApiId|ResourceId[|HttpMethod]`). Modeled as a `delete`-kind item carrying a

--- a/tests/revert-added-delete-gate-764.test.ts
+++ b/tests/revert-added-delete-gate-764.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { revertConfirmMessage } from '../src/commands/stack-actions.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+// #764: a RECORDED (endorsed) `added` out-of-band resource that later CHANGED stays tier
+// `added` with `unrecorded` UNSET and the recorded baseline model on `desired` (applyBaseline
+// tags it "changed since record"). Its only revert lever is DeleteResource of the WHOLE
+// resource. Before the fix, `revert --yes` (which skips the interactive multiselect's
+// unselected-by-default `(DELETE)` rows) planned that delete straight away and DELETED an
+// endorsed out-of-band DBInstance/ECS Service with no delete-specific gate. The fix requires
+// the same `--remove-unrecorded` opt-in the unrecorded-added branch already uses.
+
+// A recorded-added-that-changed finding, as applyBaseline produces it: tier `added`,
+// path '', `desired` carrying the recorded baseline model, `unrecorded` UNSET.
+const recordedAddedChanged = (): Finding => ({
+  tier: 'added',
+  logicalId: 'Cluster/reader-xyz',
+  physicalId: 'reader-xyz',
+  resourceType: 'AWS::RDS::DBInstance',
+  path: '',
+  actual: { DBInstanceClass: 'db.r6g.2xlarge' }, // changed live value
+  desired: { DBInstanceClass: 'db.r6g.large' }, // recorded baseline model
+  note: 'changed since record',
+});
+
+describe('#764 recorded-added delete gate', () => {
+  it('a recorded added resource that changed is NOT deletable under --yes without --remove-unrecorded (gated to notRevertable)', () => {
+    const f = recordedAddedChanged();
+    const plan = buildRevertPlan([f], undefined);
+    // NO delete item is emitted — the destructive delete is gated behind the opt-in.
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('recorded added resource changed since record');
+    expect(plan.notRevertable[0]!.reason).toContain('--remove-unrecorded');
+  });
+
+  it('with --remove-unrecorded the same finding DOES produce a delete-kind item', () => {
+    const f = recordedAddedChanged();
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]).toMatchObject({
+      kind: 'delete',
+      physicalId: 'reader-xyz',
+      resourceType: 'AWS::RDS::DBInstance',
+    });
+    expect(plan.items[0]!.ops[0]!.human).toContain('DELETE');
+  });
+
+  it('an UNRECORDED added resource stays gated by --remove-unrecorded (unchanged behavior)', () => {
+    const f: Finding = {
+      tier: 'added',
+      logicalId: 'Cluster/reader-abc',
+      physicalId: 'reader-abc',
+      resourceType: 'AWS::RDS::DBInstance',
+      path: '',
+      unrecorded: true,
+    };
+    const noFlag = buildRevertPlan([f], undefined);
+    expect(noFlag.items).toHaveLength(0);
+    expect(noFlag.notRevertable[0]!.reason).toContain('unrecorded');
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('delete');
+  });
+});
+
+describe('#764 revertConfirmMessage names the DELETE count', () => {
+  it('mentions how many ops DELETE a whole out-of-band resource', () => {
+    const msg = revertConfirmMessage('s', 'us-east-1', 3, 0, 2);
+    expect(msg).toContain('2 of these DELETE(S) a whole out-of-band resource');
+    expect(msg).toContain('WRITES to AWS');
+  });
+
+  it('says nothing about deletes when there are none (backward compatible)', () => {
+    const msg = revertConfirmMessage('s', 'us-east-1', 2, 0);
+    expect(msg).not.toContain('DELETE');
+    expect(msg).toBe('Apply 2 revert op(s) to s (us-east-1)? This WRITES to AWS.');
+  });
+});


### PR DESCRIPTION
## What

A recorded (endorsed, still-watched) out-of-band `added` resource that later CHANGED stayed tier `added` with the recorded baseline model on the finding, but revert's only lever was `DeleteResource` of the **whole** resource — and `revert --yes` applied it with **no delete-specific gate**. So `cdkrd revert --yes` would DELETE an endorsed out-of-band `RDS::DBInstance` (an Aurora reader) / `ECS::Service` / `EC2::Subnet` after a single property changed on it (#764).

The asymmetry was the bug: an undeclared **value** changed since record is restored to the baseline value; an added **resource** changed since record was deleted.

## Fix

- `src/revert/plan.ts`: a recorded-added finding (baseline model present, non-unrecorded) whose only action is a whole-resource delete is now gated behind the **same `--remove-unrecorded` opt-in** as an unrecorded added resource. Without the opt-in, `revert --yes` SKIPS the delete — it lands in `notRevertable` with a clear message (re-`record` if the change is right, or `--remove-unrecorded` to delete). The interactive path was already safe (rows unselected + `(DELETE)` marker).
- `src/commands/stack-actions.ts`: `revertConfirmMessage` now names the delete count when the plan contains delete-kind items.

Restore-to-baseline (UpdateResource) for a changed recorded-added resource was considered but not implemented — a whole-resource RFC6902 restore does not fit the property-scoped patch machinery cleanly; gating the destructive delete is the safe, surgical fix.

## Tests

`tests/revert-added-delete-gate-764.test.ts` (5): recorded-added-changed under no opt-in → delete gated (not emitted); with `--remove-unrecorded` → delete emitted; unrecorded added still gated; confirm message names the delete count; backward-compatible at count 0. Verified fails-without / passes-with.

Closes #764
