### PR TITLE
fix(normalize): stop stripAwsTagsDeep from stripping declared aws:* tag-FILTER elements (#864)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3252,14 +3252,38 @@ export function resolveGeneratedDefault(
 // every CDK enforceSSL-style statement into a desired-vs-undefined false drift
 // (found by the first live policies integ run).
 export function stripAwsTagsDeep(v: unknown): unknown {
-  return stripTagsWalk(v, false);
+  return stripTagsWalk(v, false, undefined);
 }
 
-function stripTagsWalk(v: unknown, underTagsKey: boolean): unknown {
+// Tag-FILTER property names whose array elements share the `{Key,...}` tag-element
+// shape but are NOT tag LISTS — they are targeting FILTERS that legitimately select
+// resources BY an `aws:*` tag (a documented pattern). The `aws:*`-element strip below
+// must NOT apply to these: an element like `{Key:'aws:cloudformation:stack-name',...}`
+// is DECLARED intent (scope a CodeDeploy group / ResourceGroups query / DLM policy to a
+// stack's resources), and the service echoes it verbatim. Stripping it from the live
+// side leaves declared `[{Key:'aws:...'}]` vs live `[]` — a permanent declared-tier
+// false positive that survives record and churns on revert (#864). Covers:
+//   - CodeDeploy `Ec2TagFilters` (elements `{Key,Value,Type}`) and `Ec2TagSet`, whose
+//     filter elements live one level deeper under `Ec2TagSetList[].Ec2TagGroup` — so the
+//     array parent to exclude is `Ec2TagGroup` (the immediate holder of the elements)
+//   - ResourceGroups `Query.TagFilters` (elements `{Key,Values}`)
+//   - DLM policy `TargetTags`
+// (Backup selection `ListOfTags` is unaffected — its field is `ConditionKey`, not `Key`.)
+const AWS_TAG_FILTER_PROPS = new Set([
+  'TagFilters',
+  'Ec2TagFilters',
+  'Ec2TagSet',
+  'Ec2TagGroup',
+  'TargetTags',
+]);
+
+function stripTagsWalk(v: unknown, underTagsKey: boolean, parentKey: string | undefined): unknown {
   if (Array.isArray(v)) {
+    const underFilter = parentKey !== undefined && AWS_TAG_FILTER_PROPS.has(parentKey);
     return v
       .filter(
         (t) =>
+          underFilter ||
           !(
             t &&
             typeof t === 'object' &&
@@ -3267,13 +3291,13 @@ function stripTagsWalk(v: unknown, underTagsKey: boolean): unknown {
             (t as { Key: string }).Key.startsWith('aws:')
           )
       )
-      .map((t) => stripTagsWalk(t, false));
+      .map((t) => stripTagsWalk(t, false, undefined));
   }
   if (v && typeof v === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
       if (underTagsKey && k.startsWith('aws:')) continue;
-      out[k] = stripTagsWalk(val, k === 'Tags');
+      out[k] = stripTagsWalk(val, k === 'Tags', k);
     }
     return out;
   }

--- a/tests/noise-tagfilter-864.test.ts
+++ b/tests/noise-tagfilter-864.test.ts
@@ -1,0 +1,80 @@
+// #864 — stripAwsTagsDeep must not strip `aws:*`-keyed elements from tag-FILTER
+// properties (CodeDeploy Ec2TagFilters/Ec2TagSet, ResourceGroups TagFilters, DLM
+// TargetTags). Those elements share the `{Key,...}` tag-element shape but are DECLARED
+// targeting intent (select resources BY an `aws:*` tag), not tag LISTS — stripping the
+// live echo leaves declared `[{Key:'aws:...'}]` vs live `[]`, a permanent declared FP.
+// The genuine-`Tags`-list strip must still work.
+import { describe, expect, it } from 'vite-plus/test';
+import { stripAwsTagsDeep } from '../src/normalize/noise.js';
+
+describe('#864 stripAwsTagsDeep tag-FILTER exclusion', () => {
+  it('preserves an aws:* CodeDeploy Ec2TagFilters element on both sides', () => {
+    const declared = {
+      Ec2TagFilters: [
+        { Key: 'aws:cloudformation:stack-name', Value: 'MyStack', Type: 'KEY_AND_VALUE' },
+      ],
+    };
+    // The service echoes the declared filter verbatim, so the live side is identical.
+    const live = {
+      Ec2TagFilters: [
+        { Key: 'aws:cloudformation:stack-name', Value: 'MyStack', Type: 'KEY_AND_VALUE' },
+      ],
+    };
+    // Regression assertion: without the fix, the live element is stripped → [] and the
+    // two sides diverge into a permanent declared-tier FP.
+    expect(stripAwsTagsDeep(live)).toEqual(declared);
+    expect(stripAwsTagsDeep(live)).toEqual(live);
+    expect((stripAwsTagsDeep(live) as typeof live).Ec2TagFilters).toHaveLength(1);
+  });
+
+  it('preserves an aws:* CodeDeploy Ec2TagSet element (nested under Ec2TagGroup)', () => {
+    const live = {
+      Ec2TagSet: {
+        Ec2TagSetList: [
+          {
+            Ec2TagGroup: [
+              { Key: 'aws:cloudformation:stack-name', Value: 'MyStack', Type: 'KEY_AND_VALUE' },
+            ],
+          },
+        ],
+      },
+    };
+    // The CodeDeploy Ec2TagSet filter elements live under Ec2TagSetList[].Ec2TagGroup,
+    // so the immediate array parent is `Ec2TagGroup` — which is in AWS_TAG_FILTER_PROPS.
+    expect(stripAwsTagsDeep(live)).toEqual(live);
+    expect(
+      (stripAwsTagsDeep(live) as typeof live).Ec2TagSet.Ec2TagSetList[0].Ec2TagGroup
+    ).toHaveLength(1);
+  });
+
+  it('preserves an aws:* ResourceGroups Query.TagFilters element', () => {
+    const live = {
+      Query: {
+        TagFilters: [{ Key: 'aws:cloudformation:stack-name', Values: ['MyStack'] }],
+      },
+    };
+    expect(stripAwsTagsDeep(live)).toEqual(live);
+    expect((stripAwsTagsDeep(live) as typeof live).Query.TagFilters).toHaveLength(1);
+  });
+
+  it('preserves an aws:* DLM TargetTags element', () => {
+    const live = { TargetTags: [{ Key: 'aws:cloudformation:stack-name', Value: 'MyStack' }] };
+    expect(stripAwsTagsDeep(live)).toEqual(live);
+    expect((stripAwsTagsDeep(live) as typeof live).TargetTags).toHaveLength(1);
+  });
+
+  it('still strips aws:* elements from a genuine Tags list', () => {
+    const live = {
+      Tags: [
+        { Key: 'aws:cloudformation:stack-name', Value: 'MyStack' },
+        { Key: 'MyTag', Value: 'mine' },
+      ],
+    };
+    expect(stripAwsTagsDeep(live)).toEqual({ Tags: [{ Key: 'MyTag', Value: 'mine' }] });
+  });
+
+  it('still strips aws:* map keys under a Tags map', () => {
+    const live = { Tags: { 'aws:cloudformation:stack-name': 'MyStack', MyTag: 'mine' } };
+    expect(stripAwsTagsDeep(live)).toEqual({ Tags: { MyTag: 'mine' } });
+  });
+});


### PR DESCRIPTION
## What

`stripAwsTagsDeep`'s list branch stripped any array element shaped `{Key: 'aws:...'}` at any depth under any property name (`src/normalize/noise.ts`). Tag-**filter** properties share that exact element shape, and filtering **by** `aws:*` tags is a documented targeting pattern. So a user who **declares** such a filter got the live echo stripped → declared `[{Key:'aws:cloudformation:stack-name', ...}]` vs live `[]` → a permanent **declared-tier false positive** that survives `record` and churns on revert. Affected: CodeDeploy `Ec2TagFilters` / `Ec2TagSet`, ResourceGroups `Query.TagFilters`, DLM `TargetTags`.

## Fix

Thread the parent property key through the `stripAwsTagsDeep` recursion and exclude a named `AWS_TAG_FILTER_PROPS` set (`TagFilters`, `Ec2TagFilters`, `Ec2TagSet`, `Ec2TagGroup`, `TargetTags`) from the `aws:*`-element strip. The exclusion is narrow (filter-property-scoped) — genuine `Tags` arrays and maps still have their `aws:*` entries stripped. (`Ec2TagGroup` is included because CodeDeploy's `Ec2TagSet` filter elements sit one level deeper at `Ec2TagSetList[].Ec2TagGroup[]`.) Backup `ListOfTags` was never affected — its field is `ConditionKey`, not `Key`.

## Tests

`tests/noise-tagfilter-864.test.ts` (6): declared `aws:*` `Ec2TagFilters` / nested `Ec2TagGroup` / ResourceGroups `TagFilters` / DLM `TargetTags` all SURVIVE on both sides; genuine `Tags` array **and** map still strip their `aws:*` entries (proves the strip still works). Regression-proven by temporarily disabling the gate.

Closes #864
