### PR TITLE
fix(check): emit the no-baseline note under --json + carry a baseline-presence flag (#1095)

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,16 @@ If the whole invocation fails before any stack is reached (bad config, an
 un-synthesizable app, or a zero-stack app), stdout is still a valid empty array
 `[]` (exit code non-zero, the reason on stderr) — never empty bytes.
 
-Each stack element is `{ "stack": "<name> (<region>)", "drifted": <n>, "findings": [...] }`
+Every successfully-checked stack element carries a `"baseline": <bool>` flag —
+`true` when the stack has a committed `.cdkrd` baseline (its undeclared dimension is
+**watched**), `false` when it has never been recorded. Without a baseline the
+classification shifts: appeared-since-record out-of-band values read as `unrecorded`
+and are excluded from `drifted`, so a QUIET never-recorded stack emits the
+byte-identical `"drifted": 0` of a watched-clean one. A consumer summing `drifted`
+uses `baseline` to tell an UNWATCHED stack from a watched-clean one (#1095). It is
+omitted on the `error` / `stackDeleted` shapes (never reconciled against a baseline).
+
+Each stack element is `{ "stack": "<name> (<region>)", "drifted": <n>, "baseline": <bool>, "findings": [...] }`
 (`error` added only on a pre-check failure; `stackDeleted: true` only on a deleted
 stack). Each **finding** has a stable shape:
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -777,7 +777,16 @@ export async function runCheck(args: string[]): Promise<number> {
       // suppressed under --json, so this branch is the whole json output path.
       let code: number;
       if (a.json) {
-        const { json, code: jsonCode } = buildStackJson(reconciled, reportHeader);
+        // #1095: pass baseline presence so the --json element carries a `baseline` flag —
+        // a QUIET no-baseline stack (unwatched) is otherwise byte-identical to a
+        // watched-clean one (`drifted: 0`, `findings: []`), so a consumer summing
+        // `drifted` cannot tell them apart. `baseline` is already undefined under
+        // --show-all (loaded that way above), so this correctly reports false there.
+        const { json, code: jsonCode } = buildStackJson(
+          reconciled,
+          reportHeader,
+          baseline !== undefined
+        );
         jsonReports.push(json);
         code = jsonCode;
       } else {
@@ -823,10 +832,18 @@ export async function runCheck(args: string[]): Promise<number> {
           verbose: a.verbose,
           positionPrefix: posPrefix,
         });
-      } else if (!baseline && !hasUnrecorded && !a.json && !a.showAll && !a.preDeploy) {
-        // R142: no interactive establish prompt could fire (non-TTY, or --fail) and there is
-        // no baseline on an otherwise-quiet stack — the report gave no record cue (nothing is
-        // unrecorded), so point at how to create the day-1 baseline. stderr keeps stdout clean.
+      } else if (!baseline && !hasUnrecorded && !a.showAll && !a.preDeploy) {
+        // R142: no interactive establish prompt could fire (non-TTY, --fail, OR --json —
+        // shouldOfferInteractiveResolve is false in all of those) and there is no baseline on
+        // an otherwise-quiet stack — the report gave no record cue (nothing is unrecorded), so
+        // point at how to create the day-1 baseline. #1095: emit UNCONDITIONALLY to stderr
+        // (the old `!a.json` gate dropped it NOWHERE under --json), matching the schema-v1
+        // note above (#944): a no-baseline stack SHIFTS the classification semantics
+        // (appeared-since-record out-of-band values read as `unrecorded`, excluded from
+        // `drifted`), so the --json consumer is exactly who must see it. The sink is
+        // `console.error`, so JSON stdout stays pure. No double-print: this `else if` and the
+        // interactive `if` above are mutually exclusive, and the TTY-interactive no-baseline
+        // case takes the `if` branch (R141 establish prompt), never this note.
         console.error(
           `note: ${stackName}: no .cdkrd baseline yet — run \`cdkrd record\` to establish one (future out-of-band changes then report as drift).`
         );

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -320,6 +320,15 @@ export interface StackJsonReport {
   stack: string;
   drifted: number;
   findings: Finding[];
+  // Whether this stack has a committed `.cdkrd` baseline (undeclared state is being
+  // WATCHED). Present on every successfully-checked stack (#1095): without a baseline the
+  // classification semantics shift — appeared-since-record out-of-band values read as
+  // `unrecorded` and are excluded from `drifted`, so a QUIET no-baseline stack emits the
+  // byte-identical `drifted: 0` of a watched-clean stack. A --json consumer summing
+  // `drifted` cannot otherwise tell an UNWATCHED stack from a watched clean one — this
+  // field is that distinguisher (false = never recorded / unwatched). Omitted on the
+  // error / deleted-stack shapes below (they were never reconciled against a baseline).
+  baseline?: boolean;
   // Present ONLY on a stack that ERRORED before it could be checked — so a --json
   // consumer sees WHICH stacks ran and which failed, rather than a silent omission (the
   // pre-#755 behavior printed nothing for an errored stack). Never set on a
@@ -343,7 +352,12 @@ export function deletedStackReport(label: string): StackJsonReport {
 
 export function buildStackJson(
   rawFindings: Finding[],
-  header: string
+  header: string,
+  // Whether this stack has a committed `.cdkrd` baseline (#1095). Threaded through so the
+  // --json element carries a `baseline` presence flag — a consumer can then tell an
+  // UNWATCHED (never-recorded) stack from a watched-clean one, which otherwise emit the
+  // byte-identical `drifted: 0`.
+  hasBaseline?: boolean
 ): { json: StackJsonReport; code: number } {
   // Annotate origin hints (diff/hints.ts) so the --json payload carries them exactly as
   // the text path does — the single render chokepoint. A hint is display-only.
@@ -352,7 +366,10 @@ export function buildStackJson(
   // never counted toward the verdict/exit.
   const isDriftHere = (f: Finding): boolean => DRIFT_TIERS.includes(f.tier) && !f.unrecorded;
   const drifted = findings.filter(isDriftHere).length;
-  return { json: { stack: header, drifted, findings }, code: drifted === 0 ? 0 : 1 };
+  return {
+    json: { stack: header, drifted, findings, baseline: hasBaseline === true },
+    code: drifted === 0 ? 0 : 1,
+  };
 }
 
 export function report(rawFindings: Finding[], header: string, opts: ReportOptions = {}): number {

--- a/tests/json-baseline-presence-1095.test.ts
+++ b/tests/json-baseline-presence-1095.test.ts
@@ -1,0 +1,130 @@
+// #1095 — sibling of #944. A missing baseline SHIFTS the classification semantics: the
+// undeclared dimension is not watched, so appeared-since-record out-of-band values read
+// as `unrecorded` and are excluded from `drifted`. Under `--json` a QUIET stack with NO
+// baseline therefore emitted `{ stack, drifted: 0, findings: [] }` — byte-identical to a
+// baselined, fully-watched clean stack. A CI consumer summing `drifted` could not tell an
+// UNWATCHED stack from a watched clean one. The fix does two things, both mirroring #944:
+//  (a) the R142 "no baseline yet" note drops its `!a.json` gate and is emitted
+//      UNCONDITIONALLY to stderr (the old gate dropped it NOWHERE under --json), and
+//  (b) the --json element gains a `baseline` presence flag (false = never recorded).
+// This drives runCheck end to end (synth/read mocked) with and without a baseline on disk
+// and asserts the flag AND the stderr note.
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { baselinePath } from '../src/baseline/baseline-file.js';
+import type { StackJsonReport } from '../src/report/report.js';
+
+const STACK = 'MyStack';
+const ACCOUNT = '111122223333';
+const REGION = 'us-east-1';
+
+// One resolved stack, no synth needed. gatherFindings returns a CLEAN gather (no findings)
+// whose desired accountId matches any on-disk baseline's account (so the per-account guard
+// is silent). This is the QUIET no-drift case — exactly where a no-baseline stack is
+// otherwise indistinguishable from a watched clean one.
+vi.mock('../src/commands/resolve-stacks.js', () => ({
+  resolveStacks: () =>
+    Promise.resolve([{ stackName: 'MyStack', region: 'us-east-1', template: {} }]),
+}));
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: () =>
+    Promise.resolve({
+      desired: {
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        accountId: '111122223333',
+        resources: [],
+        rawTemplate: '{}',
+        ctx: {},
+      },
+      findings: [],
+      schemas: new Map(),
+      liveByLogical: new Map(),
+    }),
+}));
+
+import { runCheck } from '../src/commands/check.js';
+
+// A v2 (snapshot-tracking) baseline so the schema-v1 warning does NOT fire (isolating the
+// baseline-presence signal from #944's).
+async function writeBaseline(): Promise<void> {
+  const p = baselinePath(STACK, ACCOUNT, REGION);
+  await mkdir(dirname(p), { recursive: true });
+  const file = {
+    schemaVersion: 2,
+    stackName: STACK,
+    region: REGION,
+    accountId: ACCOUNT,
+    capturedAt: '',
+    templateHash: '', // empty → warnTemplateHashDrift is a no-op
+    recorded: [],
+    completeResources: [],
+  };
+  await writeFile(p, JSON.stringify(file), 'utf8');
+}
+
+const NO_BASELINE_NOTE = 'no .cdkrd baseline yet';
+
+describe('#1095 --json carries a baseline-presence flag + the no-baseline note survives --json', () => {
+  let cwd: string;
+  let dir: string;
+  let out: string[];
+  let err: string[];
+  beforeEach(async () => {
+    cwd = process.cwd();
+    dir = await mkdtemp(join(tmpdir(), 'cdkrd-json-baseline-1095-'));
+    process.chdir(dir);
+    out = [];
+    err = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      out.push(String(m));
+    });
+    vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+      err.push(String(m));
+    });
+  });
+  afterEach(async () => {
+    process.chdir(cwd);
+    await rm(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function parsed(): StackJsonReport[] {
+    // stdout stays a single JSON.parse-able array (no note ever leaked onto it).
+    expect(out).toHaveLength(1);
+    const value = JSON.parse(out[0]!);
+    expect(Array.isArray(value)).toBe(true);
+    return value as StackJsonReport[];
+  }
+
+  it('--json, NO baseline: element carries baseline=false AND the note lands on STDERR', async () => {
+    // No baseline written to disk.
+    const code = await runCheck(['--json', STACK]);
+
+    const el = parsed()[0]!;
+    // (a) the new distinguisher: an unwatched (never-recorded) stack is baseline=false.
+    expect(el.baseline).toBe(false);
+    expect(el.drifted).toBe(0); // quiet + unwatched still reports drifted 0 …
+    // (b) … but the note now makes it discoverable — and it goes to STDERR, not stdout.
+    expect(err.join('\n')).toContain(NO_BASELINE_NOTE);
+    expect(out.join('\n')).not.toContain(NO_BASELINE_NOTE);
+    expect(code).toBe(0);
+  });
+
+  it('--json, WITH baseline: element carries baseline=true AND no no-baseline note', async () => {
+    await writeBaseline();
+    const code = await runCheck(['--json', STACK]);
+
+    const el = parsed()[0]!;
+    // A watched clean stack: baseline=true — now distinguishable from the unwatched case
+    // above even though both are drifted:0.
+    expect(el.baseline).toBe(true);
+    expect(el.drifted).toBe(0);
+    // No day-1 note when a baseline already exists.
+    expect(err.join('\n')).not.toContain(NO_BASELINE_NOTE);
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #1095. See commit body. Offline JSON-contract + check.ts fix; unit test `tests/json-baseline-presence-1095.test.ts` is the evidence (drives runCheck end to end, asserts baseline:false + stderr note with no baseline, baseline:true with one). README --json contract updated.