### PR TITLE
fix(diff): subtract sibling EventBusPolicy statements from a bus's reflected Policy (#699)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -249,6 +249,7 @@ interface ClassifyOpts {
   kmsAliasTargets: Record<string, string>;
   oaiCanonicalIds: Record<string, string>;
   siblingSgRules: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+  siblingEventBusPolicies: Record<string, unknown[]>;
   bucketNotificationManaged: Set<string>;
   clusterEchoModel: Record<string, Record<string, unknown>>;
 }
@@ -292,6 +293,48 @@ export function buildSiblingSgRules(
       rule.SourceSecurityGroupOwnerId = desired.accountId;
     }
     (map[groupId] ??= { ingress: [], egress: [] })[side].push(rule);
+  }
+  return map;
+}
+
+// Statements declared by sibling AWS::Events::EventBusPolicy resources, keyed by their
+// TARGET bus identifier (the resolved `EventBusName` == the bus's physical id; an absent /
+// "default" name targets the default bus, keyed "default"). The live AWS::Events::EventBus
+// REFLECTS these statements in an aggregated undeclared `Policy` = `{Version, Statement[]}`,
+// so classify subtracts them (see subtractSiblingEventBusStatements in diff/classify.ts) to
+// avoid a first-run FP + double-reporting — the sibling EventBusPolicy is tracked + compared
+// as its own resource. Each sibling contributes ONE statement (its resolved `Statement`, a
+// single statement object; CFn EventBusPolicy declares exactly one), stamped with its
+// `StatementId` as the reflected `Sid` when the statement omits one. Fail-open: a policy whose
+// target bus did not resolve to a concrete string is skipped (the bus keeps the reflected
+// statement -> a one-time visible FP, never a hidden change). Any live statement that matches
+// NO sibling (a purely out-of-band injection) is left to surface.
+const EVENT_BUS_POLICY_TYPE = 'AWS::Events::EventBusPolicy';
+const DEFAULT_EVENT_BUS = 'default';
+export function buildSiblingEventBusPolicies(desired: Desired): Record<string, unknown[]> {
+  const map: Record<string, unknown[]> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== EVENT_BUS_POLICY_TYPE) continue;
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const d = decl as Record<string, unknown>;
+    // An absent EventBusName (or the literal "default") targets the default event bus. A
+    // custom bus is targeted by its resolved Name (== the bus's physical id). Skip an
+    // unresolved intrinsic (fail-open — the bus keeps the reflected statement).
+    const busName = d.EventBusName;
+    let busKey: string;
+    if (busName === undefined) busKey = DEFAULT_EVENT_BUS;
+    else if (typeof busName === 'string' && busName) busKey = busName;
+    else continue;
+    // The single statement this policy declares (`Statement`), stamped with its `StatementId`
+    // as the `Sid` AWS reflects when the statement itself omits one.
+    const stmt = d.Statement;
+    if (!stmt || typeof stmt !== 'object') continue;
+    const statement = { ...(stmt as Record<string, unknown>) };
+    if (statement.Sid === undefined && typeof d.StatementId === 'string' && d.StatementId) {
+      statement.Sid = d.StatementId;
+    }
+    (map[busKey] ??= []).push(statement);
   }
   return map;
 }
@@ -640,6 +683,7 @@ export async function gatherFindings(
     kmsAliasTargets,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
+    siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
   };
@@ -727,6 +771,7 @@ export async function regatherTouched(
     kmsAliasTargets,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
+    siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
   };

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -372,6 +372,62 @@ const REFLECTED_CHILD_PROPS: Record<string, string> = {
   'AWS::SNS::Topic': 'Subscription',
 };
 
