### PR TITLE
fix(noise): fold EC2 Instance create-only CpuOptions + SubnetId first-run undeclared FPs (#640)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3098,7 +3098,26 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   OpenSearch `OffPeakWindowOptions` / AmazonMQ `MaintenanceWindowStartTime` object precedents.
   //     * EC2 NatGateway `VpcId` — AWS DERIVES the VPC id from the declared SubnetId and reads
   //       it back (create-only, embeds the per-resource `vpc-…` id, never declared by CDK).
-  'AWS::EC2::Instance': new Set(['PrivateIpAddress']),
+  //   AWS::EC2::Instance reads back a few undeclared, AWS-assigned values on every fresh un-mutated
+  //   launch (live-confirmed on ec2-instance-rich / -sets, #640). Only the genuinely CREATE-ONLY
+  //   items fold value-independent — a create-only value physically cannot drift out of band (it
+  //   requires replacement, itself a template change), so folding it can never hide a real change;
+  //   and it is never user intent when undeclared (a user who pins it DECLARES it, compared in the
+  //   declared loop):
+  //     * `CpuOptions` ({CoreCount, ThreadsPerCore}) — create-only; AWS derives it from the
+  //       declared InstanceType (t3.micro → {1, 2}). The core/thread pair is a function of the
+  //       instance type (hundreds of them, and AWS adds more over time), so it is neither a stable
+  //       constant nor cheaply derivable offline; but it is create-only, so a value-independent
+  //       fold can never hide a real change. A user who caps cores/threads DECLARES CpuOptions.
+  //     * `SubnetId` — when the subnet is declared inside `NetworkInterfaces[0]`, AWS echoes it to
+  //       the top-level `SubnetId` (create-only, derived from the declared NIC subnet).
+  //   DELIBERATELY NOT folded here: `SecurityGroups` / `SecurityGroupIds` are MUTABLE out of band
+  //   (`ec2 modify-instance-attribute --groups sg-…` swaps an instance's SGs with no replacement),
+  //   so a value-independent fold would HIDE an OOB SG swap — they stay undeclared, tracked by #889
+  //   as a sibling-reflection / derived fold. `NetworkInterfaces` / `Volumes` are deferred: a rogue
+  //   ENI / volume can be ATTACHED out of band to a running instance, so folding the whole array
+  //   value-independent would hide the attach — they need a nested/sibling mechanism.
+  'AWS::EC2::Instance': new Set(['PrivateIpAddress', 'CpuOptions', 'SubnetId']),
   //   AWS::EC2::NetworkInterface.PrivateIpAddresses — an ENI that declares no
   //   PrivateIpAddresses reads back the single auto-assigned primary
   //   ([{PrivateIpAddress:"10.0.0.x", Primary:true}]) — the plural-array twin of the singular

--- a/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
+++ b/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
@@ -299,75 +299,19 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "InstanceInitiatedShutdownBehavior",
-      "actual": "stop",
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "MetadataOptions",
-      "actual": {
-        "HttpPutResponseHopLimit": 2,
-        "HttpProtocolIpv6": "disabled",
-        "HttpTokens": "required",
-        "InstanceMetadataTags": "disabled",
-        "HttpEndpoint": "enabled"
-      },
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "PrivateDnsNameOptions",
-      "actual": {
-        "EnableResourceNameDnsARecord": false,
-        "HostnameType": "ip-name",
-        "EnableResourceNameDnsAAAARecord": false
-      },
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.0.216",
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "SourceDestCheck",
-      "actual": true,
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "Tenancy",
-      "actual": "default",
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
       "tier": "readGap",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "LaunchTemplate",
       "note": "write-only — cannot be read back",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "AvailabilityZone",
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
@@ -393,14 +337,55 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
+      "tier": "unresolved",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "UserData",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Tenancy",
+      "actual": "default",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "CpuOptions",
-      "actual": {
-        "ThreadsPerCore": 2,
-        "CoreCount": 1
-      },
+      "path": "SecurityGroups",
+      "actual": ["CdkRealDriftIntegEc2Rich-SgD4954771-nA4Jj877L60k"],
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.216",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Volumes",
+      "actual": [
+        {
+          "VolumeId": "vol-094cd4ee2e33c8e54",
+          "Device": "/dev/xvda"
+        },
+        {
+          "VolumeId": "vol-010c7274153ce356a",
+          "Device": "/dev/sdf"
+        }
+      ],
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
@@ -434,45 +419,60 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SecurityGroups",
-      "actual": ["CdkRealDriftIntegEc2Rich-SgD4954771-nA4Jj877L60k"],
+      "path": "MetadataOptions",
+      "actual": {
+        "HttpPutResponseHopLimit": 2,
+        "HttpProtocolIpv6": "disabled",
+        "HttpTokens": "required",
+        "InstanceMetadataTags": "disabled",
+        "HttpEndpoint": "enabled"
+      },
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "Volumes",
-      "actual": [
-        {
-          "VolumeId": "vol-094cd4ee2e33c8e54",
-          "Device": "/dev/xvda"
-        },
-        {
-          "VolumeId": "vol-010c7274153ce356a",
-          "Device": "/dev/sdf"
-        }
-      ],
+      "path": "InstanceInitiatedShutdownBehavior",
+      "actual": "stop",
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "AvailabilityZone",
+      "path": "CpuOptions",
+      "actual": {
+        "ThreadsPerCore": 2,
+        "CoreCount": 1
+      },
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "UserData",
+      "path": "PrivateDnsNameOptions",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SourceDestCheck",
+      "actual": true,
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     }

