### PR TITLE
fix(diff): subtract sibling IAM attachments from Role.ManagedPolicyArns / User.Groups reflections (#698)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -250,6 +250,8 @@ interface ClassifyOpts {
   oaiCanonicalIds: Record<string, string>;
   siblingSgRules: Record<string, { ingress: unknown[]; egress: unknown[] }>;
   siblingEventBusPolicies: Record<string, unknown[]>;
+  siblingManagedPolicyAttachments: Record<string, string[]>;
+  siblingUserGroups: Record<string, string[]>;
   bucketNotificationManaged: Set<string>;
   clusterEchoModel: Record<string, Record<string, unknown>>;
 }
@@ -367,6 +369,98 @@ export function buildBucketNotificationManaged(desired: Desired): Set<string> {
     }
   }
   return managed;
+}
+
+// A sibling AWS::IAM::ManagedPolicy declaring `Roles:[thisRole]` (/`Users`/`Groups`) attaches
+// ITSELF to the principal; the principal's live read (a ListAttached*Policies UNION) then echoes
+// that policy's ARN in its own `ManagedPolicyArns` — a value the principal never declared. Because
+// a Role/User/Group DECLARES `ManagedPolicyArns` (or is compared as an ordinary array when it
+// does), the sibling ARN reads as a DECLARED-tier drift that survives `record`, and a whole-array
+// revert would DETACH the sibling-managed policy (destructive collateral, #698). The sibling
+// ManagedPolicy is tracked + compared as its own resource, so classify subtracts its ARN from the
+// principal's reflected live `ManagedPolicyArns` (see subtractSiblingManagedPolicyArns). Keyed by
+// the principal identifier the classify finding uses (the principal's physical id == RoleName /
+// UserName / GroupName; a sibling's `Roles`/`Users`/`Groups` entry is that same name, or a `Ref`
+// that resolves to it). The attached value is the ManagedPolicy's physical id (== its ARN); if the
+// policy has no resolved physical id, its `ManagedPolicyName` is used so a name-form live entry
+// still matches. Fail-open: a principal reference that cannot be resolved, or a sibling policy with
+// neither an ARN nor a name, is skipped (the principal keeps the reflected ARN → a one-time visible
+// FP, never a hidden change); an out-of-band ARN matching NO sibling still surfaces.
+const MANAGED_POLICY_TYPE = 'AWS::IAM::ManagedPolicy';
+const MANAGED_POLICY_ATTACH_SIDES = ['Roles', 'Users', 'Groups'] as const;
+export function buildSiblingManagedPolicyAttachments(desired: Desired): Record<string, string[]> {
+  const byLogicalId = new Map<string, string>();
+  for (const r of desired.resources) if (r.physicalId) byLogicalId.set(r.logicalId, r.physicalId);
+  const map: Record<string, string[]> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== MANAGED_POLICY_TYPE) continue;
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const d = decl as Record<string, unknown>;
+    // The attached value the principal's live ManagedPolicyArns echoes: the policy's ARN (==
+    // its physical id). Fall back to its declared ManagedPolicyName so a name-form live entry
+    // matches; skip the policy entirely if neither is resolvable (fail-open).
+    const attached =
+      r.physicalId ??
+      (typeof d.ManagedPolicyName === 'string' && d.ManagedPolicyName
+        ? d.ManagedPolicyName
+        : undefined);
+    if (!attached) continue;
+    for (const side of MANAGED_POLICY_ATTACH_SIDES) {
+      const list = d[side];
+      if (!Array.isArray(list)) continue;
+      for (const principal of list) {
+        const key = resolvePrincipalKey(principal, byLogicalId);
+        if (key) (map[key] ??= []).push(attached);
+      }
+    }
+  }
+  return map;
+}
+
+// A sibling AWS::IAM::UserToGroupAddition (`Users:[thisUser], GroupName:g`) adds the user to a
+// group; the user's live read echoes that group in an undeclared `Groups` list. The addition
+// resource itself is a CC-gap `skipped` type (UnsupportedActionException), so the membership is
+// verified nowhere and surfaces as a first-run undeclared FP on every such user (#698). Classify
+// subtracts these sibling-declared groups from the user's live `Groups` (see
+// subtractSiblingUserGroups), leaving any out-of-band group (matching no sibling) to still surface.
+// Keyed by the user identifier the classify finding uses (the user's physical id == UserName; a
+// `Users` entry is that name or a `Ref` resolving to it). The group value is the addition's
+// resolved `GroupName` (== the group's physical id, which the live `Groups` echoes), or a `Ref`
+// resolved via the logical-id map. Fail-open: an unresolved user or group reference is skipped.
+const USER_TO_GROUP_TYPE = 'AWS::IAM::UserToGroupAddition';
+export function buildSiblingUserGroups(desired: Desired): Record<string, string[]> {
+  const byLogicalId = new Map<string, string>();
+  for (const r of desired.resources) if (r.physicalId) byLogicalId.set(r.logicalId, r.physicalId);
+  const map: Record<string, string[]> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== USER_TO_GROUP_TYPE) continue;
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const d = decl as Record<string, unknown>;
+    const group = resolvePrincipalKey(d.GroupName, byLogicalId);
+    if (!group) continue; // unresolved group name -> fail-open (the user keeps the reflected group)
+    const users = d.Users;
+    if (!Array.isArray(users)) continue;
+    for (const user of users) {
+      const key = resolvePrincipalKey(user, byLogicalId);
+      if (key) (map[key] ??= []).push(group);
+    }
+  }
+  return map;
+}
+
+// Resolve an IAM principal/group reference to the concrete identity the live read echoes: a plain
+// string is the resolved name (== physical id); a `{Ref: logicalId}` resolves via the logical-id ->
+// physical-id map. Any other shape (an unresolved intrinsic) yields undefined -> the caller skips
+// it (fail-open).
+function resolvePrincipalKey(ref: unknown, byLogicalId: Map<string, string>): string | undefined {
+  if (typeof ref === 'string' && ref) return ref;
+  if (ref && typeof ref === 'object' && 'Ref' in ref) {
+    const logicalId = (ref as { Ref: unknown }).Ref;
+    if (typeof logicalId === 'string') return byLogicalId.get(logicalId);
+  }
+  return undefined;
 }
 
 // Per Aurora DBInstance physical id, the parent DBCluster's live model — the source for the
