### PR TITLE
fix(revert): converge the six remaining Cognito UserPool folded defaults via REVERT_SET_DEFAULT_PATHS (#702)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -82,7 +82,10 @@ const CC_REVERTABLE_DESPITE_READ_OVERRIDE = new Set<string>([
 //     the existing value), so a bare `remove` is a silent no-op — Cloud Control reports
 //     SUCCESS yet the live description persists. Writing the empty-string default (an
 //     `add /Description ""`) clears it. Both behaviours proven live.
-const REVERT_SET_DEFAULT_PATHS = new Set<string>([
+// Exported so a guard test can assert every KNOWN_DEFAULTS UserPool fold has a matching
+// entry here (#702): UpdateUserPool ignores an omitted property, so a fold WITHOUT an RSDP
+// entry silently reverts as a no-op `remove`. Keyed `${resourceType}\0${path}`.
+export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   'AWS::IAM::Role\0MaxSessionDuration',
   // IAM UpdateRole ignores an omitted Description the same way it ignores an omitted
   // MaxSessionDuration (both are UpdateRole params) — a `remove` revert of an out-of-band
@@ -162,10 +165,25 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // KNOWN_DEFAULTS default (min length 8, all four char classes, 7-day temp lifetime, PASSWORD
   // first factor) is written back explicitly so revert converges.
   // BLAST RADIUS: UpdateUserPool ignores EVERY omitted field, so ANY future UserPool
-  // KNOWN_DEFAULTS addition needs a matching entry here. VerificationMessageTemplate /
-  // AccountRecoverySetting are the next two (their folds land with #701 — add them once the
-  // KNOWN_DEFAULTS defaults exist so the set-default write resolves a value).
+  // KNOWN_DEFAULTS addition needs a matching entry here (a guard test asserts this pairing so
+  // a future fold cannot silently regress to a `remove` no-op — see revert-cognito-rsdp-702).
   'AWS::Cognito::UserPool\0Policies',
+  // The remaining six UserPool KNOWN_DEFAULTS folds (#702, addendum 2026-07-10): each has a
+  // fold but was still planning a bare `remove` that UpdateUserPool ignores. Two are
+  // security-relevant out of band — EmailConfiguration switched to a DEVELOPER SES identity
+  // (mail interception) and AccountRecoverySetting weakened (account-takeover surface) would
+  // be detected yet never revertable without an explicit set-default write. The set-default
+  // value for each resolves from KNOWN_DEFAULTS (VerificationMessageTemplate
+  // {DefaultEmailOption:'CONFIRM_WITH_CODE'} / AccountRecoverySetting {RecoveryMechanisms:[...]}
+  // / EmailConfiguration {EmailSendingAccount:'COGNITO_DEFAULT'} / KeyConfiguration
+  // {KeyType:'AWS_OWNED_KEY'} / IssuerConfiguration {Type:'ORIGINAL'} /
+  // WebAuthnFactorConfiguration 'SINGLE_FACTOR').
+  'AWS::Cognito::UserPool\0VerificationMessageTemplate',
+  'AWS::Cognito::UserPool\0AccountRecoverySetting',
+  'AWS::Cognito::UserPool\0EmailConfiguration',
+  'AWS::Cognito::UserPool\0KeyConfiguration',
+  'AWS::Cognito::UserPool\0IssuerConfiguration',
+  'AWS::Cognito::UserPool\0WebAuthnFactorConfiguration',
   // SNS SetSubscriptionAttributes HARD-FAILS a `remove` of FilterPolicyScope (#630,
   // live-proven: setting it to MessageBody out of band, then reverting via `remove` fails with
   // InvalidRequest "FilterPolicyScope: Invalid value [null]. Please use either MessageBody or

--- a/tests/revert-cognito-rsdp-702.test.ts
+++ b/tests/revert-cognito-rsdp-702.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
+import { REVERT_SET_DEFAULT_PATHS, buildRevertPlan } from '../src/revert/plan.js';
+import type { BaselineFile } from '../src/baseline/baseline-file.js';
+import type { Finding } from '../src/types.js';
+
+const F = (over: Partial<Finding>): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'R',
+  physicalId: 'us-east-1_pool',
+  resourceType: 'AWS::Cognito::UserPool',
+  path: 'VerificationMessageTemplate',
+  ...over,
+});
+
+const baseline = (recorded: BaselineFile['recorded']): BaselineFile => ({
+  schemaVersion: 1,
+  stackName: 's',
+  region: 'r',
+  accountId: '111122223333',
+  capturedAt: '',
+  templateHash: '',
+  recorded,
+});
+
+// GUARD: UpdateUserPool is a full-PUT that IGNORES an omitted property, so a KNOWN_DEFAULTS
+// UserPool fold WITHOUT a matching REVERT_SET_DEFAULT_PATHS entry plans a bare `remove` that
+// the provider silently no-ops (#702). This test pairs every current + future UserPool
+// KNOWN_DEFAULTS key with its RSDP entry so a forgotten pairing fails CI, not live revert.
+describe('#702 guard: every Cognito UserPool KNOWN_DEFAULTS fold has an RSDP entry', () => {
+  const userPoolDefaults = KNOWN_DEFAULTS['AWS::Cognito::UserPool'];
+
+  it('KNOWN_DEFAULTS[AWS::Cognito::UserPool] is non-empty (guard has something to check)', () => {
+    expect(userPoolDefaults).toBeDefined();
+    expect(Object.keys(userPoolDefaults ?? {}).length).toBeGreaterThan(0);
+  });
+
+  for (const path of Object.keys(userPoolDefaults ?? {})) {
+    it(`${path} is in REVERT_SET_DEFAULT_PATHS`, () => {
+      expect(REVERT_SET_DEFAULT_PATHS.has(`AWS::Cognito::UserPool\0${path}`)).toBe(true);
+    });
+  }
+});
+
+// FUNCTIONAL: the remaining six paths (#702 addendum) must now plan an explicit set-default
+// `add` write (value present, resolved from KNOWN_DEFAULTS), NOT a bare `remove`.
+describe('#702: UserPool folded defaults revert as explicit set-default writes, not bare remove', () => {
+  const cases: Array<[string, unknown, unknown]> = [
+    [
+      'VerificationMessageTemplate',
+      { DefaultEmailOption: 'CONFIRM_WITH_LINK' },
+      { DefaultEmailOption: 'CONFIRM_WITH_CODE' },
+    ],
+    [
+      'AccountRecoverySetting',
+      { RecoveryMechanisms: [{ Priority: 1, Name: 'admin_only' }] },
+      {
+        RecoveryMechanisms: [
+          { Priority: 1, Name: 'verified_email' },
+          { Priority: 2, Name: 'verified_phone_number' },
+        ],
+      },
+    ],
+    [
+      'EmailConfiguration',
+      { EmailSendingAccount: 'DEVELOPER' },
+      { EmailSendingAccount: 'COGNITO_DEFAULT' },
+    ],
+    ['KeyConfiguration', { KeyType: 'CUSTOMER_KEY' }, { KeyType: 'AWS_OWNED_KEY' }],
+    ['IssuerConfiguration', { Type: 'CUSTOM' }, { Type: 'ORIGINAL' }],
+    ['WebAuthnFactorConfiguration', 'MULTI_FACTOR', 'SINGLE_FACTOR'],
+  ];
+
+  for (const [path, actual, expectedDefault] of cases) {
+    it(`${path} -> add op writing the KNOWN_DEFAULTS default`, () => {
+      const f = F({ path, actual });
+      const plan = buildRevertPlan([f], baseline([]));
+      const op = plan.items[0]!.ops[0]!;
+      // NOT a bare no-op remove — an explicit set-default write.
+      expect(op.op).toBe('add');
+      expect(op.path).toBe(`/${path}`);
+      expect(op.value).toEqual(expectedDefault);
+      expect(op.prior).toEqual(actual);
+    });
+  }
+
+  it('the set-default value is sourced from KNOWN_DEFAULTS (not hard-coded in plan.ts)', () => {
+    const f = F({ path: 'VerificationMessageTemplate', actual: {} });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]!.value).toEqual(
+      KNOWN_DEFAULTS['AWS::Cognito::UserPool']!.VerificationMessageTemplate
+    );
+  });
+});


