### PR TITLE
fix(diff): fold 5 derived-echo first-run FPs computable from declared inputs (#975)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1946,6 +1946,61 @@ export function classifyResource(
       knownDef = { ...knownDef, StorageType: storageDefault };
     }
   }
+  // #975: a CE AnomalySubscription declaring the LEGACY numeric `Threshold` reads back an
+  // undeclared `ThresholdExpression` — the service DERIVES a JSON-string expression from it
+  // (`{"Dimensions":{"Key":"ANOMALY_TOTAL_IMPACT_ABSOLUTE","MatchOptions":["GREATER_THAN_OR_EQUAL"],
+  // "Values":["<Threshold>"]}}`, the Threshold echoed as a decimal string, `5` -> `"5.0"`).
+  // Derive the expression from the declared Threshold and equality-gate it (fold tier 2): an
+  // out-of-band edit of the expression still surfaces. A subscription that declares
+  // ThresholdExpression directly carries it and is compared in the declared loop.
+  if (resourceType === 'AWS::CE::AnomalySubscription') {
+    const threshold = declared['Threshold'];
+    if (typeof threshold === 'number' && Number.isFinite(threshold)) {
+      const decimal = Number.isInteger(threshold) ? `${threshold}.0` : String(threshold);
+      // The live value is a JSON-STRING prop the normalize pipeline canonicalizes to compact +
+      // ALPHABETICALLY-sorted keys, so the object literal below is written in alphabetical key
+      // order (Key < MatchOptions < Values) to serialize to the identical string it compares against.
+      knownDef = {
+        ...knownDef,
+        ThresholdExpression: JSON.stringify({
+          Dimensions: {
+            Key: 'ANOMALY_TOTAL_IMPACT_ABSOLUTE',
+            MatchOptions: ['GREATER_THAN_OR_EQUAL'],
+            Values: [decimal],
+          },
+        }),
+      };
+    }
+  }
+  // #975: an ElastiCache ReplicationGroup with in-transit encryption enabled at creation
+  // (`TransitEncryptionEnabled: true`) but no explicit `TransitEncryptionMode` reads back the
+  // documented default `"required"` (`"preferred"` is an explicit opt-in). Derive it from the
+  // declared flag and equality-gate it (fold tier 2): a group that pins `preferred` declares it
+  // and is compared, and an out-of-band flip to `preferred` still surfaces.
+  if (
+    resourceType === 'AWS::ElastiCache::ReplicationGroup' &&
+    declared['TransitEncryptionEnabled'] === true
+  ) {
+    knownDef = { ...knownDef, TransitEncryptionMode: 'required' };
+  }
+  // #975: a TransitGatewayRoute / TransitGatewayRouteTableAssociation registry schema ships an
+  // EMPTY `readOnly` list, so the schema-strip never removes the primaryIdentifier echo — the
+  // undeclared `Id` is an EXACT underscore-join of two DECLARED properties. Derive it and
+  // equality-gate it (fold tier 2): the value is a deterministic function of the declared inputs.
+  if (resourceType === 'AWS::EC2::TransitGatewayRoute') {
+    const rtb = declared['TransitGatewayRouteTableId'];
+    const cidr = declared['DestinationCidrBlock'];
+    if (typeof rtb === 'string' && typeof cidr === 'string') {
+      knownDef = { ...knownDef, Id: `${rtb}_${cidr}` };
+    }
+  }
+  if (resourceType === 'AWS::EC2::TransitGatewayRouteTableAssociation') {
+    const attach = declared['TransitGatewayAttachmentId'];
+    const rtb = declared['TransitGatewayRouteTableId'];
+    if (typeof attach === 'string' && typeof rtb === 'string') {
+      knownDef = { ...knownDef, Id: `${attach}_${rtb}` };
+    }
+  }
   // #701: an EventSourceMapping's default BatchSize depends on the source service — 10 for
   // SQS, 100 for Kinesis / DynamoDB streams / MSK / Kafka. Derive the expected default from
   // the declared EventSourceArn's service segment (arn:<p>:<service>:...) and equality-gate