@@ -684,6 +778,8 @@ export async function gatherFindings(
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
+    siblingManagedPolicyAttachments: buildSiblingManagedPolicyAttachments(desired),
+    siblingUserGroups: buildSiblingUserGroups(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
   };
@@ -772,6 +868,8 @@ export async function regatherTouched(
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
+    siblingManagedPolicyAttachments: buildSiblingManagedPolicyAttachments(desired),
+    siblingUserGroups: buildSiblingUserGroups(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
   };

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -498,6 +498,67 @@ function subtractSiblingSgRules(
   if (arr.length === 0) delete live[prop]; // empty array == absent; don't introduce a []-vs-absent FP
 }
 
+// An IAM Role/User/Group reflects, in its live `ManagedPolicyArns` (a ListAttached*Policies
+// UNION), the ARNs of SIBLING AWS::IAM::ManagedPolicy resources that declare `Roles`/`Users`/
+// `Groups` pointing back at it — a policy the principal never declared in its OWN
+// `ManagedPolicyArns`. Because the principal compares `ManagedPolicyArns` (an ordinary array when
+// it declares only its own ARNs), the sibling ARN reads as a DECLARED-tier drift that survives
+// `record`, and a whole-array revert would DETACH the sibling-managed policy (#698). The sibling
+// ManagedPolicy is tracked + compared as its own resource, so subtract its ARN (/name) from the
+// principal's reflected live list. Match the live entry against the sibling value by exact equality
+// OR by ARN-tail == name (the sibling was resolved to a bare ManagedPolicyName while the live entry
+// is a full ARN, or vice versa). One removal per sibling. Any live ARN matching NO sibling — a
+// genuinely out-of-band attachment — stays and surfaces. Fail-open: an unmatched sibling is a no-op.
+const IAM_ATTACHMENT_REFLECTION_TYPES: ReadonlySet<string> = new Set([
+  'AWS::IAM::Role',
+  'AWS::IAM::User',
+  'AWS::IAM::Group',
+]);
+const MANAGED_POLICY_ARNS_PROP = 'ManagedPolicyArns';
+
+// True when a live `ManagedPolicyArns` entry denotes the same managed policy as a sibling value.
+// Exact match first; then tolerate the ARN-vs-name mismatch (the sibling was keyed by a bare
+// ManagedPolicyName, the live read returns the full ARN) by comparing an ARN's policy-name tail
+// (everything after the last `/`) — either side may be the ARN.
+function managedPolicyRefMatches(liveVal: unknown, sibVal: unknown): boolean {
+  if (typeof liveVal !== 'string' || typeof sibVal !== 'string') return false;
+  if (liveVal === sibVal) return true;
+  const tail = (s: string): string => (s.startsWith('arn:') ? (s.split('/').pop() ?? s) : s);
+  return tail(liveVal) === tail(sibVal);
+}
+
+// Remove from a principal's live `ManagedPolicyArns` each ARN attached by a declared sibling
+// ManagedPolicy. Only the principal's OWN declared ARNs (and any out-of-band ARN matching no
+// sibling) remain, so the sibling attachment is neither a declared FP nor a revert-detach hazard.
+function subtractSiblingManagedPolicyArns(
+  live: Record<string, unknown>,
+  siblingArns: string[]
+): void {
+  const arr = live[MANAGED_POLICY_ARNS_PROP];
+  if (!Array.isArray(arr) || siblingArns.length === 0) return;
+  for (const sib of siblingArns) {
+    const i = arr.findIndex((el) => managedPolicyRefMatches(el, sib));
+    if (i >= 0) arr.splice(i, 1);
+  }
+  if (arr.length === 0) delete live[MANAGED_POLICY_ARNS_PROP]; // empty == absent; no []-vs-absent FP
+}
+
+// An IAM User reflects, in an undeclared live `Groups`, the group memberships added by SIBLING
+// AWS::IAM::UserToGroupAddition resources — a value the user never declared, verified nowhere else
+// (the addition resource is a CC-gap `skipped` type). Subtract each sibling-added group so it is
+// not a first-run undeclared FP; a group added purely out of band (matching no sibling) stays and
+// surfaces. If `Groups` empties, drop it (empty == absent).
+const USER_GROUPS_PROP = 'Groups';
+function subtractSiblingUserGroups(live: Record<string, unknown>, siblingGroups: string[]): void {
+  const arr = live[USER_GROUPS_PROP];
+  if (!Array.isArray(arr) || siblingGroups.length === 0) return;
+  for (const sib of siblingGroups) {
+    const i = arr.findIndex((el) => el === sib);
+    if (i >= 0) arr.splice(i, 1);
+  }
+  if (arr.length === 0) delete live[USER_GROUPS_PROP]; // empty == absent; no []-vs-absent FP
+}
+
 // Cloud Control returns an ALTERNATIVE representation of a declared value as a separate
 // live-only field. Keyed resourceType -> { liveOnlyField: declaredSiblingField }: drop the
 // live-only field when its declared sibling is present (the template already pins the value
@@ -1435,6 +1496,19 @@ export function classifyResource(
     // from an AWS::Events::EventBus's reflected `Policy.Statement[]` so sibling-owned statements
     // are not double-counted; any out-of-band statement (matching no sibling) still surfaces.
     siblingEventBusPolicies?: Record<string, unknown[]>;
+    // Managed-policy ARNs (/names) attached by SIBLING AWS::IAM::ManagedPolicy resources whose
+    // `Roles`/`Users`/`Groups` reference this principal, keyed by the principal identifier (==
+    // physical id == RoleName/UserName/GroupName). Subtracted from an IAM Role/User/Group's
+    // reflected live `ManagedPolicyArns` (a ListAttached*Policies union) so a sibling-attached
+    // policy is not a declared-tier FP that survives record + a detach-hazard on revert (#698); an
+    // out-of-band attachment matching no sibling still surfaces.
+    siblingManagedPolicyAttachments?: Record<string, string[]>;
+    // Group names added by SIBLING AWS::IAM::UserToGroupAddition resources whose `Users` reference
+    // this user, keyed by the user identifier (== physical id == UserName). Subtracted from an IAM
+    // User's reflected live `Groups` so the sibling-added membership is not a first-run undeclared
+    // FP (the addition resource is itself a CC-gap skipped type, checked nowhere); an out-of-band
+    // group matching no sibling still surfaces.
+    siblingUserGroups?: Record<string, string[]>;
     // Bucket physical ids whose S3 notifications are managed by a Custom::S3BucketNotifications
     // custom resource (see buildBucketNotificationManaged): the live bucket reflects the
     // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
@@ -1529,6 +1603,25 @@ export function classifyResource(
       for (const [prop, side] of Object.entries(SG_RULE_REFLECTION)) {
         subtractSiblingSgRules(live, prop, sib[side]);
       }
+    }
+  }
+  // Subtract from an IAM Role/User/Group's reflected live `ManagedPolicyArns` (a
+  // ListAttached*Policies union) the ARNs attached by SIBLING AWS::IAM::ManagedPolicy resources
+  // (keyed by the principal's physical id in opts.siblingManagedPolicyAttachments). The siblings
+  // are tracked + compared as their own resources, so leaving their ARNs on the principal is a
+  // declared-tier FP that survives record + a whole-array-revert detach hazard (#698). Runs
+  // regardless of whether the principal declares `ManagedPolicyArns` — only sibling-OWNED ARNs are
+  // removed, so the principal's own declared ARNs still compare and a genuinely out-of-band ARN
+  // (matching no sibling) still surfaces.
+  if (IAM_ATTACHMENT_REFLECTION_TYPES.has(resourceType)) {
+    const sibArns = physicalId ? opts.siblingManagedPolicyAttachments?.[physicalId] : undefined;
+    if (sibArns) subtractSiblingManagedPolicyArns(live, sibArns);
+    // Subtract from an IAM User's undeclared live `Groups` the memberships added by sibling
+    // AWS::IAM::UserToGroupAddition resources (which are themselves CC-gap skipped). Any group
+    // added purely out of band (matching no sibling) still surfaces.
+    if (resourceType === 'AWS::IAM::User') {
+      const sibGroups = physicalId ? opts.siblingUserGroups?.[physicalId] : undefined;
+      if (sibGroups) subtractSiblingUserGroups(live, sibGroups);
     }
   }
   // A bucket whose notifications are managed by a Custom::S3BucketNotifications CR reflects

--- a/tests/classify-iam-reflect-698.test.ts
+++ b/tests/classify-iam-reflect-698.test.ts
@@ -1,0 +1,118 @@
+// #698 — two IAM sibling attachment/membership reflections, live-proven on a clean deploy:
+//  1. A sibling AWS::IAM::ManagedPolicy declaring `Roles:[thisRole]` attaches itself; the role's
+//     live `ManagedPolicyArns` (a ListAttachedRolePolicies union) then carries the sibling ARN,
+//     differing from its own declared `ManagedPolicyArns` — a DECLARED-tier FP that SURVIVES
+//     record, whose whole-array revert would DETACH the sibling policy (destructive collateral).
+//  2. A sibling AWS::IAM::UserToGroupAddition puts the user in a group; the user's live read echoes
+//     an undeclared `Groups`. The addition resource is a CC-gap `skipped` type, verified nowhere.
+// Fix: classify subtracts sibling-OWNED attachments/memberships from the reflected live arrays
+// (fed from gather's buildSiblingManagedPolicyAttachments / buildSiblingUserGroups), leaving a
+// genuinely out-of-band attachment/group (matching no sibling) to still surface.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (fs: Finding[], t: string) => fs.filter((f) => f.tier === t).map((f) => f.path);
+
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({ logicalId: 'R', resourceType, physicalId, declared });
+
+const OWN_ARN = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole';
+const SIBLING_ARN = 'arn:aws:iam::111111111111:policy/CdkRealDriftHuntIamSib-SiblingManaged-CMBNc4';
+const OOB_ARN = 'arn:aws:iam::111111111111:policy/RogueManualAttachment';
+const ROLE_PHYS = 'CdkRealDriftHuntIamSib-ProbeRole-e7vbvyk';
+
+describe('#698 Role.ManagedPolicyArns sibling-ManagedPolicy attachment subtraction', () => {
+  it('folds a sibling-attached ARN — no declared drift (the record-surviving FP is gone)', () => {
+    const f = classifyResource(
+      mk('AWS::IAM::Role', { ManagedPolicyArns: [OWN_ARN] }, ROLE_PHYS),
+      { ManagedPolicyArns: [OWN_ARN, SIBLING_ARN] },
+      emptySchema,
+      { siblingManagedPolicyAttachments: { [ROLE_PHYS]: [SIBLING_ARN] } }
+    );
+    // The sibling ARN is subtracted from live, so live == declared == [OWN_ARN]: no drift at all.
+    expect(tierPaths(f, 'declared')).not.toContain('ManagedPolicyArns');
+    expect(tierPaths(f, 'undeclared')).not.toContain('ManagedPolicyArns');
+    expect(f).toHaveLength(0);
+  });
+
+  it('still surfaces an out-of-band attached ARN with no matching sibling', () => {
+    const f = classifyResource(
+      mk('AWS::IAM::Role', { ManagedPolicyArns: [OWN_ARN] }, ROLE_PHYS),
+      { ManagedPolicyArns: [OWN_ARN, SIBLING_ARN, OOB_ARN] },
+      emptySchema,
+      { siblingManagedPolicyAttachments: { [ROLE_PHYS]: [SIBLING_ARN] } }
+    );
+    // Sibling gone, but the rogue ARN remains → surfaces as a drift finding (declared array diff).
+    expect(f.length).toBeGreaterThan(0);
+    const drift = [...tierPaths(f, 'declared'), ...tierPaths(f, 'undeclared')];
+    expect(drift).toContain('ManagedPolicyArns');
+  });
+
+  it('matches a sibling resolved to a bare name against a full-ARN live entry', () => {
+    const NAME = 'CdkRealDriftHuntIamSib-SiblingManaged-CMBNc4';
+    const f = classifyResource(
+      mk('AWS::IAM::Role', { ManagedPolicyArns: [OWN_ARN] }, ROLE_PHYS),
+      { ManagedPolicyArns: [OWN_ARN, SIBLING_ARN] },
+      emptySchema,
+      { siblingManagedPolicyAttachments: { [ROLE_PHYS]: [NAME] } }
+    );
+    expect(f).toHaveLength(0);
+  });
+
+  it('fails open — no sibling map leaves the reflected ARN surfaced (never hidden)', () => {
+    const f = classifyResource(
+      mk('AWS::IAM::Role', { ManagedPolicyArns: [OWN_ARN] }, ROLE_PHYS),
+      { ManagedPolicyArns: [OWN_ARN, SIBLING_ARN] },
+      emptySchema,
+      {}
+    );
+    expect(f.length).toBeGreaterThan(0);
+  });
+});
+
+const USER_PHYS = 'CdkRealDriftHuntIamSib-ProbeUser-L5Vk4Z';
+const SIBLING_GROUP = 'CdkRealDriftHuntIamSib-ProbeGroup-ZSZE1sa';
+const OOB_GROUP = 'ManuallyAddedGroup';
+
+describe('#698 User.Groups sibling-UserToGroupAddition membership subtraction', () => {
+  it('folds a group added only by a sibling UserToGroupAddition (undeclared FP is gone)', () => {
+    const f = classifyResource(
+      mk('AWS::IAM::User', {}, USER_PHYS),
+      { UserName: USER_PHYS, Groups: [SIBLING_GROUP] },
+      emptySchema,
+      { siblingUserGroups: { [USER_PHYS]: [SIBLING_GROUP] } }
+    );
+    expect(tierPaths(f, 'undeclared')).not.toContain('Groups');
+    // The whole Groups array folds away (empty == absent) — no per-member undeclared entry either.
+    expect(f.some((x) => typeof x.path === 'string' && x.path.startsWith('Groups'))).toBe(false);
+  });
+
+  it('still surfaces an out-of-band group with no matching sibling', () => {
+    const f = classifyResource(
+      mk('AWS::IAM::User', {}, USER_PHYS),
+      { UserName: USER_PHYS, Groups: [SIBLING_GROUP, OOB_GROUP] },
+      emptySchema,
+      { siblingUserGroups: { [USER_PHYS]: [SIBLING_GROUP] } }
+    );
+    // Sibling group subtracted; the manual group remains as undeclared inventory.
+    const undeclared = tierPaths(f, 'undeclared');
+    expect(undeclared.some((p) => typeof p === 'string' && p.includes('Groups'))).toBe(true);
+    // And the sibling group is NOT reported anywhere.
+    expect(JSON.stringify(f)).not.toContain(SIBLING_GROUP);
+  });
+});

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -18,7 +18,9 @@ import {
   buildBucketNotificationManaged,
   buildClusterEchoModels,
   buildSiblingEventBusPolicies,
+  buildSiblingManagedPolicyAttachments,
   buildSiblingSgRules,
+  buildSiblingUserGroups,
   type GatherResult,
   gatherFindings,
   isManagedBySiblingStack,
@@ -794,6 +796,152 @@ describe('buildSiblingEventBusPolicies', () => {
     );
     expect(map.CustomBus).toHaveLength(2);
     expect(map.CustomBus!.map((s) => (s as { Sid: string }).Sid)).toEqual(['A', 'B']);
+  });
+});
+
+describe('buildSiblingManagedPolicyAttachments', () => {
+  const desiredWith = (resources: DesiredResource[]): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111111111111',
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  const SIB_ARN = 'arn:aws:iam::111111111111:policy/Stack-SiblingManaged-abc';
+
+  it('keys the sibling ARN by the principal name in Roles/Users/Groups', () => {
+    const map = buildSiblingManagedPolicyAttachments(
+      desiredWith([
+        {
+          logicalId: 'SiblingManaged',
+          resourceType: 'AWS::IAM::ManagedPolicy',
+          physicalId: SIB_ARN,
+          declared: { Roles: ['role-phys'], Users: ['user-phys'], Groups: ['group-phys'] },
+        },
+      ])
+    );
+    expect(map['role-phys']).toEqual([SIB_ARN]);
+    expect(map['user-phys']).toEqual([SIB_ARN]);
+    expect(map['group-phys']).toEqual([SIB_ARN]);
+  });
+
+  it('resolves a {Ref: logicalId} principal via the logical-id -> physical-id map', () => {
+    const map = buildSiblingManagedPolicyAttachments(
+      desiredWith([
+        {
+          logicalId: 'ProbeRole',
+          resourceType: 'AWS::IAM::Role',
+          physicalId: 'role-phys',
+          declared: {},
+        },
+        {
+          logicalId: 'SiblingManaged',
+          resourceType: 'AWS::IAM::ManagedPolicy',
+          physicalId: SIB_ARN,
+          declared: { Roles: [{ Ref: 'ProbeRole' }] },
+        },
+      ])
+    );
+    expect(map['role-phys']).toEqual([SIB_ARN]);
+  });
+
+  it('falls back to ManagedPolicyName when the policy has no resolved physical id', () => {
+    const map = buildSiblingManagedPolicyAttachments(
+      desiredWith([
+        {
+          logicalId: 'SiblingManaged',
+          resourceType: 'AWS::IAM::ManagedPolicy',
+          declared: { ManagedPolicyName: 'MyPolicy', Roles: ['role-phys'] },
+        } as DesiredResource,
+      ])
+    );
+    expect(map['role-phys']).toEqual(['MyPolicy']);
+  });
+
+  it('skips a policy with neither an ARN nor a name, and an unresolved principal (fail-open)', () => {
+    const map = buildSiblingManagedPolicyAttachments(
+      desiredWith([
+        {
+          logicalId: 'NoId',
+          resourceType: 'AWS::IAM::ManagedPolicy',
+          declared: { Roles: ['role-phys'] },
+        } as DesiredResource,
+        {
+          logicalId: 'UnresolvedPrincipal',
+          resourceType: 'AWS::IAM::ManagedPolicy',
+          physicalId: SIB_ARN,
+          declared: { Roles: [{ 'Fn::GetAtt': ['X', 'Arn'] }] },
+        },
+      ])
+    );
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+});
+
+describe('buildSiblingUserGroups', () => {
+  const desiredWith = (resources: DesiredResource[]): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111111111111',
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  it('keys the resolved group name by each user in Users', () => {
+    const map = buildSiblingUserGroups(
+      desiredWith([
+        {
+          logicalId: 'Membership',
+          resourceType: 'AWS::IAM::UserToGroupAddition',
+          declared: { GroupName: 'group-phys', Users: ['user-a', 'user-b'] },
+        } as DesiredResource,
+      ])
+    );
+    expect(map['user-a']).toEqual(['group-phys']);
+    expect(map['user-b']).toEqual(['group-phys']);
+  });
+
+  it('resolves {Ref} for both the group and the user', () => {
+    const map = buildSiblingUserGroups(
+      desiredWith([
+        {
+          logicalId: 'ProbeGroup',
+          resourceType: 'AWS::IAM::Group',
+          physicalId: 'group-phys',
+          declared: {},
+        },
+        {
+          logicalId: 'ProbeUser',
+          resourceType: 'AWS::IAM::User',
+          physicalId: 'user-phys',
+          declared: {},
+        },
+        {
+          logicalId: 'Membership',
+          resourceType: 'AWS::IAM::UserToGroupAddition',
+          declared: { GroupName: { Ref: 'ProbeGroup' }, Users: [{ Ref: 'ProbeUser' }] },
+        } as DesiredResource,
+      ])
+    );
+    expect(map['user-phys']).toEqual(['group-phys']);
+  });
+
+  it('skips an unresolved group name (fail-open)', () => {
+    const map = buildSiblingUserGroups(
+      desiredWith([
+        {
+          logicalId: 'Membership',
+          resourceType: 'AWS::IAM::UserToGroupAddition',
+          declared: { GroupName: { 'Fn::GetAtt': ['G', 'GroupName'] }, Users: ['user-a'] },
+        } as DesiredResource,
+      ])
+    );
+    expect(Object.keys(map)).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## What

Two IAM sibling-attachment reflections, live-proven on a clean deploy:
1. **`Role.ManagedPolicyArns` DECLARED-tier FP that survives record** — a sibling `AWS::IAM::ManagedPolicy` with `Roles:[thisRole]` attaches itself; the role's live read (`ListAttachedRolePolicies` union) then includes that ARN, differing from the declared `ManagedPolicyArns`. record can't accept it; revert would **detach** the sibling-managed policy (destructive collateral).
2. **`User.Groups` undeclared FP** — a sibling `AWS::IAM::UserToGroupAddition` echoes onto the user's live `Groups` (and the addition resource itself is a CC-gap `skipped` type, so the membership is checked nowhere).

## Fix

Statement-level sibling subtraction (tier-2 *derive from siblings*, preserving out-of-band detection):
- `src/commands/gather.ts`: `buildSiblingManagedPolicyAttachments` (per-principal map of attached ARNs, resolving `{Ref}` → physical id, ARN-or-name form) and `buildSiblingUserGroups` (per-user sibling group map). Threaded into `ClassifyOpts` at both classify call sites. Fail-open on unresolvable refs.
- `src/diff/classify.ts`: `subtractSiblingManagedPolicyArns` (ARN-tail matching so a bare `ManagedPolicyName` matches a full-ARN live entry) runs for Role/User/Group; `subtractSiblingUserGroups` for User. Only sibling-owned entries are removed — an out-of-band attachment/membership with no matching sibling still surfaces.

## Tests

`tests/classify-iam-reflect-698.test.ts` (6): sibling-attached ARN → no declared drift (record-surviving FP gone); out-of-band ARN → surfaces; sibling group → folds; out-of-band group → surfaces; ARN-vs-name match; fail-open. `tests/gather.test.ts` (7): both builders' keying / `{Ref}` resolution / name fallback / unresolvable-skip.

Closes #698
