### PR TITLE
fix(report): mask secret-bearing values in text + --json output (#798)

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,14 @@ builds printed one pretty-printed `{...}` per stack back-to-back, which was neit
 valid JSON value nor JSONL; multi-stack `--json` was unparseable — issue #755.) All
 `note` / `warning` / progress lines go to **stderr**, so stdout stays pure JSON.
 
+**Secret redaction.** Values on known secret-bearing properties — Lambda
+`Environment.Variables`, CodeBuild `Environment.EnvironmentVariables[].Value`,
+Elastic Beanstalk env-namespace `OptionSettings`, EC2 LaunchTemplate `UserData` —
+are masked as `<redacted:NN chars>` in both text and `--json` output, so a rotated
+secret surfacing as drift does not leak its plaintext into CI logs. The finding
+still surfaces (detection is preserved) and the property/key name stays visible —
+only the value is hidden (#798).
+
 A **stack that errored or was skipped** before it could be checked still appears as an
 element so a consumer sees which stacks ran: it carries `"error": "<reason>"` alongside
 `"drifted": 0` and an empty `"findings": []`. (`error` is absent on a

--- a/src/report/redact.ts
+++ b/src/report/redact.ts
@@ -1,0 +1,169 @@
+// #798 — report-layer redaction of secret-bearing live-readable property VALUES.
+//
+// Several CC/SDK-readable properties routinely carry live secrets (a Lambda env var
+// holding an API token, a CodeBuild PLAINTEXT env var, an EC2 LaunchTemplate UserData
+// bootstrap script, an ElasticBeanstalk `aws:elasticbeanstalk:application:environment`
+// env var). cdkrd deliberately SURFACES a drift on these (hiding the finding would be a
+// false negative — a rotated token IS drift), but printing the raw value leaks the live
+// secret into a CI log (`cdkrd check --fail`) or the --json stream. This module masks the
+// displayed VALUE only — the finding's tier / drift-ness / count are unchanged (detection
+// preserved), the path/key name stays visible (it is not secret), and the plaintext never
+// reaches the output.
+//
+// SCOPE: OUTPUT ONLY. This layer is consulted by the report renderers (text + --json). It
+// does NOT change classification, folding, or what `record` writes to the baseline (that
+// persistence half is a separate deferred lane, #798). A non-secret property's value is
+// NEVER masked — the table is curated to the secret-bearing paths and nothing else.
+
+// The masked placeholder. Keeps the char length as a signal (a rotated 40-char token vs a
+// blanked env var reads differently) without revealing any plaintext. A non-string value
+// (an object/array/number that slipped a matcher) masks to the length-less form.
+export function maskPlaceholder(value: unknown): string {
+  if (typeof value === 'string') return `<redacted:${value.length} chars>`;
+  return '<redacted>';
+}
+
+// A matcher decides, for one resourceType, whether a given finding path is secret-bearing
+// and how to mask the value being rendered at that path. `pathRe` is tested against the
+// finding path (which may carry an array index like `.0.` or a composite `[ns|name]`
+// segment). `redact` returns the masked form of the value to DISPLAY (the caller has
+// already done any comparison against the raw value, so masking the display never hides a
+// finding).
+interface RedactMatcher {
+  pathRe: RegExp;
+  redact: (value: unknown) => unknown;
+}
+
+// Mask the whole value (a scalar env-var value / UserData blob).
+const maskWhole = (value: unknown): unknown => maskPlaceholder(value);
+
+// Mask ONLY the `Value` sub-field of an object entry, keeping the identity fields
+// (Namespace / OptionName / Name) visible. Used where the finding value is the WHOLE
+// element object (EB OptionSettings composite-key subset, path `OptionSettings[ns|name]`)
+// rather than a bare scalar. A non-object value falls back to whole-masking.
+const maskEntryValueField = (value: unknown): unknown => {
+  if (value && typeof value === 'object' && !Array.isArray(value) && 'Value' in value) {
+    return {
+      ...(value as Record<string, unknown>),
+      Value: maskPlaceholder((value as Record<string, unknown>).Value),
+    };
+  }
+  return maskPlaceholder(value);
+};
+
+// Mask EVERY value of a free-form map (path is the whole map property, e.g. a Lambda
+// `Environment.Variables` emitted whole because a key holds a `.`), keeping the KEY names
+// visible. A non-object value falls back to whole-masking.
+const maskMapValues = (value: unknown): unknown => {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>))
+      out[k] = maskPlaceholder(v);
+    return out;
+  }
+  return maskPlaceholder(value);
+};
+
+// The curated table: resourceType -> secret-bearing path matchers. A finding whose
+// resourceType + path matches has its DISPLAYED value masked; everything else prints in
+// full (subject to the existing 200-char cap). The paths mirror the secret-bearing
+// live-readable properties enumerated in #798.
+const REDACTED_VALUE_PATHS: Record<string, RedactMatcher[]> = {
+  // Lambda env vars: the per-key finding path is `Environment.Variables.<KEY>` (freeForm
+  // per-key surfacing, classify.ts) — its scalar value is the secret. The whole map may
+  // also be emitted at `Environment.Variables` when a key holds a `.` (drift-calculator
+  // whole-map emit) — mask every value, keep the keys.
+  'AWS::Lambda::Function': [
+    { pathRe: /(^|\.)Environment\.Variables\./, redact: maskWhole },
+    { pathRe: /(^|\.)Environment\.Variables$/, redact: maskMapValues },
+  ],
+  // CodeBuild PLAINTEXT env var: the reader projects `[{Name,Value,Type}]`, so a per-value
+  // drift path is `Environment.EnvironmentVariables.<idx>.Value` (dot-indexed array).
+  'AWS::CodeBuild::Project': [
+    { pathRe: /(^|\.)Environment\.EnvironmentVariables\.\d+\.Value$/, redact: maskWhole },
+  ],
+  // EC2 LaunchTemplate UserData (base64 bootstrap script — may embed secrets). The
+  // writeOnly strip is lifted for LaunchTemplateData so it is comparable; the UserData leaf
+  // path is `LaunchTemplateData.UserData`.
+  'AWS::EC2::LaunchTemplate': [
+    { pathRe: /(^|\.)LaunchTemplateData\.UserData$/, redact: maskWhole },
+  ],
+  // ElasticBeanstalk env vars: the composite-key subset (Namespace|OptionName) emits a
+  // finding at `OptionSettings[<ns>|<name>]` whose value is the WHOLE entry object. Only
+  // the `aws:elasticbeanstalk:application:environment` namespace holds user env vars — mask
+  // that entry's `Value` field, leaving the identity fields and every OTHER namespace's
+  // option value visible (do NOT over-mask a non-secret InstanceType etc.).
+  'AWS::ElasticBeanstalk::Environment': [
+    {
+      pathRe: /(^|\.)OptionSettings\[aws:elasticbeanstalk:application:environment\|/,
+      redact: maskEntryValueField,
+    },
+  ],
+};
+
+// Return the masked form of a value if (resourceType, path) is a secret-bearing path in the
+// table; otherwise return the value unchanged. The caller renders the returned value.
+// Pure — no side effects, does not mutate the input.
+export function redactValue(resourceType: string, path: string, value: unknown): unknown {
+  const matchers = REDACTED_VALUE_PATHS[resourceType];
+  if (!matchers) return value;
+  for (const m of matchers) {
+    if (m.pathRe.test(path)) return m.redact(value);
+  }
+  return value;
+}
+
+// True if (resourceType, path) is a secret-bearing path in the table.
+export function isRedactedPath(resourceType: string, path: string): boolean {
+  const matchers = REDACTED_VALUE_PATHS[resourceType];
+  return !!matchers && matchers.some((m) => m.pathRe.test(path));
+}
+
+// Redact a whole finding for the --json output: returns a shallow copy whose `desired` /
+// `actual` (and any `arrayDelta` element values) are masked WHERE the finding's
+// resourceType + path is secret-bearing, leaving every other field (tier, path, note,
+// hint, …) intact so detection/counting is unchanged. For a per-KEY / per-element site
+// where the leaf path extends the finding path (a whole free-form map, an identity-keyed
+// array), the mask is applied at the finding-path level (maskMapValues / maskEntryValueField
+// handle the sub-key masking), which covers the shapes the report renders.
+export function redactFinding<
+  T extends {
+    resourceType: string;
+    path: string;
+    desired?: unknown;
+    actual?: unknown;
+    arrayDelta?: unknown;
+  },
+>(f: T): T {
+  if (!isRedactedPath(f.resourceType, f.path)) return f;
+  const out: T = { ...f };
+  if ('desired' in f && f.desired !== undefined)
+    out.desired = redactValue(f.resourceType, f.path, f.desired);
+  if ('actual' in f && f.actual !== undefined)
+    out.actual = redactValue(f.resourceType, f.path, f.actual);
+  // An identity-keyed array delta carries per-element values — mask those too so a recorded
+  // secret array's --json element values are not leaked.
+  if (f.arrayDelta && typeof f.arrayDelta === 'object') {
+    out.arrayDelta = redactArrayDelta(f.resourceType, f.path, f.arrayDelta as ArrayDeltaShape);
+  }
+  return out;
+}
+
+// Minimal structural shape of ArrayDelta needed for masking (avoids importing the report's
+// type here — this module stays dependency-light and testable in isolation).
+interface ArrayDeltaShape {
+  identityField: string;
+  added: { id: string; value: unknown }[];
+  removed: { id: string; value: unknown }[];
+  changed: { id: string; recorded: unknown; actual: unknown }[];
+}
+
+function redactArrayDelta(resourceType: string, path: string, d: ArrayDeltaShape): ArrayDeltaShape {
+  const mv = (v: unknown): unknown => redactValue(resourceType, path, v);
+  return {
+    identityField: d.identityField,
+    added: d.added.map((a) => ({ id: a.id, value: mv(a.value) })),
+    removed: d.removed.map((r) => ({ id: r.id, value: mv(r.value) })),
+    changed: d.changed.map((c) => ({ id: c.id, recorded: mv(c.recorded), actual: mv(c.actual) })),
+  };
+}

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -24,6 +24,7 @@ import { deepEqual } from '../diff/drift-calculator.js';
 import { annotateHints } from '../diff/hints.js';
 import { UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import type { ArrayDelta, Finding, Tier } from '../types.js';
+import { redactFinding, redactValue } from './redact.js';
 import { style } from './style.js';
 
 // The report header is `<stackName> (<region>)`; recover the bare stack name (used to
@@ -142,23 +143,32 @@ export function formatFinding(f: Finding, stackName = ''): string {
   const pathDisplay = f.attributeKey ? `${f.path}[${sanitizeForTerminal(f.attributeKey)}]` : f.path;
   let s = `${pathDisplay ? `${id}.${pathDisplay}` : id} (${f.resourceType})`;
   if (f.note) s += ` — ${sanitizeForTerminal(f.note)}`;
+  // #798: mask a secret-bearing VALUE before it is rendered — a Lambda/CodeBuild env var, an
+  // EC2 LaunchTemplate UserData blob, an EB env-var OptionSetting. The masking is applied to
+  // the DISPLAY value only, AFTER any comparison (so a rotated secret still SURFACES as
+  // drift — detection is preserved); the path/key stays visible, only the plaintext is
+  // hidden. `redactValue` is a no-op for every non-secret path (see report/redact.ts).
+  const rt = f.resourceType;
+  const rd = (v: unknown): unknown => redactValue(rt, f.path, v);
   if (f.tier === 'declared') {
     // A map-valued drift (both sides objects) is shown as a per-KEY delta, not a truncated
     // whole-object dump (see formatMapDelta) — the user's case: one ResponseParameters
     // header value changed but the raw pair-truncation windowed on the template-vs-live key
     // ORDER and hid it. A scalar drift keeps the plain desired/actual lines.
-    if (isRecord(f.desired) && isRecord(f.actual)) s += formatMapDelta(f.desired, f.actual, false);
+    if (isRecord(f.desired) && isRecord(f.actual))
+      s += formatMapDelta(f.desired, f.actual, false, rt, f.path);
     else {
-      const { a: d, b: act } = jPair(f.desired, f.actual);
+      const { a: d, b: act } = jPair(rd(f.desired), rd(f.actual));
       s += `\n      desired=${style.desired(d)}\n      actual =${style.actual(act)}`;
     }
   } else if (f.tier === 'added' && f.desired !== undefined) {
     // PR4: a recorded `added` resource whose live model CHANGED since record — show the
     // recorded baseline model vs the live one so the user sees WHAT changed. Both are full
     // models (objects), so the same per-key delta applies (baseline-vs-actual labels).
-    if (isRecord(f.desired) && isRecord(f.actual)) s += formatMapDelta(f.desired, f.actual, true);
+    if (isRecord(f.desired) && isRecord(f.actual))
+      s += formatMapDelta(f.desired, f.actual, true, rt, f.path);
     else {
-      const { a: base, b: act } = jPair(f.desired, f.actual);
+      const { a: base, b: act } = jPair(rd(f.desired), rd(f.actual));
       s += `\n      baseline=${style.desired(base)}\n      actual  =${style.actual(act)}`;
     }
   } else if (f.tier === 'added' && f.actual !== undefined) {
@@ -168,11 +178,11 @@ export function formatFinding(f: Finding, stackName = ''): string {
     // of a bare id+type line (the live model was previously only visible under --json). The
     // `f.actual !== undefined` guard keeps a degraded read (identity-only, no model) rendering
     // as its bare id+type line rather than a stray `actual =undefined`.
-    s += `\n      actual =${style.actual(j(f.actual))}`;
+    s += `\n      actual =${style.actual(j(rd(f.actual)))}`;
   } else if (f.tier === 'undeclared' && f.arrayDelta)
     // R128: a recorded identity-keyed array changed — show the element delta, not the
     // whole array dump (the property stays recorded; this is the WHICH-element view).
-    s += formatArrayDelta(f.arrayDelta);
+    s += formatArrayDelta(f.arrayDelta, rt, f.path);
   else if (f.tier === 'undeclared' && f.desired !== undefined) {
     // #758 follow-up: a RECORDED undeclared value that CHANGED out of band since record —
     // applyBaseline (baseline-file.ts) threads the recorded baseline value onto `f.desired`
@@ -180,9 +190,10 @@ export function formatFinding(f: Finding, stackName = ''): string {
     // value changed FROM, not just the (possibly attacker-set) live value. Same `baseline`-vs-
     // `actual` wording as the recorded `added` tier: a per-key delta for maps (both objects),
     // stacked `baseline=`/`actual  =` lines for scalars.
-    if (isRecord(f.desired) && isRecord(f.actual)) s += formatMapDelta(f.desired, f.actual, true);
+    if (isRecord(f.desired) && isRecord(f.actual))
+      s += formatMapDelta(f.desired, f.actual, true, rt, f.path);
     else {
-      const { a: base, b: act } = jPair(f.desired, f.actual);
+      const { a: base, b: act } = jPair(rd(f.desired), rd(f.actual));
       s += `\n      baseline=${style.desired(base)}\n      actual  =${style.actual(act)}`;
     }
   } else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
@@ -190,7 +201,7 @@ export function formatFinding(f: Finding, stackName = ''): string {
     // column — a long ARN/JSON list crammed inline after the id was unreadable, and it read
     // inconsistently next to a declared drift's stacked desired/actual. An undeclared value
     // has only the live side, so it's a single `actual =` line (no desired to contrast).
-    s += `\n      actual =${style.actual(j(f.actual))}`;
+    s += `\n      actual =${style.actual(j(rd(f.actual)))}`;
   // A non-classifying origin hint (diff/hints.ts) — the finding is still real drift; this
   // just names where the live value likely came from. Readable (style.note) trailing line
   // below the values — it is meant to be read, so NOT dim.
@@ -215,24 +226,38 @@ const isRecord = (v: unknown): v is Record<string, unknown> =>
 function formatMapDelta(
   desired: Record<string, unknown>,
   actual: Record<string, unknown>,
-  baselineLabels: boolean
+  baselineLabels: boolean,
+  // #798: the finding's resourceType + the map's base path, so a per-KEY value that is
+  // secret-bearing (e.g. a Lambda `Environment.Variables` map emitted WHOLE at
+  // `Environment.Variables` — each key's effective path is `Environment.Variables.<KEY>`)
+  // is masked in its DISPLAY. Masking is applied AFTER the deepEqual compare below (which
+  // runs on the RAW value), so a changed secret still surfaces — only the printed value is
+  // hidden. Omitted (undefined) by direct unit callers → no redaction, byte-identical output.
+  resourceType?: string,
+  basePath?: string
 ): string {
   const lhs = baselineLabels ? 'baseline' : 'desired';
   const rhs = baselineLabels ? 'actual  ' : 'actual ';
   const keys = [...new Set([...Object.keys(desired), ...Object.keys(actual)])].sort();
+  // Redact the DISPLAY value for key `k` (effective path `<basePath>.<k>`) — a no-op when
+  // no resourceType/basePath is threaded, or the path is not secret-bearing.
+  const rd = (k: string, v: unknown): unknown =>
+    resourceType !== undefined && basePath !== undefined
+      ? redactValue(resourceType, `${basePath}.${k}`, v)
+      : v;
   let s = '';
   for (const k of keys) {
     const inD = Object.hasOwn(desired, k);
     const inA = Object.hasOwn(actual, k);
     if (inD && inA) {
       if (deepEqual(desired[k], actual[k])) continue;
-      const { a, b } = jPair(desired[k], actual[k]);
+      const { a, b } = jPair(rd(k, desired[k]), rd(k, actual[k]));
       const sk = sanitizeForTerminal(k);
       s += `\n      ~ ${sk}\n          ${lhs}=${style.desired(a)}\n          ${rhs}=${style.actual(b)}`;
     } else if (inD) {
-      s += `\n      - ${sanitizeForTerminal(k)} (in ${baselineLabels ? 'baseline' : 'template'}, absent in live)\n          ${lhs}=${style.desired(j(desired[k]))}`;
+      s += `\n      - ${sanitizeForTerminal(k)} (in ${baselineLabels ? 'baseline' : 'template'}, absent in live)\n          ${lhs}=${style.desired(j(rd(k, desired[k])))}`;
     } else {
-      s += `\n      + ${sanitizeForTerminal(k)} (in live, not in ${baselineLabels ? 'baseline' : 'template'})\n          ${rhs}=${style.actual(j(actual[k]))}`;
+      s += `\n      + ${sanitizeForTerminal(k)} (in live, not in ${baselineLabels ? 'baseline' : 'template'})\n          ${rhs}=${style.actual(j(rd(k, actual[k])))}`;
     }
   }
   // A whole-object swap with NO per-key difference shouldn't happen (deepEqual gates the
@@ -251,15 +276,20 @@ function formatMapDelta(
 // follow on their own indented lines (mirrors the declared tier's desired/actual
 // layout — `baseline`/`actual` are padded so the `=` aligns), so two long policy
 // documents are read top-to-bottom instead of wrapping on one line (R130).
-function formatArrayDelta(d: ArrayDelta): string {
+function formatArrayDelta(d: ArrayDelta, resourceType?: string, path?: string): string {
+  // #798: mask a secret-bearing element value in its DISPLAY (a no-op when no
+  // resourceType/path is threaded or the path is not secret-bearing). The element id
+  // (identity key) stays visible.
+  const rd = (v: unknown): unknown =>
+    resourceType !== undefined && path !== undefined ? redactValue(resourceType, path, v) : v;
   // 8 = len('baseline'); pad 'actual' to match so the '=' column lines up.
-  const baseline = (v: unknown): string => `\n          baseline=${style.desired(j(v))}`;
-  const actual = (v: unknown): string => `\n          actual  =${style.actual(j(v))}`;
+  const baseline = (v: unknown): string => `\n          baseline=${style.desired(j(rd(v)))}`;
+  const actual = (v: unknown): string => `\n          actual  =${style.actual(j(rd(v)))}`;
   let s = ` — ${sanitizeForTerminal(d.identityField)}-keyed element(s) changed vs .cdkrd baseline:`;
   for (const a of d.added) s += `\n      + [${sanitizeForTerminal(a.id)}]${actual(a.value)}`;
   for (const c of d.changed) {
     // pair-aware truncation so a long recorded-vs-live element shows WHERE it diverges
-    const { a: base, b: act } = jPair(c.recorded, c.actual);
+    const { a: base, b: act } = jPair(rd(c.recorded), rd(c.actual));
     s += `\n      ~ [${sanitizeForTerminal(c.id)}]\n          baseline=${style.desired(base)}\n          actual  =${style.actual(act)}`;
   }
   for (const r of d.removed) s += `\n      - [${sanitizeForTerminal(r.id)}]${baseline(r.value)}`;
@@ -366,8 +396,15 @@ export function buildStackJson(
   // never counted toward the verdict/exit.
   const isDriftHere = (f: Finding): boolean => DRIFT_TIERS.includes(f.tier) && !f.unrecorded;
   const drifted = findings.filter(isDriftHere).length;
+  // #798: mask secret-bearing VALUES in the --json findings (a Lambda/CodeBuild env var,
+  // an EC2 LaunchTemplate UserData blob, an EB env-var OptionSetting) BEFORE they are
+  // serialized — the raw text-path 200-char cap does not apply to --json, so an unmasked
+  // value would ship the full plaintext to a CI log. `redactFinding` preserves tier/count
+  // (detection unchanged), masking only the VALUE — so `drifted` above (counted on the raw
+  // findings) is identical either way; every non-secret finding is returned unchanged.
+  const redacted = findings.map((f) => redactFinding(f));
   return {
-    json: { stack: header, drifted, findings, baseline: hasBaseline === true },
+    json: { stack: header, drifted, findings: redacted, baseline: hasBaseline === true },
     code: drifted === 0 ? 0 : 1,
   };
 }

--- a/tests/report-redact-798.test.ts
+++ b/tests/report-redact-798.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  isRedactedPath,
+  maskPlaceholder,
+  redactFinding,
+  redactValue,
+} from '../src/report/redact.js';
+import { buildStackJson, formatFinding, report } from '../src/report/report.js';
+import type { Finding } from '../src/types.js';
+
+// #798 — report-layer redaction: a secret-bearing live-readable VALUE (Lambda / CodeBuild
+// env var, EC2 LaunchTemplate UserData, EB env-var OptionSetting) must be MASKED in BOTH
+// the text report and the --json output, while the finding STILL surfaces as drift
+// (detection preserved). A normal (non-secret) value must NEVER be masked.
+
+const SECRET = 'super-secret-token-abcdef0123456789';
+
+// A Lambda console-added env var surfaces as an undeclared per-key finding at
+// `Environment.Variables.<KEY>` with the value as `actual` (classify.ts freeForm).
+const lambdaEnvFinding = (): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'Fn',
+  resourceType: 'AWS::Lambda::Function',
+  path: 'Environment.Variables.API_TOKEN',
+  actual: SECRET,
+  nested: true,
+  freeFormKey: true,
+});
+
+// A CodeBuild PLAINTEXT env var surfaces at `Environment.EnvironmentVariables.<idx>.Value`.
+const codeBuildEnvFinding = (): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'Proj',
+  resourceType: 'AWS::CodeBuild::Project',
+  path: 'Environment.EnvironmentVariables.0.Value',
+  actual: SECRET,
+  nested: true,
+});
+
+// A normal (non-secret) property value — a Lambda Timeout — must print in full.
+const normalFinding = (): Finding => ({
+  tier: 'declared',
+  logicalId: 'Fn',
+  resourceType: 'AWS::Lambda::Function',
+  path: 'Timeout',
+  desired: 30,
+  actual: 900,
+});
+
+function runText(findings: Finding[]): string {
+  const lines: string[] = [];
+  report(findings, 'stack (us-east-1)', { log: (s) => lines.push(s) });
+  return lines.join('\n');
+}
+
+describe('#798 report redaction — text output masks secret VALUES', () => {
+  it('a Lambda Environment.Variables secret value is masked in the text report', () => {
+    const text = runText([lambdaEnvFinding()]);
+    expect(text).not.toContain(SECRET); // plaintext never printed
+    expect(text).toContain('<redacted:'); // masked placeholder present
+    // the path / key stays visible (it is not secret)
+    expect(text).toContain('Environment.Variables.API_TOKEN');
+  });
+
+  it('a CodeBuild EnvironmentVariables Value is masked in the text report', () => {
+    const text = runText([codeBuildEnvFinding()]);
+    expect(text).not.toContain(SECRET);
+    expect(text).toContain('<redacted:');
+    expect(text).toContain('Environment.EnvironmentVariables.0.Value');
+  });
+
+  it('the secret finding STILL surfaces as a finding (masking never drops it)', () => {
+    // a recorded (not unrecorded) undeclared secret is confirmed drift and counts
+    const recorded: Finding = { ...lambdaEnvFinding(), desired: 'old-value' };
+    const text = runText([recorded]);
+    // the finding line is present (id.path + type), just with a masked value
+    expect(text).toContain('Environment.Variables.API_TOKEN');
+    expect(text).toContain('CFn-Undeclared Drift');
+    expect(text).not.toContain(SECRET);
+    expect(text).not.toContain('old-value'); // the baseline side is masked too
+  });
+
+  it('a normal (non-secret) property value is NOT masked', () => {
+    const text = runText([normalFinding()]);
+    expect(text).toContain('900'); // the live Timeout prints in full
+    expect(text).toContain('30');
+    expect(text).not.toContain('<redacted');
+  });
+
+  it('a Lambda Environment.Variables map emitted WHOLE masks per-key values but keeps keys', () => {
+    // whole-map emit (a key holds a `.`): path is `Environment.Variables`, both sides objects.
+    // Masking is applied AFTER the per-key compare, so the CHANGED key still surfaces.
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Environment.Variables',
+      desired: { 'a.b': 'old', KEEP: 'same' },
+      actual: { 'a.b': SECRET, KEEP: 'same' },
+    };
+    const text = runText([f]);
+    expect(text).not.toContain(SECRET);
+    expect(text).not.toContain('old');
+    expect(text).toContain('a.b'); // the changed key name stays visible
+    expect(text).toContain('<redacted:'); // its value is masked
+  });
+});
+
+describe('#798 report redaction — --json output masks secret VALUES', () => {
+  it('a Lambda env secret is masked in the --json findings and still counts as drift', () => {
+    const recorded: Finding = { ...lambdaEnvFinding(), desired: 'old-value' };
+    const { json, code } = buildStackJson([recorded], 'stack (us-east-1)');
+    const serialized = JSON.stringify(json);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain('old-value');
+    expect(serialized).toContain('<redacted:');
+    // detection preserved: the finding is present and counts as drift
+    expect(json.findings.length).toBe(1);
+    expect(json.findings[0]?.path).toBe('Environment.Variables.API_TOKEN');
+    expect(json.drifted).toBe(1);
+    expect(code).toBe(1);
+  });
+
+  it('a CodeBuild env Value is masked in the --json findings', () => {
+    const { json } = buildStackJson([codeBuildEnvFinding()], 'stack (us-east-1)');
+    const serialized = JSON.stringify(json);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).toContain('<redacted:');
+  });
+
+  it('a normal (non-secret) value is NOT masked in --json', () => {
+    const { json } = buildStackJson([normalFinding()], 'stack (us-east-1)');
+    const serialized = JSON.stringify(json);
+    expect(serialized).toContain('900');
+    expect(serialized).not.toContain('<redacted');
+  });
+
+  it('report() --json path also masks (single-report callers)', () => {
+    const lines: string[] = [];
+    report([lambdaEnvFinding()], 'stack (us-east-1)', { json: true, log: (s) => lines.push(s) });
+    const out = lines.join('\n');
+    expect(out).not.toContain(SECRET);
+    expect(out).toContain('<redacted:');
+  });
+});
+
+describe('#798 redact module unit behavior', () => {
+  it('maskPlaceholder keeps the char length for a string, length-less for non-string', () => {
+    expect(maskPlaceholder('abcd')).toBe('<redacted:4 chars>');
+    expect(maskPlaceholder({ x: 1 })).toBe('<redacted>');
+  });
+
+  it('redactValue masks the secret paths and passes non-secret paths through unchanged', () => {
+    expect(redactValue('AWS::Lambda::Function', 'Environment.Variables.T', SECRET)).toBe(
+      `<redacted:${SECRET.length} chars>`
+    );
+    expect(
+      redactValue('AWS::EC2::LaunchTemplate', 'LaunchTemplateData.UserData', '#!/bin/bash secret')
+    ).toBe('<redacted:18 chars>');
+    // non-secret path / type -> unchanged
+    expect(redactValue('AWS::Lambda::Function', 'Timeout', 900)).toBe(900);
+    expect(redactValue('AWS::S3::Bucket', 'Environment.Variables.X', 'x')).toBe('x');
+  });
+
+  it('EB env-var OptionSetting masks the Value field, keeps Namespace/OptionName + other namespaces', () => {
+    const entry = {
+      Namespace: 'aws:elasticbeanstalk:application:environment',
+      OptionName: 'DB_PASSWORD',
+      Value: SECRET,
+    };
+    const masked = redactValue(
+      'AWS::ElasticBeanstalk::Environment',
+      'OptionSettings[aws:elasticbeanstalk:application:environment|DB_PASSWORD]',
+      entry
+    ) as Record<string, unknown>;
+    expect(masked.Value).toBe(`<redacted:${SECRET.length} chars>`);
+    expect(masked.Namespace).toBe('aws:elasticbeanstalk:application:environment');
+    expect(masked.OptionName).toBe('DB_PASSWORD');
+    // a NON-env-namespace option value is not a secret path -> unchanged
+    expect(
+      redactValue(
+        'AWS::ElasticBeanstalk::Environment',
+        'OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]',
+        {
+          Namespace: 'aws:autoscaling:launchconfiguration',
+          OptionName: 'InstanceType',
+          Value: 't3.micro',
+        }
+      )
+    ).toEqual({
+      Namespace: 'aws:autoscaling:launchconfiguration',
+      OptionName: 'InstanceType',
+      Value: 't3.micro',
+    });
+  });
+
+  it('isRedactedPath is true only for secret paths', () => {
+    expect(isRedactedPath('AWS::Lambda::Function', 'Environment.Variables.X')).toBe(true);
+    expect(isRedactedPath('AWS::Lambda::Function', 'Timeout')).toBe(false);
+    expect(
+      isRedactedPath('AWS::CodeBuild::Project', 'Environment.EnvironmentVariables.2.Value')
+    ).toBe(true);
+  });
+
+  it('redactFinding returns the finding unchanged for a non-secret path', () => {
+    const f = normalFinding();
+    expect(redactFinding(f)).toBe(f); // same reference — no copy for non-secret
+  });
+
+  it('formatFinding masks a secret scalar directly', () => {
+    const line = formatFinding(lambdaEnvFinding());
+    expect(line).not.toContain(SECRET);
+    expect(line).toContain('<redacted:');
+  });
+});


### PR DESCRIPTION
Addresses #798 (CI-log-leak half). New src/report/redact.ts masks Lambda/CodeBuild/EB/LaunchTemplate secret VALUES as `<redacted:NN chars>` in text + --json, AFTER the compare so a changed secret still surfaces as drift (detection preserved, keys visible). Output-only — classification/baseline unchanged. Persistence half deferred. See commit body.