### PR TITLE
fix(desired): under --pre-deploy, local param Default wins over the deployed value so a changed Default is not masked (#728)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -128,7 +128,14 @@ export function buildResolverContext(
   region: string,
   accountId: string,
   stackName: string,
-  stackId: string
+  stackId: string,
+  // #728: whether this is a --pre-deploy run (templateOverride set in loadDesired). It
+  // flips the deployed-value overlay below: under --pre-deploy the declared source is the
+  // LOCAL template, so a local param Default is authoritative and the deployed DescribeStacks
+  // value only FILLS params that have no local Default (rather than overriding it). Defaults
+  // to false — the deployed-path behaviour (deployed wins) — so existing non-pre-deploy
+  // callers are unchanged.
+  preDeploy = false
 ): ResolverContext {
   // CommaDelimitedList / List<> params must resolve to ARRAYS so Fn::Join /
   // Fn::Select / conditions over them evaluate correctly (a string would break
@@ -180,7 +187,23 @@ export function buildResolverContext(
     if ((def?.Type ?? '').includes('::Parameter::Value<')) continue;
     if (def && 'Default' in def) params[k] = toParam(k, String(def.Default));
   }
-  for (const [k, v] of Object.entries(stackParams)) params[k] = toParam(k, v); // deployed values win
+  if (preDeploy) {
+    // #728: under --pre-deploy the declared source is the LOCAL template, so its param
+    // Defaults are the values the next `cdk deploy` will apply. A DescribeStacks value is the
+    // OLD deployed value (DescribeStacks returns an effective value for ALL params, including
+    // default-materialized ones) — letting it override a CHANGED local Default masks exactly
+    // the drift --pre-deploy exists to preview (the run reports CLEAN). So the local Default
+    // wins; the deployed value only fills params with NO local Default (a required param set
+    // at deploy time — we still need a value to resolve its Refs). NoEcho / SSM
+    // `::Parameter::Value<` params were intentionally NOT seeded above, so they are absent
+    // from `params` and still pick up their deployed value here (the fill step), preserving
+    // their existing safe treatment.
+    for (const [k, v] of Object.entries(stackParams)) {
+      if (!(k in params)) params[k] = toParam(k, v);
+    }
+  } else {
+    for (const [k, v] of Object.entries(stackParams)) params[k] = toParam(k, v); // deployed values win
+  }
   // logicalId -> type and -> raw declared Properties, for resolveGetAtt's
   // declared-property-mirroring attributes (GETATT_DECLARED_PROPERTY).
   const templateResources = (template.Resources ?? {}) as Record<
@@ -372,7 +395,10 @@ export async function loadDesired(
     region,
     accountId,
     stackName,
-    stackId
+    stackId,
+    // #728: templateOverride set == --pre-deploy run. Pass it so a changed LOCAL param Default
+    // wins over the OLD deployed value instead of being masked by it.
+    !!templateOverride
   );
 
   // AWS::NotificationARNs is a LIST-valued pseudo-parameter that DescribeStacks already

--- a/tests/predeploy-params-728.test.ts
+++ b/tests/predeploy-params-728.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildResolverContext } from '../src/desired/template-adapter.js';
+
+// #728: under --pre-deploy the declared source is the LOCAL synth template, so a param's
+// LOCAL Default is authoritative. DescribeStacks returns an effective value for ALL params
+// (incl. default-materialized ones), so overriding a CHANGED local Default with the deployed
+// value masks exactly the drift --pre-deploy exists to preview. buildResolverContext takes a
+// trailing `preDeploy` flag: when true the local Default wins and the deployed value only
+// FILLS params that have no local Default.
+describe('#728 — buildResolverContext --pre-deploy param resolution', () => {
+  it('CHANGED local Default is masked by deployed value on the deployed path, but WINS under --pre-deploy', () => {
+    const template = { Parameters: { Foo: { Default: 'NEW' } } };
+    // Deployed path (preDeploy=false): deployed value wins (unchanged behaviour).
+    const deployed = buildResolverContext(
+      template,
+      { Foo: 'OLD' },
+      {},
+      'us-east-1',
+      '999',
+      'S',
+      'arn'
+      // preDeploy defaults to false
+    );
+    expect(deployed.params.Foo).toBe('OLD');
+    // Pre-deploy path (preDeploy=true): the local Default is authoritative → the changed
+    // Default is NOT masked, so the drift the next `cdk deploy` would apply is visible.
+    const pre = buildResolverContext(
+      template,
+      { Foo: 'OLD' },
+      {},
+      'us-east-1',
+      '999',
+      'S',
+      'arn',
+      true
+    );
+    expect(pre.params.Foo).toBe('NEW');
+  });
+
+  it('a param with NO local Default still resolves from the deployed value under --pre-deploy (fill step)', () => {
+    // A required param (no Default) set at deploy time: we still need a value to resolve its
+    // Refs, so the deployed value fills it even though the local Default does not win.
+    const template = { Parameters: { Bar: { Type: 'String' } } };
+    const pre = buildResolverContext(
+      template,
+      { Bar: 'deployedVal' },
+      {},
+      'us-east-1',
+      '999',
+      'S',
+      'arn',
+      true
+    );
+    expect(pre.params.Bar).toBe('deployedVal');
+  });
+
+  it('preserves list typing of a local Default under --pre-deploy (CommaDelimitedList → array)', () => {
+    // The local Default wins AND is still split/trimmed to an array, so an Fn::Join /
+    // Fn::Select / condition over the list evaluates correctly.
+    const template = { Parameters: { Csv: { Type: 'CommaDelimitedList', Default: 'a,b' } } };
+    const pre = buildResolverContext(
+      template,
+      { Csv: 'x,y,z' }, // OLD deployed value must NOT override the local Default
+      {},
+      'us-east-1',
+      '999',
+      'S',
+      'arn',
+      true
+    );
+    expect(pre.params.Csv).toEqual(['a', 'b']);
+  });
+
+  it('NoEcho / SSM ::Parameter::Value< Default-skipping is unaffected under --pre-deploy (deployed value still applies)', () => {
+    // These params are intentionally NOT seeded from their Default (the Default is a
+    // placeholder / SSM key, not the real value). They are absent from `params`, so the
+    // fill step still applies their deployed value under --pre-deploy — the same safe
+    // treatment as the deployed path.
+    const template = {
+      Parameters: {
+        Secret: { Type: 'String', NoEcho: true, Default: 'changeme' },
+        Ssm: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/golden/ami' },
+      },
+    };
+    const pre = buildResolverContext(
+      template,
+      { Secret: 'liveSecret', Ssm: 'ami-0abc' },
+      {},
+      'us-east-1',
+      '999',
+      'S',
+      'arn',
+      true
+    );
+    // The placeholder/key Default was NOT used; the deployed value filled it instead.
+    expect(pre.params.Secret).toBe('liveSecret');
+    expect(pre.params.Ssm).toBe('ami-0abc');
+  });
+});


