### PR TITLE
fix(revert): verify op.prior against the fresh model before a whole-document SDK write (#805)

### DIFF
--- a/src/revert/apply-ops.ts
+++ b/src/revert/apply-ops.ts
@@ -2,10 +2,66 @@
 // of a resource model, by JSON pointer. Used by the SDK writers to reconstruct
 // the DESIRED full property value before a whole-property SDK write (e.g. set the
 // full bucket policy), so sub-path drifts revert correctly too.
+import { deepEqual } from '../diff/drift-calculator.js';
 import type { PatchOp } from './plan.js';
 
 function unescape(seg: string): string {
   return seg.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function pointerSegs(path: string): string[] {
+  return path.split('/').slice(1).map(unescape);
+}
+
+// #805: a revert op that a whole-document SDK writer applies (PutBucketPolicy /
+// PutRolePolicy / CreatePolicyVersion / UpdateWebACL, …) carries a numeric index
+// (`…/Statement/1/Resource`, `…/Rules/1/…`) computed against the CHECK-time,
+// canonically-SORTED model. The writer re-reads the live model at apply time and
+// re-canonicalizes it so the index still ALIGNS BY ORDER — but if a statement/rule
+// was added or removed while the user sat on the confirm prompt (#760's mutation
+// window), the sorted FRESH array puts a DIFFERENT element at that index. The
+// whole-document PUT would then overwrite an innocent (security-relevant) element
+// AND leave the real drift unreverted — the SDK-path twin of the CC stale-index
+// window #762 wrongly assumed the SDK re-read closed (the re-read fixes ORDER, not
+// index FRESHNESS). Every op carries `prior` (the check-time live value at its
+// path, = f.actual, set by plan.ts revertOp); before a whole-document write, verify
+// the FRESH model still holds `prior` at each op's path. Any mismatch means the
+// array shifted under the plan — ABORT rather than wrong-write. The model passed
+// here MUST already be canonicalized the same way the op index was (the caller
+// aligns it), so a stable model compares equal.
+export class StaleRevertModelError extends Error {
+  readonly pointerPath: string;
+  constructor(pointerPath: string) {
+    super(
+      `revert aborted: the live value at ${pointerPath} changed since drift was detected ` +
+        `(an element in the same array was added or removed) — re-run \`check\` and revert again`
+    );
+    this.name = 'StaleRevertModelError';
+    this.pointerPath = pointerPath;
+  }
+}
+
+export function assertPriorUnchanged(
+  model: Record<string, unknown>,
+  ops: readonly PatchOp[]
+): void {
+  for (const op of ops) {
+    // `prior` is absent for a re-add of a live-REMOVED value (nothing at the path
+    // to protect) and for contract plumbing ops — nothing to verify in either case.
+    if (op.prior === undefined) continue;
+    if (!deepEqual(getAt(model, pointerSegs(op.path)), op.prior)) {
+      throw new StaleRevertModelError(op.path);
+    }
+  }
+}
+
+function getAt(root: unknown, segs: string[]): unknown {
+  let node: unknown = root;
+  for (const seg of segs) {
+    if (node === null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[seg];
+  }
+  return node;
 }
 
 export function applyOps(
@@ -14,7 +70,7 @@ export function applyOps(
 ): Record<string, unknown> {
   const out = structuredClone(model);
   for (const op of ops) {
-    const segs = op.path.split('/').slice(1).map(unescape);
+    const segs = pointerSegs(op.path);
     if (op.op === 'add') setAt(out, segs, op.value);
     else removeAt(out, segs);
   }

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -214,7 +214,7 @@ import {
   type OverrideCtx,
   SDK_OVERRIDES,
 } from '../read/overrides.js';
-import { applyOps } from './apply-ops.js';
+import { applyOps, assertPriorUnchanged } from './apply-ops.js';
 import type { PatchOp } from './plan.js';
 import { classifyTransient, errorText } from './transient.js';
 
@@ -278,6 +278,11 @@ async function desiredModel(
     current.PolicyDocument === undefined
       ? current
       : { ...current, PolicyDocument: canonicalizeForCompare(current.PolicyDocument) };
+  // #805: the op indices were computed against the check-time model; abort if the
+  // freshly re-read (aligned) model no longer holds each op's `prior` at its path
+  // (a statement added/removed at the confirm prompt would land the whole-document
+  // PUT on an innocent statement).
+  assertPriorUnchanged(aligned, ops);
   return applyOps(aligned, ops);
 }
 const policyJson = (m: Record<string, unknown>): string | undefined =>
@@ -770,13 +775,14 @@ const writeWafv2WebAcl: SdkWriter = async (ctx, ops) => {
   // misalignment class, here on the SDK-writer path). Canonicalize the current model the
   // same way so an indexed op hits the SAME rule; Rule order is not significant to WAFv2
   // (Priority governs evaluation), so re-sending the sorted array changes no behavior.
-  const m = applyOps(
-    canonicalizeForCompare(cur.WebACL as unknown as Record<string, unknown>) as Record<
-      string,
-      unknown
-    >,
-    ops
-  );
+  const alignedWebAcl = canonicalizeForCompare(
+    cur.WebACL as unknown as Record<string, unknown>
+  ) as Record<string, unknown>;
+  // #805: same stale-index guard as desiredModel — a Rule added/removed while the
+  // user sat on the confirm prompt would put a different rule at the op's sorted
+  // index; abort rather than UpdateWebACL an innocent (security-relevant) rule.
+  assertPriorUnchanged(alignedWebAcl, ops);
+  const m = applyOps(alignedWebAcl, ops);
   const desc = m.Description;
   await c.send(
     new UpdateWebACLCommand({

--- a/tests/apply-ops.test.ts
+++ b/tests/apply-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { applyOps } from '../src/revert/apply-ops.js';
+import { applyOps, assertPriorUnchanged, StaleRevertModelError } from '../src/revert/apply-ops.js';
 import type { PatchOp } from '../src/revert/plan.js';
 
 const op = (o: Partial<PatchOp>): PatchOp => ({ op: 'add', path: '/X', human: '', ...o });
@@ -29,5 +29,88 @@ describe('applyOps (reconstruct desired model for SDK writers)', () => {
       op({ op: 'add', path: '/Statement/0/Effect', value: 'Deny' }),
     ]);
     expect(out).toEqual({ Version: '2012-10-17', Statement: [{ Effect: 'Deny' }] });
+  });
+});
+
+describe('assertPriorUnchanged (#805 stale-index guard before a whole-document write)', () => {
+  // A canonically-sorted policy: Statement is sorted by Sid, so index 1 is Sid "b".
+  const freshPolicy = () => ({
+    PolicyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        { Sid: 'a', Effect: 'Allow', Resource: 'arnA' },
+        { Sid: 'b', Effect: 'Allow', Resource: 'arnB' },
+      ],
+    },
+  });
+
+  it('passes when the fresh model still holds each op prior at its path', () => {
+    // Reverting Sid "b"'s Resource; prior is what check saw at that index, still there.
+    expect(() =>
+      assertPriorUnchanged(freshPolicy(), [
+        op({
+          op: 'add',
+          path: '/PolicyDocument/Statement/1/Resource',
+          value: 'arnB',
+          prior: 'arnB',
+        }),
+      ])
+    ).not.toThrow();
+  });
+
+  it('throws StaleRevertModelError when a statement was added/removed so the sorted index now points elsewhere', () => {
+    // At check time index 1 (sorted) was Sid "b" with Resource 'arnB' (the op prior).
+    // A statement inserted at the confirm prompt re-sorts the array so index 1 is now a
+    // DIFFERENT statement (Resource 'arnX') — writing 'arnB' there would corrupt it.
+    const shifted = {
+      PolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          { Sid: 'a', Effect: 'Allow', Resource: 'arnA' },
+          { Sid: 'aa', Effect: 'Deny', Resource: 'arnX' },
+          { Sid: 'b', Effect: 'Allow', Resource: 'arnB' },
+        ],
+      },
+    };
+    expect(() =>
+      assertPriorUnchanged(shifted, [
+        op({
+          op: 'add',
+          path: '/PolicyDocument/Statement/1/Resource',
+          value: 'arnB',
+          prior: 'arnB',
+        }),
+      ])
+    ).toThrow(StaleRevertModelError);
+  });
+
+  it('throws when the value at a top-level path changed since check (whole-document drift)', () => {
+    expect(() =>
+      assertPriorUnchanged(
+        { PolicyDocument: { Version: '2012-10-17', Statement: [{ Effect: 'Deny' }] } },
+        [
+          op({
+            op: 'add',
+            path: '/PolicyDocument',
+            value: {},
+            prior: { Version: '2012-10-17', Statement: [{ Effect: 'Allow' }] },
+          }),
+        ]
+      )
+    ).toThrow(StaleRevertModelError);
+  });
+
+  it('skips ops with no prior (a re-add of a live-removed value has nothing to protect)', () => {
+    expect(() =>
+      assertPriorUnchanged({ A: 1 }, [op({ op: 'add', path: '/B', value: 2 })])
+    ).not.toThrow();
+  });
+
+  it('deep-compares object priors so a same-shape live value passes', () => {
+    expect(() =>
+      assertPriorUnchanged({ Env: { KEY: 'v' } }, [
+        op({ op: 'add', path: '/Env', value: { KEY: 'w' }, prior: { KEY: 'v' } }),
+      ])
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
Closes #805.

## Problem

The SDK-writer whole-document PUTs (`PutBucketPolicy` / `SetTopicAttributes` / `CreatePolicyVersion` / `UpdateWebACL`, …) re-read and re-canonicalize the live model at apply time so an indexed op (`/PolicyDocument/Statement/1/…`, `/Rules/1/…`) still **aligns by ORDER** — but the re-read fixes ORDER, not index **FRESHNESS**. If a statement/rule is added or removed while the user sits on the revert confirm prompt (#760's mutation window), the canonically-SORTED fresh array puts a **different** element at that index. The whole-document PUT then overwrites an innocent (security-relevant) element AND leaves the real drift unreverted. This is the SDK-path twin of the Cloud Control stale-index window — #762 wrongly assumed the SDK re-read closed it.

## Fix

Every op already carries `prior` (the check-time live value at its path, set by `plan.ts` `revertOp`). Add `assertPriorUnchanged` (in `src/revert/apply-ops.ts`), called in `desiredModel` and `writeWafv2WebAcl` **right before** `applyOps` on the already-aligned model: if the fresh model no longer holds each op's `prior` at its path, the array shifted under the plan → abort with a clear `StaleRevertModelError` rather than wrong-write. `prior`-less ops (a re-add of a live-removed value, contract plumbing) are skipped. Scoped to the two canonicalize-then-PUT writers the issue names, so it compares apples-to-apples with the shape the op index was computed against.

## Verification

- **Unit tests** (`tests/apply-ops.test.ts`): shifted-index abort, top-level whole-document abort, stable-model pass, prior-less skip, deep-equal object prior.
- **Live** (us-east-1, throwaway `Cdkrd805Verify`, `cdkrd:ephemeral=1`, swept clean): deploy S3 Bucket + BucketPolicy (2 statements) → mutate `AllowGetA` actions out of band → `check` detects the declared drift at the canonical **index-1** (`PolicyDocument.Statement.1.Action`) → `revert --yes` converges (guard passes because `prior` still matches live) → live policy back to declared `["s3:GetObject"]`. Confirms the guard does **not** break a legitimate revert; the abort-on-race path is unit-tested (the race is not deterministically reproducible live).