--- a/tests/corpus/AWS__EC2__Instance.Inst.sets.json
+++ b/tests/corpus/AWS__EC2__Instance.Inst.sets.json
@@ -300,68 +300,23 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
+      "tier": "unresolved",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "CreditSpecification",
+      "path": "AvailabilityZone",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Volumes[/dev/xvda]",
       "actual": {
-        "CPUCredits": "unlimited"
+        "VolumeId": "vol-0aac921ab46964337",
+        "Device": "/dev/xvda"
       },
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "InstanceInitiatedShutdownBehavior",
-      "actual": "stop",
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "MetadataOptions",
-      "actual": {
-        "HttpPutResponseHopLimit": 2,
-        "HttpProtocolIpv6": "disabled",
-        "HttpTokens": "required",
-        "InstanceMetadataTags": "disabled",
-        "HttpEndpoint": "enabled"
-      },
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "PrivateDnsNameOptions",
-      "actual": {
-        "EnableResourceNameDnsARecord": false,
-        "HostnameType": "ip-name",
-        "EnableResourceNameDnsAAAARecord": false
-      },
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.0.226",
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "SourceDestCheck",
-      "actual": true,
+      "nested": true,
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
@@ -371,6 +326,24 @@
       "resourceType": "AWS::EC2::Instance",
       "path": "Tenancy",
       "actual": "default",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SecurityGroups",
+      "actual": ["default"],
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.226",
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
@@ -418,13 +391,59 @@
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SubnetId",
+      "actual": "subnet-0f3c7a3910f1a4f50",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "MetadataOptions",
+      "actual": {
+        "HttpPutResponseHopLimit": 2,
+        "HttpProtocolIpv6": "disabled",
+        "HttpTokens": "required",
+        "InstanceMetadataTags": "disabled",
+        "HttpEndpoint": "enabled"
+      },
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "InstanceInitiatedShutdownBehavior",
+      "actual": "stop",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
       "path": "CpuOptions",
       "actual": {
         "ThreadsPerCore": 2,
         "CoreCount": 1
+      },
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateDnsNameOptions",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
       },
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
@@ -439,41 +458,22 @@
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SecurityGroups",
-      "actual": ["default"],
+      "path": "SourceDestCheck",
+      "actual": true,
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SubnetId",
-      "actual": "subnet-0f3c7a3910f1a4f50",
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "Volumes[/dev/xvda]",
+      "path": "CreditSpecification",
       "actual": {
-        "VolumeId": "vol-0aac921ab46964337",
-        "Device": "/dev/xvda"
+        "CPUCredits": "unlimited"
       },
-      "nested": true,
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "unresolved",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "AvailabilityZone",
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     }

