### PR TITLE
fix(synth): carry env.account through discovery so multi-account stacks are not silently skipped or wrong-account compared (#740)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -336,6 +336,39 @@ export async function resolveCallerAccount(region: string): Promise<string | und
   }
 }
 
+/**
+ * #740: decide whether a stack must be SKIPPED because it is pinned (via `env.account`) to a
+ * different AWS account than the active credentials are for.
+ *
+ * A CDK app with dev+prod stacks in DIFFERENT accounts (the CDK Pipelines / multi-env staple)
+ * is checked one account at a time — the caller runs `check --all` per account with that
+ * account's credentials. A stack whose `env.account` names an OTHER account cannot be read
+ * with the current creds: `DescribeStacks` throws "does not exist" (the stack IS deployed, just
+ * in its own account), which `isStackNotDeployed` mistakes for "never deployed yet — skipped"
+ * — a misleading green pass that hides an UNCHECKED stack. Worse, if a SAME-NAMED stack happens
+ * to exist in the reachable account, cdkrd would silently compare intent against the WRONG
+ * account's live resources. Detecting the mismatch UP FRONT lets check skip accurately without
+ * reading the wrong account.
+ *
+ * Rule: skip ONLY when BOTH accounts are known (concrete) AND they differ — a proven mismatch.
+ * When either is undefined (an env-agnostic stack with no account pin, or STS could not resolve
+ * the caller) we CANNOT prove a mismatch, so we do NOT skip — behavior is identical to today
+ * (the stack is read; a real "not deployed" still surfaces as before). Pure (no AWS) + exported
+ * for unit tests.
+ */
+export function classifyAccountMismatch(
+  declaredAccount: string | undefined,
+  callerAccount: string | undefined
+): { skip: boolean; message: string } {
+  if (declaredAccount && callerAccount && declaredAccount !== callerAccount) {
+    return {
+      skip: true,
+      message: `stack is pinned to account ${declaredAccount} but the active credentials are for account ${callerAccount} — skipped (run with account-${declaredAccount} credentials to check it)`,
+    };
+  }
+  return { skip: false, message: '' };
+}
+
 // #1060 — the top-level `--json` emit runs AFTER the per-stack loop, OUTSIDE any
 // try/catch, so a non-serializable finding value (a BigInt, a circular reference)
 // that survived the per-stack try detonates `JSON.stringify` and crashes the whole
