### PR TITLE
fix(revert): whole-type SDK writers report unconsumed ops as not-reverted instead of a silent false success (#804)

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -230,6 +230,34 @@ const str = (v: unknown): string | undefined =>
 const strList = (v: unknown): string[] =>
   (Array.isArray(v) ? v : [v]).map(str).filter((s): s is string => s !== undefined);
 
+// Top-level JSON-pointer segment of an op path (`/EBSOptions/VolumeSize` -> `EBSOptions`,
+// `/Description` -> `Description`). Empty string for a `/` or malformed path.
+const opTopSeg = (path: string): string => path.replace(/^\//, '').split('/')[0] ?? '';
+
+// #804 — a whole-type SDK writer that only honors an INTERNAL allowlist of top-level props
+// must NOT silently drop an op outside that allowlist while reporting `reverted:`. The caller
+// (stack-actions.ts) records `ok:false` when a writer THROWS, surfacing the finding as still
+// unreverted; a silent `if (!any) return` instead prints a false success while AWS is
+// unchanged and the drift persists forever. Compare the incoming ops' top-level path segments
+// against the set the writer actually handles and, for any unhandled one, throw an honest
+// failure naming the dropped prop(s). `handled` may be a Set of top segments or a predicate.
+// Call this at the END of an allowlist writer (after it has done every write it can), so the
+// convergeable ops still land and only the genuinely-dropped ones are reported not-reverted.
+const assertOpsConsumed = (
+  resourceType: string,
+  ops: PatchOp[],
+  handled: Set<string> | ((topSeg: string) => boolean)
+): void => {
+  const isHandled = typeof handled === 'function' ? handled : (s: string) => handled.has(s);
+  const dropped = [...new Set(ops.map((o) => opTopSeg(o.path)).filter((s) => !isHandled(s)))];
+  if (dropped.length > 0)
+    throw new Error(
+      `${resourceType} revert cannot apply ${dropped.join(', ')}: this SDK writer supports only ` +
+        `a subset of properties and does not handle ${dropped.length > 1 ? 'these' : 'this one'}; ` +
+        `update ${dropped.length > 1 ? 'them' : 'it'} manually`
+    );
+};
+
 // reconstruct the desired full model = current (read back) with revert ops applied
 async function desiredModel(
   type: string,
@@ -612,10 +640,13 @@ const writeDocDbCluster: SdkWriter = async (ctx, ops) => {
     }
     any = true;
   }
-  if (!any) return;
-  await new DocDBClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
-    new ModifyDBClusterCommand(input)
-  );
+  // Send the convergeable (allowlist) ops FIRST, then report any op outside the allowlist as
+  // NOT reverted (#804) — a silent no-op here would print a false `reverted:`.
+  if (any)
+    await new DocDBClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+      new ModifyDBClusterCommand(input)
+    );
+  assertOpsConsumed('DocDB DBCluster', ops, DOCDB_CLUSTER_MODIFY_PARAMS);
 };
 
 // AWS::DocDB::DBInstance — Cloud Control cannot read OR write the DocDB family, so it is
@@ -662,10 +693,11 @@ const writeDocDbInstance: SdkWriter = async (ctx, ops) => {
     }
     any = true;
   }
-  if (!any) return;
-  await new DocDBClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
-    new ModifyDBInstanceCommand(input)
-  );
+  if (any)
+    await new DocDBClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+      new ModifyDBInstanceCommand(input)
+    );
+  assertOpsConsumed('DocDB DBInstance', ops, DOCDB_INSTANCE_MODIFY_PARAMS);
 };
 
 // AWS::CloudFront::Distribution — Cloud Control CAN read this type, but its
@@ -811,6 +843,18 @@ const writeGlueJob: SdkWriter = async (ctx, ops) => {
     if (m.AllocatedCapacity !== undefined) update.AllocatedCapacity = m.AllocatedCapacity;
   }
   await c.send(new UpdateJobCommand({ JobName: name, JobUpdate: update as never }));
