### PR TITLE
fix(sweep): honor aws:cloudformation:stack-name in the generic tag net so a peer's live resource is never flagged an orphan

### DIFF
--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -96,6 +96,16 @@ MEMBER_IDS="$(
 # is_member <name> — the resource IS a member of a protected stack (exact physical-id match).
 is_member() { [ -n "$MEMBER_IDS" ] && printf '%s\n' "$MEMBER_IDS" | grep -qFx "$1"; }
 
+# stack_is_active <stack-name> — the name matches an active (any region) or sentinel-tracked
+# stack, case-insensitively (whole line). Used by the generic tag net to honor a resource's own
+# `aws:cloudformation:stack-name` tag: a resource CloudFormation still manages is never an orphan,
+# even when the id-vs-ARN mismatch defeats is_member and name mangling defeats _name_backed_by.
+stack_is_active() {
+  [ -n "$1" ] || return 1
+  printf '%s\n%s\n' "$ACTIVE_STACKS_GLOBAL" "$PROTECTED_STACKS" | grep -viE '^[[:space:]]*$' \
+    | grep -qiFx "$1"
+}
+
 # A cdkrd-token resource is an orphan unless its name embeds an active stack name.
 # `stacks` selects the guard set: the region-local set for regional resources, the
 # all-regions set for global (IAM) ones. Match is CASE-INSENSITIVE: AWS lowercases
@@ -319,10 +329,19 @@ done < <(aws iam list-instance-profiles --query 'InstanceProfiles[].[InstancePro
 # (RGT API is regional and does not cover IAM — handled above — but does cover most
 # taggable service resources.)
 note "--- Tagged ephemeral resources (generic, any type) ---"
-for arn in $(aws resourcegroupstaggingapi get-resources --region "$REGION" \
-  --tag-filters Key=cdkrd:ephemeral,Values=1 \
-  --query 'ResourceTagMappingList[].ResourceARN' --output text 2>/dev/null | tr '\t' '\n'); do
+# Pull each resource's own `aws:cloudformation:stack-name` tag alongside its ARN. That tag is the
+# AUTHORITATIVE membership signal for the generic net: is_member matches the CFn PhysicalResourceId
+# (a bare id/name like `vpc-0abc…`) but RGT hands us the full ARN (`arn:…:vpc/vpc-0abc…`), so the
+# id-vs-ARN mismatch made a tagged member (a peer's live VPC/NACL/… whose id does not embed the
+# stack name either) false-flag as an orphan — risking a `--delete` of a peer's active resource.
+while IFS=$'\t' read -r arn cfn_stack; do
   [ -n "$arn" ] || continue
+  # A resource CloudFormation still manages (its stack-name tag names an active/sentinel stack) is
+  # never an orphan — honor that before the id/name heuristics below.
+  if [ "$cfn_stack" != "None" ] && stack_is_active "$cfn_stack"; then
+    note "  SKIP (active-stack member via aws:cloudformation:stack-name=$cfn_stack): $arn"
+    continue
+  fi
   # ARN already deleted by a per-type sweep above may still be listed briefly; the
   # active-stack guard + a existence-agnostic report is fine (verify re-runs later).
   if is_backed "$arn" || is_backed_global "$arn"; then
@@ -336,7 +355,10 @@ for arn in $(aws resourcegroupstaggingapi get-resources --region "$REGION" \
   hit
   failed=$((failed + 1)) # unresolved by this script → keep verify RED until handled
   note "  ORPHAN (needs manual delete — delstack/console): $arn"
-done
+done < <(aws resourcegroupstaggingapi get-resources --region "$REGION" \
+  --tag-filters Key=cdkrd:ephemeral,Values=1 \
+  --query 'ResourceTagMappingList[].[ResourceARN, Tags[?Key==`aws:cloudformation:stack-name`].Value | [0]]' \
+  --output text 2>/dev/null)
 
 note "=== summary: $found orphan(s) found, $failed delete failure(s) ==="
 if [ "$found" -eq 0 ]; then


### PR DESCRIPTION
## Problem (safety)

`tests/integration/sweep-orphans.sh`'s generic `cdkrd:ephemeral=1` tag net passed the **full ARN** (`arn:…:vpc/vpc-0abc…`) to `is_backed`, but `is_member` matches the CloudFormation **PhysicalResourceId** (a bare id like `vpc-0abc…`). That id-vs-ARN mismatch — plus a physical id that doesn't embed the mixed-case stack name (so `_name_backed_by` also misses) — made a tagged resource that **is a member of an ACTIVE stack** false-flag as `ORPHAN (needs manual delete)`.

Under `sweep-orphans.sh --delete` this risks **deleting a peer's live resource** — the account runs concurrent live-tests / hunts.

**Live-observed 2026-07-10:** sweeping one agent's OptionGroup test flagged a *different* agent's active `Cdkrd1045Verify` VPC as an orphan.

## Fix

`tests/integration/sweep-orphans.sh`: the generic net now pulls each resource's own `aws:cloudformation:stack-name` tag alongside its ARN and, when that tag names an active or sentinel-tracked stack (`stack_is_active`, case-insensitive), SKIPs it as an active-stack member **before** the id/name heuristics. That tag is the authoritative membership signal — immune to the id-vs-ARN mismatch and to name mangling.

A resource whose stack-name tag names a **deleted** stack still falls through to the existing `resource_gone` / ORPHAN handling, so a genuine orphan is never hidden (fail-safe unchanged).

## Live verification (us-east-1, A/B)

Deployed a VPC-only stack `CdkrdSweepFixVerify` (its `vpc-…` id embeds no stack name — the exact repro shape):

```
OLD sweep (main): 2 ORPHANs — vpc-0a55… (mine) AND vpc-014f… (a peer's live VPC)
NEW sweep (fix):  SKIP (active-stack member via aws:cloudformation:stack-name=CdkrdSweepFixVerify)
                  → summary: 0 orphan(s) → SWEEP CLEAN
```

Stack torn down (`delstack`).

## Scope

Tooling only — no `src/**` (change is `tests/integration/sweep-orphans.sh`). No unit harness exists for this integration shell script (excluded from vitest, needs real AWS); coverage is the live A/B above. Full local gates green: typecheck / lint / build / 4232 unit tests / `bash -n`.