### PR DESCRIPTION
Closes #728

## Root cause

Under `--pre-deploy` the declared source is the LOCAL synth template, and parameters are seeded from the local template Defaults then overlaid with the DEPLOYED stack's DescribeStacks values. In `buildResolverContext` (src/desired/template-adapter.ts) the overlay was unconditional:

```ts
for (const [k, v] of Object.entries(stackParams)) params[k] = toParam(k, v); // deployed values win
```

DescribeStacks returns an effective value for ALL params (including default-materialized ones), so editing a param `Default` in local code still resolved `Ref`s with the OLD deployed value. The declared drift the next `cdk deploy` would apply was invisible under `--pre-deploy` (the run reported CLEAN) — the exact drift the flag exists to preview.

## Fix

Thread a `preDeploy: boolean` (appended, defaults to false) into `buildResolverContext`; `loadDesired` passes `!!templateOverride` (templateOverride set == a `--pre-deploy` run). Under `--pre-deploy` the LOCAL Default is authoritative and the deployed value only FILLS params that have no local Default (a required param set at deploy time, so we still have a value to resolve Refs with). The deployed path is unchanged (deployed still wins).

NoEcho / SSM `::Parameter::Value<` params were already intentionally NOT seeded from their Default, so they stay absent from `params` and still pick up their deployed value via the fill step — their existing safe treatment is preserved.

## Tests

New tests/predeploy-params-728.test.ts unit-tests `buildResolverContext` directly:
- CHANGED local Default masked on the deployed path (preDeploy=false → OLD) but WINS under --pre-deploy (preDeploy=true → NEW) — the core fix.
- A param with NO local Default still resolves from the deployed value under --pre-deploy (fill step).
- List typing of a local Default preserved under --pre-deploy (CommaDelimitedList Default → array).
- NoEcho / SSM `::Parameter::Value<` Default-skipping unaffected under --pre-deploy (deployed value still applies).

## Follow-up (deferred — case 1 in the issue)

Case 2 (changed Defaults masked) is fixed here. Case 1 — new/renamed local params with no value anywhere (legacy-synth `AssetParameters<newhash>` after an asset change, or a new user param) genuinely cannot resolve and stay UNRESOLVED; surfacing them more LOUDLY than the "not compared" info line under --pre-deploy is a separate reporting change that reaches beyond template-adapter.ts, so it is left as a follow-up.