+  // #804 — an op on a prop outside the JobUpdate field set (e.g. read-only CreatedOn, or a
+  // prop this writer does not model) is applied to `m` then dropped by the explicit field
+  // copy; report it not-reverted rather than a false `reverted:`. MaxCapacity/AllocatedCapacity
+  // ARE handled (for a non-WorkerType job) so they are in the handled set.
+  assertOpsConsumed(
+    'Glue Job',
+    ops,
+    (top) =>
+      (GLUE_JOB_UPDATE_FIELDS as readonly string[]).includes(top) ||
+      top === 'MaxCapacity' ||
+      top === 'AllocatedCapacity'
+  );
 };
 
 // AWS::Glue::Table — Cloud Control GetResource throws UnsupportedActionException for the
@@ -1270,6 +1314,9 @@ const writeOpenSearchDomain: SdkWriter = async (ctx, ops) => {
     }
   }
   await c.send(new UpdateDomainConfigCommand(input as never));
+  // #804 — EngineVersion / Tags (and any other prop outside OS_UPDATABLE_OPTIONS) are dropped
+  // by UpdateDomainConfig here; report them not-reverted rather than a false `reverted:`.
+  assertOpsConsumed('OpenSearch Domain', ops, OS_UPDATABLE_OPTIONS);
 };
 
 // AWS::Logs::LogGroup.BearerTokenAuthenticationEnabled — Cloud Control CAN read this
@@ -1488,7 +1535,10 @@ function camelKeysDeep(v: unknown): unknown {
 const writeEcsServiceWriteOnlyProps: SdkWriter = async (ctx, ops) => {
   const cluster = str(ctx.declared['Cluster']);
   const service = str(ctx.physicalId);
-  if (!cluster || !service) return;
+  // #804 — a silent `return` here (the only writer that did) prints a false `reverted:` when the
+  // target cannot be resolved (a raw-CFn service on the DEFAULT cluster declares no Cluster).
+  // Fail honestly like every sibling writer so the finding stays surfaced as not-reverted.
+  if (!cluster || !service) throw new Error('cannot resolve ECS cluster/service for revert');
   const input: { cluster: string; service: string } & Record<string, unknown> = {
     cluster,
     service,
@@ -1869,6 +1919,17 @@ const writeEc2ClientVpnEndpoint: SdkWriter = async (ctx, ops) => {
         `(unset state is not expressible in a selective modify)${any ? '; the other revert op(s) were applied' : ''}; ` +
         `update ${unExpressible.length > 1 ? 'them' : 'it'} manually`
     );
+  // #804 — a prop the writer does not model at all (SelfServicePortal / ClientConnectOptions /
+  // ClientLoginBannerOptions) is silently ignored above; report it not-reverted.
+  assertOpsConsumed(
+    'EC2 ClientVpnEndpoint',
+    ops,
+    (top) =>
+      CLIENT_VPN_SCALAR_PARAMS.has(top) ||
+      top === 'ConnectionLogOptions' ||
+      top === 'DnsServers' ||
+      top === 'SecurityGroupIds'
+  );
 };
 
 // AWS::Lex::Bot `BotLocales` is the ENTIRE conversational model (locales → intents → slots +
@@ -2325,10 +2386,14 @@ const writeElasticBeanstalkApplication: SdkWriter = async (ctx, ops) => {
       any = true;
     }
   }
-  if (!any) return;
-  await new ElasticBeanstalkClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
-    new UpdateApplicationCommand(input)
-  );
+  if (any)
+    await new ElasticBeanstalkClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+      new UpdateApplicationCommand(input)
+    );
+  // #804 — ResourceLifecycleConfig (needs a separate UpdateApplicationResourceLifecycle call)
+  // and any other prop outside EB_APPLICATION_MODIFY_PARAMS are NOT applied here; report them
+  // not-reverted instead of silently succeeding.
+  assertOpsConsumed('ElasticBeanstalk Application', ops, EB_APPLICATION_MODIFY_PARAMS);
 };
 
 const EB_ENVIRONMENT_MODIFY_PARAMS = new Set(['Description']);
@@ -2344,10 +2409,14 @@ const writeElasticBeanstalkEnvironment: SdkWriter = async (ctx, ops) => {
       any = true;
     }
   }
