### PR TITLE
fix(revert): coerce a string-typed declared scalar to the live value's type on the revert patch (#725)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -958,13 +958,53 @@ export function buildRevertPlan(
   return { items, notRevertable };
 }
 
+// Raw CFn / SAM templates legally declare integers/booleans as STRINGS
+// (`"DelaySeconds": "300"`, `"Enabled": "true"` — CloudFormation coerces them to the
+// resource's real type at deploy). Detection folds `"300"` vs `100` fine (the global
+// stringly-equal guard), but a genuine drift's revert patch would write the STRING
+// `"300"` into an integer-typed Cloud Control model property, which CC rejects with
+// `ValidationException: expected type: Integer, found: String` — the drift is then
+// permanently unrevertable for raw-CFn/SAM users (#725).
+//
+// The target property's real JSON type is exactly the type CloudFormation already
+// coerced the live value to, so `live` (the finding's `actual`) IS the type oracle:
+// coerce a string `desired` toward `live`'s type when `live` is a number or boolean.
+// Only a CLEAN, LOSSLESS representation coerces (a finite numeric string for a number;
+// `"true"`/`"false"` for a boolean) — anything else (`"abc"` for an integer, an empty
+// string, whitespace) is left VERBATIM so a malformed declaration is never corrupted
+// (fail safe = today's behavior). A `desired` that is genuinely a string coerces
+// nothing, because when the property's real type is string the LIVE value is a string
+// too, so neither branch below fires. This changes ONLY the value written on the revert
+// path; detection/fold are untouched.
+function coerceDeclaredScalar(desired: unknown, live: unknown): unknown {
+  if (typeof desired !== 'string') return desired;
+  if (typeof live === 'number') {
+    // Number('') / Number('  ') are 0 (a silent, lossy coercion), so require the string
+    // to actually contain a digit before trusting Number().
+    const n = Number(desired);
+    if (Number.isFinite(n) && desired.trim() !== '') return n;
+    return desired;
+  }
+  if (typeof live === 'boolean') {
+    if (desired === 'true') return true;
+    if (desired === 'false') return false;
+    return desired;
+  }
+  // bigint live is out of scope (CC models use JSON number/integer); string/object/etc.
+  // targets are left verbatim.
+  return desired;
+}
+
 function revertOp(f: Finding, recorded: BaselineFile['recorded']): PatchOp {
   const pointer = toPointer(f.path);
   if (f.tier === 'declared') {
     return {
       op: 'add',
       path: pointer,
-      value: f.desired,
+      // Coerce a string-typed declared scalar toward the live value's real JSON type
+      // (#725) — see coerceDeclaredScalar. A non-scalar `desired` (whole object/array
+      // drift) passes straight through: coerceDeclaredScalar only touches a string.
+      value: coerceDeclaredScalar(f.desired, f.actual),
       // Carry the current live value as `prior`, exactly like the undeclared branches
       // below. A property-scoped SDK writer that reverts PER ENTRY needs it:
       // `writeIamRoleInlinePolicies` deletes every inline policy present in `prior`

--- a/tests/revert-scalar-coerce-725.test.ts
+++ b/tests/revert-scalar-coerce-725.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildRevertPlan, type PatchOp } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+// #725: raw CFn / SAM templates legally declare integers/booleans as STRINGS
+// ("DelaySeconds": "300"). Detection folds the stringly-equal difference, but the
+// revert patch must not write the string into an integer/boolean-typed Cloud Control
+// model property — CC rejects it with `ValidationException: expected type: Integer,
+// found: String`, leaving the genuine drift permanently unrevertable. buildRevertPlan
+// coerces the declared string scalar toward the LIVE value's real JSON type (the type
+// CloudFormation already coerced the live value to), losslessly, and leaves anything
+// non-clean verbatim (fail safe).
+
+const F = (over: Partial<Finding>): Finding => ({
+  tier: 'declared',
+  logicalId: 'R',
+  physicalId: 'phys-1',
+  resourceType: 'AWS::SQS::Queue',
+  path: 'DelaySeconds',
+  ...over,
+});
+
+const op0 = (f: Finding): PatchOp => {
+  const plan = buildRevertPlan([f], undefined);
+  expect(plan.items).toHaveLength(1);
+  return plan.items[0]!.ops[0]!;
+};
+
+describe('#725 revert scalar type coercion (declared drift)', () => {
+  it('string "300" desired + integer live 100 → patch value is the NUMBER 300', () => {
+    const op = op0(F({ desired: '300', actual: 100 }));
+    expect(op).toMatchObject({ op: 'add', path: '/DelaySeconds' });
+    expect(op.value).toBe(300);
+    expect(typeof op.value).toBe('number');
+  });
+
+  it('string "true" desired + boolean live false → patch value is the boolean true', () => {
+    const op = op0(
+      F({
+        resourceType: 'AWS::SQS::Queue',
+        path: 'FifoQueue',
+        desired: 'true',
+        actual: false,
+      })
+    );
+    expect(op.value).toBe(true);
+    expect(typeof op.value).toBe('boolean');
+  });
+
+  it('string "false" desired + boolean live true → patch value is the boolean false', () => {
+    const op = op0(F({ path: 'FifoQueue', desired: 'false', actual: true }));
+    expect(op.value).toBe(false);
+  });
+
+  it('genuinely-string property (string desired + string live) is left as a string — no coercion', () => {
+    // The property's real type is string, so the live value is a string too; nothing coerces.
+    const op = op0(
+      F({
+        resourceType: 'AWS::SQS::Queue',
+        path: 'QueueName',
+        desired: 'my-queue',
+        actual: 'other-queue',
+      })
+    );
+    expect(op.value).toBe('my-queue');
+    expect(typeof op.value).toBe('string');
+  });
+
+  it('a numeric-LOOKING string ("100") stays a string when the live value is also a string', () => {
+    // Live is a string → the real type is string, so a numeric-looking value must NOT
+    // be turned into a number (that would corrupt a genuinely-string property).
+    const op = op0(F({ path: 'ContentBasedDeduplication', desired: '100', actual: '200' }));
+    expect(op.value).toBe('100');
+    expect(typeof op.value).toBe('string');
+  });
+
+  it('non-numeric string for an integer property is left VERBATIM (fail safe, no NaN)', () => {
+    const op = op0(F({ desired: 'abc', actual: 100 }));
+    expect(op.value).toBe('abc');
+  });
+
+  it('empty / whitespace string for an integer property is left verbatim (Number("") is a lossy 0)', () => {
+    expect(op0(F({ desired: '', actual: 100 })).value).toBe('');
+    expect(op0(F({ desired: '   ', actual: 100 })).value).toBe('   ');
+  });
+
+  it('non-"true"/"false" string for a boolean property is left verbatim', () => {
+    const op = op0(F({ path: 'FifoQueue', desired: 'yes', actual: false }));
+    expect(op.value).toBe('yes');
+  });
+
+  it('already-numeric desired + numeric live passes through unchanged', () => {
+    const op = op0(F({ desired: 300, actual: 100 }));
+    expect(op.value).toBe(300);
+  });
+
+  it('a non-scalar (object) declared drift is untouched by scalar coercion', () => {
+    const desired = { deadLetterTargetArn: 'arn:x', maxReceiveCount: 5 };
+    const op = op0(F({ path: 'RedrivePolicy', desired, actual: { maxReceiveCount: 3 } }));
+    expect(op.value).toEqual(desired);
+  });
+
+  it('negative and decimal numeric strings coerce for a number-typed live value', () => {
+    expect(op0(F({ desired: '-5', actual: 10 })).value).toBe(-5);
+    expect(op0(F({ path: 'Weight', desired: '1.5', actual: 2 })).value).toBe(1.5);
+  });
+});


### PR DESCRIPTION
## What

`revert` built its Cloud Control patch from the declared value **type-verbatim**. Raw CFn / SAM templates legally declare integers/booleans as strings (`"DelaySeconds": "300"` — CFn coerces at deploy). Detection folds `"300"` vs `300` fine, but reverting a genuine out-of-band drift wrote the string into an integer-typed CC property → `ValidationException: expected type: Integer, found: String` → the drift was **permanently unrevertable** for raw-CFn/SAM users.

## Fix

`src/revert/plan.ts` `coerceDeclaredScalar(desired, live)` hooked into `revertOp`'s declared branch. The **live value** (`f.actual`) carries the property's real CFn-coerced type, so it is the type oracle (this is exactly the issue's endorsed "coerce toward the live value's type", and keeps the fix contained to `plan.ts` — no schema-type map needed). When `desired` is a string and `live` is a number → `Number(desired)` (only finite, non-empty); `live` boolean → `"true"`/`"false"` → boolean. A non-numeric string, empty/whitespace, or a genuinely string-typed property (even numeric-looking `"100"` with string live) is left verbatim — fail safe. Detection/fold untouched.

## Tests

`tests/revert-scalar-coerce-725.test.ts` (12): the `"300"`→`300` repro; `"true"`/`"false"`→booleans; string property stays string; `"abc"`/empty/whitespace → verbatim; object drift untouched; negative/decimal numeric strings coerce.

Closes #725
