### PR TITLE
fix(noise): fold AWS-assigned identifiers / generated names surfacing as first-run undeclared FPs (#844)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1024,6 +1024,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::EC2::FlowLog': {
     MaxAggregationInterval: 600,
+    // A flow log that declares no LogFormat reads back AWS's documented default 14-field
+    // format string. It is a STABLE, documented constant, so an equality-gated KNOWN_DEFAULTS
+    // fold preserves detection: a user who sets a CUSTOM format out of band no longer matches
+    // and surfaces. Corpus baked FP (#844).
+    LogFormat:
+      '${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}',
   },
   // EC2 echoes SpreadLevel "rack" even on partition-strategy groups (where the
   // property is inapplicable); "rack" is also the documented default for spread.
@@ -2547,6 +2553,15 @@ export const GENERATED_LOGICALID_PREFIX_PATHS: Record<string, ReadonlySet<string
   // #525/#537 over-fold concern does not apply). A user-SET name has no logical-id prefix
   // and still surfaces. Live, hunt 2026-07-08 #639.
   'AWS::EC2::LaunchTemplate': new Set(['LaunchTemplateName']),
+  // A WAFv2 WebACL / RegexPatternSet that declares no `Name` reads back CFn's
+  // `<logicalId>-<random>` minted name (e.g. "Edge-iCCoPGcllLnA", "RegexSet-CTQHtT5iegpr")
+  // — the same generated-name class as the Cognito/Batch/LaunchTemplate names above (hash
+  // suffix present, so the #525/#537 over-fold concern does not apply). A user-SET name has
+  // no logical-id prefix and still surfaces. (`Name` is also segment-1 of the composite
+  // physicalId `Name|id|Scope`, but the logical-id-prefix fold is the tighter gate.) Corpus
+  // baked FP (#844).
+  'AWS::WAFv2::WebACL': new Set(['Name']),
+  'AWS::WAFv2::RegexPatternSet': new Set(['Name']),
 };
 
 // True when `value` is the `<logicalId><sep><random>` CFn auto-generated-name form: the logical
@@ -2801,6 +2816,20 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   so whatever SG AWS attached is its default, never user intent — a user who wants a
   //   specific SG DECLARES it, and it is then compared in the declared loop.
   'AWS::ElasticLoadBalancingV2::LoadBalancer': new Set(['SecurityGroups']),
+  //   AWS::ApiGateway::ApiKey.Value — an API key that declares no Value reads back AWS-generated
+  //   40-char key material (createOnly — it can never drift out of band). It is a service-minted
+  //   secret, not user intent — a user who pins a specific key DECLARES Value, compared in the
+  //   declared loop. Folding value-independent ALSO keeps an AWS-generated secret out of the report
+  //   and the git-committed baseline (overlaps the redaction concern in #798). Corpus baked FP (#844).
+  'AWS::ApiGateway::ApiKey': new Set(['Value']),
+  //   AWS::Backup::BackupVault.EncryptionKeyArn — a vault that declares no EncryptionKeyArn reads
+  //   back the account's AWS-managed `aws/backup` key ARN. The ARN carries the account-specific KMS
+  //   key-ID (a per-account GUID, not a stable `alias/…`), so a CONTEXT_ARN_DEFAULTS template cannot
+  //   pin it. createOnly (immutable — it can never drift out of band), and undeclared, so whatever
+  //   default key AWS assigned is not user intent (a user who pins a CMK DECLARES it, compared in the
+  //   declared loop). Fold value-independent (same class as the RDS KmsKeyId fold below). Corpus
+  //   baked FP (#844).
+  'AWS::Backup::BackupVault': new Set(['EncryptionKeyArn']),
   //   AWS::Batch::JobQueue.JobQueueType — a queue that declares no JobQueueType reads back
   //   the type AWS DERIVES from its attached compute environment (ECS_FARGATE for a Fargate
   //   CE, ECS for EC2, EKS for EKS). The value lives on a DIFFERENT resource (the CE), not in
@@ -3038,7 +3067,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   back an AWS-assigned one as an OBJECT ({DayOfWeek, TimeOfDay, TimeZone}); value-independent
   //   folds the whole top-level property whatever its shape, so the assigned window is not first-
   //   run noise (a DECLARED window is compared in the declared loop).
