### PR TITLE
fix(noise): tolerate AWS::Cognito::UserPool.EnabledMfas reorder (#1093)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -4541,6 +4541,19 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   'AWS::CloudFront::Distribution': new Set([
     'DistributionConfig.Restrictions.GeoRestriction.Locations',
   ]),
+  // #1093: Cognito does NOT store a UserPool's EnabledMfas as a list — SetUserPoolMfaConfig
+  // takes per-method config objects (SmsMfaConfiguration / SoftwareTokenMfaConfiguration /
+  // EmailMfaConfiguration) and the read handler RECONSTRUCTS the EnabledMfas list in its own
+  // canonical order, so template order cannot round-trip: a clean UserPool declaring
+  // EnabledMfas ["SOFTWARE_TOKEN_MFA","SMS_MFA"] reads back ["SMS_MFA","SOFTWARE_TOKEN_MFA"],
+  // a false declared-tier drift with identical elements. The registry schema marks EnabledMfas
+  // insertionOrder:None so neither the schema fold nor the uniqueItems heuristic catches it.
+  // Set-semantic (each MFA method is present-or-not), so a positional compare false-drifts the
+  // identical method set; a genuine method add/remove still changes the multiset. Same set-
+  // reorder class as the sibling UserPoolClient lists below (#875). NOTE: scoped STRICTLY to
+  // EnabledMfas — UsernameAttributes / AutoVerifiedAttributes / AliasAttributes are genuine
+  // stored-list create-params that were live-proven ORDER-PRESERVING and are NOT folded.
+  'AWS::Cognito::UserPool': new Set(['EnabledMfas']),
   'AWS::Cognito::UserPoolClient': new Set([
     'AllowedOAuthFlows',
     'AllowedOAuthScopes',

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1700,6 +1700,37 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       }
     });
 
+    // #1093: Cognito reconstructs a UserPool's EnabledMfas list in its own canonical order
+    // (SetUserPoolMfaConfig takes per-method config objects, not a list) — declared
+    // ["SOFTWARE_TOKEN_MFA","SMS_MFA"] reads back ["SMS_MFA","SOFTWARE_TOKEN_MFA"], a false
+    // declared-tier drift. Set-semantic; a genuine method add/remove still changes the multiset.
+    it('UNORDERED_ARRAY_PROPS: Cognito UserPool EnabledMfas reorder is NOT drift (#1093)', () => {
+      const pool = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Pool',
+        resourceType: 'AWS::Cognito::UserPool',
+        physicalId: 'us-east-1_abc123',
+        declared,
+      });
+      // same MFA-method set, echoed in the service's canonical order -> no drift
+      expect(
+        classifyResource(
+          pool({ EnabledMfas: ['SOFTWARE_TOKEN_MFA', 'SMS_MFA'] }),
+          { EnabledMfas: ['SMS_MFA', 'SOFTWARE_TOKEN_MFA'] },
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine added MFA method still changes the multiset -> reports declared drift
+      expect(
+        tiers(
+          classifyResource(
+            pool({ EnabledMfas: ['SMS_MFA'] }),
+            { EnabledMfas: ['SMS_MFA', 'SOFTWARE_TOKEN_MFA'] },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['EnabledMfas']);
+    });
+
     it('UNORDERED_ARRAY_PROPS: WAFv2 IPSet Addresses in a different order is NOT drift (R84)', () => {
       const ipset = (declared: Record<string, unknown>): DesiredResource => ({
         logicalId: 'IpSet',


### PR DESCRIPTION
Closes #1093. Adds EnabledMfas to UNORDERED_ARRAY_PROPS (multiset compare) so the service's reconstructed order is not a false declared drift; a real added/removed method still surfaces. Scoped to EnabledMfas only. See commit body.