### PR TITLE
fix(revert): extend the silent-no-op detector to add-shaped set-default writes (#763)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1340,23 +1340,38 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   const okIds = new Set(applied.filter((a) => a.ok).map((a) => a.logicalId));
   const preActual = new Map<string, unknown>();
   for (const f of gathered.findings) preActual.set(`${f.logicalId}\0${f.path}`, f.actual);
-  const noOpRemovals: { displayId: string; path: string }[] = [];
+  // #763: an `add`-shaped set-default write (REVERT_SET_DEFAULT_PATHS / KNOWN_DEFAULT_PATHS
+  // — the very fix for the remove no-op) can ITSELF be silently ignored by an
+  // UpdateUserPool-style omit/ignore provider whose EXPLICIT write is also dropped. Its live
+  // value re-reads unchanged, and when the value is UNRECORDED undeclared that re-read is
+  // NON-drift (not `isDrift`) → it escapes `remaining`; the item applied ok → not in
+  // `failedUpdateIds`; the op is `add` → the remove loop above skipped it → falsely CLEAN.
+  // Flag such an add as a no-op when ALL hold: the item applied ok, the post finding at the
+  // path is non-drift, the live value did NOT change across the revert (deepEqual pre/post),
+  // AND the live value is NOT what the add tried to write (`!deepEqual(post, op.value)` — a
+  // successful write that HAPPENED to match op.value is correctly NOT flagged). The
+  // declared/recorded cases stay covered by `remaining` (they re-read as drift); this only
+  // closes the unrecorded corner.
+  const noOpRemovals: { displayId: string; path: string; kind: 'remove' | 'add' }[] = [];
   for (const item of plan.items) {
     if (item.kind === 'delete' || !okIds.has(item.logicalId)) continue;
     for (const op of item.ops) {
-      if (op.op !== 'remove') continue;
+      if (op.op !== 'remove' && op.op !== 'add') continue;
       const dotted = op.path.replace(/^\//, '').replace(/\//g, '.');
       const key = `${item.logicalId}\0${dotted}`;
       if (!preActual.has(key)) continue;
       const pre = preActual.get(key);
-      const persisted = post.some(
-        (f) =>
-          f.logicalId === item.logicalId &&
-          f.path === dotted &&
-          !isDrift(f) &&
-          deepEqual(f.actual, pre)
+      const post0 = post.find(
+        (f) => f.logicalId === item.logicalId && f.path === dotted && !isDrift(f)
       );
-      if (persisted) noOpRemovals.push({ displayId: item.displayId, path: dotted });
+      // Same non-drift persisted-value proof for both op kinds: the pre-revert value is
+      // still live after a SUCCESSFUL apply. For `add`, additionally require the live value
+      // to NOT equal what we tried to write — else a write that landed (post === op.value)
+      // would be mis-flagged.
+      const persisted = post0 !== undefined && deepEqual(post0.actual, pre);
+      const ignoredWrite =
+        op.op === 'remove' ? persisted : persisted && !deepEqual(post0.actual, op.value);
+      if (ignoredWrite) noOpRemovals.push({ displayId: item.displayId, path: dotted, kind: op.op });
     }
   }
   // A touched resource whose verification RE-READ failed (skipped tier — a throttle /
@@ -1374,7 +1389,10 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   for (const n of noOpRemovals)
     out(
       style.fail(
-        `  NOT reverted: ${n.displayId}.${n.path} — removal was a no-op (the provider ignored the omitted property; it needs an explicit default write — see #597 / REVERT_SET_DEFAULT_PATHS)`
+        n.kind === 'remove'
+          ? `  NOT reverted: ${n.displayId}.${n.path} — removal was a no-op (the provider ignored the omitted property; it needs an explicit default write — see #597 / REVERT_SET_DEFAULT_PATHS)`
+          : // #763: the explicit default write was itself ignored by an omit/ignore provider.
+            `  NOT reverted: ${n.displayId}.${n.path} — the default-value write was a no-op (the provider accepted but ignored it; the out-of-band value persists — see #763 / REVERT_SET_DEFAULT_PATHS)`
       )
     );
   const notConverged = unconfirmed + noOpRemovals.length;

--- a/tests/revert-noop-add-763.test.ts
+++ b/tests/revert-noop-add-763.test.ts
@@ -1,0 +1,150 @@
+import {
+  CloudControlClient,
+  GetResourceCommand,
+  UpdateResourceCommand,
+} from '@aws-sdk/client-cloudcontrol';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { GatherResult } from '../src/commands/gather.js';
+import { revertStack } from '../src/commands/stack-actions.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+// #763: the #631 silent-no-op detector only inspected `remove` ops. An `add`-shaped
+// set-default write (REVERT_SET_DEFAULT_PATHS / KNOWN_DEFAULT_PATHS) that an omit/ignore
+// provider ACCEPTS-BUT-IGNORES slips through every net and prints a false "CLEAN after
+// revert." while the out-of-band value persists:
+//   - the value re-reads as an UNRECORDED undeclared → excluded by isDrift → not in `remaining`;
+//   - the item applied "ok" → not in `failedUpdateIds`;
+//   - the op is `add` → skipped by the old no-op loop → converged = true.
+// AWS::IAM::Role\0MaxSessionDuration is a REVERT_SET_DEFAULT_PATHS entry (KNOWN_DEFAULTS
+// default 3600): reverting an unrecorded out-of-band value emits an `add` op writing 3600.
+
+const EMPTY_SCHEMA = {
+  readOnly: new Set<string>(),
+  writeOnly: new Set<string>(),
+  createOnly: new Set<string>(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+} as SchemaInfo;
+
+// An out-of-band MaxSessionDuration (7200) on a role that never declared it → an
+// unrecorded undeclared finding (no baseline). Revert emits `add /MaxSessionDuration = 3600`.
+const undeclaredMsd = (): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'R',
+  resourceType: 'AWS::IAM::Role',
+  path: 'MaxSessionDuration',
+  physicalId: 'r-phys',
+  actual: 7200,
+});
+
+const gathered = (): GatherResult =>
+  ({
+    desired: {
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources: [
+        { logicalId: 'R', resourceType: 'AWS::IAM::Role', physicalId: 'r-phys', declared: {} },
+      ],
+      rawTemplate: '{}',
+      ctx: {
+        params: {},
+        pseudo: {},
+        conditions: {},
+        physIds: {},
+        liveAttrs: {},
+        mappings: {},
+        exports: {},
+        condCache: new Map(),
+      },
+    },
+    findings: [undeclaredMsd()],
+    schemas: new Map([['AWS::IAM::Role', EMPTY_SCHEMA]]),
+    liveByLogical: new Map(),
+  }) as GatherResult;
+
+const params = () => ({
+  stackName: 's',
+  region: 'r',
+  gathered: gathered(),
+  baseline: undefined,
+  config: { ignore: [] },
+  dryRun: false,
+  yes: true,
+  removeUnrecorded: true, // include the unrecorded add-op default write in the plan
+  verbose: false,
+  interactive: false,
+  convergeRetryDelayMs: 0,
+});
+
+// The live re-read returns a role whose MaxSessionDuration is `value`.
+const liveRead = (value: number) => ({
+  ResourceDescription: {
+    Identifier: 'r-phys',
+    Properties: JSON.stringify({ MaxSessionDuration: value }),
+  },
+});
+
+const run = async () => {
+  const logs: string[] = [];
+  const orig = console.log;
+  console.log = (s: unknown) => logs.push(String(s));
+  try {
+    const outcome = await revertStack(params());
+    return { outcome, logs: logs.join('\n') };
+  } finally {
+    console.log = orig;
+  }
+};
+
+describe('revertStack #763 — an ignored add-op set-default write is NOT CLEAN', () => {
+  let cfnMock: ReturnType<typeof mockClient>;
+  beforeEach(() => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' } as never] });
+  });
+  afterEach(() => cfnMock.restore());
+
+  const mockApplySuccess = (cc: ReturnType<typeof mockClient>) => {
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' },
+    });
+  };
+
+  // The provider accepted the UpdateResource (SUCCESS) but IGNORED the explicit default
+  // write: the live value re-reads UNCHANGED at the out-of-band 7200 (== pre.actual, and
+  // != the 3600 the add tried to write). Before the fix this printed a false CLEAN.
+  it('add-op default write the provider ignored → NOT CLEAN, exit 1 (persisted value detected)', async () => {
+    const cc = mockClient(CloudControlClient);
+    mockApplySuccess(cc); // UpdateResource "succeeds"...
+    cc.on(GetResourceCommand).resolves(liveRead(7200)); // ...but the value persists unchanged
+
+    const { outcome, logs } = await run();
+    expect(logs).not.toContain('CLEAN after revert');
+    expect(logs).toContain('NOT reverted:');
+    expect(logs).toContain('MaxSessionDuration');
+    expect(logs).toContain('the default-value write was a no-op');
+    expect(logs).toContain('could not be confirmed converged');
+    expect(outcome.exit).toBe(1);
+  });
+
+  // Control (no false negative): the add-op write DID take — the live value re-reads as the
+  // 3600 default (!= the 7200 pre value). It is NOT a no-op, so the stack is CLEAN, exit 0.
+  it('add-op default write that DID take (live == op.value) → CLEAN, exit 0', async () => {
+    const cc = mockClient(CloudControlClient);
+    mockApplySuccess(cc);
+    cc.on(GetResourceCommand).resolves(liveRead(3600)); // the default write landed
+
+    const { outcome, logs } = await run();
+    expect(logs).toContain('s: CLEAN after revert.');
+    expect(logs).not.toContain('NOT reverted:');
+    expect(outcome.exit).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

The #631 silent-no-op revert detector (`src/commands/stack-actions.ts`) only inspected `remove` ops (`if (op.op !== 'remove') continue;`). An `add`-shaped set-default write (`REVERT_SET_DEFAULT_PATHS` / `KNOWN_DEFAULT_PATHS`) that a provider **accepts-but-ignores** slipped every net and printed a false **"CLEAN after revert."** while the out-of-band value persisted: the value re-reads as an unrecorded undeclared → excluded from `remaining`; the item applied "ok" → not in `failedUpdateIds`; the op is `add` → skipped by the no-op loop → `converged = true`.

## Fix

Extend the same convergence loop to `add` ops (reusing its `pre`/`post` plumbing + `deepEqual`). Flag an add-op silent no-op when ALL hold: item applied ok; the post-revert finding at the path is non-drift; `deepEqual(post.actual, pre.actual)` (live unchanged); AND `!deepEqual(post.actual, op.value)` (the write did not take). Flagged ops feed the same not-converged / exit-1 channel — no false CLEAN. A write that DID take (`post.actual == op.value`) still converges (no false negative).

## Tests

`tests/revert-noop-add-763.test.ts`: drives the real `revertStack` convergence path with a `MaxSessionDuration` set-default `add` op — ignored write (re-read == pre != op.value) → reports `NOT reverted` + exit 1 (fails without the fix, which falsely prints CLEAN); control where the write took (re-read == op.value) → CLEAN + exit 0.

Closes #763
