### PR TITLE
fix(diff): derive GlobalAccelerator EndpointGroup HealthCheckPort from its listener (#975)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -576,6 +576,28 @@ export function buildSiblingLifecycleHooks(desired: Desired): Record<string, str
   return map;
 }
 
+// #975: an AWS::GlobalAccelerator::EndpointGroup that omits HealthCheckPort reads back its
+// LISTENER's port (AWS resolves the schema's -1 sentinel default to the listener's first
+// PortRanges FromPort). Map each AWS::GlobalAccelerator::Listener's first port, keyed by the
+// listener's physical id (== its ARN, which the EndpointGroup references via the declared
+// ListenerArn), so classify derives + equality-gates the undeclared HealthCheckPort (see the
+// EndpointGroup block in classifyResource). Fail-open: a listener with no physical id / no numeric
+// first port is skipped (its EndpointGroup then keeps the value as a one-time visible FP, never a
+// hidden change).
+const GA_LISTENER_TYPE = 'AWS::GlobalAccelerator::Listener';
+export function buildSiblingListenerPorts(desired: Desired): Record<string, number> {
+  const map: Record<string, number> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== GA_LISTENER_TYPE || !r.physicalId) continue;
+    const ranges = (r.declared as Record<string, unknown> | undefined)?.PortRanges;
+    const first = Array.isArray(ranges) ? ranges[0] : undefined;
+    const from =
+      first && typeof first === 'object' ? (first as Record<string, unknown>).FromPort : undefined;
+    if (typeof from === 'number') map[r.physicalId] = from;
+  }
+  return map;
+}
+
 // Resolve an IAM principal/group reference to the concrete identity the live read echoes: a plain
 // string is the resolved name (== physical id); a `{Ref: logicalId}` resolves via the logical-id ->
 // physical-id map. Any other shape (an unresolved intrinsic) yields undefined -> the caller skips
