### PR TITLE
fix(revert): stream each resource's revert outcome as it completes (#952)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1359,6 +1359,50 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       out(style.note(`    ↻ ${displayId}: ${reason} — retry ${attempt} (next in ${secs}s)…`));
     },
   });
+  // #952: stream each resource's `reverted:`/`FAILED:` line the moment its last item
+  // resolves — instead of buffering the whole batch and printing only after every item
+  // completes. On a long (10-item) revert the user now sees progress as it happens, and a
+  // Ctrl-C mid-apply leaves a visible trace of what already succeeded/failed rather than
+  // nothing. To avoid double-printing (the end-of-batch summary still runs for the --json
+  // tallies), we track how many items each resource contributes and print its collapsed
+  // outcome once all of them have landed in `applied`. A resource that split into a `cc` +
+  // `sdk` item (two results, same logicalId) still prints exactly ONE line, identical to
+  // what summarizeRevertResults would render — the shared helper guarantees byte-for-byte
+  // parity. Streaming goes through `out`, so it is already suppressed under --json.
+  const itemsPerLogical = new Map<string, number>();
+  for (const item of plan.items)
+    itemsPerLogical.set(item.logicalId, (itemsPerLogical.get(item.logicalId) ?? 0) + 1);
+  const streamedLogical = new Set<string>();
+  const streamResultLine = (logicalId: string): void => {
+    if (streamedLogical.has(logicalId)) return;
+    const forResource = applied.filter((a) => a.logicalId === logicalId);
+    if (forResource.length < (itemsPerLogical.get(logicalId) ?? 0)) return;
+    streamedLogical.add(logicalId);
+    for (const s of summarizeRevertResults(forResource)) printRevertResultLine(s);
+  };
+  // Shared renderer for one collapsed per-resource outcome — used BOTH by the streaming
+  // path (as each resource finishes) and, for anything not yet streamed, by the
+  // end-of-batch pass below. Kept as one function so the two paths cannot drift in format.
+  const printRevertResultLine = (s: {
+    displayId: string;
+    ok: boolean;
+    error?: string;
+    hint?: string;
+  }): void => {
+    if (s.ok) {
+      out(style.ok(`  reverted: ${s.displayId}`));
+    } else {
+      out(style.fail(`  FAILED: ${s.displayId} — ${s.error}`));
+      // Transient "resource is mid-update" failure that survived the retries: add a
+      // targeted hint so the user knows this is retry-later, not a real failure. When we
+      // did NOT already wait (`--wait` off), point at it as the one-command settle path.
+      if (s.hint) {
+        const suffix =
+          waitMs === undefined ? ' (or re-run with --wait to block until it settles)' : '';
+        out(style.note(`    ↳ ${s.hint}${suffix}`));
+      }
+    }
+  };
   // Partition `delete`-kind items out of the main loop: they are applied as a batch AFTER
   // all non-delete items, with dependency-aware retry (issue #765). Non-deletes (plan.ts
   // already orders them first) keep their inline path and MUST run before the deletes.
@@ -1432,6 +1476,8 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     // A failed NON-delete op (this loop no longer runs deletes) — feed the convergence
     // verdict so a FAILED update never rides under a CLEAN summary.
     if (!r.ok) failedUpdateIds.add(item.logicalId);
+    // #952: stream this resource's outcome now if this was its last item.
+    streamResultLine(item.logicalId);
   }
   // Apply the `delete`-kind items as a dependency-aware batch AFTER the non-deletes
   // (issue #765): a delete that first fails on a DependencyViolation is retried once the
@@ -1456,28 +1502,25 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       ...(r.hint !== undefined && { hint: r.hint }),
     });
     if (!r.ok) worst = Math.max(worst, 2);
+    // #952: stream this delete's outcome now if this was its resource's last item.
+    streamResultLine(item.logicalId);
   }
-  // Print ONE outcome per resource (a resource that split into a `cc` + `sdk` item
-  // produced two results) so a fully reverted resource never prints `reverted:` twice.
+  // Collapse per-item results into ONE outcome per resource (a resource that split into a
+  // `cc` + `sdk` item produced two results) — used here for the --json tallies AND as a
+  // BACKSTOP printer for any resource the streaming path did not already emit.
   // #868: per-resource revert tallies for the --json element (summarize collapses a
   // resource that split into cc + sdk items so it is counted once).
   const summarized = summarizeRevertResults(applied);
   const revertedCount = summarized.filter((s) => s.ok).length;
   const failedCount = summarized.filter((s) => !s.ok).length;
