### PR TITLE
fix(normalize+revert): handle map-shaped tag properties under service-specific names (#862)

### DIFF
--- a/src/normalize/cc-api-strip.ts
+++ b/src/normalize/cc-api-strip.ts
@@ -41,7 +41,37 @@ export const FREE_FORM_MAP_PARENTS = new Set([
   'DefaultArguments', // AWS::Glue::Job
   'DockerLabels', // AWS::ECS::TaskDefinition container definitions
   'Labels', // generic label maps
-  'Tags', // map-shaped Tags (a user tag keyed like a managed field)
+  // Map-shaped tag properties (a user tag keyed like a managed field must not be
+  // name-stripped) — `Tags` plus the service-specific map-shaped tag names (#862).
+  'Tags',
+  'UserPoolTags', // AWS::Cognito::UserPool
+  'BackupPlanTags', // AWS::Backup::BackupPlan
+  'BackupVaultTags', // AWS::Backup::BackupVault
+  'RecoveryPointTags', // AWS::Backup::* recovery points
+]);
+
+// Tag-property names that carry the same semantics as `Tags` but live under a
+// SERVICE-SPECIFIC name (#862) — both MAP-shaped ({k:v}: UserPoolTags, Backup*Tags) and
+// LIST-shaped ({Key,Value}[]: IdentityPoolTags, BotTags, ...). AWS augments every one of
+// them with managed `aws:*` tags, so the three sites that special-case `Tags` must treat
+// them identically: the live `aws:*` strip (noise.stripAwsTagsDeep, so a first `check` of
+// a tagged resource is clean), the free-form-map name-strip exemption above, and the
+// revert managed-tag preservation (revert/plan.tagPreservingOps, so a tag revert never
+// tries to untag `aws:cloudformation:*` and get rejected). Over-inclusion is SAFE at every
+// site: each only acts on `aws:*`-prefixed data (never user intent) or a value AWS
+// actually echoes as managed, so a non-tag property that happens to share one of these
+// names is untouched.
+export const TAG_PROPERTY_NAMES: ReadonlySet<string> = new Set([
+  'Tags',
+  'UserPoolTags', // AWS::Cognito::UserPool (map)
+  'BackupPlanTags', // AWS::Backup::BackupPlan (map)
+  'BackupVaultTags', // AWS::Backup::BackupVault (map)
+  'RecoveryPointTags', // AWS::Backup::* (map)
+  'IdentityPoolTags', // AWS::Cognito::IdentityPool (list)
+  'BotTags', // AWS::Lex::Bot (list)
+  'ResourceTags', // AWS::CE::AnomalySubscription (list)
+  'FileSystemTags', // AWS::EFS::FileSystem (list)
+  'HostedZoneTags', // AWS::Route53::HostedZone (list)
 ]);
 
 export function stripCcApiAwsManagedFields(

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -6,6 +6,7 @@
 // genuine YAML string alike (SSM Document.Content declared `DocumentFormat: YAML`
 // reads back as canonical JSON — #713).
 import { parse as parseYaml } from 'yaml';
+import { TAG_PROPERTY_NAMES } from './cc-api-strip.js';
 
 // A4: defaults AWS applies that are NOT in the CFn schema's `default` field.
 // Every entry is equality-gated: it only suppresses a live value EQUAL to the
@@ -3412,7 +3413,10 @@ function stripTagsWalk(v: unknown, underTagsKey: boolean, parentKey: string | un
     const out: Record<string, unknown> = {};
     for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
       if (underTagsKey && k.startsWith('aws:')) continue;
-      out[k] = stripTagsWalk(val, k === 'Tags', k);
+      // #862: arm the map-key `aws:*` strip under ANY tag-property name (UserPoolTags,
+      // BackupPlanTags, …), not just the literal `Tags` — a map-shaped tag prop otherwise
+      // surfaces `<Prop>.aws:cloudformation:stack-name` etc. as first-run undeclared FPs.
+      out[k] = stripTagsWalk(val, TAG_PROPERTY_NAMES.has(k), k);
     }
     return out;
   }

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -11,6 +11,7 @@
 // CC-gap types (revert for those is a follow-up).
 import type { BaselineFile } from '../baseline/baseline-file.js';
 import { withinStackPath } from '../construct-path.js';
+import { TAG_PROPERTY_NAMES } from '../normalize/cc-api-strip.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
   awsManagedTags,
@@ -1193,64 +1194,76 @@ export function writeOnlyReincludeOps(
 // passes through unchanged: a single-key `remove`/`add` leaves every OTHER key — including
 // the live `aws:*` managed ones — in Cloud Control's read-modify-write model, so the
 // provider never untags the managed keys (proven live on an SSM Parameter).
-const TAGS_POINTER = '/Tags';
 function asTagList(v: unknown): unknown[] {
   return Array.isArray(v) ? v : [];
+}
+// Rewrite ONE whole-property tag `add`/`remove` op so the revert re-attaches the live
+// `aws:*` managed tags it would otherwise strip. `pointer` is the op's own `/<Name>`
+// pointer and `liveTags` the live value read under that name — so this works for `/Tags`
+// AND every service-specific tag property (#862), MAP- or LIST-shaped.
+function preserveManagedTags(op: PatchOp, pointer: string, liveTags: unknown): PatchOp {
+  // MAP-shaped tags (key->value, e.g. SSM Parameter Tags, Cognito UserPoolTags): the
+  // managed tags are aws:* KEYS. A whole-map revert that dropped them -> AWS rejects
+  // ("aws: prefixed tag key names are not allowed for external use"). Preserve them.
+  if (liveTags !== null && typeof liveTags === 'object' && !Array.isArray(liveTags)) {
+    const managedMap = Object.fromEntries(
+      Object.entries(liveTags).filter(([k]) => k.startsWith('aws:'))
+    );
+    if (Object.keys(managedMap).length === 0) return op;
+    const userMap =
+      op.op === 'add' &&
+      op.value !== null &&
+      typeof op.value === 'object' &&
+      !Array.isArray(op.value)
+        ? Object.fromEntries(
+            Object.entries(op.value as Record<string, unknown>).filter(
+              ([k]) => !k.startsWith('aws:')
+            )
+          )
+        : {};
+    return {
+      op: 'add',
+      path: pointer,
+      value: { ...userMap, ...managedMap },
+      ...(op.prior !== undefined && { prior: op.prior }),
+      human: `${op.human} (preserving aws:* managed tags)`,
+    };
+  }
+  // LIST-shaped tags ({Key,Value}[]): the managed tags are aws:* ELEMENTS.
+  const managed = awsManagedTags(liveTags);
+  if (managed.length === 0) return op; // nothing managed to protect — leave the op as-is
+  // user (non-managed) tags the revert wants to KEEP: an `add` keeps its value's tags, a
+  // `remove` keeps none — either way, drop any aws:* entry from the value (it should never
+  // carry one, but be defensive) and re-attach the live managed set.
+  const userTags =
+    op.op === 'add' ? asTagList(op.value).filter((t) => awsManagedTags([t]).length === 0) : [];
+  return {
+    op: 'add',
+    path: pointer,
+    value: [...userTags, ...managed],
+    ...(op.prior !== undefined && { prior: op.prior }),
+    human: `${op.human} (preserving aws:* managed tags)`,
+  };
 }
 export function tagPreservingOps(
   ops: PatchOp[],
   liveRaw: Record<string, unknown> | undefined
 ): PatchOp[] {
-  const liveTags = liveRaw?.['Tags'];
-  // MAP-shaped Tags (key->value, e.g. AWS::SSM::Parameter): the managed tags are aws:*
-  // KEYS. awsManagedTags only understood the {Key,Value}[] list shape, so a map-shaped
-  // /Tags revert dropped the aws:* keys -> AWS rejects ("aws: prefixed tag key names are
-  // not allowed for external use"). Mirror stripTagsWalk/isAllAwsTags and preserve them.
-  if (liveTags !== null && typeof liveTags === 'object' && !Array.isArray(liveTags)) {
-    const managedMap = Object.fromEntries(
-      Object.entries(liveTags).filter(([k]) => k.startsWith('aws:'))
-    );
-    if (Object.keys(managedMap).length === 0) return ops;
-    return ops.map((op) => {
-      if (op.path !== TAGS_POINTER) return op;
-      const userMap =
-        op.op === 'add' &&
-        op.value !== null &&
-        typeof op.value === 'object' &&
-        !Array.isArray(op.value)
-          ? Object.fromEntries(
-              Object.entries(op.value as Record<string, unknown>).filter(
-                ([k]) => !k.startsWith('aws:')
-              )
-            )
-          : {};
-      return {
-        op: 'add',
-        path: TAGS_POINTER,
-        value: { ...userMap, ...managedMap },
-        ...(op.prior !== undefined && { prior: op.prior }),
-        human: `${op.human} (preserving aws:* managed tags)`,
-      };
-    });
-  }
-  const managed = awsManagedTags(liveTags);
-  if (managed.length === 0) return ops; // nothing managed to protect — leave ops as-is
-  return ops.map((op) => {
-    if (op.path !== TAGS_POINTER) return op;
-    // user (non-managed) tags the revert wants to KEEP: an `add` keeps its value's
-    // tags, a `remove` keeps none — either way, drop any aws:* entry from the value
-    // (it should never carry one, but be defensive — same per-element predicate as
-    // awsManagedTags) and re-attach the live managed set.
-    const userTags =
-      op.op === 'add' ? asTagList(op.value).filter((t) => awsManagedTags([t]).length === 0) : [];
-    return {
-      op: 'add',
-      path: TAGS_POINTER,
-      value: [...userTags, ...managed],
-      ...(op.prior !== undefined && { prior: op.prior }),
-      human: `${op.human} (preserving aws:* managed tags)`,
-    };
+  let changed = false;
+  const out = ops.map((op) => {
+    // Only a WHOLE-PROPERTY tag pointer `/<Name>` where Name is a known tag property is
+    // rewritten. A NESTED single-key op (`/Tags/<key>`, `/UserPoolTags/<key>`) passes
+    // through unchanged: it leaves every OTHER key — including the live aws:* managed ones
+    // — in Cloud Control's read-modify-write model, so the provider never untags them.
+    const name = /^\/([^/]+)$/.exec(op.path)?.[1];
+    if (name === undefined || !TAG_PROPERTY_NAMES.has(name)) return op;
+    const rewritten = preserveManagedTags(op, op.path, liveRaw?.[name]);
+    if (rewritten !== op) changed = true;
+    return rewritten;
   });
+  // Preserve the by-reference "nothing to protect" contract callers rely on (return the
+  // exact input array when no op was rewritten).
+  return changed ? out : ops;
 }
 
 // Service-echoed EMPTY sub-arrays that the service itself REJECTS when a Cloud Control

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -996,6 +996,42 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('#862: stripAwsTagsDeep strips aws:* map keys under a SERVICE-SPECIFIC tag name too', () => {
+    // Map-shaped tag props under non-`Tags` names (UserPoolTags, Backup*Tags) must have
+    // their aws:cloudformation:* keys stripped, exactly like `Tags` — otherwise a tagged
+    // resource surfaces `<Prop>.aws:cloudformation:stack-name` as first-run undeclared FPs.
+    expect(
+      stripAwsTagsDeep({
+        UserPoolTags: { 'aws:cloudformation:stack-name': 'S', env: 'prod' },
+      })
+    ).toEqual({ UserPoolTags: { env: 'prod' } });
+    expect(
+      stripAwsTagsDeep({ BackupPlanTags: { 'aws:cloudformation:logical-id': 'P', team: 'x' } })
+    ).toEqual({ BackupPlanTags: { team: 'x' } });
+    // A list-shaped service-specific tag name (IdentityPoolTags) already stripped by shape;
+    // confirm it still does.
+    expect(
+      stripAwsTagsDeep({
+        IdentityPoolTags: [
+          { Key: 'aws:cloudformation:stack-id', Value: 'x' },
+          { Key: 'env', Value: 'prod' },
+        ],
+      })
+    ).toEqual({ IdentityPoolTags: [{ Key: 'env', Value: 'prod' }] });
+    // A non-tag map that merely SHARES a listed name but carries no aws:* keys is untouched.
+    expect(stripAwsTagsDeep({ ResourceTags: { region: 'us-east-1' } })).toEqual({
+      ResourceTags: { region: 'us-east-1' },
+    });
+  });
+
+  it('#862: stripCcApiAwsManagedFields never name-strips a user key inside a map-shaped tag prop', () => {
+    // A user tag keyed like an ALWAYS_STRIPPED field (`CreatedBy`) under UserPoolTags must
+    // survive — otherwise it reads live-absent and becomes a permanent declared FP.
+    expect(
+      stripCcApiAwsManagedFields({ UserPoolTags: { CreatedBy: 'team-x', env: 'prod' } })
+    ).toEqual({ UserPoolTags: { CreatedBy: 'team-x', env: 'prod' } });
+  });
+
   it('isPemEqual: trailing-newline / CRLF differences on a PEM block are not drift (R125)', () => {
     const key = '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqAQAB\n-----END PUBLIC KEY-----';
     // CloudFront PublicKey EncodedKey: AWS appends a trailing newline on read

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -2533,6 +2533,38 @@ describe('tagPreservingOps (revert must not strip aws:* managed tags — the SNS
     expect(out[1]).toBe(other); // the non-Tags op is returned by reference, unchanged
   });
 
+  describe('#862: service-specific tag property names (not literal /Tags)', () => {
+    it('a `remove /UserPoolTags` (MAP-shaped) keeps the live aws:* map keys', () => {
+      const [out] = tagPreservingOps([op({ op: 'remove', path: '/UserPoolTags' })], {
+        UserPoolTags: { 'aws:cloudformation:stack-name': 'S', env: 'prod' },
+      });
+      expect(out).toMatchObject({
+        op: 'add',
+        path: '/UserPoolTags',
+        value: { 'aws:cloudformation:stack-name': 'S' },
+      });
+      expect(out!.value).not.toHaveProperty('env'); // user key dropped by the remove
+    });
+
+    it('a `remove /IdentityPoolTags` (LIST-shaped) re-attaches the live aws:* elements', () => {
+      const [out] = tagPreservingOps([op({ op: 'remove', path: '/IdentityPoolTags' })], {
+        IdentityPoolTags: [
+          { Key: 'aws:cloudformation:logical-id', Value: 'Pool' },
+          { Key: 'team', Value: 'x' },
+        ],
+      });
+      expect(out).toMatchObject({ op: 'add', path: '/IdentityPoolTags' });
+      expect(out!.value).toEqual([{ Key: 'aws:cloudformation:logical-id', Value: 'Pool' }]);
+    });
+
+    it('a NESTED single-key op (/UserPoolTags/<key>) passes through unchanged', () => {
+      const ops = [op({ op: 'remove', path: '/UserPoolTags/env' })];
+      expect(
+        tagPreservingOps(ops, { UserPoolTags: { 'aws:cloudformation:stack-name': 'S' } })
+      ).toBe(ops);
+    });
+  });
+
   describe('MAP-shaped Tags (AWS::SSM::Parameter — key->value, WAVE24)', () => {
     // CC returns SSM Parameter Tags as a map; the managed tags are aws:* KEYS
     const liveMapManaged = {


### PR DESCRIPTION
Closes #862.

Map-shaped tag properties under names OTHER than `Tags` (`UserPoolTags`, `BackupPlanTags`/`BackupVaultTags`/`RecoveryPointTags`, ...) plus list-shaped service-specific names (`IdentityPoolTags`, `BotTags`, `ResourceTags`, `FileSystemTags`, `HostedZoneTags`) were mishandled at three sites that all keyed on the literal parent name `Tags`:

- **Site 1** (`normalize/noise.ts` `stripTagsWalk`) — the aws:* MAP-KEY strip was armed only under `Tags`, so a tagged resource surfaced `<Prop>.aws:cloudformation:stack-name` etc. as first-run undeclared FPs (**live-confirmed on Cognito UserPool** per the issue).
- **Site 2** (`revert/plan.ts` `tagPreservingOps`) — the `/Tags` pointer was hardcoded, so a tag revert on a non-`Tags` name rebuilt the payload WITHOUT the managed aws:* tags → Cloud Control's read-modify-write then tried to untag `aws:cloudformation:*` and got rejected. Generalized to any `/<TagProp>` pointer, MAP- or LIST-shaped; a nested single-key op (`/UserPoolTags/<key>`) still passes through.
- **Site 3** (`normalize/cc-api-strip.ts` `FREE_FORM_MAP_PARENTS`) — a user tag keyed like an ALWAYS_STRIPPED field under a map-shaped tag prop was name-stripped from live → permanent declared FP. Added the map-shaped tag names to the exemption.

One shared `TAG_PROPERTY_NAMES` set (in `cc-api-strip.ts`) drives all three. Over-inclusion is safe: each site only acts on `aws:*`-prefixed data (never user intent) or a value AWS echoes as managed, and the `tagPreservingOps` array-reference contract is preserved (returns the input array when nothing is rewritten).

## Verification
- 5 new unit tests (one+ per site): map-shaped strip under service names, free-form exemption for a `CreatedBy` user key, `/UserPoolTags` map + `/IdentityPoolTags` list revert preservation, nested-key pass-through.
- corpus-replay unchanged (the existing UserPool case with undeclared all-aws:* tags still folds).
- typecheck / `vp check` (0 errors) / build / 4277 unit tests all green.