### PR TITLE
fix(read): match alias/version-bound Lambda EventSourceMappings on unqualified function identity (#803)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -155,6 +155,46 @@ function parentRefMatches(declaredValue: unknown, ...candidates: (string | undef
   return candidates.some((c) => c !== undefined && declaredValue === c);
 }
 
+// Drop a trailing `:qualifier` (an alias name, a numeric version, or `$LATEST`) from a
+// Lambda function reference — the bare name / unqualified ARN / short `name:qualifier`
+// form — returning the UNQUALIFIED function identity used for matching. An ESM bound to
+// an alias/version (`alias.addEventSource(...)`) declares its `FunctionName` as the
+// QUALIFIED ref (`fn:prod`, `arn:…:function:fn:prod`, `fn:1`, `fn:$LATEST`); its live
+// mapping reads back the same qualified ARN, so it matches NEITHER the bare function name
+// NOR the bare function ARN and the DECLARED alias-bound ESM is falsely flagged `added`
+// (#803). Only a qualifier that FOLLOWS the function name is stripped: the `function:`
+// ARN segment itself is preserved (`arn:…:function:fn` → unchanged), and a bare name / a
+// full unqualified ARN passes through untouched.
+export function unqualifiedFunctionRef(ref: unknown): unknown {
+  if (typeof ref !== 'string') return ref;
+  if (ref.startsWith('arn:')) {
+    // arn:partition:service:region:account:function:NAME[:QUALIFIER] — the resource id
+    // is segments 6..; a QUALIFIER present makes it segments 6 (NAME) + 7 (QUALIFIER).
+    const seg = ref.split(':');
+    if (seg.length >= 8 && seg[5] === 'function') return seg.slice(0, 7).join(':');
+    return ref;
+  }
+  // Short forms: `NAME:QUALIFIER` (single colon) → `NAME`. A bare `NAME` has no colon.
+  const i = ref.indexOf(':');
+  return i === -1 ? ref : ref.slice(0, i);
+}
+
+// `parentRefMatches`, but comparing on the UNQUALIFIED function identity of BOTH sides —
+// an alias/version-bound child's qualified `FunctionName` matches its unqualified parent
+// function (#803). Out-of-band detection is preserved: only the identity used for the
+// parent membership test is normalized; the per-child match downstream stays on the
+// UUID / versioned-ARN.
+function lambdaFunctionRefMatches(
+  declaredValue: unknown,
+  ...candidates: (string | undefined)[]
+): boolean {
+  const declaredUnqualified = unqualifiedFunctionRef(declaredValue);
+  return parentRefMatches(
+    declaredUnqualified,
+    ...candidates.map((c) => (c === undefined ? undefined : (unqualifiedFunctionRef(c) as string)))
+  );
+}
+
 // One out-of-band child resource: present live, absent from the template.
 export interface AddedChild {
   resourceType: string; // CC TypeName of the child (e.g. AWS::ApiGateway::Method)
@@ -1335,7 +1375,10 @@ export async function enumerateLambdaFunctionChildren(
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::EventSourceMapping' || !r.physicalId) continue;
     const fn = r.declared.FunctionName;
-    if (parentRefMatches(fn, functionName, fnArn)) {
+    // An ESM bound to an alias/version declares a QUALIFIED FunctionName (`fn:prod`,
+    // `arn:…:function:fn:prod`); compare on the UNQUALIFIED function identity so the
+    // declared alias-bound ESM matches this parent function (#803).
+    if (lambdaFunctionRefMatches(fn, functionName, fnArn)) {
       declaredMappingIds.push(r.physicalId);
     }
   }
@@ -1383,7 +1426,9 @@ export async function enumerateLambdaFunctionChildren(
   const declaredVersionArns: string[] = [];
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::Version' || !r.physicalId) continue;
-    if (parentRefMatches(r.declared.FunctionName, functionName, fnArn)) {
+    // Same unqualified-identity match as the ESM path: a Version whose declared
+    // FunctionName carries a qualifier still targets this parent function (#803).
+    if (lambdaFunctionRefMatches(r.declared.FunctionName, functionName, fnArn)) {
       declaredVersionArns.push(r.physicalId);
     }
   }

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -64,6 +64,7 @@ import {
   isEnumerableRoute,
   isQuickCreateHttpApi,
   routeDestination,
+  unqualifiedFunctionRef,
 } from '../src/read/child-enumerators.js';
 
 const API = 'abc123';
@@ -906,6 +907,41 @@ describe('diffLambdaFunctionChildren (Lambda event source mappings)', () => {
         ],
       })
     ).toEqual([]);
+  });
+});
+
+describe('unqualifiedFunctionRef (#803 alias/version-bound Lambda children)', () => {
+  const ARN = 'arn:aws:lambda:us-east-1:111122223333:function:my-fn';
+
+  it('strips an alias qualifier from a qualified ARN', () => {
+    expect(unqualifiedFunctionRef(`${ARN}:prod`)).toBe(ARN);
+  });
+
+  it('strips a numeric version qualifier from a qualified ARN', () => {
+    expect(unqualifiedFunctionRef(`${ARN}:1`)).toBe(ARN);
+  });
+
+  it('strips $LATEST from a qualified ARN', () => {
+    expect(unqualifiedFunctionRef(`${ARN}:$LATEST`)).toBe(ARN);
+  });
+
+  it('strips the qualifier from the short `name:qualifier` form', () => {
+    expect(unqualifiedFunctionRef('my-fn:prod')).toBe('my-fn');
+    expect(unqualifiedFunctionRef('my-fn:1')).toBe('my-fn');
+    expect(unqualifiedFunctionRef('my-fn:$LATEST')).toBe('my-fn');
+  });
+
+  it('preserves a bare function name (no colon)', () => {
+    expect(unqualifiedFunctionRef('my-fn')).toBe('my-fn');
+  });
+
+  it('preserves a full UNqualified ARN (does not strip the `function:` segment)', () => {
+    expect(unqualifiedFunctionRef(ARN)).toBe(ARN);
+  });
+
+  it('passes through non-string refs untouched', () => {
+    expect(unqualifiedFunctionRef(UNRESOLVED)).toBe(UNRESOLVED);
+    expect(unqualifiedFunctionRef(undefined)).toBe(undefined);
   });
 });
 