@@ -987,6 +1009,7 @@ export async function gatherFindings(
     siblingManagedPolicyAttachments: buildSiblingManagedPolicyAttachments(desired),
     siblingUserGroups: buildSiblingUserGroups(desired),
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
+    siblingListenerPorts: buildSiblingListenerPorts(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
@@ -1079,6 +1102,7 @@ export async function regatherTouched(
     siblingManagedPolicyAttachments: buildSiblingManagedPolicyAttachments(desired),
     siblingUserGroups: buildSiblingUserGroups(desired),
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
+    siblingListenerPorts: buildSiblingListenerPorts(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -90,6 +90,10 @@ export interface CorpusCase {
     // on an AWS::RDS::OptionGroup case, so replay reproduces the default-fill fold. Optional for
     // back-compat (pre-#978 cases and non-OptionGroup cases lack it).
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
+    // #975: the sibling listener's first port, keyed by its ARN — present only on an
+    // AWS::GlobalAccelerator::EndpointGroup case (carried by its declared ListenerArn), so replay
+    // reproduces the HealthCheckPort derive. Optional for back-compat (non-EndpointGroup cases lack it).
+    siblingListenerPorts?: Record<string, number>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -124,6 +128,7 @@ export function buildCorpusCase(
     bucketNotificationManaged?: Set<string>;
     clusterEchoModel?: Record<string, Record<string, unknown>>;
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
+    siblingListenerPorts?: Record<string, number>;
   },
   findings: Finding[]
 ): CorpusCase {
@@ -147,6 +152,16 @@ export function buildCorpusCase(
   const rdsOptCatalog =
     resource.physicalId && opts.rdsOptionSettingDefaults?.[resource.physicalId]
       ? opts.rdsOptionSettingDefaults[resource.physicalId]
+      : undefined;
+  // #975: carry ONLY this EndpointGroup's listener-port entry (keyed by its declared ListenerArn),
+  // so replay reproduces the HealthCheckPort derive without bloating every case with the map.
+  const listenerArn =
+    resource.resourceType === 'AWS::GlobalAccelerator::EndpointGroup'
+      ? (resource.declared as Record<string, unknown>)?.ListenerArn
+      : undefined;
+  const gaListenerPort =
+    typeof listenerArn === 'string' && opts.siblingListenerPorts?.[listenerArn] !== undefined
+      ? { [listenerArn]: opts.siblingListenerPorts[listenerArn] }
       : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
@@ -189,6 +204,7 @@ export function buildCorpusCase(
       ...(rdsOptCatalog && resource.physicalId
         ? { rdsOptionSettingDefaults: { [resource.physicalId]: rdsOptCatalog } }
         : {}),
+      ...(gaListenerPort ? { siblingListenerPorts: gaListenerPort } : {}),
     },
     expected: findings,
   };

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1644,6 +1644,12 @@ export function classifyResource(
     // could not verify them. Each is surfaced as a `readGap` (not a false declared removal, not
     // a silent hole) regardless of declared-ness or value shape.
     supplementReadGapPaths?: string[] | undefined;
+    // #975: first `PortRanges` FromPort of each AWS::GlobalAccelerator::Listener, keyed by the
+    // listener's physical id (== its ARN, which an EndpointGroup references via ListenerArn). An
+    // EndpointGroup that omits HealthCheckPort reads back this port (AWS resolves the schema's -1
+    // sentinel default to the listener's port), so classify derives + equality-gates the undeclared
+    // HealthCheckPort from it. Built from the desired set in gather.ts (buildSiblingListenerPorts).
+    siblingListenerPorts?: Record<string, number>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -2117,6 +2123,21 @@ export function classifyResource(
     const rtb = declared['TransitGatewayRouteTableId'];
     if (typeof attach === 'string' && typeof rtb === 'string') {
       knownDef = { ...knownDef, Id: `${attach}_${rtb}` };
+    }
+  }
+  // #975: an AWS::GlobalAccelerator::EndpointGroup that omits HealthCheckPort reads back the port
+  // of its LISTENER — AWS resolves the schema's -1 sentinel default ("use the listener port") to
+  // the listener's first PortRanges FromPort. The listener is the sibling referenced by the
+  // declared ListenerArn; its first port is threaded via opts.siblingListenerPorts (keyed by that
+  // ARN, built in gather.ts). Derive + equality-gate it (fold tier 2): a group that pins an
+  // explicit HealthCheckPort declares it and is compared, and an out-of-band port change still
+  // surfaces. Fail-open: an unresolved ListenerArn / missing sibling leaves the value unfolded.
+  if (resourceType === 'AWS::GlobalAccelerator::EndpointGroup') {
+    const listenerArn = declared['ListenerArn'];
+    const port =
+      typeof listenerArn === 'string' ? opts.siblingListenerPorts?.[listenerArn] : undefined;
+    if (typeof port === 'number') {
+      knownDef = { ...knownDef, HealthCheckPort: port };
     }
   }
   // #701: an EventSourceMapping's default BatchSize depends on the source service — 10 for

--- a/tests/classify-975-ga-hcport-derived.test.ts
+++ b/tests/classify-975-ga-hcport-derived.test.ts
@@ -1,0 +1,69 @@
+// #975 item 4 — an AWS::GlobalAccelerator::EndpointGroup that omits HealthCheckPort reads back
+// its LISTENER's port (AWS resolves the schema -1 sentinel default to the listener's first
+// PortRanges FromPort). classify derives + equality-gates the undeclared HealthCheckPort from the
+// sibling listener's port, threaded via opts.siblingListenerPorts (keyed by the declared
+// ListenerArn). Assert the clean-deploy fold to atDefault AND that a value away from the derived
+// port still surfaces as undeclared (out-of-band change detection preserved).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const LISTENER_ARN = 'arn:aws:globalaccelerator::111111111111:accelerator/abc/listener/98a22ab1';
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Group',
+  resourceType: 'AWS::GlobalAccelerator::EndpointGroup',
+  physicalId: `${LISTENER_ARN}/endpoint-group/363328af8002`,
+  declared,
+});
+
+describe('#975 GlobalAccelerator EndpointGroup HealthCheckPort derived from sibling listener', () => {
+  it('folds HealthCheckPort to the sibling listener first PortRanges FromPort', () => {
+    const res = mk({ EndpointGroupRegion: 'us-east-1', ListenerArn: LISTENER_ARN });
+    const f = classifyResource(res, { HealthCheckPort: 80 }, emptySchema, {
+      siblingListenerPorts: { [LISTENER_ARN]: 80 },
+    });
+    expect(tier(f, 'atDefault')).toContain('HealthCheckPort');
+    expect(tier(f, 'undeclared')).not.toContain('HealthCheckPort');
+  });
+
+  it('surfaces an out-of-band HealthCheckPort away from the listener port — detection preserved', () => {
+    const res = mk({ EndpointGroupRegion: 'us-east-1', ListenerArn: LISTENER_ARN });
+    const f = classifyResource(res, { HealthCheckPort: 9999 }, emptySchema, {
+      siblingListenerPorts: { [LISTENER_ARN]: 80 },
+    });
+    expect(tier(f, 'undeclared')).toContain('HealthCheckPort');
+    expect(tier(f, 'atDefault')).not.toContain('HealthCheckPort');
+  });
+
+  it('does NOT fold when no sibling listener port is threaded (fail-open, surfaces)', () => {
+    const res = mk({ EndpointGroupRegion: 'us-east-1', ListenerArn: LISTENER_ARN });
+    const f = classifyResource(res, { HealthCheckPort: 80 }, emptySchema, {});
+    expect(tier(f, 'undeclared')).toContain('HealthCheckPort');
+    expect(tier(f, 'atDefault')).not.toContain('HealthCheckPort');
+  });
+
+  it('does NOT fold when the listener declares a different port (443 listener, 80 live)', () => {
+    const res = mk({ EndpointGroupRegion: 'us-east-1', ListenerArn: LISTENER_ARN });
+    const f = classifyResource(res, { HealthCheckPort: 80 }, emptySchema, {
+      siblingListenerPorts: { [LISTENER_ARN]: 443 },
+    });
+    expect(tier(f, 'undeclared')).toContain('HealthCheckPort');
+  });
+});

--- a/tests/corpus/AWS__GlobalAccelerator__EndpointGroup.AccelListenerGroupBA727A76.json
+++ b/tests/corpus/AWS__GlobalAccelerator__EndpointGroup.AccelListenerGroupBA727A76.json
@@ -51,7 +51,10 @@
     "accountId": "111111111111",
     "region": "us-east-1",
     "kmsAliasTargets": {},
-    "oaiCanonicalIds": {}
+    "oaiCanonicalIds": {},
+    "siblingListenerPorts": {
+      "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1": 80
+    }
   },
   "expected": [
     {
@@ -91,7 +94,7 @@
       "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener/Group"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AccelListenerGroupBA727A76",
       "resourceType": "AWS::GlobalAccelerator::EndpointGroup",
       "path": "HealthCheckPort",

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -19,6 +19,7 @@ import {
   buildClusterEchoModels,
   buildSiblingEventBusPolicies,
   buildSiblingLifecycleHooks,
+  buildSiblingListenerPorts,
   buildSiblingManagedPolicyAttachments,
   buildSiblingSgRules,
   buildSiblingUserGroups,
@@ -1700,5 +1701,69 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
         isDefinitiveNotManaged('arn:aws:iam::111122223333:role/R', LOCAL_ACCOUNT, LOCAL_REGION)
       ).toBe(true);
     });
+  });
+});
+
+describe('buildSiblingListenerPorts (#975)', () => {
+  const desiredWith = (resources: DesiredResource[]): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111111111111',
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  it('keys the first PortRanges FromPort by the listener physical id (== ARN)', () => {
+    const map = buildSiblingListenerPorts(
+      desiredWith([
+        {
+          logicalId: 'Listener',
+          resourceType: 'AWS::GlobalAccelerator::Listener',
+          physicalId: 'arn:...:listener/abc',
+          declared: {
+            PortRanges: [
+              { FromPort: 80, ToPort: 80 },
+              { FromPort: 443, ToPort: 443 },
+            ],
+          },
+        } as DesiredResource,
+      ])
+    );
+    expect(map['arn:...:listener/abc']).toBe(80);
+  });
+
+  it('skips a listener with no physical id or no numeric first port (fail-open)', () => {
+    const map = buildSiblingListenerPorts(
+      desiredWith([
+        {
+          logicalId: 'NoPhys',
+          resourceType: 'AWS::GlobalAccelerator::Listener',
+          declared: { PortRanges: [{ FromPort: 80 }] },
+        } as DesiredResource,
+        {
+          logicalId: 'NoPort',
+          resourceType: 'AWS::GlobalAccelerator::Listener',
+          physicalId: 'arn:...:listener/xyz',
+          declared: { PortRanges: [] },
+        } as DesiredResource,
+      ])
+    );
+    expect(map).toEqual({});
+  });
+
+  it('ignores non-listener resource types', () => {
+    const map = buildSiblingListenerPorts(
+      desiredWith([
+        {
+          logicalId: 'Group',
+          resourceType: 'AWS::GlobalAccelerator::EndpointGroup',
+          physicalId: 'arn:...:endpoint-group/g',
+          declared: { PortRanges: [{ FromPort: 80 }] },
+        } as DesiredResource,
+      ])
+    );
+    expect(map).toEqual({});
   });
 });


