### PR TITLE
fix(desired): resolve crossRegionReferences reader GetAtt via SSM /cdk/exports prefetch (#741)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -404,6 +404,21 @@ a principal without `cloudformation:ListExports`) DEGRADES to empty exports — 
 consuming properties resolve `UNRESOLVED`, with a one-line warning — rather than
 hard-failing the whole stack check.
 
+**`crossRegionReferences: true` (CDK cross-region GetAtt).** CDK cannot use
+`Fn::ImportValue` across regions, so it synthesizes a `Custom::CrossRegionExportReader`
+in the CONSUMER stack that materializes each imported value as an SSM parameter
+`/cdk/exports/<name>` in the consumer region; the consumer property becomes
+`{ Fn::GetAtt: [<Reader>, "/cdk/exports/<name>"] }`. The reader is a `Custom::*`
+resource with no live model, so that GetAtt would resolve `UNRESOLVED` forever —
+leaving an out-of-band console swap (e.g. a CloudFront distribution's ACM certificate)
+invisible on exactly the value the pattern exists to pin. Mirroring the `ListExports`
+prefetch, `loadDesired` scans the template for such reader GetAtts and — ONLY when one
+exists — batch-fetches the referenced parameters via `ssm:GetParameters`
+(account+region-scoped, cached in a module-level Map keyed by `${accountId}:${region}`).
+`resolveGetAtt` then resolves the reader GetAtt against that map, so a live cert
+mismatch surfaces as declared drift. A read failure / missing parameter DEGRADES to
+`UNRESOLVED` (with a one-line warning), never a fabricated value (#741).
+
 > Trade-off to review: cdkd has a fuller `IntrinsicFunctionResolver`. We
 > deliberately wrote a focused, fail-closed one. The remaining `unresolved`
 > residual is exotic intrinsics — reported honestly, never false drift.

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -9,6 +9,7 @@ import {
   ListExportsCommand,
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
+import { GetParametersCommand, SSMClient, type SSMClientConfig } from '@aws-sdk/client-ssm';
 import { classifyStackStatus, StackNotCheckableError } from '../aws-errors.js';
 import { evalCondition, resolveProperties } from '../normalize/intrinsic-resolver.js';
 import type { DesiredResource, ResolverContext } from '../types.js';
@@ -340,6 +341,97 @@ export async function listExports(
   return exports;
 }
 
+// Per-account+region cache of resolved `/cdk/exports/*` SSM parameters (name -> value), for
+// the CDK `crossRegionReferences: true` pattern. Like exportsCache, these parameters are scoped
+// to an account AND a region (they are written into the CONSUMER region by the reader), so the
+// cache key MUST carry BOTH axes. A single prefetch serves every reader GetAtt in the stack.
+const crossRegionExportsCache = new Map<string, Record<string, string>>();
+
+// The CDK cross-region-reference reader custom-resource type.
+const CROSS_REGION_EXPORT_READER_TYPE = 'Custom::CrossRegionExportReader';
+
+/**
+ * Scan the parsed template for `Fn::GetAtt` references whose logicalId is a
+ * `Custom::CrossRegionExportReader` resource and whose attribute is an SSM parameter name
+ * (`/cdk/exports/<name>`). Returns the DISTINCT parameter names to prefetch. Pure + exported
+ * for unit tests. Both GetAtt forms are handled: the array form `[LogicalId, AttrName]` and
+ * the long-form string `"LogicalId./cdk/exports/name"` (split on the FIRST dot — the attribute
+ * itself may contain dots).
+ */
+export function collectCrossRegionExportNames(template: Record<string, any>): string[] {
+  const resources = (template.Resources ?? {}) as Record<string, { Type?: string }>;
+  const readerIds = new Set(
+    Object.entries(resources)
+      .filter(([, r]) => r?.Type === CROSS_REGION_EXPORT_READER_TYPE)
+      .map(([lid]) => lid)
+  );
+  if (readerIds.size === 0) return [];
+  const names = new Set<string>();
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const x of node) walk(x);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      const obj = node as Record<string, unknown>;
+      const g = obj['Fn::GetAtt'];
+      if (g !== undefined) {
+        let logicalId: string | undefined;
+        let attr: string | undefined;
+        if (typeof g === 'string') {
+          const dot = g.indexOf('.');
+          if (dot >= 0) {
+            logicalId = g.slice(0, dot);
+            attr = g.slice(dot + 1);
+          }
+        } else if (Array.isArray(g) && g.length >= 2) {
+          logicalId = String(g[0]);
+          attr = String(g[1]);
+        }
+        if (
+          logicalId !== undefined &&
+          readerIds.has(logicalId) &&
+          attr !== undefined &&
+          attr.startsWith('/cdk/exports/')
+        ) {
+          names.add(attr);
+        }
+      }
+      for (const v of Object.values(obj)) walk(v);
+    }
+  };
+  walk(template.Resources ?? {});
+  return [...names].sort();
+}
+
+// Resolve the given `/cdk/exports/*` SSM parameter names in the stack's region via
+// ssm:GetParameters (batched 10 at a time). Returns name -> value; a name that is missing /
+// unreadable is simply LEFT OUT (fail closed — resolveGetAtt then yields UNRESOLVED). Cached
+// per account:region so repeated gather runs in the same process don't re-fetch. Mirrors the
+// listExports prefetch/cache idiom.
+export async function getCrossRegionExports(
+  ssm: SSMClient,
+  accountId: string,
+  region: string,
+  names: string[]
+): Promise<Record<string, string>> {
+  const cacheKey = `${accountId}:${region}`;
+  const cached = crossRegionExportsCache.get(cacheKey);
+  if (cached) return cached;
+  const out: Record<string, string> = {};
+  for (let i = 0; i < names.length; i += 10) {
+    const batch = names.slice(i, i + 10);
+    const res = await ssm.send(new GetParametersCommand({ Names: batch }));
+    for (const p of res.Parameters ?? []) {
+      if (p.Name && typeof p.Value === 'string') out[p.Name] = p.Value;
+    }
+    // InvalidParameters (names that don't exist) are returned separately and intentionally
+    // dropped — the reader GetAtt for a missing name stays UNRESOLVED (fail closed).
+  }
+  crossRegionExportsCache.set(cacheKey, out);
+  return out;
+}
+
 // Page ListStackResources (DescribeStackResources caps at 100; CDK stacks reach ~500).
 async function listStackResources(
   client: CloudFormationClient,
@@ -511,6 +603,41 @@ export async function loadDesired(
         `warning: ${stackName}: cloudformation:ListExports failed — Fn::ImportValue references ` +
           `will resolve UNRESOLVED (their declared properties are skipped, not compared). ` +
           `Grant cloudformation:ListExports for full coverage. (${msg})`
+      );
+    }
+  }
+
+  // CDK `crossRegionReferences: true` pattern: a `Custom::CrossRegionExportReader` custom
+  // resource materializes each cross-region import as an SSM parameter `/cdk/exports/<name>`
+  // in THIS (consumer) region, and the consumer property is a GetAtt to that parameter name.
+  // The reader has no live model, so those GetAtts would resolve UNRESOLVED forever — leaving
+  // an out-of-band cert swap invisible. Prefetch the referenced parameters (one ssm:GetParameters
+  // batch) so resolveGetAtt can resolve them. Only fetch when the template actually has such a
+  // reader + reference, so normal stacks pay nothing. Fail closed: on any read failure the map
+  // stays empty and those GetAtts remain UNRESOLVED (the pre-fix behavior).
+  const crossRegionExportNames = collectCrossRegionExportNames(template);
+  if (crossRegionExportNames.length > 0) {
+    try {
+      // Build the SSM client for the SAME region as the stack (the reader writes its SSM
+      // parameters into the consumer region). Reuse the CFn client's resolved credentials so a
+      // `--profile` run hits the same account; fall back to the default chain when the client
+      // exposes none (e.g. a bare mock in tests). `config`/`credentials` are typed as always
+      // defined, but a bare mock leaves them undefined at runtime — read defensively.
+      const credentials = (client as { config?: { credentials?: SSMClientConfig['credentials'] } })
+        .config?.credentials;
+      const ssm = new SSMClient(credentials ? { region, credentials } : { region });
+      ctx.crossRegionExports = await getCrossRegionExports(
+        ssm,
+        accountId,
+        region,
+        crossRegionExportNames
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `warning: ${stackName}: ssm:GetParameters failed — crossRegionReferences reader GetAtt ` +
+          `references (/cdk/exports/*) will resolve UNRESOLVED (their declared properties are ` +
+          `skipped, not compared). Grant ssm:GetParameters for full coverage. (${msg})`
       );
     }
   }

