### PR TITLE
fix(check): a Custom::* skip is informational, not a --strict failure (#724)

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,16 @@ CI (with `--yes`).
 - **`--fail`** (the `cdk diff --fail` / `cdk drift --fail` convention) exits `1` on
   drift and suppresses all prompts. It's the one flag for scripts and CI.
 - **`--strict`** is the orthogonal **coverage** axis: it exits `1` when a run was
-  incomplete (any resource skipped, or a nested stack not recursed into). The gap
-  is always surfaced regardless (as the `skipped=N` footer line or a loud
-  `warning:`); `--strict` only decides whether it fails the build.
+  incomplete (a resource skipped for an ACTIONABLE reason — a CC-unsupported type
+  with no override, a read error / throttle / AccessDenied — or a nested stack not
+  recursed into). A **custom resource** (`Custom::*` /
+  `AWS::CloudFormation::CustomResource`, e.g. `Custom::S3AutoDeleteObjects` /
+  `Custom::LogRetention`) has no cloud-side model to read, so it is a
+  permanent-by-nature gap that no `record` / `ignore` could clear — it is
+  **informational** and does NOT fail `--strict` (otherwise the flag would exit `1`
+  forever on nearly every real CDK app). The gap is always surfaced regardless (as
+  the `skipped=N` footer line or a loud `warning:`); `--strict` only decides whether
+  an actionable gap fails the build.
 - Errors always exit `2`; `revert` exits `1` when drift remains after it.
 - Interrupting a run with **Ctrl-C** (or **ESC** / SIGINT) during the gather/read
   phase exits `130` (128 + SIGINT) for every verb, and a **SIGTERM** (CI

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -143,6 +143,23 @@ export function isPendingCreationSkip(f: Finding): boolean {
   return f.tier === 'skipped' && f.note === 'no physical id';
 }
 
+// #724: a `Custom::*` / `AWS::CloudFormation::CustomResource` skip is a PERMANENT-by-nature
+// coverage gap — a custom resource has no cloud-side model to read (router.ts short-circuits
+// it), and nearly every real CDK app carries one (`Custom::S3AutoDeleteObjects`,
+// `Custom::LogRetention`, `Custom::CDKBucketDeployment`). Failing `--strict` on it would exit
+// 1 FOREVER on typical apps with nothing the user could record / ignore / fix — making the flag
+// unusable exactly in the CI it is meant for. So it is INFORMATIONAL: still surfaced in the
+// coverage warning + `skipped` footer (visibility preserved), but excluded from the `--strict`
+// exit gate. An ACTIONABLE gap (a CC-unsupported type with no override, a read error / throttle
+// / AccessDenied, an un-recursed nested stack) still fails `--strict`. Pure + exported.
+export function isCustomResourceSkip(f: Finding): boolean {
+  return (
+    f.tier === 'skipped' &&
+    (f.resourceType === 'AWS::CloudFormation::CustomResource' ||
+      f.resourceType.startsWith('Custom::'))
+  );
+}
+
 // Resources cdkrd could NOT read this run land in the `skipped` tier — a
 // CC-unsupported type with no SDK override, a read error (throttle / AccessDenied), a
 // missing physical id, a Custom resource. They are genuinely UNCHECKED, yet `skipped`
@@ -189,16 +206,22 @@ export function pendingCreationInfo(findings: Finding[], stackName: string): str
 // nested stack not recursed into. Under --pre-deploy (#727) a "no physical id" skip is a
 // not-yet-deployed local resource (pending creation), which is EXPECTED and therefore not
 // a gap — excluded so `--strict --pre-deploy` no longer false-fails on a feature branch
-// that merely ADDS a resource with zero real drift. Non-pre-deploy behavior is unchanged.
-// Pure + exported.
+// that merely ADDS a resource with zero real drift. A `Custom::*` skip (#724) is a
+// PERMANENT-by-nature gap (no cloud-side model exists) present in nearly every CDK app, so
+// it is EXCLUDED here too — it stays visible in the coverage warning + footer but never
+// fails `--strict` (else the flag would exit 1 forever on any app with `autoDeleteObjects` /
+// `LogRetention`). Non-custom / non-pending skips (CC-unsupported types, read errors) still
+// gap. Non-pre-deploy behavior is otherwise unchanged. Pure + exported.
 export function hasCoverageGap(
   findings: Finding[],
   resources: DesiredResource[],
   preDeploy = false
 ): boolean {
   return (
-    findings.some((f) => f.tier === 'skipped' && !(preDeploy && isPendingCreationSkip(f))) ||
-    resources.some((r) => r.resourceType === 'AWS::CloudFormation::Stack')
+    findings.some(
+      (f) =>
+        f.tier === 'skipped' && !(preDeploy && isPendingCreationSkip(f)) && !isCustomResourceSkip(f)
+    ) || resources.some((r) => r.resourceType === 'AWS::CloudFormation::Stack')
   );
 }
 

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -3,6 +3,7 @@ import {
   coverageWarning,
   finalCheckExit,
   hasCoverageGap,
+  isCustomResourceSkip,
   nestedStackWarning,
   preDeployFindings,
   reconcileBaseline,
@@ -376,6 +377,42 @@ describe('coverageWarning / hasCoverageGap (--strict + loud coverage gap)', () =
     expect(strictCoverageExit(true, clean, res)).toBe(0); // strict but no gap → 0
     // a nested stack is a coverage gap too (the value shared with the --pre-deploy path)
     expect(strictCoverageExit(true, clean, [dr('AWS::CloudFormation::Stack')])).toBe(1);
+  });
+
+  // #724: a Custom::* skip is a permanent-by-nature gap → informational, never fails --strict.
+  it('isCustomResourceSkip matches only skipped Custom::* / AWS::CloudFormation::CustomResource', () => {
+    expect(
+      isCustomResourceSkip(skipped('A', { resourceType: 'Custom::S3AutoDeleteObjects' }))
+    ).toBe(true);
+    expect(
+      isCustomResourceSkip(skipped('A', { resourceType: 'AWS::CloudFormation::CustomResource' }))
+    ).toBe(true);
+    // not a custom resource
+    expect(isCustomResourceSkip(skipped('A', { resourceType: 'AWS::SNS::Topic' }))).toBe(false);
+    // right type but not the skipped tier
+    expect(isCustomResourceSkip({ ...F('undeclared'), resourceType: 'Custom::LogRetention' })).toBe(
+      false
+    );
+  });
+
+  it('hasCoverageGap: a Custom::* skip does NOT fail --strict (permanent-by-nature gap, #724)', () => {
+    const custom = [skipped('AutoDelete', { resourceType: 'Custom::S3AutoDeleteObjects' })];
+    expect(hasCoverageGap(custom, [dr('AWS::S3::Bucket')])).toBe(false);
+    expect(strictCoverageExit(true, custom, [dr('AWS::S3::Bucket')])).toBe(0);
+  });
+
+  it('hasCoverageGap: an ACTIONABLE skip (read error / CC-unsupported) still fails --strict', () => {
+    const readGap = [skipped('X', { resourceType: 'AWS::Some::Unsupported' })];
+    expect(hasCoverageGap(readGap, [dr('AWS::SNS::Topic')])).toBe(true);
+    expect(strictCoverageExit(true, readGap, [dr('AWS::SNS::Topic')])).toBe(1);
+  });
+
+  it('hasCoverageGap: a Custom::* skip alongside a real read gap STILL fails (only the custom one is exempt)', () => {
+    const mixed = [
+      skipped('AutoDelete', { resourceType: 'Custom::S3AutoDeleteObjects' }),
+      skipped('X', { resourceType: 'AWS::Some::Unsupported' }),
+    ];
+    expect(hasCoverageGap(mixed, [dr('AWS::SNS::Topic')])).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #724 (live-proven usability bug)

## Problem
A `Custom::*` / `AWS::CloudFormation::CustomResource` resource has no cloud-side model to read (router.ts short-circuits it to `skipped`), yet `hasCoverageGap` counted **every** skipped finding. So `check --strict` exited `1` **forever** on nearly every real CDK app — `Custom::S3AutoDeleteObjects`, `Custom::LogRetention`, `Custom::CDKBucketDeployment` are ubiquitous — on a fully-recorded, drift-free stack, with nothing the user could `record` / `ignore` / fix. The flag was unusable exactly in the CI it is meant for.

## Fix
A custom-resource skip is a **permanent-by-nature** gap. `hasCoverageGap` now excludes it (new pure `isCustomResourceSkip` predicate): it stays visible in the coverage `warning:` + `skipped=N` footer, but no longer fails `--strict`. An **actionable** gap (a CC-unsupported type with no override, a read error / throttle / AccessDenied, an un-recursed nested stack) still fails `--strict`. README `--strict` doc updated.

## Design choice (flagging for your call)
This implements #724's **"gap KIND"** option (auto-exempt the permanent kind) rather than the **"make `skipped` ignorable via `ignore.yaml`"** option — a custom resource can never become checkable, so failing on it is never actionable, and auto-exemption needs no per-resource rule. If you'd rather keep an escape hatch, a `--strict=all` opt-in to restore the all-gaps behavior is a small follow-up.

## Tests
`tests/check.test.ts` (+4): `isCustomResourceSkip` matches only skipped `Custom::*`/`AWS::CloudFormation::CustomResource`; a custom-only skip → `hasCoverageGap` false / `--strict` exit 0; an actionable skip → still true / exit 1; a custom skip **alongside** a real read gap still fails (only the custom one is exempt).

Files: `src/commands/check.ts`, README.