### PR TITLE
fix(diff): subtract sibling standalone LifecycleHooks from an ASG's live list (#700)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -507,6 +507,43 @@ export function buildSiblingUserGroups(desired: Desired): Record<string, string[
   return map;
 }
 
+// A standalone AWS::AutoScaling::LifecycleHook (`AutoScalingGroupName: <asg>`) attaches a hook to an
+// ASG; that hook then appears in the ASG's live `LifecycleHookSpecificationList` — origin-
+// indistinguishable from a hook the ASG declared INLINE. So a stack that mixes an inline
+// `LifecycleHookSpecificationList` with a standalone `CfnLifecycleHook` produces a DECLARED-tier FP
+// that survives `record` (the declared inline list never equals the inline+standalone live list),
+// and a standalone-ONLY ASG additionally FPs the whole list as UNDECLARED (#700). The standalone
+// hook is tracked + compared as its OWN resource, so classify subtracts sibling-declared hooks from
+// the ASG's live list BY NAME (see subtractSiblingLifecycleHooks) — leaving the inline-declared
+// hooks (and any out-of-band hook, matching no sibling) to compare. Keyed by the target ASG
+// identifier the classify finding uses (the ASG's physical id == AutoScalingGroupName; a
+// `{Ref: <asgLogicalId>}` resolves via the logical-id map). The hook NAME the live list echoes is
+// the LifecycleHook's physical id (== its name); fall back to a declared `LifecycleHookName`. Fail-
+// open: an unresolved ASG reference or a nameless hook is skipped (the ASG keeps the reflected hook
+// -> a one-time visible FP, never a hidden change).
+const LIFECYCLE_HOOK_TYPE = 'AWS::AutoScaling::LifecycleHook';
+export function buildSiblingLifecycleHooks(desired: Desired): Record<string, string[]> {
+  const byLogicalId = new Map<string, string>();
+  for (const r of desired.resources) if (r.physicalId) byLogicalId.set(r.logicalId, r.physicalId);
+  const map: Record<string, string[]> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== LIFECYCLE_HOOK_TYPE) continue;
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const d = decl as Record<string, unknown>;
+    const asgKey = resolvePrincipalKey(d.AutoScalingGroupName, byLogicalId);
+    if (!asgKey) continue; // unresolved ASG reference -> fail-open
+    const name =
+      r.physicalId ??
+      (typeof d.LifecycleHookName === 'string' && d.LifecycleHookName
+        ? d.LifecycleHookName
+        : undefined);
+    if (!name) continue;
+    (map[asgKey] ??= []).push(name);
+  }
+  return map;
+}
+
 // Resolve an IAM principal/group reference to the concrete identity the live read echoes: a plain
 // string is the resolved name (== physical id); a `{Ref: logicalId}` resolves via the logical-id ->
 // physical-id map. Any other shape (an unresolved intrinsic) yields undefined -> the caller skips
