### PR TITLE
fix(normalize): tolerate IPv6-CIDR representation variants (RFC 5952 canonicalization) (#981)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -4512,6 +4512,134 @@ export function canonicalizeIdArraysDeep(v: unknown): unknown {
   return v;
 }
 
+// #981 — EC2 stores/echoes IPv6 CIDRs in RFC 5952 canonical form (lowercase hex,
+// leading zeros stripped per group, the LONGEST all-zero run compressed to `::`). A
+// template declaring an equivalent NON-canonical spelling — uppercase
+// (`2001:DB8::/32`), uncompressed (`2001:db8:0:0::/32`), `::0/0` /
+// `0:0:0:0:0:0:0:0/0` for all-v6 — otherwise false-flags declared drift on every
+// check (declared `2001:DB8:0:0::/32` vs live `2001:db8::/32`), survives record, and
+// the offered revert writes the non-canonical string back → EC2 re-canonicalizes →
+// the revert NEVER converges (the #877 `IpProtocol 'TCP' vs 'tcp'` loop, IPv6
+// edition). Fold BOTH compare sides to the one RFC 5952 form so an equivalent
+// spelling compares equal, while a GENUINELY different CIDR (`2001:db8::/32` vs
+// `2001:dead::/32`) still lands on distinct canonical forms and surfaces.
+//
+// FP-safety: this only transforms a string that passes a STRICT IPv6-CIDR parse gate
+// (`canonicalIpv6Cidr` returns undefined otherwise) — an IPv4 CIDR, an ARN (colon-
+// heavy but not a valid hextet structure), or any arbitrary string passes through
+// UNCHANGED. The embedded-IPv4 tail form (`::ffff:1.2.3.4`) is handled
+// conservatively: `parseIpv6Groups` rejects it (an IPv4 dotted tail is not a hextet),
+// so it is left unchanged. Because the gate is a strict parse, this is FP-safe to
+// apply UNSCOPED (deep over the whole model), exactly like the other deep
+// canonicalizers — no path table needed.
+
+// Parse an IPv6 address literal into its 8 16-bit groups, or undefined if it is not a
+// valid, unambiguous IPv6 address. Rejects: embedded-IPv4 tails, non-hex groups,
+// groups > 4 hex digits, multiple `::`, and any form that does not expand to exactly 8
+// groups. `::` expands the missing groups to zero (but only when it genuinely elides
+// ≥1 group — `1:2:3:4:5:6:7::` with `::` at the end eliding zero groups is rejected as
+// the non-canonical spelling of a full address's trailing group, which EC2 would never
+// echo, keeping the gate strict).
+function parseIpv6Groups(addr: string): number[] | undefined {
+  if (addr.includes('.')) return undefined; // reject embedded-IPv4 tail forms
+  const dc = addr.indexOf('::');
+  if (dc !== addr.lastIndexOf('::')) return undefined; // at most one `::`
+  const hextet = (part: string): number | undefined => {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(part)) return undefined;
+    return Number.parseInt(part, 16);
+  };
+  if (dc === -1) {
+    const parts = addr.split(':');
+    if (parts.length !== 8) return undefined;
+    const groups: number[] = [];
+    for (const p of parts) {
+      const g = hextet(p);
+      if (g === undefined) return undefined;
+      groups.push(g);
+    }
+    return groups;
+  }
+  // `::` present: split into the head (before `::`) and tail (after `::`).
+  const head = addr.slice(0, dc);
+  const tail = addr.slice(dc + 2);
+  const headParts = head === '' ? [] : head.split(':');
+  const tailParts = tail === '' ? [] : tail.split(':');
+  const headGroups: number[] = [];
+  for (const p of headParts) {
+    const g = hextet(p);
+    if (g === undefined) return undefined;
+    headGroups.push(g);
+  }
+  const tailGroups: number[] = [];
+  for (const p of tailParts) {
+    const g = hextet(p);
+    if (g === undefined) return undefined;
+    tailGroups.push(g);
+  }
+  const missing = 8 - headGroups.length - tailGroups.length;
+  if (missing < 1) return undefined; // `::` must elide at least one group
+  return [...headGroups, ...new Array(missing).fill(0), ...tailGroups];
+}
+
+// RFC 5952-canonicalize an IPv6 CIDR string (`<addr>/<prefix>`), or undefined if it is
+// not a valid IPv6 CIDR. Lowercase hex, strip leading zeros per group, compress the
+// LONGEST run of ≥1 all-zero groups to `::` (leftmost on ties), reattach `/prefix`.
+export function canonicalIpv6Cidr(s: string): string | undefined {
+  const slash = s.indexOf('/');
+  if (slash === -1) return undefined; // must be a CIDR, not a bare address
+  const addr = s.slice(0, slash);
+  const prefixStr = s.slice(slash + 1);
+  if (!/^\d{1,3}$/.test(prefixStr)) return undefined;
+  const prefix = Number.parseInt(prefixStr, 10);
+  if (prefix < 0 || prefix > 128) return undefined;
+  const groups = parseIpv6Groups(addr);
+  if (!groups) return undefined;
+  // Find the longest run of consecutive all-zero groups (length ≥ 2 to compress).
+  let bestStart = -1;
+  let bestLen = 0;
+  let curStart = -1;
+  let curLen = 0;
+  for (let i = 0; i < 8; i++) {
+    if (groups[i] === 0) {
+      if (curStart === -1) curStart = i;
+      curLen++;
+      if (curLen > bestLen) {
+        bestLen = curLen;
+        bestStart = curStart;
+      }
+    } else {
+      curStart = -1;
+      curLen = 0;
+    }
+  }
+  const hex = groups.map((g) => g.toString(16));
+  let addrOut: string;
+  if (bestLen >= 2) {
+    const before = hex.slice(0, bestStart).join(':');
+    const after = hex.slice(bestStart + bestLen).join(':');
+    addrOut = `${before}::${after}`;
+  } else {
+    addrOut = hex.join(':');
+  }
+  return `${addrOut}/${prefix}`;
+}
+
+// Deep-walk every string value, RFC 5952-canonicalizing any that unambiguously parses
+// as an IPv6 CIDR and passing everything else through unchanged (see block comment
+// above). Applied to BOTH compare sides in `canonicalizeForCompare` so equivalent
+// spellings fold, mirroring `canonicalizeIdArraysDeep`'s structure.
+export function canonicalizeIpv6CidrsDeep(v: unknown): unknown {
+  if (typeof v === 'string') return canonicalIpv6Cidr(v) ?? v;
+  if (Array.isArray(v)) return v.map(canonicalizeIpv6CidrsDeep);
+  if (v && typeof v === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>))
+      out[k] = canonicalizeIpv6CidrsDeep(val);
+    return out;
+  }
+  return v;
+}
+
 // Per-type SCALAR-array props AWS treats as UNORDERED SETS but whose elements
 // match none of the content-shape canonicalizers above (not ids/ARNs, not HTTP
 // verbs, no identity field): the service stores a set and echoes it in ITS

