### PR TITLE
feat(read): add SDK read override for Glue::SecurityConfiguration (#857, Glue half)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -55,6 +55,7 @@ import {
 import {
   GetClassifierCommand,
   GetConnectionCommand,
+  GetSecurityConfigurationCommand,
   GetTableCommand,
   GetWorkflowCommand,
   GlueClient,
@@ -1532,6 +1533,48 @@ const readGlueConnection: OverrideReader = async ({ physicalId, declared, region
   return out;
 };
 
+// AWS::Glue::SecurityConfiguration — CC API GetResource throws UnsupportedActionException
+// (the registry type has `handlers: []` — NO read handler), so a Glue stack's encryption
+// posture was silently `skipped`: an out-of-band KMS-key swap or an encryption-mode
+// downgrade (e.g. CSE-KMS -> DISABLED on a bookmark / CloudWatch / S3 target) was invisible,
+// exactly the security-relevant drift a Glue user wants watched (#857). Read via Glue
+// GetSecurityConfiguration — the CFn physical id IS the configuration Name. Project the CFn
+// `EncryptionConfiguration` shape.
+//
+// KEY SHAPE MISMATCH: the SDK spells the S3 array `S3Encryption` (SINGULAR) inside
+// EncryptionConfiguration, while the CFn schema declares it `S3Encryptions` (PLURAL) — map
+// it across, or a declared S3Encryptions became a `readGap` and an undeclared one was wholly
+// invisible. The three member sub-fields (S3EncryptionMode / CloudWatchEncryptionMode /
+// JobBookmarksEncryptionMode + KmsKeyArn) match the CFn schema 1:1 and pass through verbatim.
+// DataQualityEncryption is dropped — the SDK returns it but the CFn schema does NOT model it
+// (verified against the live registry schema: EncryptionConfiguration has only
+// S3Encryptions / JobBookmarksEncryption / CloudWatchEncryption), so projecting it would be a
+// permanent undeclared false inventory. CreatedTimeStamp is an AWS-managed field, dropped.
+// Each member is projected ONLY when AWS returns it, so a config that declares (say) just an
+// S3 encryption stays absent on the other members (FP-safe). Read-ONLY: a SecurityConfiguration
+// is immutable in Glue (there is no UpdateSecurityConfiguration API — you delete + recreate),
+// so there is no meaningful in-place revert to offer. A deleted config surfaces as
+// EntityNotFoundException → the router maps it to `deleted`.
+const readGlueSecurityConfiguration: OverrideReader = async ({ physicalId, declared, region }) => {
+  const name = str(physicalId) ?? str(declared.Name);
+  if (!name) return undefined;
+  const c = new GlueClient({ region, ...READ_RETRY });
+  const sc = (await c.send(new GetSecurityConfigurationCommand({ Name: name })))
+    .SecurityConfiguration;
+  if (!sc) throw new ResourceGoneError(`Glue SecurityConfiguration ${name} absent`);
+  const enc = sc.EncryptionConfiguration;
+  const ec: Record<string, unknown> = {};
+  // SDK S3Encryption (singular) -> CFn S3Encryptions (plural).
+  if (Array.isArray(enc?.S3Encryption) && enc.S3Encryption.length > 0)
+    ec.S3Encryptions = enc.S3Encryption;
+  if (enc?.CloudWatchEncryption !== undefined) ec.CloudWatchEncryption = enc.CloudWatchEncryption;
+  if (enc?.JobBookmarksEncryption !== undefined)
+    ec.JobBookmarksEncryption = enc.JobBookmarksEncryption;
+  const model: Record<string, unknown> = { Name: sc.Name ?? name };
+  if (Object.keys(ec).length > 0) model.EncryptionConfiguration = ec;
+  return model;
+};
+
 // AWS::Logs::MetricFilter — CC API GetResource throws ValidationException. Read via
 // CloudWatch Logs DescribeMetricFilters. The CFn physical id IS the filter name;
 // the log group comes from the declared (GetAtt-resolved) LogGroupName.
@@ -2324,6 +2367,7 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::Glue::Classifier': readGlueClassifier,
   'AWS::Glue::Workflow': readGlueWorkflow,
   'AWS::Glue::Connection': readGlueConnection,
+  'AWS::Glue::SecurityConfiguration': readGlueSecurityConfiguration,
   'AWS::Logs::MetricFilter': readMetricFilter,
   'AWS::Scheduler::Schedule': readSchedulerSchedule,
 };

--- a/tests/overrides-glue-sagemaker-857.test.ts
+++ b/tests/overrides-glue-sagemaker-857.test.ts
@@ -1,0 +1,107 @@
+import { GetSecurityConfigurationCommand, GlueClient } from '@aws-sdk/client-glue';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { ResourceGoneError } from '../src/aws-errors.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+// #857 — AWS::Glue::SecurityConfiguration has NO Cloud Control read handler
+// (registry `handlers: []`), so it was silently `skipped` on every check and a
+// stack's Glue encryption posture went unwatched. This exercises the SDK_OVERRIDES
+// reader that reads it back via glue:GetSecurityConfiguration and maps the response
+// to the CFn `EncryptionConfiguration` shape.
+
+const glue = mockClient(GlueClient);
+
+const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId,
+});
+
+beforeEach(() => {
+  glue.reset();
+});
+
+describe('Glue SecurityConfiguration (#857)', () => {
+  it('maps EncryptionConfiguration; SDK S3Encryption (singular) -> CFn S3Encryptions (plural), drops AWS-managed + non-CFn fields', async () => {
+    glue.on(GetSecurityConfigurationCommand).resolves({
+      SecurityConfiguration: {
+        Name: 'sec-cfg',
+        // AWS-managed field that must NOT appear:
+        CreatedTimeStamp: new Date(0),
+        EncryptionConfiguration: {
+          // SDK uses S3Encryption (singular array); CFn schema is S3Encryptions (plural):
+          S3Encryption: [{ S3EncryptionMode: 'SSE-KMS', KmsKeyArn: 'arn:aws:kms:...:key/s3' }],
+          CloudWatchEncryption: {
+            CloudWatchEncryptionMode: 'SSE-KMS',
+            KmsKeyArn: 'arn:aws:kms:...:key/cw',
+          },
+          JobBookmarksEncryption: {
+            JobBookmarksEncryptionMode: 'CSE-KMS',
+            KmsKeyArn: 'arn:aws:kms:...:key/jb',
+          },
+          // Returned by the SDK but NOT in the CFn schema — must be dropped:
+          DataQualityEncryption: { DataQualityEncryptionMode: 'SSE-KMS' },
+        },
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::Glue::SecurityConfiguration'](
+      ctx({ Name: 'sec-cfg' }, 'sec-cfg')
+    );
+    expect(out).toEqual({
+      Name: 'sec-cfg',
+      EncryptionConfiguration: {
+        S3Encryptions: [{ S3EncryptionMode: 'SSE-KMS', KmsKeyArn: 'arn:aws:kms:...:key/s3' }],
+        CloudWatchEncryption: {
+          CloudWatchEncryptionMode: 'SSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:...:key/cw',
+        },
+        JobBookmarksEncryption: {
+          JobBookmarksEncryptionMode: 'CSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:...:key/jb',
+        },
+      },
+    });
+  });
+
+  it('projects only the members AWS returns (a config with just S3 encryption)', async () => {
+    glue.on(GetSecurityConfigurationCommand).resolves({
+      SecurityConfiguration: {
+        Name: 's3-only',
+        EncryptionConfiguration: {
+          S3Encryption: [{ S3EncryptionMode: 'DISABLED' }],
+        },
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::Glue::SecurityConfiguration'](
+      ctx({ Name: 's3-only' }, 's3-only')
+    );
+    expect(out).toEqual({
+      Name: 's3-only',
+      EncryptionConfiguration: {
+        S3Encryptions: [{ S3EncryptionMode: 'DISABLED' }],
+      },
+    });
+  });
+
+  it('falls back to the declared Name when the physical id is empty', async () => {
+    glue.on(GetSecurityConfigurationCommand).resolves({
+      SecurityConfiguration: { Name: 'from-decl' },
+    });
+    const out = await SDK_OVERRIDES['AWS::Glue::SecurityConfiguration'](ctx({ Name: 'from-decl' }));
+    // No EncryptionConfiguration returned -> the key is omitted (not an empty object).
+    expect(out).toEqual({ Name: 'from-decl' });
+  });
+
+  it('undefined when the name cannot be resolved (physical id + declared Name both absent)', async () => {
+    expect(await SDK_OVERRIDES['AWS::Glue::SecurityConfiguration'](ctx({}))).toBeUndefined();
+  });
+
+  it('a deleted configuration (null SecurityConfiguration) -> ResourceGoneError (deleted, not skipped)', async () => {
+    glue.on(GetSecurityConfigurationCommand).resolves({ SecurityConfiguration: undefined });
+    await expect(
+      SDK_OVERRIDES['AWS::Glue::SecurityConfiguration'](ctx({ Name: 'gone' }, 'gone'))
+    ).rejects.toBeInstanceOf(ResourceGoneError);
+  });
+});


### PR DESCRIPTION
## What

`AWS::Glue::SecurityConfiguration` has **no Cloud Control read handler** (`describe-type` → `handlers: []`), so it was silently `skipped=` on every check. A Glue stack currently watches its Database/Job/Crawler/Table/Trigger/... but NOT its encryption posture — exactly the setting a security-conscious user wants drift-watched (an out-of-band KMS key swap or encryption-mode downgrade was invisible).

## Fix

`src/read/overrides.ts`: add `readGlueSecurityConfiguration` (mirrors the existing Glue overrides) via `glue:GetSecurityConfiguration(Name)`, mapping the response to the CFn `EncryptionConfiguration` shape.

Mapping decisions (verified against the live CFn registry schema):
- SDK `S3Encryption` (singular array) → CFn `S3Encryptions` (plural) — the one non-trivial mapping.
- `DataQualityEncryption` dropped (returned by the SDK but not modeled in the CFn `EncryptionConfiguration` — projecting it would be a permanent false inventory).
- `CreatedTimeStamp` dropped (AWS-managed). Not-found → `deleted` (ResourceGone). Read-only: the type is immutable (no update API), so no writer.

## Deferred — SageMaker::EndpointConfig half

`AWS::SageMaker::EndpointConfig` (the other half of #857) needs `@aws-sdk/client-sagemaker`, which is **not currently a dependency**. Adding a new dep is out of scope for this lane, so **#857 stays open** for that half. (The sibling `SageMaker::Model`/`Endpoint` are covered via Cloud Control, so no sagemaker client was ever needed before.)

## Tests

`tests/overrides-glue-sagemaker-857.test.ts` (5, `aws-sdk-client-mock`): full mapping (S3Encryption→S3Encryptions, drops), partial config, physical-id fallback to declared Name, unresolvable identity → skipped, null → deleted.

Addresses #857
