### PR TITLE
fix(noise): fold nested-stack AWS::CloudFormation::Stack undeclared props (#723)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3320,6 +3320,26 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'SecurityGroupIds',
     'SubnetIds',
   ]),
+  //   AWS::CloudFormation::Stack (the parent-side resource of every CDK `NestedStack`) is
+  //   CC-read and returns the child stack's FULL live model, but the template's Stack resource
+  //   declares only `TemplateURL` (an S3 asset URL) + `Parameters` + `Tags` — so three live
+  //   props are always UNDECLARED and surface on a clean first check:
+  //     * `TemplateBody` — the ENTIRE resolved child template as one string. It is never in the
+  //       parent template (which carries `TemplateURL`), it changes on every legitimate child
+  //       redeploy, and reverting it would issue a CC UpdateResource against the live child stack
+  //       (cdkrd triggering a child-stack update to a stale template — a real hazard). Undeclared,
+  //       unpinnable, moves per deploy → value-independent (a user who wants to compare the child
+  //       compares the child stack itself; the parent never declares its body).
+  //     * `RoleARN` — the CloudFormation service role (the `cdk-hnb659fds-cfn-exec-role-…` CDK
+  //       bootstrap role) AWS/CDK attaches; undeclared on the Stack resource, per-account/region
+  //       AWS-assigned, not user intent when undeclared.
+  //     * `Capabilities` — the capability set AWS records for the child (e.g.
+  //       `["CAPABILITY_IAM","CAPABILITY_AUTO_EXPAND"]`); undeclared, AWS-assigned, and a plain
+  //       reflection of what the child needs, not intent on the parent Stack resource.
+  //   All three are undeclared → whatever AWS assigned is its default, never user intent; a real
+  //   drift in the child's own resources surfaces when that child stack is checked directly.
+  //   First-run FP on every nested-stack deploy (#723, live-repro'd on tests/integration/nested).
+  'AWS::CloudFormation::Stack': new Set(['TemplateBody', 'RoleARN', 'Capabilities']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/noise-nestedstack-723.test.ts
+++ b/tests/noise-nestedstack-723.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #723 — the parent-side AWS::CloudFormation::Stack resource of every CDK NestedStack is
+// CC-read and returns the child's FULL live model, but the template declares only
+// TemplateURL + Parameters + Tags. Three live props are therefore always UNDECLARED and
+// surfaced on a clean first check (core-invariant violation), the worst being TemplateBody
+// = the entire child template as one string (also a revert hazard: reverting it issues a
+// CC UpdateResource against the live child stack). They are AWS-assigned / per-deploy and
+// cannot be pinned or derived, so they fold value-independent (tier 3).
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string): string[] =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const declared = {
+  TemplateURL: 'https://s3.amazonaws.com/cdk-hnb659fds-assets/abc.json',
+  Parameters: { referencetoParentBucket: 'parent-bucket' },
+};
+const mk = (): DesiredResource => ({
+  logicalId: 'ChildNestedStackResource',
+  resourceType: 'AWS::CloudFormation::Stack',
+  physicalId: 'arn:aws:cloudformation:us-east-1:111111111111:stack/Child/uuid',
+  declared,
+});
+
+describe('#723 nested-stack AWS::CloudFormation::Stack undeclared folds', () => {
+  it('folds undeclared TemplateBody / RoleARN / Capabilities to atDefault (zero first-run FP)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        TemplateBody: '{"Resources":{"CDKMetadata":{"Type":"AWS::CDK::Metadata"}}}',
+        RoleARN:
+          'arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1',
+        Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_AUTO_EXPAND'],
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['Capabilities', 'RoleARN', 'TemplateBody'])
+    );
+    for (const p of ['TemplateBody', 'RoleARN', 'Capabilities'])
+      expect(tier(f, 'undeclared')).not.toContain(p);
+  });
+
+  it('value-independent: any TemplateBody folds (it moves on every legitimate child redeploy)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        TemplateBody: '{"Resources":{"NewChildResource":{"Type":"AWS::SQS::Queue"}}}',
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('TemplateBody');
+    expect(tier(f, 'undeclared')).not.toContain('TemplateBody');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #723.

The parent-side `AWS::CloudFormation::Stack` resource of every CDK `NestedStack` is CC-read and returns the child stack's **full** live model, but the template declares only `TemplateURL` + `Parameters` + `Tags`. Three live props are therefore always **undeclared** and surface as `[Potential Drift]` on a clean first `check` (a core-invariant violation):

- **`TemplateBody`** — the ENTIRE child template as one string. Never in the parent template (which carries `TemplateURL`), it changes on every legitimate child redeploy (a record-surviving FP), bloats the baseline, and reverting it issues a CC `UpdateResource` against the live child stack (cdkrd triggering a child-stack update to a stale template — a real hazard).
- **`RoleARN`** — the CDK `cfn-exec` bootstrap role AWS attaches (per-account/region).
- **`Capabilities`** — the capability set AWS records for the child.

## Fix
Add `AWS::CloudFormation::Stack -> {TemplateBody, RoleARN, Capabilities}` to `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (`src/normalize/noise.ts`). All three are undeclared + AWS-assigned/per-deploy (unpinnable, underivable) → tier-3. Real drift in the child's own resources still surfaces when that child stack is checked directly.

## Test
`tests/noise-nestedstack-723.test.ts` — asserts the three undeclared props fold to `atDefault` (zero first-run FP) and that `TemplateBody` folds value-independently (any body, since it moves each redeploy).

## Verification
- typecheck / lint+format / build / unit tests (4297) green.
- Fold/FP fix: **live-proven in the issue** (0.2.37 repro on `tests/integration/nested`, the exact 3 findings) + unit-pinned; fresh deploy deferred per the corpus/hunt-proven rule.