-  for (const s of summarized) {
-    if (s.ok) {
-      out(style.ok(`  reverted: ${s.displayId}`));
-    } else {
-      out(style.fail(`  FAILED: ${s.displayId} — ${s.error}`));
-      // Transient "resource is mid-update" failure that survived the retries: add a
-      // targeted hint so the user knows this is retry-later, not a real failure. When we
-      // did NOT already wait (`--wait` off), point at it as the one-command settle path.
-      if (s.hint) {
-        const suffix =
-          waitMs === undefined ? ' (or re-run with --wait to block until it settles)' : '';
-        out(style.note(`    ↳ ${s.hint}${suffix}`));
-      }
-    }
+  // #952: every resource whose items all landed was already streamed above the moment it
+  // finished, so we must NOT reprint it here (that would double every line). Print only the
+  // stragglers — a resource whose item count was never fully reached (should not happen on a
+  // normal run; this keeps output complete if it ever does) — mapped back to logicalId via
+  // its first applied item.
+  for (const item of plan.items) {
+    if (streamedLogical.has(item.logicalId)) continue;
+    streamResultLine(item.logicalId);
   }
 
   // Re-check convergence — scoped to the resources the revert just touched (R44).

--- a/tests/revert-stream-interrupt-952.test.ts
+++ b/tests/revert-stream-interrupt-952.test.ts
@@ -1,0 +1,164 @@
+import {
+  CloudControlClient,
+  GetResourceCommand,
+  UpdateResourceCommand,
+} from '@aws-sdk/client-cloudcontrol';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { GatherResult } from '../src/commands/gather.js';
+import { revertStack } from '../src/commands/stack-actions.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+// #952: the apply loop must STREAM each resource's `reverted:`/`FAILED:` line the moment
+// its item resolves, instead of buffering the whole batch and printing only after every
+// item completes. A Ctrl-C mid-apply otherwise leaves ZERO trace of what already happened.
+// We assert the streaming ORDERING: when a LATER resource's UpdateResource runs, the EARLIER
+// resource's `reverted:` line is ALREADY in the log — impossible under the old buffered path
+// (which emitted nothing until both items had finished).
+
+const EMPTY_SCHEMA = {
+  readOnly: new Set<string>(),
+  writeOnly: new Set<string>(),
+  createOnly: new Set<string>(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+} as SchemaInfo;
+
+// Two roles, each with an out-of-band MaxSessionDuration (undeclared) → each reverts an
+// `add /MaxSessionDuration = 3600` op. A per-resource item → two apply iterations.
+const undeclaredMsd = (logicalId: string, physicalId: string): Finding => ({
+  tier: 'undeclared',
+  logicalId,
+  resourceType: 'AWS::IAM::Role',
+  path: 'MaxSessionDuration',
+  physicalId,
+  actual: 7200,
+});
+
+const gathered = (): GatherResult =>
+  ({
+    desired: {
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources: [
+        { logicalId: 'A', resourceType: 'AWS::IAM::Role', physicalId: 'a-phys', declared: {} },
+        { logicalId: 'B', resourceType: 'AWS::IAM::Role', physicalId: 'b-phys', declared: {} },
+      ],
+      rawTemplate: '{}',
+      ctx: {
+        params: {},
+        pseudo: {},
+        conditions: {},
+        physIds: {},
+        liveAttrs: {},
+        mappings: {},
+        exports: {},
+        condCache: new Map(),
+      },
+    },
+    findings: [undeclaredMsd('A', 'a-phys'), undeclaredMsd('B', 'b-phys')],
+    schemas: new Map([['AWS::IAM::Role', EMPTY_SCHEMA]]),
+    liveByLogical: new Map(),
+  }) as GatherResult;
+
+const params = (extra: Record<string, unknown> = {}) => ({
+  stackName: 's',
+  region: 'r',
+  gathered: gathered(),
+  baseline: undefined,
+  config: { ignore: [] },
+  dryRun: false,
+  yes: true,
+  removeUnrecorded: true,
+  verbose: false,
+  interactive: false,
+  convergeRetryDelayMs: 0,
+  ...extra,
+});
+
+const liveRead = (value: number) => ({
+  ResourceDescription: {
+    Identifier: 'x',
+    Properties: JSON.stringify({ MaxSessionDuration: value }),
+  },
+});
+
+describe('revertStack #952 — per-item outcome is streamed, not buffered', () => {
+  let cfnMock: ReturnType<typeof mockClient>;
+  let ccMock: ReturnType<typeof mockClient>;
+  beforeEach(() => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' } as never] });
+    ccMock = mockClient(CloudControlClient);
+    // The default write lands (live re-reads 3600) so both revert cleanly.
+    ccMock.on(GetResourceCommand).resolves(liveRead(3600));
+  });
+  afterEach(() => {
+    cfnMock.restore();
+    ccMock.restore();
+  });
+
+  const runCapturing = async (onUpdate?: (physicalId: string, logs: string[]) => void) => {
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (s: unknown) => logs.push(String(s));
+    ccMock.on(UpdateResourceCommand).callsFake((input: { Identifier?: string }) => {
+      onUpdate?.(String(input.Identifier), logs);
+      return { ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' } };
+    });
+    try {
+      const outcome = await revertStack(params());
+      return { outcome, logs };
+    } finally {
+      console.log = orig;
+    }
+  };
+
+  it("the earlier resource's `reverted:` line is already printed when the next item applies", async () => {
+    // Count how many `reverted:` lines exist AT THE MOMENT each resource's UpdateResource runs.
+    const revertedLinesSeenBeforeUpdate = new Map<string, number>();
+    await runCapturing((physicalId, logs) => {
+      const count = logs.filter((l) => l.includes('reverted:')).length;
+      revertedLinesSeenBeforeUpdate.set(physicalId, count);
+    });
+    // The first item's UpdateResource runs with 0 prior `reverted:` lines (nothing done yet).
+    expect(revertedLinesSeenBeforeUpdate.get('a-phys')).toBe(0);
+    // The SECOND item's UpdateResource runs AFTER the first was streamed → 1 prior line.
+    // Under the OLD buffered path this would still be 0 (nothing printed until the batch end).
+    expect(revertedLinesSeenBeforeUpdate.get('b-phys')).toBe(1);
+  });
+
+  it('does not double-print: each resource yields exactly ONE `reverted:` line', async () => {
+    const { logs } = await runCapturing();
+    const joined = logs.join('\n');
+    // One line per resource — the end-of-batch pass must NOT reprint the streamed lines.
+    const revertedLines = logs.filter((l) => l.includes('reverted:'));
+    expect(revertedLines).toHaveLength(2);
+    expect(joined).toContain('reverted: A');
+    expect(joined).toContain('reverted: B');
+  });
+
+  it('streams under text mode but stays silent under --json (no per-item lines on stdout)', async () => {
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (s: unknown) => logs.push(String(s));
+    ccMock.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' },
+    });
+    try {
+      const outcome = await revertStack(params({ json: true }));
+      expect(logs.some((l) => l.includes('reverted:'))).toBe(false);
+      // The machine-readable tallies are still produced on the outcome.
+      expect(outcome.reverted).toBe(2);
+    } finally {
+      console.log = orig;
+    }
+  });
+});


### PR DESCRIPTION
Closes #952.

The `revert` apply loop buffered every `reverted:`/`FAILED:` line and printed the whole batch only **after** both the non-delete loop and the delete batch finished. On a long (10-item) revert the user saw nothing for minutes, and a Ctrl-C mid-apply left **zero trace** of what had already been written to AWS.

Now each resource's collapsed outcome is streamed the moment its last plan item resolves:
- a `cc`+`sdk` split still prints exactly **one** line, via a shared renderer, so output is byte-for-byte identical to before;
- the end-of-batch pass still runs for the `--json` tallies but skips anything already streamed → nothing double-prints;
- streaming goes through `out`, so it stays suppressed under `--json`.

This is the primary fix from the issue (the optional scoped-SIGINT handler was intentionally skipped to avoid regressing the non-interrupt path — streaming alone resolves the zero-trace symptom).

## Verification
- New unit test `tests/revert-stream-interrupt-952.test.ts`: asserts resource A is streamed *before* resource B's write runs (fails without the fix), no double-print, and `--json` suppression.
- typecheck / `vp check` (0 errors) / build / 4235 unit tests all green.

Note: pure output-timing change on the revert code path; no live AWS mutation semantics change.