### PR TITLE
fix(revert): whole-array revert for value changes inside canonicalize-sorted tag lists (#750)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1163,6 +1163,21 @@ const isPolicyStatementArray = (arr: unknown[]): boolean =>
 const isInlinePolicyArray = (arr: unknown[]): boolean =>
   arr.length > 0 && arr.every((el) => isNestedObject(el) && 'PolicyDocument' in el);
 
+// A `{Key,Value}` tag list — the shape canonicalizeTagLists (normalize/noise.ts) SORTS on
+// BOTH compare sides by its `Key` identity field, while the live side additionally has its
+// `aws:*` tags stripped. A per-element VALUE change then diffs at a `Tags.<sortedIdx>.Value`
+// path whose index is the SORTED+STRIPPED position — it does NOT map to the RAW live model
+// (raw order, aws:* tags present) Cloud Control patches, so a sub-path patch lands on the
+// WRONG element (silent corruption) or out of range (loud reject) (#750). The safe revert is
+// a WHOLE-ARRAY `/Tags` write of the declared list (revert then re-attaches aws:* managed
+// tags via tagPreservingOps), collapsed by the revert plan exactly like an UNORDERED_OBJECT_
+// ARRAY. Recognized by the Key identity field + a Value on every element (a plain identity-
+// keyed object array — CloudFront Origins, etc. — has no Value and is unaffected).
+const isKeyValueTagList = (arr: unknown[]): boolean =>
+  arr.length > 0 &&
+  identityField(arr) === 'Key' &&
+  arr.every((el) => isNestedObject(el) && 'Value' in el);
+
 // True when every key of `sub` is present in `sup` with an equal value (objects
 // recurse so a nested declared block must also be a subset; everything else is
 // deep-equal). Used to align a declared policy statement to the live statement it is
@@ -3196,6 +3211,22 @@ export function classifyResource(
         )
       )
         continue;