--- a/src/normalize/pipeline.ts
+++ b/src/normalize/pipeline.ts
@@ -13,6 +13,7 @@
 import { stripCcApiAwsManagedFields } from './cc-api-strip.js';
 import {
   canonicalizeIdArraysDeep,
+  canonicalizeIpv6CidrsDeep,
   canonicalizeTagListsDeep,
   normalizeWafByteMatchDeep,
   ORDER_SIGNIFICANT_ARRAY_KEYS,
@@ -29,8 +30,8 @@ import { normalizePoliciesDeep } from './policy-canonical.js';
 // on undeclared snapshot values, which never carry an order-significant declared array.
 export function canonicalizeForCompare(v: unknown, resourceType?: string): unknown {
   const orderSig = resourceType ? ORDER_SIGNIFICANT_ARRAY_KEYS[resourceType] : undefined;
-  const base = canonicalizeIdArraysDeep(
-    canonicalizeTagListsDeep(normalizePoliciesDeep(v), orderSig)
+  const base = canonicalizeIpv6CidrsDeep(
+    canonicalizeIdArraysDeep(canonicalizeTagListsDeep(normalizePoliciesDeep(v), orderSig))
   );
   // A WAFv2 WebACL's ByteMatchStatement search patterns read back base64-encoded; fold both
   // sides to the plain SearchString the template declares so a clean rule is not false drift.

--- a/tests/noise-ipv6-cidr-981.test.ts
+++ b/tests/noise-ipv6-cidr-981.test.ts
@@ -1,0 +1,186 @@
+// #981 — no IPv6-CIDR representation tolerance (permanent declared FP + non-converging
+// revert). EC2 stores/echoes IPv6 CIDRs in RFC 5952 canonical form (lowercase hex,
+// leading zeros stripped per group, the longest all-zero run compressed to `::`). A
+// template declaring an equivalent NON-canonical spelling — uppercase, uncompressed,
+// `::0/0` — otherwise false-flags declared drift on every check, survives record, and
+// the offered revert writes the non-canonical string back → EC2 re-canonicalizes → the
+// revert never converges. The fix folds BOTH compare sides to the one RFC 5952 form:
+// equivalent spellings compare equal, a genuinely different CIDR still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { canonicalizeIpv6CidrsDeep, canonicalIpv6Cidr } from '../src/normalize/noise.js';
+import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+
+describe('#981 canonicalIpv6Cidr — RFC 5952 canonicalization', () => {
+  it('lowercases uppercase hex', () => {
+    expect(canonicalIpv6Cidr('2001:DB8::/32')).toBe('2001:db8::/32');
+  });
+
+  it('compresses an uncompressed all-zero run', () => {
+    expect(canonicalIpv6Cidr('2001:db8:0:0::/32')).toBe('2001:db8::/32');
+    expect(canonicalIpv6Cidr('2001:db8:0:0:0:0:0:0/32')).toBe('2001:db8::/32');
+  });
+
+  it('strips leading zeros per group', () => {
+    expect(canonicalIpv6Cidr('2001:0db8::/32')).toBe('2001:db8::/32');
+    expect(canonicalIpv6Cidr('2001:0DB8:0000:0000::/32')).toBe('2001:db8::/32');
+  });
+
+  it('canonicalizes the all-v6 forms `::0/0` and `0:0:0:0:0:0:0:0/0`', () => {
+    expect(canonicalIpv6Cidr('::0/0')).toBe('::/0');
+    expect(canonicalIpv6Cidr('0:0:0:0:0:0:0:0/0')).toBe('::/0');
+    expect(canonicalIpv6Cidr('::/0')).toBe('::/0');
+  });
+
+  it('compresses the LEFTMOST longest zero run on ties', () => {
+    // Two equal-length (2) zero runs → the leftmost is compressed.
+    expect(canonicalIpv6Cidr('2001:0:0:1:2:0:0:3/128')).toBe('2001::1:2:0:0:3/128');
+  });
+
+  it('preserves a genuinely different IPv6 CIDR as a distinct canonical form', () => {
+    expect(canonicalIpv6Cidr('2001:DB8::/32')).not.toBe(canonicalIpv6Cidr('2001:dead::/32'));
+    expect(canonicalIpv6Cidr('2001:dead::/32')).toBe('2001:dead::/32');
+  });
+
+  it('returns undefined for non-IPv6-CIDR strings (pass-through gate)', () => {
+    // IPv4 CIDR — must not be touched.
+    expect(canonicalIpv6Cidr('10.0.0.0/16')).toBeUndefined();
+    expect(canonicalIpv6Cidr('0.0.0.0/0')).toBeUndefined();
+    // ARN — colon-heavy but not a valid hextet structure.
+    expect(canonicalIpv6Cidr('arn:aws:iam::123456789012:role/MyRole')).toBeUndefined();
+    // Arbitrary strings.
+    expect(canonicalIpv6Cidr('hello:world/1')).toBeUndefined();
+    expect(canonicalIpv6Cidr('not a cidr')).toBeUndefined();
+    // Bare address with no prefix.
+    expect(canonicalIpv6Cidr('2001:db8::')).toBeUndefined();
+    // Prefix out of 0..128 range.
+    expect(canonicalIpv6Cidr('2001:db8::/129')).toBeUndefined();
+    // Embedded-IPv4 tail form — handled conservatively (left unchanged).
+    expect(canonicalIpv6Cidr('::ffff:1.2.3.4/128')).toBeUndefined();
+    // Too many / too few groups.
+    expect(canonicalIpv6Cidr('2001:db8:0:0:0:0:0:0:0/32')).toBeUndefined();
+    expect(canonicalIpv6Cidr('2001:db8/32')).toBeUndefined();
+    // Group with > 4 hex digits.
+    expect(canonicalIpv6Cidr('2001:db8:00000::/32')).toBeUndefined();
+  });
+});
+
+describe('#981 canonicalizeIpv6CidrsDeep — deep walk, FP-safe', () => {
+  it('canonicalizes IPv6 CIDR strings nested in objects and arrays', () => {
+    const model = {
+      SecurityGroupIngress: [
+        { CidrIpv6: '2001:DB8:0:0::/32', IpProtocol: 'tcp' },
+        { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp' },
+      ],
+      SecurityGroupEgress: [{ CidrIpv6: '::0/0' }],
+    };
+    expect(canonicalizeIpv6CidrsDeep(model)).toEqual({
+      SecurityGroupIngress: [
+        { CidrIpv6: '2001:db8::/32', IpProtocol: 'tcp' },
+        { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp' },
+      ],
+      SecurityGroupEgress: [{ CidrIpv6: '::/0' }],
+    });
+  });
+
+  it('leaves IPv4 CIDRs, ARNs, and arbitrary strings unchanged', () => {
+    const model = {
+      Cidr: '10.0.0.0/16',
+      Arn: 'arn:aws:iam::123456789012:role/MyRole',
+      Other: 'just a string',
+      Nested: { deep: ['a:b:c', 'foo/bar'] },
+    };
+    expect(canonicalizeIpv6CidrsDeep(model)).toEqual(model);
+  });
+});
+
+describe('#981 canonicalizeForCompare — folds equivalent IPv6-CIDR spellings', () => {
+  it('folds a non-canonical declared spelling to the canonical live form', () => {
+    const declared = { CidrIpv6: '2001:DB8:0:0::/32' };
+    const live = { CidrIpv6: '2001:db8::/32' };
+    expect(canonicalizeForCompare(declared)).toEqual(canonicalizeForCompare(live));
+  });
+
+  it('still surfaces a genuinely different IPv6 CIDR', () => {
+    const declared = { CidrIpv6: '2001:db8::/32' };
+    const live = { CidrIpv6: '2001:dead::/32' };
+    expect(canonicalizeForCompare(declared)).not.toEqual(canonicalizeForCompare(live));
+  });
+});
+
+// Mirror the issue's repro through a real classifyResource run: a declared
+// non-canonical IPv6 CIDR vs the RFC 5952 live echo must fold to NO declared drift,
+// while a genuinely widened live rule still surfaces.
+const schema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+function sgResource(declaredCidr: string): DesiredResource {
+  return {
+    logicalId: 'Sg',
+    resourceType: 'AWS::EC2::SecurityGroup',
+    physicalId: 'sg-0ba527d158588a09f',
+    constructPath: 'Stack/Sg',
+    declared: {
+      GroupDescription: 'Stack/Sg',
+      SecurityGroupIngress: [
+        {
+          CidrIpv6: declaredCidr,
+          Description: 'ssh ipv6',
+          FromPort: 22,
+          IpProtocol: 'tcp',
+          ToPort: 22,
+        },
+      ],
+      VpcId: 'vpc-079229bdc16536c07',
+    },
+  } as DesiredResource;
+}
+
+function sgLive(liveCidr: string): Record<string, unknown> {
+  return {
+    GroupDescription: 'Stack/Sg',
+    GroupId: 'sg-0ba527d158588a09f',
+    SecurityGroupIngress: [
+      {
+        CidrIpv6: liveCidr,
+        Description: 'ssh ipv6',
+        FromPort: 22,
+        IpProtocol: 'tcp',
+        ToPort: 22,
+      },
+    ],
+    VpcId: 'vpc-079229bdc16536c07',
+  };
+}
+
+describe('#981 classifyResource — SecurityGroup IPv6 CIDR', () => {
+  it('non-canonical declared vs canonical live folds to NO declared drift', () => {
+    const findings = classifyResource(
+      sgResource('2001:DB8:0:0::/32'),
+      sgLive('2001:db8::/32'),
+      schema
+    );
+    const declared = findings.filter((f) => f.tier === 'declared');
+    expect(declared).toEqual([]);
+  });
+
+  it('a genuinely different (widened) live IPv6 CIDR still surfaces as declared drift', () => {
+    const findings = classifyResource(
+      sgResource('2001:db8::/32'),
+      sgLive('2001:dead::/32'),
+      schema
+    );
+    const declared = findings.filter((f) => f.tier === 'declared');
+    expect(declared.length).toBeGreaterThan(0);
+    expect(declared.some((f) => f.path.includes('CidrIpv6'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #981

## Problem
EC2 stores/echoes IPv6 CIDRs in RFC 5952 canonical form (lowercase hex, leading zeros stripped per group, longest all-zero run compressed to `::`). A template declaring an equivalent NON-canonical spelling — uppercase (`2001:DB8::/32`), uncompressed (`2001:db8:0:0::/32`), `::0/0` / `0:0:0:0:0:0:0:0/0` for all-v6 — false-flagged DECLARED drift on every check (declared `2001:DB8:0:0::/32` vs live `2001:db8::/32`), survived record, and the offered revert wrote the non-canonical string back → EC2 re-canonicalized → the revert never converged (the #877 `IpProtocol 'TCP' vs 'tcp'` loop, IPv6 edition).

## Fix (option 2 — shape-gated deep canonicalizer)
- `src/normalize/noise.ts`: new pure `canonicalizeIpv6CidrsDeep(model)` deep-walk + `canonicalIpv6Cidr(s)` helper that RFC-5952-canonicalizes any STRING that unambiguously parses as an IPv6 CIDR (IPv6 address literal + `/prefixlen` in 0..128). No new npm dep — the RFC 5952 canonicalization (parse groups, lowercase, strip leading zeros, compress the leftmost-longest all-zero run to `::`, reattach `/prefix`) is implemented in-repo. Strict parse gate: IPv4 CIDRs, ARNs (colon-heavy), embedded-IPv4 tails (`::ffff:1.2.3.4`), and arbitrary strings pass through UNCHANGED — so it is FP-safe applied UNSCOPED, mirroring the other deep canonicalizers (no path table).
- `src/normalize/pipeline.ts`: added `canonicalizeIpv6CidrsDeep` to the `canonicalizeForCompare` composition (one line, alongside the other deep canonicalizers), applying it to BOTH the declared and live compare sides.

## Change-detection preserved
`2001:DB8::/32` (declared) folds to `2001:db8::/32` == live → no drift. But `2001:db8::/32` (declared) vs `2001:dead::/32` (live, widened rule) → distinct canonical forms → still surfaces.

## Tests
New `tests/noise-ipv6-cidr-981.test.ts` (13 cases): the helper (uppercase / uncompressed / `::0/0` / `0:0:0:0:0:0:0:0/0` / leading-zeros / leftmost-longest-tie), the FP-safety pass-through (IPv4 CIDR, ARN, arbitrary strings, embedded-IPv4 tail, out-of-range prefix, malformed hextets), through `canonicalizeForCompare`, and a real `classifyResource` run mirroring the issue repro (fold to NO declared drift + a genuinely different CIDR still surfaces). Verified the 2 pipeline/classify fold tests FAIL without the pipeline wiring. Full suite (4295 tests) + golden corpus replay green — zero regression.

Note: the 2-min live confirm is deferred (the corpus/classify replay is the evidence, per the issue).