### PR TITLE
fix(check): do not open the interactive resolve menu under --yes (#1054)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -24,7 +24,7 @@ import {
   warnBaselineSchemaV1,
   warnTemplateHashDrift,
 } from '../baseline/baseline-file.js';
-import { isInteractive, parseCommonArgs } from '../cli-args.js';
+import { type CommonArgs, isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { withinStackPath } from '../construct-path.js';
 import {
@@ -226,6 +226,36 @@ export function strictCoverageExit(
  */
 export function finalCheckExit(code: number, fail: boolean): number {
   return fail || code !== 1 ? code : 0;
+}
+
+/**
+ * Whether `check` should open its interactive after-report resolve menu (Record / Revert /
+ * Ignore / Decide-per-finding). It fires only when there is something to act on (drift,
+ * unrecorded values, or no baseline yet — R141's day-1 establish) AND the run is a TTY human
+ * who can make the decision. It is gated OUT of every machine/automation mode:
+ *   - --json / --show-all / --pre-deploy — machine output or baseline-untouched contracts,
+ *   - --fail — the CI drift-exit path,
+ *   - #1054: --yes — `--yes` has NO documented `check` contract (HELP scopes it to record /
+ *     ignore / revert; check's automation flag is --fail / non-TTY). In the menu the USER is
+ *     the decision-maker, but `--yes` means "no decision needed" in the record/ignore/revert
+ *     sub-actions it threads into — so a `check --yes` in a TTY silently overrode explicit
+ *     per-finding choices (recorded / ignored / reverted values the user declined, including
+ *     folded values never shown in the report). Under --yes, check just reports.
+ * Pure + exported for tests.
+ */
+export function shouldOfferInteractiveResolve(
+  a: Pick<CommonArgs, 'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes'>,
+  ctx: { code: number; hasUnrecorded: boolean; hasBaseline: boolean; interactive: boolean }
+): boolean {
+  return (
+    (ctx.code === 1 || ctx.hasUnrecorded || !ctx.hasBaseline) &&
+    !a.json &&
+    !a.showAll &&
+    !a.preDeploy &&
+    !a.fail &&
+    !a.yes &&
+    ctx.interactive
+  );
 }
 
 /**
@@ -692,12 +722,12 @@ export async function runCheck(args: string[]): Promise<number> {
       // through `check`'s own flow (pick Record) rather than a separate `cdkrd record`.
       // The whole resolution flow lives in interactive-resolve.ts; it returns the exit code.
       if (
-        (code === 1 || hasUnrecorded || !baseline) &&
-        !a.json &&
-        !a.showAll &&
-        !a.preDeploy &&
-        !a.fail &&
-        isInteractive()
+        shouldOfferInteractiveResolve(a, {
+          code,
+          hasUnrecorded,
+          hasBaseline: baseline !== undefined,
+          interactive: isInteractive(),
+        })
       ) {
         code = await resolveInteractively({
           stackName,

--- a/tests/check-yes-interactive-gate-1054.test.ts
+++ b/tests/check-yes-interactive-gate-1054.test.ts
@@ -1,0 +1,71 @@
+// #1054 — `--yes` must NOT open check's interactive after-report resolve menu. `--yes` has no
+// documented `check` contract (HELP scopes it to record / ignore / revert; check's automation
+// flag is --fail / non-TTY). In the menu the user is the decision-maker, so threading `--yes`
+// into the record/ignore/revert sub-actions silently overrode explicit per-finding choices
+// (recorded/ignored/reverted values the user declined, including folded values never shown).
+// The fix gates the menu on `!a.yes`. This asserts the pure gate predicate.
+import { describe, expect, it } from 'vite-plus/test';
+import { shouldOfferInteractiveResolve } from '../src/commands/check.js';
+import type { CommonArgs } from '../src/cli-args.js';
+
+type GateArgs = Pick<CommonArgs, 'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes'>;
+const args = (over: Partial<GateArgs> = {}): GateArgs => ({
+  json: false,
+  showAll: false,
+  preDeploy: false,
+  fail: false,
+  yes: false,
+  ...over,
+});
+// A TTY run that found drift on a baselined stack — the canonical "offer the menu" case.
+const drift = { code: 1, hasUnrecorded: false, hasBaseline: true, interactive: true };
+
+describe('#1054 shouldOfferInteractiveResolve gates the menu on --yes', () => {
+  it('offers the menu for an interactive drift run without --yes', () => {
+    expect(shouldOfferInteractiveResolve(args(), drift)).toBe(true);
+  });
+
+  it('does NOT offer the menu under --yes (the #1054 fix)', () => {
+    expect(shouldOfferInteractiveResolve(args({ yes: true }), drift)).toBe(false);
+  });
+
+  it('does NOT offer the menu under --yes even for the R141 no-baseline establish path', () => {
+    expect(
+      shouldOfferInteractiveResolve(args({ yes: true }), {
+        code: 0,
+        hasUnrecorded: false,
+        hasBaseline: false,
+        interactive: true,
+      })
+    ).toBe(false);
+  });
+
+  it('does NOT offer the menu under --yes even with unrecorded values present', () => {
+    expect(
+      shouldOfferInteractiveResolve(args({ yes: true }), {
+        code: 0,
+        hasUnrecorded: true,
+        hasBaseline: true,
+        interactive: true,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps the existing gates: no menu for --json / --show-all / --pre-deploy / --fail / non-TTY', () => {
+    for (const over of [{ json: true }, { showAll: true }, { preDeploy: true }, { fail: true }]) {
+      expect(shouldOfferInteractiveResolve(args(over), drift)).toBe(false);
+    }
+    expect(shouldOfferInteractiveResolve(args(), { ...drift, interactive: false })).toBe(false);
+  });
+
+  it('does not offer the menu when there is nothing to act on (clean, baselined, recorded)', () => {
+    expect(
+      shouldOfferInteractiveResolve(args(), {
+        code: 0,
+        hasUnrecorded: false,
+        hasBaseline: true,
+        interactive: true,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1054

## Problem

`check` accepts the global `--yes` flag, but `--yes` has **no documented `check` contract** — HELP scopes `--yes` to `record` / `ignore` / `revert`, and check's automation flag is `--fail` / non-TTY. Yet the interactive after-report menu (Record / Revert / Ignore / Decide-per-finding) still fired under it and threaded check's ambient `--yes` into its record/ignore/revert sub-actions, where `yes` means "no decision needed". In the menu the **user is the decision-maker**, so `--yes` silently overrode explicit choices:

- **(a) "Decide per finding" → record** ignored the picker's selection and recorded **everything** (endorsing values the user assigned `skip`/`ignore`).
- **(b) bulk "Ignore"** ignored **all** drift including folded values never shown in the report — contradicting HELP's "ignore ALL **shown** drift".
- **(c) bulk "Record"** skipped the promised multiselect.

## Fix

`src/commands/check.ts`: the menu gate now also requires `!a.yes`, extracted as the pure, exported `shouldOfferInteractiveResolve` predicate (matching the repo's other exported check helpers like `finalCheckExit` / `strictCoverageExit`). Under `--yes`, `check` simply reports.

All three sub-action hazards stem from the menu firing under `--yes`, so gating it out at the source fixes them together — and the behavior now matches the documented `--yes` contract.

## Tests

New `tests/check-yes-interactive-gate-1054.test.ts` asserts the predicate:
- `--yes` suppresses the menu on the drift / R141-no-baseline / unrecorded paths
- the existing `--json` / `--show-all` / `--pre-deploy` / `--fail` / non-TTY gates and the nothing-to-act-on case are unchanged

Full local gates green: typecheck / lint+format / build / 3964 unit tests.
