### PR TITLE
fix(revert): per-finding revert of a subset must not write unselected/skipped findings back to AWS (#756)

### DIFF
--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -587,11 +587,23 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
       region: p.region,
       gathered: {
         desired: p.desired,
-        findings: p.findings.filter((f) => revertKeys.has(keyOf(f))),
+        // #756: pass the UNFILTERED findings so revertStack's applyBaseline reconciliation
+        // (currentPaths / skippedLogical / deletedLogical / underDeclaredDrift) sees the
+        // full live reality — a recorded entry whose healthy, matching live finding the user
+        // simply did NOT pick must NOT look "removed since record" and synthesize a phantom
+        // restore op. The chosen subset is instead threaded via selectedFindingKeys below,
+        // which narrows the PLAN to exactly these findings. (Was
+        // `p.findings.filter(revertKeys)` here, which starved applyBaseline and made every
+        // unpicked/skipped/ignored recorded entry synthesize an unintended AWS write.)
+        findings: p.findings,
         schemas: p.schemas,
         liveByLogical: p.liveByLogical,
       },
       baseline: p.baseline,
+      // #756: restrict the plan to the findings the action picker assigned `revert` — the
+      // AWS writes then correspond EXACTLY to reverting those, with no restore op for a
+      // skipped/ignored/unpicked recorded entry and no same-value churn.
+      selectedFindingKeys: revertKeys,
       config: p.config,
       dryRun: false,
       // NEVER inherit --yes (see revertAll): the read-only `check` verb must still

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -64,6 +64,13 @@ const driftCount = (findings: Finding[]): number => findings.filter(isDrift).len
 const unrecordedCount = (findings: Finding[]): number =>
   findings.filter((f) => f.unrecorded === true).length;
 
+// #756: identity of a single reconciled finding, used to restrict a per-finding revert's
+// plan to exactly the findings the user picked. MUST match interactive-resolve.ts's
+// exported keyOf (same logicalId + path + attributeKey shape) — that is the format the
+// caller passes in `selectedFindingKeys`.
+const findingKeyOf = (f: Finding): string =>
+  `${f.logicalId}::${f.path}${f.attributeKey !== undefined ? `[${f.attributeKey}]` : ''}`;
+
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 /**
@@ -952,6 +959,16 @@ export interface RevertStackParams {
   // and reverts every op of the plan — but STILL shows the AWS-write confirm. Off by
   // default, so the standalone `revert` keeps its per-op multiselect.
   autoSelectAll?: boolean;
+  // #756: check's "Decide per finding" path assigns `revert` to a SUBSET of findings.
+  // The reconciliation against the baseline (applyBaseline: currentPaths / skippedLogical
+  // / deletedLogical / underDeclaredDrift) MUST see the FULL finding set — else every
+  // recorded entry whose healthy, matching live finding was filtered out looks "removed
+  // since record" and synthesizes a phantom restore op the user never chose. So the caller
+  // passes the UNFILTERED findings in `gathered.findings` AND the chosen finding identities
+  // here; the plan is then restricted to ops for exactly these findings. Key format is
+  // `${logicalId}::${path}` (+ `[attributeKey]` when present) — identical to interactive
+  // -resolve.ts's keyOf. Undefined = revert every planned finding (standalone `revert`).
+  selectedFindingKeys?: Set<string>;
   // Delay before the single convergence re-read retry (SDK-writer paths can lag
   // behind their API response — eventual consistency). Overridable so unit tests
   // don't sleep for real.
@@ -1104,6 +1121,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     verbose,
     interactive,
     autoSelectAll,
+    selectedFindingKeys,
     waitMs,
     waitNow,
     waitSleep,
@@ -1138,11 +1156,21 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     constructPathByLogical,
     allLogicalIds,
   };
-  const drifted = applyIgnores(
+  const reconciled = applyIgnores(
     applyBaseline(gathered.findings, baseline, { ...baselineOpts, warn: console.error }),
     { stackName, accountId: gathered.desired.accountId, region },
     config
   );
+  // #756: when the per-finding flow chose a SUBSET to revert, applyBaseline above ran over
+  // the UNFILTERED findings (so its removal-synthesis reconciliation saw reality — no
+  // phantom "removed since record" restore ops for entries whose healthy live finding the
+  // user simply did not pick). Now narrow the plan input to EXACTLY the chosen findings, so
+  // the AWS writes correspond to reverting only those — never a skipped / ignored / unpicked
+  // recorded entry, and no same-value churn. Undefined = standalone `revert`: plan them all.
+  const drifted =
+    selectedFindingKeys === undefined
+      ? reconciled
+      : reconciled.filter((f) => selectedFindingKeys.has(findingKeyOf(f)));
   // Resolve the declared model per logical id — needed both by writeOnlyReincludeOps (to
   // re-include declared write-only values) and by the apply loop (writer `declared` arg).
   const resByLogical = new Map(gathered.desired.resources.map((res) => [res.logicalId, res]));

--- a/tests/perfinding-revert-subset-756.test.ts
+++ b/tests/perfinding-revert-subset-756.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import type { BaselineFile } from '../src/baseline/baseline-file.js';
+import type { GatherResult } from '../src/commands/gather.js';
+import { revertStack } from '../src/commands/stack-actions.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+// #756: check's "Decide per finding" flow assigns `revert` to a SUBSET of findings. The
+// interactive path calls revertStack with the UNFILTERED findings PLUS `selectedFindingKeys`
+// (the chosen subset). revertStack's applyBaseline reconciliation must therefore see the
+// FULL live reality — so a recorded entry whose live value is HEALTHY and UNCHANGED (but
+// which the user did NOT pick / explicitly skipped) does NOT look "removed since record" and
+// synthesize a phantom restore op. The plan must contain ONLY ops for the selected findings.
+//
+// Before the fix the caller passed the FILTERED findings to revertStack, so applyBaseline's
+// `currentPaths` was starved: every unpicked recorded entry synthesized a
+// `baseline value removed since record` finding -> an `add` "restore baseline value" op ->
+// a same-value / skipped AWS write the user never chose.
+
+const EMPTY_SCHEMA = {
+  readOnly: new Set<string>(),
+  writeOnly: new Set<string>(),
+  createOnly: new Set<string>(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+} as SchemaInfo;
+
+// The finding-identity key the per-finding action picker builds (interactive-resolve.ts
+// keyOf): logicalId::path (+ [attributeKey] when present).
+const keyOf = (f: Finding): string => `${f.logicalId}::${f.path}`;
+
+// A recorded undeclared value whose live value CHANGED out of band reads as tier
+// `undeclared` (the applyBaseline "recorded value CHANGED -> drift" branch) — a REAL,
+// revertable drift. In the per-finding picker the user can `skip` it (leave it unpicked).
+const changedRecorded = (logicalId: string, path: string, liveValue: unknown): Finding => ({
+  tier: 'undeclared',
+  logicalId,
+  resourceType: 'AWS::IAM::Role',
+  path,
+  physicalId: `${logicalId}-phys`,
+  actual: liveValue,
+});
+
+// A declared drift the user WILL pick for revert.
+const declaredDriftD = (): Finding => ({
+  tier: 'declared',
+  logicalId: 'Rd',
+  resourceType: 'AWS::IAM::Role',
+  path: 'MaxSessionDuration',
+  physicalId: 'Rd-phys',
+  desired: 3600,
+  actual: 7200,
+});
+
+const baseline = (): BaselineFile => ({
+  schemaVersion: 2,
+  stackName: 's',
+  region: 'r',
+  accountId: '111122223333',
+  capturedAt: '2020-01-01T00:00:00Z',
+  templateHash: 'h',
+  // Ra + Rb are recorded undeclared values whose live value CHANGED out of band — both are
+  // real, revertable drift. In the picker the user leaves them unpicked (skip).
+  recorded: [
+    { logicalId: 'Ra', resourceType: 'AWS::IAM::Role', path: 'Description', value: 'a-recorded' },
+    { logicalId: 'Rb', resourceType: 'AWS::IAM::Role', path: 'Description', value: 'b-recorded' },
+  ],
+  completeResources: ['Ra', 'Rb', 'Rd'],
+});
+
+const gathered = (): GatherResult =>
+  ({
+    desired: {
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources: [
+        { logicalId: 'Ra', resourceType: 'AWS::IAM::Role', physicalId: 'Ra-phys', declared: {} },
+        { logicalId: 'Rb', resourceType: 'AWS::IAM::Role', physicalId: 'Rb-phys', declared: {} },
+        {
+          logicalId: 'Rd',
+          resourceType: 'AWS::IAM::Role',
+          physicalId: 'Rd-phys',
+          declared: { MaxSessionDuration: 3600 },
+        },
+      ],
+      rawTemplate: '{}',
+      ctx: {
+        params: {},
+        pseudo: {},
+        conditions: {},
+        physIds: {},
+        liveAttrs: {},
+        mappings: {},
+        exports: {},
+        condCache: new Map(),
+      },
+    },
+    // The FULL finding set: the two out-of-band-changed recorded values (real drift the user
+    // will SKIP) + the declared drift D (the user will REVERT).
+    findings: [
+      changedRecorded('Ra', 'Description', 'a-live-changed'),
+      changedRecorded('Rb', 'Description', 'b-live-changed'),
+      declaredDriftD(),
+    ],
+    schemas: new Map([['AWS::IAM::Role', EMPTY_SCHEMA]]),
+    liveByLogical: new Map(),
+  }) as GatherResult;
+
+// Run a dry-run revert (no AWS write) and capture the printed plan + returned counts.
+const run = async (selectedFindingKeys?: Set<string>) => {
+  const logs: string[] = [];
+  const orig = console.log;
+  console.log = (s: unknown) => logs.push(String(s));
+  try {
+    const outcome = await revertStack({
+      stackName: 's',
+      region: 'r',
+      gathered: gathered(),
+      baseline: baseline(),
+      config: { ignore: [] },
+      dryRun: true, // preview only — no AWS write, but the plan is built + printed
+      yes: true,
+      removeUnrecorded: true, // so a restore/removal op is NOT gated out for an unrelated reason
+      verbose: false,
+      interactive: false,
+      selectedFindingKeys,
+    });
+    return { outcome, logs: logs.join('\n') };
+  } finally {
+    console.log = orig;
+  }
+};
+
+describe('revertStack #756 — per-finding revert of a SUBSET touches only the selected findings', () => {
+  let cfnMock: ReturnType<typeof mockClient>;
+  beforeEach(() => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' } as never] });
+  });
+  afterEach(() => cfnMock.restore());
+
+  it('selecting only the declared drift plans ONE op — the SKIPPED recorded drifts (Ra/Rb) are NOT written', async () => {
+    // The user picked ONLY the declared drift D; the two out-of-band-changed recorded values
+    // Ra and Rb were left unpicked (skip). selectedFindingKeys restricts the plan to D alone.
+    const { outcome, logs } = await run(new Set([keyOf(declaredDriftD())]));
+
+    // Exactly one resource / one op — D's revert. WITHOUT the fix (no selectedFindingKeys
+    // restriction on the plan), all THREE real drifts reconcile as revertable, so the plan
+    // would be 3 resources / 3 ops — writing Ra and Rb the user explicitly SKIPPED.
+    expect(outcome.plannedResources).toBe(1);
+    expect(outcome.plannedOps).toBe(1);
+
+    // The plan must name D (Rd) and NOTHING about the skipped recorded entries Ra / Rb.
+    expect(logs).toContain('MaxSessionDuration');
+    expect(logs).not.toContain('Ra');
+    expect(logs).not.toContain('Rb');
+  });
+
+  it('control: WITHOUT selectedFindingKeys (standalone revert) every reconciled drift is planned', async () => {
+    // No subset restriction: standalone `revert` plans EVERY revertable drift — the full
+    // reconciled set here is D + Ra + Rb = 3 ops. This anchors that the one-op result above is
+    // the selectedFindingKeys restriction at work, not an artifact of the fixture.
+    const { outcome } = await run(undefined);
+    expect(outcome.plannedResources).toBe(3);
+    expect(outcome.plannedOps).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #756. Separates baseline reconciliation (unfiltered — no phantom removals) from the plan (narrowed to selectedFindingKeys), so a subset revert writes only the chosen findings. Unit test verified failing pre-fix. See commit body.