### PR TITLE
fix(diff): derive the VPC default SG to gate ENI GroupSet / ALB SecurityGroups instead of value-independent folding (#889)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -6,6 +6,7 @@ import {
   DescribeStackResourcesCommand,
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
+import { DescribeSecurityGroupsCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { DescribeOptionGroupOptionsCommand, RDSClient } from '@aws-sdk/client-rds';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
@@ -41,6 +42,49 @@ function liveModelMap(reads: Map<string, ReadResult>): Map<string, Record<string
   const out = new Map<string, Record<string, unknown>>();
   for (const [logicalId, read] of reads) if (read.live) out.set(logicalId, read.live);
   return out;
+}
+
+// #889: resource types whose UNDECLARED default security-group list (ALB SecurityGroups / ENI
+// GroupSet) is gated in classify against the VPC-default SG ids — mirror of
+// typeNeedsManagedKeyResolution. When a stack declares one, prefetch the account/region default
+// SGs so the classifier can DERIVE-gate the fold (single default SG folds; an append/swap surfaces).
+const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
+  'AWS::ElasticLoadBalancingV2::LoadBalancer',
+  'AWS::EC2::NetworkInterface',
+]);
+
+// #889: fetch the account/region VPC-default security-group ids — one `DescribeSecurityGroups`
+// filtered by group-name=default returns exactly one default SG per VPC. Mirrors the
+// fetchManagedAliasTargets prefetch pattern: cached per region, FAIL OPEN (return an empty set on
+// ANY error — missing ec2:DescribeSecurityGroups, throttle, network) so classify keeps folding the
+// undeclared SG list and a clean deploy never gains a first-run false positive. The derived
+// swap/append detection is therefore best-effort and requires ec2:DescribeSecurityGroups.
+const defaultSgIdsCache = new Map<string, Set<string>>();
+async function fetchDefaultSgIds(region: string): Promise<Set<string>> {
+  const cached = defaultSgIdsCache.get(region);
+  if (cached) return cached;
+  const ids = new Set<string>();
+  try {
+    const c = new EC2Client({ region, ...READ_RETRY });
+    let token: string | undefined;
+    do {
+      const r = await c.send(
+        new DescribeSecurityGroupsCommand({
+          Filters: [{ Name: 'group-name', Values: ['default'] }],
+          NextToken: token,
+          MaxResults: 1000,
+        })
+      );
+      for (const g of r.SecurityGroups ?? []) if (g.GroupId) ids.add(g.GroupId);
+      token = r.NextToken;
+    } while (token);
+  } catch {
+    // Fail open: leave the set empty so classify keeps folding (no new first-run false positive).
+    // Not cached on error, so the next stack in the region retries (mirrors the transient path).
+    return ids;
+  }
+  defaultSgIdsCache.set(region, ids);
+  return ids;
 }
 
 // Regions already warned about a denied kms:ListAliases — the warning is one-per-region
@@ -999,10 +1043,20 @@ export async function gatherFindings(
     if (decision.stampTransient) kmsTransientWarned.add(region);
     if (decision.warning) console.error(decision.warning);
   }