-  if (!any) return;
-  await new ElasticBeanstalkClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
-    new UpdateEnvironmentCommand(input)
-  );
+  if (any)
+    await new ElasticBeanstalkClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+      new UpdateEnvironmentCommand(input)
+    );
+  // #804 — VersionLabel / PlatformArn / SolutionStackName (the common OOB console-deploy /
+  // platform drift) are NOT in the allowlist and are not applied here; report them
+  // not-reverted rather than print a false `reverted:`.
+  assertOpsConsumed('ElasticBeanstalk Environment', ops, EB_ENVIRONMENT_MODIFY_PARAMS);
 };
 
 // Kinesis Video Stream / SignalingChannel: Cloud Control UpdateResource REJECTS ANY patch
@@ -2575,6 +2644,9 @@ const writeApiGatewayV2Stage: SdkWriter = async (ctx, ops) => {
       )
     );
   }
+  // #804 — Tags (and any prop outside APIGWV2_STAGE_UPDATE_FIELDS) are not applied by
+  // UpdateStage/DeleteRouteSettings/DeleteAccessLogSettings here; report them not-reverted.
+  assertOpsConsumed('ApiGatewayV2 Stage', ops, APIGWV2_STAGE_UPDATE_FIELDS);
 };
 
 // AWS::ApiGateway::RestApi `Policy` — the RestApi resource policy is held in the Cloud

--- a/tests/writers-dropped-op-804.test.ts
+++ b/tests/writers-dropped-op-804.test.ts
@@ -1,0 +1,91 @@
+// #804 — a whole-type SDK writer that maintains an INTERNAL allowlist of handled top-level
+// props must NOT silently drop an op OUTSIDE that allowlist while the run reports `reverted:`.
+// The client never sends anything for the dropped prop, yet stack-actions.ts prints
+// `reverted:` and the convergence re-read shows "N drift(s) remain" with no explanation.
+// The contained fix: the writer THROWS an honest failure naming the dropped prop(s), which the
+// revert caller records as `ok:false` (not-reverted) — the same channel every other writer
+// failure uses. These tests assert the un-handled op is reported not-reverted (throws), while a
+// mixed op set still applies the convergeable (allowlist) prop before reporting the dropped one.
+import { OpenSearchClient, UpdateDomainConfigCommand } from '@aws-sdk/client-opensearch';
+import { DescribeDomainConfigCommand } from '@aws-sdk/client-opensearch';
+import {
+  ElasticBeanstalkClient,
+  UpdateEnvironmentCommand,
+} from '@aws-sdk/client-elastic-beanstalk';
+import { ECSClient } from '@aws-sdk/client-ecs';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { OverrideCtx } from '../src/read/overrides.js';
+import type { PatchOp } from '../src/revert/plan.js';
+import { SDK_WRITERS, resolveSdkWriter } from '../src/revert/writers.js';
+
+const opensearch = mockClient(OpenSearchClient);
+const eb = mockClient(ElasticBeanstalkClient);
+const ecs = mockClient(ECSClient);
+
+const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
+  physicalId: 'pid',
+  declared: {},
+  region: 'us-east-1',
+  accountId: '123456789012',
+  ...over,
+});
+
+beforeEach(() => {
+  opensearch.reset();
+  eb.reset();
+  ecs.reset();
+});
+
+describe('#804 whole-type writer must report an op outside its allowlist as NOT reverted', () => {
+  it('OpenSearch: a Tags op (outside OS_UPDATABLE_OPTIONS) is reported not-reverted, not a silent success', async () => {
+    opensearch.on(DescribeDomainConfigCommand).resolves({ DomainConfig: {} } as never);
+    opensearch.on(UpdateDomainConfigCommand).resolves({});
+    // Tags is a mutable, reader-visible prop the UpdateDomainConfig path drops.
+    await expect(
+      SDK_WRITERS['AWS::OpenSearchService::Domain'](ctx({ physicalId: 'my-domain' }), [
+        { op: 'add', path: '/Tags', value: [{ Key: 'a', Value: 'b' }], human: 'Tags -> value' },
+      ])
+    ).rejects.toThrow(/Tags/);
+  });
+
+  it('OpenSearch: a mixed op set applies the allowlist prop (EBSOptions) THEN reports the dropped one (EngineVersion)', async () => {
+    opensearch.on(DescribeDomainConfigCommand).resolves({
+      DomainConfig: { EBSOptions: { Options: { VolumeSize: 20 } } },
+    } as never);
+    opensearch.on(UpdateDomainConfigCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::OpenSearchService::Domain'](ctx({ physicalId: 'd' }), [
+        { op: 'add', path: '/EBSOptions/VolumeSize', value: 10, human: 'x' },
+        { op: 'add', path: '/EngineVersion', value: 'OpenSearch_2.11', human: 'x' },
+      ])
+    ).rejects.toThrow(/EngineVersion/);
+    // the convergeable EBSOptions op WAS applied before the not-reverted report.
+    const calls = opensearch.commandCalls(UpdateDomainConfigCommand);
+    expect(calls).toHaveLength(1);
+    expect((calls[0]!.args[0].input as unknown as Record<string, unknown>).EBSOptions).toEqual({
+      VolumeSize: 10,
+    });
+  });
+
+  it('ElasticBeanstalk Environment: a VersionLabel op (the common OOB drift) is reported not-reverted', async () => {
+    eb.on(UpdateEnvironmentCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::ElasticBeanstalk::Environment'](
+        ctx({ physicalId: 'env', declared: { EnvironmentName: 'env' } }),
+        [{ op: 'add', path: '/VersionLabel', value: 'v2', human: 'VersionLabel -> v2' }]
+      )
+    ).rejects.toThrow(/VersionLabel/);
+    // nothing convergeable → no UpdateEnvironment call was sent.
+    expect(eb.commandCalls(UpdateEnvironmentCommand)).toHaveLength(0);
+  });
+
+  it('ECS write-only-props writer: an unresolvable target throws instead of a silent success', async () => {
+    // A raw-CFn service on the DEFAULT cluster declares no Cluster — the target cannot be
+    // resolved. Before #804 the writer `return`ed silently (false `reverted:`); now it throws.
+    const ops: PatchOp[] = [{ op: 'remove', path: '/ServiceConnectConfiguration', human: '' }];
+    await expect(
+      resolveSdkWriter('AWS::ECS::Service', ops)!(ctx({ physicalId: 'svc', declared: {} }), ops)
+    ).rejects.toThrow(/ECS cluster\/service/);
+  });
+});

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -1509,13 +1509,17 @@ describe('DocDB DBCluster writer (CC read+write gap)', () => {
     });
   });
 
