### PR TITLE
feat(read): add SDK_OVERRIDES readers for DMS ReplicationInstance + ReplicationTask (#856)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -102,7 +102,9 @@ import { DLMClient, GetLifecyclePolicyCommand } from '@aws-sdk/client-dlm';
 import {
   DatabaseMigrationServiceClient,
   DescribeEndpointsCommand,
+  DescribeReplicationInstancesCommand,
   DescribeReplicationSubnetGroupsCommand,
+  DescribeReplicationTasksCommand,
 } from '@aws-sdk/client-database-migration-service';
 import {
   GetJobTemplateCommand,
@@ -768,6 +770,108 @@ const readDmsReplicationSubnetGroup: OverrideReader = async ({ physicalId, regio
     .filter((v): v is string => v !== undefined)
     .sort();
   if (subnetIds.length > 0) model.SubnetIds = subnetIds;
+  return model;
+};
+
+// AWS::DMS::ReplicationInstance — NON_PROVISIONABLE in the registry (describe-type returns
+// `handlers: []`; issue #856, completing #497 alongside the Endpoint / ReplicationSubnetGroup
+// readers above). Without a Cloud Control read handler every migration/CDC pipeline's core
+// compute box was a silent `skipped` read-gap, so console-toggled props people tweak
+// (AllocatedStorage, MultiAZ, PubliclyAccessible, EngineVersion, the maintenance window) were
+// invisible. The CFn physical id (Ref → `Id`) IS the replication-instance ARN, which DMS
+// DescribeReplicationInstances filters on via `replication-instance-arn`; a bare identifier
+// (older stacks / imports) filters on `replication-instance-id`. The API models the instance in
+// the SAME PascalCase shape the CFn registry uses, so the CFn-declarable scalars project 1:1.
+// ReplicationSubnetGroupIdentifier is nested under `ReplicationSubnetGroup` in the API but flat
+// in CFn; VpcSecurityGroups come back as `{VpcSecurityGroupId}` objects while CFn declares a flat
+// `VpcSecurityGroupIds` string list (project the ids, SORTED, so a live-vs-declared order
+// difference is not false drift). Read-ONLY: a ModifyReplicationInstance writer is deferred to a
+// follow-up. A deleted instance surfaces as ResourceNotFoundFault → the router maps it to
+// `deleted`; an empty result → ResourceGoneError with the same effect.
+const readDmsReplicationInstance: OverrideReader = async ({ physicalId, region }) => {
+  const id = str(physicalId);
+  if (!id) return undefined;
+  const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
+  const filterName = id.startsWith('arn:') ? 'replication-instance-arn' : 'replication-instance-id';
+  // ResourceNotFoundFault propagates so a deleted instance maps to `deleted`.
+  const r = await c.send(
+    new DescribeReplicationInstancesCommand({ Filters: [{ Name: filterName, Values: [id] }] })
+  );
+  const i = r.ReplicationInstances?.[0];
+  if (!i) throw new ResourceGoneError(`DMS ReplicationInstance ${id} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(i.ReplicationInstanceIdentifier))
+    model.ReplicationInstanceIdentifier = i.ReplicationInstanceIdentifier;
+  if (str(i.ReplicationInstanceClass)) model.ReplicationInstanceClass = i.ReplicationInstanceClass;
+  if (typeof i.AllocatedStorage === 'number') model.AllocatedStorage = i.AllocatedStorage;
+  if (typeof i.MultiAZ === 'boolean') model.MultiAZ = i.MultiAZ;
+  if (str(i.EngineVersion)) model.EngineVersion = i.EngineVersion;
+  if (typeof i.AutoMinorVersionUpgrade === 'boolean')
+    model.AutoMinorVersionUpgrade = i.AutoMinorVersionUpgrade;
+  if (typeof i.PubliclyAccessible === 'boolean') model.PubliclyAccessible = i.PubliclyAccessible;
+  if (str(i.AvailabilityZone)) model.AvailabilityZone = i.AvailabilityZone;
+  if (str(i.PreferredMaintenanceWindow))
+    model.PreferredMaintenanceWindow = i.PreferredMaintenanceWindow;
+  if (str(i.KmsKeyId)) model.KmsKeyId = i.KmsKeyId;
+  if (str(i.ReplicationSubnetGroup?.ReplicationSubnetGroupIdentifier))
+    model.ReplicationSubnetGroupIdentifier =
+      i.ReplicationSubnetGroup?.ReplicationSubnetGroupIdentifier;
+  const sgIds = (i.VpcSecurityGroups ?? [])
+    .map((g) => str(g.VpcSecurityGroupId))
+    .filter((v): v is string => v !== undefined)
+    .sort();
+  if (sgIds.length > 0) model.VpcSecurityGroupIds = sgIds;
+  return model;
+};
+
+// AWS::DMS::ReplicationTask — NON_PROVISIONABLE (describe-type → `handlers: []`; issue #856),
+// the actual migration/CDC job that every DMS stack declares next to its instance and endpoints.
+// Without a read handler it was a silent `skipped`, so out-of-band edits to the task's table
+// mappings or tuning settings were invisible. The CFn physical id (Ref → `Id`) IS the
+// replication-task ARN, which DMS DescribeReplicationTasks filters on via `replication-task-arn`;
+// a bare identifier filters on `replication-task-id`. The API returns TableMappings and
+// ReplicationTaskSettings as JSON STRINGS, while CFn declares them as strings too but CDK / raw
+// templates commonly author them as OBJECTS — parse the API's JSON strings into objects here so
+// the compare is structural (key-order-insensitive) regardless of the declared form; the
+// downstream `isJsonStringStructEqual` fold covers the string-declared vs object-live direction,
+// and an unparseable blob falls back to the raw string. Read-ONLY (ModifyReplicationTask
+// deferred). A deleted task surfaces as ResourceNotFoundFault → `deleted`; an empty result →
+// ResourceGoneError.
+const readDmsReplicationTask: OverrideReader = async ({ physicalId, region }) => {
+  const id = str(physicalId);
+  if (!id) return undefined;
+  const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
+  const filterName = id.startsWith('arn:') ? 'replication-task-arn' : 'replication-task-id';
+  const r = await c.send(
+    new DescribeReplicationTasksCommand({ Filters: [{ Name: filterName, Values: [id] }] })
+  );
+  const t = r.ReplicationTasks?.[0];
+  if (!t) throw new ResourceGoneError(`DMS ReplicationTask ${id} absent`);
+  // TableMappings / ReplicationTaskSettings come back as JSON STRINGS; parse them to objects so
+  // an object-declared side compares structurally. An unparseable value keeps the raw string.
+  const parseJsonMaybe = (s: unknown): unknown => {
+    const v = str(s);
+    if (v === undefined) return undefined;
+    try {
+      return JSON.parse(v);
+    } catch {
+      return v;
+    }
+  };
+  const model: Record<string, unknown> = {};
+  if (str(t.ReplicationTaskIdentifier))
+    model.ReplicationTaskIdentifier = t.ReplicationTaskIdentifier;
+  if (str(t.SourceEndpointArn)) model.SourceEndpointArn = t.SourceEndpointArn;
+  if (str(t.TargetEndpointArn)) model.TargetEndpointArn = t.TargetEndpointArn;
+  if (str(t.ReplicationInstanceArn)) model.ReplicationInstanceArn = t.ReplicationInstanceArn;
+  if (str(t.MigrationType)) model.MigrationType = t.MigrationType;
+  const tableMappings = parseJsonMaybe(t.TableMappings);
+  if (tableMappings !== undefined) model.TableMappings = tableMappings;
+  const taskSettings = parseJsonMaybe(t.ReplicationTaskSettings);
+  if (taskSettings !== undefined) model.ReplicationTaskSettings = taskSettings;
+  if (str(t.CdcStartPosition)) model.CdcStartPosition = t.CdcStartPosition;
+  if (str(t.CdcStopPosition)) model.CdcStopPosition = t.CdcStopPosition;
+  if (str(t.TaskData)) model.TaskData = t.TaskData;
   return model;
 };
 
@@ -2449,6 +2553,8 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::DLM::LifecyclePolicy': readDlmLifecyclePolicy,
   'AWS::DMS::Endpoint': readDmsEndpoint,
   'AWS::DMS::ReplicationSubnetGroup': readDmsReplicationSubnetGroup,
+  'AWS::DMS::ReplicationInstance': readDmsReplicationInstance,
+  'AWS::DMS::ReplicationTask': readDmsReplicationTask,
   'AWS::MediaConvert::Queue': readMediaConvertQueue,
   'AWS::MediaConvert::JobTemplate': readMediaConvertJobTemplate,
   'AWS::Route53::RecordSet': readRoute53RecordSet,

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -4,7 +4,9 @@ import { DLMClient, GetLifecyclePolicyCommand } from '@aws-sdk/client-dlm';
 import {
   DatabaseMigrationServiceClient,
   DescribeEndpointsCommand,
+  DescribeReplicationInstancesCommand,
   DescribeReplicationSubnetGroupsCommand,
+  DescribeReplicationTasksCommand,
 } from '@aws-sdk/client-database-migration-service';
 import {
   GetJobTemplateCommand,
@@ -1446,6 +1448,176 @@ describe('SDK overrides', () => {
         .resolves({ ReplicationSubnetGroups: [] } as never);
       await expect(
         SDK_OVERRIDES['AWS::DMS::ReplicationSubnetGroup'](ctx({}, 'dms-subnet-grp'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+  });
+
+  describe('DMS ReplicationInstance (NON_PROVISIONABLE, issue #856)', () => {
+    it('reads DescribeReplicationInstances by ARN and projects the CFn-declarable scalars', async () => {
+      dms.on(DescribeReplicationInstancesCommand).resolves({
+        ReplicationInstances: [
+          {
+            ReplicationInstanceArn: 'arn:aws:dms:us-east-1:123456789012:rep:ABCDEF',
+            ReplicationInstanceIdentifier: 'my-repl',
+            ReplicationInstanceClass: 'dms.t3.medium',
+            AllocatedStorage: 50,
+            MultiAZ: true,
+            EngineVersion: '3.5.2',
+            AutoMinorVersionUpgrade: true,
+            PubliclyAccessible: false,
+            AvailabilityZone: 'us-east-1a',
+            PreferredMaintenanceWindow: 'sun:03:00-sun:03:30',
+            KmsKeyId: 'arn:aws:kms:us-east-1:123456789012:key/abc',
+            ReplicationSubnetGroup: {
+              ReplicationSubnetGroupIdentifier: 'dms-subnet-grp',
+              VpcId: 'vpc-123',
+            },
+            VpcSecurityGroups: [
+              { VpcSecurityGroupId: 'sg-bbb', Status: 'active' },
+              { VpcSecurityGroupId: 'sg-aaa', Status: 'active' },
+            ],
+            // computed/managed fields the projection must drop
+            ReplicationInstanceStatus: 'available',
+            ReplicationInstancePrivateIpAddresses: ['10.0.0.5'],
+            InstanceCreateTime: new Date(),
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::DMS::ReplicationInstance'](
+        ctx({}, 'arn:aws:dms:us-east-1:123456789012:rep:ABCDEF')
+      );
+      expect(out).toEqual({
+        ReplicationInstanceIdentifier: 'my-repl',
+        ReplicationInstanceClass: 'dms.t3.medium',
+        AllocatedStorage: 50,
+        MultiAZ: true,
+        EngineVersion: '3.5.2',
+        AutoMinorVersionUpgrade: true,
+        PubliclyAccessible: false,
+        AvailabilityZone: 'us-east-1a',
+        PreferredMaintenanceWindow: 'sun:03:00-sun:03:30',
+        KmsKeyId: 'arn:aws:kms:us-east-1:123456789012:key/abc',
+        ReplicationSubnetGroupIdentifier: 'dms-subnet-grp',
+        // Subnet-group id flattened out of the nested API object; SGs sorted
+        VpcSecurityGroupIds: ['sg-aaa', 'sg-bbb'],
+      });
+      const call = dms.commandCalls(DescribeReplicationInstancesCommand)[0]!;
+      expect(call.args[0].input).toEqual({
+        Filters: [
+          {
+            Name: 'replication-instance-arn',
+            Values: ['arn:aws:dms:us-east-1:123456789012:rep:ABCDEF'],
+          },
+        ],
+      });
+    });
+
+    it('a bare (non-ARN) physical id filters on replication-instance-id', async () => {
+      dms.on(DescribeReplicationInstancesCommand).resolves({
+        ReplicationInstances: [{ ReplicationInstanceIdentifier: 'my-repl' }],
+      } as never);
+      await SDK_OVERRIDES['AWS::DMS::ReplicationInstance'](ctx({}, 'my-repl'));
+      const call = dms.commandCalls(DescribeReplicationInstancesCommand)[0]!;
+      expect(call.args[0].input).toEqual({
+        Filters: [{ Name: 'replication-instance-id', Values: ['my-repl'] }],
+      });
+    });
+
+    it('no physical id -> undefined (skipped, never a false read)', async () => {
+      expect(await SDK_OVERRIDES['AWS::DMS::ReplicationInstance'](ctx({}, ''))).toBeUndefined();
+    });
+
+    it('the instance is absent -> ResourceGoneError (deleted out of band)', async () => {
+      dms.on(DescribeReplicationInstancesCommand).resolves({ ReplicationInstances: [] } as never);
+      await expect(
+        SDK_OVERRIDES['AWS::DMS::ReplicationInstance'](ctx({}, 'my-repl'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+  });
+
+  describe('DMS ReplicationTask (NON_PROVISIONABLE, issue #856)', () => {
+    it('reads DescribeReplicationTasks by ARN and parses JSON-string TableMappings/ReplicationTaskSettings', async () => {
+      dms.on(DescribeReplicationTasksCommand).resolves({
+        ReplicationTasks: [
+          {
+            ReplicationTaskArn: 'arn:aws:dms:us-east-1:123456789012:task:ABCDEF',
+            ReplicationTaskIdentifier: 'my-task',
+            SourceEndpointArn: 'arn:aws:dms:us-east-1:123456789012:endpoint:SRC',
+            TargetEndpointArn: 'arn:aws:dms:us-east-1:123456789012:endpoint:TGT',
+            ReplicationInstanceArn: 'arn:aws:dms:us-east-1:123456789012:rep:ABCDEF',
+            MigrationType: 'full-load',
+            // the API returns these as JSON STRINGS
+            TableMappings: '{"rules":[{"rule-type":"selection","rule-id":"1"}]}',
+            ReplicationTaskSettings: '{"TargetMetadata":{"SupportLobs":true}}',
+            CdcStartPosition: 'checkpoint:v1',
+            TaskData: 'extra',
+            // computed/managed fields the projection must drop
+            Status: 'ready',
+            LastFailureMessage: '',
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::DMS::ReplicationTask'](
+        ctx({}, 'arn:aws:dms:us-east-1:123456789012:task:ABCDEF')
+      );
+      expect(out).toEqual({
+        ReplicationTaskIdentifier: 'my-task',
+        SourceEndpointArn: 'arn:aws:dms:us-east-1:123456789012:endpoint:SRC',
+        TargetEndpointArn: 'arn:aws:dms:us-east-1:123456789012:endpoint:TGT',
+        ReplicationInstanceArn: 'arn:aws:dms:us-east-1:123456789012:rep:ABCDEF',
+        MigrationType: 'full-load',
+        // JSON strings normalized to objects so an object-declared side compares structurally
+        TableMappings: { rules: [{ 'rule-type': 'selection', 'rule-id': '1' }] },
+        ReplicationTaskSettings: { TargetMetadata: { SupportLobs: true } },
+        CdcStartPosition: 'checkpoint:v1',
+        TaskData: 'extra',
+      });
+      const call = dms.commandCalls(DescribeReplicationTasksCommand)[0]!;
+      expect(call.args[0].input).toEqual({
+        Filters: [
+          {
+            Name: 'replication-task-arn',
+            Values: ['arn:aws:dms:us-east-1:123456789012:task:ABCDEF'],
+          },
+        ],
+      });
+    });
+
+    it('a bare (non-ARN) physical id filters on replication-task-id', async () => {
+      dms.on(DescribeReplicationTasksCommand).resolves({
+        ReplicationTasks: [{ ReplicationTaskIdentifier: 'my-task' }],
+      } as never);
+      await SDK_OVERRIDES['AWS::DMS::ReplicationTask'](ctx({}, 'my-task'));
+      const call = dms.commandCalls(DescribeReplicationTasksCommand)[0]!;
+      expect(call.args[0].input).toEqual({
+        Filters: [{ Name: 'replication-task-id', Values: ['my-task'] }],
+      });
+    });
+
+    it('an unparseable JSON-string blob falls back to the raw string', async () => {
+      dms.on(DescribeReplicationTasksCommand).resolves({
+        ReplicationTasks: [
+          {
+            ReplicationTaskIdentifier: 'my-task',
+            TableMappings: 'not-json{',
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::DMS::ReplicationTask'](ctx({}, 'my-task'));
+      expect(out).toEqual({
+        ReplicationTaskIdentifier: 'my-task',
+        TableMappings: 'not-json{',
+      });
+    });
+
+    it('no physical id -> undefined (skipped, never a false read)', async () => {
+      expect(await SDK_OVERRIDES['AWS::DMS::ReplicationTask'](ctx({}, ''))).toBeUndefined();
+    });
+
+    it('the task is absent -> ResourceGoneError (deleted out of band)', async () => {
+      dms.on(DescribeReplicationTasksCommand).resolves({ ReplicationTasks: [] } as never);
+      await expect(
+        SDK_OVERRIDES['AWS::DMS::ReplicationTask'](ctx({}, 'my-task'))
       ).rejects.toBeInstanceOf(ResourceGoneError);
     });
   });


### PR DESCRIPTION
## What

`AWS::DMS::ReplicationInstance` and `AWS::DMS::ReplicationTask` have no Cloud Control read handler (`describe-type` returns `handlers: []`), so every DMS stack silently `skipped`s its core two resources. This completes #497, which already added `SDK_OVERRIDES` readers for `AWS::DMS::Endpoint` and `AWS::DMS::ReplicationSubnetGroup` in the same file.

Adds two `OverrideReader`s and registers them in `SDK_OVERRIDES`:

- **`AWS::DMS::ReplicationInstance`** — `DescribeReplicationInstances` filtered by `replication-instance-arn` (or `replication-instance-id` for a bare identifier). Projects the CFn-declarable scalars (ReplicationInstanceClass, AllocatedStorage, MultiAZ, EngineVersion, AutoMinorVersionUpgrade, PubliclyAccessible, AvailabilityZone, PreferredMaintenanceWindow, KmsKeyId, ReplicationInstanceIdentifier). Flattens the nested `ReplicationSubnetGroup.ReplicationSubnetGroupIdentifier` and the `VpcSecurityGroups[].VpcSecurityGroupId` list (sorted) to the flat CFn shape. Read-only (writer deferred).
- **`AWS::DMS::ReplicationTask`** — `DescribeReplicationTasks` filtered by `replication-task-arn` (or `replication-task-id`). Projects the identity + endpoint ARNs + MigrationType + CDC positions + TaskData. `TableMappings` and `ReplicationTaskSettings` come back from the API as JSON **strings** while the declared side is commonly an object, so they are parsed into objects in the reader for a structural / key-order-insensitive compare (the downstream `isJsonStringStructEqual` fold covers the string-declared vs object-live direction). An unparseable blob falls back to the raw string. Read-only.

Both throw `ResourceGoneError` when the resource is absent (router maps to `deleted`); an empty physical id yields `undefined` (skipped, never a false read).

## Tests

`tests/overrides.test.ts` gains two `describe` blocks (9 new tests): scalar projection + filter syntax (ARN and bare-id), nested-subnet-group flatten, sorted SG ids, JSON-string TableMappings/ReplicationTaskSettings normalization to objects, unparseable-blob fallback, no-physical-id to undefined, and the ResourceGoneError absent path.

Gates (from the worktree): `vp run typecheck` clean, `vp check --fix` 0 errors, `vp pack` OK, `vp test run` 4291 passed (180 in overrides.test.ts), `vp run check` 0 errors.

## Follow-up (docs, out of this PR scope)

This PR is scoped to `src/read/overrides.ts` + tests. Two docs spots reference DMS/override coverage and are now slightly stale — worth updating during integration: README (~L780) lists the DMS SDK calls and could add `dms:DescribeReplicationInstances` + `dms:DescribeReplicationTasks`; `docs/ARCHITECTURE.md` (~L78) says "SDK_OVERRIDES holds 14 types" (now 16).

Closes #856
