### PR TITLE
fix(noise): fold RDS OptionGroup default-fill OptionSettings to atDefault (#978)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -843,6 +843,44 @@ function isSelfEchoTrivialEmpty(v: unknown, physicalId: string | undefined): boo
   return rest.length < entries.length && rest.every(([, val]) => isTrivialEmpty(val));
 }
 
+// #978: AWS::RDS::OptionGroup default-fill — configuring an option (e.g. MARIADB_AUDIT_PLUGIN)
+// makes RDS materialize EVERY plugin setting the template did not declare, in two shapes:
+//   1. value-bearing AWS defaults (stable per plugin) — SERVER_AUDIT=FORCE_PLUS_PERMANENT, ...
+//   2. value-less `{Name}`-only husks — a listed-but-unset setting (no `Value` member).
+// Both are service-materialized first-run defaults, never user intent, so each folds
+// `atDefault` (the undeclared-tier twin of the closed #480 declared-tier fold). Equality-gated
+// so out-of-band detection survives: a husk that GAINS a Value, or a pinned default whose Value
+// CHANGES, no longer matches and surfaces as undeclared. Setting names are plugin-unique
+// (SERVER_AUDIT_* belong only to MARIADB_AUDIT_PLUGIN), so keying by Name alone carries no
+// cross-option collision. Values observed live (mariadb 10.11, us-east-1; corpus
+// AWS__RDS__OptionGroup.HuntOptionGroup).
+const RDS_OPTION_SETTING_DEFAULTS: Record<string, string> = {
+  SERVER_AUDIT: 'FORCE_PLUS_PERMANENT',
+  SERVER_AUDIT_LOGGING: 'ON',
+  SERVER_AUDIT_FILE_PATH: '/rdsdbdata/log/audit/',
+};
+
+// A `{<idField>: X}` element whose ONLY non-trivial member is its identity field — an
+// identity-only husk (the #648 `Targets[].AvailabilityZone` in-element husk class). Carries no
+// configuration, so it is a listed-but-unset default placeholder; a real value under any other
+// member makes it non-trivial and it stops folding.
+function isIdentityOnlyHusk(el: Record<string, unknown>, idField: string): boolean {
+  return Object.entries(el).every(([k, v]) => k === idField || isTrivialEmpty(v));
+}
+
+// True when a live-only RDS OptionGroup OptionSetting is a service-materialized default-fill
+// (value-bearing pinned default OR identity-only husk) that must fold `atDefault`.
+function isRdsOptionSettingDefault(
+  resourceType: string,
+  el: Record<string, unknown>,
+  name: string,
+  value: unknown
+): boolean {
+  if (resourceType !== 'AWS::RDS::OptionGroup') return false;
+  if (isIdentityOnlyHusk(el, 'Name')) return true;
+  return name in RDS_OPTION_SETTING_DEFAULTS && value === RDS_OPTION_SETTING_DEFAULTS[name];
+}
+
 // A live-only policy DOCUMENT whose statements were ALL subtracted as AWS-managed
 // (canonicalizePolicy drops the delivery.logs `AWSLogDelivery*` statements a service
 // auto-attaches when vended logs are pointed at a log group — a CloudWatch Logs
