### PR TITLE
fix(diff): demote non-ASCII-masked SFN DefinitionString to readGap, not declared drift

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -28,6 +28,7 @@ import {
   BOOLEAN_PARAM_MAP_PATHS,
   isBooleanTokenEquivalent,
   isCfnTemplateNonAsciiMask,
+  deepEqualModuloNonAsciiMask,
   isEqualUnorderedScalarSet,
   isEquivalentRateExpression,
   isJsonStringStructEqual,
@@ -2581,6 +2582,28 @@ export function classifyResource(
         declaredParsed = undefined;
       }
       if (declaredParsed !== undefined && deepEqual(declaredParsed, liveParsed)) continue;
+      // GetTemplate masks every non-ASCII character in a stored string literal as `?`
+      // (see isCfnTemplateNonAsciiMask), so a definition carrying non-ASCII text (a
+      // Japanese `Cause` message) arrives corrupted on the DECLARED side while the live
+      // read is intact — the structural compare above can never match, and pushing the
+      // declared finding here would bypass the general mask→readGap demotion the plain
+      // string-diff path applies. When the two definitions differ ONLY at such masked
+      // leaves, the declared value is unknowable from GetTemplate (CloudFormation itself
+      // reports it IN_SYNC), so surface a readGap instead of a false drift; a genuine
+      // out-of-band edit still fails the mask-tolerant compare and is reported.
+      if (
+        (declaredParsed !== undefined && deepEqualModuloNonAsciiMask(declaredParsed, liveParsed)) ||
+        isCfnTemplateNonAsciiMask(v, live[k])
+      ) {
+        findings.push({
+          tier: 'readGap',
+          logicalId,
+          resourceType,
+          path: k,
+          note: 'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"',
+        });
+        continue;
+      }
       findings.push({
         tier: 'declared',
         logicalId,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -4457,6 +4457,44 @@ export function isCfnTemplateNonAsciiMask(declared: unknown, live: unknown): boo
   return sawNonAscii && masked === declared;
 }
 
+// Structural variant of the GetTemplate `?`-mask test, for JSON-DOCUMENT string properties
+// that are compared PARSED rather than byte-wise (a StepFunctions `DefinitionString` — the
+// service may re-serialize on read, so the string forms need not align even when the
+// documents agree). Deep-equal with ONE relaxation: a string leaf also matches when the
+// declared side is the GetTemplate non-ASCII mask of the live side. Everything else keeps
+// the strict deepEqual shape (same keysets, index-wise arrays, strict scalar equality), so
+// a genuine out-of-band edit — a changed ASCII char, an added state, a re-typed leaf —
+// still differs and is reported; only differences GetTemplate itself made invisible are
+// excused (and isCfnTemplateNonAsciiMask only fires when the declared leaf actually
+// carries a `?` standing in for a live non-ASCII char, so a pure-ASCII document never
+// takes the relaxed path).
+export function deepEqualModuloNonAsciiMask(declared: unknown, live: unknown): boolean {
+  if (declared === live) return true;
+  if (typeof declared === 'string' && typeof live === 'string')
+    return isCfnTemplateNonAsciiMask(declared, live);
+  if (
+    typeof declared !== 'object' ||
+    typeof live !== 'object' ||
+    declared === null ||
+    live === null
+  )
+    return false;
+  if (Array.isArray(declared) || Array.isArray(live)) {
+    if (!Array.isArray(declared) || !Array.isArray(live) || declared.length !== live.length)
+      return false;
+    return declared.every((v, i) => deepEqualModuloNonAsciiMask(v, live[i]));
+  }
+  const declaredObj = declared as Record<string, unknown>;
+  const liveObj = live as Record<string, unknown>;
+  const keys = Object.keys(declaredObj);
+  if (keys.length !== Object.keys(liveObj).length) return false;
+  for (const key of keys) {
+    if (!Object.hasOwn(liveObj, key)) return false;
+    if (!deepEqualModuloNonAsciiMask(declaredObj[key], liveObj[key])) return false;
+  }
+  return true;
+}
+
 // AWS resource-id / ARN lists (SubnetIds, SecurityGroupIds, VPCSecurityGroups, ...)
 // are UNORDERED sets too, but unlike tags their elements
 // are bare scalars, so the tag canonicalizer doesn't touch them and a positional

--- a/tests/classify-sfn-definition-712.test.ts
+++ b/tests/classify-sfn-definition-712.test.ts
@@ -135,3 +135,74 @@ describe('#712 symptom B — DefinitionSubstitutions resolved into the declared 
     expect(tier(f, 'declared')).toContain('DefinitionString');
   });
 });