@@ -2521,6 +2557,153 @@ describe('child enumerators fail safe on an UNRESOLVED parent-ref (#962)', () =>
     const added = await enumerateSnsTopicChildren(ctx);
     expect(added).toEqual([]);
     sns.restore();
+  });
+});
+
+// #803: an EventSourceMapping (or Version) bound to an ALIAS/VERSION declares a QUALIFIED
+// FunctionName (`fn:prod`, `arn:…:function:fn:prod`), while the enumerator lists live
+// children by the UNqualified function name. Matching the parent linkage on the
+// unqualified function identity keeps the declared alias-bound child out of the `added`
+// tier, while a genuinely out-of-band child still surfaces.
+describe('Lambda alias/version-bound children match on unqualified function identity (#803)', () => {
+  const fnArn = 'arn:aws:lambda:us-east-1:111122223333:function:my-fn';
+
+  it('a declared ESM referencing an ALIAS (fn:prod) is NOT flagged added', async () => {
+    const declaredUuid = '11111111-2222-3333-4444-555555555555';
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [{ UUID: declaredUuid, EventSourceArn: 'q' }] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        // The declared ESM targets the ALIAS: its FunctionName is the qualified ARN.
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::EventSourceMapping',
+            physicalId: declaredUuid,
+            declared: { FunctionName: `${fnArn}:prod` },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added).toEqual([]);
+    lambda.restore();
+  });
+
+  it('a declared ESM by plain function name still matches its live mapping', async () => {
+    const declaredUuid = '99999999-8888-7777-6666-555555555555';
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [{ UUID: declaredUuid, EventSourceArn: 'q' }] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::EventSourceMapping',
+            physicalId: declaredUuid,
+            declared: { FunctionName: 'my-fn' },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added).toEqual([]);
+    lambda.restore();
+  });
+
+  it('a genuinely out-of-band ESM (no declared counterpart) IS still flagged added', async () => {
+    const declaredUuid = '11111111-2222-3333-4444-555555555555';
+    const rogueUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({
+        EventSourceMappings: [
+          { UUID: declaredUuid, EventSourceArn: 'q' },
+          { UUID: rogueUuid, EventSourceArn: 'rogue' },
+        ],
+      })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        // Only ONE ESM is declared (alias-bound); the rogue mapping is not in the template.
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::EventSourceMapping',
+            physicalId: declaredUuid,
+            declared: { FunctionName: `${fnArn}:prod` },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added.map((a) => a.identifier)).toEqual([rogueUuid]);
+    lambda.restore();
+  });
+
+  it('a declared Version whose FunctionName carries a qualifier is NOT flagged added', async () => {
+    const versionArn = `${fnArn}:3`;
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({
+        Versions: [
+          { FunctionArn: fnArn, Version: '$LATEST' }, // pseudo-version, skipped
+          { FunctionArn: versionArn, Version: '3' },
+        ],
+      });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::Version',
+            physicalId: versionArn,
+            // A qualified FunctionName still targets this parent function.
+            declared: { FunctionName: `${fnArn}:prod` },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added).toEqual([]);
+    lambda.restore();
   });
 });
 