@@ -3195,6 +3250,25 @@ export function classifyResource(
     if (namePattern !== undefined && typeof v === 'string' && namePattern.test(v)) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;
+    }
+    // #975: ElastiCache picks a member cluster `<ReplicationGroupId>-NNN` as the default
+    // snapshotting cluster (which member is a per-deploy AWS choice, but the name always has
+    // this deterministic shape). Fold the undeclared `SnapshottingClusterId` when it matches
+    // `^<ReplicationGroupId>-\d{3}$` (the declared id, falling back to the physical id). An
+    // out-of-band re-point to an UNRELATED cluster does not match the prefix and surfaces.
+    if (
+      resourceType === 'AWS::ElastiCache::ReplicationGroup' &&
+      k === 'SnapshottingClusterId' &&
+      typeof v === 'string'
+    ) {
+      const rgId = declared['ReplicationGroupId'] ?? physicalId;
+      if (
+        typeof rgId === 'string' &&
+        new RegExp(`^${rgId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}-\\d{3}$`).test(v)
+      ) {
+        findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+        continue;
+      }
     }
     // A live value EQUAL to the AWS/CDK-generated value for this resource (its minted
     // physical name, a default-named log group) is the `generated` tier: folded

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -11486,3 +11486,105 @@ describe('#980 clean-deploy first-run folds', () => {
     expect(drifted.undeclared).toEqual(['DBSubnetGroupName']);
   });
 });
