### PR TITLE
fix(read): enumerate IPv6 + prefix-list routes in the route-table child enumerator (#1081)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -2312,41 +2312,61 @@ async function enumerateVpcChildren(ctx: EnumeratorContext): Promise<AddedChild[
 // Non-declarable routes are skipped by `isEnumerableRoute`: the auto-created VPC-CIDR
 // LOCAL route (`Origin CreateRouteTable` / `GatewayId local`) and VGW-PROPAGATED routes
 // (`Origin EnableVgwRoutePropagation` — BGP/propagated, not declarable `AWS::EC2::Route`
-// resources). Only IPv4 routes (those with a DestinationCidrBlock) are handled, since the
-// CC identifier keys on CidrBlock. The CC primaryIdentifier for AWS::EC2::Route is the
-// composite `["/properties/RouteTableId","/properties/CidrBlock"]`, so the `identifier`
-// is the composite `RouteTableId|CidrBlock` (RouteTableId first) — that is what CC
-// GetResource / DeleteResource consume.
+// resources). A route is declarable on ANY of its THREE destination axes — an IPv4
+// `DestinationCidrBlock`, an IPv6 `DestinationIpv6CidrBlock`, or a `DestinationPrefixListId`
+// (exactly one is set per route) — so all three are enumerated (#1081). An out-of-band IPv6
+// `::/0` route to a rogue IGW/ENI (a traffic-hijack / exfil path) or a prefix-list route
+// added out of band is thus caught by the `added` tier, not silently ignored. The CC
+// primaryIdentifier for AWS::EC2::Route keys on the destination: IPv4 on `CidrBlock`, IPv6 on
+// `Ipv6CidrBlock`, prefix-list on `DestinationPrefixListId` — so the `identifier` is the
+// composite `RouteTableId|<destination>` (RouteTableId first) and the `live` model carries
+// RouteTableId + the matching CC destination key. That is what CC GetResource / DeleteResource
+// consume.
 
-// Pure diff: declared cidrs + live inventory -> the added routes.
+// The destination axis of a route: the live route's destination VALUE, plus the CC identifier
+// property that keys it (`CidrBlock` for IPv4, `Ipv6CidrBlock` for IPv6,
+// `DestinationPrefixListId` for a prefix list). Exactly one axis is set per route.
+export interface LiveRouteDest {
+  value: string;
+  ccKey: 'CidrBlock' | 'Ipv6CidrBlock' | 'DestinationPrefixListId';
+}
+
+// Pure diff: declared destinations + live inventory -> the added routes.
 export interface RouteTableChildInput {
   routeTableId: string;
-  declaredCidrs: string[]; // DestinationCidrBlocks of AWS::EC2::Route declared on this table
-  liveRoutes: { cidr: string }[];
+  // Declared destination VALUES of AWS::EC2::Route on this table, across all three axes
+  // (DestinationCidrBlock / DestinationIpv6CidrBlock / DestinationPrefixListId). A route's
+  // identity within a table is its destination, so matching a live destination value against
+  // this set folds a DECLARED route regardless of axis.
+  declaredDests: string[];
+  liveRoutes: LiveRouteDest[];
   // Fail-safe (#1082): at least one declared route on this table has an UNRESOLVED
-  // DestinationCidrBlock (a `{{resolve:ssm:...}}` dynamic ref, a degraded Fn::ImportValue,
-  // or a no-default NoEcho Ref → the UNRESOLVED symbol). The route's identity is matched
-  // ONLY through its DestinationCidrBlock (the CFn physical id is a generated token), so an
-  // UNRESOLVED cidr cannot be matched to any live route. Reporting a live route as `added`
-  // then risks a destructive `revert --remove-unrecorded` DeleteResource against a route the
+  // destination (a `{{resolve:ssm:...}}` dynamic ref, a degraded Fn::ImportValue, or a
+  // no-default NoEcho Ref → the UNRESOLVED symbol). The route's identity is matched ONLY
+  // through its destination (the CFn physical id is a generated token), so an UNRESOLVED
+  // destination cannot be matched to any live route. Reporting a live route as `added` then
+  // risks a destructive `revert --remove-unrecorded` DeleteResource against a route the
   // template DECLARES. When true, suppress `added` for THIS table's routes entirely.
   hasUnresolvedDeclaredRoute?: boolean;
 }
 
 export function diffRouteTableChildren(input: RouteTableChildInput): AddedChild[] {
-  const { routeTableId, declaredCidrs, liveRoutes, hasUnresolvedDeclaredRoute } = input;
-  // A declared route with an UNRESOLVED DestinationCidrBlock could be ANY of the live
-  // routes — we can't tell which — so we cannot safely call any live route `added`.
+  const { routeTableId, declaredDests, liveRoutes, hasUnresolvedDeclaredRoute } = input;
+  // A declared route with an UNRESOLVED destination could be ANY of the live routes — we
+  // can't tell which — so we cannot safely call any live route `added`.
   if (hasUnresolvedDeclaredRoute) return [];
-  const declared = new Set(declaredCidrs);
+  const declared = new Set(declaredDests);
   const added: AddedChild[] = [];
   for (const route of liveRoutes) {
-    if (declared.has(route.cidr)) continue;
+    if (declared.has(route.value)) continue;
     added.push({
       resourceType: 'AWS::EC2::Route',
-      identifier: `${routeTableId}|${route.cidr}`, // CC composite RouteTableId|CidrBlock
-      label: route.cidr,
-      live: { RouteTableId: routeTableId, CidrBlock: route.cidr },
+      // CC composite RouteTableId|<destination> (RouteTableId first).
+      identifier: `${routeTableId}|${route.value}`,
+      label: route.value,
+      // The `live` model keys the destination on its CC identifier property (CidrBlock /
+      // Ipv6CidrBlock / DestinationPrefixListId) so a DeleteResource targets the right route.
+      live: { RouteTableId: routeTableId, [route.ccKey]: route.value },
     });
   }
   return added;
@@ -2357,34 +2377,55 @@ async function describeRouteTable(client: EC2Client, routeTableId: string): Prom
   return res.RouteTables?.[0]?.Routes ?? [];
 }
 
-// A live route is an enumerable out-of-band `AWS::EC2::Route` only if it is one a user
-// could have declared. EXCLUDED:
-//   - the auto-created VPC-CIDR LOCAL route (Origin CreateRouteTable / GatewayId local);
-//   - an IPv6-only route (no DestinationCidrBlock — the CC identifier keys on CidrBlock);
+// A live route is an enumerable out-of-band `AWS::EC2::Route` only if it is one a user could
+// have declared, i.e. it has a destination on one of the three declarable axes
+// (DestinationCidrBlock / DestinationIpv6CidrBlock / DestinationPrefixListId — exactly one is
+// set per route). EXCLUDED regardless of axis:
+//   - the auto-created VPC-CIDR LOCAL route (Origin CreateRouteTable / GatewayId local) — an
+//     IPv6 VPC also gets an auto LOCAL IPv6 route, so the exclusion is axis-independent;
 //   - a route inserted by VGW route PROPAGATION (Origin EnableVgwRoutePropagation): these
 //     are BGP/propagated, not declarable `AWS::EC2::Route` resources, and AWS re-creates
 //     them — flagging one as `added` is a false positive, and a `revert` DeleteResource
 //     would either churn (AWS re-propagates) or fail. Pure + exported for unit tests.
-export function isEnumerableRoute(
-  route: Ec2Route
-): route is Ec2Route & { DestinationCidrBlock: string } {
+export function isEnumerableRoute(route: Ec2Route): boolean {
+  const hasDeclarableDest =
+    typeof route.DestinationCidrBlock === 'string' ||
+    typeof route.DestinationIpv6CidrBlock === 'string' ||
+    typeof route.DestinationPrefixListId === 'string';
   return (
-    typeof route.DestinationCidrBlock === 'string' &&
+    hasDeclarableDest &&
     route.Origin !== 'CreateRouteTable' &&
     route.Origin !== 'EnableVgwRoutePropagation' &&
     route.GatewayId !== 'local'
   );
 }
 
-async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+// The destination axis of a live route: pick whichever of the three destination fields is set
+// (exactly one is per route) and pair it with its CC identifier key. Returns undefined for a
+// route with no declarable destination (should be pre-filtered by isEnumerableRoute).
+function liveRouteDest(route: Ec2Route): LiveRouteDest | undefined {
+  if (typeof route.DestinationCidrBlock === 'string') {
+    return { value: route.DestinationCidrBlock, ccKey: 'CidrBlock' };
+  }
+  if (typeof route.DestinationIpv6CidrBlock === 'string') {
+    return { value: route.DestinationIpv6CidrBlock, ccKey: 'Ipv6CidrBlock' };
+  }
+  if (typeof route.DestinationPrefixListId === 'string') {
+    return { value: route.DestinationPrefixListId, ccKey: 'DestinationPrefixListId' };
+  }
+  return undefined;
+}
+
+export async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
   const { parent, desired, region } = ctx;
   const routeTableId = parent.physicalId; // a RouteTable's physical id IS its RouteTableId
   if (!routeTableId) return [];
 
   // Declared routes on THIS route table (Ref/GetAtt RouteTableId already resolved to the
-  // physical id by gather). A route's CFn physical id is a generated token, so MATCH
-  // declared routes by DestinationCidrBlock (the route's identity within the table).
-  const declaredCidrs: string[] = [];
+  // physical id by gather). A route's CFn physical id is a generated token, so MATCH declared
+  // routes by their destination — whichever of the three axes the route declares
+  // (DestinationCidrBlock / DestinationIpv6CidrBlock / DestinationPrefixListId).
+  const declaredDests: string[] = [];
   let hasUnresolvedDeclaredRoute = false;
   for (const r of desired.resources) {
     if (
@@ -2393,15 +2434,18 @@ async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<Adde
     ) {
       continue;
     }
-    const cidr = r.declared.DestinationCidrBlock;
-    if (typeof cidr === 'string') {
-      declaredCidrs.push(cidr);
-    } else if (cidr === UNRESOLVED || hasUnresolved(cidr)) {
-      // Fail-safe (#1082): an UNRESOLVED DestinationCidrBlock (dynamic ref / degraded
-      // ImportValue / no-default NoEcho Ref) is this route's ONLY identity handle, so its
-      // live counterpart cannot be matched. Suppress `added` for this table's routes rather
-      // than offer a destructive delete of a route the template declares. Mirrors the
-      // parentRefMatches / #962 fail-safe, applied to the child IDENTITY property.
+    const dest =
+      r.declared.DestinationCidrBlock ??
+      r.declared.DestinationIpv6CidrBlock ??
+      r.declared.DestinationPrefixListId;
+    if (typeof dest === 'string') {
+      declaredDests.push(dest);
+    } else if (dest === UNRESOLVED || hasUnresolved(dest)) {
+      // Fail-safe (#1082): an UNRESOLVED destination (dynamic ref / degraded ImportValue /
+      // no-default NoEcho Ref) is this route's ONLY identity handle, so its live counterpart
+      // cannot be matched. Suppress `added` for this table's routes rather than offer a
+      // destructive delete of a route the template declares. Mirrors the parentRefMatches /
+      // #962 fail-safe, applied to the child IDENTITY property.
       hasUnresolvedDeclaredRoute = true;
     }
   }
@@ -2410,11 +2454,12 @@ async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<Adde
   const routes = await describeRouteTable(client, routeTableId);
   const liveRoutes = routes
     .filter(isEnumerableRoute)
-    .map((route) => ({ cidr: route.DestinationCidrBlock }));
+    .map(liveRouteDest)
+    .filter((d): d is LiveRouteDest => d !== undefined);
 
   return diffRouteTableChildren({
     routeTableId,
-    declaredCidrs,
+    declaredDests,
     liveRoutes,
     hasUnresolvedDeclaredRoute,
   });

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -10,6 +10,7 @@ import {
   DescribeDBInstancesCommand,
   RDSClient,
 } from '@aws-sdk/client-rds';
+import { DescribeRouteTablesCommand, EC2Client, type Route as Ec2Route } from '@aws-sdk/client-ec2';
 import { ListResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { ListSubscriptionsByTopicCommand, SNSClient } from '@aws-sdk/client-sns';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -20,6 +21,7 @@ import {
   enumerateLambdaFunctionChildren,
   enumerateRdsClusterChildren,
   enumerateRoute53HostedZoneChildren,
+  enumerateRouteTableChildren,
   enumerateSnsTopicChildren,
   diffApiGatewayAuthorizers,
   diffApiGatewayChildren,
@@ -1640,8 +1642,11 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
   it('flags an out-of-band route added via the console (not in the template)', () => {
     const added = diffRouteTableChildren({
       routeTableId: RT,
-      declaredCidrs: ['0.0.0.0/0'],
-      liveRoutes: [{ cidr: '0.0.0.0/0' }, { cidr: '10.99.0.0/16' }],
+      declaredDests: ['0.0.0.0/0'],
+      liveRoutes: [
+        { value: '0.0.0.0/0', ccKey: 'CidrBlock' },
+        { value: '10.99.0.0/16', ccKey: 'CidrBlock' },
+      ],
     });
     expect(added).toEqual([
       {
@@ -1656,8 +1661,8 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
   it('identifier is the CC composite RouteTableId|CidrBlock', () => {
     const added = diffRouteTableChildren({
       routeTableId: RT,
-      declaredCidrs: [],
-      liveRoutes: [{ cidr: '10.98.0.0/16' }],
+      declaredDests: [],
+      liveRoutes: [{ value: '10.98.0.0/16', ccKey: 'CidrBlock' }],
     });
     expect(added[0]!.identifier).toBe(`${RT}|10.98.0.0/16`);
   });
@@ -1666,8 +1671,60 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
     expect(
       diffRouteTableChildren({
         routeTableId: RT,
-        declaredCidrs: ['0.0.0.0/0', '192.168.0.0/16'],
-        liveRoutes: [{ cidr: '0.0.0.0/0' }, { cidr: '192.168.0.0/16' }],
+        declaredDests: ['0.0.0.0/0', '192.168.0.0/16'],
+        liveRoutes: [
+          { value: '0.0.0.0/0', ccKey: 'CidrBlock' },
+          { value: '192.168.0.0/16', ccKey: 'CidrBlock' },
+        ],
+      })
+    ).toEqual([]);
+  });
+
+  // #1081: an AWS::EC2::Route can be declared on ANY of three destination axes —
+  // DestinationCidrBlock (IPv4), DestinationIpv6CidrBlock (IPv6), or DestinationPrefixListId.
+  // An out-of-band IPv6 or prefix-list route (a rogue `::/0` to an IGW/ENI is a traffic-hijack
+  // / exfil path) must surface as `added`; a DECLARED IPv6/prefix-list route must fold.
+  it('flags an out-of-band IPv6 route (::/0) not in the template (#1081)', () => {
+    const added = diffRouteTableChildren({
+      routeTableId: RT,
+      declaredDests: [],
+      liveRoutes: [{ value: '::/0', ccKey: 'Ipv6CidrBlock' }],
+    });
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::EC2::Route',
+        identifier: `${RT}|::/0`,
+        label: '::/0',
+        live: { RouteTableId: RT, Ipv6CidrBlock: '::/0' },
+      },
+    ]);
+  });
+
+  it('flags an out-of-band prefix-list route not in the template (#1081)', () => {
+    const added = diffRouteTableChildren({
+      routeTableId: RT,
+      declaredDests: [],
+      liveRoutes: [{ value: 'pl-0a1b2c3d', ccKey: 'DestinationPrefixListId' }],
+    });
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::EC2::Route',
+        identifier: `${RT}|pl-0a1b2c3d`,
+        label: 'pl-0a1b2c3d',
+        live: { RouteTableId: RT, DestinationPrefixListId: 'pl-0a1b2c3d' },
+      },
+    ]);
+  });
+
+  it('folds a DECLARED IPv6 / prefix-list route (no false-added, #1081)', () => {
+    expect(
+      diffRouteTableChildren({
+        routeTableId: RT,
+        declaredDests: ['::/0', 'pl-0a1b2c3d'],
+        liveRoutes: [
+          { value: '::/0', ccKey: 'Ipv6CidrBlock' },
+          { value: 'pl-0a1b2c3d', ccKey: 'DestinationPrefixListId' },
+        ],
       })
     ).toEqual([]);
   });
@@ -1684,10 +1741,10 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
     expect(
       diffRouteTableChildren({
         routeTableId: RT,
-        // The declared cidr was UNRESOLVED, so it never made it into declaredCidrs; the
+        // The declared destination was UNRESOLVED, so it never made it into declaredDests; the
         // enumerator instead raised the fail-safe flag.
-        declaredCidrs: [],
-        liveRoutes: [{ cidr: '10.99.0.0/16' }],
+        declaredDests: [],
+        liveRoutes: [{ value: '10.99.0.0/16', ccKey: 'CidrBlock' }],
         hasUnresolvedDeclaredRoute: true,
       })
     ).toEqual([]);
@@ -1696,8 +1753,11 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
   it('with no UNRESOLVED declared route, a genuinely out-of-band route is STILL added (no regression, #1082)', () => {
     const added = diffRouteTableChildren({
       routeTableId: RT,
-      declaredCidrs: ['0.0.0.0/0'],
-      liveRoutes: [{ cidr: '0.0.0.0/0' }, { cidr: '10.99.0.0/16' }],
+      declaredDests: ['0.0.0.0/0'],
+      liveRoutes: [
+        { value: '0.0.0.0/0', ccKey: 'CidrBlock' },
+        { value: '10.99.0.0/16', ccKey: 'CidrBlock' },
+      ],
       hasUnresolvedDeclaredRoute: false,
     });
     expect(added.map((a) => a.identifier)).toEqual([`${RT}|10.99.0.0/16`]);
@@ -1737,15 +1797,226 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
       ).toBe(false);
     });
 
-    it('excludes an IPv6-only route (no DestinationCidrBlock)', () => {
+    it('keeps a user-declarable IPv6 route (::/0 to a gateway) (#1081)', () => {
+      // The reported false-NEGATIVE: an out-of-band IPv6 route was invisible because the old
+      // filter required a DestinationCidrBlock. A rogue `::/0` to an IGW/ENI must be enumerable.
       expect(
         isEnumerableRoute({
           DestinationIpv6CidrBlock: '::/0',
           Origin: 'CreateRoute',
           GatewayId: 'igw-123',
         })
+      ).toBe(true);
+    });
+
+    it('keeps a user-declarable prefix-list route (#1081)', () => {
+      expect(
+        isEnumerableRoute({
+          DestinationPrefixListId: 'pl-0a1b2c3d',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-123',
+        })
+      ).toBe(true);
+    });
+
+    it('excludes the auto-created VPC-local IPv6 route (Origin CreateRouteTable / GatewayId local) (#1081)', () => {
+      // An IPv6-enabled VPC auto-creates a LOCAL IPv6 route just like the IPv4 one; the
+      // exclusion must apply to the IPv6 axis too.
+      expect(
+        isEnumerableRoute({
+          DestinationIpv6CidrBlock: '2600:1f18:abcd::/56',
+          Origin: 'CreateRouteTable',
+          GatewayId: 'local',
+        })
       ).toBe(false);
     });
+
+    it('excludes a VGW-propagated IPv6 route (Origin EnableVgwRoutePropagation) (#1081)', () => {
+      expect(
+        isEnumerableRoute({
+          DestinationIpv6CidrBlock: '2600:1f18:cafe::/56',
+          Origin: 'EnableVgwRoutePropagation',
+          GatewayId: 'vgw-0abc123',
+        })
+      ).toBe(false);
+    });
+
+    it('excludes a route with no declarable destination (blackhole with no CIDR)', () => {
+      expect(
+        isEnumerableRoute({
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-123',
+        })
+      ).toBe(false);
+    });
+  });
+});
+
+// #1081 (end-to-end): the enumerator must read live routes across all three destination axes
+// via DescribeRouteTablesCommand, match them against declared AWS::EC2::Route resources on the
+// same table (folding a DECLARED IPv6/prefix-list route), and flag only the out-of-band ones.
+describe('enumerateRouteTableChildren (EC2 routes, all destination axes, #1081)', () => {
+  const RT = 'rtb-0123456789abcdef0';
+  // The auto-created VPC-local routes (IPv4 + IPv6) that every route table carries — must be
+  // excluded on both axes.
+  const LOCAL_V4 = {
+    DestinationCidrBlock: '10.0.0.0/16',
+    Origin: 'CreateRouteTable' as const,
+    GatewayId: 'local',
+  };
+  const LOCAL_V6 = {
+    DestinationIpv6CidrBlock: '2600:1f18:abcd::/56',
+    Origin: 'CreateRouteTable' as const,
+    GatewayId: 'local',
+  };
+
+  const ctxWith = (routes: Ec2Route[], declared: unknown[]) => {
+    const ec2 = mockClient(EC2Client);
+    ec2
+      .on(DescribeRouteTablesCommand)
+      .resolves({ RouteTables: [{ RouteTableId: RT, Routes: routes }] });
+    const ctx = {
+      parent: { physicalId: RT, logicalId: 'Rt' },
+      desired: { resources: declared, ctx: { liveAttrs: {} } },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    return { ec2, ctx };
+  };
+
+  it('flags an out-of-band IPv6 route (::/0 to a rogue IGW) — the reported false negative', async () => {
+    const { ec2, ctx } = ctxWith(
+      [
+        LOCAL_V4,
+        LOCAL_V6,
+        {
+          DestinationIpv6CidrBlock: '::/0',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-rogue',
+        },
+      ],
+      [] // template declares no routes on this table
+    );
+    const added = await enumerateRouteTableChildren(ctx);
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::EC2::Route',
+        identifier: `${RT}|::/0`,
+        label: '::/0',
+        live: { RouteTableId: RT, Ipv6CidrBlock: '::/0' },
+      },
+    ]);
+    ec2.restore();
+  });
+
+  it('flags an out-of-band prefix-list route not in the template', async () => {
+    const { ec2, ctx } = ctxWith(
+      [
+        LOCAL_V4,
+        {
+          DestinationPrefixListId: 'pl-0a1b2c3d',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-rogue',
+        },
+      ],
+      []
+    );
+    const added = await enumerateRouteTableChildren(ctx);
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::EC2::Route',
+        identifier: `${RT}|pl-0a1b2c3d`,
+        label: 'pl-0a1b2c3d',
+        live: { RouteTableId: RT, DestinationPrefixListId: 'pl-0a1b2c3d' },
+      },
+    ]);
+    ec2.restore();
+  });
+
+  it('does NOT flag a DECLARED IPv6 route (folds — no false-added)', async () => {
+    const { ec2, ctx } = ctxWith(
+      [
+        LOCAL_V4,
+        LOCAL_V6,
+        {
+          DestinationIpv6CidrBlock: '::/0',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-123',
+        },
+      ],
+      [
+        {
+          resourceType: 'AWS::EC2::Route',
+          declared: { RouteTableId: RT, DestinationIpv6CidrBlock: '::/0', GatewayId: 'igw-123' },
+        },
+      ]
+    );
+    const added = await enumerateRouteTableChildren(ctx);
+    expect(added).toEqual([]);
+    ec2.restore();
+  });
+
+  it('excludes the auto-created LOCAL (IPv4 + IPv6) and VGW-propagated routes (all axes)', async () => {
+    const { ec2, ctx } = ctxWith(
+      [
+        LOCAL_V4,
+        LOCAL_V6,
+        {
+          DestinationIpv6CidrBlock: '2600:1f18:cafe::/56',
+          Origin: 'EnableVgwRoutePropagation',
+          GatewayId: 'vgw-0abc123',
+        },
+      ],
+      []
+    );
+    const added = await enumerateRouteTableChildren(ctx);
+    expect(added).toEqual([]);
+    ec2.restore();
+  });
+
+  it('still flags an out-of-band IPv4 route (no regression)', async () => {
+    const { ec2, ctx } = ctxWith(
+      [
+        LOCAL_V4,
+        {
+          DestinationCidrBlock: '10.99.0.0/16',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-rogue',
+        },
+      ],
+      []
+    );
+    const added = await enumerateRouteTableChildren(ctx);
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::EC2::Route',
+        identifier: `${RT}|10.99.0.0/16`,
+        label: '10.99.0.0/16',
+        live: { RouteTableId: RT, CidrBlock: '10.99.0.0/16' },
+      },
+    ]);
+    ec2.restore();
+  });
+
+  it('fails safe: an UNRESOLVED declared IPv6 destination suppresses ALL added for this table (#1082)', async () => {
+    const { ec2, ctx } = ctxWith(
+      [
+        LOCAL_V4,
+        {
+          DestinationIpv6CidrBlock: '::/0',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-123',
+        },
+      ],
+      [
+        {
+          resourceType: 'AWS::EC2::Route',
+          declared: { RouteTableId: RT, DestinationIpv6CidrBlock: UNRESOLVED },
+        },
+      ]
+    );
+    const added = await enumerateRouteTableChildren(ctx);
+    expect(added).toEqual([]);
+    ec2.restore();
   });
 });
 


