### PR TITLE
fix(added): fail safe when the sibling-stack check cannot verify a cross-account/region child (#959)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -171,13 +171,47 @@ async function readAddedModel(
 // parent can enumerate the same live child under multiple declared parents).
 // 'managed' = a CFn stack owns it (sibling-managed, not out of band); 'notManaged' = no stack
 // owns it (genuinely out of band -> report as `added`); 'unverified' = the membership check
-// itself FAILED (throttle / AccessDenied / network), so we CANNOT say either way (#754).
+// itself FAILED (throttle / AccessDenied / network) OR could not reach the owning scope
+// (a cross-account / cross-region CFn-managed child), so we CANNOT say either way (#754, #959).
 export type SiblingCheck = 'managed' | 'notManaged' | 'unverified';
+
+// The sibling-membership probe (DescribeStackResources) runs on the check's OWN CloudFormation
+// client, scoped to the run's account+region. Its `ValidationError` ("Stack for <id> does not
+// exist") therefore only proves the child is not in a stack of THIS account+region — NOT that it
+// is unmanaged everywhere. A child fully CFn-managed by a stack in a DIFFERENT account or region
+// (the canonical case: an SNS cross-account / cross-region `AWS::SNS::Subscription` fan-out — the
+// subscription lives on the topic's account+region but is declared in the SUBSCRIBER's foreign
+// stack) is invisible to that call and would be false-flagged `added` with a DESTRUCTIVE
+// DeleteResource revert offer (#959). The child's physical id is an ARN carrying its own
+// account+region, so parse it: only when the ARN's account AND region MATCH the check's scope is
+// a `ValidationError` a DEFINITIVE not-managed (safe to report `added`); an ARN in a foreign
+// account or region is UNVERIFIABLE — the owning stack is simply unreachable from here. Returns
+// `true` (definitive) only for a same-account+region ARN (or an id we cannot parse as an ARN,
+// which is inherently local — a bare name/UUID minted in this account+region). Returns `false`
+// (unverifiable) for a foreign-scope ARN.
+export function isDefinitiveNotManaged(
+  physicalId: string,
+  accountId: string,
+  region: string
+): boolean {
+  // ARN form: arn:partition:service:region:account-id:resource — region at [3], account at [4].
+  if (!physicalId.startsWith('arn:')) return true;
+  const seg = physicalId.split(':');
+  const arnRegion = seg[3] ?? '';
+  const arnAccount = seg[4] ?? '';
+  // Some ARNs omit region and/or account (empty segment) — those carry no foreign signal and are
+  // treated as local (definitive). Only a NON-EMPTY segment that DIFFERS marks a foreign scope.
+  if (arnRegion !== '' && arnRegion !== region) return false;
+  if (arnAccount !== '' && arnAccount !== accountId) return false;
+  return true;
+}
 
 export async function isManagedBySiblingStack(
   cfn: CloudFormationClient,
   c: AddedChild,
-  cache: Map<string, SiblingCheck>
+  cache: Map<string, SiblingCheck>,
+  accountId: string,
+  region: string
 ): Promise<SiblingCheck> {
   // The sibling-stack lookup uses the CloudFormation PHYSICAL-ID form, which for most child
   // types IS the CC primaryIdentifier (`identifier`); it diverges only where CC's identifier
@@ -235,15 +269,26 @@ export async function isManagedBySiblingStack(
       }
     }
   } catch (e) {
-    // Distinguish a GENUINE not-found from a FAILED check (#754). CloudFormation answers
-    // DescribeStackResources for a physical id that belongs to no stack with a ValidationError
-    // ("Stack for <id> does not exist") — that is a definite "not managed", cacheable. Any other
-    // error (Throttling under an --all sweep, AccessDenied without cloudformation:DescribeStack-
-    // Resources, a network blip) means we could NOT determine membership: return 'unverified' and
-    // do NOT memoize it (so a transient throttle does not poison the whole run, and the caller can
-    // report coverage-incomplete instead of a false `added` whose revert offers a destructive
-    // DeleteResource on a possibly CFn-managed resource).
-    if ((e as { name?: string }).name === 'ValidationError') {
+    // Distinguish a GENUINE not-found from a FAILED / UNREACHABLE check (#754, #959).
+    // CloudFormation answers DescribeStackResources for a physical id that belongs to no stack of
+    // THIS account+region with a ValidationError ("Stack for <id> does not exist"). That is only a
+    // definite "not managed" when the child's own scope IS this account+region — a child managed
+    // by a stack in a DIFFERENT account/region is equally invisible to this scoped client and
+    // yields the SAME ValidationError, so treating every ValidationError as `notManaged` would
+    // false-flag a foreign-managed child `added` and offer a destructive DeleteResource on a
+    // resource another stack legitimately owns (#959, the SNS cross-account/region fan-out). Parse
+    // the physical-id ARN's account+region: only when it MATCHES the check's scope is this a
+    // definitive, cacheable `notManaged` (a real out-of-band addition — still reported `added`);
+    // a foreign-scope ARN is UNVERIFIABLE, so fall through to `unverified` (fail safe: reported as
+    // coverage-incomplete, NEVER a destructive delete). Any OTHER error (Throttling under an --all
+    // sweep, AccessDenied without cloudformation:DescribeStackResources, a network blip) is also
+    // 'unverified' and NOT memoized (a transient throttle must not poison the run). The foreign-
+    // scope determination IS deterministic per physical id, so caching it as 'notManaged' is not
+    // done — we leave it un-cached like the other unverifiable cases for uniform handling.
+    if (
+      (e as { name?: string }).name === 'ValidationError' &&
+      isDefinitiveNotManaged(physicalId, accountId, region)
+    ) {
       cache.set(physicalId, 'notManaged');
       return 'notManaged';
     }
@@ -795,7 +840,13 @@ export async function gatherFindings(
       for (const c of children) {
         // A child CDK placed in a SIBLING stack of the same app (cross-stack refs, #666)
         // is fully CloudFormation-managed — not out of band, so skip it.
-        const sibling = await isManagedBySiblingStack(cfn, c, siblingStackCache);
+        const sibling = await isManagedBySiblingStack(
+          cfn,
+          c,
+          siblingStackCache,
+          desired.accountId,
+          region
+        );
         if (sibling === 'managed') continue;
         if (sibling === 'unverified') {
           // The sibling-membership check FAILED (throttle / denied), so we cannot say whether this

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -23,6 +23,7 @@ import {
   buildSiblingUserGroups,
   type GatherResult,
   gatherFindings,
+  isDefinitiveNotManaged,
   isManagedBySiblingStack,
   regatherTouched,
   type SiblingCheck,
@@ -1084,6 +1085,10 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     label: identifier,
     live: {},
   });
+  // The check-run's own account+region — match the ARNs below so a ValidationError is a
+  // DEFINITIVE local not-managed (the #959 foreign-scope cases override these deliberately).
+  const LOCAL_ACCOUNT = '111122223333';
+  const LOCAL_REGION = 'us-east-1';
   const subArn = 'arn:aws:sns:us-east-1:111122223333:NotifTopic:0000-1111-2222';
 
   it('folds a subscription CDK placed in a SIBLING stack (DescribeStackResources resolves it)', async () => {
@@ -1103,7 +1108,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('managed');
   });
@@ -1116,7 +1123,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('notManaged');
   });
@@ -1141,7 +1150,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('notManaged');
   });
