### PR TITLE
chore(revert): add a staleness watch-list for moving REVERT_SET_DEFAULT pins (#1072)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -286,6 +286,53 @@ const REVERT_SET_DEFAULT_VALUES: Record<string, unknown> = {
 };
 
 /**
+ * #1072 — the staleness WATCH-LIST for REVERT_SET_DEFAULT_PATHS entries whose set-default
+ * WRITE value is a MOVING AWS default (a create-time default AWS advances over time), not a
+ * stable constant. Failure mode: when AWS moves the default and our pin lags, reverting an
+ * undeclared out-of-band change WRITES yesterday's default to AWS — and because the written
+ * value still equals the (also-stale) fold pin, the post-revert `check` folds it `atDefault`
+ * and reports CLEAN, so the wrong write is INVISIBLE. For a security-typed path that is a
+ * silent DOWNGRADE write (e.g. an old TLS policy). Unlike a fold-only pin (whose rot
+ * self-surfaces as a returning first-run FP via the #581 note), a revert-write pin's rot is
+ * NOT self-surfacing — hence this explicit list.
+ *
+ * This is a REVIEW artifact, not a runtime check (staleness can only be confirmed against
+ * live AWS): the guard test `revert-pin-staleness-1072` asserts every key here is a real
+ * REVERT_SET_DEFAULT_PATHS entry (so a rename/removal of a pin can't silently drop it from
+ * tracking) and that the resolved write value still matches. RE-VERIFY CADENCE: re-check each
+ * `value` against a fresh live deploy on the noted `moveAxis` at least quarterly, and
+ * whenever AWS announces a move; bump `lastVerified` when confirmed. Fold-only moving pins
+ * (ApiGateway RestApi SecurityPolicy, Logs::Delivery RecordFields, Cognito IdP token_url,
+ * EKS SupportType, Bedrock Guardrail tier configs) live in noise.ts / KNOWN_DEFAULT_PATHS and
+ * are self-surfacing (failure mode 1) — tracked there, not here.
+ */
+export interface MovingRevertPin {
+  value: unknown; // the current pinned write value (must equal the KNOWN_DEFAULTS/VALUES source)
+  lastVerified: string; // ISO date the value was last confirmed against a fresh live deploy
+  moveAxis: string; // why/how AWS may move this default (what to watch for)
+}
+export const MOVING_REVERT_PINS: Record<string, MovingRevertPin> = {
+  'AWS::Transfer::Server\0SecurityPolicyName': {
+    value: 'TransferSecurityPolicy-2018-11',
+    lastVerified: '2026-07-07',
+    moveAxis:
+      'AWS ships newer named TLS policies (2020-06 … 2024-01) and pushes TLS 1.2+ floors; a create-default bump would make revert write a TLS 1.0/1.1-era policy — a security downgrade.',
+  },
+  'AWS::Cognito::UserPool\0UserPoolTier': {
+    value: 'ESSENTIALS',
+    lastVerified: '2026-07-10',
+    moveAxis:
+      'AWS repriced/renamed the pool feature plans once already (advanced-security → feature plans, Nov 2024); a rename/re-default makes revert write a stale billing tier.',
+  },
+  'AWS::DocDB::DBInstance\0CACertificateIdentifier': {
+    value: 'rds-ca-rsa2048-g1',
+    lastVerified: '2026-07-10',
+    moveAxis:
+      'RDS/DocDB rotate the default server CA on a published schedule; a bump makes revert write a superseded CA identifier (reboots the instance onto an old cert).',
+  },
+};
+
+/**
  * A nested undeclared value (a live sub-key inside a declared object, R96/R98) — a dotted
  * path (`Conf.Destination`) or an identity-keyed array element (`Prop[<id>].sub`). Pure +
  * exported. Detected by PATH SHAPE, not just `Finding.nested`: a baseline value removed

--- a/tests/revert-pin-staleness-1072.test.ts
+++ b/tests/revert-pin-staleness-1072.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
+import { MOVING_REVERT_PINS, REVERT_SET_DEFAULT_PATHS } from '../src/revert/plan.js';
+
+// #1072 — REVERT_SET_DEFAULT_PATHS writes a pinned constant verbatim to AWS. When the pin is
+// a MOVING AWS default and it rots, revert writes yesterday's default and — because it still
+// equals the (stale) fold pin — the post-revert check reads CLEAN, so the wrong write is
+// invisible (a silent DOWNGRADE for a security-typed path). MOVING_REVERT_PINS is the
+// staleness watch-list for exactly those pins; this guard keeps it honest so a moving pin can
+// never silently fall out of tracking.
+describe('#1072 REVERT_SET_DEFAULT moving-pin staleness watch-list', () => {
+  it('every watch-list entry is a real REVERT_SET_DEFAULT_PATHS pin (rename/removal cannot silently drop it)', () => {
+    for (const key of Object.keys(MOVING_REVERT_PINS)) {
+      expect(REVERT_SET_DEFAULT_PATHS.has(key), `${key} must be in REVERT_SET_DEFAULT_PATHS`).toBe(
+        true
+      );
+    }
+  });
+
+  it("each pin's recorded value still equals its live KNOWN_DEFAULTS write source (drift-of-the-pin guard)", () => {
+    for (const [key, pin] of Object.entries(MOVING_REVERT_PINS)) {
+      const [resourceType, path] = key.split('\0');
+      const known = KNOWN_DEFAULTS[resourceType!]?.[path!];
+      expect(known, `${key} must have a KNOWN_DEFAULTS source`).toBeDefined();
+      // If someone bumps the fold pin but forgets the watch-list value (or vice versa), this
+      // fails — forcing both to move together and lastVerified to be reconsidered.
+      expect(pin.value, `${key} watch-list value must match KNOWN_DEFAULTS`).toEqual(known);
+    }
+  });
+
+  it('each entry carries an ISO lastVerified date and a non-empty moveAxis (re-verify cadence)', () => {
+    for (const [key, pin] of Object.entries(MOVING_REVERT_PINS)) {
+      expect(pin.lastVerified, `${key} lastVerified`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(pin.moveAxis.length, `${key} moveAxis`).toBeGreaterThan(20);
+    }
+  });
+
+  it('the known security-sensitive moving pins are tracked (Transfer TLS policy, Cognito tier, DocDB CA)', () => {
+    for (const key of [
+      'AWS::Transfer::Server\0SecurityPolicyName',
+      'AWS::Cognito::UserPool\0UserPoolTier',
+      'AWS::DocDB::DBInstance\0CACertificateIdentifier',
+    ]) {
+      expect(MOVING_REVERT_PINS[key], `${key} must be on the watch-list`).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Closes #1072.

`REVERT_SET_DEFAULT_PATHS` writes a pinned constant verbatim to AWS. When that pin is a **moving** AWS default and it rots, reverting an undeclared out-of-band change writes yesterday's default — and because the written value still equals the (also-stale) fold pin, the post-revert `check` folds it `atDefault` and reports **CLEAN**, so the wrong write is invisible. For a security-typed path (e.g. `AWS::Transfer::Server.SecurityPolicyName`) that is a silent **TLS downgrade** write. Unlike a fold-only pin (whose rot self-surfaces as a returning first-run FP via the #581 note), a revert-write pin's rot is **not** self-surfacing.

## Fix
Add `MOVING_REVERT_PINS` (`src/revert/plan.ts`) — the explicit staleness watch-list of the set-default pins whose write value is a moving default:
- `AWS::Transfer::Server\0SecurityPolicyName` (`TransferSecurityPolicy-2018-11` — AWS pushes TLS 1.2+ floors)
- `AWS::Cognito::UserPool\0UserPoolTier` (`ESSENTIALS` — AWS repriced/renamed plans once already)
- `AWS::DocDB::DBInstance\0CACertificateIdentifier` (`rds-ca-rsa2048-g1` — CA certs rotate on schedule)

Each carries its current `value`, a `lastVerified` date, and the `moveAxis` to watch, with a documented re-verify cadence. It's a review artifact (staleness can only be confirmed against live AWS), enforced by a guard test.

## Test
`tests/revert-pin-staleness-1072.test.ts` — asserts every watch-list key is a real `REVERT_SET_DEFAULT_PATHS` pin (a rename/removal can't silently drop it from tracking), that each recorded `value` still equals its `KNOWN_DEFAULTS` write source (bumping the fold pin without the watch-list — or vice versa — fails the build), and that the security-sensitive pins are present.

## Verification
- typecheck / lint+format / build / unit tests (4299) green.
- No live-test applicable (a watch-list guard; staleness is confirmed against live AWS on the re-verify cadence, not in CI). No runtime behavior change.