### PR TITLE
fix(diff): gate GuardDuty Detector Features per-name Status instead of value-independent (#1092)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -161,7 +161,45 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // default as false — the KNOWN_DEFAULTS pin), so an OFF state (a live/declared `false`) is an
   // out-of-band DISABLE of that monitoring toggle and is meaningful. Live-confirmed (#841/#925).
   'AWS::ApplicationInsights::Application': { CWEMonitorEnabled: () => true },
+  // #1092: a GuardDuty detector is created with its legacy DataSources surface FULLY enabled
+  // (the KNOWN_DEFAULTS pin: S3 protection, EKS audit logs, EBS-malware all true). A single-
+  // source disable already surfaces (the object keeps a `true` leaf, so it is not trivially
+  // empty). But disabling EVERY legacy source at once turns DataSources into an ALL-FALSE
+  // object, which isTrivialEmpty would swallow BEFORE the pin gate — hiding a wholesale
+  // security disable. It is unconditionally meaningful when off, so surface it.
+  'AWS::GuardDuty::Detector': { DataSources: () => true },
 };
+
+// #1092: GuardDuty protection Features whose new-detector default Status is DISABLED (not the
+// ENABLED norm) — a newer/preview protection AWS ships OFF by default. Its DISABLED state on a
+// clean detector is the default (folds), so only these names are exempt from the "ENABLED is the
+// default" rule below. Extend as AWS ships more OFF-by-default features.
+const GUARDDUTY_DEFAULT_DISABLED_FEATURES: ReadonlySet<string> = new Set(['AI_ANALYST']);
+// True when every GuardDuty Feature (and every nested AdditionalConfiguration entry) is at its
+// per-name default Status — ENABLED for every protection except the known OFF-by-default set.
+// Name-independent for UNKNOWN names (a brand-new protection AWS ships ENABLED still folds), but
+// an out-of-band disable of a protection whose default is ENABLED (RUNTIME_MONITORING,
+// RDS_LOGIN_EVENTS, LAMBDA_NETWORK_LOGS — none have a legacy DataSources mirror) surfaces. Errs
+// toward VISIBILITY: a future OFF-by-default feature not yet in the set surfaces (a recordable FP)
+// rather than hiding a real security downgrade.
+function guardDutyFeaturesAllAtDefault(features: unknown[]): boolean {
+  const atDefault = (node: unknown): boolean => {
+    if (Array.isArray(node)) return node.every(atDefault);
+    if (node !== null && typeof node === 'object') {
+      const rec = node as Record<string, unknown>;
+      if ('Status' in rec) {
+        const name = typeof rec['Name'] === 'string' ? rec['Name'] : '';
+        const defaultStatus = GUARDDUTY_DEFAULT_DISABLED_FEATURES.has(name)
+          ? 'DISABLED'
+          : 'ENABLED';
+        if (rec['Status'] !== defaultStatus) return false;
+      }
+      return Object.values(rec).every(atDefault);
+    }
+    return true;
+  };
+  return features.every(atDefault);
+}
 
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements
 // AWS always returns — keyed by the property -> the element's identity field. Cognito
@@ -3178,6 +3216,20 @@ export function classifyResource(
       }
       continue;
     }
+    // #1092: GuardDuty Detector Features — fold atDefault ONLY when EVERY protection is
+    // ENABLED (the new-detector default). Replaces the old value-independent fold, which hid
+    // an out-of-band disable of a Features-only protection (a real security downgrade that
+    // never even got recorded). Name-independent, Status-gated (see guardDutyFeaturesAllEnabled).
+    if (resourceType === 'AWS::GuardDuty::Detector' && k === 'Features' && Array.isArray(v)) {
+      findings.push({
+        tier: guardDutyFeaturesAllAtDefault(v) ? 'atDefault' : 'undeclared',
+        logicalId,
+        resourceType,
+        path: k,
+        actual: v,
+      });
+      continue;
+    }
     // NOTE: no `schema.writeOnly.has(k)` guard — a top-level write-only key was
     // already stripped from `live` by writeOnlyPaths above, so it cannot reach here
     // (the old guard was dead code for top-level keys).