@@ -1151,7 +1162,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child('api123|res456|GET', 'AWS::ApiGateway::Method'),
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('notManaged');
     expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(0);
@@ -1196,7 +1209,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       rule,
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('managed');
     // it looked up the CFn physical-id form, NOT the CC Arn
@@ -1220,7 +1235,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       rule,
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('notManaged');
     // the composite-looking `|` lookup id was NOT short-circuited by the pipe guard: it queried CFn
@@ -1242,8 +1259,20 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
       ],
     });
     const cache = new Map<string, SiblingCheck>();
-    await isManagedBySiblingStack(cfn as unknown as CloudFormationClient, child(subArn), cache);
-    await isManagedBySiblingStack(cfn as unknown as CloudFormationClient, child(subArn), cache);
+    await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
     expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
     expect(cache.get(subArn)).toBe('managed');
   });
@@ -1257,7 +1286,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const first = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
-      cache
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     // a failed check is 'unverified' (the caller reports coverage-incomplete, never a false added)
     expect(first).toBe('unverified');
@@ -1266,7 +1297,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const second = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
-      cache
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(second).toBe('unverified');
     expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(2);
@@ -1317,7 +1350,9 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('managed');
     // it queried the OWNING stack by name and paginated to page 2
@@ -1357,8 +1392,105 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
-      new Map()
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
     );
     expect(managed).toBe('notManaged');
