### PR TITLE
feat(read): fold RDS OptionGroup default-fill via the live option catalog (#978 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,7 +824,13 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `glue:GetClassifier` + `glue:GetWorkflow` + `glue:GetConnection`
   (`glue:GetConnection` is issued with `HidePassword` so NO credential enters the
   baseline — read an `AWS::Glue::Classifier` / `Workflow` / `Connection`, the rest
-  of the Glue family that has no Cloud Control handler)
+  of the Glue family that has no Cloud Control handler),
+  `rds:DescribeOptionGroupOptions` (reads an `AWS::RDS::OptionGroup`'s option-default
+  catalog — the `DefaultValue` AWS materializes for every plugin setting the template
+  did not declare — so the service default-fill folds to `atDefault` instead of
+  flooding a clean first check with undeclared settings; equality-gated, so an
+  out-of-band setting change is still detected. Without the permission cdkrd warns
+  once and those default-fill settings surface as first-run drift)
 - Optional: `elasticloadbalancing:GetTrustStoreCaCertificatesBundle` records a
   content hash of an `AWS::ElasticLoadBalancingV2::TrustStore`'s live mTLS CA
   bundle (`CaCertificatesBundleSha256`) so an out-of-band CA-bundle swap

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -6,6 +6,7 @@ import {
   DescribeStackResourcesCommand,
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
+import { DescribeOptionGroupOptionsCommand, RDSClient } from '@aws-sdk/client-rds';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
 import { CLUSTER_ECHO_CHILD, classifyResource, normalizeLiveModel } from '../diff/classify.js';
@@ -254,6 +255,7 @@ interface ClassifyOpts {
   siblingUserGroups: Record<string, string[]>;
   bucketNotificationManaged: Set<string>;
   clusterEchoModel: Record<string, Record<string, unknown>>;
+  rdsOptionSettingDefaults: Record<string, Record<string, Record<string, string | null>>>;
 }
 
 // Rules declared by standalone AWS::EC2::SecurityGroupIngress / ::SecurityGroupEgress
@@ -493,6 +495,80 @@ export function buildClusterEchoModels(desired: Desired): Record<string, Record<
     if (clusterLive) map[r.physicalId] = clusterLive;
   }
   return map;
+}
+
+// #978: resolve each AWS::RDS::OptionGroup's option-default catalog from
+// `describe-option-group-options` (per engine+version, cached and paginated), keyed
+// `physicalId -> optionName -> settingName -> DefaultValue|null`. classify folds a live-only
+// setting whose value equals its catalog default (or an unset `{Name}` husk) to atDefault, so a
+// clean OptionGroup shows zero first-run drift while an out-of-band change still surfaces. The
+// catalog is read LIVE (never pinned) so it cannot rot (#1072) and needs no per-plugin constant
+// table. Fail-soft: a denied/failed describe warns ONCE and leaves that group out of the map — its
+// value-bearing defaults then surface undeclared (the pre-#978 behavior), never a crash.
+export async function buildRdsOptionSettingDefaults(
+  desired: Desired,
+  region: string
+): Promise<Record<string, Record<string, Record<string, string | null>>>> {
+  const groups = desired.resources.filter(
+    (r) => r.resourceType === 'AWS::RDS::OptionGroup' && r.physicalId
+  );
+  if (groups.length === 0) return {};
+  const client = new RDSClient({ region, ...READ_RETRY });
+  const catalogCache = new Map<string, Record<string, Record<string, string | null>>>();
+  const out: Record<string, Record<string, Record<string, string | null>>> = {};
+  let warned = false;
+  for (const r of groups) {
+    const decl = r.declared as { EngineName?: unknown; MajorEngineVersion?: unknown } | undefined;
+    const engine = typeof decl?.EngineName === 'string' ? decl.EngineName : undefined;
+    const version = decl?.MajorEngineVersion != null ? String(decl.MajorEngineVersion) : undefined;
+    if (!engine || !version || !r.physicalId) continue;
+    const key = `${engine}:${version}`;
+    let catalog = catalogCache.get(key);
+    if (!catalog) {
+      try {
+        catalog = await fetchOptionCatalog(client, engine, version);
+        catalogCache.set(key, catalog);
+      } catch (e) {
+        if (!warned) {
+          console.error(
+            `warning: describe-option-group-options failed for ${engine} ${version} (${(e as Error).name}) — RDS OptionGroup default-fill settings may surface as first-run drift; grant rds:DescribeOptionGroupOptions`
+          );
+          warned = true;
+        }
+        continue;
+      }
+    }
+    out[r.physicalId] = catalog;
+  }
+  return out;
+}
+
+async function fetchOptionCatalog(
+  client: RDSClient,
+  engineName: string,
+  majorEngineVersion: string
+): Promise<Record<string, Record<string, string | null>>> {
+  const catalog: Record<string, Record<string, string | null>> = {};
+  let marker: string | undefined;
+  do {
+    const resp = await client.send(
+      new DescribeOptionGroupOptionsCommand({
+        EngineName: engineName,
+        MajorEngineVersion: majorEngineVersion,
+        Marker: marker,
+      })
+    );
+    for (const opt of resp.OptionGroupOptions ?? []) {
+      if (!opt.Name) continue;
+      const settings: Record<string, string | null> = catalog[opt.Name] ?? {};
+      for (const s of opt.OptionGroupOptionSettings ?? []) {
+        if (s.SettingName) settings[s.SettingName] = s.DefaultValue ?? null;
+      }
+      catalog[opt.Name] = settings;
+    }
+    marker = resp.Marker;
+  } while (marker);
+  return catalog;
 }
 
 // CloudFront legacy OAI id -> S3CanonicalUserId, harvested from the stack's own
