### PR TITLE
fix(normalize): strip managed-timestamp name variants ALWAYS_STRIPPED misses (#915)

### DIFF
--- a/src/normalize/cc-api-strip.ts
+++ b/src/normalize/cc-api-strip.ts
@@ -88,6 +88,21 @@ export function stripCcApiAwsManagedFields(
 // protection and a user key colliding with an ALWAYS_STRIPPED name (e.g. `CreatedBy`)
 // would be stripped one level down. No real type nests objects under these parents today,
 // so this is a defensive hardening to keep the two free-form guards consistent.
+// #915: ALWAYS_STRIPPED is EXACT-match, so managed-timestamp NAME VARIANTS AWS uses on some
+// types (CreateTime, UpdateTime, ModifiedAt, ModificationTime, LastUpdatedAt, CreationTimestamp,
+// LastModifiedTimeStamp, …) leak through — and on a MODELED (non-readOnly) time prop that is a
+// hidden #847-class moving value, that becomes a first-run FP which re-drifts on every read.
+// Catch them with an ANCHORED, separator/case-normalized match: a curated managed-audit PREFIX
+// immediately followed by a time SUFFIX. Anchored (`^…$`) so a user field that merely CONTAINS a
+// time word is NEVER stripped — `StartTime`/`EndTime` (declarable), `ActiveDate`/`InactiveDate`,
+// `ExpireTime`, `ValidFrom`, `UpdateTimeout` all fail the match. Errs toward UNDER-stripping (a
+// managed variant not in the prefix set stays a harmless FP) rather than over-stripping (hiding
+// real drift). Complements — does not replace — the exact ALWAYS_STRIPPED set + free-form guard.
+const MANAGED_TIMESTAMP_NAME =
+  /^(creation|created|create|lastmodified|lastupdated|lastupdate|modification|modified|updated|update)(date|time|timestamp|at)$/;
+function isManagedTimestampName(key: string): boolean {
+  return MANAGED_TIMESTAMP_NAME.test(key.toLowerCase().replace(/[^a-z0-9]/g, ''));
+}
 function stripWalk(value: unknown, freeForm: boolean): unknown {
   if (value === null || value === undefined) return value;
   if (Array.isArray(value)) {
@@ -107,7 +122,7 @@ function stripWalk(value: unknown, freeForm: boolean): unknown {
   if (typeof value === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, child] of Object.entries(value as Record<string, unknown>)) {
-      if (!freeForm && ALWAYS_STRIPPED.has(k)) continue;
+      if (!freeForm && (ALWAYS_STRIPPED.has(k) || isManagedTimestampName(k))) continue;
       out[k] = stripWalk(child, freeForm || FREE_FORM_MAP_PARENTS.has(k));
     }
     return out;

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -1032,6 +1032,45 @@ describe('noise suppressors', () => {
     ).toEqual({ UserPoolTags: { CreatedBy: 'team-x', env: 'prod' } });
   });
 
+  it('#915: strips managed-timestamp NAME VARIANTS the exact ALWAYS_STRIPPED set misses', () => {
+    const out = stripCcApiAwsManagedFields({
+      Name: 'keep',
+      CreateTime: 't',
+      UpdateTime: 't',
+      ModifiedAt: 't',
+      ModificationTime: 't',
+      LastUpdatedAt: 't',
+      CreationTimestamp: 't',
+      LastModifiedTimeStamp: 't',
+      ModificationTimestamp: 't',
+    });
+    expect(out).toEqual({ Name: 'keep' });
+    // nested (structured, non-free-form) variants strip too
+    expect(stripCcApiAwsManagedFields({ Config: { CreatedAt: 't', Threshold: 5 } })).toEqual({
+      Config: { Threshold: 5 },
+    });
+  });
+
+  it('#915: the anchored match NEVER over-strips a user field that merely contains a time word', () => {
+    // declarable / user-meaningful time props must survive (a false strip would HIDE real drift)
+    const props = {
+      StartTime: '2020',
+      EndTime: '2021',
+      ActiveDate: '2020',
+      InactiveDate: '2021',
+      ExpireTime: '2022',
+      ValidFrom: '2020',
+      ValidUntil: '2021',
+      UpdateTimeout: 30,
+      CreationPolicy: 'x',
+    };
+    expect(stripCcApiAwsManagedFields({ ...props })).toEqual(props);
+    // and a user key colliding with a variant, inside a free-form map, is preserved
+    expect(stripCcApiAwsManagedFields({ Variables: { CreateTime: 'user-value' } })).toEqual({
+      Variables: { CreateTime: 'user-value' },
+    });
+  });
+
   it('isPemEqual: trailing-newline / CRLF differences on a PEM block are not drift (R125)', () => {
     const key = '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqAQAB\n-----END PUBLIC KEY-----';
     // CloudFront PublicKey EncodedKey: AWS appends a trailing newline on read


### PR DESCRIPTION
Addresses #915 (the no-live `ALWAYS_STRIPPED` variant-blindness hardening).

`ALWAYS_STRIPPED` in `cc-api-strip.ts` is **exact-match**, so managed-timestamp name variants AWS uses on some types (`CreateTime`, `UpdateTime`, `ModifiedAt`, `ModificationTime`, `LastUpdatedAt`, `CreationTimestamp`, `LastModifiedTimeStamp`, …) leak through — and on a **modeled (non-readOnly)** time prop that is a hidden #847-class moving value (the issue's SageMaker MonitoringSchedule case), that becomes a first-run FP which re-drifts on every read.

Add an **anchored, separator/case-normalized** predicate — a curated managed-audit prefix immediately followed by a time suffix:
```
^(creation|created|create|lastmodified|lastupdated|lastupdate|modification|modified|updated|update)(date|time|timestamp|at)$
```
Anchored (`^…$`) so a user field that merely **contains** a time word is **never** stripped — `StartTime`/`EndTime` (declarable), `ActiveDate`/`InactiveDate`, `ExpireTime`, `ValidFrom`, `UpdateTimeout` all fail the match. It errs toward **under**-stripping (a harmless residual FP) rather than **over**-stripping (which would HIDE real drift). Free-form user maps stay protected by the existing guard.

## Scope
This is the issue's **"hardening candidate (separate, no live needed)"**. The 3 live-probe suspects (SageMaker MonitoringSchedule `LastMonitoringExecutionSummary`, Redshift + AAS `ScheduledAction` `StartTime`) each need a live probe (hourly executions / heavy clusters) and remain tracked on #915 for a live hunt.

## Verification
- corpus-replay **unchanged** — no current corpus type leaks these (the issue confirms every type carrying them is already schema-readOnly), so this is pure preventive hardening with zero behavior change on existing data.
- 2 new unit tests: managed variants (`CreateTime`/`ModifiedAt`/`CreationTimestamp`/… + nested) strip; user time-ish fields (`StartTime`/`ActiveDate`/`ExpireTime`/`ValidFrom`/`UpdateTimeout`) + free-form-map collisions are preserved.
- typecheck / `vp check` (0 errors) / build / 4417 unit tests green.