+
+describe('#975 derived-echo folds (deterministic function of declared inputs)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'R',
+    resourceType,
+    physicalId: (declared.ReplicationGroupId as string) ?? 'phys',
+    declared,
+  });
+
+  it('CE AnomalySubscription ThresholdExpression derives from the declared Threshold', () => {
+    // The service canonicalizes the JSON-string prop to compact + alphabetically-sorted keys.
+    const canonical =
+      '{"Dimensions":{"Key":"ANOMALY_TOTAL_IMPACT_ABSOLUTE","MatchOptions":["GREATER_THAN_OR_EQUAL"],"Values":["5.0"]}}';
+    const t = tiers(
+      classifyResource(
+        res('AWS::CE::AnomalySubscription', { Threshold: 5 }),
+        { ThresholdExpression: canonical },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual(['ThresholdExpression']);
+    expect(t.undeclared).toEqual([]);
+    // An out-of-band expression edit (different Values) still surfaces.
+    const drifted = tiers(
+      classifyResource(
+        res('AWS::CE::AnomalySubscription', { Threshold: 5 }),
+        {
+          ThresholdExpression:
+            '{"Dimensions":{"Key":"ANOMALY_TOTAL_IMPACT_ABSOLUTE","MatchOptions":["GREATER_THAN_OR_EQUAL"],"Values":["99.0"]}}',
+        },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['ThresholdExpression']);
+  });
+
+  it('ElastiCache TransitEncryptionMode + SnapshottingClusterId fold from declared inputs', () => {
+    const t = tiers(
+      classifyResource(
+        res('AWS::ElastiCache::ReplicationGroup', {
+          ReplicationGroupId: 'cdkrd-ec-rich',
+          TransitEncryptionEnabled: true,
+        }),
+        { TransitEncryptionMode: 'required', SnapshottingClusterId: 'cdkrd-ec-rich-001' },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual(['SnapshottingClusterId', 'TransitEncryptionMode']);
+    expect(t.undeclared).toEqual([]);
+    // Out of band: an explicit `preferred` mode + a snapshotting cluster for an UNRELATED group
+    // both surface.
+    const drifted = tiers(
+      classifyResource(
+        res('AWS::ElastiCache::ReplicationGroup', {
+          ReplicationGroupId: 'cdkrd-ec-rich',
+          TransitEncryptionEnabled: true,
+        }),
+        { TransitEncryptionMode: 'preferred', SnapshottingClusterId: 'other-group-001' },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['SnapshottingClusterId', 'TransitEncryptionMode']);
+  });
+
+  it('TGW Route / RouteTableAssociation Id fold from the underscore-joined declared props', () => {
+    const route = tiers(
+      classifyResource(
+        res('AWS::EC2::TransitGatewayRoute', {
+          TransitGatewayRouteTableId: 'tgw-rtb-1',
+          DestinationCidrBlock: '10.99.0.0/16',
+          TransitGatewayAttachmentId: 'tgw-attach-1',
+        }),
+        { Id: 'tgw-rtb-1_10.99.0.0/16' },
+        emptySchema
+      )
+    );
+    expect(route.atDefault).toEqual(['Id']);
+    expect(route.undeclared).toEqual([]);
+    const assoc = tiers(
+      classifyResource(
+        res('AWS::EC2::TransitGatewayRouteTableAssociation', {
+          TransitGatewayAttachmentId: 'tgw-attach-1',
+          TransitGatewayRouteTableId: 'tgw-rtb-1',
+        }),
+        { Id: 'tgw-attach-1_tgw-rtb-1' },
+        emptySchema
+      )
+    );
+    expect(assoc.atDefault).toEqual(['Id']);
+    expect(assoc.undeclared).toEqual([]);
+  });
+});

--- a/tests/corpus/AWS__CE__AnomalySubscription.CfnAnomalySubscription.json
+++ b/tests/corpus/AWS__CE__AnomalySubscription.CfnAnomalySubscription.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (dogfood): the service DERIVES ThresholdExpression (a JSON string) from the declared legacy Threshold — surfaces as the one undeclared value (accept-once material, locked as-is); the live Subscribers entry gains a Status field the declared side never set (nested live-extra, ignored).",
+  "description": "RECORDED LIVE (dogfood): the service DERIVES ThresholdExpression (a JSON string) from the declared legacy Threshold — folds atDefault via the #975 derived equality gate (an out-of-band expression edit still surfaces); the live Subscribers entry gains a Status field the declared side never set (nested live-extra, ignored).",
   "resource": {
     "logicalId": "CfnAnomalySubscription",
     "resourceType": "AWS::CE::AnomalySubscription",
@@ -69,7 +69,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "CfnAnomalySubscription",
       "resourceType": "AWS::CE::AnomalySubscription",
       "path": "ThresholdExpression",

--- a/tests/corpus/AWS__EC2__TransitGatewayRoute.Route.json
+++ b/tests/corpus/AWS__EC2__TransitGatewayRoute.Route.json
@@ -46,7 +46,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Route",
       "resourceType": "AWS::EC2::TransitGatewayRoute",
       "path": "Id",

--- a/tests/corpus/AWS__EC2__TransitGatewayRouteTableAssociation.Association.json
+++ b/tests/corpus/AWS__EC2__TransitGatewayRouteTableAssociation.Association.json
@@ -33,7 +33,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Association",
       "resourceType": "AWS::EC2::TransitGatewayRouteTableAssociation",
       "path": "Id",

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
@@ -235,7 +235,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "TransitEncryptionMode",
@@ -244,7 +244,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "SnapshottingClusterId",


### PR DESCRIPTION
Closes part of #975 (items 1, 2, 3, 5).

Five first-run undeclared FPs fossilized in the golden corpus, each a DETERMINISTIC FUNCTION of declared inputs (tier-2 derived fold):

1. **CE AnomalySubscription `ThresholdExpression`** — derived from the declared legacy `Threshold` (the service builds the JSON-string expression; `5` → `"5.0"`). The object literal is written in alphabetical key order to match the normalize pipeline's JSON-string canonicalization.
2. **ElastiCache ReplicationGroup `TransitEncryptionMode`** — `"required"` when `TransitEncryptionEnabled: true` (the documented default; `preferred` is an explicit opt-in).
3. **ElastiCache ReplicationGroup `SnapshottingClusterId`** — folded when it matches `^<ReplicationGroupId>-\d{3}$` (the member-cluster name shape AWS picks); an out-of-band pointer to an unrelated cluster surfaces.
4. **TGW Route / RouteTableAssociation `Id`** — the underscore-join of two declared props. Their registry schemas ship an empty `readOnly` list, so the primaryIdentifier echo is never schema-stripped.

Every fold is equality-gated, so an out-of-band change away from the derived value still surfaces (proven by the new unit tests). Corpus `expected` updated in the same diff (`undeclared` → `atDefault`).

**Deferred:** item 4 (GA EndpointGroup `HealthCheckPort` from the sibling Listener's `PortRanges`) needs new sibling threading through gather + corpus regen — left open on #975 for a follow-up lane.

## Verification
- `corpus-replay` passes (the 4 corpus cases are authoritative live data — replay-proven at HEAD).
- New focused unit tests in `tests/classify.test.ts` (fold + out-of-band-surfaces for each item).
- typecheck / `vp check` (0 errors) / build / 4235 unit tests all green.