### PR TITLE
fix(check): do not offer the inline Record/Revert menu under --declared-only / --undeclared-only (#779)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,10 @@ error (they select which comparison runs, so a combination is contradictory).
 ### Interactive prompts (TTY only, CI is never prompted)
 
 Every option runs exactly the same code as the standalone commands. Prompts are
-skipped under `--json`, `--show-all`, `--pre-deploy`, and `--fail`. A non-TTY run
+skipped under `--json`, `--show-all`, `--pre-deploy`, `--fail`, and the scope
+filters `--declared-only` / `--undeclared-only` (a filtered finding set must never
+become a snapshot-complete baseline via the inline Record — use the standalone
+`record` verb, which sees the unfiltered state, #779). A non-TTY run
 never prompts: a required write decision without `--yes` errors with exit 2 (the
 safe side). "Interactive" requires **both** a TTY stdin and a TTY stdout — so
 **redirecting or piping the output** (`cdkrd check > report.txt`, `| tee`) is also

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -258,6 +258,19 @@ export function finalCheckExit(code: number, fail: boolean): number {
  * who can make the decision. It is gated OUT of every machine/automation mode:
  *   - --json / --show-all / --pre-deploy — machine output or baseline-untouched contracts,
  *   - --fail — the CI drift-exit path,
+ *   - #779: --declared-only / --undeclared-only — a SCOPE filter is active, so `findings`
+ *     has been reduced to one tier (declared-only drops the whole undeclared/added/atDefault
+ *     tier; undeclared-only drops declared plus its readGap/unresolved byproducts). The
+ *     interactive menu's Record path feeds THAT filtered set into writeBaseline, and
+ *     computeCompleteResources — which only blocks snapshot-completeness on the tiers that
+ *     were just filtered out (skipped/deleted/readGap/unrecorded-undeclared) — then stamps
+ *     every readable resource snapshot-complete with an INCOMPLETE `recorded` list. A later
+ *     plain `check` reads the genuinely-undeclared values on those "complete" resources as
+ *     "appeared since record" -> a false confirmed-drift storm (exit 1 under --fail). Under
+ *     --declared-only the HELP/in-run note also PROMISES the baseline is untouched, which the
+ *     Record offer would violate. A filtered finding set must never become a snapshot-complete
+ *     baseline, so no interactive Record/Revert is offered under either scope flag; the
+ *     standalone `record` verb (unfiltered) remains the way to establish one.
  *   - #1054: --yes — `--yes` has NO documented `check` contract (HELP scopes it to record /
  *     ignore / revert; check's automation flag is --fail / non-TTY). In the menu the USER is
  *     the decision-maker, but `--yes` means "no decision needed" in the record/ignore/revert
@@ -267,7 +280,10 @@ export function finalCheckExit(code: number, fail: boolean): number {
  * Pure + exported for tests.
  */
 export function shouldOfferInteractiveResolve(
-  a: Pick<CommonArgs, 'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes'>,
+  a: Pick<
+    CommonArgs,
+    'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes' | 'declaredOnly' | 'undeclaredOnly'
+  >,
   ctx: { code: number; hasUnrecorded: boolean; hasBaseline: boolean; interactive: boolean }
 ): boolean {
   return (
@@ -277,6 +293,8 @@ export function shouldOfferInteractiveResolve(
     !a.preDeploy &&
     !a.fail &&
     !a.yes &&
+    !a.declaredOnly &&
+    !a.undeclaredOnly &&
     ctx.interactive
   );
 }

--- a/tests/check-scope-only-interactive-gate-779.test.ts
+++ b/tests/check-scope-only-interactive-gate-779.test.ts
@@ -1,0 +1,68 @@
+// #779 — `cdkrd check --declared-only` (and its `--undeclared-only` twin) must NOT open
+// check's interactive after-report resolve menu. Under a scope filter the run's `findings`
+// have been reduced to a single tier:
+//   - --declared-only drops the WHOLE undeclared / added / atDefault tier (preDeployFindings).
+//   - --undeclared-only drops declared plus its readGap / unresolved byproducts.
+// The menu's interactive Record path feeds THAT filtered set into writeBaseline. Because
+// computeCompleteResources only blocks snapshot-completeness on the tiers that were just
+// filtered out (skipped/deleted/readGap/unrecorded-undeclared), every readable resource would
+// be stamped snapshot-complete with an INCOMPLETE `recorded` list — so the next plain `check`
+// reads the genuinely-undeclared values as "appeared since record" = a false confirmed-drift
+// storm (exit 1 under --fail). Under --declared-only the HELP/in-run note also PROMISES the
+// baseline is untouched, which the Record offer would break. The fix gates the menu on
+// `!a.declaredOnly && !a.undeclaredOnly` so a filtered finding set can never become a
+// snapshot-complete baseline; the unfiltered standalone `record` verb still establishes one.
+import { describe, expect, it } from 'vite-plus/test';
+import { shouldOfferInteractiveResolve } from '../src/commands/check.js';
+import type { CommonArgs } from '../src/cli-args.js';
+
+type GateArgs = Pick<
+  CommonArgs,
+  'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes' | 'declaredOnly' | 'undeclaredOnly'
+>;
+const args = (over: Partial<GateArgs> = {}): GateArgs => ({
+  json: false,
+  showAll: false,
+  preDeploy: false,
+  fail: false,
+  yes: false,
+  declaredOnly: false,
+  undeclaredOnly: false,
+  ...over,
+});
+
+// The R141 day-1 establish path: a TTY run with NO baseline yet. This is the exact context
+// that, under a scope flag, would let interactive Record write a filtered snapshot-complete
+// baseline — so it is the case the fix must gate OUT.
+const establish = { code: 0, hasUnrecorded: false, hasBaseline: false, interactive: true };
+// A TTY run that found unrecorded values on a baselined stack — the `--undeclared-only`
+// NORMAL first-run path (any run with undeclared/added values is `hasUnrecorded`).
+const unrecorded = { code: 0, hasUnrecorded: true, hasBaseline: true, interactive: true };
+
+describe('#779 shouldOfferInteractiveResolve gates the menu under a scope filter', () => {
+  it('does NOT offer the establish/Record menu under --declared-only (the #779 fix)', () => {
+    expect(shouldOfferInteractiveResolve(args({ declaredOnly: true }), establish)).toBe(false);
+  });
+
+  it('does NOT offer the establish/Record menu under --undeclared-only (the #779 twin)', () => {
+    expect(shouldOfferInteractiveResolve(args({ undeclaredOnly: true }), establish)).toBe(false);
+  });
+
+  it('does NOT offer the menu under --declared-only even with unrecorded values present', () => {
+    expect(shouldOfferInteractiveResolve(args({ declaredOnly: true }), unrecorded)).toBe(false);
+  });
+
+  it('does NOT offer the menu under --undeclared-only even with unrecorded values present', () => {
+    expect(shouldOfferInteractiveResolve(args({ undeclaredOnly: true }), unrecorded)).toBe(false);
+  });
+
+  // Do NOT over-block: a PLAIN check (no scope flag) must still open the R141 establish
+  // prompt — that is the day-1 baseline flow the whole interactive menu exists for.
+  it('STILL offers the establish prompt for a plain check with no scope flag (no over-block)', () => {
+    expect(shouldOfferInteractiveResolve(args(), establish)).toBe(true);
+  });
+
+  it('STILL offers the menu for a plain check with unrecorded values (no over-block)', () => {
+    expect(shouldOfferInteractiveResolve(args(), unrecorded)).toBe(true);
+  });
+});

--- a/tests/check-yes-interactive-gate-1054.test.ts
+++ b/tests/check-yes-interactive-gate-1054.test.ts
@@ -8,13 +8,18 @@ import { describe, expect, it } from 'vite-plus/test';
 import { shouldOfferInteractiveResolve } from '../src/commands/check.js';
 import type { CommonArgs } from '../src/cli-args.js';
 
-type GateArgs = Pick<CommonArgs, 'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes'>;
+type GateArgs = Pick<
+  CommonArgs,
+  'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes' | 'declaredOnly' | 'undeclaredOnly'
+>;
 const args = (over: Partial<GateArgs> = {}): GateArgs => ({
   json: false,
   showAll: false,
   preDeploy: false,
   fail: false,
   yes: false,
+  declaredOnly: false,
+  undeclaredOnly: false,
   ...over,
 });
 // A TTY run that found drift on a baselined stack — the canonical "offer the menu" case.


### PR DESCRIPTION
Closes #779. Gates shouldOfferInteractiveResolve on the scope filters so a filtered finding set can never become a snapshot-complete baseline via inline Record. Closes all three addendum symptoms at one boundary. New synth-mock test + README note. See commit body.