@@ -2417,8 +2455,16 @@ export function classifyResource(
               resourceType === 'AWS::KinesisFirehose::DeliveryStream' &&
               loName === 'NumberOfRetries' &&
               loValue === '3';
+            // #978: RDS OptionGroup materializes every unset plugin setting as a default-fill
+            // (value-bearing default or `{Name}`-only husk) — fold atDefault, equality-gated.
+            const isRdsOptionDefault = isRdsOptionSettingDefault(
+              resourceType,
+              loRec,
+              loName,
+              loValue
+            );
             findings.push({
-              tier: isFirehoseRetriesDefault ? 'atDefault' : 'undeclared',
+              tier: isFirehoseRetriesDefault || isRdsOptionDefault ? 'atDefault' : 'undeclared',
               logicalId,
               resourceType,
               path: `${d.path}[${loName}]`,

--- a/tests/classify-978-rds-optiongroup-default-fill.test.ts
+++ b/tests/classify-978-rds-optiongroup-default-fill.test.ts
@@ -1,0 +1,126 @@
+// #978 — AWS::RDS::OptionGroup undeclared default-fill. Configuring an option
+// (MARIADB_AUDIT_PLUGIN) makes RDS materialize EVERY plugin setting the template did not
+// declare: value-bearing AWS defaults (SERVER_AUDIT=FORCE_PLUS_PERMANENT, ...) and value-less
+// `{Name}`-only husks (a listed-but-unset setting). Both are service first-run defaults, not
+// user intent, so each must fold `atDefault` (zero first-run drift) — the undeclared-tier twin
+// of the closed #480 declared-tier fold. Detection is preserved: a husk that GAINS a Value or a
+// pinned default whose Value CHANGES still surfaces as undeclared.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'HuntOptionGroup',
+  resourceType: 'AWS::RDS::OptionGroup',
+  physicalId: 'og-phys',
+  declared,
+});
+
+// The template declares only two audit settings.
+const declared = {
+  EngineName: 'mariadb',
+  MajorEngineVersion: '10.11',
+  OptionConfigurations: [
+    {
+      OptionName: 'MARIADB_AUDIT_PLUGIN',
+      OptionSettings: [
+        { Name: 'SERVER_AUDIT_EVENTS', Value: 'CONNECT,QUERY' },
+        { Name: 'SERVER_AUDIT_QUERY_LOG_LIMIT', Value: '2048' },
+      ],
+    },
+  ],
+};
+
+// Live reads back the declared two plus RDS's default-fill of every other plugin setting.
+const liveOptionSettings = (extra: Record<string, unknown>[] = []) => ({
+  EngineName: 'mariadb',
+  MajorEngineVersion: '10.11',
+  OptionConfigurations: [
+    {
+      OptionName: 'MARIADB_AUDIT_PLUGIN',
+      VpcSecurityGroupMemberships: [],
+      OptionSettings: [
+        { Name: 'SERVER_AUDIT_QUERY_LOG_LIMIT', Value: '2048' },
+        { Name: 'SERVER_AUDIT_EVENTS', Value: 'CONNECT,QUERY' },
+        { Name: 'SERVER_AUDIT_LOGGING', Value: 'ON' },
+        { Name: 'SERVER_AUDIT_INCL_USERS' },
+        { Name: 'SERVER_AUDIT', Value: 'FORCE_PLUS_PERMANENT' },
+        { Name: 'SERVER_AUDIT_FILE_ROTATIONS' },
+        { Name: 'SERVER_AUDIT_FILE_PATH', Value: '/rdsdbdata/log/audit/' },
+        { Name: 'SERVER_AUDIT_FILE_ROTATE_SIZE' },
+        { Name: 'SERVER_AUDIT_EXCL_USERS' },
+        ...extra,
+      ],
+    },
+  ],
+});
+
+const p = (name: string) => `OptionConfigurations.0.OptionSettings[${name}]`;
+
+describe('#978 RDS OptionGroup default-fill folds to atDefault', () => {
+  it('folds every service-materialized default setting (value-bearing + husk) to atDefault', () => {
+    const f = classifyResource(mk(declared), liveOptionSettings(), emptySchema);
+    const atDefault = tier(f, 'atDefault');
+    for (const name of [
+      'SERVER_AUDIT',
+      'SERVER_AUDIT_LOGGING',
+      'SERVER_AUDIT_FILE_PATH',
+      'SERVER_AUDIT_INCL_USERS',
+      'SERVER_AUDIT_EXCL_USERS',
+      'SERVER_AUDIT_FILE_ROTATIONS',
+      'SERVER_AUDIT_FILE_ROTATE_SIZE',
+    ]) {
+      expect(atDefault).toContain(p(name));
+    }
+    // zero-first-run invariant: nothing default-filled surfaces as undeclared drift
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces a value-bearing default whose value diverged out of band — detection preserved', () => {
+    // SERVER_AUDIT_LOGGING flipped ON -> OFF is a real out-of-band mutation.
+    const live = liveOptionSettings();
+    (live.OptionConfigurations[0].OptionSettings as Record<string, unknown>[]).find(
+      (s) => s.Name === 'SERVER_AUDIT_LOGGING'
+    )!.Value = 'OFF';
+    const f = classifyResource(mk(declared), live, emptySchema);
+    expect(tier(f, 'undeclared')).toContain(p('SERVER_AUDIT_LOGGING'));
+    expect(tier(f, 'atDefault')).not.toContain(p('SERVER_AUDIT_LOGGING'));
+  });
+
+  it('surfaces a husk that GAINS a value out of band — detection preserved', () => {
+    // SERVER_AUDIT_EXCL_USERS gains a value: no longer an identity-only husk.
+    const live = liveOptionSettings();
+    (live.OptionConfigurations[0].OptionSettings as Record<string, unknown>[]).find(
+      (s) => s.Name === 'SERVER_AUDIT_EXCL_USERS'
+    )!.Value = 'rogueuser';
+    const f = classifyResource(mk(declared), live, emptySchema);
+    expect(tier(f, 'undeclared')).toContain(p('SERVER_AUDIT_EXCL_USERS'));
+    expect(tier(f, 'atDefault')).not.toContain(p('SERVER_AUDIT_EXCL_USERS'));
+  });
+
+  it('surfaces an unknown value-bearing setting the table does not pin — fail-closed', () => {
+    // A setting not in the default table, carrying a value, is genuine undeclared inventory.
+    const f = classifyResource(
+      mk(declared),
+      liveOptionSettings([{ Name: 'SOME_UNKNOWN_SETTING', Value: 'x' }]),
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain(p('SOME_UNKNOWN_SETTING'));
+  });
+});

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2701,15 +2701,21 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       { Name: 'SERVER_AUDIT_EXCL_USERS' },
     ];
 
-    it('a reordered + default-filled OptionSettings is NOT declared drift; live-only settings surface as undeclared', () => {
+    it('a reordered + default-filled OptionSettings is NOT declared drift; live-only default-fill settings fold to atDefault (#978)', () => {
+      // #978: the service-materialized default-fill settings (value-bearing AWS defaults +
+      // value-less `{Name}`-only husks) are not user intent, so they fold `atDefault` (zero
+      // first-run drift) instead of surfacing as undeclared — the undeclared-tier twin of the
+      // #480 declared-tier fold. Detection is preserved (a diverged value / a husk that gains a
+      // value re-surfaces undeclared; covered in classify-978-rds-optiongroup-default-fill).
       const findings = classifyResource(
         res(T, declared),
         liveConfigs(liveDefaultFilled),
         emptySchema
       );
       expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
-      const undeclared = findings.filter((f) => f.tier === 'undeclared');
-      expect(undeclared.map((f) => f.path).sort()).toEqual([
+      expect(findings.filter((f) => f.tier === 'undeclared')).toEqual([]);
+      const atDefault = findings.filter((f) => f.tier === 'atDefault');
+      expect(atDefault.map((f) => f.path).sort()).toEqual([
         'OptionConfigurations.0.OptionSettings[SERVER_AUDIT]',
         'OptionConfigurations.0.OptionSettings[SERVER_AUDIT_EXCL_USERS]',
         'OptionConfigurations.0.OptionSettings[SERVER_AUDIT_FILE_PATH]',
@@ -2718,7 +2724,7 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
         'OptionConfigurations.0.OptionSettings[SERVER_AUDIT_INCL_USERS]',
         'OptionConfigurations.0.OptionSettings[SERVER_AUDIT_LOGGING]',
       ]);
-      expect(undeclared.every((f) => f.nested === true)).toBe(true);
+      expect(atDefault.every((f) => f.nested === true)).toBe(true);
     });
 
     it('a genuine change to a DECLARED setting value still surfaces as declared drift (fail-closed)', () => {

--- a/tests/corpus/AWS__RDS__OptionGroup.HuntOptionGroup.json
+++ b/tests/corpus/AWS__RDS__OptionGroup.HuntOptionGroup.json
@@ -123,7 +123,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntOptionGroup",
       "resourceType": "AWS::RDS::OptionGroup",
       "path": "OptionConfigurations.0.OptionSettings[SERVER_AUDIT]",
@@ -136,7 +136,7 @@
       "constructPath": "CdkRealDriftIntegRdsOptEvsub/HuntOptionGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntOptionGroup",
       "resourceType": "AWS::RDS::OptionGroup",
       "path": "OptionConfigurations.0.OptionSettings[SERVER_AUDIT_EXCL_USERS]",
@@ -148,7 +148,7 @@
       "constructPath": "CdkRealDriftIntegRdsOptEvsub/HuntOptionGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntOptionGroup",
       "resourceType": "AWS::RDS::OptionGroup",
       "path": "OptionConfigurations.0.OptionSettings[SERVER_AUDIT_FILE_PATH]",
@@ -161,7 +161,7 @@
       "constructPath": "CdkRealDriftIntegRdsOptEvsub/HuntOptionGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntOptionGroup",
       "resourceType": "AWS::RDS::OptionGroup",
       "path": "OptionConfigurations.0.OptionSettings[SERVER_AUDIT_FILE_ROTATE_SIZE]",
@@ -173,7 +173,7 @@
       "constructPath": "CdkRealDriftIntegRdsOptEvsub/HuntOptionGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntOptionGroup",
       "resourceType": "AWS::RDS::OptionGroup",
       "path": "OptionConfigurations.0.OptionSettings[SERVER_AUDIT_FILE_ROTATIONS]",
@@ -185,7 +185,7 @@
       "constructPath": "CdkRealDriftIntegRdsOptEvsub/HuntOptionGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntOptionGroup",
       "resourceType": "AWS::RDS::OptionGroup",
       "path": "OptionConfigurations.0.OptionSettings[SERVER_AUDIT_INCL_USERS]",
@@ -197,7 +197,7 @@
       "constructPath": "CdkRealDriftIntegRdsOptEvsub/HuntOptionGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntOptionGroup",
       "resourceType": "AWS::RDS::OptionGroup",
       "path": "OptionConfigurations.0.OptionSettings[SERVER_AUDIT_LOGGING]",


### PR DESCRIPTION
Closes #978

## Problem

Configuring an `AWS::RDS::OptionGroup` option (MARIADB_AUDIT_PLUGIN) makes RDS materialize EVERY plugin setting the template did not declare. The closed #480 fix suppressed the DECLARED-tier whole-array FP but surfaced those live-only settings as **undeclared** inventory, so a clean first `check` of the standard MariaDB audit option group still showed **7 `[Potential Drift]` entries** — a zero-first-run invariant violation (the undeclared-tier twin of #480, fossilized in the golden corpus).

The 7 are all service-materialized defaults, never user intent:
- **value-bearing AWS defaults** — `SERVER_AUDIT=FORCE_PLUS_PERMANENT`, `SERVER_AUDIT_LOGGING=ON`, `SERVER_AUDIT_FILE_PATH=/rdsdbdata/log/audit/`
- **value-less `{Name}`-only husks** — `SERVER_AUDIT_EXCL_USERS`, `_INCL_USERS`, `_FILE_ROTATE_SIZE`, `_FILE_ROTATIONS` (escape `isTrivialEmpty` via their `Name` field)

## Fix

At the `NAME_VALUE_SUBSET_PATHS` live-only emit in `src/diff/classify.ts` (the same site as the #845 Firehose `NumberOfRetries` default fold), each RDS OptionGroup default-fill setting now folds `atDefault` instead of `undeclared`:
- value-bearing defaults are **equality-gated** against a pinned `RDS_OPTION_SETTING_DEFAULTS` table (setting names are plugin-unique, so keying by `Name` carries no cross-option collision)
- **identity-only husks** (`{Name}` with no other non-trivial member — the #648 `Targets[].AvailabilityZone` in-element husk class) fold generically

**Detection preserved (equality-gated):** a husk that GAINS a `Value`, or a pinned default whose `Value` CHANGES out of band, no longer matches and re-surfaces `undeclared`.

## Tests

- Corpus `AWS__RDS__OptionGroup.HuntOptionGroup` `expected` updated (the 7 flip `undeclared` → `atDefault`) — visible in the corpus-replay diff.
- New `tests/classify-978-rds-optiongroup-default-fill.test.ts`: all 7 fold `atDefault`, zero undeclared; plus three detection-preserving paths (diverged value, husk-gains-value, unknown value-bearing setting stays undeclared fail-closed).
- The #480 declared-tier tests updated to the new `atDefault` behavior.

Full local gates green: typecheck / lint+format / build / 3962 unit tests.