@@ -782,6 +858,7 @@ export async function gatherFindings(
     siblingUserGroups: buildSiblingUserGroups(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
+    rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
@@ -872,6 +949,7 @@ export async function regatherTouched(
     siblingUserGroups: buildSiblingUserGroups(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
+    rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 
   const fresh: Finding[] = [];

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -86,6 +86,10 @@ export interface CorpusCase {
     // cluster-echo strip. Without it a fresh-harvested reader/writer replays the un-folded echo
     // props as false undeclared drift. Optional for back-compat (pre-clusterEcho cases lack it).
     clusterEchoModel?: Record<string, Record<string, unknown>>;
+    // #978: this OptionGroup's option-default catalog keyed by its own physical id — present only
+    // on an AWS::RDS::OptionGroup case, so replay reproduces the default-fill fold. Optional for
+    // back-compat (pre-#978 cases and non-OptionGroup cases lack it).
+    rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -119,6 +123,7 @@ export function buildCorpusCase(
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
     bucketNotificationManaged?: Set<string>;
     clusterEchoModel?: Record<string, Record<string, unknown>>;
+    rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
   },
   findings: Finding[]
 ): CorpusCase {
@@ -137,6 +142,11 @@ export function buildCorpusCase(
   const echoModel =
     resource.physicalId && opts.clusterEchoModel?.[resource.physicalId]
       ? opts.clusterEchoModel[resource.physicalId]
+      : undefined;
+  // #978: carry ONLY this OptionGroup's catalog entry (keyed by its own physical id).
+  const rdsOptCatalog =
+    resource.physicalId && opts.rdsOptionSettingDefaults?.[resource.physicalId]
+      ? opts.rdsOptionSettingDefaults[resource.physicalId]
       : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
@@ -175,6 +185,9 @@ export function buildCorpusCase(
       ...(bucketNotif ? { bucketNotificationManaged: bucketNotif } : {}),
       ...(echoModel && resource.physicalId
         ? { clusterEchoModel: { [resource.physicalId]: echoModel } }
+        : {}),
+      ...(rdsOptCatalog && resource.physicalId
+        ? { rdsOptionSettingDefaults: { [resource.physicalId]: rdsOptCatalog } }
         : {}),
     },
     expected: findings,

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -960,22 +960,28 @@ function isSelfEchoTrivialEmpty(v: unknown, physicalId: string | undefined): boo
   return rest.length < entries.length && rest.every(([, val]) => isTrivialEmpty(val));
 }
 
-// #978: AWS::RDS::OptionGroup default-fill — configuring an option (e.g. MARIADB_AUDIT_PLUGIN)
-// makes RDS materialize EVERY plugin setting the template did not declare, in two shapes:
-//   1. value-bearing AWS defaults (stable per plugin) — SERVER_AUDIT=FORCE_PLUS_PERMANENT, ...
+// #978: AWS::RDS::OptionGroup default-fill — configuring an option (e.g. MARIADB_AUDIT_PLUGIN,
+// Oracle NATIVE_NETWORK_ENCRYPTION, SQLServer SQLSERVER_AUDIT) makes RDS materialize EVERY plugin
+// setting the template did not declare, in two shapes:
+//   1. value-bearing AWS defaults — SERVER_AUDIT=FORCE_PLUS_PERMANENT,
+//      SQLNET.ENCRYPTION_CLIENT=REQUESTED, ... (the value equals the option's catalog default), and
 //   2. value-less `{Name}`-only husks — a listed-but-unset setting (no `Value` member).
-// Both are service-materialized first-run defaults, never user intent, so each folds
-// `atDefault` (the undeclared-tier twin of the closed #480 declared-tier fold). Equality-gated
-// so out-of-band detection survives: a husk that GAINS a Value, or a pinned default whose Value
-// CHANGES, no longer matches and surfaces as undeclared. Setting names are plugin-unique
-// (SERVER_AUDIT_* belong only to MARIADB_AUDIT_PLUGIN), so keying by Name alone carries no
-// cross-option collision. Values observed live (mariadb 10.11, us-east-1; corpus
-// AWS__RDS__OptionGroup.HuntOptionGroup).
-const RDS_OPTION_SETTING_DEFAULTS: Record<string, string> = {
-  SERVER_AUDIT: 'FORCE_PLUS_PERMANENT',
-  SERVER_AUDIT_LOGGING: 'ON',
-  SERVER_AUDIT_FILE_PATH: '/rdsdbdata/log/audit/',
-};
+// Both are service-materialized first-run defaults, never user intent, so each folds `atDefault`
+// (the undeclared-tier twin of the closed #480 declared-tier fold). Equality-gated so out-of-band
+// detection survives: a husk that GAINS a Value, or a default whose Value CHANGES, no longer
+// matches and surfaces undeclared.
+//
+// The value-bearing defaults are (engine, version, option, setting)-specific, so instead of
+// PINNING constants (which rot over time — the #1072 class — and collide across options, e.g.
+// SQLServer SSAS.MAX_MEMORY=45 vs SSRS.MAX_MEMORY=30) gather RESOLVES them LIVE from
+// `describe-option-group-options` into `opts.rdsOptionSettingDefaults[physicalId][option]`
+// (`{settingName: DefaultValue|null}`) — the same "what AWS assigns undeclared == the option's
+// catalog default" fact CFn drift detection leans on. Empirically the catalog DefaultValue equals
+// the value RDS materializes for an unset setting (verified live: mariadb audit + oracle
+// native-network-encryption). Keyed by (physicalId, OptionName, SettingName), so it is
+// collision-free across options and never rots (re-read every run); when the catalog is absent
+// (read denied / offline replay without it) the value-bearing fold simply does not apply
+// (fail-open — the setting surfaces undeclared, the pre-#978 behavior), while husks still fold.
 
 // A `{<idField>: X}` element whose ONLY non-trivial member is its identity field — an
 // identity-only husk (the #648 `Targets[].AvailabilityZone` in-element husk class). Carries no
@@ -985,17 +991,28 @@ function isIdentityOnlyHusk(el: Record<string, unknown>, idField: string): boole
   return Object.entries(el).every(([k, v]) => k === idField || isTrivialEmpty(v));
 }
 
-// True when a live-only RDS OptionGroup OptionSetting is a service-materialized default-fill
-// (value-bearing pinned default OR identity-only husk) that must fold `atDefault`.
-function isRdsOptionSettingDefault(
-  resourceType: string,
-  el: Record<string, unknown>,
-  name: string,
-  value: unknown
-): boolean {
-  if (resourceType !== 'AWS::RDS::OptionGroup') return false;
-  if (isIdentityOnlyHusk(el, 'Name')) return true;
-  return name in RDS_OPTION_SETTING_DEFAULTS && value === RDS_OPTION_SETTING_DEFAULTS[name];
+// The gather-resolved catalog default for `settingName` under the OptionConfiguration at `path`'s
+// array index (its OptionName read from the declared side). Returns the DefaultValue string, `null`
+// for a catalog husk, or `undefined` when unresolvable (no catalog, unknown option/setting) — in
+// which case the value-bearing fold does not apply.
+function rdsMaterializedDefault(
+  catalog: Record<string, Record<string, Record<string, string | null>>> | undefined,
+  physicalId: string | undefined,
+  declared: unknown,
+  path: string,
+  settingName: string
+): string | null | undefined {
+  if (!catalog || physicalId === undefined) return undefined;
+  const m = /OptionConfigurations\.(\d+)\.OptionSettings$/.exec(path);
+  if (!m) return undefined;
+  const configs = (declared as { OptionConfigurations?: unknown } | undefined)
+    ?.OptionConfigurations;
+  const optName = Array.isArray(configs)
+    ? (configs[Number(m[1])] as { OptionName?: unknown } | undefined)?.OptionName
+    : undefined;
+  if (typeof optName !== 'string') return undefined;
+  const perOption = catalog[physicalId]?.[optName];
+  return perOption && settingName in perOption ? perOption[settingName] : undefined;
 }
 
 // A live-only policy DOCUMENT whose statements were ALL subtracted as AWS-managed
@@ -1517,6 +1534,11 @@ export function classifyResource(
     // Per child physical id, the parent cluster's live model — for the CLUSTER_ECHO_CHILD
     // strip (an Aurora DBInstance echoing its DBCluster's cluster-level config).
     clusterEchoModel?: Record<string, Record<string, unknown>>;
+    // #978: per AWS::RDS::OptionGroup physical id, the option-default catalog resolved live from
+    // `describe-option-group-options` — `{ optionName: { settingName: DefaultValue | null } }`.
+    // Folds RDS-materialized value-bearing default-fill settings to atDefault (see
+    // rdsMaterializedDefault). Absent when the read was denied / on offline replay without it.
+    rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
     // Top-level exempted props whose SDK_SUPPLEMENTS read FAILED (#849, from router.ts): they
     // are absent from the live model NOT because the resource lacks them, but because the read
     // could not verify them. Each is surfaced as a `readGap` (not a false declared removal, not
@@ -2622,14 +2644,24 @@ export function classifyResource(
               resourceType === 'AWS::KinesisFirehose::DeliveryStream' &&
               loName === 'NumberOfRetries' &&
               loValue === '3';
-            // #978: RDS OptionGroup materializes every unset plugin setting as a default-fill
-            // (value-bearing default or `{Name}`-only husk) — fold atDefault, equality-gated.
-            const isRdsOptionDefault = isRdsOptionSettingDefault(
-              resourceType,
-              loRec,
-              loName,
-              loValue
-            );
+            // #978: RDS OptionGroup materializes every unset plugin setting as a default-fill —
+            // an identity-only `{Name}` husk (unset), or a value equal to the option's catalog
+            // DefaultValue (gather-resolved live). Fold both atDefault, equality-gated.
+            let isRdsOptionDefault = false;
+            if (resourceType === 'AWS::RDS::OptionGroup') {
+              if (isIdentityOnlyHusk(loRec, nvSubsetSpec.nameField)) {
+                isRdsOptionDefault = true;
+              } else {
+                const matDefault = rdsMaterializedDefault(
+                  opts.rdsOptionSettingDefaults,
+                  physicalId,
+                  declaredIn,
+                  d.path,
+                  loName
+                );
+                isRdsOptionDefault = matDefault != null && matDefault === loValue;
+              }
+            }
             findings.push({
               tier: isFirehoseRetriesDefault || isRdsOptionDefault ? 'atDefault' : 'undeclared',
               logicalId,

--- a/tests/classify-978-rds-optiongroup-default-fill.test.ts
+++ b/tests/classify-978-rds-optiongroup-default-fill.test.ts
@@ -1,10 +1,14 @@
 // #978 — AWS::RDS::OptionGroup undeclared default-fill. Configuring an option
-// (MARIADB_AUDIT_PLUGIN) makes RDS materialize EVERY plugin setting the template did not
-// declare: value-bearing AWS defaults (SERVER_AUDIT=FORCE_PLUS_PERMANENT, ...) and value-less
-// `{Name}`-only husks (a listed-but-unset setting). Both are service first-run defaults, not
-// user intent, so each must fold `atDefault` (zero first-run drift) — the undeclared-tier twin
-// of the closed #480 declared-tier fold. Detection is preserved: a husk that GAINS a Value or a
-// pinned default whose Value CHANGES still surfaces as undeclared.
+// (MARIADB_AUDIT_PLUGIN, Oracle NATIVE_NETWORK_ENCRYPTION, ...) makes RDS materialize EVERY plugin
+// setting the template did not declare: value-bearing AWS defaults and value-less `{Name}`-only
+// husks. Both are service first-run defaults, not user intent, so each folds `atDefault` (zero
+// first-run drift) — the undeclared-tier twin of the closed #480 declared-tier fold.
+//
+// The value-bearing defaults come from the gather-resolved option-default catalog
+// (`opts.rdsOptionSettingDefaults`, read live from describe-option-group-options), NOT a pinned
+// table. Detection is preserved (equality-gated): a value diverging from its catalog default, or a
+// husk that gains a value, still surfaces undeclared. When the catalog is absent (read denied /
+// offline), value-bearing settings surface undeclared (fail-open) but husks still fold.
 import { describe, expect, it } from 'vite-plus/test';
 import { classifyResource } from '../src/diff/classify.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
@@ -25,10 +29,11 @@ const tier = (fs: Finding[], t: string) =>
     .map((f) => f.path)
     .sort();
 
+const PHYS = 'og-phys';
 const mk = (declared: Record<string, unknown>): DesiredResource => ({
   logicalId: 'HuntOptionGroup',
   resourceType: 'AWS::RDS::OptionGroup',
-  physicalId: 'og-phys',
+  physicalId: PHYS,
   declared,
 });
 
@@ -71,11 +76,31 @@ const liveOptionSettings = (extra: Record<string, unknown>[] = []) => ({
   ],
 });
 
+// The gather-resolved catalog (as describe-option-group-options returns it for mariadb 10.11):
+// value-bearing DefaultValues + null for the unset (husk) settings.
+const catalogOpts = () => ({
+  rdsOptionSettingDefaults: {
+    [PHYS]: {
+      MARIADB_AUDIT_PLUGIN: {
+        SERVER_AUDIT_EVENTS: 'CONNECT,QUERY',
+        SERVER_AUDIT_QUERY_LOG_LIMIT: '1024',
+        SERVER_AUDIT_LOGGING: 'ON',
+        SERVER_AUDIT_FILE_PATH: '/rdsdbdata/log/audit/',
+        SERVER_AUDIT: 'FORCE_PLUS_PERMANENT',
+        SERVER_AUDIT_INCL_USERS: null,
+        SERVER_AUDIT_EXCL_USERS: null,
+        SERVER_AUDIT_FILE_ROTATE_SIZE: null,
+        SERVER_AUDIT_FILE_ROTATIONS: null,
+      },
+    },
+  },
+});
+
 const p = (name: string) => `OptionConfigurations.0.OptionSettings[${name}]`;
 
-describe('#978 RDS OptionGroup default-fill folds to atDefault', () => {
+describe('#978 RDS OptionGroup default-fill folds to atDefault via the live catalog', () => {
   it('folds every service-materialized default setting (value-bearing + husk) to atDefault', () => {
-    const f = classifyResource(mk(declared), liveOptionSettings(), emptySchema);
+    const f = classifyResource(mk(declared), liveOptionSettings(), emptySchema, catalogOpts());
     const atDefault = tier(f, 'atDefault');
     for (const name of [
       'SERVER_AUDIT',
@@ -98,7 +123,7 @@ describe('#978 RDS OptionGroup default-fill folds to atDefault', () => {
     (live.OptionConfigurations[0].OptionSettings as Record<string, unknown>[]).find(
       (s) => s.Name === 'SERVER_AUDIT_LOGGING'
     )!.Value = 'OFF';
-    const f = classifyResource(mk(declared), live, emptySchema);
+    const f = classifyResource(mk(declared), live, emptySchema, catalogOpts());
     expect(tier(f, 'undeclared')).toContain(p('SERVER_AUDIT_LOGGING'));
     expect(tier(f, 'atDefault')).not.toContain(p('SERVER_AUDIT_LOGGING'));
   });
@@ -109,18 +134,31 @@ describe('#978 RDS OptionGroup default-fill folds to atDefault', () => {
     (live.OptionConfigurations[0].OptionSettings as Record<string, unknown>[]).find(
       (s) => s.Name === 'SERVER_AUDIT_EXCL_USERS'
     )!.Value = 'rogueuser';
-    const f = classifyResource(mk(declared), live, emptySchema);
+    const f = classifyResource(mk(declared), live, emptySchema, catalogOpts());
     expect(tier(f, 'undeclared')).toContain(p('SERVER_AUDIT_EXCL_USERS'));
     expect(tier(f, 'atDefault')).not.toContain(p('SERVER_AUDIT_EXCL_USERS'));
   });
 
-  it('surfaces an unknown value-bearing setting the table does not pin — fail-closed', () => {
-    // A setting not in the default table, carrying a value, is genuine undeclared inventory.
+  it('surfaces a value-bearing setting the catalog does not know — fail-closed', () => {
     const f = classifyResource(
       mk(declared),
       liveOptionSettings([{ Name: 'SOME_UNKNOWN_SETTING', Value: 'x' }]),
-      emptySchema
+      emptySchema,
+      catalogOpts()
     );
     expect(tier(f, 'undeclared')).toContain(p('SOME_UNKNOWN_SETTING'));
+  });
+
+  it('without a catalog: husks still fold but value-bearing defaults surface undeclared (fail-open degrade)', () => {
+    const f = classifyResource(mk(declared), liveOptionSettings(), emptySchema); // no opts
+    const undeclared = tier(f, 'undeclared');
+    // value-bearing defaults surface (no catalog to confirm them)
+    expect(undeclared).toContain(p('SERVER_AUDIT'));
+    expect(undeclared).toContain(p('SERVER_AUDIT_LOGGING'));
+    expect(undeclared).toContain(p('SERVER_AUDIT_FILE_PATH'));
+    // husks still fold generically (they carry no value to verify)
+    const atDefault = tier(f, 'atDefault');
+    expect(atDefault).toContain(p('SERVER_AUDIT_INCL_USERS'));
+    expect(atDefault).toContain(p('SERVER_AUDIT_FILE_ROTATIONS'));
   });
 });

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2705,12 +2705,29 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       // #978: the service-materialized default-fill settings (value-bearing AWS defaults +
       // value-less `{Name}`-only husks) are not user intent, so they fold `atDefault` (zero
       // first-run drift) instead of surfacing as undeclared — the undeclared-tier twin of the
-      // #480 declared-tier fold. Detection is preserved (a diverged value / a husk that gains a
+      // #480 declared-tier fold. The value-bearing defaults are confirmed against the live
+      // option-default catalog (opts.rdsOptionSettingDefaults, from describe-option-group-options);
+      // husks fold generically. Detection is preserved (a diverged value / a husk that gains a
       // value re-surfaces undeclared; covered in classify-978-rds-optiongroup-default-fill).
       const findings = classifyResource(
         res(T, declared),
         liveConfigs(liveDefaultFilled),
-        emptySchema
+        emptySchema,
+        {
+          rdsOptionSettingDefaults: {
+            phys: {
+              MARIADB_AUDIT_PLUGIN: {
+                SERVER_AUDIT: 'FORCE_PLUS_PERMANENT',
+                SERVER_AUDIT_LOGGING: 'ON',
+                SERVER_AUDIT_FILE_PATH: '/rdsdbdata/log/audit/',
+                SERVER_AUDIT_INCL_USERS: null,
+                SERVER_AUDIT_EXCL_USERS: null,
+                SERVER_AUDIT_FILE_ROTATE_SIZE: null,
+                SERVER_AUDIT_FILE_ROTATIONS: null,
+              },
+            },
+          },
+        }
       );
       expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
       expect(findings.filter((f) => f.tier === 'undeclared')).toEqual([]);

--- a/tests/corpus/AWS__RDS__OptionGroup.HuntOptionGroup.json
+++ b/tests/corpus/AWS__RDS__OptionGroup.HuntOptionGroup.json
@@ -119,7 +119,22 @@
     "accountId": "111111111111",
     "region": "us-east-1",
     "kmsAliasTargets": {},
-    "oaiCanonicalIds": {}
+    "oaiCanonicalIds": {},
+    "rdsOptionSettingDefaults": {
+      "cdkrealdriftintegrdsoptevsub-huntoptiongroup-ukvbr6ytu287": {
+        "MARIADB_AUDIT_PLUGIN": {
+          "SERVER_AUDIT_EVENTS": "CONNECT,QUERY",
+          "SERVER_AUDIT_QUERY_LOG_LIMIT": "1024",
+          "SERVER_AUDIT_INCL_USERS": null,
+          "SERVER_AUDIT_EXCL_USERS": null,
+          "SERVER_AUDIT_FILE_ROTATE_SIZE": null,
+          "SERVER_AUDIT_FILE_ROTATIONS": null,
+          "SERVER_AUDIT_LOGGING": "ON",
+          "SERVER_AUDIT_FILE_PATH": "/rdsdbdata/log/audit/",
+          "SERVER_AUDIT": "FORCE_PLUS_PERMANENT"
+        }
+      }
+    }
   },
   "expected": [
     {

--- a/tests/gather-rds-optiongroup-catalog-978.test.ts
+++ b/tests/gather-rds-optiongroup-catalog-978.test.ts
@@ -1,0 +1,122 @@
+// #978 — buildRdsOptionSettingDefaults resolves each AWS::RDS::OptionGroup's option-default
+// catalog from describe-option-group-options (per engine+version, cached + paginated), keyed
+// physicalId -> optionName -> settingName -> DefaultValue|null. classify folds a live-only setting
+// matching its catalog default (or a `{Name}` husk) to atDefault. This guards the LIVE wiring (the
+// #980 "corpus-green but live-broken" class): the classify fold is inert unless this builder
+// populates the catalog and gather threads it into classifyOpts.
+import { DescribeOptionGroupOptionsCommand, RDSClient } from '@aws-sdk/client-rds';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { buildRdsOptionSettingDefaults } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import type { DesiredResource, ResolverContext } from '../src/types.js';
+
+const rds = mockClient(RDSClient);
+afterEach(() => rds.reset());
+
+const desiredWith = (resources: DesiredResource[]): Desired =>
+  ({
+    stackName: 's',
+    region: 'us-east-1',
+    accountId: '111122223333',
+    resources,
+    rawTemplate: '',
+    ctx: { liveAttrs: {} } as unknown as ResolverContext,
+  }) as Desired;
+
+const optionGroup = (physicalId: string, engine: string, version: string): DesiredResource => ({
+  logicalId: 'OG',
+  resourceType: 'AWS::RDS::OptionGroup',
+  physicalId,
+  declared: { EngineName: engine, MajorEngineVersion: version },
+});
+
+describe('#978 buildRdsOptionSettingDefaults', () => {
+  it('builds the per-physicalId option->setting->default catalog (value + null husk)', async () => {
+    rds.on(DescribeOptionGroupOptionsCommand).resolves({
+      OptionGroupOptions: [
+        {
+          Name: 'MARIADB_AUDIT_PLUGIN',
+          OptionGroupOptionSettings: [
+            { SettingName: 'SERVER_AUDIT', DefaultValue: 'FORCE_PLUS_PERMANENT' },
+            { SettingName: 'SERVER_AUDIT_LOGGING', DefaultValue: 'ON' },
+            { SettingName: 'SERVER_AUDIT_INCL_USERS' }, // no DefaultValue -> husk (null)
+          ],
+        },
+      ],
+    });
+    const cat = await buildRdsOptionSettingDefaults(
+      desiredWith([optionGroup('og-1', 'mariadb', '10.11')]),
+      'us-east-1'
+    );
+    expect(cat['og-1']?.MARIADB_AUDIT_PLUGIN).toEqual({
+      SERVER_AUDIT: 'FORCE_PLUS_PERMANENT',
+      SERVER_AUDIT_LOGGING: 'ON',
+      SERVER_AUDIT_INCL_USERS: null,
+    });
+  });
+
+  it('returns {} and makes no AWS call when the stack has no OptionGroup', async () => {
+    const cat = await buildRdsOptionSettingDefaults(
+      desiredWith([
+        { logicalId: 'Q', resourceType: 'AWS::SQS::Queue', physicalId: 'q', declared: {} },
+      ]),
+      'us-east-1'
+    );
+    expect(cat).toEqual({});
+    expect(rds.calls()).toHaveLength(0);
+  });
+
+  it('caches per engine+version — two groups on the same engine describe once', async () => {
+    rds.on(DescribeOptionGroupOptionsCommand).resolves({
+      OptionGroupOptions: [
+        {
+          Name: 'MARIADB_AUDIT_PLUGIN',
+          OptionGroupOptionSettings: [{ SettingName: 'X', DefaultValue: '1' }],
+        },
+      ],
+    });
+    const cat = await buildRdsOptionSettingDefaults(
+      desiredWith([
+        optionGroup('og-a', 'mariadb', '10.11'),
+        optionGroup('og-b', 'mariadb', '10.11'),
+      ]),
+      'us-east-1'
+    );
+    expect(Object.keys(cat).sort()).toEqual(['og-a', 'og-b']);
+    expect(rds.calls()).toHaveLength(1); // one describe for the shared engine+version
+  });
+
+  it('fail-soft: a denied describe leaves the group out of the map (no throw)', async () => {
+    rds
+      .on(DescribeOptionGroupOptionsCommand)
+      .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+    const cat = await buildRdsOptionSettingDefaults(
+      desiredWith([optionGroup('og-1', 'oracle-se2', '19')]),
+      'us-east-1'
+    );
+    expect(cat).toEqual({});
+  });
+
+  it('paginates via Marker', async () => {
+    rds
+      .on(DescribeOptionGroupOptionsCommand)
+      .resolvesOnce({
+        OptionGroupOptions: [
+          { Name: 'OPT1', OptionGroupOptionSettings: [{ SettingName: 'A', DefaultValue: '1' }] },
+        ],
+        Marker: 'next',
+      })
+      .resolvesOnce({
+        OptionGroupOptions: [
+          { Name: 'OPT2', OptionGroupOptionSettings: [{ SettingName: 'B', DefaultValue: '2' }] },
+        ],
+      });
+    const cat = await buildRdsOptionSettingDefaults(
+      desiredWith([optionGroup('og-1', 'oracle-se2', '19')]),
+      'us-east-1'
+    );
+    expect(cat['og-1']).toEqual({ OPT1: { A: '1' }, OPT2: { B: '2' } });
+    expect(rds.calls()).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Follow-up to #978 — generalizes the RDS OptionGroup default-fill fold from one pinned plugin to **all engines/options/versions**, via the live option catalog.

## Problem

#978 (shipped 0.7.x) folded `MARIADB_AUDIT_PLUGIN`'s default-fill with a small **pinned constant table** + a generic `{Name}`-only husk drop. But the value-bearing defaults are `(engine, version, option, setting)`-specific, so the pin covered exactly one plugin. Every other configured option still floods a clean first `check`:

- **Oracle `NATIVE_NETWORK_ENCRYPTION`** materializes **~10 undeclared `SQLNET.*` defaults**
- SQLServer `SQLSERVER_AUDIT`, MySQL `MEMCACHED`, and even MySQL `SERVER_AUDIT_QUERY_LOG_LIMIT` (which the pin missed)

— a zero-first-run invariant violation per plugin.

## Root insight (verified live)

`describe-option-group-options`' `DefaultValue` is **exactly** the value RDS materializes for a setting the template did not declare — the same "AWS assigns undeclared == the catalog default" fact CFn drift detection leans on. So resolve the defaults **live** instead of pinning constants that rot (#1072) and collide across options (`SSAS.MAX_MEMORY=45` vs `SSRS.MAX_MEMORY=30`).

## Change

- **read** (`src/commands/gather.ts`): `buildRdsOptionSettingDefaults` reads `describe-option-group-options` per `(engine, version)` (cached + paginated), keyed `physicalId → optionName → settingName → DefaultValue|null`, wired into both classifyOpts paths. Fail-soft: a denied describe warns **once** and leaves the group out (its value-bearing defaults surface undeclared — the pre-#978 behavior — never a crash; needs `rds:DescribeOptionGroupOptions`).
- **classify** (`src/diff/classify.ts`): **drops the pinned `RDS_OPTION_SETTING_DEFAULTS` table**; a live-only OptionSetting folds `atDefault` when it is an identity-only `{Name}` husk (generic) OR its value equals the option's catalog default (resolved via the declared `OptionName` at the path's array index). Equality-gated: a husk that gains a value or a default that changes still surfaces undeclared.
- **corpus** (`src/corpus/record.ts` + the HuntOptionGroup case): carry the per-OptionGroup catalog in `opts` so replay exercises the live fold path now that the pin is gone.

## Tests

- New `tests/gather-rds-optiongroup-catalog-978.test.ts` (mocked RDS): catalog build, per-engine caching, pagination, fail-soft, no-OptionGroup no-op — guards the LIVE wiring (the #980 "corpus-green but live-broken" class).
- `tests/classify-978-…` rewritten to the catalog path incl. the fail-open degrade; the #480/#978 classify tests updated.
- Corpus-replay exercises the catalog fold.

## Live verification (Oracle NNE + MySQL AUDIT, us-east-1)

- pre-fix: **10 `[Potential Drift]`** (9 Oracle `SQLNET.*` + 1 MySQL `SERVER_AUDIT_QUERY_LOG_LIMIT`) → post-fix: **CLEAN**
- an out-of-band setting change is still **detected** while the 9 SQLNET defaults stay `atDefault` (`info: atDefault=9`)

Full local gates green: typecheck / lint+format / build / 4138 unit tests.