@@ -3434,7 +3486,16 @@ export function classifyResource(
     // is entirely AWS-materialized — fold the WHOLE object atDefault. Fail-closed: a single
     // non-default leaf (or any array) leaves it surfacing whole. Runs AFTER the per-type descends
     // above, so a type curated to fragment (Athena WorkGroupConfiguration) keeps that behavior.
-    if (isNestedObject(v) && Object.keys(v).length > 0 && allLeavesAtSchemaDefault(v, k)) {
+    // #1092: but NOT when the value is a meaningful-when-off divergence from its pin — an
+    // all-false object is trivially-empty, which allLeavesAtSchemaDefault would (wrongly) treat as
+    // "all at default" and fold, re-hiding the wholesale disable the trivial-drop guard above just
+    // preserved (a folded atDefault is never recorded, so record would never start watching).
+    if (
+      !offStateIsMeaningful &&
+      isNestedObject(v) &&
+      Object.keys(v).length > 0 &&
+      allLeavesAtSchemaDefault(v, k)
+    ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;
     }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2929,18 +2929,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   without enumerating each. Both observed live first-run (LineLink cognito, my-app
   //   AimAssociation TOKEN "custom") with no out-of-band edit.
   'AWS::ApiGateway::Authorizer': new Set(['AuthType']),
-  //   AWS::GuardDuty::Detector.Features — a detector declared with only `Enable: true`
-  //   reads back the full list of protection Features AWS materializes on a new detector
-  //   ([{Name:"CLOUD_TRAIL",Status:"ENABLED"}, {Name:"DNS_LOGS",...}, ...]). AWS EXTENDS
-  //   this list over time — new feature names appear as GuardDuty ships them (AI_ANALYST,
-  //   S3_DATA_EVENTS, RUNTIME_MONITORING, …), so a pinned constant would rot into a false
-  //   positive the moment AWS adds one. Fold value-independent: the property is undeclared,
-  //   so whatever feature set AWS enabled is its default, never user intent — a user who
-  //   cares about a specific feature's status DECLARES `Features`, which is then compared in
-  //   the declared loop (detected). (The legacy `DataSources` surface + the SIX_HOURS
-  //   publishing cadence are stable constants folded via KNOWN_DEFAULTS above.) Live-confirmed
-  //   on a fresh `Enable: true`-only detector (CdkrdHuntUGd, 2026-07-09; #879).
-  'AWS::GuardDuty::Detector': new Set(['Features']),
+  //   AWS::GuardDuty::Detector.Features is NO LONGER value-independent (#1092): folding any
+  //   Status hid an out-of-band disable of a Features-only protection (RUNTIME_MONITORING,
+  //   RDS_LOGIN_EVENTS, LAMBDA_NETWORK_LOGS — none have a legacy DataSources mirror) FOREVER,
+  //   and atDefault findings are never recorded, so `record` never started watching. It is
+  //   now folded by a name-independent, Status-gated per-element check in classify.ts (fold
+  //   atDefault only when every protection is ENABLED; any DISABLED surfaces). AWS still
+  //   EXTENDS the name set over time, but a new name is ENABLED at creation so it folds.
   //   AWS::RDS::DBCluster / ::DBInstance — an Aurora cluster/instance that declares no explicit
   //   KMS key, availability-zone placement, or maintenance/backup window reads back the values
   //   AWS ASSIGNED at creation: a specific `KmsKeyId` (the account/CDK key — create-only, so it

--- a/tests/noise-guardduty-879.test.ts
+++ b/tests/noise-guardduty-879.test.ts
@@ -90,13 +90,13 @@ describe('#879 GuardDuty::Detector undeclared first-run defaults', () => {
     expect(pathsByTier(f, 'undeclared')).not.toContain('DataSources');
   });
 
-  it('folds the Features list value-independently (folds AI_ANALYST + any future feature)', () => {
+  it('#1092: folds the Features list at its per-name defaults (AI_ANALYST DISABLED + ENABLED rest)', () => {
     const f = classifyResource(res, cleanLive, emptySchema);
     expect(pathsByTier(f, 'atDefault')).toContain('Features');
     expect(pathsByTier(f, 'undeclared')).not.toContain('Features');
   });
 
-  it('folds Features even after AWS adds a brand-new feature name', () => {
+  it('#1092: folds Features even after AWS adds a brand-new (ENABLED) feature name', () => {
     const withNewFeature = {
       ...cleanLive,
       Features: [...defaultFeatures, { Status: 'ENABLED', Name: 'BRAND_NEW_FEATURE_2027' }],
@@ -117,6 +117,51 @@ describe('#879 GuardDuty::Detector undeclared first-run defaults', () => {
     const changed = {
       ...cleanLive,
       DataSources: { ...defaultDataSources, S3Logs: { Enable: false } },
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('DataSources');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('DataSources');
+  });
+
+  // #1092: the security FNs the old value-independent Features fold + the trivial-empty drop hid.
+  it('#1092: surfaces an out-of-band disable of a Features-only protection (RUNTIME_MONITORING)', () => {
+    const changed = {
+      ...cleanLive,
+      Features: [
+        ...defaultFeatures,
+        { Status: 'ENABLED', Name: 'RDS_LOGIN_EVENTS' },
+        { Status: 'DISABLED', Name: 'RUNTIME_MONITORING' }, // ENABLED-by-default -> disable surfaces
+      ],
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('Features');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('Features');
+  });
+
+  it('#1092: surfaces a disable nested in a feature AdditionalConfiguration', () => {
+    const changed = {
+      ...cleanLive,
+      Features: [
+        ...defaultFeatures,
+        {
+          Status: 'ENABLED',
+          Name: 'RUNTIME_MONITORING',
+          AdditionalConfiguration: [{ Status: 'DISABLED', Name: 'EKS_ADDON_MANAGEMENT' }],
+        },
+      ],
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('Features');
+  });
+
+  it('#1092: surfaces a WHOLESALE all-false DataSources (was trivial-empty-dropped, invisible)', () => {
+    const changed = {
+      ...cleanLive,
+      DataSources: {
+        MalwareProtection: { ScanEc2InstanceWithFindings: { EbsVolumes: false } },
+        S3Logs: { Enable: false },
+        Kubernetes: { AuditLogs: { Enable: false } },
+      },
     };
     const f = classifyResource(res, changed, emptySchema);
     expect(pathsByTier(f, 'undeclared')).toContain('DataSources');


### PR DESCRIPTION
Closes #1092.

`AWS::GuardDuty::Detector` `Features` was folded **value-independently**, hiding an out-of-band disable of a Features-only protection (`RUNTIME_MONITORING`, `RDS_LOGIN_EVENTS`, `LAMBDA_NETWORK_LOGS` — none have a legacy `DataSources` mirror) **forever**: a folded `atDefault` is never recorded, so `record` never even started watching. And a **wholesale** legacy-source disable was doubly hidden — an all-false `DataSources` object is trivially-empty, dropped before the `KNOWN_DEFAULTS` pin gate.

**Fix (two parts):**
1. **Features** — removed from `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`; folded via a name-independent, **Status-gated** per-element check (`guardDutyFeaturesAllAtDefault`): fold when every protection is at its per-name default Status — ENABLED for all but a known OFF-by-default set (`{AI_ANALYST}`, live-harvested). A brand-new ENABLED feature still folds; a DISABLED of an ENABLED-default protection surfaces. Errs toward **visibility** (a future OFF-by-default name surfaces as a recordable FP, never hiding a downgrade).
2. **All-false DataSources** — added `MEANINGFUL_WHEN_OFF['AWS::GuardDuty::Detector'].DataSources` (the proven #632 mechanism) so the wholesale disable is not trivial-dropped, **and** gated the #624 `allLeavesAtSchemaDefault` fold with the same `offStateIsMeaningful` flag (its `isTrivialEmpty` short-circuit otherwise re-folds the all-false object `atDefault`).

## Verification
- The existing 8 `noise-guardduty-879` tests still pass (clean detector = ZERO drift, incl. `AI_ANALYST: DISABLED` at its default), + 3 new #1092 tests: a `RUNTIME_MONITORING` disable surfaces, a nested `AdditionalConfiguration` disable surfaces, a wholesale all-false `DataSources` surfaces (was invisible).
- typecheck / `vp check` (0 errors) / build / 4295 unit tests green.
- No GuardDuty corpus case exists; the fixture Features shape is live-harvested (per the #879 test header) and the security repro is in the issue (hunt-x GD-3/GD-4).