-  'AWS::AmazonMQ::Broker': new Set(['MaintenanceWindowStartTime']),
+  //   AWS::AmazonMQ::Broker.SecurityGroups / .SubnetIds — a broker that declares neither reads back
+  //   a single-element default-VPC placement (an AWS-assigned sg-… / subnet-… id, not in the
+  //   broker's declared inputs and not derivable without a VPC lookup). Verbatim twin of the ELBv2
+  //   LoadBalancer.SecurityGroups fold above: undeclared, so whatever placement AWS chose is its
+  //   default, never user intent — a user who wants specific SGs/subnets DECLARES them, compared in
+  //   the declared loop. Corpus baked FP (#844).
+  'AWS::AmazonMQ::Broker': new Set(['MaintenanceWindowStartTime', 'SecurityGroups', 'SubnetIds']),
   //   Core VPC-networking types whose undeclared, AWS-ASSIGNED, CREATE-ONLY placement identifiers
   //   read back on every first run. Each is a per-resource value AWS picks at creation from the
   //   surrounding VPC/subnet/region — never a constant we can pin, and never user intent when

--- a/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
+++ b/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
@@ -170,7 +170,7 @@
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
       "path": "SecurityGroups",
@@ -188,7 +188,7 @@
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
       "path": "SubnetIds",

--- a/tests/corpus/AWS__ApiGateway__ApiKey.ApiKey.json
+++ b/tests/corpus/AWS__ApiGateway__ApiKey.ApiKey.json
@@ -50,7 +50,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiKey",
       "resourceType": "AWS::ApiGateway::ApiKey",
       "path": "Value",

--- a/tests/corpus/AWS__Backup__BackupVault.Vault23237E5B.json
+++ b/tests/corpus/AWS__Backup__BackupVault.Vault23237E5B.json
@@ -36,7 +36,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Vault23237E5B",
       "resourceType": "AWS::Backup::BackupVault",
       "path": "EncryptionKeyArn",

--- a/tests/corpus/AWS__EC2__FlowLog.FlowLog3CB084E9.json
+++ b/tests/corpus/AWS__EC2__FlowLog.FlowLog3CB084E9.json
@@ -93,7 +93,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FlowLog3CB084E9",
       "resourceType": "AWS::EC2::FlowLog",
       "path": "LogFormat",

--- a/tests/corpus/AWS__WAFv2__RegexPatternSet.RegexSet.json
+++ b/tests/corpus/AWS__WAFv2__RegexPatternSet.RegexSet.json
@@ -48,7 +48,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "RegexSet",
       "resourceType": "AWS::WAFv2::RegexPatternSet",
       "path": "Name",