+
+describe('GetTemplate non-ASCII mask inside a DefinitionString — readGap, not declared drift', () => {
+  // GetTemplate returns every non-ASCII char in a stored string literal as `?`, so a
+  // definition carrying e.g. a Japanese Fail-state Cause arrives masked on the declared
+  // side while the live read is intact. The SFN structural-compare branch must demote
+  // that to a readGap (declared-but-unverifiable) instead of pushing a false declared
+  // drift whose desired shows `????…` (observed live: two Japanese Cause runs of 13 and
+  // 24 chars masked 1:1 while CloudFormation's own drift detection reported IN_SYNC).
+  const LIVE_JP =
+    '{"StartAt":"Check","States":{"Check":{"Type":"Choice","Choices":[{"Condition":"{% $ok %}","Next":"Done"}],"Default":"Bad"},"Bad":{"Type":"Fail","Cause":"復元先インスタンスクラスが db.<family>.<size> 形式ではない","Error":"InvalidInstanceClass"},"Done":{"Type":"Pass","End":true}}}';
+  const mask = (s: string): string => s.replace(/[^\x00-\x7f]/gu, '?');
+
+  it('demotes to readGap when the declared definition differs from live ONLY at masked non-ASCII leaves', () => {
+    const res = mk({
+      DefinitionString: mask(LIVE_JP),
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    });
+    const live = { DefinitionString: LIVE_JP, RoleArn: 'arn:aws:iam::111111111111:role/r' };
+    const f = classifyResource(res, live, sfnSchema);
+    expect(tier(f, 'declared')).not.toContain('DefinitionString');
+    const gap = f.find((x) => x.tier === 'readGap' && x.path === 'DefinitionString');
+    expect(gap?.note).toContain('masks non-ASCII');
+  });
+
+  it('demotes to readGap even when the live definition is re-serialized with a different key order (structural mask compare)', () => {
+    // Byte-alignment breaks (Cause/Error/Type reordered), so the raw-string mask check
+    // cannot fire — only the structural mask-tolerant compare can.
+    const liveReordered = LIVE_JP.replace(
+      '"Type":"Fail","Cause":"復元先インスタンスクラスが db.<family>.<size> 形式ではない","Error":"InvalidInstanceClass"',
+      '"Cause":"復元先インスタンスクラスが db.<family>.<size> 形式ではない","Error":"InvalidInstanceClass","Type":"Fail"'
+    );
+    const res = mk({
+      DefinitionString: mask(LIVE_JP),
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    });
+    const live = { DefinitionString: liveReordered, RoleArn: 'arn:aws:iam::111111111111:role/r' };
+    const f = classifyResource(res, live, sfnSchema);
+    expect(tier(f, 'declared')).not.toContain('DefinitionString');
+    expect(tier(f, 'readGap')).toContain('DefinitionString');
+  });
+
+  it('still reports declared drift when a genuine ASCII edit exists alongside the masks (fail-toward-reporting)', () => {
+    // An out-of-band edit changed an ASCII leaf (Error code) — masks alone no longer
+    // explain the difference, so the finding must surface as declared drift.
+    const liveEdited = LIVE_JP.replace('"Error":"InvalidInstanceClass"', '"Error":"SomethingElse"');
+    const res = mk({
+      DefinitionString: mask(LIVE_JP),
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    });
+    const live = { DefinitionString: liveEdited, RoleArn: 'arn:aws:iam::111111111111:role/r' };
+    const f = classifyResource(res, live, sfnSchema);
+    expect(tier(f, 'declared')).toContain('DefinitionString');
+    expect(tier(f, 'readGap')).not.toContain('DefinitionString');
+  });
+
+  it('does NOT demote a pure-ASCII genuine change even when the declared side contains a literal "?"', () => {
+    // A real `?` character in a definition (a regex, a message) must never excuse a diff:
+    // isCfnTemplateNonAsciiMask requires the live side to carry non-ASCII at the masked
+    // positions, so an ASCII-vs-ASCII difference always surfaces.
+    const declared =
+      '{"StartAt":"P","States":{"P":{"Type":"Fail","Cause":"expected db.<family>.<size>?","Error":"E"}}}';
+    const live = {
+      DefinitionString:
+        '{"StartAt":"P","States":{"P":{"Type":"Fail","Cause":"expected db.<family>.<size>!","Error":"E"}}}',
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    };
+    const res = mk({ DefinitionString: declared, RoleArn: 'arn:aws:iam::111111111111:role/r' });
+    const f = classifyResource(res, live, sfnSchema);
+    expect(tier(f, 'declared')).toContain('DefinitionString');
+  });
+});