### PR DESCRIPTION
## Summary

An `AWS::Lambda::EventSourceMapping` (or `AWS::Lambda::Version`) bound to an **alias/version** — the standard `alias.addEventSource(...)` provisioned-concurrency / CodeDeploy pattern — declares a **qualified** `FunctionName` (`fn:prod`, `arn:...:function:fn:prod`, `fn:1`, `fn:$LATEST`). `enumerateLambdaFunctionChildren` lists live children by the **unqualified** function name and matched the declared parent linkage (`parentRefMatches`) against only the bare function name / bare ARN — so a qualified `FunctionName` matched **neither**, the declared alias-bound ESM dropped out of the declared set, and its live counterpart was falsely reported out-of-band `added` (a first-run zero-drift violation, offering a **destructive** `DeleteResource` against a CFn-managed resource).

## Fix

- New `unqualifiedFunctionRef(ref)` helper: strips a trailing `:qualifier` (alias name, numeric version, or `$LATEST`) from a bare name / unqualified ARN / short `name:qualifier` form, while **preserving** the `function:` ARN segment itself and passing a bare name / full unqualified ARN through untouched.
- New `lambdaFunctionRefMatches(...)`: `parentRefMatches` on the unqualified identity of **both** sides.
- Applied to the **ESM** and **Version** declared-collection loops in `enumerateLambdaFunctionChildren`.

Out-of-band detection is preserved: only the parent-membership identity is normalized; the per-child match stays on the UUID / versioned ARN, so a genuinely undeclared ESM/Version still surfaces as `added`.

## Tests

`tests/child-enumerators.test.ts`:
- `unqualifiedFunctionRef` unit tests — strips alias / numeric / `$LATEST` qualifiers (both ARN and short form), preserves a bare name and a full unqualified ARN, passes non-strings through.
- Integration (mocked `LambdaClient`): (a) a declared ESM referencing an alias (`fn:prod`) → NOT flagged `added`; (b) a declared ESM by plain function name still matches; (c) a genuinely out-of-band ESM (no declared counterpart, alongside a declared alias-bound one) IS still flagged `added`; (d) a declared Version with a qualified FunctionName → NOT flagged `added`.

## Gates

`vp run typecheck` / `vp check --fix` / `vp pack` / `vp test run` (4407 pass) / `vp run check` (0 errors) all green.

## Live confirmation

Deferred (offline-predicted, unit-tested). The unqualified-match logic fixes both directions and is unit-tested; a live `fn + alias + addEventSource` deploy to observe which direction manifests is a standard follow-up hunt cycle.

Closes #803