@@ -498,7 +531,17 @@ export async function runCheck(args: string[]): Promise<number> {
   // `undefined` `callerAccount` afterwards means STS could not answer → wildcard fallback.
   let callerAccount: string | undefined;
   let callerAccountResolved = false;
-  for (const [idx, { stackName, region, template }] of stacks.entries()) {
+  // #740: resolve the caller account AT MOST ONCE (region-free `sts:GetCallerIdentity` — the
+  // account is the same across regions) and cache it, so both the pre-read account-mismatch
+  // gate below AND the not-deployed catch reuse the same one-shot resolution.
+  const ensureCallerAccount = async (region: string): Promise<string | undefined> => {
+    if (!callerAccountResolved) {
+      callerAccount = await resolveCallerAccount(region);
+      callerAccountResolved = true;
+    }
+    return callerAccount;
+  };
+  for (const [idx, { stackName, region, account, template }] of stacks.entries()) {
     if (!region) {
       const msg =
         'no region — set env on the stack, pass --region, or set a region for the AWS profile';
@@ -513,6 +556,25 @@ export async function runCheck(args: string[]): Promise<number> {
     // not only on the scrolled-away spinner line.
     const posPrefix = a.json ? '' : positionPrefix(idx, stacks.length);
     try {
+      // #740: if this stack is pinned (via env.account) to an account the active credentials
+      // are NOT for, SKIP it accurately here — BEFORE any live read — instead of reading the
+      // wrong account. A multi-account CDK app (dev+prod in different accounts, the Pipelines
+      // staple) is checked one account at a time; the other account's stack is unreadable with
+      // these creds. Without this the DescribeStacks "does not exist" it would throw looks like
+      // "never deployed yet — skipped" (a misleading green pass over an UNCHECKED stack), or, if
+      // a same-named stack exists in the reachable account, we would silently compare against the
+      // WRONG account. Only skips on a PROVEN mismatch (both accounts concrete + differing); an
+      // env-agnostic stack or an unresolved caller account is NOT skipped (see classifyAccountMismatch).
+      const mismatch = classifyAccountMismatch(account, await ensureCallerAccount(region));
+      if (mismatch.skip) {
+        console.error(`note: ${stackName}: ${mismatch.message}`);
+        jsonError(stackName, region, mismatch.message);
+        // #948: a skipped whole stack is the maximal coverage gap, so under --strict it fails
+        // (mirroring the other whole-stack skips). A plain (non-strict) run stays exit 0 — a
+        // multi-account CI checks per account, so a cross-account skip must NOT fail --fail.
+        worst = Math.max(worst, a.strict ? 1 : 0);
+        continue;
+      }
       const sKey = synthKey(stackName, region);
       if (synthTemplates && !synthTemplates.has(sKey)) {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
@@ -534,6 +596,22 @@ export async function runCheck(args: string[]): Promise<number> {
       );
       const { desired, schemas, liveByLogical } = gathered;
       let findings = gathered.findings;
+
+      // #740 (belt-and-suspenders for case 2): the pre-read gate above skips a proven
+      // cross-account mismatch, but if the caller account could not be resolved (STS blocked)
+      // it lets the read proceed — and a SAME-NAMED stack in the reachable account would then
+      // be compared against the WRONG account, potentially writing a wrong-account baseline.
+      // After the read we KNOW the deployed stack's account (desired.accountId); if this stack
+      // is pinned to a concrete account that differs, the live state we just read is the wrong
+      // account's — skip rather than trust it. Defense-in-depth; the pre-read gate covers the
+      // common case where the caller account IS known.
+      if (account && desired.accountId !== account) {
+        const msg = `compared against account ${desired.accountId} but the stack is pinned to ${account} — skipped (run with account-${account} credentials to check it)`;
+        console.error(`note: ${stackName}: ${msg}`);
+        jsonError(stackName, region, msg);
+        worst = Math.max(worst, a.strict ? 1 : 0);
+        continue;
+      }
 
       // Loudly flag incomplete coverage — a CLEAN verdict must never silently hide an
       // unchecked nested stack or an unread (skipped) resource. To stderr so it survives
@@ -769,10 +847,7 @@ export async function runCheck(args: string[]): Promise<number> {
         // #1046: resolve the current account (once per run, cached) and pin the baseline's
         // account segment — else another account's committed baseline false-flags a stack
         // never deployed in THIS account as "deleted out of band" (multi-account CI red).
-        if (!callerAccountResolved) {
-          callerAccount = await resolveCallerAccount(region);
-          callerAccountResolved = true;
-        }
+        await ensureCallerAccount(region);
         if (hasBaselineForStack(stackName, region, callerAccount)) {
           const msg = 'deployed baseline exists but the stack is gone — deleted out of band';
           const label = `${stackName} (${region})`;

--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -121,6 +121,10 @@ export async function resolveProfileRegion(
 export interface ResolvedStack {
   stackName: string;
   region: string | undefined; // region to query this stack in (may be undefined → caller errors)
+  // #740: the stack's own env.account (concrete 12-digit id, else undefined). Carried from
+  // discovery so check can skip a stack pinned to an account the active creds are NOT for
+  // (rather than misreporting it "not deployed yet") and never wrong-account compare it.
+  account: string | undefined;
   // the synthesized template for this stack — used by check to recover GetTemplate's
   // `?`-masked non-ASCII literals. Carried from the same synth that discovered the stack.
   template: Record<string, unknown>;
@@ -178,6 +182,7 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
     return discovered.map((s) => ({
       stackName: s.stackName,
       region: s.region ?? fallbackRegion,
+      account: s.account, // #740: carry env.account through so check can gate on it
       template: s.template,
     }));
   }
@@ -188,12 +193,13 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
   const add = (
     stackName: string,
     region: string | undefined,
+    account: string | undefined, // #740: the stack's own env.account (concrete, else undefined)
     template: Record<string, unknown>
   ): void => {
     const key = `${stackName}\0${region ?? ''}`;
     if (seen.has(key)) return;
     seen.add(key);
-    out.push({ stackName, region, template });
+    out.push({ stackName, region, account, template });
   };
   const known = (): string => discovered.map((s) => s.stackName).join(', ') || 'none';
   for (const name of a.stackNames) {
@@ -208,7 +214,7 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
       for (const s of discovered) {
         if (matchesGlob(name, s.stackName)) {
           matched++;
-          add(s.stackName, s.region ?? fallbackRegion, s.template);
+          add(s.stackName, s.region ?? fallbackRegion, s.account, s.template);
         }
       }
       if (matched === 0)
@@ -225,7 +231,8 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
       const hits = discovered.filter((s) => s.stackName === name);
       if (hits.length === 0)
         throw new Error(`stack "${name}" is not defined by the CDK app (found: ${known()})`);
-      for (const hit of hits) add(hit.stackName, hit.region ?? fallbackRegion, hit.template);
+      for (const hit of hits)
+        add(hit.stackName, hit.region ?? fallbackRegion, hit.account, hit.template);
     }
   }
   if (out.length === 0) {

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -63,6 +63,11 @@ export function buildStackSelector(patterns: string[] | undefined): StackSelecto
 export interface SynthStack {
   stackName: string;
   region: string | undefined; // the stack's own env.region (concrete) — for per-stack drift reads
+  // #740: the stack's own env.account (concrete 12-digit id), or undefined for an
+  // env-agnostic stack — used by check to skip a stack pinned to an account the active
+  // credentials are NOT for (instead of misreporting it "not deployed yet") and to guard
+  // against a same-named stack in the reachable account being wrong-account compared.
+  account: string | undefined;
   template: Record<string, unknown>;
 }
 
@@ -71,6 +76,20 @@ export interface SynthStack {
 // three-segment commercial form — otherwise those pins test false and env.region is silently
 // discarded, so the stack is read against the wrong region (#742).
 export const CONCRETE_REGION = /^[a-z]{2}(-[a-z]+)+-\d+$/;
+
+// A concrete AWS account pin: exactly 12 digits (#740). toolkit-lib yields the literal
+// `"unknown-account"` or a `${Token[...]}` placeholder for an env-agnostic stack's account,
+// neither of which matches — so an unpinned account maps to undefined (see concreteAccount),
+// mirroring how CONCRETE_REGION distinguishes a real region pin from a token/placeholder.
+export const CONCRETE_ACCOUNT = /^\d{12}$/;
+
+// Map a raw `s.environment.account` to a concrete 12-digit account id, or undefined when it
+// is not pinned (toolkit-lib's `"unknown-account"` / a `${Token...}` for an env-agnostic
+// stack). Pure + exported so the synth extraction is unit-testable without a real assembly
+// (#740). Used in both the stacksRecursively map and discoverStacks.
+export function concreteAccount(raw: string | undefined): string | undefined {
+  return raw && CONCRETE_ACCOUNT.test(raw) ? raw : undefined;
+}
 
 /**
  * Build the stderr message body (no `warning:` prefix — the caller adds it) for the case where
@@ -226,6 +245,9 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
     return cached.cloudAssembly.stacksRecursively.map((s) => ({
       stackName: s.stackName,
       region: CONCRETE_REGION.test(s.environment.region) ? s.environment.region : undefined,
+      // #740: carry the stack's own env.account (concrete 12-digit id, else undefined) so
+      // check can tell a stack pinned to ANOTHER account from a genuinely-undeployed one.
+      account: concreteAccount(s.environment.account),
       template: s.template as Record<string, unknown>,
     }));
   } finally {
@@ -236,12 +258,18 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
 export interface DiscoveredStack {
   stackName: string;
   region: string | undefined; // the stack's own env.region, when concrete
+  // #740: the stack's own env.account, when concrete (12-digit) — see SynthStack.account.
+  account: string | undefined;
   // the synthesized template — carried through so the check path can recover GetTemplate's
   // `?`-masked non-ASCII literals from it without re-synthesizing (synthApp already built it).
   template: Record<string, unknown>;
 }
 
-/** Synth and return each stack's name + its own (concrete) region + template, for discovery. */
+/**
+ * Synth and return each stack's name + its own (concrete) region + account + template, for
+ * discovery. The account (#740) lets check distinguish a stack pinned to another account from
+ * a never-deployed one.
+ */
 export async function discoverStacks(
   app: string,
   opts: SynthOptions = {}
@@ -249,6 +277,7 @@ export async function discoverStacks(
   return (await synthApp(app, opts)).map((s) => ({
     stackName: s.stackName,
     region: s.region,
+    account: s.account,
     template: s.template,
   }));
 }

--- a/tests/synth-account-740.test.ts
+++ b/tests/synth-account-740.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyAccountMismatch } from '../src/commands/check.js';
+import { CONCRETE_ACCOUNT, concreteAccount } from '../src/synth/synth.js';
+
+// #740: a multi-account CDK app (dev+prod in different accounts — the CDK Pipelines staple)
+// must not silently green-pass an other-account stack as "not deployed yet", nor compare
+// intent against a same-named stack in the WRONG (reachable) account. The fix threads each
+// stack's concrete env.account through discovery and skips a proven cross-account mismatch.
+
+describe('CONCRETE_ACCOUNT (env.account pin recognition, #740)', () => {
+  it('accepts a 12-digit AWS account id', () => {
+    for (const a of ['123456789012', '000000000000', '999999999999']) {
+      expect(CONCRETE_ACCOUNT.test(a)).toBe(true);
+    }
+  });
+
+  it('rejects toolkit-lib placeholders / non-concrete values', () => {
+    for (const a of [
+      '',
+      'unknown-account', // toolkit-lib's env-agnostic sentinel
+      '${Token[AWS.AccountId.42]}', // an unresolved token
+      '12345678901', // 11 digits
+      '1234567890123', // 13 digits
+      '12345678901a', // non-digit
+    ]) {
+      expect(CONCRETE_ACCOUNT.test(a)).toBe(false);
+    }
+  });
+});
+
+describe('concreteAccount (synth env.account extraction, #740)', () => {
+  it('carries a concrete 12-digit account through', () => {
+    expect(concreteAccount('123456789012')).toBe('123456789012');
+  });
+
+  it('maps an env-agnostic / token account to undefined', () => {
+    expect(concreteAccount('unknown-account')).toBeUndefined();
+    expect(concreteAccount('${Token[AWS.AccountId.42]}')).toBeUndefined();
+    expect(concreteAccount(undefined)).toBeUndefined();
+    expect(concreteAccount('')).toBeUndefined();
+  });
+});
+
+describe('classifyAccountMismatch (#740)', () => {
+  it('does NOT skip when both accounts are the same', () => {
+    const r = classifyAccountMismatch('123456789012', '123456789012');
+    expect(r.skip).toBe(false);
+  });
+
+  it('SKIPS (with the pinned/creds message) when the accounts differ', () => {
+    const r = classifyAccountMismatch('111111111111', '222222222222');
+    expect(r.skip).toBe(true);
+    expect(r.message).toContain('111111111111'); // the pinned account
+    expect(r.message).toContain('222222222222'); // the active-credentials account
+    expect(r.message).toContain('pinned to account');
+    expect(r.message).toContain('active credentials');
+    // points the user at how to check it (run with the pinned account's creds)
+    expect(r.message).toContain('account-111111111111 credentials');
+  });
+
+  it('does NOT skip when the declared account is undefined (env-agnostic stack)', () => {
+    expect(classifyAccountMismatch(undefined, '222222222222').skip).toBe(false);
+  });
+
+  it('does NOT skip when the caller account is undefined (STS unresolved)', () => {
+    expect(classifyAccountMismatch('111111111111', undefined).skip).toBe(false);
+  });
+
+  it('does NOT skip when both are undefined (cannot prove a mismatch)', () => {
+    expect(classifyAccountMismatch(undefined, undefined).skip).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #740

## Root cause

A CDK app with stacks pinned to more than one **account** (dev+prod / CDK Pipelines staple) was mishandled because the cloud-assembly artifact's `s.environment.account` was **dropped** during discovery — `SynthStack` / `DiscoveredStack` / `ResolvedStack` carried only `region`, never `account`. With no account to gate on, `check` read every stack with the *active* credentials:

1. **Silent green pass over an unchecked stack.** An other-account stack's `DescribeStacks` throws `does not exist` under the active account's creds (the stack IS deployed, just in the account its `env.account` names). `isStackNotDeployed` misread that as *never deployed*, so `check --all --fail` printed the misleading `note: <stack>: not deployed yet — skipped` and exited **0** while the stack was never checked.
2. **Wrong-account comparison.** If a *same-named* stack existed in the reachable account+region (fixed `stackName`, `env.account` varied by context), cdkrd silently compared intent against the WRONG account's live resources (FP/FN both possible) and would write the baseline under the wrong account key.

## Fix

- **`src/synth/synth.ts`** — add `account: string | undefined` to `SynthStack` / `DiscoveredStack`. New exported `CONCRETE_ACCOUNT = /^\d{12}$/` regex (mirrors `CONCRETE_REGION`) + a pure exported `concreteAccount(raw)` helper that maps toolkit-lib's `unknown-account` / `${Token...}` env-agnostic placeholders to `undefined`. Thread `account` through the `stacksRecursively.map(...)` and `discoverStacks` maps.
- **`src/commands/resolve-stacks.ts`** — add `account` to `ResolvedStack`; carry it through both the `--all`/no-names path and the named `add(...)` path (region logic untouched).
- **`src/commands/check.ts`** — new pure exported `classifyAccountMismatch(declaredAccount, callerAccount)`: skips **only** on a proven mismatch (both concrete AND differing); an env-agnostic stack or an unresolved caller account is never skipped (behavior identical to today). Wired in the per-stack loop:
  - **Pre-read gate** (case 1): resolve the caller account once (reused one-shot resolver shared with the not-deployed catch) and, before any live read, skip a proven cross-account stack with an accurate note, emitting the same `jsonError` shape. Non-strict stays exit 0 (multi-account CI checks per account); `--strict` treats it as a whole-stack coverage gap (non-zero), mirroring the #948 whole-stack skips.
  - **Post-load guard** (case 2, belt-and-suspenders): after the read, if the stack is pinned to a concrete account that differs from `desired.accountId`, skip rather than trust a wrong-account comparison / write a wrong-account baseline — covers the case where STS could not resolve the caller account up front.

## Tests

New `tests/synth-account-740.test.ts` (9 tests):
- `CONCRETE_ACCOUNT` — matches a 12-digit id; rejects `unknown-account`, a token, wrong-length / non-digit strings.
- `concreteAccount` — carries a concrete id; maps `unknown-account` / token / `undefined` / `''` to undefined.
- `classifyAccountMismatch` — same account → no skip; differing → skip with the pinned/creds message (naming both accounts + the remediation); either side undefined → no skip.

All gates green: typecheck, lint+format, build, and unit tests (139 files / 4079 tests).
