### PR TITLE
fix(noise): fold undeclared Neptune DBCluster EngineVersion value-independent (#1186)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2977,7 +2977,20 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   (undeclared on every one, no out-of-band edit). Equality is irrelevant — any window folds.
   'AWS::DocDB::DBCluster': new Set(['PreferredMaintenanceWindow', 'PreferredBackupWindow']),
   'AWS::DocDB::DBInstance': new Set(['PreferredMaintenanceWindow']),
-  'AWS::Neptune::DBCluster': new Set(['PreferredMaintenanceWindow', 'PreferredBackupWindow']),
+  //   AWS::Neptune::DBCluster.EngineVersion — a cluster that declares no EngineVersion reads
+  //   back the current GA Neptune engine version AWS provisioned ("1.4.7.0" today), which AWS
+  //   moves over time as it ships new GA versions — not a constant we can pin. Undeclared →
+  //   whatever GA AWS assigned is its default, never user intent; a user who pins a version
+  //   DECLARES it and it is then compared (VERSION_PREFIX_PATHS tolerates the declared
+  //   partial-vs-concrete echo, e.g. declared "1.3" vs live "1.3.5.0"). Undeclared-only, the
+  //   canonical moving-GA-version tier-3 case — sibling of the ElastiCache::ReplicationGroup /
+  //   DocDB EngineVersion folds. Live-confirmed undeclared on a fresh no-version Neptune cluster
+  //   (Cdkrd980Verify, us-east-1: "1.4.7.0"; #1186).
+  'AWS::Neptune::DBCluster': new Set([
+    'PreferredMaintenanceWindow',
+    'PreferredBackupWindow',
+    'EngineVersion',
+  ]),
   //   AWS::Neptune::DBInstance.AvailabilityZone — AWS places an undeclared instance in an AZ it
   //   picks (create-only, so it can never drift; never user intent when undeclared), exactly like
   //   AWS::RDS::DBInstance.AvailabilityZone above. A user who pins a placement DECLARES it and is

--- a/tests/noise-neptune-engineversion-1186.test.ts
+++ b/tests/noise-neptune-engineversion-1186.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #1186 — a fresh AWS::Neptune::DBCluster that declares NO EngineVersion reads back the
+// current GA Neptune engine version AWS provisioned ("1.4.7.0" today), surfacing as an
+// undeclared [Potential Drift] on a first check (core-invariant violation). It is the
+// sibling of the DocDB / ElastiCache::ReplicationGroup EngineVersion folds: a moving GA
+// version = the canonical value-independent (tier-3) case. Undeclared-only — a user who
+// PINS a version declares it (compared in the declared loop; the partial-vs-concrete echo
+// stays folded by VERSION_PREFIX_PATHS). The existing Neptune corpus case DECLARES
+// EngineVersion, so it never covered this undeclared scenario.
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string): string[] =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const declaredMinimal = { DBSubnetGroupName: 'neptune-subnet-group' };
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Cluster',
+  resourceType: 'AWS::Neptune::DBCluster',
+  physicalId: 'neptune-cluster',
+  declared,
+});
+
+describe('#1186 Neptune DBCluster undeclared EngineVersion fold', () => {
+  it('folds the undeclared GA EngineVersion to atDefault (zero first-run FP)', () => {
+    const f = classifyResource(
+      mk(declaredMinimal),
+      { ...declaredMinimal, EngineVersion: '1.4.7.0' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('EngineVersion');
+    expect(tier(f, 'undeclared')).not.toContain('EngineVersion');
+  });
+
+  it('folds value-independent (any moving GA version folds, not just one pinned constant)', () => {
+    const f = classifyResource(
+      mk(declaredMinimal),
+      { ...declaredMinimal, EngineVersion: '1.3.5.0' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('EngineVersion');
+    expect(tier(f, 'undeclared')).not.toContain('EngineVersion');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #1186.

A clean `AWS::Neptune::DBCluster` that declares **no** `EngineVersion` reads back the current GA Neptune engine version AWS provisioned (`"1.4.7.0"` today) as an undeclared `[Potential Drift]` on a first `check` — a core-invariant violation (a clean, un-mutated deploy must produce zero potential drift).

## Root cause
There was no value-independent undeclared fold for `AWS::Neptune::DBCluster.EngineVersion`. The existing Neptune corpus case **declares** `EngineVersion` (`1.3`→`1.3.5.0`, the `VERSION_PREFIX_PATHS` declared path), so `corpus-replay` was green while a real no-EngineVersion cluster is a first-run FP.

## Fix
Add `EngineVersion` to the `AWS::Neptune::DBCluster` set in `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (`src/normalize/noise.ts`) — the canonical tier-3 moving-GA-version case, identical treatment to the DocDB / ElastiCache::ReplicationGroup `EngineVersion` folds.

**Detection preserved:** a user who PINS `EngineVersion` declares it, so it is still compared in the declared loop (the partial-vs-concrete echo folded by `VERSION_PREFIX_PATHS`). The fold is undeclared-only.

## Test
`tests/noise-neptune-engineversion-1186.test.ts` — asserts an undeclared GA `EngineVersion` folds to `atDefault` (zero first-run FP), value-independently (any moving version folds). The existing corpus case cannot cover this (it declares EngineVersion).

## Verification
- typecheck / lint+format / build / unit tests green.
- Fold/FP fix: LIVE-confirmed in #980's live-verify (`Cdkrd980Verify`, us-east-1: `EngineVersion = "1.4.7.0"`); no fresh deploy needed per the corpus-authoritative rule.