-  it('does NOT send EngineVersion (off the safe-modify allowlist -> no accidental upgrade)', async () => {
+  it('does NOT send EngineVersion (off the safe-modify allowlist) AND reports it not-reverted (#804)', async () => {
     stubClusterRead({ EngineVersion: '4.0.0' });
     docdb.on(ModifyDBClusterCommand).resolves({});
-    // a hypothetical EngineVersion revert op must be ignored (no modifiable param emitted)
-    await SDK_WRITERS['AWS::DocDB::DBCluster'](ctx({ physicalId: CLID }), [
-      { op: 'add', path: '/EngineVersion', value: '5.0.0', human: 'x' },
-    ]);
+    // EngineVersion is off the safe-modify allowlist (a version write can trigger an upgrade),
+    // so no ModifyDBCluster is sent — but before #804 the writer also printed a false
+    // `reverted:`. It now throws so the finding stays surfaced as not-reverted.
+    await expect(
+      SDK_WRITERS['AWS::DocDB::DBCluster'](ctx({ physicalId: CLID }), [
+        { op: 'add', path: '/EngineVersion', value: '5.0.0', human: 'x' },
+      ])
+    ).rejects.toThrow(/EngineVersion/);
     expect(docdb.commandCalls(ModifyDBClusterCommand)).toHaveLength(0);
   });
 
@@ -1584,14 +1588,18 @@ describe('DocDB DBInstance writer (CC read+write gap; mirror of the cluster writ
     });
   });
 
