### PR TITLE
fix(record): keep the ignore->record->un-ignore lifecycle correct — no false 'appeared since record' (#1078)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -402,11 +402,27 @@ export async function writeBaselineFile(b: BaselineFile): Promise<string> {
  * be read this run (#795), so undeclared values hidden behind that gap were NOT
  * captured — the resource must not claim completeness, else a later cdkrd that
  * closes the read gap would surface those newly-visible values as false "appeared
- * since record" drift. Ignored-tier values do not block completeness: they were
- * visible and deliberately ruled out.
+ * since record" drift.
+ *
+ * #1078: an `ignored`-tier value whose path is ABSENT from `recorded` also blocks
+ * completeness (and — unlike the other blocks — DEMOTES a previously-complete
+ * resource, overriding monotonicity). An ignore rule re-tags an undeclared finding
+ * `ignored`, so `buildRecorded` drops it and this value never enters the snapshot;
+ * marking the resource complete anyway would treat that value as "known-absent". But
+ * an ignore rule can be DELETED (the documented un-ignore) — and when it dies the
+ * value (unchanged all along) would then read as false CONFIRMED "appeared since
+ * record" drift against a complete resource, instead of returning to `unrecorded`
+ * `[Potential Drift]`. So an ignored-and-unrecorded path keeps its resource
+ * INCOMPLETE, so un-ignoring lands the untouched value back at `unrecorded`. This
+ * pairs with `carryForwardIgnored` (WRITE side): a value with a PRIOR recorded entry
+ * IS carried into `recorded`, so its path IS present, so it does NOT block here — a
+ * previously-endorsed value survives an ignore-era record and stays complete. Only a
+ * NEVER-recorded ignored path (no entry to carry) demotes completeness.
  * Monotonic via `previousComplete`: once complete, a resource stays complete
  * (declining to record an appeared-since-record value keeps it drift, instead of
- * demoting it back to unrecorded) — pruned to ids still in the template.
+ * demoting it back to unrecorded) — pruned to ids still in the template. The #1078
+ * ignored-and-unrecorded demotion is the one deliberate exception (the un-ignore
+ * lifecycle must round-trip).
  */
 export function computeCompleteResources(
   allLogicalIds: string[],
@@ -416,14 +432,22 @@ export function computeCompleteResources(
 ): string[] {
   const recordedKeys = new Set(recorded.map(recordedKey));
   const blocked = new Set<string>();
+  // #1078: ids blocked because an ignored value is not in the snapshot — these DEMOTE a
+  // previously-complete resource too (they win over `previousComplete` monotonicity), so
+  // deleting the ignore rule returns the value to `unrecorded`, never false "appeared".
+  const blockedByIgnore = new Set<string>();
   for (const f of findings) {
     if (f.tier === 'skipped' || f.tier === 'deleted' || f.tier === 'readGap')
       blocked.add(f.logicalId);
     if (f.tier === 'undeclared' && !recordedKeys.has(recordedKey(f))) blocked.add(f.logicalId);
+    if (f.tier === 'ignored' && !recordedKeys.has(recordedKey(f))) blockedByIgnore.add(f.logicalId);
   }
   const all = new Set(allLogicalIds);
-  const complete = new Set(previousComplete.filter((id) => all.has(id)));
-  for (const id of allLogicalIds) if (!blocked.has(id)) complete.add(id);
+  const complete = new Set(
+    previousComplete.filter((id) => all.has(id) && !blockedByIgnore.has(id))
+  );
+  for (const id of allLogicalIds)
+    if (!blocked.has(id) && !blockedByIgnore.has(id)) complete.add(id);
   return [...complete].sort();
 }
 
@@ -616,6 +640,46 @@ export function carryForwardUnreadable(
     return parent !== undefined && unreadable.has(parent);
   };
   const preserved = prior.filter((e) => isUnread(e) && !present.has(recordedKey(e)));
+  return preserved.length === 0 ? recorded : [...recorded, ...preserved];
+}
+
+/**
+ * #1078: carry forward a previously-recorded entry for a path that is CURRENTLY
+ * suppressed by an ignore rule (tier `ignored` this run), so an ignore-era `record`
+ * does not silently PRUNE a value the user already endorsed.
+ *
+ * The `findings` reaching `record` are `applyIgnores`'d first (record.ts /
+ * interactive-resolve.ts), so a value with a live ignore rule arrives tier `ignored`
+ * — and `buildRecorded` keeps only `undeclared`/`added`, so it produces NO entry.
+ * Because `writeBaseline` full-replaces `recorded`, the endorsed entry for that path
+ * would vanish from the git-committed baseline (an unexplained deletion to the PR
+ * reviewer). Then, when the user later DELETES the rule (the documented un-ignore),
+ * the value — unchanged all along — would false-surface as confirmed drift.
+ *
+ * So for every ignored finding whose path already has an entry in the EXISTING
+ * baseline, carry that entry forward. While the rule lives the entry is inert
+ * (`applyIgnores` runs AFTER `applyBaseline` everywhere, so ignore keeps winning — the
+ * value is never reported); when the rule dies, watching resumes against the real,
+ * preserved snapshot (a later genuine change still correctly reports "changed since
+ * record"). Only carries an EXISTING entry — a never-recorded ignored path has none to
+ * carry, and its completeness demotion (see `computeCompleteResources`) makes the
+ * un-ignore land at `unrecorded`, not false "appeared since record".
+ */
+export function carryForwardIgnored(
+  recorded: RecordedEntry[],
+  existing: BaselineFile | undefined,
+  findings: Finding[]
+): RecordedEntry[] {
+  const prior = existing?.recorded;
+  if (!prior || prior.length === 0) return recorded;
+  const ignoredKeys = new Set(
+    findings.filter((f) => f.tier === 'ignored').map((f) => recordedKey(f))
+  );
+  if (ignoredKeys.size === 0) return recorded;
+  const present = new Set(recorded.map(recordedKey));
+  const preserved = prior.filter(
+    (e) => ignoredKeys.has(recordedKey(e)) && !present.has(recordedKey(e))
+  );
   return preserved.length === 0 ? recorded : [...recorded, ...preserved];
 }
 

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -11,6 +11,7 @@ import {
   type BaselineFile,
   baselineOnlyEntries,
   buildRecorded,
+  carryForwardIgnored,
   carryForwardUnreadable,
   checkBaselineAccount,
   constructPathsByLogical,
@@ -467,7 +468,19 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
   // Seed with this run's observed entries, then carry forward any prior baseline
   // entries for resources this run could NOT read (skipped / model-read-failed) so a
   // re-record never silently shrinks the committed baseline (writeBaseline full-replaces).
-  let recorded = carryForwardUnreadable(buildRecorded(findings), existing, findings);
+  // #1078: also carry forward any prior entry for a path CURRENTLY suppressed by an
+  // ignore rule (tier `ignored` this run — the findings are `applyIgnores`'d before
+  // reaching record). buildRecorded drops ignored findings, so without this the endorsed
+  // entry would be full-replaced away, and deleting the rule later would false-surface the
+  // untouched value as confirmed "appeared since record" drift. The carried entry is inert
+  // while the rule lives (ignore wins in applyBaseline); it lets watching resume against a
+  // real snapshot once the rule is deleted. Pairs with computeCompleteResources's #1078
+  // demotion for the never-recorded variant (no prior entry to carry).
+  let recorded = carryForwardIgnored(
+    carryForwardUnreadable(buildRecorded(findings), existing, findings),
+    existing,
+    findings
+  );
   // #790: baseline entries with NO current undeclared finding for a resource read cleanly —
   // a recorded value reverted to its AWS default (folded away) or removed out of band. A naive
   // full-replace re-record would silently DROP these (accepting drift `check` force-surfaces).

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -682,11 +682,32 @@ describe('baseline', () => {
       expect(computeCompleteResources(['A'], findings, recorded)).toEqual([]);
     });
 
-    it('ignored-tier values do not block completeness (visible, deliberately ruled out)', () => {
+    it('#1078: an ignored value whose path IS recorded does not block completeness', () => {
+      // The value was carried into `recorded` (carryForwardIgnored) — an endorsed value
+      // stays complete even while an ignore rule suppresses reporting it. Preserves the
+      // intended behavior for recorded values.
       const findings: Finding[] = [
         { tier: 'ignored', logicalId: 'A', resourceType: 'T', path: 'P', actual: 1 },
       ];
-      expect(computeCompleteResources(['A'], findings, [])).toEqual(['A']);
+      const recorded = [{ logicalId: 'A', resourceType: 'T', path: 'P', value: 1 }];
+      expect(computeCompleteResources(['A'], findings, recorded)).toEqual(['A']);
+    });
+
+    it('#1078: an ignored-and-UNRECORDED value blocks completeness (un-ignore must round-trip)', () => {
+      // No recorded entry for the ignored path: marking the resource complete would treat
+      // the value as known-absent, so deleting the rule (un-ignore) would false-surface the
+      // untouched value as confirmed "appeared since record". It must stay INCOMPLETE.
+      const findings: Finding[] = [
+        { tier: 'ignored', logicalId: 'A', resourceType: 'T', path: 'P', actual: 1 },
+      ];
+      expect(computeCompleteResources(['A'], findings, [])).toEqual([]);
+    });
+
+    it('#1078: an ignored-and-unrecorded value DEMOTES a previously-complete resource', () => {
+      const findings: Finding[] = [
+        { tier: 'ignored', logicalId: 'A', resourceType: 'T', path: 'P', actual: 1 },
+      ];
+      expect(computeCompleteResources(['A'], findings, [], ['A'])).toEqual([]);
     });
 
     it('monotonic: a previously-complete resource stays complete when a new value is declined', () => {

--- a/tests/ignore-record-unignore-1078.test.ts
+++ b/tests/ignore-record-unignore-1078.test.ts
@@ -1,0 +1,228 @@
+// #1078: the ignore -> record -> un-ignore lifecycle trap.
+//
+// The documented way to RESUME watching an ignored path is to delete its rule from
+// .cdkrd/ignore.yaml. But if ANY `record` ran while the rule was live, un-ignoring
+// used to surface the (untouched) value as CONFIRMED "appeared since record" drift —
+// because `record` DROPPED the ignore-suppressed value from the snapshot yet still
+// stamped its resource snapshot-complete, treating an `ignored` value as "known-absent".
+//
+// This is fixed by TWO cooperating changes (both exercised here):
+//   (A) carryForwardIgnored — a prior recorded entry for a currently-ignored path is
+//       carried into the new baseline, so an endorsed value survives an ignore-era record.
+//   (B) computeCompleteResources — an ignored-and-UNRECORDED path blocks (and demotes)
+//       its resource's completeness, so un-ignoring a never-recorded value returns it to
+//       `unrecorded` (`[Potential Drift]`), not confirmed "appeared since record".
+//
+// Both variants (prior-entry + no-prior-entry) are driven end to end through the real
+// `recordStack` (writes a baseline to a temp path) and then read back with applyBaseline
+// simulating the ignore rule DELETED (un-ignore) — the finding re-tags to `undeclared`.
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import {
+  applyBaseline,
+  type BaselineFile,
+  baselinePath,
+  carryForwardIgnored,
+  computeCompleteResources,
+  type RecordedEntry,
+} from '../src/baseline/baseline-file.js';
+import { recordStack } from '../src/commands/stack-actions.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import type { Finding } from '../src/types.js';
+
+const RES = { logicalId: 'Res', resourceType: 'AWS::S3::Bucket', path: 'OwnershipControls' };
+
+// An `undeclared` finding: the live value cdkrd sees for the churning path.
+const undeclaredFinding = (actual: unknown): Finding => ({ tier: 'undeclared', ...RES, actual });
+// The SAME finding after `applyIgnores` re-tags it (record.ts / interactive-resolve.ts
+// run applyIgnores BEFORE recordStack): tier `ignored`, `unrecorded` cleared, a note.
+const ignoredFinding = (actual: unknown): Finding => ({
+  tier: 'ignored',
+  ...RES,
+  actual,
+  note: 'ignored by config rule "Res.OwnershipControls"',
+});
+
+// -------------------------------------------------------------------------------------------
+// (A) carryForwardIgnored — unit
+// -------------------------------------------------------------------------------------------
+describe('carryForwardIgnored (#1078 — preserve an endorsed entry across an ignore-era record)', () => {
+  const priorEntry: RecordedEntry = { ...RES, value: 'V' };
+  const b = (recorded: RecordedEntry[]): BaselineFile => ({
+    schemaVersion: 2,
+    stackName: 's',
+    region: 'r',
+    accountId: '111122223333',
+    capturedAt: '',
+    templateHash: '',
+    recorded,
+    completeResources: ['Res'],
+  });
+
+  it('carries a prior recorded entry forward when its path is ignored this run', () => {
+    // buildRecorded([ignored]) === [] (ignored tier is excluded), so without the carry the
+    // full-replace write would prune the endorsed entry.
+    const out = carryForwardIgnored([], b([priorEntry]), [ignoredFinding('V')]);
+    expect(out).toEqual([priorEntry]);
+  });
+
+  it('does NOT duplicate an entry already present in the recorded set', () => {
+    const out = carryForwardIgnored([priorEntry], b([priorEntry]), [ignoredFinding('V')]);
+    expect(out).toEqual([priorEntry]);
+  });
+
+  it('carries NOTHING when the ignored path has no prior entry (nothing to preserve)', () => {
+    // The no-prior-entry variant: completeness demotion (test below) handles it instead.
+    expect(carryForwardIgnored([], b([]), [ignoredFinding('V')])).toEqual([]);
+  });
+
+  it('is a no-op when nothing is ignored this run', () => {
+    const other: Finding = { tier: 'undeclared', ...RES, actual: 'V' };
+    expect(carryForwardIgnored([], b([priorEntry]), [other])).toEqual([]);
+  });
+
+  it('is a no-op with no existing baseline', () => {
+    expect(carryForwardIgnored([], undefined, [ignoredFinding('V')])).toEqual([]);
+  });
+});
+
+// -------------------------------------------------------------------------------------------
+// (B) computeCompleteResources — unit
+// -------------------------------------------------------------------------------------------
+describe('computeCompleteResources (#1078 — an ignored-and-unrecorded path blocks/demotes completeness)', () => {
+  it('does NOT mark a resource complete when an ignored value is absent from the recorded set', () => {
+    const complete = computeCompleteResources(['Res'], [ignoredFinding('V')], []);
+    expect(complete).toEqual([]);
+  });
+
+  it('DEMOTES a previously-complete resource for an ignored-and-unrecorded path (overrides monotonicity)', () => {
+    // Res was complete before; the ignore rule now suppresses its only value from the
+    // snapshot. It must NOT stay complete, else un-ignoring lands false "appeared".
+    const complete = computeCompleteResources(['Res'], [ignoredFinding('V')], [], ['Res']);
+    expect(complete).toEqual([]);
+  });
+
+  it('KEEPS a resource complete when the ignored path IS in the recorded set (carried forward)', () => {
+    // With (A), an endorsed value is carried into `recorded`, so its path is present and the
+    // resource legitimately stays complete — ignored values do not block completeness for
+    // values that ARE recorded (the intended pre-#1078 behavior, preserved).
+    const recorded: RecordedEntry[] = [{ ...RES, value: 'V' }];
+    const complete = computeCompleteResources(['Res'], [ignoredFinding('V')], recorded, ['Res']);
+    expect(complete).toEqual(['Res']);
+  });
+
+  it('still marks a clean resource complete when nothing is ignored', () => {
+    expect(computeCompleteResources(['Res'], [], [])).toEqual(['Res']);
+  });
+});
+
+// -------------------------------------------------------------------------------------------
+// Full lifecycle through recordStack (writes a real baseline file), both variants
+// -------------------------------------------------------------------------------------------
+describe('ignore -> record -> un-ignore lifecycle (#1078 — untouched value must NOT become confirmed drift)', () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths.splice(0)) if (existsSync(p)) rmSync(p);
+  });
+
+  function makeDesired(): Desired {
+    return {
+      stackName: 'Unignore1078',
+      region: 'ui-1078-region',
+      accountId: '999988887777',
+      resources: [{ logicalId: 'Res', resourceType: 'AWS::S3::Bucket', declared: {} }],
+      rawTemplate: '{}',
+      ctx: {},
+    } as unknown as Desired;
+  }
+
+  function seedBaseline(desired: Desired, recorded: RecordedEntry[], complete: string[]): string {
+    const p = baselinePath(desired.stackName, desired.accountId, desired.region);
+    mkdirSync(dirname(p), { recursive: true });
+    const b: BaselineFile = {
+      schemaVersion: 2,
+      stackName: desired.stackName,
+      region: desired.region,
+      accountId: desired.accountId,
+      capturedAt: '',
+      templateHash: '',
+      recorded,
+      completeResources: complete,
+    };
+    writeFileSync(p, JSON.stringify(b), 'utf8');
+    paths.push(p);
+    return p;
+  }
+
+  async function recordWithIgnored(desired: Desired): Promise<BaselineFile> {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // record.ts / interactive-resolve.ts applyIgnores the findings BEFORE recordStack, so
+      // the churning path arrives tier `ignored`.
+      const res = await recordStack({
+        stackName: desired.stackName,
+        region: desired.region,
+        desired,
+        findings: [ignoredFinding('V')],
+        yes: true,
+        interactive: false,
+      });
+      expect(res.wrote).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+    const p = baselinePath(desired.stackName, desired.accountId, desired.region);
+    return JSON.parse(readFileSync(p, 'utf8')) as BaselineFile;
+  }
+
+  it('variant 1 (prior entry): the endorsed entry SURVIVES the ignore-era record and un-ignore suppresses it (unchanged)', async () => {
+    const desired = makeDesired();
+    // Step 1-2: recorded { Res.OwnershipControls: V }, resource complete; then ignored.
+    seedBaseline(desired, [{ ...RES, value: 'V' }], ['Res']);
+
+    // Step 3: a `record` runs while the rule is live.
+    const written = await recordWithIgnored(desired);
+
+    // (A) the endorsed entry is NOT pruned — it is carried forward.
+    expect(written.recorded).toEqual([{ ...RES, value: 'V' }]);
+
+    // Step 4-5: the user deletes the ignore rule; the live value is UNCHANGED. The finding is
+    // now plain `undeclared` again (no ignore re-tag). applyBaseline must SUPPRESS it (matches
+    // the carried entry), never surface it as confirmed "appeared since record" drift.
+    const out = applyBaseline([undeclaredFinding('V')], written, { allLogicalIds: ['Res'] });
+    expect(out).toHaveLength(0);
+  });
+
+  it('variant 2 (no prior entry): un-ignore returns the untouched value to `unrecorded`, not confirmed "appeared since record"', async () => {
+    const desired = makeDesired();
+    // Step 2 (no prior record): the value was ignored before ever being recorded. Seed a
+    // baseline that exists but has NO entry for Res and does NOT list Res complete.
+    seedBaseline(desired, [], []);
+
+    // Step 3: a `record` runs while the rule is live.
+    const written = await recordWithIgnored(desired);
+
+    // (B) the resource is NOT stamped complete over the ignored-and-unrecorded path.
+    expect(written.completeResources ?? []).not.toContain('Res');
+    expect(written.recorded).toEqual([]);
+
+    // Step 4-5: delete the rule; the live value is unchanged. With Res incomplete, an
+    // entry-less undeclared value is `unrecorded` (`[Potential Drift]`), NOT confirmed drift.
+    const out = applyBaseline([undeclaredFinding('V')], written, { allLogicalIds: ['Res'] });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.tier).toBe('undeclared');
+    expect(out[0]?.unrecorded).toBe(true);
+    expect(out[0]?.note ?? '').not.toContain('appeared since record');
+  });
+
+  it('regression: after un-ignore, a GENUINE later change to a carried (variant-1) value still surfaces as drift', async () => {
+    const desired = makeDesired();
+    seedBaseline(desired, [{ ...RES, value: 'V' }], ['Res']);
+    const written = await recordWithIgnored(desired);
+    // rule deleted, and the value CHANGED out of band from V to V2 → real drift.
+    const out = applyBaseline([undeclaredFinding('V2')], written, { allLogicalIds: ['Res'] });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'undeclared', desired: 'V', actual: 'V2' });
+  });
+});


### PR DESCRIPTION
Closes #1078. carryForwardIgnored preserves an endorsed entry through an ignore-era record (variant 1); computeCompleteResources stops stamping a never-recorded ignored path complete so un-ignore returns it to unrecorded (variant 2). Both-variant + regression tests. See commit body.