+      // A per-element drift INSIDE a `{Key,Value}` tag list (#750): canonicalizeTagLists
+      // sorted the list by `Key` on both compare sides (and stripped the live side's aws:*
+      // tags), so `d.path`'s index is the SORTED+STRIPPED position that does NOT map to the
+      // RAW live model Cloud Control patches — a sub-path `add /Tags/<i>/Value` patch would
+      // corrupt the wrong live element or go out of range. Carry the WHOLE declared tag list
+      // on wholeArrayRevert so the revert plan collapses these into ONE whole-array `/Tags`
+      // replacement (tagPreservingOps then re-attaches the live aws:* managed tags), never a
+      // per-element pointer against a sorted index that does not exist in the raw model.
+      // Only fires for a per-element (`${k}.` sub-path) drift; a whole-array drift already
+      // carries the right path. The unorderedObjArray branch above handles the type-/schema-
+      // opted-in unordered object arrays; this covers the identity-sorted tag lists it misses.
+      const tagListWhole =
+        !unorderedObjArray &&
+        Array.isArray(v) &&
+        isKeyValueTagList(v) &&
+        d.path.startsWith(`${k}.`);
       const unorderedExtra =
         unorderedObjArray && Array.isArray(declaredVal) && declaredRemapSource
           ? {
@@ -3206,7 +3237,9 @@ export function classifyResource(
               path: remapSortedIndexToDeclared(d.path, k, declaredVal, declaredRemapSource),
               wholeArrayRevert: { path: k, value: v },
             }
-          : {};
+          : tagListWhole
+            ? { wholeArrayRevert: { path: k, value: v } }
+            : {};
       findings.push({
         tier: 'declared',
         logicalId,

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vite-plus/test';
 import type { BaselineFile } from '../src/baseline/baseline-file.js';
+import { classifyResource } from '../src/diff/classify.js';
 import { type CorpusCase, reviveSchema } from '../src/corpus/record.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
@@ -205,6 +206,97 @@ describe('buildRevertPlan', () => {
     const plan = buildRevertPlan([f], undefined);
     expect(plan.items).toHaveLength(1);
     expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'add', path: '/SecurityGroupIngress' });
+  });
+
+  it('#750: a value change inside a canonicalize-SORTED tag list reverts as a WHOLE-ARRAY /Tags write, not a per-element /Tags/<i>/Value patch', () => {
+    // canonicalizeTagLists (normalize/noise.ts) sorts a {Key,Value} tag list by `Key` on
+    // BOTH compare sides, and the live side additionally has its aws:* tags stripped. So a
+    // per-element VALUE change diffs at a SORTED+STRIPPED index that does NOT map to the RAW
+    // live model (raw order, aws:* tags present) Cloud Control patches — a `add /Tags/<i>/Value`
+    // patch would land on the WRONG element or go out of range. The revert must be a whole-array
+    // /Tags write of the declared list (tagPreservingOps then re-attaches the aws:* tags).
+
+    // Tags declared in NON-sorted key order (b before a); tag `b`'s value drifted out of band.
+    const declaredTags = [
+      { Key: 'b', Value: 'want-b' }, // desired value (drifted live)
+      { Key: 'a', Value: 'val-a' },
+    ];
+    // RAW live model: aws:cloudformation:* managed tag PRESENT, raw (unsorted) order, and the
+    // out-of-band value on `b`. The managed tag sits at raw index 0 — exactly the index a
+    // sorted+stripped `/Tags/0/...` patch would collide with.
+    const liveRaw: Record<string, unknown> = {
+      Tags: [
+        { Key: 'aws:cloudformation:stack-name', Value: 'MyStack' },
+        { Key: 'b', Value: 'HACKED' },
+        { Key: 'a', Value: 'val-a' },
+      ],
+    };
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const findings = classifyResource(
+      {
+        logicalId: 'Bkt',
+        resourceType: 'AWS::S3::Bucket',
+        physicalId: 'my-bucket',
+        declared: { Tags: declaredTags },
+      },
+      liveRaw,
+      emptySchema
+    );
+    const drift = findings.find((f) => f.tier === 'declared');
+    expect(drift).toBeDefined();
+    // The finding's raw path is a per-element SORTED index (`Tags.<i>.Value`) — but it must
+    // carry a wholeArrayRevert hoisting to the whole /Tags array with the DECLARED list.
+    expect(drift!.wholeArrayRevert).toBeDefined();
+    expect(drift!.wholeArrayRevert!.path).toBe('Tags');
+    expect(drift!.wholeArrayRevert!.value).toEqual(
+      // canonicalizeForCompare sorted the declared list by Key (a before b); the revert value
+      // is the whole declared list, order-agnostic.
+      expect.arrayContaining([
+        { Key: 'a', Value: 'val-a' },
+        { Key: 'b', Value: 'want-b' },
+      ])
+    );
+
+    // The revert plan collapses it to ONE whole-array `add /Tags` op — never a
+    // `/Tags/<sortedIdx>/Value` patch against an index that does not exist in the raw model.
+    const plan = buildRevertPlan(findings, undefined, {
+      liveByLogical: new Map([['Bkt', liveRaw]]),
+    });
+    expect(plan.items).toHaveLength(1);
+    const ops = plan.items[0]!.ops;
+    expect(ops).toHaveLength(1);
+    expect(ops[0]!.path).toBe('/Tags');
+    expect(ops[0]!.op).toBe('add');
+    // No per-element pointer anywhere in the plan.
+    expect(ops.some((o) => /^\/Tags\/\d+\//.test(o.path))).toBe(false);
+
+    // The apply path re-attaches the live aws:* managed tags (tagPreservingOps) so the
+    // whole-array write does not drop them, and the final patch lands CORRECTLY on the raw
+    // model: exactly the declared user tags + the untouched aws:* tag.
+    const tagged = tagPreservingOps(ops, liveRaw);
+    const finalOp = tagged[0]!;
+    expect(finalOp.op).toBe('add');
+    expect(finalOp.path).toBe('/Tags');
+    const finalTags = finalOp.value as { Key: string; Value: string }[];
+    // The desired value for `b` is applied (drift reverted), `a` preserved, aws:* preserved.
+    expect(finalTags).toEqual(
+      expect.arrayContaining([
+        { Key: 'b', Value: 'want-b' },
+        { Key: 'a', Value: 'val-a' },
+        { Key: 'aws:cloudformation:stack-name', Value: 'MyStack' },
+      ])
+    );
+    // No aws:* tag was clobbered and no bogus element (the raw-model landing is correct).
+    expect(finalTags).toHaveLength(3);
   });
 
   it('ManagedPolicy attachment detach -> SDK item, op carries the member on attributeKey', () => {


### PR DESCRIPTION
## Summary

`canonicalizeTagLists` (`normalize/noise.ts`) SORTS every `{Key,Value}` tag list by `Key` on BOTH compare sides, and the live side additionally has its `aws:*` tags stripped. A same-length tag **value** change then diffs per-element at the **sorted+stripped** index → `toPointer` → e.g. `/Tags/1/Value` → Cloud Control applies it to its **raw** model (raw order, `aws:*` tags present) → the patch lands on the **wrong** element (silent corruption) or out of range (loud reject).

Existing guards missed it: `wholeArrayRevert` covered only `UNORDERED_OBJECT_ARRAY_PROPS` / schema-unordered arrays (not the `canonicalizeTagLists`-sorted tag lists), and `tagPreservingOps` rewrites only the exact `/Tags` whole-array pointer.

## Fix

`classify` now recognizes a per-element drift inside a `{Key,Value}` tag list and carries `wholeArrayRevert: { path: 'Tags', value: <declared list> }` on the finding — the **same mechanism** unordered object arrays already use. The revert plan collapses it to ONE whole-array `add /Tags` op, and `tagPreservingOps` re-attaches the live `aws:*` managed tags. The desired value is the declared tag list, which round-trips through the same normalization so a subsequent `check` converges. Fail-safe: only a per-element (`Tags.<i>.…`) drift on a genuine `{Key,Value}` tag list is hoisted; a whole-array drift or a non-tag identity array is untouched.

## Test

`tests/revert-plan.test.ts` drives `classifyResource` end to end: tags declared in **non-sorted** order (`b` before `a`), an `aws:cloudformation:*` tag present in the raw live model at the exact raw index a sorted patch would collide with, and a value change on one tag. It asserts the emitted revert op is a **whole-array** `add /Tags` write of the desired list (NOT a `/Tags/<i>/Value` patch against a sorted index), and that after `tagPreservingOps` the final patch lands **correctly on the raw model** (declared user tags reverted + the `aws:*` tag preserved, no clobber, no bogus element).

## Scope

Touches `src/diff/classify.ts` (the `wholeArrayRevert` extension) + the test only. **Did NOT need** `src/revert/plan.ts`, `src/diff/drift-calculator.ts`, or `src/normalize/noise.ts` — the plan's existing whole-array collapse + `tagPreservingOps` already handle a `/Tags` op once the finding carries `wholeArrayRevert`. `plan.ts` alone could not fix it: the per-element finding carries only the scalar, not the whole declared array to hoist.

## Gates

`vp run typecheck` / `vp check --fix` / `vp pack` / `vp test run` (4368 pass) / `vp run check` → **0 errors** (88 pre-existing warnings, unchanged).

Live confirm (a bucket with non-sorted tags + an `aws:*` tag) is **deferred** — the unit test's raw-model landing assertion is the evidence.

Closes #750