--- a/tests/corpus/AWS__WAFv2__WebACL.Edge.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.Edge.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::WAFv2::WebACL with deep declared config classifies as recorded (undeclared:Name, undeclared:OnSourceDDoSProtectionConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::WAFv2::WebACL with deep declared config classifies as recorded (generated:Name, atDefault:OnSourceDDoSProtectionConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Edge",
     "resourceType": "AWS::WAFv2::WebACL",
@@ -138,7 +138,7 @@
       "constructPath": "CdkrdIntegHarvest2/Edge"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Edge",
       "resourceType": "AWS::WAFv2::WebACL",
       "path": "Name",

--- a/tests/noise-assigned-ids-844.test.ts
+++ b/tests/noise-assigned-ids-844.test.ts
@@ -1,0 +1,144 @@
+// #844: corpus baked first-run FPs — a batch of undeclared, AWS-assigned identifiers /
+// generated names / AWS-managed cosmetic values that surfaced as undeclared [Potential Drift]
+// instead of folding. Each is folded via the WEAKEST tier that fits (fold-strategy order):
+//   - WAFv2 WebACL / RegexPatternSet Name -> GENERATED_LOGICALID_PREFIX_PATHS (generated, value-
+//     dependent: a <logicalId>-<random> name folds, a user-SET name still surfaces).
+//   - EC2 FlowLog LogFormat -> KNOWN_DEFAULTS (equality-gated constant: the stock 14-field default
+//     folds, a custom format still surfaces).
+//   - ApiGateway ApiKey Value / AmazonMQ Broker SecurityGroups+SubnetIds / Backup BackupVault
+//     EncryptionKeyArn -> VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS (createOnly / AWS-assigned
+//     placement / AWS-generated secret — undeclared, so any value is AWS's choice, not user intent).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const opts = { accountId: '111111111111', region: 'us-east-1' };
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#844 WAFv2 WebACL/RegexPatternSet generated Name', () => {
+  const webAcl: DesiredResource = {
+    logicalId: 'Edge',
+    resourceType: 'AWS::WAFv2::WebACL',
+    physicalId: 'Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL',
+    declared: { Scope: 'REGIONAL' },
+  };
+  it('folds the CFn-generated <logicalId>-<random> Name to generated', () => {
+    const f = classifyResource(webAcl, { Name: 'Edge-iCCoPGcllLnA' }, emptySchema, opts);
+    expect(pathsByTier(f, 'generated')).toContain('Name');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Name');
+  });
+  it('surfaces a user-SET Name (no logical-id prefix) as undeclared', () => {
+    const f = classifyResource(webAcl, { Name: 'my-custom-acl' }, emptySchema, opts);
+    expect(pathsByTier(f, 'undeclared')).toContain('Name');
+    expect(pathsByTier(f, 'generated')).not.toContain('Name');
+  });
+  it('folds a RegexPatternSet generated Name to generated', () => {
+    const regexSet: DesiredResource = {
+      logicalId: 'RegexSet',
+      resourceType: 'AWS::WAFv2::RegexPatternSet',
+      physicalId: 'RegexSet-CTQHtT5iegpr|86885cf4-7aa6-4169-92a4-c9d9ac32aed5|REGIONAL',
+      declared: { Scope: 'REGIONAL' },
+    };
+    const f = classifyResource(regexSet, { Name: 'RegexSet-CTQHtT5iegpr' }, emptySchema, opts);
+    expect(pathsByTier(f, 'generated')).toContain('Name');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Name');
+  });
+});
+
+describe('#844 EC2 FlowLog default LogFormat', () => {
+  const res: DesiredResource = {
+    logicalId: 'FlowLog',
+    resourceType: 'AWS::EC2::FlowLog',
+    physicalId: 'fl-036ddfda22c64b9f1',
+    declared: { ResourceType: 'VPC', TrafficType: 'ALL' },
+  };
+  const DEFAULT_FORMAT =
+    '${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}';
+  it('folds the stock 14-field default LogFormat to atDefault', () => {
+    const f = classifyResource(res, { LogFormat: DEFAULT_FORMAT }, emptySchema, opts);
+    expect(pathsByTier(f, 'atDefault')).toContain('LogFormat');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('LogFormat');
+  });
+  it('surfaces a custom LogFormat as undeclared', () => {
+    const f = classifyResource(res, { LogFormat: '${version} ${srcaddr}' }, emptySchema, opts);
+    expect(pathsByTier(f, 'undeclared')).toContain('LogFormat');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('LogFormat');
+  });
+});
+
+describe('#844 ApiGateway ApiKey generated Value (value-independent)', () => {
+  const res: DesiredResource = {
+    logicalId: 'ApiKey',
+    resourceType: 'AWS::ApiGateway::ApiKey',
+    physicalId: '6r6yg8wk4j',
+    declared: { Enabled: true, Name: 'cdkrd-key' },
+  };
+  it('folds AWS-generated key material to atDefault regardless of value', () => {
+    const f = classifyResource(
+      res,
+      { Value: 'OL2cc3xWoX85uZuwBZpvO311UM7TN5ke2SyXoEYD' },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('Value');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Value');
+  });
+});
+
+describe('#844 AmazonMQ Broker default-VPC placement (value-independent)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Broker',
+    resourceType: 'AWS::AmazonMQ::Broker',
+    physicalId: 'b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86',
+    declared: { BrokerName: 'cdkrd-mq', EngineType: 'ACTIVEMQ' },
+  };
+  it('folds AWS-assigned SecurityGroups/SubnetIds to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { SecurityGroups: ['sg-0a26e23e2310ee0c9'], SubnetIds: ['subnet-0ddbb00e7c1d5b679'] },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual(['SecurityGroups', 'SubnetIds']);
+    expect(pathsByTier(f, 'undeclared')).not.toContain('SecurityGroups');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('SubnetIds');
+  });
+});
+
+describe('#844 Backup BackupVault default EncryptionKeyArn (value-independent)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Vault',
+    resourceType: 'AWS::Backup::BackupVault',
+    physicalId: 'CdkrdVault',
+    declared: { BackupVaultName: 'CdkrdVault' },
+  };
+  it('folds the AWS-managed aws/backup key ARN to atDefault', () => {
+    const f = classifyResource(
+      res,
+      {
+        EncryptionKeyArn:
+          'arn:aws:kms:us-east-1:111111111111:key/b405e2ab-23b0-48e9-834e-aa3aeeded51d',
+      },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('EncryptionKeyArn');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('EncryptionKeyArn');
+  });
+});


### PR DESCRIPTION
Addresses #844 (5 of 6 items; Cognito UserPoolUser sub deferred — needs a classify.ts per-element value-independent skip). Folds each at the weakest tier that preserves detection (KNOWN_DEFAULTS / GENERATED_LOGICALID_PREFIX_PATHS / value-independent). Corpus cases + a focused unit test asserting the folds AND that user-set values still surface. See commit body.