@@ -917,6 +954,7 @@ export async function gatherFindings(
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
     siblingManagedPolicyAttachments: buildSiblingManagedPolicyAttachments(desired),
     siblingUserGroups: buildSiblingUserGroups(desired),
+    siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
@@ -1008,6 +1046,7 @@ export async function regatherTouched(
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
     siblingManagedPolicyAttachments: buildSiblingManagedPolicyAttachments(desired),
     siblingUserGroups: buildSiblingUserGroups(desired),
+    siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -559,6 +559,31 @@ function subtractSiblingUserGroups(live: Record<string, unknown>, siblingGroups:
   if (arr.length === 0) delete live[USER_GROUPS_PROP]; // empty == absent; no []-vs-absent FP
 }
 
+// An ASG's live `LifecycleHookSpecificationList` merges its INLINE-declared hooks with the hooks
+// applied by SIBLING standalone AWS::AutoScaling::LifecycleHook resources — origin-indistinguishable.
+// Remove each sibling-declared hook by its unique `LifecycleHookName` (AWS enforces per-ASG name
+// uniqueness, so name IS identity), leaving the inline-declared hooks (compared normally) and any
+// out-of-band hook (matching no sibling) to surface. If the list empties (a standalone-only ASG),
+// drop it — empty == absent, so no []-vs-absent undeclared FP.
+const LIFECYCLE_HOOK_SPEC_PROP = 'LifecycleHookSpecificationList';
+function subtractSiblingLifecycleHooks(
+  live: Record<string, unknown>,
+  siblingHookNames: string[]
+): void {
+  const arr = live[LIFECYCLE_HOOK_SPEC_PROP];
+  if (!Array.isArray(arr) || siblingHookNames.length === 0) return;
+  for (const name of siblingHookNames) {
+    const i = arr.findIndex(
+      (el) =>
+        el !== null &&
+        typeof el === 'object' &&
+        (el as Record<string, unknown>).LifecycleHookName === name
+    );
+    if (i >= 0) arr.splice(i, 1);
+  }
+  if (arr.length === 0) delete live[LIFECYCLE_HOOK_SPEC_PROP]; // empty == absent; no []-vs-absent FP
+}
+
 // Cloud Control returns an ALTERNATIVE representation of a declared value as a separate
 // live-only field. Keyed resourceType -> { liveOnlyField: declaredSiblingField }: drop the
 // live-only field when its declared sibling is present (the template already pins the value
@@ -1545,6 +1570,14 @@ export function classifyResource(
     // FP (the addition resource is itself a CC-gap skipped type, checked nowhere); an out-of-band
     // group matching no sibling still surfaces.
     siblingUserGroups?: Record<string, string[]>;
+    // LifecycleHook NAMES declared by SIBLING standalone AWS::AutoScaling::LifecycleHook resources
+    // targeting this ASG, keyed by the ASG identifier (== physical id == AutoScalingGroupName).
+    // Subtracted BY NAME from an AWS::AutoScaling::AutoScalingGroup's reflected live
+    // `LifecycleHookSpecificationList` (which merges inline + standalone hooks, origin-
+    // indistinguishable) so a mixed inline+standalone stack is not a declared-tier FP that survives
+    // record + a revert that would DELETE the sibling hook, and a standalone-only ASG is not an
+    // undeclared FP; an out-of-band hook matching no sibling still surfaces (#700).
+    siblingLifecycleHooks?: Record<string, string[]>;
     // Bucket physical ids whose S3 notifications are managed by a Custom::S3BucketNotifications
     // custom resource (see buildBucketNotificationManaged): the live bucket reflects the
     // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
@@ -1664,6 +1697,17 @@ export function classifyResource(
       const sibGroups = physicalId ? opts.siblingUserGroups?.[physicalId] : undefined;
       if (sibGroups) subtractSiblingUserGroups(live, sibGroups);
     }
+  }
+  // Subtract from an ASG's reflected live `LifecycleHookSpecificationList` the hooks applied by
+  // SIBLING standalone AWS::AutoScaling::LifecycleHook resources (keyed by the ASG's physical id in
+  // opts.siblingLifecycleHooks). Runs regardless of whether the ASG declares an inline list — only
+  // sibling-NAMED hooks are removed, so the ASG's own inline hooks still compare (declared tier) and
+  // a hook added purely out of band (matching no sibling) still surfaces. The sibling hook is
+  // tracked + compared as its own resource, so leaving it on the ASG double-reports it, is a
+  // declared-tier FP that survives record, and a revert would DELETE the sibling-declared hook (#700).
+  if (resourceType === 'AWS::AutoScaling::AutoScalingGroup') {
+    const sibHooks = physicalId ? opts.siblingLifecycleHooks?.[physicalId] : undefined;
+    if (sibHooks) subtractSiblingLifecycleHooks(live, sibHooks);
   }
   // A bucket whose notifications are managed by a Custom::S3BucketNotifications CR reflects
   // the CR-applied NotificationConfiguration it never declares itself (CDK renders

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4557,6 +4557,107 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  // #700: an ASG's live LifecycleHookSpecificationList merges inline-declared hooks with the hooks
+  // applied by SIBLING standalone AWS::AutoScaling::LifecycleHook resources (origin-
+  // indistinguishable). classify subtracts sibling hooks BY NAME (opts.siblingLifecycleHooks) so a
+  // mixed inline+standalone stack is not a declared FP and a standalone-only ASG is not an
+  // undeclared FP; an out-of-band hook (matching no sibling) still surfaces.
+  describe('#700 ASG sibling LifecycleHook subtraction', () => {
+    const bare: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const hook = (name: string, transition = 'autoscaling:EC2_INSTANCE_LAUNCHING') => ({
+      LifecycleHookName: name,
+      LifecycleTransition: transition,
+      DefaultResult: 'CONTINUE',
+    });
+    const asg = (declared: Record<string, unknown>): DesiredResource => ({
+      logicalId: 'Asg',
+      resourceType: 'AWS::AutoScaling::AutoScalingGroup',
+      physicalId: 'asg-phys',
+      declared,
+    });
+
+    it('inline + standalone mix: no declared FP (standalone subtracted by name)', () => {
+      const declared = { LifecycleHookSpecificationList: [hook('inline-launch')] };
+      const live = {
+        LifecycleHookSpecificationList: [
+          hook('inline-launch'),
+          hook('standalone-terminate', 'autoscaling:EC2_INSTANCE_TERMINATING'),
+        ],
+      };
+      const t = tiers(
+        classifyResource(asg(declared), live, bare, {
+          siblingLifecycleHooks: { 'asg-phys': ['standalone-terminate'] },
+        })
+      );
+      expect(t.declared).toEqual([]);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('standalone-only ASG: no undeclared FP (whole list subtracts to empty → dropped)', () => {
+      const live = {
+        LifecycleHookSpecificationList: [
+          hook('standalone-terminate', 'autoscaling:EC2_INSTANCE_TERMINATING'),
+        ],
+      };
+      const t = tiers(
+        classifyResource(asg({}), live, bare, {
+          siblingLifecycleHooks: { 'asg-phys': ['standalone-terminate'] },
+        })
+      );
+      expect(t.undeclared).toEqual([]);
+      expect(t.declared).toEqual([]);
+    });
+
+    it('out-of-band hook (matching no sibling) still surfaces as undeclared', () => {
+      const live = { LifecycleHookSpecificationList: [hook('rogue-oob')] };
+      const t = tiers(classifyResource(asg({}), live, bare, { siblingLifecycleHooks: {} }));
+      expect(t.undeclared).toContain('LifecycleHookSpecificationList');
+    });
+
+    it('out-of-band hook alongside a sibling hook is NOT hidden (declared list still differs)', () => {
+      const declared = { LifecycleHookSpecificationList: [hook('inline-launch')] };
+      const live = {
+        LifecycleHookSpecificationList: [
+          hook('inline-launch'),
+          hook('standalone-terminate', 'autoscaling:EC2_INSTANCE_TERMINATING'),
+          hook('rogue-oob', 'autoscaling:EC2_INSTANCE_TERMINATING'),
+        ],
+      };
+      const t = tiers(
+        classifyResource(asg(declared), live, bare, {
+          siblingLifecycleHooks: { 'asg-phys': ['standalone-terminate'] },
+        })
+      );
+      // standalone subtracted, but the rogue hook remains → declared inline list no longer matches.
+      expect(t.declared.some((p) => p.startsWith('LifecycleHookSpecificationList'))).toBe(true);
+    });
+
+    it('a changed inline hook still surfaces even with a sibling present (no over-fold)', () => {
+      const declared = { LifecycleHookSpecificationList: [hook('inline-launch')] };
+      const live = {
+        LifecycleHookSpecificationList: [
+          { ...hook('inline-launch'), DefaultResult: 'ABANDON' }, // CONTINUE -> ABANDON, out of band
+          hook('standalone-terminate', 'autoscaling:EC2_INSTANCE_TERMINATING'),
+        ],
+      };
+      const t = tiers(
+        classifyResource(asg(declared), live, bare, {
+          siblingLifecycleHooks: { 'asg-phys': ['standalone-terminate'] },
+        })
+      );
+      expect(t.declared.some((p) => p.startsWith('LifecycleHookSpecificationList'))).toBe(true);
+    });
+  });
+
   describe('SecretsManager Secret ReplicaRegions reordered (object set keyed by Region ∉ IDENTITY_FIELDS, found by secret-replica-regions)', () => {
     const T = 'AWS::SecretsManager::Secret';
     const declared = {

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -18,6 +18,7 @@ import {
   buildBucketNotificationManaged,
   buildClusterEchoModels,
   buildSiblingEventBusPolicies,
+  buildSiblingLifecycleHooks,
   buildSiblingManagedPolicyAttachments,
   buildSiblingSgRules,
   buildSiblingUserGroups,
@@ -939,6 +940,86 @@ describe('buildSiblingUserGroups', () => {
           logicalId: 'Membership',
           resourceType: 'AWS::IAM::UserToGroupAddition',
           declared: { GroupName: { 'Fn::GetAtt': ['G', 'GroupName'] }, Users: ['user-a'] },
+        } as DesiredResource,
+      ])
+    );
+    expect(Object.keys(map)).toHaveLength(0);
+  });
+});
+
+describe('buildSiblingLifecycleHooks (#700)', () => {
+  const desiredWith = (resources: DesiredResource[]): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111111111111',
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  it('keys the hook physical-id name by the resolved AutoScalingGroupName', () => {
+    const map = buildSiblingLifecycleHooks(
+      desiredWith([
+        {
+          logicalId: 'Hook',
+          resourceType: 'AWS::AutoScaling::LifecycleHook',
+          physicalId: 'standalone-terminate',
+          declared: { AutoScalingGroupName: 'asg-phys', LifecycleHookName: 'standalone-terminate' },
+        } as DesiredResource,
+      ])
+    );
+    expect(map['asg-phys']).toEqual(['standalone-terminate']);
+  });
+
+  it('resolves {Ref} to the ASG physical id and prefers the hook physical id over the declared name', () => {
+    const map = buildSiblingLifecycleHooks(
+      desiredWith([
+        {
+          logicalId: 'Asg',
+          resourceType: 'AWS::AutoScaling::AutoScalingGroup',
+          physicalId: 'asg-phys',
+          declared: {},
+        },
+        {
+          logicalId: 'Hook',
+          resourceType: 'AWS::AutoScaling::LifecycleHook',
+          physicalId: 'gen-hook-name', // AWS-generated name that the live list echoes
+          declared: { AutoScalingGroupName: { Ref: 'Asg' } }, // no LifecycleHookName declared
+        } as DesiredResource,
+      ])
+    );
+    expect(map['asg-phys']).toEqual(['gen-hook-name']);
+  });
+
+  it('groups multiple sibling hooks under the same ASG', () => {
+    const map = buildSiblingLifecycleHooks(
+      desiredWith([
+        {
+          logicalId: 'H1',
+          resourceType: 'AWS::AutoScaling::LifecycleHook',
+          physicalId: 'launch',
+          declared: { AutoScalingGroupName: 'asg-phys' },
+        } as DesiredResource,
+        {
+          logicalId: 'H2',
+          resourceType: 'AWS::AutoScaling::LifecycleHook',
+          physicalId: 'terminate',
+          declared: { AutoScalingGroupName: 'asg-phys' },
+        } as DesiredResource,
+      ])
+    );
+    expect(map['asg-phys']?.sort()).toEqual(['launch', 'terminate']);
+  });
+
+  it('skips a hook whose ASG reference is unresolved (fail-open)', () => {
+    const map = buildSiblingLifecycleHooks(
+      desiredWith([
+        {
+          logicalId: 'Hook',
+          resourceType: 'AWS::AutoScaling::LifecycleHook',
+          physicalId: 'h',
+          declared: { AutoScalingGroupName: { 'Fn::GetAtt': ['A', 'Name'] } },
         } as DesiredResource,
       ])
     );


### PR DESCRIPTION
## Summary

Closes #700.

An `AWS::AutoScaling::AutoScalingGroup`'s live `LifecycleHookSpecificationList` merges its **inline-declared** hooks with the hooks applied by **sibling standalone `AWS::AutoScaling::LifecycleHook`** resources — origin-indistinguishable in the live read. So:
- a stack that **mixes** an inline list with a standalone `CfnLifecycleHook` produces a **declared-tier FP that survives `record`** (the declared inline list never equals the inline+standalone live list), and `revert` would DELETE the sibling-declared hook (destructive collateral);
- a **standalone-only** ASG additionally FPs the whole list as **undeclared**.

Same reflection family as ECS `CapacityProviders` (`hasSiblingCapacityProviders`), SG rules (`subtractSiblingSgRules`), and IAM attachments — none existed for ASG lifecycle hooks.

## Change

- `src/commands/gather.ts`: `buildSiblingLifecycleHooks(desired)` collects the hook name (the LifecycleHook's physical id, falling back to declared `LifecycleHookName`) of every standalone `AWS::AutoScaling::LifecycleHook`, keyed by the resolved target ASG identifier (`AutoScalingGroupName` string or `{Ref}`). Wired into **both** `classifyResource` opts sites (so offline corpus-replay and the live gather path can't diverge — the [gather-path lesson](https://github.com/go-to-k/cdk-real-drift/issues/) from #980).
- `src/diff/classify.ts`: `subtractSiblingLifecycleHooks(live, names)` removes matching entries from the ASG's live `LifecycleHookSpecificationList` **by `LifecycleHookName`** (unique per ASG = identity). Runs regardless of inline declaration; **subset** subtraction, so inline hooks still compare (declared tier) and an out-of-band hook (matching no sibling) still surfaces. Empties → drop (empty == absent).

## Tests

- `tests/classify.test.ts`: inline+standalone mix → no declared FP; standalone-only → no undeclared FP; OOB hook surfaces; OOB hook alongside a sibling is not hidden; a changed inline hook still surfaces (no over-fold).
- `tests/gather.test.ts`: keys by resolved `AutoScalingGroupName`; resolves `{Ref}` + prefers the hook physical id; groups multiple hooks; fail-open on unresolved ASG ref.

Full suite: 160 files / 4278 tests pass. Live-verified on real AWS (fresh `Cdkrd700Verify` ASG with inline + standalone hooks: clean `record`→`check` CLEAN; out-of-band mutation detected).