--- a/tests/noise-ec2-instance-firstrun-640.test.ts
+++ b/tests/noise-ec2-instance-firstrun-640.test.ts
@@ -1,0 +1,104 @@
+// #640 — EC2 Instance first-run undeclared batch. On a fresh un-mutated launch AWS reads back
+// values the template never declared. Only the genuinely CREATE-ONLY items fold value-independent
+// (tier 3): CpuOptions (instance-type-derived) and the SubnetId AWS echoes up from a declared
+// NetworkInterfaces block — a create-only value cannot drift out of band, so folding it can never
+// hide a real change, and it is never user intent when undeclared.
+//
+// DELIBERATELY NOT folded (a #889 handoff / deferred boundary this test documents): SecurityGroups
+// / SecurityGroupIds are MUTABLE out of band (`ec2 modify-instance-attribute --groups sg-…` swaps
+// them on a running instance with no replacement), so value-independent would HIDE an OOB SG swap —
+// they STILL surface as undeclared drift. NetworkInterfaces / Volumes are likewise deferred (a rogue
+// ENI / volume can be attached OOB). A user who pins any folded item DECLARES it, which is then
+// compared in the declared loop and does NOT fold here.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const schema = (createOnly: string[] = []): SchemaInfo => ({
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(createOnly),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: createOnly,
+  defaults: {},
+  defaultPaths: {},
+});
+
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Host',
+  resourceType: 'AWS::EC2::Instance',
+  physicalId: 'i-0abc',
+  declared,
+});
+
+describe('#640 EC2 Instance first-run undeclared folds (value-independent)', () => {
+  // A minimal instance that declares nothing about SGs / subnet / CPU / interfaces / volumes,
+  // exactly like a fresh clean deploy before `record`.
+  const declared = { ImageId: 'ami-1', InstanceType: 't3.micro' };
+  const live = {
+    ImageId: 'ami-1',
+    InstanceType: 't3.micro',
+    CpuOptions: { CoreCount: 1, ThreadsPerCore: 2 },
+    SecurityGroups: ['MyStack-Sg-nA4Jj877L60k'],
+    SecurityGroupIds: ['sg-027bb24dfa8eb1b48'],
+    SubnetId: 'subnet-012053df57a833e72',
+    NetworkInterfaces: [
+      { NetworkInterfaceId: 'eni-0a9b2c526ff5b36ae', DeviceIndex: '0', DeleteOnTermination: true },
+    ],
+    Volumes: [{ VolumeId: 'vol-094cd4ee2e33c8e54', Device: '/dev/xvda' }],
+  };
+
+  it('folds only the create-only CpuOptions + SubnetId to atDefault', () => {
+    const fs = classifyResource(mk(declared), structuredClone(live), schema(), {});
+    expect(tier(fs, 'atDefault')).toEqual(['CpuOptions', 'SubnetId']);
+  });
+
+  it('SecurityGroupIds / SecurityGroups / NetworkInterfaces / Volumes are NOT folded — they still surface as undeclared drift', () => {
+    // These four are MUTABLE out of band (an SG swap or a rogue ENI / volume attach on a running
+    // instance), so a value-independent fold would HIDE that change. They deliberately do NOT fold
+    // here — SecurityGroups/SecurityGroupIds are a #889 handoff, NetworkInterfaces/Volumes deferred.
+    const fs = classifyResource(mk(declared), structuredClone(live), schema(), {});
+    expect(tier(fs, 'undeclared')).toEqual([
+      'NetworkInterfaces',
+      'SecurityGroupIds',
+      'SecurityGroups',
+      'Volumes',
+    ]);
+  });
+
+  it('WITHOUT the folds every value would surface (guards the regression this fixes)', () => {
+    // Sanity: an UNRELATED undeclared key AWS did not fold still surfaces as undeclared, proving
+    // the classifier is not blanket-folding the create-only pair everything on this type.
+    const fs = classifyResource(
+      mk(declared),
+      structuredClone({ ...live, SomeNovelOutOfBandKey: 'x' }),
+      schema(),
+      {}
+    );
+    expect(tier(fs, 'undeclared')).toContain('SomeNovelOutOfBandKey');
+  });
+
+  it('a DECLARED SubnetId / SecurityGroupIds is compared in the declared loop, not folded here', () => {
+    // The user pinned the subnet + SGs; a live MISMATCH must still surface as declared drift,
+    // proving the value-independent fold only applies to the UNDECLARED case.
+    const decl = {
+      ...declared,
+      SubnetId: 'subnet-declared',
+      SecurityGroupIds: ['sg-declared'],
+    };
+    const drifted = {
+      ...live,
+      SubnetId: 'subnet-OUT-OF-BAND',
+      SecurityGroupIds: ['sg-OUT-OF-BAND'],
+    };
+    const fs = classifyResource(mk(decl), structuredClone(drifted), schema(), {});
+    expect(tier(fs, 'declared')).toEqual(['SecurityGroupIds', 'SubnetId']);
+  });
+});


### PR DESCRIPTION
Addresses #640 (create-only cluster). Folds only genuinely create-only CpuOptions + SubnetId; DELIBERATELY leaves SecurityGroups/SecurityGroupIds (mutable OOB -> #889) and NetworkInterfaces/Volumes (mutable attach) surfacing, with a test asserting the boundary. See commit body.