+  });
+
+  // #959: the DescribeStackResources probe runs on the check's OWN account+region client, so a
+  // ValidationError only proves the child is not in a stack of THIS scope — a child managed by a
+  // stack in a DIFFERENT account/region yields the SAME error but is NOT out of band. It must be
+  // 'unverified' (coverage-incomplete, never a destructive DeleteResource), not 'notManaged'.
+  it('#959: a CROSS-ACCOUNT-managed subscription (ValidationError, foreign account ARN) is UNVERIFIED, not added', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // The subscription ARN's account (999988887777) differs from the check's account.
+    const foreignAccountArn = 'arn:aws:sns:us-east-1:999988887777:NotifTopic:aaaa-bbbb-cccc';
+    const notFound = new Error(`Stack for ${foreignAccountArn} does not exist`);
+    notFound.name = 'ValidationError';
+    cfn.on(DescribeStackResourcesCommand).rejects(notFound);
+    const cache = new Map<string, SiblingCheck>();
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(foreignAccountArn),
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    // fail safe: unverifiable, so NOT a destructive-deletable `added`
+    expect(managed).toBe('unverified');
+    // and NOT memoized as notManaged (uniform with the other unverifiable cases)
+    expect(cache.has(foreignAccountArn)).toBe(false);
+  });
+
+  it('#959: a CROSS-REGION-managed subscription (ValidationError, foreign region ARN) is UNVERIFIED, not added', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // Same account, but the topic/subscription live in eu-west-1 while the check runs in us-east-1.
+    const foreignRegionArn = 'arn:aws:sns:eu-west-1:111122223333:NotifTopic:dddd-eeee-ffff';
+    const notFound = new Error(`Stack for ${foreignRegionArn} does not exist`);
+    notFound.name = 'ValidationError';
+    cfn.on(DescribeStackResourcesCommand).rejects(notFound);
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(foreignRegionArn),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('unverified');
+  });
+
+  it('#959: a genuinely out-of-band SAME-account+region subscription is STILL added (ValidationError, local ARN)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // subArn is arn:aws:sns:us-east-1:111122223333:... — exactly the check's account+region.
+    const notFound = new Error(`Stack for ${subArn} does not exist`);
+    notFound.name = 'ValidationError';
+    cfn.on(DescribeStackResourcesCommand).rejects(notFound);
+    const cache = new Map<string, SiblingCheck>();
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    // a real local out-of-band addition is verifiable and MUST still surface (and be cached)
+    expect(managed).toBe('notManaged');
+    expect(cache.get(subArn)).toBe('notManaged');
+  });
+
+  describe('isDefinitiveNotManaged (#959 foreign-scope classifier)', () => {
+    it('a same-account+region ARN is definitive (safe to report added)', () => {
+      expect(isDefinitiveNotManaged(subArn, LOCAL_ACCOUNT, LOCAL_REGION)).toBe(true);
+    });
+    it('a foreign-account ARN is NOT definitive (unverifiable)', () => {
+      expect(
+        isDefinitiveNotManaged(
+          'arn:aws:sns:us-east-1:999988887777:T:x',
+          LOCAL_ACCOUNT,
+          LOCAL_REGION
+        )
+      ).toBe(false);
+    });
+    it('a foreign-region ARN is NOT definitive (unverifiable)', () => {
+      expect(
+        isDefinitiveNotManaged(
+          'arn:aws:sns:eu-west-1:111122223333:T:x',
+          LOCAL_ACCOUNT,
+          LOCAL_REGION
+        )
+      ).toBe(false);
+    });
+    it('a non-ARN physical id (bare name/UUID minted in this scope) is definitive', () => {
+      expect(isDefinitiveNotManaged('MyBus|MyRule', LOCAL_ACCOUNT, LOCAL_REGION)).toBe(true);
+      expect(isDefinitiveNotManaged('some-bare-name', LOCAL_ACCOUNT, LOCAL_REGION)).toBe(true);
+    });
+    it('an ARN with an empty region/account segment carries no foreign signal (definitive)', () => {
+      // e.g. a global/partition-scoped ARN like arn:aws:iam::111122223333:role/... (no region).
+      expect(
+        isDefinitiveNotManaged('arn:aws:iam::111122223333:role/R', LOCAL_ACCOUNT, LOCAL_REGION)
+      ).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Closes #959. A ValidationError from the local-account/region CFn client no longer counts as a definitive not-managed: a foreign-scope ARN falls through to the non-destructive 'unverified' tier, so revert never offers a DeleteResource on a cross-account/region CFn-managed child (SNS Subscription fan-out). Same-account/region OOB resources still surface as added. See commit body.