### PR TITLE
fix(diff): fold Neptune default-SG list via the #889 derived gate + Cognito UserPoolUser sub (#976, #844)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -51,6 +51,9 @@ function liveModelMap(reads: Map<string, ReadResult>): Map<string, Record<string
 const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   'AWS::ElasticLoadBalancingV2::LoadBalancer',
   'AWS::EC2::NetworkInterface',
+  // #976: Neptune DBCluster's undeclared VpcSecurityGroupIds default is the VPC default SG —
+  // gated in classify against the prefetched default-SG ids so an OOB swap/append surfaces.
+  'AWS::Neptune::DBCluster',
 ]);
 
 // #889: fetch the account/region VPC-default security-group ids — one `DescribeSecurityGroups`

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -223,6 +223,12 @@ function guardDutyFeaturesAllAtDefault(features: unknown[]): boolean {
 const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   'AWS::ElasticLoadBalancingV2::LoadBalancer': 'SecurityGroups',
   'AWS::EC2::NetworkInterface': 'GroupSet',
+  // #976: a Neptune DBCluster that declares no VpcSecurityGroupIds reads back the VPC's DEFAULT
+  // security group — a single SG, the same AWS first-run default the ALB/ENI cases fold. It is
+  // OOB-mutable (`ModifyDBCluster --vpc-security-group-ids`), so a value-independent fold would
+  // hide an out-of-band SG swap/append (the exact security FN #889 fixed). Gate it through the
+  // same derived VPC-default-SG check: fold a single default SG, surface an append or a swap.
+  'AWS::Neptune::DBCluster': 'VpcSecurityGroupIds',
 };
 /** #889 fold decision for an UNDECLARED default-SG list (ALB SecurityGroups / ENI GroupSet).
  *  Returns whether the value-independent fold should still apply for this live value:
@@ -351,6 +357,18 @@ const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpe
   'AWS::EC2::VPNConnection': {
     VpnTunnelOptionsSpecifications: { idField: 'TunnelInsideCidr', foldHuskExtras: true },
   },
+};
+// #844: identity-keyed live-only elements to fold VALUE-INDEPENDENT (atDefault) by identity —
+// keyed by resourceType -> property -> the SET of identity values that are AWS-assigned. Unlike
+// IDENTITY_KEYED_DEFAULT_ELEMENTS (which deep-equals a curated fixed shape), these carry a
+// per-resource AWS-generated value that has no fixed shape to match, so the fold is by identity
+// alone. Cognito UserPoolUser's `sub` is the server-generated immutable user id (a per-user UUID
+// assigned at creation, never declared) — it must fold, but ONLY `sub`: a console/OOB-added
+// attribute (e.g. `custom:role`, `email_verified`) is NOT in the set, so it still surfaces
+// undeclared (folding all UserAttributes would hide out-of-band attribute injection = a security
+// FN). Consulted from BOTH subset blocks (declared and undeclared UserAttributes).
+const VALUE_INDEPENDENT_KEYED_ELEMENTS: Record<string, Record<string, ReadonlySet<string>>> = {
+  'AWS::Cognito::UserPoolUser': { UserAttributes: new Set(['sub']) },
 };
 // Nested object-arrays whose element identity is a NON-standard field (not Key/Id/
 // AttributeName/IndexName/Name). collectNestedUndeclared aligns identity-keyed arrays so a
@@ -2959,8 +2977,14 @@ export function classifyResource(
             subsetSpec.foldHuskExtras === true &&
             isNestedObject(lEl) &&
             Object.entries(lEl).every(([ek, ev]) => ek === idField || isTrivialEmpty(ev));
+          // #844: an identity whose value AWS assigns (Cognito UserPoolUser `sub` — a per-user
+          // UUID) folds value-independent by identity; a non-listed identity still surfaces.
+          const isValueIndependentId =
+            VALUE_INDEPENDENT_KEYED_ELEMENTS[resourceType]?.[k]?.has(id) ?? false;
           const atDefault =
-            isHuskExtra || (defaultEls && id in defaultEls && deepEqual(lEl, defaultEls[id]));
+            isHuskExtra ||
+            isValueIndependentId ||
+            (defaultEls && id in defaultEls && deepEqual(lEl, defaultEls[id]));
           findings.push({
             tier: atDefault ? 'atDefault' : 'undeclared',
             logicalId,
@@ -3679,7 +3703,15 @@ export function classifyResource(
     // array sibling of the #555/#624 object descend.
     const subsetSpecU = IDENTITY_KEYED_SUBSET_ARRAYS[resourceType]?.[k];
     const defaultElsU = IDENTITY_KEYED_DEFAULT_ELEMENTS[resourceType]?.[k];
-    if (subsetSpecU !== undefined && defaultElsU !== undefined && Array.isArray(v)) {
+    // #844: a fully-undeclared UserAttributes array reaches here (nothing declared) — its
+    // AWS-assigned `sub` must fold value-independent by identity too, so enter this block when
+    // EITHER a curated default-shape table or a value-independent-identity table exists.
+    const viIdsU = VALUE_INDEPENDENT_KEYED_ELEMENTS[resourceType]?.[k];
+    if (
+      subsetSpecU !== undefined &&
+      (defaultElsU !== undefined || viIdsU !== undefined) &&
+      Array.isArray(v)
+    ) {
       const { idField, normalizeId } = subsetSpecU;
       for (const lEl of v) {
         if (!isNestedObject(lEl) || typeof lEl[idField] !== 'string') {
@@ -3688,7 +3720,9 @@ export function classifyResource(
         }
         const raw = lEl[idField] as string;
         const id = normalizeId ? normalizeId(raw) : raw;
-        const atDefault = id in defaultElsU && deepEqual(lEl, defaultElsU[id]);
+        const atDefault =
+          (viIdsU?.has(id) ?? false) ||
+          (defaultElsU !== undefined && id in defaultElsU && deepEqual(lEl, defaultElsU[id]));
         findings.push({
           tier: atDefault ? 'atDefault' : 'undeclared',
           logicalId,

--- a/tests/classify-cognito-userpooluser-sub-844.test.ts
+++ b/tests/classify-cognito-userpooluser-sub-844.test.ts
@@ -1,0 +1,81 @@
+// #844 — a Cognito UserPoolUser's UserAttributes reads back the server-generated immutable `sub`
+// (a per-user UUID assigned at creation, never declared). It must fold atDefault, but ONLY `sub`:
+// a console/OOB-added attribute (custom:role, email_verified, …) MUST still surface as undeclared
+// (folding all UserAttributes would hide out-of-band attribute injection = a security FN). The
+// fold is a PER-ELEMENT value-independent gate keyed on the attribute Name === 'sub'.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const pathsOf = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const SUB = { Name: 'sub', Value: '04c894d8-20e1-70ed-175e-9a01d11f7f45' };
+const ROLE = { Name: 'custom:role', Value: 'admin' };
+const EMAIL = { Name: 'email', Value: 'cdkrd@example.com' };
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'User',
+  resourceType: 'AWS::Cognito::UserPoolUser',
+  physicalId: 'cdkrd-user',
+  declared,
+});
+
+describe('#844 Cognito UserPoolUser UserAttributes[sub] value-independent fold', () => {
+  it('folds the AWS-assigned `sub` to atDefault (declared email present)', () => {
+    // Template declares only `email`; live returns email + the AWS-injected `sub`.
+    const f = classifyResource(
+      mk({ UserAttributes: [EMAIL] }),
+      {
+        UserAttributes: [EMAIL, SUB],
+      },
+      emptySchema,
+      {}
+    );
+    expect(pathsOf(f, 'atDefault')).toContain('UserAttributes[sub]');
+    expect(pathsOf(f, 'undeclared')).not.toContain('UserAttributes[sub]');
+  });
+
+  it('STILL surfaces a non-sub undeclared attribute (custom:role) while folding sub', () => {
+    // sub folds; a console/OOB-added custom:role must remain undeclared (security-relevant).
+    const f = classifyResource(
+      mk({ UserAttributes: [EMAIL] }),
+      {
+        UserAttributes: [EMAIL, SUB, ROLE],
+      },
+      emptySchema,
+      {}
+    );
+    expect(pathsOf(f, 'atDefault')).toContain('UserAttributes[sub]');
+    expect(pathsOf(f, 'undeclared')).toContain('UserAttributes[custom:role]');
+    expect(pathsOf(f, 'undeclared')).not.toContain('UserAttributes[sub]');
+  });
+
+  it('folds sub value-independently even in a fully-undeclared UserAttributes array', () => {
+    // Nothing declared: the whole live array reaches the undeclared subset path; sub still folds,
+    // a non-sub attribute still surfaces. Proves the fold is sub-ONLY, not whole-array.
+    const f = classifyResource(
+      mk({}),
+      {
+        UserAttributes: [SUB, ROLE],
+      },
+      emptySchema,
+      {}
+    );
+    expect(pathsOf(f, 'atDefault')).toContain('UserAttributes[sub]');
+    expect(pathsOf(f, 'undeclared')).toContain('UserAttributes[custom:role]');
+    expect(pathsOf(f, 'undeclared')).not.toContain('UserAttributes[sub]');
+  });
+});

--- a/tests/classify-sgderive-889.test.ts
+++ b/tests/classify-sgderive-889.test.ts
@@ -45,6 +45,13 @@ const CASES: Array<{ label: string; type: string; key: string }> = [
     type: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
     key: 'SecurityGroups',
   },
+  // #976: Neptune DBCluster's undeclared VpcSecurityGroupIds defaults to the VPC default SG and is
+  // OOB-mutable (ModifyDBCluster) — same derived gate as ALB/ENI, not a value-independent fold.
+  {
+    label: 'Neptune DBCluster VpcSecurityGroupIds',
+    type: 'AWS::Neptune::DBCluster',
+    key: 'VpcSecurityGroupIds',
+  },
 ];
 
 for (const { label, type, key } of CASES) {
@@ -106,5 +113,21 @@ describe('#889 shouldFoldDefaultSgList (pure decision)', () => {
     expect(shouldFoldDefaultSgList(t, 'GroupSet', [ROGUE_SG], new Set())).toBe(true);
     // a non-gated (type, key) pair is not this gate's business
     expect(shouldFoldDefaultSgList(t, 'PrivateIpAddress', ['10.0.0.1'], defaultSgIds)).toBe(false);
+  });
+
+  it('#976: Neptune DBCluster VpcSecurityGroupIds folds single-default / surfaces swap / fails open', () => {
+    const n = 'AWS::Neptune::DBCluster';
+    const k = 'VpcSecurityGroupIds';
+    // single VPC-default SG → fold
+    expect(shouldFoldDefaultSgList(n, k, [DEFAULT_SG], defaultSgIds)).toBe(true);
+    // 2-element append → surface
+    expect(shouldFoldDefaultSgList(n, k, [DEFAULT_SG, ROGUE_SG], defaultSgIds)).toBe(false);
+    // single non-default (swap) → surface
+    expect(shouldFoldDefaultSgList(n, k, [ROGUE_SG], defaultSgIds)).toBe(false);
+    // fail open: no resolved ids → fold (empty or undefined)
+    expect(shouldFoldDefaultSgList(n, k, [ROGUE_SG], undefined)).toBe(true);
+    expect(shouldFoldDefaultSgList(n, k, [ROGUE_SG], new Set())).toBe(true);
+    // a DIFFERENT Neptune key is not this gate's business (only VpcSecurityGroupIds is gated)
+    expect(shouldFoldDefaultSgList(n, 'DBSubnetGroupName', ['x'], defaultSgIds)).toBe(false);
   });
 });

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -8057,18 +8057,38 @@ describe('Cognito UserPoolUser UserAttributes identity-keyed subset (found by co
   const liveEmail = { Value: 'cdkrd@example.com', Name: 'email' }; // key order differs
   const liveSub = { Value: '04c894d8-20e1-70ed-175e-9a01d11f7f45', Name: 'sub' };
 
-  it('the AWS-injected sub attribute does NOT false-drift the whole UserAttributes array', () => {
+  it('the AWS-injected sub attribute folds atDefault (#844) — not undeclared, not declared drift', () => {
     const findings = classifyResource(
       user({ UserAttributes: [declaredEmail] }),
       { UserAttributes: [liveEmail, liveSub] },
       bare
     );
     expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
-    // sub surfaces as nested undeclared inventory, keyed by Name
-    const undeclared = findings.filter(
-      (f) => f.tier === 'undeclared' && f.path === 'UserAttributes[sub]'
+    // #844: sub is the AWS-assigned immutable user id — folds atDefault (value-independent),
+    // never surfaces as undeclared [Potential Drift] on a clean first check.
+    expect(
+      findings.filter((f) => f.tier === 'undeclared' && f.path === 'UserAttributes[sub]')
+    ).toHaveLength(0);
+    expect(
+      findings.filter((f) => f.tier === 'atDefault' && f.path === 'UserAttributes[sub]')
+    ).toHaveLength(1);
+  });
+
+  it('a non-sub OOB-added UserAttribute STILL surfaces as undeclared while sub folds (#844)', () => {
+    const findings = classifyResource(
+      user({ UserAttributes: [declaredEmail] }),
+      {
+        UserAttributes: [liveEmail, liveSub, { Name: 'custom:role', Value: 'admin' }],
+      },
+      bare
     );
-    expect(undeclared).toHaveLength(1);
+    // sub folds atDefault; the console/OOB-added custom:role must remain visible (security FN guard).
+    expect(
+      findings.filter((f) => f.tier === 'atDefault' && f.path === 'UserAttributes[sub]')
+    ).toHaveLength(1);
+    expect(
+      findings.filter((f) => f.tier === 'undeclared' && f.path === 'UserAttributes[custom:role]')
+    ).toHaveLength(1);
   });
 
   it('an out-of-band change to the DECLARED email attribute is reported as declared drift', () => {

--- a/tests/corpus/AWS__Cognito__UserPoolUser.User.json
+++ b/tests/corpus/AWS__Cognito__UserPoolUser.User.json
@@ -88,7 +88,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolUserRich/User"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "User",
       "resourceType": "AWS::Cognito::UserPoolUser",
       "path": "UserAttributes[sub]",

--- a/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
+++ b/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
@@ -146,7 +146,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Neptune::DBCluster",
       "path": "VpcSecurityGroupIds",

--- a/tests/noise-corpus-placement-976.test.ts
+++ b/tests/noise-corpus-placement-976.test.ts
@@ -9,9 +9,10 @@ import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
 // (core-invariant violation). All fold value-independent (tier-3): moving GA version / per-
 // account managed-key ARN / per-deploy placement / per-resource AWS-assigned identifier — never
 // a constant we can pin, and never user intent when undeclared (a user who cares DECLARES it, and
-// it is then compared in the declared loop). Neptune's VpcSecurityGroupIds is DELIBERATELY NOT
-// folded — it is MUTABLE out of band (ModifyDBCluster swaps SGs with no replacement), so folding
-// it would hide an OOB SG swap; it stays undeclared, tracked by #889.
+// it is then compared in the declared loop). Neptune's VpcSecurityGroupIds is MUTABLE out of band
+// (ModifyDBCluster swaps SGs) — folding it value-independent would hide an OOB SG swap. #976 folds
+// it through the SAME #889 derived VPC-default-SG gate: a single VPC-default SG folds atDefault
+// (or fail-open when the default-SG prefetch is unavailable), while a swap/append SURFACES.
 const emptySchema: SchemaInfo = {
   readOnly: new Set(),
   writeOnly: new Set(),
@@ -74,15 +75,35 @@ describe('#976 corpus baked first-run FP batch: AWS-assigned placement/key/versi
     expect(tier(f, 'undeclared')).not.toContain('AvailabilityZones');
   });
 
-  it('Neptune DBCluster: VpcSecurityGroupIds is NOT folded — mutable, still surfaces (#889)', () => {
+  it('Neptune DBCluster: VpcSecurityGroupIds folds a single default SG, surfaces an OOB swap (#976/#889)', () => {
     const declared = { DBSubnetGroupName: 'neptune-subnet-group' };
-    const f = classifyResource(
+    const defaultSgIds = new Set(['sg-09a4346aa4ef78d16']);
+    // Single VPC-default SG with the default-SG prefetch resolved → fold atDefault (clean deploy).
+    const clean = classifyResource(
+      mk('AWS::Neptune::DBCluster', declared),
+      { ...declared, VpcSecurityGroupIds: ['sg-09a4346aa4ef78d16'] },
+      emptySchema,
+      { defaultSgIds }
+    );
+    expect(tier(clean, 'atDefault')).toContain('VpcSecurityGroupIds');
+    expect(tier(clean, 'undeclared')).not.toContain('VpcSecurityGroupIds');
+    // An out-of-band SG swap (a non-default SG) SURFACES — the security detection #889 preserves.
+    const swapped = classifyResource(
+      mk('AWS::Neptune::DBCluster', declared),
+      { ...declared, VpcSecurityGroupIds: ['sg-0rogue00000000000'] },
+      emptySchema,
+      { defaultSgIds }
+    );
+    expect(tier(swapped, 'undeclared')).toContain('VpcSecurityGroupIds');
+    expect(tier(swapped, 'atDefault')).not.toContain('VpcSecurityGroupIds');
+    // Fail open: no default-SG prefetch (corpus replay path) → fold, no first-run FP.
+    const failOpen = classifyResource(
       mk('AWS::Neptune::DBCluster', declared),
       { ...declared, VpcSecurityGroupIds: ['sg-09a4346aa4ef78d16'] },
       emptySchema
     );
-    expect(tier(f, 'undeclared')).toContain('VpcSecurityGroupIds');
-    expect(tier(f, 'atDefault')).not.toContain('VpcSecurityGroupIds');
+    expect(tier(failOpen, 'atDefault')).toContain('VpcSecurityGroupIds');
+    expect(tier(failOpen, 'undeclared')).not.toContain('VpcSecurityGroupIds');
   });
 
   it('TransitGateway: undeclared minted default route-table ids fold to atDefault', () => {


### PR DESCRIPTION
## Summary

Two closing fixes for the AWS-assigned-at-creation undeclared-FP class.

### FIX 1 — #976 remaining item: Neptune `DBCluster` `VpcSecurityGroupIds`
An undeclared `VpcSecurityGroupIds` defaults to the VPC's DEFAULT security group (a single SG) and is OOB-mutable (`ModifyDBCluster --vpc-security-group-ids`). It now folds through the SAME #889 DERIVED VPC-default-SG gate (`DEFAULT_SG_LIST_PATHS` + `shouldFoldDefaultSgList`), NOT a value-independent fold:
- a single VPC-default SG folds `atDefault` (clean deploy), or fails open when the default-SG prefetch is unavailable;
- a 2+-element APPEND or a single NON-default SWAP **SURFACES** — the OOB security detection is preserved.

`gather.ts` adds `AWS::Neptune::DBCluster` to `DEFAULT_SG_LIST_TYPES` so a Neptune-bearing stack prefetches the default SGs (otherwise it always fails open and never detects a swap). DocDB's `VpcSecurityGroupIds` is DECLARED and untouched.

### FIX 2 — #844 remaining item: Cognito `UserPoolUser` `UserAttributes[sub]`
`sub` is the AWS-generated immutable per-user UUID assigned at creation, never declared. A new PER-ELEMENT value-independent gate (`VALUE_INDEPENDENT_KEYED_ELEMENTS`) folds ONLY the `sub` element `atDefault`; a console/OOB-added attribute (`custom:role`, `email_verified`, …) STILL surfaces as `undeclared` — folding all UserAttributes would hide OOB attribute injection (a security FN). Consulted from both the declared and fully-undeclared subset paths.

### Out-of-band detection preserved
- Neptune: a single default SG folds; an SG swap/append surfaces (unit-tested).
- Cognito: `sub` folds; a non-`sub` UserAttribute surfaces (unit-tested, proving sub-only).

### Tests
- `tests/classify-sgderive-889.test.ts`: Neptune added to the derived-gate cases + pure-decision assertions.
- `tests/classify-cognito-userpooluser-sub-844.test.ts` (new): sub-only fold, non-sub surfaces, fully-undeclared array.
- `tests/classify.test.ts` + `tests/noise-corpus-placement-976.test.ts`: updated to the new folded behavior.
- Corpus `AWS__Neptune__DBCluster.Cluster.json` + `AWS__Cognito__UserPoolUser.User.json` expected: `undeclared` → `atDefault`.

Gates: `vp run typecheck` clean, `vp run check` 0 errors, `vp pack` ok, `vp test run` 4425 passed.

Closes #976
Closes #844