### PR TITLE
fix(revert): --wait delete-batch deadline computed once per run, not re-armed per pass (#969)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -755,7 +755,10 @@ only when non-zero — unrecorded values are named as such, never folded into
     non-blocking + explanatory (issue #467's design call), and when `--wait` is off the
     hint points at it (`… or re-run with --wait to block until it settles`). Backoff is
     linear (3s, 6s, …) capped at `DEFAULT_MAX_DELAY_MS` (30s), and never sleeps past the
-    deadline.
+    deadline. The `delete`-kind batch (dependency-aware passes, #765) shares a SINGLE
+    deadline computed once for the run (#969) — `applyRevertDeletes` re-invokes the per-item
+    retry builder on each pass, so a per-pass `clock() + waitMs` would re-arm a fresh full
+    budget every pass; one hoisted deadline bounds the whole delete phase to a single DURATION.
 - **Write mechanism** (`plan.ts` chooses `kind`):
   - `kind: 'cc'` — generic Cloud Control `UpdateResource` RFC6902 PatchDocument,
     polled via `GetResourceRequestStatus` ([apply.ts](../src/revert/apply.ts)).

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1144,11 +1144,16 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   }[] = [];
   // Per-item transient-retry options (issue #467). `--wait` turns the short default
   // backoff into a deadline-bounded wait so a minutes-long UPDATING window (RSLVR-00705)
-  // converges in one command; each item gets its OWN wait budget. `onRetry` prints a
-  // per-retry progress line so the wait never looks frozen (see #477's spinner ethos).
+  // converges in one command; a non-delete item runs ONCE so it gets its OWN wait budget.
+  // `onRetry` prints a per-retry progress line so the wait never looks frozen (see #477's
+  // spinner ethos). `deadlineMsOverride` pins a SHARED deadline for the delete batch (#969):
+  // `applyRevertDeletes` re-invokes this builder for the SAME item on every dependency-aware
+  // pass, so without a shared deadline a persistent throttle on a delete would re-arm a fresh
+  // full `--wait` budget each pass (a genuine spanning-throttle could wait N × waitMs). One
+  // deadline per revert run bounds the whole delete phase to a single budget.
   const clock = waitNow ?? Date.now;
-  const buildRetryOpts = (displayId: string): RetryOptions => ({
-    ...(waitMs !== undefined && { deadlineMs: clock() + waitMs }),
+  const buildRetryOpts = (displayId: string, deadlineMsOverride?: number): RetryOptions => ({
+    ...(waitMs !== undefined && { deadlineMs: deadlineMsOverride ?? clock() + waitMs }),
     ...(waitNow && { now: waitNow }),
     ...(waitSleep && { sleep: waitSleep }),
     onRetry: ({ attempt, delayMs, hint }) => {
@@ -1248,9 +1253,14 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // (issue #765): a delete that first fails on a DependencyViolation is retried once the
   // pass that frees its dependency has run. Fold each outcome back into applied / worst /
   // failedDeleteIds exactly as the old inline single-item delete path did.
+  // ONE deadline for the entire delete phase (#969): computed once here so every
+  // dependency-aware pass over the same item shares it, instead of re-arming a fresh
+  // `--wait` budget per pass. Undefined without `--wait` (falls back to the default
+  // fixed-attempt backoff, unaffected by the deadline).
+  const deleteDeadlineMs = waitMs !== undefined ? clock() + waitMs : undefined;
   const deleteOutcomes = await applyRevertDeletes(deleteItems, (item) =>
     // physicalId IS the CC identifier (the composite the finding carried); delete it.
-    applyRevertDelete(cc, item, item.physicalId, buildRetryOpts(item.displayId))
+    applyRevertDelete(cc, item, item.physicalId, buildRetryOpts(item.displayId, deleteDeadlineMs))
   );
   for (const { item, result: r } of deleteOutcomes) {
     if (!r.ok) failedDeleteIds.add(item.logicalId);

--- a/tests/revert-delete-wait-deadline-969.test.ts
+++ b/tests/revert-delete-wait-deadline-969.test.ts
@@ -1,0 +1,159 @@
+// #969 (remainder) — the `revert --wait` deadline for the DELETE batch must be computed ONCE
+// per revert run, not re-armed per dependency-aware pass. `applyRevertDeletes` re-invokes the
+// per-item apply closure on every pass, so the closure must NOT recompute `clock() + waitMs`
+// each time (that lets a genuine persistent throttle on a delete spanning passes wait N × waitMs,
+// re-arming a fresh full budget each pass). We assert the SAME delete item receives an IDENTICAL
+// `deadlineMs` across its two pass-invocations even though the injected clock advances between
+// them — which is only true when the deadline is hoisted out of the per-item builder.
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { GatherResult } from '../src/commands/gather.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+// Record every applyRevertDelete invocation's (physicalId, deadlineMs) while keeping the REAL
+// applyRevertDeletes pass loop. 'a-phys' succeeds (drives a 2nd pass); 'b-phys' fails transient
+// so it is retried on the next pass — the case whose deadline must not re-arm.
+const { deadlineCalls } = vi.hoisted(() => ({
+  deadlineCalls: [] as { id: string; deadlineMs: number | undefined }[],
+}));
+vi.mock('../src/revert/apply.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/revert/apply.js')>();
+  return {
+    ...actual,
+    applyRevertDelete: vi.fn(
+      async (
+        _cc: unknown,
+        item: { physicalId: string },
+        _identifier: string,
+        retry: { deadlineMs?: number } = {}
+      ) => {
+        deadlineCalls.push({ id: item.physicalId, deadlineMs: retry.deadlineMs });
+        return item.physicalId === 'a-phys'
+          ? { ok: true }
+          : { ok: false, error: 'ThrottlingException', transient: true };
+      }
+    ),
+  };
+});
+
+// Imported AFTER the mock is registered (vi.mock is hoisted, so this picks up the mocked apply).
+const { revertStack } = await import('../src/commands/stack-actions.js');
+
+const EMPTY_SCHEMA = {
+  readOnly: new Set<string>(),
+  writeOnly: new Set<string>(),
+  createOnly: new Set<string>(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+} as SchemaInfo;
+
+const addedDelete = (logicalId: string, physicalId: string): Finding => ({
+  tier: 'added',
+  logicalId,
+  resourceType: 'AWS::ApiGateway::Method',
+  path: '',
+  physicalId,
+  unrecorded: true, // + removeUnrecorded below → becomes a `delete`-kind plan item
+  actual: { HttpMethod: 'ANY' },
+});
+
+const gathered = (): GatherResult =>
+  ({
+    desired: {
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources: [
+        {
+          logicalId: 'DelA',
+          resourceType: 'AWS::ApiGateway::Method',
+          physicalId: 'a-phys',
+          declared: {},
+        },
+        {
+          logicalId: 'DelB',
+          resourceType: 'AWS::ApiGateway::Method',
+          physicalId: 'b-phys',
+          declared: {},
+        },
+      ],
+      rawTemplate: '{}',
+      ctx: {
+        params: {},
+        pseudo: {},
+        conditions: {},
+        physIds: {},
+        liveAttrs: {},
+        mappings: {},
+        exports: {},
+        condCache: new Map(),
+      },
+    },
+    findings: [addedDelete('DelA', 'a-phys'), addedDelete('DelB', 'b-phys')],
+    schemas: new Map([['AWS::ApiGateway::Method', EMPTY_SCHEMA]]),
+    liveByLogical: new Map(),
+  }) as GatherResult;
+
+describe('#969 revert --wait delete-batch deadline is computed ONCE, not re-armed per pass', () => {
+  let cc: ReturnType<typeof mockClient>;
+  let cfn: ReturnType<typeof mockClient>;
+  beforeEach(() => {
+    deadlineCalls.length = 0;
+    cc = mockClient(CloudControlClient);
+    // The scoped convergence re-read after apply — resource "gone" is fine; we only assert on
+    // the recorded apply-time deadlines.
+    cc.on(GetResourceCommand).rejects(
+      Object.assign(new Error('not found'), { name: 'ResourceNotFoundException' })
+    );
+    cfn = mockClient(CloudFormationClient);
+    cfn
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' } as never] });
+  });
+  afterEach(() => {
+    cc.restore();
+    cfn.restore();
+  });
+
+  it('the same delete item gets an IDENTICAL deadline across its two dependency-aware passes', async () => {
+    // A clock that ADVANCES on every read — so a per-pass `clock() + waitMs` (the bug) would
+    // yield a LATER deadline on the 2nd pass; a hoisted single deadline stays constant.
+    let t = 1000;
+    const waitNow = () => (t += 1000);
+    const orig = console.log;
+    console.log = () => {};
+    try {
+      await revertStack({
+        stackName: 's',
+        region: 'r',
+        gathered: gathered(),
+        baseline: undefined,
+        config: { ignore: [] },
+        dryRun: false,
+        yes: true,
+        removeUnrecorded: true, // unrecorded added → delete items
+        verbose: false,
+        interactive: false,
+        convergeRetryDelayMs: 0,
+        waitMs: 500_000,
+        waitNow,
+        waitSleep: () => Promise.resolve(),
+      } as Parameters<typeof revertStack>[0]);
+    } finally {
+      console.log = orig;
+    }
+
+    // 'a-phys' succeeds pass 0 (progress) → 'b-phys' is retried on pass 1: two invocations.
+    const bCalls = deadlineCalls.filter((c) => c.id === 'b-phys');
+    expect(bCalls.length).toBe(2);
+    expect(bCalls[0]!.deadlineMs).toBeDefined();
+    // The fix: identical deadline both passes (single per-run budget). The bug (per-pass
+    // clock() + waitMs) would make the 2nd strictly greater because the clock advanced.
+    expect(bCalls[1]!.deadlineMs).toBe(bCalls[0]!.deadlineMs);
+  });
+});


### PR DESCRIPTION
Closes #969 (completes the follow-up to PR #1164; stack-actions.ts freed by #1181).

#765's `applyRevertDeletes` runs delete-kind items in dependency-aware PASSES, re-invoking the per-item apply closure on each pass. The closure built its retry options via `buildRetryOpts`, which computed `deadlineMs = clock() + waitMs` FRESH every call — so a genuine persistent throttle on a delete that spans passes got a fresh full `--wait` budget re-armed each pass (a spanning throttle could wait up to N × waitMs instead of one DURATION).

Fix (stack-actions.ts): compute ONE `deleteDeadlineMs = clock() + waitMs` before `applyRevertDeletes` and thread it into `buildRetryOpts(displayId, deleteDeadlineMs)` so every pass over the same item shares it. Non-delete items are unchanged — they run once, so `buildRetryOpts` still computes a per-item deadline (their #467 "own budget" semantics preserved). Without `--wait` the override is undefined and the default fixed-attempt backoff is unaffected.

Test (`tests/revert-delete-wait-deadline-969.test.ts`): drives `revertStack` with two added→delete items (one succeeds to force a 2nd pass, one persistently throttles) under an ADVANCING injected clock, with the real `applyRevertDeletes` pass loop and `applyRevertDelete` mocked to record each call's `deadlineMs`. Asserts the throttled item's deadline is IDENTICAL across its two passes — verified to FAIL on the pre-fix code (504000 vs 505000, the clock having advanced). ARCHITECTURE.md `--wait` note updated.

Offline: unit-covered end to end (the re-arm is a wall-clock/pass-structure interaction, deterministically driven by the injected clock).