### PR TITLE
fix(diff): fold EKS AccessEntry.Username via a derived gate, not value-independent (#890)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1843,6 +1843,32 @@ export function classifyResource(
       ...(protocolVersion === 'GRPC' ? { Matcher: { GrpcCode: '12' } } : {}),
     };
   }
+  // #890: an EKS AccessEntry that declares no explicit Username reads back the value EKS
+  // DERIVES from the declared PrincipalArn — a DETERMINISTIC transform, not an opaque
+  // per-resource id, so it must be a tier-2 derived equality gate (not value-independent):
+  // Username is MUTABLE (`eks update-access-entry --username`) and RBAC-load-bearing, so an
+  // out-of-band re-map of a principal to a different Kubernetes identity must SURFACE.
+  //   - a role principal `arn:<p>:iam::<acct>:role/<path.../name>` derives
+  //     `arn:<p>:sts::<acct>:assumed-role/<name>/{{SessionName}}` (iam->sts, role/->
+  //     assumed-role/, the path stripped to the bare role name, `/{{SessionName}}` appended);
+  //   - any other principal (an IAM user ARN) echoes the PrincipalArn verbatim.
+  // Equality-gated: a custom Username the user set is declared and compared in the declared
+  // loop; a value that differs from the derived default falls through to `undeclared`.
+  if (resourceType === 'AWS::EKS::AccessEntry') {
+    const principalArn = declared['PrincipalArn'];
+    if (typeof principalArn === 'string') {
+      const roleMatch = /^arn:([^:]+):iam::([^:]*):role\/(.+)$/.exec(principalArn);
+      let derivedUsername = principalArn;
+      if (roleMatch) {
+        const partition = roleMatch[1] ?? 'aws';
+        const acct = roleMatch[2] ?? '';
+        const pathAndName = roleMatch[3] ?? '';
+        const roleName = pathAndName.split('/').pop() ?? pathAndName;
+        derivedUsername = `arn:${partition}:sts::${acct}:assumed-role/${roleName}/{{SessionName}}`;
+      }
+      knownDef = { ...knownDef, Username: derivedUsername };
+    }
+  }
   // AWS/CDK-generated values for THIS resource (its minted name, a default log group
   // derived from the physical id), with the live physical id substituted in — keyed
   // by property, consulted by the undeclared loop below. Empty when the type has no

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2953,13 +2953,10 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'PreferredBackupWindow',
     'EngineLifecycleSupport',
   ]),
-  //   AWS::EKS::AccessEntry.Username — an access entry that declares no explicit Username reads
-  //   back the value EKS DERIVES from the declared PrincipalArn
-  //   ("arn:aws:sts::<acct>:assumed-role/<role>/{{SessionName}}" for an IAM role). It can never
-  //   be a constant we pin (it embeds the per-resource role name), and it is never user intent
-  //   when undeclared — a user who sets a custom Username declares it (compared in the declared
-  //   loop). Fold value-independent. Observed live first-run (hunt 2026-07-03 round E).
-  'AWS::EKS::AccessEntry': new Set(['Username']),
+  //   AWS::EKS::AccessEntry.Username is NO LONGER value-independent (#890): the undeclared
+  //   default is a DETERMINISTIC transform of the declared PrincipalArn, so it is folded by a
+  //   tier-2 derived equality gate in classify.ts (which STILL surfaces an out-of-band RBAC
+  //   identity re-map — a mutable, security-relevant change a value-independent fold hid forever).
   //   AWS::EKS::Cluster.Version — a cluster that declares no Version is provisioned at the
   //   CURRENT default Kubernetes version (the canonical moving-GA-version tier-3 case), which
   //   also MOVES afterward under EKS auto-upgrade — so a recorded baseline value re-drifts and

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -11588,3 +11588,70 @@ describe('#975 derived-echo folds (deterministic function of declared inputs)', 
     expect(assoc.undeclared).toEqual([]);
   });
 });
+
+describe('#890 EKS AccessEntry.Username derived fold (deterministic transform of PrincipalArn)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const entry = (principalArn: string): DesiredResource => ({
+    logicalId: 'Entry',
+    resourceType: 'AWS::EKS::AccessEntry',
+    physicalId: `${principalArn}|cdkrd-eks`,
+    declared: { PrincipalArn: principalArn, ClusterName: 'cdkrd-eks' },
+  });
+
+  it('a role PrincipalArn folds the derived assumed-role Username atDefault', () => {
+    const roleArn =
+      'arn:aws:iam::111111111111:role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4';
+    const t = tiers(
+      classifyResource(
+        entry(roleArn),
+        {
+          Username:
+            'arn:aws:sts::111111111111:assumed-role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4/{{SessionName}}',
+        },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual(['Username']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('a role with a PATH strips the path to the bare role name', () => {
+    const roleArn = 'arn:aws:iam::111111111111:role/some/deep/path/MyRole';
+    const t = tiers(
+      classifyResource(
+        entry(roleArn),
+        { Username: 'arn:aws:sts::111111111111:assumed-role/MyRole/{{SessionName}}' },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual(['Username']);
+  });
+
+  it('a user PrincipalArn echoes verbatim', () => {
+    const userArn = 'arn:aws:iam::111111111111:user/alice';
+    const t = tiers(classifyResource(entry(userArn), { Username: userArn }, emptySchema));
+    expect(t.atDefault).toEqual(['Username']);
+  });
+
+  it('an OUT-OF-BAND Username re-map (RBAC identity change) SURFACES as undeclared', () => {
+    const roleArn = 'arn:aws:iam::111111111111:role/EntryRole';
+    const t = tiers(
+      classifyResource(
+        entry(roleArn),
+        { Username: 'arn:aws:sts::111111111111:assumed-role/cluster-admin/{{SessionName}}' },
+        emptySchema
+      )
+    );
+    expect(t.undeclared).toEqual(['Username']);
+    expect(t.atDefault).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #890.

`AWS::EKS::AccessEntry` `Username` was folded **value-independent** in `noise.ts`, which hid an out-of-band RBAC identity re-map (`eks update-access-entry --username`) **forever** — a mutable, security-relevant change (a principal silently re-bound to a cluster-admin Kubernetes identity read CLEAN).

But the undeclared default is a **deterministic transform** of the declared `PrincipalArn`:
- a role principal `arn:<p>:iam::<acct>:role/<path.../name>` derives `arn:<p>:sts::<acct>:assumed-role/<name>/{{SessionName}}` (iam→sts, role/→assumed-role/, path stripped to the bare role name, `/{{SessionName}}` appended);
- any other principal (an IAM user ARN) echoes verbatim.

So it belongs in fold **tier 2**: I replaced the value-independent entry with a derived equality gate in `classify.ts` (same shape as the Glue `Registry.Name` derivation). A clean deploy still folds `atDefault`; an out-of-band Username re-map now surfaces.

## Verification
- corpus-replay unchanged — `AWS__EKS__AccessEntry.EntryEksRich.json` still folds `Username` `atDefault` (the derived value equals the recorded live default: replay-proven at HEAD, live-harvested in its originating hunt).
- 4 new unit tests: role form, role-with-path, user form, and an **out-of-band re-map surfacing** as undeclared.
- typecheck / `vp check` (0 errors) / build / 4286 unit tests green.