### PR TITLE
fix(read): probe each segment of a composite CC identifier in the sibling-stack check (#800)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -206,32 +206,18 @@ export function isDefinitiveNotManaged(
   return true;
 }
 
-export async function isManagedBySiblingStack(
+// Probe ONE candidate CloudFormation physical id against the run's account+region: does a
+// stack own a resource of THIS child's type (`c.resourceType`) with this exact physical id?
+// Returns the tri-state and memoizes any DEFINITIVE answer per physical id (a transient
+// throttle / unverifiable foreign-scope id is left un-cached so a retry can resolve it).
+async function probeSiblingPhysicalId(
   cfn: CloudFormationClient,
   c: AddedChild,
+  physicalId: string,
   cache: Map<string, SiblingCheck>,
   accountId: string,
   region: string
 ): Promise<SiblingCheck> {
-  // The sibling-stack lookup uses the CloudFormation PHYSICAL-ID form, which for most child
-  // types IS the CC primaryIdentifier (`identifier`); it diverges only where CC's identifier
-  // is not the CFn physical id — e.g. AWS::Events::Rule, whose CC identifier is the rule Arn
-  // but whose CFn physical id is `<busName>|<ruleName>` for a custom-bus rule (#895). The
-  // enumerator carries that form on `siblingLookupId` (defaulting to `identifier`).
-  const physicalId = c.siblingLookupId ?? c.identifier;
-  // Pipe-composite CC identifiers (`RestApiId|…`, `UserPoolId|…`) are not CloudFormation
-  // physical resource ids — they belong to within-stack API Gateway / Cognito sub-resources
-  // outside this cross-stack class, so never spend a call on them. Bare ids that are ARNs
-  // (SNS Subscription, ELBv2 Listener/Rule, EventBus Rule, Lambda Alias/Version) contain
-  // `:` and ARE the class, so `:` is NOT a composite marker here; the lone `:`-joined
-  // composite (API Gateway GatewayResponse `RestApiId:ResponseType`) simply fails the
-  // DescribeStackResources lookup and falls through to "report as added" (fail open).
-  // NOTE: an Events::Rule custom-bus `siblingLookupId` (`<busName>|<ruleName>`) IS a valid
-  // CFn physical id despite the `|`; it is set explicitly so it is NOT a CC composite —
-  // hence the `|` guard would wrongly skip it. The guard therefore only applies to the CC
-  // `identifier` composites, which never set `siblingLookupId`, so it stays correct: a rule
-  // whose lookup id contains `|` still runs the DescribeStackResources check below.
-  if (c.siblingLookupId === undefined && physicalId.includes('|')) return 'notManaged';
   const cached = cache.get(physicalId);
   if (cached !== undefined) return cached;
   let managed = false;
@@ -297,6 +283,52 @@ export async function isManagedBySiblingStack(
   const result: SiblingCheck = managed ? 'managed' : 'notManaged';
   cache.set(physicalId, result);
   return result;
+}
+
+export async function isManagedBySiblingStack(
+  cfn: CloudFormationClient,
+  c: AddedChild,
+  cache: Map<string, SiblingCheck>,
+  accountId: string,
+  region: string
+): Promise<SiblingCheck> {
+  // The sibling-stack lookup uses the CloudFormation PHYSICAL-ID form, which for most child
+  // types IS the CC primaryIdentifier (`identifier`); it diverges only where CC's identifier
+  // is not the CFn physical id — e.g. AWS::Events::Rule, whose CC identifier is the rule Arn
+  // but whose CFn physical id is `<busName>|<ruleName>` for a custom-bus rule (#895). The
+  // enumerator carries that form on `siblingLookupId` (defaulting to `identifier`).
+  const physicalId = c.siblingLookupId ?? c.identifier;
+  // A `siblingLookupId` explicitly set by the enumerator (Events::Rule custom-bus
+  // `<busName>|<ruleName>`) IS a valid CFn physical id verbatim (even with a `|`), so probe it
+  // as-is. Only the CC `identifier` composites — which NEVER set `siblingLookupId` — need the
+  // per-segment fan-out below.
+  if (c.siblingLookupId !== undefined || !physicalId.includes('|')) {
+    return probeSiblingPhysicalId(cfn, c, physicalId, cache, accountId, region);
+  }
+  // A pipe-composite CC identifier (`ServiceArn|Cluster`, `UserPoolId|ClientId`,
+  // `LogGroupName|FilterName`, …) is the join of a PARENT id + the child's own id — and the
+  // child's CFn PHYSICAL id is the BARE half (ECS = ServiceArn, Cognito = ClientId, Logs =
+  // FilterName). A shared-parent split (a cluster stack + per-service stacks, an auth stack +
+  // app stacks) makes such a child fully CloudFormation-managed by a SIBLING stack, yet the
+  // old wholesale `physicalId.includes('|') → 'notManaged'` short-circuit false-flagged every
+  // one `added` with a destructive DeleteResource revert offer (#800). Which segment is the
+  // child's physical id varies per type (first, second, and the two Logs filter types even
+  // ORDER it oppositely), so probe EACH segment; the `owns` predicate already gates on
+  // `ResourceType === c.resourceType`, so a segment that is the (differently-typed) parent id
+  // — or a non-physical-id half of a genuine within-stack API Gateway / Cognito sub-resource —
+  // never false-matches, and those simply fall through to `notManaged`/`unverified` as before.
+  // Combine the segment results fail-SAFE: ANY segment proving sibling ownership wins
+  // ('managed'); otherwise if ANY segment was UNVERIFIABLE (throttle / foreign-scope) return
+  // 'unverified' (report as coverage-incomplete, never a destructive delete — #754); only when
+  // EVERY segment is a definitive not-managed is the composite a genuine out-of-band `added`.
+  let sawUnverified = false;
+  for (const segment of physicalId.split('|')) {
+    if (!segment) continue; // skip an empty segment (defensive: leading/trailing/double `|`)
+    const seg = await probeSiblingPhysicalId(cfn, c, segment, cache, accountId, region);
+    if (seg === 'managed') return 'managed';
+    if (seg === 'unverified') sawUnverified = true;
+  }
+  return sawUnverified ? 'unverified' : 'notManaged';
 }
 
 interface ClassifyOpts {

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -1157,8 +1157,19 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     expect(managed).toBe('notManaged');
   });
 
-  it('skips the API call for a pipe-composite CC identifier (within-stack sub-resource)', async () => {
+  // #800: a pipe-composite CC identifier is the join of a PARENT id + the child's own id, so
+  // the sibling check must NOT wholesale-skip it — it probes each segment against CFn. A genuine
+  // within-stack API Gateway sub-resource (whose child-id halves are not CFn physical ids that
+  // DescribeStackResources accepts on their own) still resolves to `notManaged`, just now via a
+  // real probe rather than a blind short-circuit.
+  it('#800: a within-stack composite sub-resource whose segments own no matching child is notManaged', async () => {
     const cfn = mockClient(CloudFormationClient);
+    // Every segment ValidationErrors (no stack owns an ApiGateway::Method by that bare id).
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
     const managed = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child('api123|res456|GET', 'AWS::ApiGateway::Method'),
@@ -1167,7 +1178,123 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
       LOCAL_REGION
     );
     expect(managed).toBe('notManaged');
-    expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(0);
+    // it probed the segments rather than blindly short-circuiting on the `|`
+    expect(cfn.commandCalls(DescribeStackResourcesCommand).length).toBeGreaterThan(0);
+  });
+
+  // #800: the core fix — a shared-parent split (cluster stack + per-service stacks, auth stack +
+  // app stacks, imported LogGroup + sibling filter) makes a composite-id child fully CFn-managed
+  // by a SIBLING stack, yet the old `physicalId.includes('|') → 'notManaged'` short-circuit
+  // false-flagged every one `added` with a destructive DeleteResource offer. The child's CFn
+  // physical id is the BARE half; probing the segments recognizes the sibling-managed child.
+  it('#800: folds an ECS Service on a shared cluster a SIBLING stack manages (ServiceArn|Cluster, physical id = ServiceArn FIRST half)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    const serviceArn = 'arn:aws:ecs:us-east-1:111122223333:service/shared-cluster/websvc';
+    // The composite is `${ServiceArn}|${Cluster}`; the child's CFn physical id is the ServiceArn.
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      if (input.PhysicalResourceId === serviceArn) {
+        return {
+          StackResources: [
+            {
+              StackName: 'WebServiceStack',
+              LogicalResourceId: 'WebSvc',
+              PhysicalResourceId: serviceArn,
+              ResourceType: 'AWS::ECS::Service',
+              Timestamp: new Date(0),
+              ResourceStatus: 'CREATE_COMPLETE',
+            },
+          ],
+        };
+      }
+      // the Cluster segment is a different (declared parent) resource type — never matches
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(`${serviceArn}|shared-cluster`, 'AWS::ECS::Service'),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('managed');
+  });
+
+  it('#800: folds a Cognito UserPoolClient on an imported pool a SIBLING stack manages (UserPoolId|ClientId, physical id = ClientId SECOND half)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    const clientId = '1example23clientid45';
+    // The composite is `${UserPoolId}|${ClientId}`; the child's CFn physical id is the ClientId.
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      if (input.PhysicalResourceId === clientId) {
+        return {
+          StackResources: [
+            {
+              StackName: 'AppStack',
+              LogicalResourceId: 'AppClient',
+              PhysicalResourceId: clientId,
+              ResourceType: 'AWS::Cognito::UserPoolClient',
+              Timestamp: new Date(0),
+              ResourceStatus: 'CREATE_COMPLETE',
+            },
+          ],
+        };
+      }
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(`us-east-1_ABC123|${clientId}`, 'AWS::Cognito::UserPoolClient'),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('managed');
+  });
+
+  it('#800: still reports a GENUINELY out-of-band composite child as added (no segment owns it)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // Both segments are same-account/region bare ids -> ValidationError is a DEFINITIVE
+    // not-managed, so the composite resolves to notManaged (a real out-of-band addition).
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child('shared-lg|rogue-metric-filter', 'AWS::Logs::MetricFilter'),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('notManaged');
+  });
+
+  it('#800/#754: an UNVERIFIABLE segment (throttle) makes the composite unverified, never a false added', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      // the first segment throttles (transient) -> the whole composite must be unverified,
+      // NOT reported as a destructive-delete `added`
+      if (input.PhysicalResourceId === 'shared-lg') {
+        const throttle = new Error('Rate exceeded');
+        throttle.name = 'Throttling';
+        throw throttle;
+      }
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child('shared-lg|some-filter', 'AWS::Logs::MetricFilter'),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('unverified');
   });
 
   // #895: AWS::Events::Rule's CC identifier is the rule Arn, but its CFn physical id for a