--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -374,6 +374,26 @@ export function resolveGetAtt(v: unknown, ctx: ResolverContext): unknown {
   // not cascade into phantom drift on consumers. Fall through to live when the declared
   // property is absent or itself does not statically resolve to a scalar.
   const type = ctx.typeOf?.[logicalId];
+  // CDK `crossRegionReferences: true` pattern: a `Custom::CrossRegionExportReader`
+  // materializes each imported value as an SSM parameter `/cdk/exports/<name>` in the
+  // consumer region, and the consumer property is `{ Fn::GetAtt: [<Reader>, "/cdk/exports/<name>"] }`.
+  // The reader has no live model (router.ts short-circuits Custom::* to skipped), so this
+  // GetAtt would otherwise be permanently UNRESOLVED — leaving an out-of-band cert swap
+  // invisible. Resolve it from the prefetched SSM map (template-adapter.ts). Gate on the
+  // reader Type when known; else on the unambiguous `/cdk/exports/` attribute shape (only
+  // this pattern produces a GetAtt attribute starting with a slash). Missing from the map
+  // (unread/unresolvable) falls through to UNRESOLVED as before — so ordinary GetAtts and a
+  // fail-closed prefetch are unaffected.
+  if (
+    attr.startsWith('/cdk/exports/') &&
+    (type === undefined || type === 'Custom::CrossRegionExportReader')
+  ) {
+    const val = ctx.crossRegionExports?.[attr];
+    if (typeof val === 'string') return val;
+    // Reader GetAtt but no prefetched value → fail closed. Do not fall through to the
+    // live-model path below (a reader has no live model, so it would also be UNRESOLVED).
+    return UNRESOLVED;
+  }
   const declaredKey = type ? GETATT_DECLARED_PROPERTY[type]?.[attr] : undefined;
   if (declaredKey !== undefined) {
     const rawProps = ctx.declaredRawProps?.[logicalId];

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,15 @@ export interface ResolverContext {
   // template.Mappings (MapName -> TopKey -> SecondKey -> value), for Fn::FindInMap
   mappings: Record<string, Record<string, Record<string, unknown>>>;
   exports: Record<string, string>; // CFn export Name -> Value, for Fn::ImportValue (prefetched)
+  // SSM parameter name -> value, for the CDK `crossRegionReferences: true` pattern. A
+  // `Custom::CrossRegionExportReader` materializes each imported value as an SSM parameter
+  // named `/cdk/exports/<exportName>` in the CONSUMER region, and the consumer property
+  // becomes `{ Fn::GetAtt: [<Reader>, "/cdk/exports/<name>"] }`. Prefetched (one
+  // ssm:GetParameters batch) so resolveGetAtt can resolve that GetAtt instead of leaving it
+  // UNRESOLVED (which would make an out-of-band cert swap invisible). Optional: absent unless
+  // the template actually references such a reader; a name missing here fails closed to
+  // UNRESOLVED. Keyed by the FULL SSM parameter name (the GetAtt attribute).
+  crossRegionExports?: Record<string, string>;
   condCache: Map<string, unknown>; // true | false | UNRESOLVED (fail-closed)
 }
 

--- a/tests/crossregion-exports-741.test.ts
+++ b/tests/crossregion-exports-741.test.ts
@@ -1,0 +1,244 @@
+// #741 — crossRegionReferences (Custom::CrossRegionExportReader) GetAtt resolution.
+//
+// CDK's `crossRegionReferences: true` pattern synthesizes a `Custom::CrossRegionExportReader`
+// in the consumer stack, and the consumer property becomes
+// `{ Fn::GetAtt: [<Reader>, "/cdk/exports/<name>"] }`. The reader has no live model, so that
+// GetAtt used to resolve UNRESOLVED forever — leaving an out-of-band cert swap invisible.
+// The fix prefetches the reader-materialized SSM parameters (`/cdk/exports/*`) and resolves
+// the GetAtt from that map, so a live cert-ARN mismatch is now detected as declared drift.
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  GetTemplateCommand,
+  ListStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { GetParametersCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, expect, it } from 'vite-plus/test';
+import { collectCrossRegionExportNames, loadDesired } from '../src/desired/template-adapter.js';
+import { resolveGetAtt, UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
+import type { ResolverContext } from '../src/types.js';
+
+function ctx(over: Partial<ResolverContext> = {}): ResolverContext {
+  return {
+    params: {},
+    pseudo: {
+      'AWS::Region': 'eu-west-1',
+      'AWS::AccountId': '123',
+      'AWS::Partition': 'aws',
+      'AWS::URLSuffix': 'amazonaws.com',
+      'AWS::StackName': 'S',
+      'AWS::StackId': 'id',
+    },
+    conditions: {},
+    physIds: {},
+    liveAttrs: {},
+    typeOf: {},
+    mappings: {},
+    exports: {},
+    condCache: new Map(),
+    ...over,
+  };
+}
+
+describe('#741 resolveGetAtt — crossRegionReferences reader GetAtt', () => {
+  const READER = 'ExportsReader8B249524';
+  const PARAM = '/cdk/exports/MyCertArn';
+  const CERT_ARN = 'arn:aws:acm:us-east-1:123456789012:certificate/abc-123';
+
+  it('resolves a Custom::CrossRegionExportReader GetAtt from ctx.crossRegionExports', () => {
+    const c = ctx({
+      typeOf: { [READER]: 'Custom::CrossRegionExportReader' },
+      crossRegionExports: { [PARAM]: CERT_ARN },
+    });
+    // Both GetAtt forms produce the arn — so a live cert mismatch WOULD now surface as drift.
+    expect(resolveGetAtt([READER, PARAM], c)).toBe(CERT_ARN);
+    expect(resolveGetAtt(`${READER}.${PARAM}`, c)).toBe(CERT_ARN);
+  });
+
+  it('resolves on the /cdk/exports/ attribute shape even when the Type is unknown', () => {
+    // Belt-and-suspenders: the `/cdk/exports/` attribute shape is unambiguous to this pattern,
+    // so a reader whose Type is not in ctx.typeOf still resolves.
+    const c = ctx({ typeOf: {}, crossRegionExports: { [PARAM]: CERT_ARN } });
+    expect(resolveGetAtt([READER, PARAM], c)).toBe(CERT_ARN);
+  });
+
+  it('stays UNRESOLVED when the parameter is not in the prefetched map (fail closed)', () => {
+    const c = ctx({
+      typeOf: { [READER]: 'Custom::CrossRegionExportReader' },
+      crossRegionExports: {}, // prefetch failed / parameter missing
+    });
+    expect(resolveGetAtt([READER, PARAM], c)).toBe(UNRESOLVED);
+  });
+
+  it('stays UNRESOLVED when there is no crossRegionExports map at all', () => {
+    const c = ctx({ typeOf: { [READER]: 'Custom::CrossRegionExportReader' } });
+    expect(resolveGetAtt([READER, PARAM], c)).toBe(UNRESOLVED);
+  });
+
+  it('does NOT intercept an ordinary GetAtt (no /cdk/exports/ prefix)', () => {
+    // An ordinary GetAtt against a resource with a live model still resolves normally, and one
+    // without a live model is UNRESOLVED — the reader gate never fires for a normal attribute.
+    const c = ctx({
+      typeOf: { Bucket: 'AWS::S3::Bucket' },
+      liveAttrs: { Bucket: { Arn: 'arn:aws:s3:::b' } },
+      crossRegionExports: { [PARAM]: CERT_ARN },
+    });
+    expect(resolveGetAtt(['Bucket', 'Arn'], c)).toBe('arn:aws:s3:::b');
+    expect(resolveGetAtt(['Bucket', 'DoesNotExist'], c)).toBe(UNRESOLVED);
+  });
+});
+
+describe('#741 collectCrossRegionExportNames', () => {
+  it('collects distinct /cdk/exports/ names referenced by reader GetAtts (array + string form)', () => {
+    const template = {
+      Resources: {
+        Reader: { Type: 'Custom::CrossRegionExportReader' },
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            ViewerCertificate: {
+              AcmCertificateArn: { 'Fn::GetAtt': ['Reader', '/cdk/exports/CertArn'] },
+            },
+            Comment: { 'Fn::GetAtt': 'Reader./cdk/exports/CommentVal' },
+            // a duplicate reference to CertArn — must dedupe
+            Aliases: [{ 'Fn::GetAtt': ['Reader', '/cdk/exports/CertArn'] }],
+          },
+        },
+      },
+    };
+    expect(collectCrossRegionExportNames(template)).toEqual([
+      '/cdk/exports/CertArn',
+      '/cdk/exports/CommentVal',
+    ]);
+  });
+
+  it('returns [] when there is no reader resource (normal stack pays nothing)', () => {
+    const template = {
+      Resources: {
+        Bucket: { Type: 'AWS::S3::Bucket', Properties: { Tags: { 'Fn::GetAtt': ['X', 'Y'] } } },
+      },
+    };
+    expect(collectCrossRegionExportNames(template)).toEqual([]);
+  });
+
+  it('ignores a /cdk/exports/ GetAtt whose logicalId is NOT a reader', () => {
+    // A GetAtt to a non-reader logicalId with a slash-attribute (contrived) is not collected.
+    const template = {
+      Resources: {
+        NotAReader: { Type: 'AWS::S3::Bucket' },
+        R: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { X: { 'Fn::GetAtt': ['NotAReader', '/cdk/exports/Nope'] } },
+        },
+      },
+    };
+    expect(collectCrossRegionExportNames(template)).toEqual([]);
+  });
+});
+
+describe('#741 loadDesired — prefetches /cdk/exports/* and resolves the consumer GetAtt', () => {
+  const CERT_ARN = 'arn:aws:acm:us-east-1:111122223333:certificate/live-cert';
+
+  function mockCfn(template: Record<string, unknown>): ReturnType<typeof mockClient> {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).resolves({ TemplateBody: JSON.stringify(template) });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Dist',
+          PhysicalResourceId: 'dist-phys',
+          ResourceType: 'AWS::CloudFront::Distribution',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+        {
+          LogicalResourceId: 'Reader',
+          PhysicalResourceId: 'reader-phys',
+          ResourceType: 'Custom::CrossRegionExportReader',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          // NOTE: distinct account per test avoids the module-level prefetch cache bleeding
+          StackId: 'arn:aws:cloudformation:eu-west-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+    return cfn;
+  }
+
+  const template = {
+    Resources: {
+      Reader: { Type: 'Custom::CrossRegionExportReader' },
+      Dist: {
+        Type: 'AWS::CloudFront::Distribution',
+        Properties: {
+          ViewerCertificate: {
+            AcmCertificateArn: { 'Fn::GetAtt': ['Reader', '/cdk/exports/MyCertArn'] },
+          },
+        },
+      },
+    },
+  };
+
+  it('resolves the reader GetAtt to the live SSM parameter value (drift now detectable)', async () => {
+    const cfn = mockCfn(template);
+    const ssm = mockClient(SSMClient);
+    ssm
+      .on(GetParametersCommand, { Names: ['/cdk/exports/MyCertArn'] })
+      .resolves({ Parameters: [{ Name: '/cdk/exports/MyCertArn', Value: CERT_ARN }] });
+
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'eu-west-1');
+    const dist = desired.resources.find((r) => r.logicalId === 'Dist');
+    expect(dist).toBeDefined();
+    expect((dist!.declared.ViewerCertificate as Record<string, unknown>).AcmCertificateArn).toBe(
+      CERT_ARN
+    );
+  });
+
+  it('leaves the GetAtt UNRESOLVED when the SSM parameter is unreadable (fail closed)', async () => {
+    // Different account => different cache key, so the prior success does not leak in.
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).resolves({ TemplateBody: JSON.stringify(template) });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Dist',
+          PhysicalResourceId: 'dist-phys',
+          ResourceType: 'AWS::CloudFront::Distribution',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:eu-west-1:999988887777:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+    const ssm = mockClient(SSMClient);
+    ssm.on(GetParametersCommand).rejects(new Error('AccessDenied'));
+
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'eu-west-1');
+    const dist = desired.resources.find((r) => r.logicalId === 'Dist');
+    // The GetAtt stays UNRESOLVED (as before the fix) — a symbol, never a fabricated value —
+    // so the AcmCertificateArn is skipped from comparison rather than compared against a guess.
+    const vc = dist!.declared.ViewerCertificate as Record<string, unknown>;
+    expect(vc.AcmCertificateArn).toBe(UNRESOLVED);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #741 — the CDK `crossRegionReferences: true` pattern (a us-east-1 ACM cert stack consumed by a CloudFront stack in another region) synthesizes a `Custom::CrossRegionExportReader` in the consumer stack, and the consumer property becomes `{"Fn::GetAtt": ["ExportsReader...", "/cdk/exports/<name>"]}`. That reader has no live model, so the GetAtt landed in the `unresolved` tier and was skipped from comparison forever — an out-of-band console cert swap on the distribution was **invisible** (a false negative on exactly the value this pattern exists to pin).

## Fix

The reader materializes each imported value as an SSM parameter `/cdk/exports/<name>` in the **consumer** region. This PR resolves the reader GetAtt from those parameters:

1. **`src/desired/template-adapter.ts`** — mirror the existing `ListExports` prefetch: scan the template for `Fn::GetAtt` refs whose logicalId is a `Custom::CrossRegionExportReader` and whose attribute starts with `/cdk/exports/`, collect the distinct SSM param names, and batch-fetch them via `ssm:GetParameters` (10/call). Cached per `${accountId}:${region}` like `exportsCache`. **Fail closed:** any read failure / missing parameter is left out of the map (the GetAtt then stays UNRESOLVED as before) with a one-line `warning:` to stderr, analogous to the ListExports-failure warning. Only fetches when such a reader actually exists — a normal stack pays nothing.
2. **`src/types.ts`** — one additive optional field `crossRegionExports?: Record<string, string>` (SSM param name -> value) on `ResolverContext`.
3. **`src/normalize/intrinsic-resolver.ts`** — `resolveGetAtt` resolves a GetAtt whose attribute starts with `/cdk/exports/` (gated on the reader Type when known, else on the unambiguous attribute shape) from `ctx.crossRegionExports`; missing -> UNRESOLVED (fail closed). Ordinary GetAtts are unaffected.
4. **`docs/ARCHITECTURE.md`** — documents the new prefetch alongside the `Fn::ImportValue` / `ListExports` one.

`@aws-sdk/client-ssm` was already a dependency (no new dep added).

## Tests

`tests/crossregion-exports-741.test.ts` (10 cases): resolver-level (resolves from the map both GetAtt forms; UNRESOLVED when missing / no map; ordinary GetAtt unaffected), `collectCrossRegionExportNames` (dedupe, both forms, no-reader = empty, non-reader logicalId ignored), and a `loadDesired` prefetch integration test (mocked CFN + SSM) proving the consumer property resolves to the live SSM value — and stays UNRESOLVED (never fabricated) on a read failure.

## Gates

- `vp run typecheck` — clean
- `vp run check` (non-fixing) — 0 errors
- `vp pack` — builds
- `vp test run` — 4292 passed (162 files)

## Live-test deferral

Deferred: a real two-region deploy (cert in us-east-1 + CloudFront in another region, swap the cert in the console, confirm `check` now reports declared drift) is NOT run here — the unit tests (including the mocked SSM prefetch) are the evidence. Flagging explicitly for the reviewer.

Closes #741