+// AWS::Events::EventBus reflects its RESOURCE POLICY — set by the declared sibling
+// AWS::Events::EventBusPolicy resources that target it — as an undeclared `Policy`
+// property (an IAM policy document `{Version, Statement:[...]}`) on the bus's live
+// model. Each sibling EventBusPolicy's `StatementId` becomes a statement `Sid`. The
+// sibling policies are tracked + compared as their OWN resources (they read fine via
+// Cloud Control), so leaving the aggregated policy on the bus double-reports every
+// statement AND surfaces a first-run [Potential Drift] on every custom bus that carries
+// a policy — the standard cross-account eventing setup (#699).
+//
+// The fix is STATEMENT-LEVEL subtraction (mirroring subtractSiblingSgRules): subtract
+// from the bus's live `Policy.Statement[]` the statements owned by a declared sibling
+// EventBusPolicy (match by `Sid` == `StatementId`, or by resolved content), leaving any
+// out-of-band statement (matching NO sibling) to still surface — so a directly-injected
+// bus statement is NOT blinded (the whole-prop drop would have silenced it). The sibling
+// statements are resolved from the full desired set in gather.ts (buildSiblingEventBusPolicies)
+// and threaded through opts.siblingEventBusPolicies, keyed by the bus's identifier. Fail-open:
+// an inline-declared `Policy` (a raw bus that pins the whole policy inline — not the standard
+// CDK shape) is compared normally (the subtraction is skipped when Policy is declared).
+const EVENT_BUS_TYPE = 'AWS::Events::EventBus';
+const EVENT_BUS_POLICY_PROP = 'Policy';
+
+// Remove from a bus's live `Policy.Statement[]` each statement owned by a declared sibling
+// EventBusPolicy. A sibling matches a live statement when their `Sid`s are equal (the
+// StatementId AWS reflects as the Sid) OR, when neither has a resolvable Sid, when the live
+// statement is a SUPERSET of the sibling's resolved fields (AWS canonicalizes/injects extras
+// the sibling never declared, so an exact equality compare would miss). One removal per sibling
+// preserves a legitimately duplicated statement. If `Statement` empties, the whole `Policy`
+// prop is dropped (empty == absent — don't introduce a []-vs-absent FP); a remaining
+// out-of-band statement stays and surfaces.
+function subtractSiblingEventBusStatements(
+  live: Record<string, unknown>,
+  siblingStatements: unknown[]
+): void {
+  const policy = live[EVENT_BUS_POLICY_PROP];
+  if (!policy || typeof policy !== 'object') return;
+  const p = policy as Record<string, unknown>;
+  const arr = p.Statement;
+  if (!Array.isArray(arr) || siblingStatements.length === 0) return;
+  for (const sib of siblingStatements) {
+    if (!sib || typeof sib !== 'object') continue;
+    const sub = sib as Record<string, unknown>;
+    const sibSid = sub.Sid;
+    const i = arr.findIndex((el) => {
+      if (el === null || typeof el !== 'object') return false;
+      const e = el as Record<string, unknown>;
+      // Prefer a Sid match (the StatementId AWS stamps onto the reflected statement).
+      if (typeof sibSid === 'string' && sibSid) return e.Sid === sibSid;
+      // No usable Sid: match when the live element is a SUPERSET of the sibling's fields
+      // (skipping any UNRESOLVED sibling field, which cannot block the match).
+      return Object.entries(sub).every(([k, v]) => v === UNRESOLVED || deepEqual(e[k], v));
+    });
+    if (i >= 0) arr.splice(i, 1);
+  }
+  if (arr.length === 0) delete live[EVENT_BUS_POLICY_PROP]; // empty == absent; no []-vs-absent FP
+}
+
 // IAM principal types whose inline live `Policies` can be sibling-managed by a separate
 // AWS::IAM::Policy resource (the CDK `<Principal>DefaultPolicy` pattern). Used for the
 // revert-hazard guard when the sibling PolicyName was UNRESOLVED (see below).
