### PR TITLE
fix(baseline): re-apply the full live-value strip pipeline to the stored baseline value at compare time (#766)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -27,8 +27,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { deepEqual } from '../diff/drift-calculator.js';
-import { sortUnorderedObjectArray } from '../normalize/noise.js';
-import { canonicalizeForCompare } from '../normalize/pipeline.js';
+import { canonicalizeBaselineForCompare, canonicalizeForCompare } from '../normalize/pipeline.js';
 import type { ArrayDelta, Finding } from '../types.js';
 
 export interface RecordedEntry {
@@ -655,35 +654,24 @@ export function carryForwardUnreadable(
  * type-agnostic over UNDECLARED snapshot fragments, which never carry an
  * order-significant declared array, so an order-insensitive sort is safe here.
  */
+//
+// #766: additionally re-apply the DEEP, ROOT-AGNOSTIC strips the live value passes on its
+// way to `f.actual` (AWS-managed-field strip + `aws:*`-tag strip) and pass `resourceType`
+// through the shared pipeline, so a baseline recorded under OLDER rules re-canonicalizes to
+// match today's freshly-stripped live value — a pure cdkrd UPGRADE no longer resurfaces
+// committed baselines as false "changed/removed since record" drift. See
+// `canonicalizeBaselineForCompare` for which strips are (and are not) covered. `resourceType`
+// is optional: every call site has the recorded entry's / finding's type available and passes
+// it, but a type-less call stays correct (the type only tightens WAF/order-significant folds).
 export function baselineValueMatches(
   baselineValue: unknown,
-  currentCanonicalValue: unknown
+  currentCanonicalValue: unknown,
+  resourceType?: string
 ): boolean {
   return deepEqual(
-    sortObjectArraysDeep(canonicalizeForCompare(baselineValue)),
-    sortObjectArraysDeep(canonicalizeForCompare(currentCanonicalValue))
+    canonicalizeBaselineForCompare(baselineValue, resourceType),
+    canonicalizeBaselineForCompare(currentCanonicalValue, resourceType)
   );
-}
-
-// Deeply apply the SAME canonical-JSON total order the live side reaches (classify's
-// `sortUnorderedObjectArray`) to every plain-object array, so both compare sides of
-// `baselineValueMatches` converge on one order (#767). `sortUnorderedObjectArray`
-// only reorders a single array level and leaves non-arrays untouched, so this walk
-// recurses into every element / object value and sorts each object array it finds.
-// Applied to BOTH sides symmetrically, so it can never make two different values
-// compare equal — it only removes an ordering-only difference.
-function sortObjectArraysDeep(v: unknown): unknown {
-  if (Array.isArray(v)) {
-    const mapped = v.map(sortObjectArraysDeep);
-    return sortUnorderedObjectArray(mapped);
-  }
-  if (v && typeof v === 'object') {
-    const out: Record<string, unknown> = {};
-    for (const [k, val] of Object.entries(v as Record<string, unknown>))
-      out[k] = sortObjectArraysDeep(val);
-    return out;
-  }
-  return v;
 }
 
 // Identity fields for the ELEMENT-LEVEL DELTA display only (R128) — deliberately
@@ -778,7 +766,7 @@ export function splitRecordedByBaseline(
         a.path === entry.path &&
         a.resourceType === entry.resourceType
     );
-    if (baselineEntry && baselineValueMatches(baselineEntry.value, entry.value))
+    if (baselineEntry && baselineValueMatches(baselineEntry.value, entry.value, entry.resourceType))
       unchanged.push(entry);
     else changed.push(entry);
   }
@@ -1074,11 +1062,11 @@ export function applyBaseline(
         kept.push({ ...f, unrecorded: true });
         continue;
       }
-      if (entry && baselineValueMatches(entry.value, f.actual)) continue; // recorded, unchanged
+      if (entry && baselineValueMatches(entry.value, f.actual, f.resourceType)) continue; // recorded, unchanged
       if (entry) {
         kept.push({
           ...f,
-          desired: canonicalizeForCompare(entry.value),
+          desired: canonicalizeForCompare(entry.value, f.resourceType),
           note: f.note ? `${f.note}; changed since record` : 'changed since record',
         });
         continue;
@@ -1108,7 +1096,7 @@ export function applyBaseline(
     // (f.actual is already canonical from classify): a baseline recorded under older
     // normalization rules still matches today's live, so a cdkrd version bump alone
     // never resurfaces a suppressed value as false drift.
-    if (entry && baselineValueMatches(entry.value, f.actual)) continue; // recorded, unchanged
+    if (entry && baselineValueMatches(entry.value, f.actual, f.resourceType)) continue; // recorded, unchanged
     if (entry) {
       // recorded value CHANGED -> drift. This takes PRIORITY over the at-default fold
       // below: a recorded NON-default value reset out of band to the AWS default is a
@@ -1123,11 +1111,14 @@ export function applyBaseline(
       // the recorded→live diff is available to the report / --json / a re-record picker — the
       // user must see WHAT the out-of-band change was, not just the (possibly attacker-set)
       // live value under a bare label.
-      const delta = identityArrayDelta(canonicalizeForCompare(entry.value), f.actual);
+      const delta = identityArrayDelta(
+        canonicalizeForCompare(entry.value, f.resourceType),
+        f.actual
+      );
       kept.push({
         ...f,
         tier: 'undeclared',
-        desired: canonicalizeForCompare(entry.value),
+        desired: canonicalizeForCompare(entry.value, f.resourceType),
         ...(delta && { arrayDelta: delta }),
       });
       continue;

--- a/src/normalize/pipeline.ts
+++ b/src/normalize/pipeline.ts
@@ -10,11 +10,14 @@
 // lists (unordered set -> sorted by Key), then AWS-id arrays (unordered set ->
 // sorted). It does NOT strip AWS-managed fields / aws:* tags / schema paths — those
 // are live-only concerns the caller applies before this.
+import { stripCcApiAwsManagedFields } from './cc-api-strip.js';
 import {
   canonicalizeIdArraysDeep,
   canonicalizeTagListsDeep,
   normalizeWafByteMatchDeep,
   ORDER_SIGNIFICANT_ARRAY_KEYS,
+  sortUnorderedObjectArray,
+  stripAwsTagsDeep,
 } from './noise.js';
 import { normalizePoliciesDeep } from './policy-canonical.js';
 
@@ -34,4 +37,53 @@ export function canonicalizeForCompare(v: unknown, resourceType?: string): unkno
   return resourceType === 'AWS::WAFv2::WebACL' || resourceType === 'AWS::WAFv2::RuleGroup'
     ? normalizeWafByteMatchDeep(base)
     : base;
+}
+
+// Deeply apply the SAME canonical-JSON total order the live model reaches (classify's
+// `sortUnorderedObjectArray` inside `sortUnorderedSetProps`) to every plain-object array,
+// so both compare sides converge on one order even for an IDENTITY-LESS array
+// `canonicalizeForCompare`'s identity-sort leaves in template order (#767). Only reorders
+// (never merges/drops), and is applied to BOTH sides symmetrically, so it can never make
+// two genuinely different values compare equal.
+function sortObjectArraysDeep(v: unknown): unknown {
+  if (Array.isArray(v)) return sortUnorderedObjectArray(v.map(sortObjectArraysDeep));
+  if (v && typeof v === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>))
+      out[k] = sortObjectArraysDeep(val);
+    return out;
+  }
+  return v;
+}
+
+// #766: bring a RECORDED baseline value into the SAME canonical, noise-subtracted form the
+// live value reaches before it becomes a finding's `f.actual`, so a baseline recorded under
+// OLDER cdkrd rules re-canonicalizes to match today's freshly-stripped live value — a pure
+// cdkrd UPGRADE (no template / AWS change) then never turns committed baselines into a
+// "changed/removed since record" drift storm.
+//
+// `canonicalizeForCompare` alone covers only the pipeline INSIDE it (policies, tag lists,
+// id arrays, WAF). The live value additionally passes, in classify's `normalizeLiveModel`,
+// `stripCcApiAwsManagedFields` (drop AWS-managed timestamps / owner ids / revision ids),
+// `stripAwsTagsDeep` (drop `aws:*` tags), the shared `canonicalizeForCompare`, then the
+// readOnly/writeOnly schema strip + `sortUnorderedSetProps`. This mirrors the ones that are
+// DEEP + ROOT-AGNOSTIC and so are safe to re-apply to a bare stored value fragment:
+//   - `stripCcApiAwsManagedFields` — strips managed fields by NAME at any depth;
+//   - `stripAwsTagsDeep` — strips `aws:*` tag elements by SHAPE at any depth;
+//   - `canonicalizeForCompare(v, resourceType)` — the shared pipeline (now type-aware);
+//   - `sortObjectArraysDeep` — the #767 canonical-JSON object-array order the live model
+//     lands in via `sortUnorderedObjectArray`.
+// All four are IDEMPOTENT, so a value recorded under TODAY's rules is unchanged (the
+// predicate stays reflexive) and change detection is preserved (they only strip AWS-managed
+// noise / reorder unordered sets, never merge or drop meaningful user values).
+//
+// NOT covered here (would need info a bare fragment lacks): the resourceType SCHEMA strip
+// (`deepStripPaths(readOnly/writeOnly)`) and the scalar-set sort inside `sortUnorderedSetProps`
+// are keyed on ROOT-anchored dotted paths + an ASYNC schema fetch, which this synchronous,
+// model-root-less compare cannot supply. In practice those two already ran on both sides at
+// record/read time via `normalizeLiveModel` (the recorded value came from a normalized model),
+// so only a NEW schema readOnly/writeOnly path added in a later version is left uncovered.
+export function canonicalizeBaselineForCompare(v: unknown, resourceType?: string): unknown {
+  const stripped = stripAwsTagsDeep(stripCcApiAwsManagedFields(v as Record<string, unknown>));
+  return sortObjectArraysDeep(canonicalizeForCompare(stripped, resourceType));
 }

--- a/tests/baseline-recanon-766.test.ts
+++ b/tests/baseline-recanon-766.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { baselineValueMatches } from '../src/baseline/baseline-file.js';
+import { stripAwsTagsDeep } from '../src/normalize/noise.js';
+import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
+import { stripCcApiAwsManagedFields } from '../src/normalize/cc-api-strip.js';
+
+// #766: `baselineValueMatches` covered only PART of the live-value pipeline. The live value
+// that becomes a finding's `f.actual` (and therefore the recorded `entry.value`) passes,
+// in classify's `normalizeLiveModel`, `stripCcApiAwsManagedFields` + `stripAwsTagsDeep` +
+// `canonicalizeForCompare` + the schema strip + `sortUnorderedSetProps`. But
+// `baselineValueMatches` re-applied ONLY `canonicalizeForCompare` to the stored baseline
+// value. So when a later cdkrd version ADDS/CHANGES one of the OTHER strips (a new
+// AWS-managed field name, a new `aws:*`-tag-strip case), a baseline recorded PRE-strip no
+// longer matches the freshly-stripped live value — a pure cdkrd UPGRADE (no template / AWS
+// change) turns committed baselines into a "changed since record" drift storm.
+//
+// The fix re-applies the DEEP, ROOT-AGNOSTIC strips (`stripCcApiAwsManagedFields`,
+// `stripAwsTagsDeep`) + the #767 canonical-JSON object-array sort to the stored value too,
+// and threads `resourceType` through the pipeline. Each test below records a baseline value
+// in the OLD (un-stripped) shape and shows it now compares EQUAL to the freshly-stripped
+// live value. Without the fix (`canonicalizeForCompare` alone) the compare mismatches.
+describe('#766 baselineValueMatches re-applies the full live-value strip pipeline', () => {
+  // The freshly-stripped live value the finding carries as `f.actual` (classify has already
+  // dropped the AWS-managed field / `aws:*` tag from the live model).
+  const strip = (v: unknown): unknown =>
+    canonicalizeForCompare(stripAwsTagsDeep(stripCcApiAwsManagedFields(v as never)));
+
+  it('(recanon) baseline recorded WITH an AWS-managed field matches the stripped live value', () => {
+    // A baseline recorded before the version that started stripping this managed field —
+    // it kept the raw `LastModified` / `RevisionId` AWS echoes inside the value.
+    const recordedOldShape = {
+      Runtime: 'nodejs20.x',
+      LastModified: '2024-01-01T00:00:00Z',
+      RevisionId: 'abc-123-def',
+    };
+    // Today's live value: classify strips those managed fields before it becomes f.actual.
+    const liveStripped = strip({
+      Runtime: 'nodejs20.x',
+      LastModified: '2099-12-31T00:00:00Z', // a DIFFERENT value — proves it is truly ignored
+      RevisionId: 'zzz-999',
+    });
+    // Sanity: the recorded old shape carries the managed field, the live one does not.
+    expect(Object.keys(recordedOldShape)).toContain('LastModified');
+    expect(Object.keys(liveStripped as object)).not.toContain('LastModified');
+    // WITH the fix: the stored value is re-stripped, so it matches. WITHOUT it (canonicalize
+    // only) the recorded `LastModified`/`RevisionId` survive and mismatch the stripped live.
+    expect(baselineValueMatches(recordedOldShape, liveStripped, 'AWS::Lambda::Function')).toBe(
+      true
+    );
+  });
+
+  it('(recanon) baseline recorded WITH an aws:* tag matches the aws:*-stripped live value', () => {
+    // A tag list recorded before the `aws:*`-tag strip covered this shape: the raw baseline
+    // kept the service-managed `aws:cloudformation:*` tag AWS auto-attaches.
+    const recordedOldShape = [
+      { Key: 'Team', Value: 'platform' },
+      { Key: 'aws:cloudformation:stack-name', Value: 'MyStack' },
+    ];
+    // Today's live value: classify's stripAwsTagsDeep drops the `aws:*` element.
+    const liveStripped = strip([
+      { Key: 'aws:cloudformation:stack-name', Value: 'MyStack' },
+      { Key: 'Team', Value: 'platform' },
+    ]);
+    expect(baselineValueMatches(recordedOldShape, liveStripped)).toBe(true);
+  });
+
+  it('(recanon) a managed field nested inside the value is also folded', () => {
+    const recordedOldShape = {
+      LoggingConfiguration: { Level: 'ALL', CreatedAt: '2024-01-01T00:00:00Z' },
+    };
+    const liveStripped = strip({
+      LoggingConfiguration: { Level: 'ALL', CreatedAt: '2030-06-06T00:00:00Z' },
+    });
+    expect(
+      baselineValueMatches(recordedOldShape, liveStripped, 'AWS::StepFunctions::StateMachine')
+    ).toBe(true);
+  });
+
+  // NEGATIVE guards: re-stripping only removes AWS-managed noise / reorders — it must NOT
+  // loosen the predicate into matching genuinely-different user values.
+  it('(negative) a real user-value change still surfaces as changed', () => {
+    const recorded = { Runtime: 'nodejs20.x', LastModified: '2024-01-01T00:00:00Z' };
+    const changed = strip({ Runtime: 'nodejs22.x', LastModified: '2024-01-01T00:00:00Z' });
+    expect(baselineValueMatches(recorded, changed, 'AWS::Lambda::Function')).toBe(false);
+  });
+
+  it('(negative) a real (non-aws:*) tag change still surfaces as changed', () => {
+    const recorded = [
+      { Key: 'Team', Value: 'platform' },
+      { Key: 'aws:cloudformation:stack-name', Value: 'MyStack' },
+    ];
+    const changed = strip([{ Key: 'Team', Value: 'CHANGED' }]);
+    expect(baselineValueMatches(recorded, changed)).toBe(false);
+  });
+
+  it('(reflexive) a value recorded under TODAY rules still matches itself', () => {
+    const v = { Runtime: 'nodejs20.x', Tags: [{ Key: 'Team', Value: 'platform' }] };
+    expect(baselineValueMatches(v, v, 'AWS::Lambda::Function')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #766. See commit body. Adds `canonicalizeBaselineForCompare` so a baseline recorded under older cdkrd rules re-canonicalizes to today's freshly-stripped live value — a pure upgrade no longer resurfaces false 'changed/removed since record' drift. Threads resourceType through the compare. Unit test `tests/baseline-recanon-766.test.ts` (3 positive cases verified to FAIL pre-fix + reflexive guards).