### PR TITLE
fix(diff): gate EIP NetworkInterfaceId on a declared sibling association instead of value-independent (#892)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -340,6 +340,7 @@ interface ClassifyOpts {
   siblingEventBusPolicies: Record<string, unknown[]>;
   siblingManagedPolicyAttachments: Record<string, string[]>;
   siblingUserGroups: Record<string, string[]>;
+  siblingEipAssociations: Set<string>;
   bucketNotificationManaged: Set<string>;
   clusterEchoModel: Record<string, Record<string, unknown>>;
   rdsOptionSettingDefaults: Record<string, Record<string, Record<string, string | null>>>;
@@ -609,6 +610,68 @@ function resolvePrincipalKey(ref: unknown, byLogicalId: Map<string, string>): st
     if (typeof logicalId === 'string') return byLogicalId.get(logicalId);
   }
   return undefined;
+}
+
+// An AWS::EC2::EIP's live `NetworkInterfaceId` reflects the ENI its address is associated with.
+// A LEGITIMATE association is DECLARED by a sibling resource — an AWS::EC2::EIPAssociation
+// (`AllocationId`/`EIP` referencing the EIP, `NetworkInterfaceId`/`InstanceId` naming the target)
+// or an AWS::EC2::NatGateway that consumes the EIP (`AllocationId` → the NAT owns the address, its
+// ENI is a legitimate binding). An association with NO declaring sibling is out of band — an
+// `ec2 associate-address` HIJACKING the allocated static IP onto an arbitrary ENI, which the old
+// blanket value-independent fold hid (#892). This set holds the identities (logicalId AND
+// physicalId == PublicIp) of every EIP a declared sibling associates, so classify FOLDS a
+// sibling-explained `NetworkInterfaceId` and SURFACES a sibling-less one. The ENI value itself is
+// AWS-assigned at association time (a NAT's ENI is created by AWS, not named in the template), so
+// the gate is PRESENCE-based: a declaring sibling explains ANY live association on that EIP. Fail-
+// open: an EIP reference that does not resolve to a known EIP is skipped (that EIP keeps the
+// reflected id → a one-time visible finding, never a hidden change).
+const EIP_ASSOCIATION_TYPE = 'AWS::EC2::EIPAssociation';
+const NAT_GATEWAY_TYPE = 'AWS::EC2::NatGateway';
+export function buildSiblingEipAssociations(desired: Desired): Set<string> {
+  // Map every EIP's logicalId to its own identities (logicalId + physicalId == PublicIp) so a
+  // sibling referencing the EIP by `{Ref: <eipLogicalId>}` (or by a GetAtt on it) can be resolved
+  // to the identities classify looks the EIP up by.
+  const eipIdentities = new Map<string, string[]>();
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::EC2::EIP') continue;
+    const ids = [r.logicalId];
+    if (r.physicalId) ids.push(r.physicalId);
+    eipIdentities.set(r.logicalId, ids);
+  }
+  const associated = new Set<string>();
+  const markEip = (ref: unknown): void => {
+    // A sibling names its EIP by `AllocationId`/`EIP`: a `{Ref: <eipLogicalId>}`, a
+    // `{Fn::GetAtt: [<eipLogicalId>, AllocationId]}`, or (for `EIP`) the resolved public-IP string.
+    // Resolve any of these to the EIP's identities and mark them all as sibling-explained.
+    let eipLogicalId: string | undefined;
+    if (ref && typeof ref === 'object') {
+      if ('Ref' in ref && typeof (ref as { Ref: unknown }).Ref === 'string') {
+        eipLogicalId = (ref as { Ref: string }).Ref;
+      } else if ('Fn::GetAtt' in ref) {
+        const g = (ref as { 'Fn::GetAtt': unknown })['Fn::GetAtt'];
+        if (Array.isArray(g) && typeof g[0] === 'string') eipLogicalId = g[0];
+      }
+    }
+    if (eipLogicalId !== undefined) {
+      const ids = eipIdentities.get(eipLogicalId);
+      if (ids) for (const id of ids) associated.add(id);
+      return;
+    }
+    // A resolved public-IP string (the `EIP` form) — mark it directly (it == the EIP's physical id).
+    if (typeof ref === 'string' && ref) associated.add(ref);
+  };
+  for (const r of desired.resources) {
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const d = decl as Record<string, unknown>;
+    if (r.resourceType === EIP_ASSOCIATION_TYPE) {
+      markEip(d.AllocationId);
+      markEip(d.EIP);
+    } else if (r.resourceType === NAT_GATEWAY_TYPE) {
+      markEip(d.AllocationId); // the NAT owns the EIP → its ENI is a legitimate association
+    }
+  }
+  return associated;
 }
 
 // Per Aurora DBInstance physical id, the parent DBCluster's live model — the source for the