+  // #889: prefetch the VPC-default security-group ids once (per region) when the stack declares an
+  // ALB or ENI, so classify can DERIVE-gate the undeclared default-SG-list fold (ALB SecurityGroups
+  // / ENI GroupSet) instead of value-independent folding it (which hid an out-of-band SG swap/append).
+  // Fail open: an empty set on missing ec2:DescribeSecurityGroups / lookup failure → classify keeps
+  // folding (no new first-run false positive). Mirrors the kmsAliasTargets prefetch above.
+  let defaultSgIds: ReadonlySet<string> = new Set();
+  if (desired.resources.some((r) => DEFAULT_SG_LIST_TYPES.has(r.resourceType))) {
+    defaultSgIds = await fetchDefaultSgIds(region);
+  }
   const classifyOpts = {
     accountId: desired.accountId,
     region,
     kmsAliasTargets,
+    defaultSgIds,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
@@ -1092,10 +1146,18 @@ export async function regatherTouched(
   // Built from desired.ctx.liveAttrs (populated by the original gather), so the OAI
   // map is complete even though regather only re-reads the touched resources.
   const oaiCanonicalIds = buildOaiCanonicalIds(desired);
+  // #889: mirror the primary gather's VPC-default-SG prefetch on the regather (revert re-check) path
+  // so the derived SG-list gate is applied identically. Cached per region, so this is a no-op read
+  // when the primary gather already resolved it. Fail open (empty set) → classify keeps folding.
+  let defaultSgIds: ReadonlySet<string> = new Set();
+  if (targets.some((r) => DEFAULT_SG_LIST_TYPES.has(r.resourceType))) {
+    defaultSgIds = await fetchDefaultSgIds(region);
+  }
   const classifyOpts = {
     accountId: desired.accountId,
     region,
     kmsAliasTargets,
+    defaultSgIds,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -201,6 +201,53 @@ function guardDutyFeaturesAllAtDefault(features: unknown[]): boolean {
   return features.every(atDefault);
 }
 
+// #889: UNDECLARED, MUTABLE security-group lists whose AWS first-run default is exactly the
+// resource's VPC default security group — one group. These were folded VALUE-INDEPENDENT
+// (tier 3), which HID an out-of-band SG swap/attach (`elbv2 set-security-groups`,
+// `ec2 modify-network-interface-attribute --groups`): an attacker replacing or APPENDING a
+// wide-open SG on an undeclared-SG ALB/ENI read CLEAN forever and survived record. The default
+// is a single group and DERIVABLE (tier 2): gather.ts prefetches the account/region VPC-default
+// SG ids (one `DescribeSecurityGroups(group-name=default)` call) into `opts.defaultSgIds`.
+//   `AWS::ElasticLoadBalancingV2::LoadBalancer` `SecurityGroups`
+//   `AWS::EC2::NetworkInterface` `GroupSet`
+// The gate folds ONLY when the live list is exactly ONE element AND that element is a known VPC
+// default SG id — a 2+-element list (APPEND) or a single NON-default SG (SWAP) SURFACES. We key
+// the fold on the SET of default SG ids rather than a VpcId lookup because the ALB Cloud Control
+// model carries no `VpcId` (an ENI does, but a set is uniform and needs no per-resource VpcId);
+// every VPC's default SG is an equally legitimate "AWS default", so a single-element list that is
+// any VPC default folds. Fail OPEN — when the prefetch is unavailable (missing
+// ec2:DescribeSecurityGroups / lookup failed → `defaultSgIds` undefined or empty) KEEP folding, so
+// a clean deploy never gains a first-run false positive; the derived detection is best-effort and
+// requires the DescribeSecurityGroups permission.
+const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
+  'AWS::ElasticLoadBalancingV2::LoadBalancer': 'SecurityGroups',
+  'AWS::EC2::NetworkInterface': 'GroupSet',
+};
+/** #889 fold decision for an UNDECLARED default-SG list (ALB SecurityGroups / ENI GroupSet).
+ *  Returns whether the value-independent fold should still apply for this live value:
+ *   - `true`  → FOLD (atDefault): the live list is a single VPC-default SG id, OR the prefetch is
+ *               unavailable (fail OPEN — no ec2:DescribeSecurityGroups / lookup failed / empty).
+ *   - `false` → SURFACE (undeclared): the live list has 2+ elements (an out-of-band SG APPEND) or
+ *               a single NON-default SG (an out-of-band SWAP) — a real, security-relevant drift.
+ *  Pure; `defaultSgIds` is the resolved set of VPC-default SG ids (undefined/empty when unresolved).*/
+export function shouldFoldDefaultSgList(
+  resourceType: string,
+  key: string,
+  liveValue: unknown,
+  defaultSgIds?: ReadonlySet<string>
+): boolean {
+  if (DEFAULT_SG_LIST_PATHS[resourceType] !== key) return false; // not a gated SG-list path
+  // Fail OPEN: no resolved default-SG ids (prefetch missing / denied / empty) → keep folding,
+  // preserving today's value-independent behavior (no new first-run false positive).
+  if (!defaultSgIds || defaultSgIds.size === 0) return true;
+  if (!Array.isArray(liveValue)) return true; // non-array live value → fold (unchanged behavior)
+  // Strict: fold ONLY a single-element list whose one SG is a known VPC default. A 2+-element
+  // list (APPEND) or a single non-default SG (SWAP) falls through to the undeclared tier.
+  return (
+    liveValue.length === 1 && typeof liveValue[0] === 'string' && defaultSgIds.has(liveValue[0])
+  );
+}
+
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements
 // AWS always returns — keyed by the property -> the element's identity field. Cognito
 // UserPool `Schema` is the case: AWS returns all ~21 standard attributes (sub, email,
@@ -1610,6 +1657,11 @@ export function classifyResource(
     accountId?: string;
     region?: string;
     kmsAliasTargets?: Record<string, string>; // alias/aws/* -> target key id, for strict KMS match
+    // #889: the account/region VPC-default security-group ids (one per VPC), prefetched by
+    // gather.ts so the UNDECLARED default-SG-list fold (ALB SecurityGroups / ENI GroupSet) is a
+    // DERIVED equality gate rather than a value-independent one: a single default SG folds, a
+    // 2+-element APPEND or a single non-default SG SWAP surfaces. Undefined/empty → fail open (fold).
+    defaultSgIds?: ReadonlySet<string>;
     oaiCanonicalIds?: Record<string, string>; // OAI id -> S3CanonicalUserId, for CloudFront OAI principal match
     // Rules declared by SIBLING standalone AWS::EC2::SecurityGroupIngress/::SecurityGroupEgress
     // resources, keyed by the target SG's resolved GroupId (== the SG's physical id). Subtracted
@@ -3321,6 +3373,22 @@ export function classifyResource(
     if (resourceType === 'AWS::GuardDuty::Detector' && k === 'Features' && Array.isArray(v)) {
       findings.push({
         tier: guardDutyFeaturesAllAtDefault(v) ? 'atDefault' : 'undeclared',
+        logicalId,
+        resourceType,
+        path: k,
+        actual: v,
+      });
+      continue;
+    }
+    // #889: an UNDECLARED default-SG list (ALB SecurityGroups / ENI GroupSet) — replaces the old
+    // value-independent fold, which hid an out-of-band SG swap/append. Fold atDefault ONLY when the
+    // live list is the single VPC-default SG (or the prefetch is unavailable → fail open); a 2+-element
+    // APPEND or a single non-default SG SWAP falls through to the undeclared tier and surfaces.
+    if (DEFAULT_SG_LIST_PATHS[resourceType] === k && !isTrivialEmpty(v)) {
+      findings.push({
+        tier: shouldFoldDefaultSgList(resourceType, k, v, opts.defaultSgIds)
+          ? 'atDefault'
+          : 'undeclared',
         logicalId,
         resourceType,
         path: k,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2842,12 +2842,15 @@ export function ebOptionSettingTier(
 //   and "DISABLED" on others (both observed live), depending on how/when the service was
 //   created; neither is "the" default.
 export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
-  //   AWS::ElasticLoadBalancingV2::LoadBalancer.SecurityGroups — an ALB that declares no
-  //   SecurityGroups is placed in its VPC's default security group (an AWS-assigned sg-…
-  //   id, not in the LB's declared inputs and not derivable without a VPC lookup). Undeclared,
-  //   so whatever SG AWS attached is its default, never user intent — a user who wants a
-  //   specific SG DECLARES it, and it is then compared in the declared loop.
-  'AWS::ElasticLoadBalancingV2::LoadBalancer': new Set(['SecurityGroups']),
+  //   #889: AWS::ElasticLoadBalancingV2::LoadBalancer.SecurityGroups and
+  //   AWS::EC2::NetworkInterface.GroupSet are NO LONGER value-independent here — an ALB/ENI that
+  //   declares no security groups is placed in its VPC's DEFAULT security group (exactly ONE
+  //   group), and a value-independent fold HID an out-of-band SG swap/append (a mutable security
+  //   boundary: `elbv2 set-security-groups`, `ec2 modify-network-interface-attribute --groups`).
+  //   That single default is DERIVABLE, so classify now gates it against the account/region
+  //   VPC-default SG ids (prefetched into opts.defaultSgIds) via shouldFoldDefaultSgList: a single
+  //   default SG folds atDefault, a 2+-element append or a single non-default swap surfaces. Fail
+  //   open (fold) when the prefetch is unavailable — no new first-run false positive.
   //   AWS::ApiGateway::ApiKey.Value — an API key that declares no Value reads back AWS-generated
   //   40-char key material (createOnly — it can never drift out of band). It is a service-minted
   //   secret, not user intent — a user who pins a specific key DECLARES Value, compared in the
@@ -3178,13 +3181,16 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   AWS::EC2::NetworkInterface.PrivateIpAddresses — an ENI that declares no
   //   PrivateIpAddresses reads back the single auto-assigned primary
   //   ([{PrivateIpAddress:"10.0.0.x", Primary:true}]) — the plural-array twin of the singular
-  //   PrivateIpAddress fold above. GroupSet — an ENI that declares no security groups is
-  //   placed in its VPC's default group (an AWS-assigned sg-… id, not derivable without a VPC
-  //   lookup); the exact twin of the ElasticLoadBalancingV2::LoadBalancer.SecurityGroups fold.
-  //   Both are undeclared → whatever AWS assigned is its default, never user intent; a user who
-  //   manages the ENI's IPs or SGs DECLARES them (the eni-rich fixture does), and they are then
-  //   compared in the declared loop. Live-confirmed on fresh eni-rich ENIs (2026-07-08, #640).
-  'AWS::EC2::NetworkInterface': new Set(['PrivateIpAddress', 'PrivateIpAddresses', 'GroupSet']),
+  //   PrivateIpAddress fold above. Undeclared → whatever AWS assigned is its default, never user
+  //   intent; a user who manages the ENI's IPs DECLARES them (the eni-rich fixture does), and they
+  //   are then compared in the declared loop. Live-confirmed on fresh eni-rich ENIs (2026-07-08,
+  //   #640).
+  //   #889: GroupSet is NO LONGER value-independent here — an ENI that declares no security groups
+  //   gets its VPC's DEFAULT security group (exactly one), a MUTABLE boundary a value-independent
+  //   fold hid from an out-of-band swap/append (`ec2 modify-network-interface-attribute --groups`).
+  //   classify now derives+gates it against the VPC-default SG ids (opts.defaultSgIds); see the
+  //   ElasticLoadBalancingV2::LoadBalancer note in VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS.
+  'AWS::EC2::NetworkInterface': new Set(['PrivateIpAddress', 'PrivateIpAddresses']),
   //   AWS::EC2::Volume.KmsKeyId — an encrypted volume (Encrypted:true) that declares no key
   //   reads back the account aws/ebs managed-key ARN (per-account, AWS-assigned) — the exact
   //   twin of the RDS/OpenSearch/EFS AWS-assigned KmsKeyId folds (#533). An EBS volume's key is

--- a/tests/classify-sgderive-889.test.ts
+++ b/tests/classify-sgderive-889.test.ts
@@ -1,0 +1,110 @@
+// #889 — UNDECLARED, MUTABLE default security-group lists (ALB SecurityGroups / ENI GroupSet)
+// were folded VALUE-INDEPENDENT (tier 3), which HID an out-of-band SG swap/append (a security
+// boundary an attacker could widen and read CLEAN forever). classify now DERIVE-gates them against
+// the account/region VPC-default SG ids (prefetched by gather.ts into opts.defaultSgIds):
+//   - a single VPC-default SG folds atDefault (the clean-deploy default);
+//   - a 2+-element APPEND or a single NON-default SG SWAP surfaces as potential (undeclared) drift;
+//   - a lookup FAILURE (defaultSgIds absent/empty) FAILS OPEN → folds (no new first-run FP).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource, shouldFoldDefaultSgList } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+// The one VPC-default SG the account/region prefetch resolved.
+const DEFAULT_SG = 'sg-0defau1t00000000';
+const ANOTHER_DEFAULT_SG = 'sg-0defau1t99999999'; // a second VPC's default SG (also in the set)
+const ROGUE_SG = 'sg-0rogue00000000000'; // an attacker-attached wide-open SG (not a default)
+const defaultSgIds = new Set([DEFAULT_SG, ANOTHER_DEFAULT_SG]);
+
+// (resourceType, undeclared-SG-list key) pairs the gate covers.
+const CASES: Array<{ label: string; type: string; key: string }> = [
+  { label: 'ENI GroupSet', type: 'AWS::EC2::NetworkInterface', key: 'GroupSet' },
+  {
+    label: 'ALB SecurityGroups',
+    type: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+    key: 'SecurityGroups',
+  },
+];
+
+for (const { label, type, key } of CASES) {
+  describe(`#889 ${label} derived VPC-default-SG gate`, () => {
+    // The resource declares NO security groups (so the live list is UNDECLARED and reaches the fold).
+    const res = mk(type, { Description: 'x' });
+
+    it('(a) folds a single VPC-default SG to atDefault (clean deploy, no drift)', () => {
+      const f = classifyResource(res, { [key]: [DEFAULT_SG] }, emptySchema, { defaultSgIds });
+      expect(tier(f, 'atDefault')).toContain(key);
+      expect(tier(f, 'undeclared')).not.toContain(key);
+    });
+
+    it('(b) SURFACES a 2-element list (out-of-band SG append)', () => {
+      const f = classifyResource(res, { [key]: [DEFAULT_SG, ROGUE_SG] }, emptySchema, {
+        defaultSgIds,
+      });
+      expect(tier(f, 'undeclared')).toContain(key);
+      expect(tier(f, 'atDefault')).not.toContain(key);
+    });
+
+    it('(c) SURFACES a single NON-default SG (out-of-band SG swap)', () => {
+      const f = classifyResource(res, { [key]: [ROGUE_SG] }, emptySchema, { defaultSgIds });
+      expect(tier(f, 'undeclared')).toContain(key);
+      expect(tier(f, 'atDefault')).not.toContain(key);
+    });
+
+    it('(d) FOLDS on lookup failure (defaultSgIds absent → fail open, no first-run FP)', () => {
+      // No opts.defaultSgIds (prefetch unavailable / ec2:DescribeSecurityGroups denied): even a
+      // rogue two-element list folds — fail-open keeps today's value-independent behavior so a
+      // clean deploy never gains a first-run false positive.
+      const f = classifyResource(res, { [key]: [ROGUE_SG, DEFAULT_SG] }, emptySchema, {});
+      expect(tier(f, 'atDefault')).toContain(key);
+      expect(tier(f, 'undeclared')).not.toContain(key);
+    });
+
+    it('folds a single SG from ANY VPC default in the set', () => {
+      const f = classifyResource(res, { [key]: [ANOTHER_DEFAULT_SG] }, emptySchema, {
+        defaultSgIds,
+      });
+      expect(tier(f, 'atDefault')).toContain(key);
+    });
+  });
+}
+
+describe('#889 shouldFoldDefaultSgList (pure decision)', () => {
+  it('folds a single default SG, surfaces append/swap, and fails open when unresolved', () => {
+    const t = 'AWS::EC2::NetworkInterface';
+    // single default → fold
+    expect(shouldFoldDefaultSgList(t, 'GroupSet', [DEFAULT_SG], defaultSgIds)).toBe(true);
+    // append (2 elements) → surface
+    expect(shouldFoldDefaultSgList(t, 'GroupSet', [DEFAULT_SG, ROGUE_SG], defaultSgIds)).toBe(
+      false
+    );
+    // single non-default (swap) → surface
+    expect(shouldFoldDefaultSgList(t, 'GroupSet', [ROGUE_SG], defaultSgIds)).toBe(false);
+    // fail open: no resolved ids → fold
+    expect(shouldFoldDefaultSgList(t, 'GroupSet', [ROGUE_SG], undefined)).toBe(true);
+    expect(shouldFoldDefaultSgList(t, 'GroupSet', [ROGUE_SG], new Set())).toBe(true);
+    // a non-gated (type, key) pair is not this gate's business
+    expect(shouldFoldDefaultSgList(t, 'PrivateIpAddress', ['10.0.0.1'], defaultSgIds)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two MUTABLE security-group lists were folded VALUE-INDEPENDENT (tier 3), so an out-of-band SG **swap/append** on them was INVISIBLE and survived `record` — the #704 class (a mutable security boundary hidden by a tier-3 fold):

- `AWS::EC2::NetworkInterface.GroupSet` (`ec2 modify-network-interface-attribute --groups`)
- `AWS::ElasticLoadBalancingV2::LoadBalancer.SecurityGroups` (`elbv2 set-security-groups`)

An attacker replacing or APPENDING a wide-open SG on an undeclared-SG ENI/ALB read CLEAN forever.

## Fix (the #704 fix shape — tier 3 → tier 2 derived gate)

The undeclared default is exactly ONE group — the resource's VPC **default** security group — which is DERIVABLE.

- **gather.ts**: prefetch the account/region VPC-default SG ids (one `DescribeSecurityGroups(group-name=default)` call, cached per region, mirroring the `kmsAliasTargets` prefetch) into `opts.defaultSgIds`, only when the stack declares an ALB/ENI. FAIL OPEN: empty set on any error (missing `ec2:DescribeSecurityGroups` / throttle / network) so classify keeps folding.
- **noise.ts**: remove the ENI `GroupSet` + ALB `SecurityGroups` entries from `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`; comments updated to describe the new derived gate.
- **classify.ts**: `shouldFoldDefaultSgList` DERIVE-gates the fold — a single VPC-default SG folds `atDefault`; a **2+-element APPEND** or a **single NON-default SG SWAP** surfaces as potential (`undeclared`) drift; **fail open** (fold) when `defaultSgIds` is absent/empty.

### Approach: **derived lookup** (not the cardinality fallback)

It catches both the append (2+ elements) AND the single-SG swap (single non-default SG), which the lookup-free cardinality fallback would miss. Keyed on a **SET of default SG ids** rather than a per-resource VpcId lookup, because the ALB Cloud Control model carries **no `VpcId`** (an ENI does, but a set is uniform and needs no per-resource VpcId); every VPC's default SG is an equally legitimate "AWS default".

### Zero-first-run invariant preserved

A clean deploy of an undeclared-SG ENI/ALB (live list = `[VPC default SG]`) still folds to `atDefault`:
- lookup success + list == `[default]` → **fold**
- lookup success + list != `[default]` (append/swap) → **surface**
- lookup FAILURE (fail open) → **fold** (current value-independent behavior, no new first-run FP)

The derived swap/append detection is best-effort and requires `ec2:DescribeSecurityGroups`.

## Tests

`tests/classify-sgderive-889.test.ts` — for BOTH the ENI GroupSet and ALB SecurityGroups paths: (a) single VPC-default SG folds; (b) 2-element append SURFACES; (c) single non-default swap SURFACES; (d) lookup-failure FOLDS (fail open); plus a pure `shouldFoldDefaultSgList` decision table.

Corpus replay stays green: the recorded ENI (`EniA/EniB/EniMultiip`) undeclared single-element `GroupSet` cases have no `defaultSgIds` in their stored opts → fail-open → still fold `atDefault` (no regression). Declared-SG ENI/ALB cases go through the declared loop and are unaffected.

## Live-verify (deferred)

A real-AWS live-test (append a rogue SG to a deployed ENI/ALB, confirm `check` surfaces it) is **deferred** — the unit tests + the fail-open design are the evidence, and the derived detection requires `ec2:DescribeSecurityGroups`.

## Gates

`vp run typecheck` ✓ · `vp check --fix` ✓ · `vp pack` ✓ · `vp test run` ✓ (4382 passed) · `vp run check` ✓ (0 errors)

Closes #889