### PR DESCRIPTION
Closes #800.

`isManagedBySiblingStack` short-circuited **every** pipe-composite CC identifier to `notManaged` on the false premise that a composite id is always a within-stack sub-resource. But the mainstream **shared-parent split** — shared-cluster ECS Service (`ServiceArn|Cluster`), imported-UserPool client (`UserPoolId|ClientId`), imported-LogGroup metric filter (`LogGroupName|FilterName`) — is a child **fully managed by a sibling stack**, so it was false-flagged `added` with a destructive `DeleteResource` revert offer.

- Extracted the single-id probe into `probeSiblingPhysicalId` (bare-id + explicit `siblingLookupId` behavior byte-for-byte unchanged, incl. the #726 paginated fallback and #754/#959 fail-safe).
- For a CC composite, probe **each `|`-segment** as a candidate CFn physical id (the child's real physical id is the bare half; which segment varies per type — Logs even orders it oppositely). The `owns` predicate already gates on `ResourceType === c.resourceType`, so the parent segment / within-stack sub-resource halves never false-match.
- Combine **fail-safe** (#754 pattern): any segment `managed` → `managed`; else any unverifiable (throttle / foreign-scope) → `unverified` (coverage-incomplete, never a destructive delete); else `notManaged`.

## Verification
- 5 new/updated `gather.test.ts` tests: ECS service on a shared cluster (physical id = first half), Cognito client on an imported pool (second half), a genuine out-of-band composite (`notManaged`), an unverifiable segment (throttle → `unverified`), and a within-stack composite owning no matching child. The managed/unverified tests fail without the fix.
- typecheck / `vp check` (0 errors) / build / full unit suite green.

(implemented by a scoped subagent; reviewed by me — the diff is confined to `gather.ts` + `gather.test.ts`)