@@ -1010,6 +1073,7 @@ export async function gatherFindings(
     siblingUserGroups: buildSiblingUserGroups(desired),
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     siblingListenerPorts: buildSiblingListenerPorts(desired),
+    siblingEipAssociations: buildSiblingEipAssociations(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
@@ -1103,6 +1167,7 @@ export async function regatherTouched(
     siblingUserGroups: buildSiblingUserGroups(desired),
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     siblingListenerPorts: buildSiblingListenerPorts(desired),
+    siblingEipAssociations: buildSiblingEipAssociations(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -81,6 +81,12 @@ export interface CorpusCase {
     // Custom::S3BucketNotifications CR, so replay reproduces the NotificationConfiguration drop.
     // Stored as an array (JSON has no Set); replay revives it to a Set. Optional for back-compat.
     bucketNotificationManaged?: string[];
+    // This EIP's own identity (physicalId, else logicalId), present only when a declared sibling
+    // (an AWS::EC2::EIPAssociation or an AWS::EC2::NatGateway consuming it) explains its live
+    // NetworkInterfaceId, so replay reproduces the reflected-association drop and the case folds
+    // atDefault exactly as a real check does. Stored as an array (JSON has no Set); replay revives
+    // it to a Set. Optional for back-compat (pre-#892 cases and non-EIP cases lack it).
+    siblingEipAssociations?: string[];
     // The parent DBCluster's live model keyed by THIS instance's physical id — present only on a
     // CLUSTER_ECHO_CHILD case (an Aurora DBInstance echoing its cluster), so replay reproduces the
     // cluster-echo strip. Without it a fresh-harvested reader/writer replays the un-folded echo
@@ -126,6 +132,7 @@ export function buildCorpusCase(
     oaiCanonicalIds: Record<string, string>;
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
     bucketNotificationManaged?: Set<string>;
+    siblingEipAssociations?: Set<string>;
     clusterEchoModel?: Record<string, Record<string, unknown>>;
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
     siblingListenerPorts?: Record<string, number>;
@@ -144,6 +151,15 @@ export function buildCorpusCase(
     resource.physicalId && opts.bucketNotificationManaged?.has(resource.physicalId)
       ? [resource.physicalId]
       : undefined;
+  // Carry ONLY this EIP's own identity from the stack-wide sibling-association set. classify keys
+  // the reflected-NetworkInterfaceId drop on the physicalId first, else the logicalId — carry the
+  // same one that is present, so replay folds the same way the live check did.
+  const eipSiblingId =
+    resource.physicalId && opts.siblingEipAssociations?.has(resource.physicalId)
+      ? resource.physicalId
+      : opts.siblingEipAssociations?.has(resource.logicalId)
+        ? resource.logicalId
+        : undefined;
   const echoModel =
     resource.physicalId && opts.clusterEchoModel?.[resource.physicalId]
       ? opts.clusterEchoModel[resource.physicalId]
@@ -198,6 +214,7 @@ export function buildCorpusCase(
         ? { siblingSgRules: { [resource.physicalId]: sgSibling } }
         : {}),
       ...(bucketNotif ? { bucketNotificationManaged: bucketNotif } : {}),
+      ...(eipSiblingId ? { siblingEipAssociations: [eipSiblingId] } : {}),
       ...(echoModel && resource.physicalId
         ? { clusterEchoModel: { [resource.physicalId]: echoModel } }
         : {}),
@@ -228,22 +245,24 @@ export function reviveSchema(s: CorpusCase['schema']): SchemaInfo {
   };
 }
 
-/** Revive a case's stored opts into the shape classifyResource expects: the JSON case
- *  stores `bucketNotificationManaged` as an array (JSON has no Set) but classify wants a
- *  Set, so convert it; every other opts field passes through unchanged. Both replay call
+/** Revive a case's stored opts into the shape classifyResource expects: the JSON case stores
+ *  `bucketNotificationManaged` / `siblingEipAssociations` as arrays (JSON has no Set) but classify
+ *  wants Sets, so convert them; every other opts field passes through unchanged. Both replay call
  *  sites (corpus-replay + measure-noise) go through here so they stay in lockstep. */
 export function reviveOpts(o: CorpusCase['opts']): Omit<
   CorpusCase['opts'],
-  'bucketNotificationManaged'
+  'bucketNotificationManaged' | 'siblingEipAssociations'
 > & {
   bucketNotificationManaged?: Set<string>;
+  siblingEipAssociations?: Set<string>;
 } {
-  const { bucketNotificationManaged, ...rest } = o;
+  const { bucketNotificationManaged, siblingEipAssociations, ...rest } = o;
   return {
     ...rest,
     ...(bucketNotificationManaged
       ? { bucketNotificationManaged: new Set(bucketNotificationManaged) }
       : {}),
+    ...(siblingEipAssociations ? { siblingEipAssociations: new Set(siblingEipAssociations) } : {}),
   };
 }
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1641,6 +1641,14 @@ export function classifyResource(
     // record + a revert that would DELETE the sibling hook, and a standalone-only ASG is not an
     // undeclared FP; an out-of-band hook matching no sibling still surfaces (#700).
     siblingLifecycleHooks?: Record<string, string[]>;
+    // Identities (logicalId + physicalId == PublicIp) of every AWS::EC2::EIP that a DECLARED
+    // sibling associates — an AWS::EC2::EIPAssociation targeting it, or an AWS::EC2::NatGateway
+    // consuming it (see buildSiblingEipAssociations). An EIP's live `NetworkInterfaceId` reflects
+    // the ENI its address is bound to; a sibling-explained association is folded to atDefault (the
+    // binding is IaC intent), but an association with NO declaring sibling is an out-of-band
+    // `associate-address` HIJACK of the static IP and SURFACES (#892). The ENI value is AWS-assigned
+    // at association time, so the fold is presence-gated (a declaring sibling explains any binding).
+    siblingEipAssociations?: Set<string>;
     // Bucket physical ids whose S3 notifications are managed by a Custom::S3BucketNotifications
     // custom resource (see buildBucketNotificationManaged): the live bucket reflects the
     // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
@@ -1777,6 +1785,21 @@ export function classifyResource(
   if (resourceType === 'AWS::AutoScaling::AutoScalingGroup') {
     const sibHooks = physicalId ? opts.siblingLifecycleHooks?.[physicalId] : undefined;
     if (sibHooks) subtractSiblingLifecycleHooks(live, sibHooks);
+  }
+  // An AWS::EC2::EIP's live `NetworkInterfaceId` reflects the ENI its address is associated with.
+  // A LEGITIMATE association is DECLARED by a sibling AWS::EC2::EIPAssociation (or an
+  // AWS::EC2::NatGateway consuming the EIP), so drop the reflected id when such a sibling exists —
+  // the binding is IaC intent, not drift (the exact eni-… is AWS-assigned at association time, so
+  // the fold is presence-gated, keyed by the EIP's identity in opts.siblingEipAssociations). With
+  // NO declaring sibling the id is KEPT and surfaces: a live association on an EIP no sibling
+  // explains is an out-of-band `associate-address` HIJACK of the allocated static IP (#892), which
+  // the old blanket value-independent fold silenced. `NetworkInterfaceId` is only ever present when
+  // an association exists (an unassociated EIP has no such key), so no fold is needed when absent.
+  if (resourceType === 'AWS::EC2::EIP' && 'NetworkInterfaceId' in live) {
+    const explained =
+      (physicalId !== undefined && opts.siblingEipAssociations?.has(physicalId)) ||
+      opts.siblingEipAssociations?.has(logicalId);
+    if (explained) delete live.NetworkInterfaceId;
   }
   // A bucket whose notifications are managed by a Custom::S3BucketNotifications CR reflects
   // the CR-applied NotificationConfiguration it never declares itself (CDK renders

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3195,11 +3195,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   'AWS::EC2::Volume': new Set(['KmsKeyId', 'AvailabilityZoneId']),
   'AWS::EC2::NatGateway': new Set(['PrivateIpAddress', 'VpcId']),
   'AWS::EFS::MountTarget': new Set(['IpAddress']),
-  //   AWS::EC2::EIP.NetworkInterfaceId — an EIP associated with an ENI (directly or via an
-  //   instance) reflects the eni-… it is bound to; the attachment is not user intent on the
-  //   EIP itself (a user who cares associates it explicitly / declares it), and the id is
-  //   AWS-assigned per-ENI, so fold value-independent.
-  'AWS::EC2::EIP': new Set(['NetworkBorderGroup', 'NetworkInterfaceId']),
+  //   AWS::EC2::EIP.NetworkBorderGroup — the address's border group, AWS-assigned per-region
+  //   and undeclared, so fold value-independent. NetworkInterfaceId is NOT folded here (#892):
+  //   a blanket fold hid an out-of-band `associate-address` hijacking a static IP onto an
+  //   arbitrary ENI. A LEGITIMATE association comes from a declared sibling
+  //   AWS::EC2::EIPAssociation (or a NAT gateway consuming the EIP); classify folds it via the
+  //   sibling-derived gate (opts.siblingEipAssociations) and SURFACES a sibling-less association.
+  'AWS::EC2::EIP': new Set(['NetworkBorderGroup']),
   //   AWS::EFS::FileSystem.KmsKeyId — an encrypted file system that declares no key reads
   //   back the account aws/elasticfilesystem managed-key ARN (per-account, AWS-assigned) —
   //   the exact twin of the RDS/OpenSearch AWS-assigned KmsKeyId folds (#533). Undeclared,

--- a/tests/classify-eip-associate-892.test.ts
+++ b/tests/classify-eip-associate-892.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildSiblingEipAssociations } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #892 (SECURITY FN): AWS::EC2::EIP `NetworkInterfaceId` was folded VALUE-INDEPENDENT, so an
+// out-of-band `ec2 associate-address` — hijacking an allocated static IP (allowlisted /
+// reputation-bearing) onto an arbitrary ENI — was INVISIBLE. The blanket fold is replaced with a
+// TIER-2 sibling-derived gate: a live association DECLARED by a sibling AWS::EC2::EIPAssociation
+// (or an AWS::EC2::NatGateway consuming the EIP) FOLDS; an association with NO declaring sibling
+// SURFACES as [Potential Drift]. The sibling identities are built by gather.buildSiblingEipAssociations
+// and consumed in classify via opts.siblingEipAssociations.
+
+const eipSchema: SchemaInfo = {
+  readOnly: new Set(['AllocationId', 'PublicIp']),
+  writeOnly: new Set(['Address', 'IpamPoolId', 'TransferAddress']),
+  createOnly: new Set(['Address', 'IpamPoolId', 'NetworkBorderGroup', 'TransferAddress']),
+  readOnlyPaths: ['AllocationId', 'PublicIp'],
+  writeOnlyPaths: ['Address', 'IpamPoolId', 'TransferAddress'],
+  createOnlyPaths: ['Address', 'IpamPoolId', 'NetworkBorderGroup', 'TransferAddress'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const eipResource: DesiredResource = {
+  logicalId: 'Ip',
+  resourceType: 'AWS::EC2::EIP',
+  physicalId: '52.4.97.166',
+  declared: { Domain: 'vpc' },
+};
+
+// An EIP associated with an ENI: the live model carries the reflected NetworkInterfaceId.
+const associatedLive = (): Record<string, unknown> => ({
+  Domain: 'vpc',
+  NetworkBorderGroup: 'us-east-1',
+  PublicIp: '52.4.97.166',
+  NetworkInterfaceId: 'eni-0f1c51db64ee88129',
+});
+
+const niiFindings = (findings: Finding[], tier: string) =>
+  findings.filter((f) => f.tier === tier && f.path === 'NetworkInterfaceId');
+
+describe('#892 EIP NetworkInterfaceId sibling-derived association gate', () => {
+  it('(map) buildSiblingEipAssociations marks an EIP referenced by a declared EIPAssociation', () => {
+    const desired: Desired = {
+      resources: [
+        eipResource,
+        {
+          logicalId: 'Assoc',
+          resourceType: 'AWS::EC2::EIPAssociation',
+          declared: {
+            AllocationId: { 'Fn::GetAtt': ['Ip', 'AllocationId'] },
+            NetworkInterfaceId: 'eni-0f1c51db64ee88129',
+          },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildSiblingEipAssociations(desired);
+    // Keyed by BOTH the EIP's logicalId and its physicalId (== PublicIp).
+    expect(map.has('Ip')).toBe(true);
+    expect(map.has('52.4.97.166')).toBe(true);
+  });
+
+  it('(map) buildSiblingEipAssociations marks an EIP consumed by a NAT gateway', () => {
+    const desired: Desired = {
+      resources: [
+        eipResource,
+        {
+          logicalId: 'Nat',
+          resourceType: 'AWS::EC2::NatGateway',
+          declared: {
+            AllocationId: { 'Fn::GetAtt': ['Ip', 'AllocationId'] },
+            SubnetId: 'subnet-abc',
+          },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildSiblingEipAssociations(desired);
+    expect(map.has('Ip')).toBe(true);
+    expect(map.has('52.4.97.166')).toBe(true);
+  });
+
+  it('(map) an EIP with NO declaring sibling is not marked', () => {
+    const desired: Desired = {
+      resources: [eipResource],
+    } as unknown as Desired;
+    const map = buildSiblingEipAssociations(desired);
+    expect(map.has('Ip')).toBe(false);
+    expect(map.has('52.4.97.166')).toBe(false);
+  });
+
+  it('(1) a sibling-explained association FOLDS (no NetworkInterfaceId drift)', () => {
+    // A declared EIPAssociation / NAT gateway explains the binding → the reflected id is dropped.
+    const siblingEipAssociations = new Set(['Ip', '52.4.97.166']);
+    const findings = classifyResource(eipResource, associatedLive(), eipSchema, {
+      siblingEipAssociations,
+    });
+    expect(findings.some((f) => f.path === 'NetworkInterfaceId')).toBe(false);
+    expect(niiFindings(findings, 'undeclared')).toEqual([]);
+    expect(niiFindings(findings, 'atDefault')).toEqual([]);
+  });
+
+  it('(2) a sibling-LESS association SURFACES (the OOB associate-address hijack)', () => {
+    // No declaring sibling → the live NetworkInterfaceId is an out-of-band hijack and must surface.
+    const findings = classifyResource(eipResource, associatedLive(), eipSchema, {
+      siblingEipAssociations: new Set<string>(),
+    });
+    const surfaced = niiFindings(findings, 'undeclared');
+    expect(surfaced.length).toBe(1);
+    expect(surfaced[0]?.actual).toBe('eni-0f1c51db64ee88129');
+  });
+
+  it('(2b) with NO sibling map at all → the association still SURFACES (fail-open to visible)', () => {
+    const findings = classifyResource(eipResource, associatedLive(), eipSchema);
+    expect(niiFindings(findings, 'undeclared').length).toBe(1);
+  });
+
+  it('(3) an unassociated EIP has no NetworkInterfaceId, so nothing surfaces regardless', () => {
+    const live: Record<string, unknown> = {
+      Domain: 'vpc',
+      NetworkBorderGroup: 'us-east-1',
+      PublicIp: '52.4.97.166',
+    };
+    const findings = classifyResource(eipResource, live, eipSchema, {
+      siblingEipAssociations: new Set<string>(),
+    });
+    expect(findings.some((f) => f.path === 'NetworkInterfaceId')).toBe(false);
+  });
+});

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): a NAT-gateway EIP. NetworkBorderGroup folds atDefault. NetworkInterfaceId folds atDefault too (#892): the blanket value-independent fold was removed so an out-of-band associate-address hijack surfaces, but this EIP's live association IS explained by a declared sibling (its NAT gateway consuming the allocation), so the reflected id is dropped via the sibling-derived gate (opts.siblingEipAssociations, carried here as this EIP's physical id so replay folds it exactly as the real check does). A change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
     "resourceType": "AWS::EC2::EIP",
@@ -67,7 +67,8 @@
       "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
       "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
-    }
+    },
+    "siblingEipAssociations": ["107.22.107.4"]
   },
   "expected": [
     {
@@ -76,15 +77,6 @@
       "resourceType": "AWS::EC2::EIP",
       "path": "NetworkBorderGroup",
       "actual": "us-east-1",
-      "physicalId": "107.22.107.4",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/EIP"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
-      "resourceType": "AWS::EC2::EIP",
-      "path": "NetworkInterfaceId",
-      "actual": "eni-0f1c51db64ee88129",
       "physicalId": "107.22.107.4",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/EIP"
     }

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): a NAT-gateway EIP. NetworkBorderGroup folds atDefault. NetworkInterfaceId folds atDefault too (#892): the blanket value-independent fold was removed so an out-of-band associate-address hijack surfaces, but this EIP's live association IS explained by a declared sibling (its NAT gateway consuming the allocation), so the reflected id is dropped via the sibling-derived gate (opts.siblingEipAssociations, carried here as this EIP's physical id so replay folds it exactly as the real check does). A change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
     "resourceType": "AWS::EC2::EIP",
@@ -67,7 +67,8 @@
       "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
       "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
-    }
+    },
+    "siblingEipAssociations": ["35.171.223.35"]
   },
   "expected": [
     {
@@ -76,15 +77,6 @@
       "resourceType": "AWS::EC2::EIP",
       "path": "NetworkBorderGroup",
       "actual": "us-east-1",
-      "physicalId": "35.171.223.35",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/EIP"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
-      "resourceType": "AWS::EC2::EIP",
-      "path": "NetworkInterfaceId",
-      "actual": "eni-09d601326197ac598",
       "physicalId": "35.171.223.35",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/EIP"
     }

--- a/tests/noise-653-folds.test.ts
+++ b/tests/noise-653-folds.test.ts
@@ -284,7 +284,20 @@ describe('#653 value-independent / generated undeclared identifiers', () => {
       )
     ).toContain('KmsKeyId');
   });
-  it('EIP NetworkInterfaceId + GlobalAccelerator IpAddresses fold', () => {
+  it('EIP NetworkInterfaceId with a declared sibling folds; sibling-less surfaces (#892)', () => {
+    // A sibling-explained association (a declared EIPAssociation / NAT gateway consuming this EIP,
+    // recorded in opts.siblingEipAssociations by gather.buildSiblingEipAssociations) is IaC intent
+    // → the reflected id is dropped (no NetworkInterfaceId finding at all).
+    expect(
+      classifyResource(
+        mk('AWS::EC2::EIP', { Domain: 'vpc' }),
+        { NetworkInterfaceId: 'eni-123' },
+        emptySchema,
+        { siblingEipAssociations: new Set(['R']) } // 'R' == mk's logicalId
+      ).some((f) => f.path === 'NetworkInterfaceId')
+    ).toBe(false);
+    // With NO declaring sibling the live association is an out-of-band associate-address hijack of
+    // the allocated static IP and must SURFACE as undeclared drift (the blanket fold hid it).
     expect(
       tier(
         classifyResource(
@@ -292,9 +305,11 @@ describe('#653 value-independent / generated undeclared identifiers', () => {
           { NetworkInterfaceId: 'eni-123' },
           emptySchema
         ),
-        'atDefault'
+        'undeclared'
       )
     ).toContain('NetworkInterfaceId');
+  });
+  it('GlobalAccelerator IpAddresses fold', () => {
     expect(
       tier(
         classifyResource(


### PR DESCRIPTION
Closes #892. Replaces the blanket value-independent fold (which silenced OOB associate-address hijacks of a static IP) with a tier-2 sibling-derived gate (#699/#700 pattern): a NetworkInterfaceId explained by a declared EIPAssociation / NAT gateway folds; a sibling-less live association SURFACES as the hijack. Corpus opts carry siblingEipAssociations so NAT-EIP cases stay folded (zero first-run preserved). Unit-tested both directions. See commit body.