### PR TITLE
fix(revert): make #641 null-husk strip ops non-selectable coupled plumbing (#967)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -37,6 +37,7 @@ import { CC_IDENTIFIER_ADAPTERS } from '../read/router.js';
 import { applyRevertDelete, applyRevertDeletes, applyRevertItem } from '../revert/apply.js';
 import {
   buildRevertPlan,
+  isContractOp,
   rejectedEmptyStripOps,
   type RevertItem,
   type RevertPlan,
@@ -323,6 +324,12 @@ export function revertSelectOptions(
   const options: { value: string; label: string; selected: boolean }[] = [];
   for (const item of plan.items) {
     for (const op of item.ops) {
+      // #967: a CONTRACT op (null-husk strip) is plumbing coupled to a real op, not a
+      // user-chosen write — never offer it as its own selectable row. filterRevertPlan
+      // always carries it through for any item that keeps ≥1 real op, and drops the
+      // whole item (contract op included) when the user selected none of its real ops,
+      // so a bucket can never be written a contract-only patch.
+      if (isContractOp(op)) continue;
       // `delete` items delete a whole out-of-band resource — the loudest destructive
       // action, marked (DELETE); a property REMOVE keeps its (REMOVE) marker.
       const marker = item.kind === 'delete' ? ' (DELETE)' : op.op === 'remove' ? ' (REMOVE)' : '';
@@ -345,16 +352,47 @@ function revertOpKey(item: RevertItem, op: RevertItem['ops'][number]): string {
   return `${item.logicalId}${item.kind}${op.path}${attr}`;
 }
 
-/** Keep only the selected ops; items left with no ops drop out. Pure + exported. */
+/**
+ * Keep only the selected ops; items left with no REAL op drop out. Pure + exported.
+ *
+ * #967: a CONTRACT op (null-husk strip) is never a selectable row, so it is never in
+ * `picked` — but it is coupled to its item's real revert ops (without the strip, the CC
+ * patch hard-fails model validation, #641). So it is NOT filtered by the pick set: it
+ * ALWAYS rides along an item that retains ≥1 real (non-contract) selected op, and is
+ * DROPPED with the whole item when the user selected none of that item's real ops.
+ * This keeps both invariants: a real revert op can never be sent without its coupled
+ * husk strip, and a husk strip can never be sent alone as a user-chosen write.
+ */
 export function filterRevertPlan(plan: RevertPlan, picked: Set<string>): RevertPlan {
   const items = plan.items
-    .map((item) => ({ ...item, ops: item.ops.filter((op) => picked.has(revertOpKey(item, op))) }))
+    .map((item) => {
+      const realSelected = item.ops.filter(
+        (op) => !isContractOp(op) && picked.has(revertOpKey(item, op))
+      );
+      // No real op survived the pick → drop the whole item (contract ops included), so a
+      // bucket the user chose nothing for is never written a contract-only patch.
+      if (realSelected.length === 0) return { ...item, ops: [] };
+      // At least one real op is kept → carry EVERY contract op through with it.
+      const contract = item.ops.filter(isContractOp);
+      return { ...item, ops: [...contract, ...realSelected] };
+    })
     .filter((item) => item.ops.length > 0);
   return { items, notRevertable: plan.notRevertable };
 }
 
 export function revertSelectMessage(stackName: string, region: string): string {
   return `${stackLabel(stackName, region)}: select the op(s) to revert (unselected are not written)`;
+}
+
+/**
+ * #967: the op count SHOWN to the user (confirm prompt + --dry-run preview) counts only
+ * REAL revert ops — a CONTRACT op (null-husk strip) is plumbing coupled to a real op,
+ * not a distinct write the user chose, so counting it would inflate the number the user
+ * consents to. The full augmented patch (contract ops included) is still what is SENT to
+ * AWS; this is purely the user-facing intent count. Pure + exported for unit tests.
+ */
+export function realOpCount(plan: RevertPlan): number {
+  return plan.items.reduce((n, i) => n + i.ops.filter((op) => !isContractOp(op)).length, 0);
 }
 
 // ---- record ----
@@ -788,7 +826,10 @@ export function formatPlan(
   >();
   for (const item of plan.items) {
     const g = planByResource.get(item.logicalId);
-    const humans = item.ops.map((op) => op.human);
+    // #967: a CONTRACT op (null-husk strip) is plumbing, not a user-chosen revert — omit
+    // it from the itemized plan (it is not counted or selectable either). A resource whose
+    // only ops are contract ops never reaches here: filterRevertPlan drops such an item.
+    const humans = item.ops.filter((op) => !isContractOp(op)).map((op) => op.human);
     if (g) g.humans.push(...humans);
     else
       planByResource.set(item.logicalId, {
@@ -1151,7 +1192,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     // real revert would SEND, including the tag-preserve / write-only-reinclude / empty-strip
     // ops the apply loop adds. Resource count is unaffected (augmentation never adds items).
     const augmented = augment(plan);
-    const opCount = augmented.items.reduce((n, i) => n + i.ops.length, 0);
+    // #967: count only REAL revert ops — contract ops (null-husk strips) are plumbing,
+    // not writes the user chose, so they never inflate the count shown to the user.
+    const opCount = realOpCount(augmented);
     out(
       `\n(dry-run) would apply ${opCount} op(s) to ${augmented.items.length} resource(s). No changes made.`
     );
@@ -1197,7 +1240,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     // survivors. The canonical `plan = augment(plan)` runs once just below (before apply),
     // so both this confirm count and the apply loop see the same augmented ops.
     const confirmPlan = augment(plan);
-    const opCount = confirmPlan.items.reduce((n, i) => n + i.ops.length, 0);
+    // #967: count only REAL revert ops for the confirm prompt (contract null-husk strips
+    // are plumbing, not user-chosen writes). The full augmented plan is still applied.
+    const opCount = realOpCount(confirmPlan);
     const deleteCount = confirmPlan.items.filter((i) => i.kind === 'delete').length;
     const ok = await confirm({
       message: revertConfirmMessage(

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -352,7 +352,24 @@ export interface PatchOp {
   // attribute-bag findings; the SDK writer sends `{Key, Value: value}` via
   // ModifyLoadBalancerAttributes. Never serialized to Cloud Control.
   attributeKey?: string;
+  // #967: a CONTRACT op — plumbing that exists ONLY to keep the Cloud Control patch
+  // valid (e.g. a null-array-husk strip, #641), NOT a revert the user chose. It
+  // corresponds to no finding, so it is NEVER offered as a standalone selectable row
+  // in the interactive multiselect and is NOT counted as user intent — it rides along
+  // an item only while that item still carries ≥1 real (non-contract) op. The KEY
+  // invariants: a real revert op can never be sent without its coupled contract op, and
+  // a contract op can never be sent alone as a user-chosen write.
+  contract?: boolean;
   human: string; // one-line description for the plan display
+}
+
+// #967: a CONTRACT op is plumbing that keeps the CC patch valid (a null-husk strip),
+// NOT a revert the user chose. The interactive multiselect must neither offer it as a
+// standalone selectable row nor count it as user intent — it rides an item only while
+// that item still carries a real (non-contract) op. Threaded as a predicate (not a
+// fragile path-string match) so any future contract-classed op is covered by tagging it.
+export function isContractOp(op: PatchOp): boolean {
+  return op.contract === true;
 }
 
 export interface RevertItem {
@@ -411,7 +428,14 @@ function nullHuskRemovalOps(model: Record<string, unknown>): PatchOp[] {
     if (Array.isArray(value)) {
       if (value.length > 0 && value.every((v) => v === null || v === undefined)) {
         if (pointer !== '')
-          ops.push({ op: 'remove', path: pointer, human: `strip null array husk at ${pointer}` });
+          ops.push({
+            op: 'remove',
+            path: pointer,
+            // #967: contract plumbing, not a user-chosen revert — never independently
+            // selectable in the interactive multiselect, never counted as user intent.
+            contract: true,
+            human: `strip null array husk at ${pointer}`,
+          });
         return; // a pure-null array has no non-null children to recurse into
       }
       value.forEach((v, i) => walk(v, `${pointer}/${i}`));

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -8,6 +8,7 @@ import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
 import {
   buildRevertPlan,
+  isContractOp,
   type PatchOp,
   rejectedEmptyStripOps,
   tagPreservingOps,
@@ -3093,6 +3094,16 @@ describe('#641 symptom 2 — CC revert strips bare-null array husks from the mod
       { op: 'remove', path: '/MetricsConfigurations/1/TagFilters' },
       { op: 'remove', path: '/IntelligentTieringConfigurations/0/TagFilters' },
       { op: 'remove', path: '/VersioningConfiguration' },
+    ]);
+    // #967: the two husk-strip ops are tagged CONTRACT (coupled plumbing, not a
+    // user-chosen revert), while the real property revert is NOT — so the interactive
+    // multiselect can exclude the husk strips from its selectable rows / op count.
+    expect(ops.filter((o) => isContractOp(o)).map((o) => o.path)).toEqual([
+      '/MetricsConfigurations/1/TagFilters',
+      '/IntelligentTieringConfigurations/0/TagFilters',
+    ]);
+    expect(ops.filter((o) => !isContractOp(o)).map((o) => o.path)).toEqual([
+      '/VersioningConfiguration',
     ]);
   });
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -32,6 +32,7 @@ import {
   formatSurvivingDrift,
   ignoreSelectOptions,
   includeUnrecordedRemovals,
+  realOpCount,
   resolveInteractiveRevertExit,
   revertConfirmMessage,
   revertSelectMessage,
@@ -1721,6 +1722,81 @@ describe('revertSelectOptions / filterRevertPlan (R57 — pick what to revert)',
       notRevertable: [{ displayId: 'X', resourceType: 'T', path: 'P', reason: 'r' }],
     };
     expect(filterRevertPlan(p, new Set()).notRevertable).toHaveLength(1);
+  });
+});
+
+describe('#967 — a CONTRACT (null-husk strip) op is coupled plumbing, never a standalone selectable/user-chosen write', () => {
+  // A bucket whose live model carries the #641 null-array husk: buildRevertPlan PREPENDS a
+  // contract (husk-strip) op ahead of the real revert op, so both live in item.ops.
+  const huskPlan = (): RevertPlan => ({
+    items: [
+      {
+        logicalId: 'B',
+        displayId: 'Stack/Bucket',
+        resourceType: 'AWS::S3::Bucket',
+        physicalId: 'b-phys',
+        kind: 'cc',
+        ops: [
+          // contract op is prepended (descending doc order) just like nullHuskRemovalOps
+          {
+            op: 'remove',
+            path: '/IntelligentTieringConfigurations/0/TagFilters',
+            contract: true,
+            human: 'strip null array husk at /IntelligentTieringConfigurations/0/TagFilters',
+          },
+          {
+            op: 'add',
+            path: '/VersioningConfiguration/Status',
+            value: 'Enabled',
+            human: 'VersioningConfiguration.Status -> deployed-template value',
+          },
+        ],
+      },
+    ],
+    notRevertable: [],
+  });
+
+  it('a contract op is NOT offered as a standalone selectable row', () => {
+    const options = revertSelectOptions(huskPlan());
+    // only the ONE real op is offered — the husk strip is not selectable
+    expect(options).toHaveLength(1);
+    expect(options[0]!.label).toBe(
+      'Stack/Bucket: VersioningConfiguration.Status -> deployed-template value'
+    );
+    expect(options.some((o) => o.label.includes('null array husk'))).toBe(false);
+  });
+
+  it('de-selecting everything for a husk-bearing item DROPS the whole item (no contract-only patch written)', () => {
+    // picking NOTHING — the #641 poisoned-patch resurrection would be a contract-only write
+    const filtered = filterRevertPlan(huskPlan(), new Set());
+    expect(filtered.items).toHaveLength(0);
+  });
+
+  it('selecting the real op carries its coupled husk strip through (guard cannot be defeated)', () => {
+    const options = revertSelectOptions(huskPlan());
+    expect(options).toHaveLength(1);
+    const filtered = filterRevertPlan(huskPlan(), new Set([options[0]!.value]));
+    expect(filtered.items).toHaveLength(1);
+    const ops = filtered.items[0]!.ops;
+    // BOTH the contract husk strip AND the real op are present …
+    expect(ops).toHaveLength(2);
+    // … with the contract op FIRST (prepended, so the strip precedes the write it protects)
+    expect(ops[0]!.contract).toBe(true);
+    expect(ops[0]!.path).toBe('/IntelligentTieringConfigurations/0/TagFilters');
+    expect(ops[1]!.contract).toBeUndefined();
+    expect(ops[1]!.path).toBe('/VersioningConfiguration/Status');
+  });
+
+  it('realOpCount excludes contract ops (they never inflate the confirm / --dry-run count)', () => {
+    // the plan has 2 ops but only 1 is a real user-chosen write
+    expect(realOpCount(huskPlan())).toBe(1);
+  });
+
+  it('formatPlan omits the contract op from the itemized preview', () => {
+    const lines = formatPlan('S', 'us-east-1', huskPlan());
+    const body = lines.join('\n');
+    expect(body).toContain('VersioningConfiguration.Status -> deployed-template value');
+    expect(body).not.toContain('null array husk');
   });
 });
 


### PR DESCRIPTION
Closes #967. Adds a `contract` flag + `isContractOp` predicate so null-husk strip ops are never a deselectable multiselect row and never sent alone; filterRevertPlan couples them to a surviving real op or drops the whole item; realOpCount de-inflates the user-facing count. Unit tests assert both invariants. See commit body.