### PR TITLE
fix(diff): gate EB SecurityGroups/InstanceType options instead of value-independent folding (#893)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -712,7 +712,17 @@ const ebOptionSettingsEntryTier: NonNullable<CompositeSubsetSpec['entryTier']> =
   const arr = Array.isArray(liveArray) ? (liveArray as Record<string, unknown>[]) : [];
   const envEntry = arr.find((e) => e && e.OptionName === 'EnvironmentType');
   const envType = typeof envEntry?.Value === 'string' ? envEntry.Value : 'LoadBalanced';
-  return ebOptionSettingTier(entry.Namespace, entry.OptionName, entry.Value, envType);
+  // #893: expose the sibling option lookup so a derived default (InstanceType = the first
+  // element of the InstanceTypes option) can be computed and equality-gated.
+  const siblingOption = (ns: string, opt: string): unknown =>
+    arr.find((e) => e && e.Namespace === ns && e.OptionName === opt)?.Value;
+  return ebOptionSettingTier(
+    entry.Namespace,
+    entry.OptionName,
+    entry.Value,
+    envType,
+    siblingOption
+  );
 };
 const ebOptionSettingsSubsetSpec: CompositeSubsetSpec = {
   re: /(^|\.)OptionSettings$/,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2760,10 +2760,11 @@ export const EB_OPTION_DERIVED: Record<string, Record<string, string>> = {
 };
 export const EB_OPTION_VALUE_INDEPENDENT: ReadonlySet<string> = new Set([
   'aws:autoscaling:launchconfiguration|ImageId',
-  'aws:autoscaling:launchconfiguration|InstanceType',
-  // the environment's own EC2 security group (an awseb-e-… generated name) + the ELB's
-  'aws:autoscaling:launchconfiguration|SecurityGroups',
-  'aws:elb:loadbalancer|SecurityGroups',
+  // #893: InstanceType and the two SecurityGroups keys are NO LONGER value-independent — they
+  // are MUTABLE security/cost settings a value-independent fold hid forever (a rogue SG on every
+  // instance, a silent p4d.24xlarge cost bomb). ebOptionSettingTier now gates them: SecurityGroups
+  // folds only the environment's own awseb-* generated group; InstanceType is derived from the
+  // sibling aws:ec2:instances|InstanceTypes option's first element. Any other value surfaces.
   'aws:cloudformation:template:parameter|AppSource',
   'aws:cloudformation:template:parameter|HooksPkgUrl',
   'aws:cloudformation:template:parameter|InstanceTypeFamily',
@@ -2783,17 +2784,47 @@ export const EB_OPTION_VALUE_INDEPENDENT: ReadonlySet<string> = new Set([
 // default (value-independent, derived-from-EnvironmentType, or equality-gated constant), else
 // 'undeclared' so a change away from the default still surfaces. `envType` is the sibling
 // `EnvironmentType` option's value (defaults to LoadBalanced, AWS's default when unset).
+// #893: an undeclared EB SecurityGroups option folds ONLY when every element is the
+// environment's own AWS-generated `awseb-*` security group (the value AWS assigns when the
+// user never set the option) — a resolved `awseb-e-…-AWSEBSecurityGroup-…` name or the
+// unresolved `{"Ref":"AWSEB…SecurityGroup"}` a ConfigurationTemplate still carries. A rogue
+// SG (`eb update-environment …SecurityGroups=sg-…`) matches neither and surfaces.
+function isAllEbGeneratedGroups(value: unknown): boolean {
+  if (typeof value !== 'string' || value === '') return false;
+  return value.split(',').every((el) => /awseb/i.test(el.trim()));
+}
 export function ebOptionSettingTier(
   namespace: unknown,
   optionName: unknown,
   value: unknown,
-  envType: string
+  envType: string,
+  // #893: look up a SIBLING option's live Value on the same environment (returns undefined
+  // when absent). Threaded by the classify caller from the full OptionSettings array so a
+  // derived default (InstanceType = InstanceTypes[0]) can be computed and equality-gated.
+  siblingOption?: (namespace: string, optionName: string) => unknown
 ): 'atDefault' | 'undeclared' {
   // An unset option: DescribeConfigurationSettings returns many option keys with a null or
   // empty Value (BlockDeviceMappings, VPCId, Notification*, RootVolume*, …). Unset is not
   // drift → fold. A change TO a non-empty value is not '' so it still runs the tables below.
   if (value == null || value === '') return 'atDefault';
   const key = `${String(namespace)}|${String(optionName)}`;
+  // #893: SecurityGroups — the environment's own awseb-* group folds; a rogue SG surfaces.
+  if (
+    key === 'aws:autoscaling:launchconfiguration|SecurityGroups' ||
+    key === 'aws:elb:loadbalancer|SecurityGroups'
+  ) {
+    return isAllEbGeneratedGroups(value) ? 'atDefault' : 'undeclared';
+  }
+  // #893: InstanceType — derived default = the first element of the sibling InstanceTypes
+  // option; a bump that differs (the silent cost bomb) surfaces. When the sibling is absent
+  // the value cannot be derived, so fall back to the prior value-independent fold (no FP).
+  if (key === 'aws:autoscaling:launchconfiguration|InstanceType') {
+    const instanceTypes = siblingOption?.('aws:ec2:instances', 'InstanceTypes');
+    const first =
+      typeof instanceTypes === 'string' ? instanceTypes.split(',')[0]?.trim() : undefined;
+    if (first !== undefined) return first === value ? 'atDefault' : 'undeclared';
+    return 'atDefault';
+  }
   if (EB_OPTION_VALUE_INDEPENDENT.has(key)) return 'atDefault';
   const derived = EB_OPTION_DERIVED[key];
   if (derived) return derived[envType] === value ? 'atDefault' : 'undeclared';

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3069,6 +3069,55 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       expect(ebOptionSettingTier('aws:x', 'Novel', 'v', 'LoadBalanced')).toBe('undeclared');
     });
 
+    it('#893: SecurityGroups folds only the awseb-* generated group; a rogue SG surfaces', () => {
+      const lc = ['aws:autoscaling:launchconfiguration', 'SecurityGroups'] as const;
+      const elb = ['aws:elb:loadbalancer', 'SecurityGroups'] as const;
+      // resolved generated group name (Environment read) + unresolved Ref (ConfigurationTemplate)
+      expect(
+        ebOptionSettingTier(
+          lc[0],
+          lc[1],
+          'awseb-e-7k58e7ph74-stack-AWSEBSecurityGroup-uvld',
+          'LoadBalanced'
+        )
+      ).toBe('atDefault');
+      expect(
+        ebOptionSettingTier(
+          elb[0],
+          elb[1],
+          '{"Ref":"AWSEBLoadBalancerSecurityGroup"}',
+          'LoadBalanced'
+        )
+      ).toBe('atDefault');
+      // a rogue SG attached out of band surfaces (the security FN this fixes)
+      expect(ebOptionSettingTier(lc[0], lc[1], 'sg-0badc0de', 'LoadBalanced')).toBe('undeclared');
+      // a mixed list where ONE element is not the awseb group surfaces
+      expect(
+        ebOptionSettingTier(
+          lc[0],
+          lc[1],
+          'awseb-e-x-AWSEBSecurityGroup-y, sg-0badc0de',
+          'LoadBalanced'
+        )
+      ).toBe('undeclared');
+    });
+
+    it('#893: InstanceType is derived from the sibling InstanceTypes option first element', () => {
+      const k = ['aws:autoscaling:launchconfiguration', 'InstanceType'] as const;
+      const sibling = (ns: string, opt: string): unknown =>
+        ns === 'aws:ec2:instances' && opt === 'InstanceTypes' ? 't3.micro, t3.small' : undefined;
+      // matches InstanceTypes[0] -> atDefault
+      expect(ebOptionSettingTier(k[0], k[1], 't3.micro', 'LoadBalanced', sibling)).toBe(
+        'atDefault'
+      );
+      // an out-of-band bump (cost bomb) that differs from InstanceTypes[0] surfaces
+      expect(ebOptionSettingTier(k[0], k[1], 'p4d.24xlarge', 'LoadBalanced', sibling)).toBe(
+        'undeclared'
+      );
+      // no sibling InstanceTypes to derive from -> falls back to the value-independent fold
+      expect(ebOptionSettingTier(k[0], k[1], 'p4d.24xlarge', 'LoadBalanced')).toBe('atDefault');
+    });
+
     it('an unset option (null or empty Value) folds — DescribeConfigurationSettings returns many', () => {
       expect(ebOptionSettingTier('aws:ec2:vpc', 'VPCId', null, 'LoadBalanced')).toBe('atDefault');
       expect(


### PR DESCRIPTION
Closes #893.

`EB_OPTION_VALUE_INDEPENDENT` folded **mutable security/cost** option keys at ANY value:
- **SecurityGroups** (`aws:autoscaling:launchconfiguration` + `aws:elb:loadbalancer`) — a rogue SG attached via `eb update-environment …SecurityGroups=<sg>` on an environment that never declared the option was invisible forever (a rogue SG on every instance).
- **InstanceType** — an out-of-band bump to `p4d.24xlarge` was a silent cost bomb.

`ebOptionSettingTier` now **gates** them (both removed from the value-independent set):
- SecurityGroups folds only the environment's own AWS-generated `awseb-*` group (a resolved `awseb-e-…-AWSEBSecurityGroup-…` name **or** the unresolved `{"Ref":"AWSEB…SecurityGroup"}` a ConfigurationTemplate carries); any other value surfaces.
- InstanceType is **derived** from the sibling `aws:ec2:instances|InstanceTypes` option's first element (threaded from the full OptionSettings array by the classify caller) and equality-gated; with no sibling it falls back to the prior fold (no FP).

`ImageId`/`ConfigDocument`/URL entries stay value-independent (legitimately AWS-moving).

## Verification
- corpus-replay unchanged: all 9 EB corpus cases (templates + environments) still fold SecurityGroups/InstanceType `atDefault` (the awseb group + `InstanceTypes[0]` match the recorded live values — replay-proven at HEAD, live-harvested).
- new unit tests: awseb group folds / rogue `sg-…` surfaces / mixed list surfaces; InstanceType matches `InstanceTypes[0]` folds / a differing bump surfaces / no-sibling fallback.
- typecheck / `vp check` (0 errors) / build / 4288 unit tests green.