### PR DESCRIPTION
## Symptom

A cleanly deployed `AWS::StepFunctions::StateMachine` whose definition contains non-ASCII text (e.g. Japanese `Cause` messages in Fail states) is reported as **CFn-Declared Drift** on every `check`, with the desired side showing `?` runs where the live side shows the intact text:

```
[CFn-Declared Drift: 1]
  .../StateMachine/Resource.DefinitionString (AWS::StepFunctions::StateMachine)
      desired=…"Cause":"????????????? db.<family>.<size> ????????????????????????"…
      actual =…"Cause":"<intact non-ASCII text> db.<family>.<size> <intact non-ASCII text>"…
```

Verified against a live stack: the Join-resolved declared string and the Cloud Control live `DefinitionString` were byte-identical modulo the GetTemplate non-ASCII `?` masks (the `?` runs mapped 1:1 onto the non-ASCII runs), and CloudFormation's own drift detection reports the property IN_SYNC.

## Root cause

The #712 SFN `DefinitionString` structural-compare branch in `src/diff/classify.ts` pushes a `declared` finding **directly** and `continue`s when `deepEqual(parsedDeclared, parsedLive)` fails — bypassing the general GetTemplate non-ASCII mask → `readGap` demotion gate (`isCfnTemplateNonAsciiMask`) that every other string-leaf diff goes through. The local-synth recovery (`desired/recover-nonascii.ts`) can't substitute the intact text when the resource no longer exists in the local synth output, so the designed degradation is `readGap` — which this branch never reached.

## Fix

When the structural compare fails, demote to `readGap` (same note as the general gate) when the two parsed definitions are deep-equal **modulo per-leaf non-ASCII masks** — new `deepEqualModuloNonAsciiMask` in `normalize/noise.ts`: string leaves also match via `isCfnTemplateNonAsciiMask`, everything else keeps the strict deepEqual shape — falling back to the raw-string mask check for the parse-failure path. A genuine out-of-band edit (a changed ASCII char, an added state, a re-typed leaf) still fails both compares and keeps surfacing as declared drift.

## Verification

- 4 new unit tests in `tests/classify-sfn-definition-712.test.ts`: mask-only diff → readGap (byte-aligned AND re-serialized/key-reordered live), genuine ASCII edit alongside masks → still declared drift, literal `?` in a pure-ASCII definition → never excused.
- Full suite: 167 files / 4377 tests pass; typecheck + lint/format + build pass.
- Live A/B on the reporting stack: the previous build surfaced the false `[CFn-Declared Drift: 1]`; this build folds it to `readGap` (3→4) with the remaining output unchanged.