### PR TITLE
revert: back out the #805 op.prior stale-index guard (shape-fragile, deterministic false-abort)

### DIFF
--- a/src/revert/apply-ops.ts
+++ b/src/revert/apply-ops.ts
@@ -2,66 +2,10 @@
 // of a resource model, by JSON pointer. Used by the SDK writers to reconstruct
 // the DESIRED full property value before a whole-property SDK write (e.g. set the
 // full bucket policy), so sub-path drifts revert correctly too.
-import { deepEqual } from '../diff/drift-calculator.js';
 import type { PatchOp } from './plan.js';
 
 function unescape(seg: string): string {
   return seg.replace(/~1/g, '/').replace(/~0/g, '~');
-}
-
-function pointerSegs(path: string): string[] {
-  return path.split('/').slice(1).map(unescape);
-}
-
-// #805: a revert op that a whole-document SDK writer applies (PutBucketPolicy /
-// PutRolePolicy / CreatePolicyVersion / UpdateWebACL, …) carries a numeric index
-// (`…/Statement/1/Resource`, `…/Rules/1/…`) computed against the CHECK-time,
-// canonically-SORTED model. The writer re-reads the live model at apply time and
-// re-canonicalizes it so the index still ALIGNS BY ORDER — but if a statement/rule
-// was added or removed while the user sat on the confirm prompt (#760's mutation
-// window), the sorted FRESH array puts a DIFFERENT element at that index. The
-// whole-document PUT would then overwrite an innocent (security-relevant) element
-// AND leave the real drift unreverted — the SDK-path twin of the CC stale-index
-// window #762 wrongly assumed the SDK re-read closed (the re-read fixes ORDER, not
-// index FRESHNESS). Every op carries `prior` (the check-time live value at its
-// path, = f.actual, set by plan.ts revertOp); before a whole-document write, verify
-// the FRESH model still holds `prior` at each op's path. Any mismatch means the
-// array shifted under the plan — ABORT rather than wrong-write. The model passed
-// here MUST already be canonicalized the same way the op index was (the caller
-// aligns it), so a stable model compares equal.
-export class StaleRevertModelError extends Error {
-  readonly pointerPath: string;
-  constructor(pointerPath: string) {
-    super(
-      `revert aborted: the live value at ${pointerPath} changed since drift was detected ` +
-        `(an element in the same array was added or removed) — re-run \`check\` and revert again`
-    );
-    this.name = 'StaleRevertModelError';
-    this.pointerPath = pointerPath;
-  }
-}
-
-export function assertPriorUnchanged(
-  model: Record<string, unknown>,
-  ops: readonly PatchOp[]
-): void {
-  for (const op of ops) {
-    // `prior` is absent for a re-add of a live-REMOVED value (nothing at the path
-    // to protect) and for contract plumbing ops — nothing to verify in either case.
-    if (op.prior === undefined) continue;
-    if (!deepEqual(getAt(model, pointerSegs(op.path)), op.prior)) {
-      throw new StaleRevertModelError(op.path);
-    }
-  }
-}
-
-function getAt(root: unknown, segs: string[]): unknown {
-  let node: unknown = root;
-  for (const seg of segs) {
-    if (node === null || typeof node !== 'object') return undefined;
-    node = (node as Record<string, unknown>)[seg];
-  }
-  return node;
 }
 
 export function applyOps(
@@ -70,7 +14,7 @@ export function applyOps(
 ): Record<string, unknown> {
   const out = structuredClone(model);
   for (const op of ops) {
-    const segs = pointerSegs(op.path);
+    const segs = op.path.split('/').slice(1).map(unescape);
     if (op.op === 'add') setAt(out, segs, op.value);
     else removeAt(out, segs);
   }

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -214,7 +214,7 @@ import {
   type OverrideCtx,
   SDK_OVERRIDES,
 } from '../read/overrides.js';
-import { applyOps, assertPriorUnchanged } from './apply-ops.js';
+import { applyOps } from './apply-ops.js';
 import type { PatchOp } from './plan.js';
 import { classifyTransient, errorText } from './transient.js';
 
@@ -278,11 +278,6 @@ async function desiredModel(
     current.PolicyDocument === undefined
       ? current
       : { ...current, PolicyDocument: canonicalizeForCompare(current.PolicyDocument) };
-  // #805: the op indices were computed against the check-time model; abort if the
-  // freshly re-read (aligned) model no longer holds each op's `prior` at its path
-  // (a statement added/removed at the confirm prompt would land the whole-document
-  // PUT on an innocent statement).
-  assertPriorUnchanged(aligned, ops);
   return applyOps(aligned, ops);
 }
 const policyJson = (m: Record<string, unknown>): string | undefined =>
@@ -775,14 +770,13 @@ const writeWafv2WebAcl: SdkWriter = async (ctx, ops) => {
   // misalignment class, here on the SDK-writer path). Canonicalize the current model the
   // same way so an indexed op hits the SAME rule; Rule order is not significant to WAFv2
   // (Priority governs evaluation), so re-sending the sorted array changes no behavior.
-  const alignedWebAcl = canonicalizeForCompare(
-    cur.WebACL as unknown as Record<string, unknown>
-  ) as Record<string, unknown>;
-  // #805: same stale-index guard as desiredModel — a Rule added/removed while the
-  // user sat on the confirm prompt would put a different rule at the op's sorted
-  // index; abort rather than UpdateWebACL an innocent (security-relevant) rule.
-  assertPriorUnchanged(alignedWebAcl, ops);
-  const m = applyOps(alignedWebAcl, ops);
+  const m = applyOps(
+    canonicalizeForCompare(cur.WebACL as unknown as Record<string, unknown>) as Record<
+      string,
+      unknown
+    >,
+    ops
+  );
   const desc = m.Description;
   await c.send(
     new UpdateWebACLCommand({

--- a/tests/apply-ops.test.ts
+++ b/tests/apply-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { applyOps, assertPriorUnchanged, StaleRevertModelError } from '../src/revert/apply-ops.js';
+import { applyOps } from '../src/revert/apply-ops.js';
 import type { PatchOp } from '../src/revert/plan.js';
 
 const op = (o: Partial<PatchOp>): PatchOp => ({ op: 'add', path: '/X', human: '', ...o });
@@ -29,88 +29,5 @@ describe('applyOps (reconstruct desired model for SDK writers)', () => {
       op({ op: 'add', path: '/Statement/0/Effect', value: 'Deny' }),
     ]);
     expect(out).toEqual({ Version: '2012-10-17', Statement: [{ Effect: 'Deny' }] });
-  });
-});
-
-describe('assertPriorUnchanged (#805 stale-index guard before a whole-document write)', () => {
-  // A canonically-sorted policy: Statement is sorted by Sid, so index 1 is Sid "b".
-  const freshPolicy = () => ({
-    PolicyDocument: {
-      Version: '2012-10-17',
-      Statement: [
-        { Sid: 'a', Effect: 'Allow', Resource: 'arnA' },
-        { Sid: 'b', Effect: 'Allow', Resource: 'arnB' },
-      ],
-    },
-  });
-
-  it('passes when the fresh model still holds each op prior at its path', () => {
-    // Reverting Sid "b"'s Resource; prior is what check saw at that index, still there.
-    expect(() =>
-      assertPriorUnchanged(freshPolicy(), [
-        op({
-          op: 'add',
-          path: '/PolicyDocument/Statement/1/Resource',
-          value: 'arnB',
-          prior: 'arnB',
-        }),
-      ])
-    ).not.toThrow();
-  });
-
-  it('throws StaleRevertModelError when a statement was added/removed so the sorted index now points elsewhere', () => {
-    // At check time index 1 (sorted) was Sid "b" with Resource 'arnB' (the op prior).
-    // A statement inserted at the confirm prompt re-sorts the array so index 1 is now a
-    // DIFFERENT statement (Resource 'arnX') — writing 'arnB' there would corrupt it.
-    const shifted = {
-      PolicyDocument: {
-        Version: '2012-10-17',
-        Statement: [
-          { Sid: 'a', Effect: 'Allow', Resource: 'arnA' },
-          { Sid: 'aa', Effect: 'Deny', Resource: 'arnX' },
-          { Sid: 'b', Effect: 'Allow', Resource: 'arnB' },
-        ],
-      },
-    };
-    expect(() =>
-      assertPriorUnchanged(shifted, [
-        op({
-          op: 'add',
-          path: '/PolicyDocument/Statement/1/Resource',
-          value: 'arnB',
-          prior: 'arnB',
-        }),
-      ])
-    ).toThrow(StaleRevertModelError);
-  });
-
-  it('throws when the value at a top-level path changed since check (whole-document drift)', () => {
-    expect(() =>
-      assertPriorUnchanged(
-        { PolicyDocument: { Version: '2012-10-17', Statement: [{ Effect: 'Deny' }] } },
-        [
-          op({
-            op: 'add',
-            path: '/PolicyDocument',
-            value: {},
-            prior: { Version: '2012-10-17', Statement: [{ Effect: 'Allow' }] },
-          }),
-        ]
-      )
-    ).toThrow(StaleRevertModelError);
-  });
-
-  it('skips ops with no prior (a re-add of a live-removed value has nothing to protect)', () => {
-    expect(() =>
-      assertPriorUnchanged({ A: 1 }, [op({ op: 'add', path: '/B', value: 2 })])
-    ).not.toThrow();
-  });
-
-  it('deep-compares object priors so a same-shape live value passes', () => {
-    expect(() =>
-      assertPriorUnchanged({ Env: { KEY: 'v' } }, [
-        op({ op: 'add', path: '/Env', value: { KEY: 'w' }, prior: { KEY: 'v' } }),
-      ])
-    ).not.toThrow();
   });
 });


### PR DESCRIPTION
Reverts #1225 (a1c8f06). Re-opens #805.

## Why

A post-merge audit of the #805 guard found it has a **deterministic** false-abort regression — no concurrent-mutation race is needed to trigger it.

`op.prior` (a finding's `f.actual`) is produced by classify's `normalizeLiveModel`, which applies `stripCcApiAwsManagedFields` → `stripAwsTagsDeep` → `rewriteOaiPrincipalsDeep` → `canonicalizeForCompare(_, resourceType)` → readOnly/writeOnly schema strip → `sortUnorderedSetProps`. The two SDK-writer sites the guard hooked (`desiredModel`, `writeWafv2WebAcl`) compare against a model canonicalized with `canonicalizeForCompare` **alone** (no `resourceType`, no strips). The shapes diverge on many paths **even with no mutation**, so `assertPriorUnchanged` throws `StaleRevertModelError` and blocks a legitimate revert:

- **`desiredModel` non-policy raw branch** (DocDB / Glue / SES / ServiceDiscovery): any value `canonicalizeForCompare` transforms — tag lists (proven with a unit repro), embedded policies, IPv6 CIDRs.
- **policy branch**: a bucket policy referencing a CloudFront OAI principal (`rewriteOaiPrincipalsDeep`).
- **WAF**: `canonicalizeForCompare` invoked without `resourceType`, plus aws:* tags / CC-managed fields / set-sorted arrays.

The guard fails safe (it aborts, never wrong-writes), but the deterministic breakage of valid reverts outweighs the protection against the rare confirm-prompt race #805 targets. Common scalar reverts still worked (why the original S3 live-test passed), which masked the gap.

## What this does

Restores the well-understood pre-#805 behavior for `apply-ops.ts` / `writers.ts` and removes the added tests. #805 is re-opened with this analysis; the correct fix needs a shape-robust mechanism — re-classify the fresh model with the **same** normalization at apply time, store the prior in the writer's shape, or detect the array shift structurally — not a leaf-value compare across two different normalization shapes.

## Verification

- Full unit suite green (166 files, 4362 tests).
- Pure revert of a merged commit (`git revert a1c8f06`); no later commit touched the three files, so it restores exactly the prior state. Removing the guard can only make reverts more permissive, never break a previously-working one.