### PR DESCRIPTION
## What

Cognito's `UpdateUserPool` **ignores omitted properties**, so reverting a folded UserPool default with a bare `remove` op is a no-op — the convergence verifier honestly reports `NOT reverted ... removal was a no-op` but the user cannot restore the default. `Policies` was wired to `REVERT_SET_DEFAULT_PATHS` in #710; the remaining six folded paths were not, so they never converged:

`VerificationMessageTemplate`, `AccountRecoverySetting`, `EmailConfiguration`, `KeyConfiguration`, `IssuerConfiguration`, `WebAuthnFactorConfiguration`.

Two are security-relevant out of band (an `EmailConfiguration` swap to a developer SES identity = mail interception; a weakened `AccountRecoverySetting` = account-takeover surface) — detected but previously never revertable.

## Fix

`src/revert/plan.ts`: add the six paths to `REVERT_SET_DEFAULT_PATHS` (next to the existing `Policies` entry) so revert writes the `KNOWN_DEFAULTS` default explicitly. All six folds already exist in `KNOWN_DEFAULTS['AWS::Cognito::UserPool']`.

## Tests

`tests/revert-cognito-rsdp-702.test.ts`: a **guard test** iterates every `KNOWN_DEFAULTS['AWS::Cognito::UserPool']` key and asserts a matching RSDP entry (any future UserPool fold that forgets its RSDP entry now fails CI); plus per-path functional tests asserting each builds an explicit set-default `add` op (value present) rather than a bare `remove`.

Closes #702
