### PR TITLE
fix(read): use the CFn physical-id form for the Events::Rule sibling-stack check (#895)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -179,7 +179,12 @@ export async function isManagedBySiblingStack(
   c: AddedChild,
   cache: Map<string, SiblingCheck>
 ): Promise<SiblingCheck> {
-  const physicalId = c.identifier;
+  // The sibling-stack lookup uses the CloudFormation PHYSICAL-ID form, which for most child
+  // types IS the CC primaryIdentifier (`identifier`); it diverges only where CC's identifier
+  // is not the CFn physical id — e.g. AWS::Events::Rule, whose CC identifier is the rule Arn
+  // but whose CFn physical id is `<busName>|<ruleName>` for a custom-bus rule (#895). The
+  // enumerator carries that form on `siblingLookupId` (defaulting to `identifier`).
+  const physicalId = c.siblingLookupId ?? c.identifier;
   // Pipe-composite CC identifiers (`RestApiId|…`, `UserPoolId|…`) are not CloudFormation
   // physical resource ids — they belong to within-stack API Gateway / Cognito sub-resources
   // outside this cross-stack class, so never spend a call on them. Bare ids that are ARNs
@@ -187,7 +192,12 @@ export async function isManagedBySiblingStack(
   // `:` and ARE the class, so `:` is NOT a composite marker here; the lone `:`-joined
   // composite (API Gateway GatewayResponse `RestApiId:ResponseType`) simply fails the
   // DescribeStackResources lookup and falls through to "report as added" (fail open).
-  if (physicalId.includes('|')) return 'notManaged';
+  // NOTE: an Events::Rule custom-bus `siblingLookupId` (`<busName>|<ruleName>`) IS a valid
+  // CFn physical id despite the `|`; it is set explicitly so it is NOT a CC composite —
+  // hence the `|` guard would wrongly skip it. The guard therefore only applies to the CC
+  // `identifier` composites, which never set `siblingLookupId`, so it stays correct: a rule
+  // whose lookup id contains `|` still runs the DescribeStackResources check below.
+  if (c.siblingLookupId === undefined && physicalId.includes('|')) return 'notManaged';
   const cached = cache.get(physicalId);
   if (cached !== undefined) return cached;
   let managed = false;

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -156,6 +156,15 @@ export interface AddedChild {
   identifier: string; // CC primaryIdentifier — feeds GetResource / DeleteResource (revert)
   label: string; // human display (e.g. 'ANY /', '/widgets')
   live: Record<string, unknown>; // live model snippet, for the report `actual`
+  // The CloudFormation PHYSICAL-ID form used ONLY by the sibling-stack membership check
+  // (DescribeStackResources). It usually EQUALS `identifier` (the CC primaryIdentifier IS
+  // the CFn physical id for the cross-stack class), so it is optional and defaults to
+  // `identifier`. It diverges when CC's identifier is NOT the CFn physical id — e.g.
+  // AWS::Events::Rule: CC uses the bare rule Arn, but CFn stores `<busName>|<ruleName>`
+  // for a custom-bus rule (bare `<ruleName>` on the default bus), so the ARN lookup always
+  // misses and a sibling-managed rule is falsely reported `added` (#895). Only the sibling
+  // lookup id changes; the CC read / DeleteResource path still uses `identifier`.
+  siblingLookupId?: string | undefined;
 }
 
 export interface EnumeratorContext {
@@ -1365,6 +1374,8 @@ export async function enumerateLambdaFunctionChildren(
 
 // Pure diff: declared rule names + live inventory -> the added rules.
 export interface EventBusChildInput {
+  busName: string; // the live bus name (a custom-bus rule's CFn physical id is `<busName>|<ruleName>`)
+  isDefaultBus: boolean; // the AWS-default bus stores the bare `<ruleName>` (no bus prefix)
   declaredRuleNames: string[]; // bare Names of AWS::Events::Rule declared on this bus
   liveRules: { name: string; arn: string; label?: string | undefined }[];
 }
@@ -1374,11 +1385,16 @@ export function diffEventBusChildren(input: EventBusChildInput): AddedChild[] {
   const added: AddedChild[] = [];
   for (const r of input.liveRules) {
     if (declared.has(r.name)) continue;
+    // The CFn physical id for the sibling-stack lookup (#895): the bare rule name on the
+    // AWS-default bus, the `<busName>|<ruleName>` composite on a custom bus. The CC
+    // `identifier` stays the Arn (that is what GetResource / DeleteResource consume).
+    const siblingLookupId = input.isDefaultBus ? r.name : `${input.busName}|${r.name}`;
     added.push({
       resourceType: 'AWS::Events::Rule',
       identifier: r.arn, // the rule Arn IS the CC primaryIdentifier
       label: r.label ?? r.name,
       live: { Name: r.name, Arn: r.arn },
+      siblingLookupId,
     });
   }
   return added;
@@ -1426,7 +1442,13 @@ async function enumerateEventBusChildren(ctx: EnumeratorContext): Promise<AddedC
     )
     .map((r) => ({ name: r.Name, arn: r.Arn, label: r.Name }));
 
-  return diffEventBusChildren({ declaredRuleNames, liveRules });
+  // CFn stores a rule's physical id as `<busName>|<ruleName>` on a custom bus, but the bare
+  // `<ruleName>` on the AWS-default bus (whose name is the literal `default`). Only declared
+  // custom buses are scanned here, so `busName` is virtually never `default`; handle both so
+  // the sibling-stack lookup id matches CFn's physical id regardless (#895).
+  const isDefaultBus = busName === 'default';
+
+  return diffEventBusChildren({ busName, isDefaultBus, declaredRuleNames, liveRules });
 }
 
 // ── Cognito ──────────────────────────────────────────────────────────────────

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -920,6 +920,8 @@ describe('diffEventBusChildren (EventBridge rules)', () => {
 
   it('flags an out-of-band rule (not in the template)', () => {
     const added = diffEventBusChildren({
+      busName: 'MyBus',
+      isDefaultBus: false,
       declaredRuleNames: ['declared'],
       liveRules: [
         { name: 'declared', arn: R('declared') },
@@ -932,21 +934,50 @@ describe('diffEventBusChildren (EventBridge rules)', () => {
         identifier: R('console'),
         label: 'console',
         live: { Name: 'console', Arn: R('console') },
+        // #895: the CFn physical id for the sibling-stack lookup — `<busName>|<ruleName>` for a custom bus
+        siblingLookupId: 'MyBus|console',
       },
     ]);
   });
 
   it('identifier is the bare rule Arn (CC primaryIdentifier)', () => {
     const added = diffEventBusChildren({
+      busName: 'MyBus',
+      isDefaultBus: false,
       declaredRuleNames: [],
       liveRules: [{ name: 'x', arn: R('x') }],
     });
     expect(added[0]!.identifier).toBe(R('x'));
   });
 
+  it('#895: siblingLookupId is the `<busName>|<ruleName>` CFn physical id for a custom bus', () => {
+    const added = diffEventBusChildren({
+      busName: 'MyBus',
+      isDefaultBus: false,
+      declaredRuleNames: [],
+      liveRules: [{ name: 'oob', arn: R('oob') }],
+    });
+    expect(added[0]!.siblingLookupId).toBe('MyBus|oob');
+    // the CC identifier stays the Arn (GetResource / DeleteResource path unchanged)
+    expect(added[0]!.identifier).toBe(R('oob'));
+  });
+
+  it('#895: siblingLookupId is the bare rule name for the AWS-default bus', () => {
+    const added = diffEventBusChildren({
+      busName: 'default',
+      isDefaultBus: true,
+      declaredRuleNames: [],
+      liveRules: [{ name: 'oob', arn: R('oob') }],
+    });
+    expect(added[0]!.siblingLookupId).toBe('oob');
+    expect(added[0]!.identifier).toBe(R('oob'));
+  });
+
   it('no drift when every live rule is declared', () => {
     expect(
       diffEventBusChildren({
+        busName: 'MyBus',
+        isDefaultBus: false,
         declaredRuleNames: ['a', 'b'],
         liveRules: [
           { name: 'a', arn: R('a') },

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -1157,6 +1157,76 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(0);
   });
 
+  // #895: AWS::Events::Rule's CC identifier is the rule Arn, but its CFn physical id for a
+  // rule on a CUSTOM bus is `<busName>|<ruleName>`. The enumerator carries that CFn form on
+  // `siblingLookupId`, so the sibling-stack check must look up THAT (not the Arn), or a
+  // sibling-managed rule is false-flagged `added` with a destructive DeleteResource offer.
+  const ruleArn = 'arn:aws:events:us-east-1:111122223333:rule/MyBus/MyRule';
+  const rulePhysicalId = 'MyBus|MyRule'; // CFn physical id for a custom-bus rule
+
+  it('#895: folds a custom-bus Events::Rule a SIBLING stack manages (looks up busName|ruleName, not the Arn)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // CFn only knows the rule by its `<busName>|<ruleName>` physical id — an Arn lookup would miss.
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      if (input.PhysicalResourceId === rulePhysicalId) {
+        return {
+          StackResources: [
+            {
+              StackName: 'SiblingStack',
+              LogicalResourceId: 'MyRule',
+              PhysicalResourceId: rulePhysicalId,
+              ResourceType: 'AWS::Events::Rule',
+              Timestamp: new Date(0),
+              ResourceStatus: 'CREATE_COMPLETE',
+            },
+          ],
+        };
+      }
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    const rule: AddedChild = {
+      resourceType: 'AWS::Events::Rule',
+      identifier: ruleArn,
+      label: 'MyRule',
+      live: {},
+      siblingLookupId: rulePhysicalId,
+    };
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      rule,
+      new Map()
+    );
+    expect(managed).toBe('managed');
+    // it looked up the CFn physical-id form, NOT the CC Arn
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)[0]!.args[0].input).toMatchObject({
+      PhysicalResourceId: rulePhysicalId,
+    });
+  });
+
+  it('#895: still reports a genuinely out-of-band custom-bus Events::Rule as added (no owning stack)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    const notFound = new Error(`Stack for ${rulePhysicalId} does not exist`);
+    notFound.name = 'ValidationError';
+    cfn.on(DescribeStackResourcesCommand).rejects(notFound);
+    const rule: AddedChild = {
+      resourceType: 'AWS::Events::Rule',
+      identifier: ruleArn,
+      label: 'MyRule',
+      live: {},
+      siblingLookupId: rulePhysicalId,
+    };
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      rule,
+      new Map()
+    );
+    expect(managed).toBe('notManaged');
+    // the composite-looking `|` lookup id was NOT short-circuited by the pipe guard: it queried CFn
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
+  });
+
   it('memoizes the resolution per physical id (one API call for a repeated child)', async () => {
     const cfn = mockClient(CloudFormationClient);
     cfn.on(DescribeStackResourcesCommand).resolves({


### PR DESCRIPTION
Closes #895. Threads a siblingLookupId (`busName|ruleName` custom / bare name default) so a cross-stack rule is not falsely 'added' with a DeleteResource offer; CC read/delete still uses the ARN. Composes for #800. Unit-tested both directions. See commit body.