### PR DESCRIPTION
Closes #975 (final item — items 1,2,3,5 shipped in #1223).

## Problem
An `AWS::GlobalAccelerator::EndpointGroup` that omits `HealthCheckPort` reads back the port of its **listener**: AWS resolves the schema's `-1` sentinel default ("use the listener port") to the listener's first `PortRanges` `FromPort`. The pinned schema default (`-1`) never equals the live value (`80`), so the undeclared `HealthCheckPort` surfaced as a first-run `[Potential Drift]` on every clean GA deploy — violating the zero-first-run invariant. This is the last residue of #975.

## Fix (fold tier 2 — derived, detection-preserving)
- `src/commands/gather.ts` — `buildSiblingListenerPorts(desired)`: maps each `AWS::GlobalAccelerator::Listener`'s first `PortRanges.FromPort`, keyed by the listener's physical id (== its ARN, which an EndpointGroup references via `ListenerArn`). Wired into both classify-opts sites.
- `src/diff/classify.ts` — for an EndpointGroup, derive `knownDef.HealthCheckPort` from the sibling listener's port (via `opts.siblingListenerPorts[ListenerArn]`) and **equality-gate** it. An out-of-band port change still surfaces; a pinned explicit port is compared. Fail-open on an unresolved `ListenerArn` / missing sibling.
- `src/corpus/record.ts` — carry the EndpointGroup's own listener-port entry into its corpus case (keyed by declared `ListenerArn`), so future re-records reproduce the derive.

## Verification
- Corpus: the harvested `AWS__GlobalAccelerator__EndpointGroup` case (from the live `CdkRealDriftIntegGlobalAcceleratorRich` stack) now carries `opts.siblingListenerPorts` and folds `HealthCheckPort` → `atDefault`; **corpus-replay pins it** (the authoritative live evidence for a fold/FP fix).
- Unit tests: `classify-975-ga-hcport-derived.test.ts` (fold + out-of-band surface + fail-open + wrong-port cases) and `buildSiblingListenerPorts` in `gather.test.ts`.
- Full suite: 4374 passed / 167 files; typecheck + lint + pack clean.