### PR DESCRIPTION
Closes #1081 (security-relevant FALSE NEGATIVE)

## Problem
The `AWS::EC2::RouteTable` child enumerator was IPv4-only (`isEnumerableRoute` gated on `DestinationCidrBlock`). An out-of-band **IPv6** route (`::/0` to a rogue IGW/ENI on a dual-stack VPC — a traffic-hijack / exfil path) or a **prefix-list** route was invisible to the `added` tier: never surfaced, survived `record`.

## Fix
`isEnumerableRoute` now accepts a route declarable on ANY of the three destination axes (`DestinationCidrBlock` / `DestinationIpv6CidrBlock` / `DestinationPrefixListId`, exactly one per route). New `liveRouteDest` picks the set axis and pairs its value with the correct CC identifier key (`CidrBlock`/`Ipv6CidrBlock`/`DestinationPrefixListId`); the diff matches a live destination against the declared-destination set (axis-agnostic → a declared IPv6/prefix-list route folds, no false-`added`) and forms `RouteTableId|<destination>` + the correct live key so a revert DeleteResource targets the right route. LOCAL / VGW-propagated exclusions and the #1082 UNRESOLVED fail-safe are axis-independent and preserved; **IPv4 output is byte-for-byte unchanged**.

## Live-verified (us-east-1, dual-stack VPC + RouteTable, ephemeral stack, swept)
- `check` before mutation → the **declared IPv6 `::/0` route folds** (no false-`added`; the auto-created IPv6 LOCAL route is excluded). No `AWS::EC2::Route` finding.
- out-of-band `create-route --destination-ipv6-cidr-block 2001:db8::/32` → `check` reports it as **`added` `AWS::EC2::Route`** (`actual` shows `DestinationIpv6CidrBlock`).

## Tests
`tests/child-enumerators.test.ts` (+15): out-of-band IPv6 + prefix-list detection (pure + enumerator-level w/ mocked `DescribeRouteTables`), declared IPv6/prefix-list fold (no false-added), IPv6 LOCAL + VGW-propagated exclusion, IPv4 no-regression, #1082 UNRESOLVED fail-safe. Also **corrected a stale existing assertion** that encoded the bug (IPv6 → excluded). 15 fail without the fix.

Docs: `docs/ARCHITECTURE.md`'s child-enumerator entry already described the IPv4/IPv6/prefix-list destination (referencing #1081) — this makes the code match that doc (closes a pre-existing doc-vs-code gap).

File: `src/read/child-enumerators.ts`.