@@ -1374,6 +1430,11 @@ export function classifyResource(
     // resources, keyed by the target SG's resolved GroupId (== the SG's physical id). Subtracted
     // from an AWS::EC2::SecurityGroup's reflected live rule arrays so they are not double-counted.
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+    // Statements declared by SIBLING AWS::Events::EventBusPolicy resources, keyed by the target
+    // bus identifier (== the bus's physical id / Name; "default" for the default bus). Subtracted
+    // from an AWS::Events::EventBus's reflected `Policy.Statement[]` so sibling-owned statements
+    // are not double-counted; any out-of-band statement (matching no sibling) still surfaces.
+    siblingEventBusPolicies?: Record<string, unknown[]>;
     // Bucket physical ids whose S3 notifications are managed by a Custom::S3BucketNotifications
     // custom resource (see buildBucketNotificationManaged): the live bucket reflects the
     // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
@@ -1426,6 +1487,19 @@ export function classifyResource(
   // (see REFLECTED_CHILD_PROPS). Fail-open: a declared inline value is still compared.
   const reflected = REFLECTED_CHILD_PROPS[resourceType];
   if (reflected && !(reflected in declared)) delete live[reflected];
+  // Subtract from an event bus's reflected resource-policy the statements owned by its
+  // sibling AWS::Events::EventBusPolicy resources (keyed by the bus identifier in
+  // opts.siblingEventBusPolicies) UNLESS the template pins `Policy` inline — the siblings
+  // are tracked + compared as their own resources, so leaving their statements on the bus
+  // double-reports them + surfaces a first-run FP (#699). This is STATEMENT-LEVEL, so a
+  // purely out-of-band statement (matching no sibling) is left to surface. Fail-open: an
+  // inline-declared `Policy` is compared normally.
+  if (resourceType === EVENT_BUS_TYPE && !(EVENT_BUS_POLICY_PROP in declared)) {
+    const busKey = physicalId ?? resource.declared.Name;
+    const sibStatements =
+      typeof busKey === 'string' ? opts.siblingEventBusPolicies?.[busKey] : undefined;
+    if (sibStatements) subtractSiblingEventBusStatements(live, sibStatements);
+  }
   // An ECS Cluster reflects the CapacityProviders / DefaultCapacityProviderStrategy declared by
   // its sibling AWS::ECS::ClusterCapacityProviderAssociations resource — the only CFn way to set
   // them (the Cluster's own schema carries neither). The association is tracked + compared as its

--- a/tests/classify-eventbus-reflect-699.test.ts
+++ b/tests/classify-eventbus-reflect-699.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #699: AWS::Events::EventBus reflects its resource policy — set by declared sibling
+// AWS::Events::EventBusPolicy resources — as an undeclared `Policy` property on the bus's
+// live model, producing a first-run [Potential Drift] FP on every custom bus with a policy
+// (the standard cross-account eventing setup), AND double-reporting each statement (the
+// sibling EventBusPolicy already covers it). classify subtracts the sibling-owned statements
+// (opts.siblingEventBusPolicies, built by gather.buildSiblingEventBusPolicies) STATEMENT by
+// STATEMENT, so an out-of-band statement (matching no sibling) still surfaces, unless the
+// template pins `Policy` inline.
+
+const busSchema: SchemaInfo = {
+  readOnly: new Set(['Arn']),
+  writeOnly: new Set(['EventSourceName']),
+  createOnly: new Set(['Name']),
+  readOnlyPaths: ['Arn'],
+  writeOnlyPaths: ['EventSourceName'],
+  createOnlyPaths: ['Name'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const busResource: DesiredResource = {
+  logicalId: 'BusEA82B648',
+  resourceType: 'AWS::Events::EventBus',
+  physicalId: 'CdkrdIntegBusABC',
+  // A custom bus declares only its Name; it never declares a `Policy` — the policy is
+  // owned by the sibling AWS::Events::EventBusPolicy resource(s).
+  declared: {
+    Name: 'CdkrdIntegBusABC',
+  },
+};
+
+// The IAM-policy-document shape AWS reflects onto the bus, aggregated from its sibling
+// EventBusPolicy statement(s). Each statement carries a `Sid` == the sibling StatementId.
+const siblingStatement = {
+  Sid: 'AllowSelfPutEvents',
+  Effect: 'Allow',
+  Principal: { AWS: ['111111111111'] },
+  Action: ['events:PutEvents'],
+  Resource: ['arn:aws:events:us-east-1:111111111111:event-bus/CdkrdIntegBusABC'],
+};
+const outOfBandStatement = {
+  Sid: 'RogueCrossAccount',
+  Effect: 'Allow',
+  Principal: { AWS: ['999999999999'] },
+  Action: ['events:PutEvents'],
+  Resource: ['arn:aws:events:us-east-1:111111111111:event-bus/CdkrdIntegBusABC'],
+};
+
+const policyPaths = (findings: Finding[], tier: string) =>
+  findings.filter((f) => f.tier === tier && f.path.startsWith('Policy'));
+
+// The sibling-statement map built by gather.buildSiblingEventBusPolicies, keyed by the bus's
+// identifier (== its physical id / Name): the statement the sibling AWS::Events::EventBusPolicy
+// declares. classify subtracts these from the bus's reflected live Policy.Statement[].
+const siblingEventBusPolicies: Record<string, unknown[]> = {
+  CdkrdIntegBusABC: [siblingStatement],
+};
+
+describe('#699 EventBus reflects sibling EventBusPolicy resource policy', () => {
+  it('(1) a bus whose live Policy holds ONLY sibling-owned statements → folds (no drift)', () => {
+    const live: Record<string, unknown> = {
+      Name: 'CdkrdIntegBusABC',
+      Arn: 'arn:aws:events:us-east-1:111111111111:event-bus/CdkrdIntegBusABC',
+      Policy: { Version: '2012-10-17', Statement: [siblingStatement] },
+    };
+    const findings = classifyResource(busResource, live, busSchema, { siblingEventBusPolicies });
+    // The regression assertion: the reflected Policy must NOT surface anywhere.
+    expect(findings.some((f) => f.path.startsWith('Policy'))).toBe(false);
+    expect(policyPaths(findings, 'undeclared')).toEqual([]);
+    expect(policyPaths(findings, 'declared')).toEqual([]);
+  });
+
+  it('(2) an inline-declared Policy is still compared (fail-open, not dropped)', () => {
+    // A raw bus that pins the whole policy inline (not the standard CDK shape) must
+    // compare normally — the reflected fold is skipped when Policy is declared inline.
+    const declaredInline: DesiredResource = {
+      ...busResource,
+      declared: {
+        Name: 'CdkrdIntegBusABC',
+        Policy: { Version: '2012-10-17', Statement: [siblingStatement] },
+      },
+    };
+    const live: Record<string, unknown> = {
+      Name: 'CdkrdIntegBusABC',
+      Arn: 'arn:aws:events:us-east-1:111111111111:event-bus/CdkrdIntegBusABC',
+      // live has an EXTRA statement the inline declaration does not → a real declared drift.
+      Policy: {
+        Version: '2012-10-17',
+        Statement: [siblingStatement, outOfBandStatement],
+      },
+    };
+    const findings = classifyResource(declaredInline, live, busSchema);
+    // Because it is declared inline, the divergence surfaces as a declared drift on Policy.
+    const drift = findings.filter(
+      (f) => (f.tier === 'declared' || f.tier === 'undeclared') && f.path.startsWith('Policy')
+    );
+    expect(drift.length).toBeGreaterThan(0);
+  });
+
+  // Statement-level subtraction (this change) removes only the sibling-OWNED statements from
+  // the bus's reflected Policy.Statement[], so a purely out-of-band statement (owned by NO
+  // sibling EventBusPolicy) is LEFT to surface — the core-invariant win vs a whole-prop drop.
+  it('(3) an out-of-band statement (no matching sibling) still surfaces', () => {
+    const live: Record<string, unknown> = {
+      Name: 'CdkrdIntegBusABC',
+      Arn: 'arn:aws:events:us-east-1:111111111111:event-bus/CdkrdIntegBusABC',
+      Policy: { Version: '2012-10-17', Statement: [outOfBandStatement] },
+    };
+    const findings = classifyResource(busResource, live, busSchema, { siblingEventBusPolicies });
+    expect(findings.some((f) => f.path.startsWith('Policy'))).toBe(true);
+  });
+
+  it('(4) sibling-owned + out-of-band → only the out-of-band surfaces', () => {
+    const live: Record<string, unknown> = {
+      Name: 'CdkrdIntegBusABC',
+      Arn: 'arn:aws:events:us-east-1:111111111111:event-bus/CdkrdIntegBusABC',
+      Policy: { Version: '2012-10-17', Statement: [siblingStatement, outOfBandStatement] },
+    };
+    const findings = classifyResource(busResource, live, busSchema, { siblingEventBusPolicies });
+    const surfaced = findings.filter(
+      (f) => (f.tier === 'undeclared' || f.tier === 'declared') && f.path.startsWith('Policy')
+    );
+    expect(surfaced.length).toBeGreaterThan(0);
+    // The surfaced value must be the ROGUE statement only — the sibling-owned one was
+    // subtracted, so no finding path/value references the sibling's Sid.
+    expect(surfaced.some((f) => JSON.stringify(f).includes('RogueCrossAccount'))).toBe(true);
+    expect(surfaced.some((f) => JSON.stringify(f).includes('AllowSelfPutEvents'))).toBe(false);
+  });
+});

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from 'vite-plus/test';
 import {
   buildBucketNotificationManaged,
   buildClusterEchoModels,
+  buildSiblingEventBusPolicies,
   buildSiblingSgRules,
   type GatherResult,
   gatherFindings,
@@ -688,6 +689,111 @@ describe('buildSiblingSgRules', () => {
       ])
     );
     expect(Object.keys(map)).toHaveLength(0);
+  });
+});
+
+describe('buildSiblingEventBusPolicies', () => {
+  const desiredWith = (resources: DesiredResource[]): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  const stmt = {
+    Effect: 'Allow',
+    Principal: { AWS: '111111111111' },
+    Action: 'events:PutEvents',
+    Resource: 'arn:aws:events:us-east-1:111111111111:event-bus/CustomBus',
+  };
+
+  it('keys a policy by its resolved EventBusName and stamps StatementId as the Sid', () => {
+    const map = buildSiblingEventBusPolicies(
+      desiredWith([
+        {
+          logicalId: 'Pol',
+          resourceType: 'AWS::Events::EventBusPolicy',
+          physicalId: 'CustomBus|Allow',
+          declared: {
+            EventBusName: 'CustomBus',
+            StatementId: 'Allow',
+            Statement: stmt,
+          },
+        },
+      ])
+    );
+    expect(map.CustomBus).toEqual([{ ...stmt, Sid: 'Allow' }]);
+  });
+
+  it('does NOT overwrite a Sid the statement already declares', () => {
+    const withSid = { ...stmt, Sid: 'InlineSid' };
+    const map = buildSiblingEventBusPolicies(
+      desiredWith([
+        {
+          logicalId: 'Pol',
+          resourceType: 'AWS::Events::EventBusPolicy',
+          physicalId: 'CustomBus|Allow',
+          declared: { EventBusName: 'CustomBus', StatementId: 'Allow', Statement: withSid },
+        },
+      ])
+    );
+    expect(map.CustomBus![0]).toMatchObject({ Sid: 'InlineSid' });
+  });
+
+  it('keys an absent EventBusName under the default bus', () => {
+    const map = buildSiblingEventBusPolicies(
+      desiredWith([
+        {
+          logicalId: 'Pol',
+          resourceType: 'AWS::Events::EventBusPolicy',
+          physicalId: 'p',
+          declared: { StatementId: 'Allow', Statement: stmt },
+        },
+      ])
+    );
+    expect(map.default).toEqual([{ ...stmt, Sid: 'Allow' }]);
+  });
+
+  it('skips a policy whose EventBusName is an unresolved intrinsic', () => {
+    const map = buildSiblingEventBusPolicies(
+      desiredWith([
+        {
+          logicalId: 'Pol',
+          resourceType: 'AWS::Events::EventBusPolicy',
+          physicalId: 'p',
+          declared: {
+            EventBusName: { Ref: 'Bus' },
+            StatementId: 'Allow',
+            Statement: stmt,
+          },
+        },
+      ])
+    );
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+
+  it('aggregates multiple policies targeting the same bus', () => {
+    const map = buildSiblingEventBusPolicies(
+      desiredWith([
+        {
+          logicalId: 'P1',
+          resourceType: 'AWS::Events::EventBusPolicy',
+          physicalId: 'CustomBus|A',
+          declared: { EventBusName: 'CustomBus', StatementId: 'A', Statement: stmt },
+        },
+        {
+          logicalId: 'P2',
+          resourceType: 'AWS::Events::EventBusPolicy',
+          physicalId: 'CustomBus|B',
+          declared: { EventBusName: 'CustomBus', StatementId: 'B', Statement: stmt },
+        },
+      ])
+    );
+    expect(map.CustomBus).toHaveLength(2);
+    expect(map.CustomBus!.map((s) => (s as { Sid: string }).Sid)).toEqual(['A', 'B']);
   });
 });
 


### PR DESCRIPTION
## What

`AWS::Events::EventBus` reflects its resource policy — set by the declared sibling `AWS::Events::EventBusPolicy` — as an undeclared `Policy` on the bus, producing a first-run `[Potential Drift]` FP on every custom bus with a policy (the standard cross-account eventing setup), plus a double-report (the statement is also checked on the `EventBusPolicy` resource).

## Fix

Statement-level sibling subtraction (tier-2 *derive from siblings*, per CLAUDE.md fold-strategy — **not** a tier-3 whole-prop value-independent drop, which would blind out-of-band-statement detection on the bus):

- `src/commands/gather.ts`: `buildSiblingEventBusPolicies(desired)` (mirrors `buildSiblingSgRules`) scans declared `EventBusPolicy` resources, keys them by resolved target bus (`EventBusName`; absent → `"default"`), and collects each sibling's `Statement` with its `Sid` stamped from `StatementId`. Threaded into `ClassifyOpts` at both classify call sites. An unresolved target-bus intrinsic is skipped (fail-open — a one-time visible FP, never a hidden change).
- `src/diff/classify.ts`: `subtractSiblingEventBusStatements` removes sibling-owned statements (match on `Sid`, else content-superset) from the bus's live `Policy.Statement[]`; empties → whole `Policy` folds; any remaining out-of-band statement surfaces.

## Tests

`tests/classify-eventbus-reflect-699.test.ts`: sibling-only policy → folds (FP gone); an inline-declared `Policy` still compares; **out-of-band statement surfaces**; mixed → only the out-of-band surfaces. `tests/gather.test.ts`: `buildSiblingEventBusPolicies` keying / Sid-stamp / default-bus / unresolved-skip / multi-policy aggregation.

Closes #699