-  it('ignores an op off the safe-modify allowlist (AutoMinorVersionUpgrade is cluster-managed)', async () => {
+  it('reports an op off the safe-modify allowlist as NOT reverted, not a silent success (#804)', async () => {
     stubInstanceRead({ AutoMinorVersionUpgrade: true });
     docdb.on(ModifyDBInstanceCommand).resolves({});
-    // AutoMinorVersionUpgrade is a DocDB CLUSTER setting — ModifyDBInstance rejects it, so
-    // it is OFF the instance allowlist and an op on it must be ignored (no Modify call).
-    await SDK_WRITERS['AWS::DocDB::DBInstance'](ctx({ physicalId: IID }), [
-      { op: 'add', path: '/AutoMinorVersionUpgrade', value: false, human: 'x' },
-    ]);
+    // AutoMinorVersionUpgrade is OFF the instance allowlist (a cluster-managed setting
+    // ModifyDBInstance rejects). Before #804 the writer dropped it silently and the run
+    // printed a false `reverted:`; now it throws so the finding stays surfaced as not-reverted.
+    await expect(
+      SDK_WRITERS['AWS::DocDB::DBInstance'](ctx({ physicalId: IID }), [
+        { op: 'add', path: '/AutoMinorVersionUpgrade', value: false, human: 'x' },
+      ])
+    ).rejects.toThrow(/AutoMinorVersionUpgrade/);
+    // No convergeable op was present, so no Modify call was sent.
     expect(docdb.commandCalls(ModifyDBInstanceCommand)).toHaveLength(0);
   });
 
@@ -1685,12 +1693,17 @@ describe('ElasticBeanstalk Application/Environment writers (CC UpdateResource Se
     expect(calls[0]!.args[0].input).toEqual({ EnvironmentName: 'my-env', Description: 'declared' });
   });
 
-  it('an off-allowlist prop (create-only Tier) sends NO update — never accidentally mutated', async () => {
+  it('an off-allowlist prop (create-only Tier) sends NO update AND is reported not-reverted (#804)', async () => {
     eb.on(UpdateEnvironmentCommand).resolves({});
-    await SDK_WRITERS['AWS::ElasticBeanstalk::Environment'](
-      ctx({ physicalId: 'my-env', declared: { EnvironmentName: 'my-env' } }),
-      [{ op: 'add', path: '/Tier', value: { Name: 'Worker' }, human: 'x' }]
-    );
+    // Tier is off the allowlist (create-only) — no UpdateEnvironment is sent (never accidentally
+    // mutated) — but before #804 the writer printed a false `reverted:`. It now throws so the
+    // finding stays surfaced as not-reverted.
+    await expect(
+      SDK_WRITERS['AWS::ElasticBeanstalk::Environment'](
+        ctx({ physicalId: 'my-env', declared: { EnvironmentName: 'my-env' } }),
+        [{ op: 'add', path: '/Tier', value: { Name: 'Worker' }, human: 'x' }]
+      )
+    ).rejects.toThrow(/Tier/);
     expect(eb.commandCalls(UpdateEnvironmentCommand)).toHaveLength(0);
   });
 


### PR DESCRIPTION
## What

Whole-type allowlist-style SDK writers (`src/revert/writers.ts` — DocDB Cluster/Instance, ElasticBeanstalk Application/Environment, OpenSearch Domain, ApiGatewayV2 Stage, Glue Job, EC2 ClientVpnEndpoint, ...) only honored ops whose top-level property was in their internal allowlist and **silently dropped** the rest, yet still resolved. The caller (`stack-actions.ts`) turns a resolved writer into `reverted:`, so a genuine drift on an un-handled path printed a **false "reverted" + CLEAN-after-revert** while AWS was unchanged.

The writer signature (`(ctx, ops) => Promise<void>`) has no per-op return channel — its only truthful signal is throw = failure. The fix uses that channel.

## Fix

`assertOpsConsumed(resourceType, ops, handled)` shared helper: each affected writer applies its allowlisted (convergeable) ops **first** (preserving the #1102 apply-then-throw isolation so the good ops still land), then calls `assertOpsConsumed`, which **throws** an honest error naming any unconsumed op. The existing caller maps that throw to a not-reverted outcome — so the `reverted:` / convergence accounting becomes truthful. `writeEcsServiceWriteOnlyProps`'s silent `return` on an unresolvable target now throws to match every sibling writer.

**Fully contained to `writers.ts`** — no orchestration change needed (the caller already turns a thrown writer error into not-reverted).

## Tests

`tests/writers-dropped-op-804.test.ts` (4): OpenSearch `Tags` op → not-reverted; OpenSearch mixed set applies `EBSOptions` then reports dropped `EngineVersion`; EB Environment `VersionLabel` → not-reverted with no UpdateEnvironment sent; ECS unresolvable target throws. All fail without the fix. Three existing `writers.test.ts` cases that encoded the old silent-drop-as-success were updated to assert the honest throw (no mutation call sent).

Closes #804
