### PR TITLE
feat(read): add SDK read override for SageMaker::EndpointConfig (#857, SageMaker half)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@aws-sdk/client-redshift-serverless": "^3.1079.0",
     "@aws-sdk/client-route-53": "^3.1066.0",
     "@aws-sdk/client-s3": "^3.1065.0",
+    "@aws-sdk/client-sagemaker": "^3.1084.0",
     "@aws-sdk/client-scheduler": "^3.1067.0",
     "@aws-sdk/client-servicediscovery": "^3.1073.0",
     "@aws-sdk/client-ses": "^3.1065.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1065.0
         version: 3.1066.0
+      '@aws-sdk/client-sagemaker':
+        specifier: ^3.1084.0
+        version: 3.1084.0
       '@aws-sdk/client-scheduler':
         specifier: ^3.1067.0
         version: 3.1067.0
@@ -491,6 +494,10 @@ packages:
 
   '@aws-sdk/client-s3@3.1066.0':
     resolution: {integrity: sha512-jfJTg6Xbyws8+YF5sVQXgCA01elkenGEYeX6+HQOovu9m/Td1Ln2xcY3lHKetVNltdArp5rykjNd56z7bnA9dw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sagemaker@3.1084.0':
+    resolution: {integrity: sha512-55htILy87rZWEELpIlLzqcAxQtPf92CO42YlmvOuR23+JgIjoC6Y9wVTYb+yhuXZm77f0mYrhHoBXAK5xiIzWw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-scheduler@3.1067.0':
@@ -4464,6 +4471,17 @@ snapshots:
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sagemaker@3.1084.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -144,6 +144,11 @@ import {
 } from '@aws-sdk/client-ses';
 import { DescribeParametersCommand, SSMClient } from '@aws-sdk/client-ssm';
 import {
+  DescribeEndpointConfigCommand,
+  type ProductionVariant,
+  SageMakerClient,
+} from '@aws-sdk/client-sagemaker';
+import {
   GetNamespaceCommand,
   GetServiceCommand,
   ServiceDiscoveryClient,
@@ -1575,6 +1580,90 @@ const readGlueSecurityConfiguration: OverrideReader = async ({ physicalId, decla
   return model;
 };
 
+// AWS::SageMaker::EndpointConfig — CC API describe-type reports `handlers: []` (NO read
+// handler), so every endpoint config was silently `skipped`: an out-of-band change to a
+// production variant's instance sizing, a DataCaptureConfig / KMS-key swap, or the network /
+// VPC posture was invisible (#857). Read via SageMaker DescribeEndpointConfig — the CFn physical
+// id IS the EndpointConfigName (Ref returns the ARN, but `Id`/the resolved name round-trips as
+// the config name; declared EndpointConfigName is the fallback). Project the CFn-declarable
+// property surface, dropping the AWS-managed readOnly response fields (EndpointConfigArn /
+// CreationTime) that the registry schema does NOT model — projecting them would be a permanent
+// undeclared false inventory.
+//
+// ProductionVariants / ShadowProductionVariants: the SDK ProductionVariant shape is mostly 1:1
+// PascalCase with the CFn ProductionVariant definition, but the SDK returns THREE fields the
+// registry schema does NOT model — `AcceleratorType` (deprecated Elastic Inference; AWS still
+// echoes it), `CoreDumpConfig`, and (for InstancePools-style variants) a nested `MetricsConfig`
+// — so each variant is projected field-by-field against the SCHEMA property set (never a
+// verbatim passthrough) to keep those AWS-only echoes out of the undeclared inventory. Every
+// field is emitted ONLY when AWS returns it, so a minimal variant (VariantName + a couple of
+// knobs) stays thin (FP-safe on a first check). The nested config blobs (ServerlessConfig /
+// ManagedInstanceScaling / RoutingConfig / InstancePools / CapacityReservationConfig) match the
+// CFn definitions 1:1 and pass through verbatim when present.
+//
+// Tags are NOT projected: DescribeEndpointConfig does not return them (there is no `Tags` field
+// on the response — tags come from a separate ListTags call), so there is nothing to map; a
+// declared Tags stays a readGap rather than a false `desired=[…] actual=undefined` drift.
+// Read-ONLY: the endpoint config is immutable (every mutable property is createOnly in the
+// schema — you replace, not update — and there is no UpdateEndpointConfig API), so there is no
+// in-place revert to offer. A deleted config surfaces as ResourceNotFound / ValidationException
+// → the router maps it to `deleted`.
+const projectSageMakerVariant = (v: ProductionVariant): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  if (str(v.VariantName)) out.VariantName = v.VariantName;
+  if (str(v.ModelName)) out.ModelName = v.ModelName;
+  if (typeof v.InitialInstanceCount === 'number') out.InitialInstanceCount = v.InitialInstanceCount;
+  if (str(v.InstanceType)) out.InstanceType = v.InstanceType;
+  if (typeof v.InitialVariantWeight === 'number') out.InitialVariantWeight = v.InitialVariantWeight;
+  if (v.ServerlessConfig !== undefined) out.ServerlessConfig = v.ServerlessConfig;
+  if (typeof v.VolumeSizeInGB === 'number') out.VolumeSizeInGB = v.VolumeSizeInGB;
+  if (typeof v.ModelDataDownloadTimeoutInSeconds === 'number')
+    out.ModelDataDownloadTimeoutInSeconds = v.ModelDataDownloadTimeoutInSeconds;
+  if (typeof v.ContainerStartupHealthCheckTimeoutInSeconds === 'number')
+    out.ContainerStartupHealthCheckTimeoutInSeconds = v.ContainerStartupHealthCheckTimeoutInSeconds;
+  if (typeof v.EnableSSMAccess === 'boolean') out.EnableSSMAccess = v.EnableSSMAccess;
+  if (v.ManagedInstanceScaling !== undefined) out.ManagedInstanceScaling = v.ManagedInstanceScaling;
+  if (v.RoutingConfig !== undefined) out.RoutingConfig = v.RoutingConfig;
+  if (typeof v.VariantInstanceProvisionTimeoutInSeconds === 'number')
+    out.VariantInstanceProvisionTimeoutInSeconds = v.VariantInstanceProvisionTimeoutInSeconds;
+  if (Array.isArray(v.InstancePools) && v.InstancePools.length > 0)
+    out.InstancePools = v.InstancePools;
+  if (v.CapacityReservationConfig !== undefined)
+    out.CapacityReservationConfig = v.CapacityReservationConfig;
+  if (str(v.InferenceAmiVersion)) out.InferenceAmiVersion = v.InferenceAmiVersion;
+  // AcceleratorType / CoreDumpConfig / MetricsConfig are deliberately NOT projected — the
+  // registry schema for the CFn ProductionVariant definition does not model them (AcceleratorType
+  // is the deprecated Elastic Inference knob AWS still echoes), so projecting them would be a
+  // permanent undeclared false inventory.
+  return out;
+};
+const readSageMakerEndpointConfig: OverrideReader = async ({ physicalId, declared, region }) => {
+  const name = str(physicalId) ?? str(declared.EndpointConfigName);
+  if (!name) return undefined;
+  const c = new SageMakerClient({ region, ...READ_RETRY });
+  // A deleted config throws ValidationException ("Could not find endpoint configuration") →
+  // the router maps it to `deleted`; it is not swallowed as an empty model.
+  const r = await c.send(new DescribeEndpointConfigCommand({ EndpointConfigName: name }));
+  if (!r.EndpointConfigName) throw new ResourceGoneError(`SageMaker EndpointConfig ${name} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(r.EndpointConfigName)) model.EndpointConfigName = r.EndpointConfigName;
+  if (Array.isArray(r.ProductionVariants) && r.ProductionVariants.length > 0)
+    model.ProductionVariants = r.ProductionVariants.map(projectSageMakerVariant);
+  if (Array.isArray(r.ShadowProductionVariants) && r.ShadowProductionVariants.length > 0)
+    model.ShadowProductionVariants = r.ShadowProductionVariants.map(projectSageMakerVariant);
+  if (r.DataCaptureConfig !== undefined) model.DataCaptureConfig = r.DataCaptureConfig;
+  if (r.AsyncInferenceConfig !== undefined) model.AsyncInferenceConfig = r.AsyncInferenceConfig;
+  if (str(r.KmsKeyId)) model.KmsKeyId = r.KmsKeyId;
+  if (r.ExplainerConfig !== undefined) model.ExplainerConfig = r.ExplainerConfig;
+  if (typeof r.EnableNetworkIsolation === 'boolean')
+    model.EnableNetworkIsolation = r.EnableNetworkIsolation;
+  if (str(r.ExecutionRoleArn)) model.ExecutionRoleArn = r.ExecutionRoleArn;
+  if (r.VpcConfig !== undefined) model.VpcConfig = r.VpcConfig;
+  // EndpointConfigArn / CreationTime are AWS-managed readOnly response fields NOT in the CFn
+  // schema — dropped (projecting them would be a permanent undeclared false inventory).
+  return model;
+};
+
 // AWS::Logs::MetricFilter — CC API GetResource throws ValidationException. Read via
 // CloudWatch Logs DescribeMetricFilters. The CFn physical id IS the filter name;
 // the log group comes from the declared (GetAtt-resolved) LogGroupName.
@@ -2368,6 +2457,7 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::Glue::Workflow': readGlueWorkflow,
   'AWS::Glue::Connection': readGlueConnection,
   'AWS::Glue::SecurityConfiguration': readGlueSecurityConfiguration,
+  'AWS::SageMaker::EndpointConfig': readSageMakerEndpointConfig,
   'AWS::Logs::MetricFilter': readMetricFilter,
   'AWS::Scheduler::Schedule': readSchedulerSchedule,
 };

--- a/tests/overrides-sagemaker-endpointconfig-857.test.ts
+++ b/tests/overrides-sagemaker-endpointconfig-857.test.ts
@@ -1,0 +1,161 @@
+import { DescribeEndpointConfigCommand, SageMakerClient } from '@aws-sdk/client-sagemaker';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { ResourceGoneError } from '../src/aws-errors.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+// #857 (SageMaker half) — AWS::SageMaker::EndpointConfig has NO Cloud Control read handler
+// (registry describe-type -> `handlers: []`), so it was silently `skipped` on every check and a
+// production variant's instance sizing / DataCaptureConfig / KMS-key / network posture went
+// unwatched. This exercises the SDK_OVERRIDES reader that reads it back via
+// sagemaker:DescribeEndpointConfig and maps the response to the CFn EndpointConfig shape,
+// dropping the AWS-managed readOnly response fields (EndpointConfigArn / CreationTime) and the
+// non-schema variant fields (AcceleratorType / CoreDumpConfig).
+
+const sagemaker = mockClient(SageMakerClient);
+
+const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId,
+});
+
+const read = SDK_OVERRIDES['AWS::SageMaker::EndpointConfig'];
+
+beforeEach(() => {
+  sagemaker.reset();
+});
+
+describe('SageMaker EndpointConfig (#857)', () => {
+  it('maps ProductionVariants + DataCaptureConfig + KmsKeyId; drops readonly (Arn/CreationTime) + non-schema variant fields', async () => {
+    sagemaker.on(DescribeEndpointConfigCommand).resolves({
+      EndpointConfigName: 'ec-full',
+      // AWS-managed readOnly response fields that must NOT appear in the projection:
+      EndpointConfigArn: 'arn:aws:sagemaker:us-east-1:123456789012:endpoint-config/ec-full',
+      CreationTime: new Date(0),
+      ProductionVariants: [
+        {
+          VariantName: 'variant-1',
+          ModelName: 'my-model',
+          InitialInstanceCount: 2,
+          InstanceType: 'ml.m5.large',
+          InitialVariantWeight: 1,
+          VolumeSizeInGB: 50,
+          ModelDataDownloadTimeoutInSeconds: 600,
+          ContainerStartupHealthCheckTimeoutInSeconds: 300,
+          EnableSSMAccess: true,
+          ServerlessConfig: { MaxConcurrency: 10, MemorySizeInMB: 2048, ProvisionedConcurrency: 5 },
+          ManagedInstanceScaling: {
+            Status: 'ENABLED',
+            MinInstanceCount: 1,
+            MaxInstanceCount: 4,
+          },
+          RoutingConfig: { RoutingStrategy: 'LEAST_OUTSTANDING_REQUESTS' },
+          // Fields NOT in the CFn ProductionVariant schema — must be dropped:
+          AcceleratorType: 'ml.eia2.medium',
+          CoreDumpConfig: { DestinationS3Uri: 's3://bucket/dumps' },
+        },
+      ],
+      DataCaptureConfig: {
+        EnableCapture: true,
+        InitialSamplingPercentage: 100,
+        DestinationS3Uri: 's3://bucket/capture',
+        KmsKeyId: 'arn:aws:kms:...:key/dc',
+        CaptureOptions: [{ CaptureMode: 'Input' }, { CaptureMode: 'Output' }],
+        CaptureContentTypeHeader: { CsvContentTypes: ['text/csv'] },
+      },
+      KmsKeyId: 'arn:aws:kms:...:key/ec',
+    });
+
+    const out = await read(ctx({ EndpointConfigName: 'ec-full' }, 'ec-full'));
+    expect(out).toEqual({
+      EndpointConfigName: 'ec-full',
+      ProductionVariants: [
+        {
+          VariantName: 'variant-1',
+          ModelName: 'my-model',
+          InitialInstanceCount: 2,
+          InstanceType: 'ml.m5.large',
+          InitialVariantWeight: 1,
+          VolumeSizeInGB: 50,
+          ModelDataDownloadTimeoutInSeconds: 600,
+          ContainerStartupHealthCheckTimeoutInSeconds: 300,
+          EnableSSMAccess: true,
+          ServerlessConfig: { MaxConcurrency: 10, MemorySizeInMB: 2048, ProvisionedConcurrency: 5 },
+          ManagedInstanceScaling: { Status: 'ENABLED', MinInstanceCount: 1, MaxInstanceCount: 4 },
+          RoutingConfig: { RoutingStrategy: 'LEAST_OUTSTANDING_REQUESTS' },
+        },
+      ],
+      DataCaptureConfig: {
+        EnableCapture: true,
+        InitialSamplingPercentage: 100,
+        DestinationS3Uri: 's3://bucket/capture',
+        KmsKeyId: 'arn:aws:kms:...:key/dc',
+        CaptureOptions: [{ CaptureMode: 'Input' }, { CaptureMode: 'Output' }],
+        CaptureContentTypeHeader: { CsvContentTypes: ['text/csv'] },
+      },
+      KmsKeyId: 'arn:aws:kms:...:key/ec',
+    });
+    // Readonly + non-schema fields explicitly absent:
+    expect(out).not.toHaveProperty('EndpointConfigArn');
+    expect(out).not.toHaveProperty('CreationTime');
+    const variants = (out ?? {}).ProductionVariants as Record<string, unknown>[];
+    const v = variants[0];
+    expect(v).not.toHaveProperty('AcceleratorType');
+    expect(v).not.toHaveProperty('CoreDumpConfig');
+  });
+
+  it('a minimal response (ProductionVariants only) projects only the returned keys — no empty objects', async () => {
+    sagemaker.on(DescribeEndpointConfigCommand).resolves({
+      EndpointConfigName: 'ec-min',
+      EndpointConfigArn: 'arn:aws:sagemaker:us-east-1:123456789012:endpoint-config/ec-min',
+      CreationTime: new Date(0),
+      ProductionVariants: [
+        {
+          VariantName: 'v1',
+          ModelName: 'm1',
+          InitialInstanceCount: 1,
+          InstanceType: 'ml.t2.large',
+        },
+      ],
+    });
+    const out = await read(ctx({ EndpointConfigName: 'ec-min' }, 'ec-min'));
+    expect(out).toEqual({
+      EndpointConfigName: 'ec-min',
+      ProductionVariants: [
+        {
+          VariantName: 'v1',
+          ModelName: 'm1',
+          InitialInstanceCount: 1,
+          InstanceType: 'ml.t2.large',
+        },
+      ],
+    });
+    // No DataCaptureConfig / VpcConfig / KmsKeyId / etc. keys fabricated:
+    expect(Object.keys(out ?? {}).sort()).toEqual(['EndpointConfigName', 'ProductionVariants']);
+  });
+
+  it('falls back to the declared EndpointConfigName when the physical id is empty', async () => {
+    sagemaker.on(DescribeEndpointConfigCommand).resolves({
+      EndpointConfigName: 'from-decl',
+      ProductionVariants: [{ VariantName: 'v1' }],
+    });
+    const out = await read(ctx({ EndpointConfigName: 'from-decl' }));
+    expect(out).toEqual({
+      EndpointConfigName: 'from-decl',
+      ProductionVariants: [{ VariantName: 'v1' }],
+    });
+  });
+
+  it('a deleted config (empty response) -> ResourceGoneError (deleted, not skipped)', async () => {
+    sagemaker.on(DescribeEndpointConfigCommand).resolves({});
+    await expect(read(ctx({ EndpointConfigName: 'gone' }, 'gone'))).rejects.toBeInstanceOf(
+      ResourceGoneError
+    );
+  });
+
+  it('undefined when identity cannot be resolved (physical id + declared name both absent) -> skipped', async () => {
+    expect(await read(ctx({}))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Completes #857 (the Glue half merged in #1183). `AWS::SageMaker::EndpointConfig` has **no Cloud Control read handler** (`describe-type` → `handlers: []`), so an ML serving stack watched its `Model` and `Endpoint` but NOT the config that binds them — instance type/count, serverless config, data-capture config were invisible (silently `skipped=`).

## Fix

`src/read/overrides.ts`: `readSageMakerEndpointConfig` via `sagemaker:DescribeEndpointConfig(EndpointConfigName)`, mapping the response to the CFn `EndpointConfig` schema shape (`ProductionVariants` / `ShadowProductionVariants` / `DataCaptureConfig` / `AsyncInferenceConfig` / `KmsKeyId` / `ExplainerConfig` / `VpcConfig` / `EnableNetworkIsolation` / `ExecutionRoleArn`).

FP-safety: each property emitted only when the SDK returns it; `ProductionVariant`/`ShadowProductionVariant` projected **field-by-field against the authoritative registry schema** so AWS-managed readonly fields (`EndpointConfigArn`, `CreationTime`) and non-schema echoes (`AcceleratorType`, `CoreDumpConfig`) are dropped — no false undeclared inventory. `Tags` omitted (DescribeEndpointConfig has no Tags field → a declared Tags stays a readGap, not a false drift). Read-only (every mutable prop is `createOnly`; no UpdateEndpointConfig API).

## Dependency

Adds `@aws-sdk/client-sagemaker` (`^3.1084.0`) — an official AWS SDK v3 sibling of the 40+ `@aws-sdk/client-*` readers already used. This was the blocker that deferred the SageMaker half in #1183.

## Tests

`tests/overrides-sagemaker-endpointconfig-857.test.ts` (5, `aws-sdk-client-mock`): full mapping (drops readonly + non-schema fields); minimal response (only returned keys, no fabricated empties); declared-name fallback; deleted → `ResourceGoneError`; unresolvable identity → skipped.

Live-verification of the fresh-deploy clean-check (does AWS echo an undeclared variant default the projector doesn't exclude) is recommended as a follow-up — an EndpointConfig is free to create without an Endpoint.

Closes #857
