### PR TITLE
fix(diff): gate TargetGroup Targets on a dynamic-registrar sibling instead of value-independent (#891)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -385,6 +385,7 @@ interface ClassifyOpts {
   siblingManagedPolicyAttachments: Record<string, string[]>;
   siblingUserGroups: Record<string, string[]>;
   siblingEipAssociations: Set<string>;
+  siblingTargetGroupRegistrars: Set<string>;
   bucketNotificationManaged: Set<string>;
   clusterEchoModel: Record<string, Record<string, unknown>>;
   rdsOptionSettingDefaults: Record<string, Record<string, Record<string, string | null>>>;
@@ -716,6 +717,88 @@ export function buildSiblingEipAssociations(desired: Desired): Set<string> {
     }
   }
   return associated;
+}
+
+// An AWS::ElasticLoadBalancingV2::TargetGroup's live `Targets` reflects whatever is REGISTERED into
+// the group. When a DECLARED sibling dynamically registers targets — an AWS::ECS::Service
+// (`LoadBalancers[].TargetGroupArn`), an AWS::AutoScaling::AutoScalingGroup (`TargetGroupARNs`), or
+// the group's own `TargetType: lambda` (a lambda registration is managed by AWS) — the membership
+// is IaC-driven runtime churn (task IPs / instances recycle), NOT template intent, so classify
+// folds it. A group with NO such registrar and a NON-EMPTY live Targets is an out-of-band
+// `elbv2 register-targets` — traffic interception — and must SURFACE (#891). This set holds the
+// identities (logicalId AND physicalId == the TG ARN) of every TargetGroup a declared sibling (or
+// its own lambda TargetType) registers into. Fail-open: a reference that does not resolve to a
+// known TargetGroup is skipped (that group keeps a visible finding, never a hidden change).
+const ECS_SERVICE_TYPE = 'AWS::ECS::Service';
+const AUTO_SCALING_GROUP_TYPE = 'AWS::AutoScaling::AutoScalingGroup';
+const TARGET_GROUP_TYPE = 'AWS::ElasticLoadBalancingV2::TargetGroup';
+export function buildSiblingTargetGroupRegistrars(desired: Desired): Set<string> {
+  // Map every TargetGroup's logicalId to its own identities (logicalId + physicalId == TG ARN) and
+  // also index by physicalId, so a sibling referencing the TG by `{Ref}` (== the ARN), a GetAtt, an
+  // ImportValue, or the raw ARN string can be resolved to the identities classify looks it up by.
+  const tgIdentitiesByLogicalId = new Map<string, string[]>();
+  const tgLogicalIdByPhysicalId = new Map<string, string>();
+  for (const r of desired.resources) {
+    if (r.resourceType !== TARGET_GROUP_TYPE) continue;
+    const ids = [r.logicalId];
+    if (r.physicalId) {
+      ids.push(r.physicalId);
+      tgLogicalIdByPhysicalId.set(r.physicalId, r.logicalId);
+    }
+    tgIdentitiesByLogicalId.set(r.logicalId, ids);
+  }
+  const registered = new Set<string>();
+  const markTg = (ref: unknown): void => {
+    // A sibling names a TG by ARN: a `{Ref: <tgLogicalId>}` (resolves to the ARN), a
+    // `{Fn::GetAtt: [<tgLogicalId>, ...]}`, a `{Fn::ImportValue: ...}` (cross-stack — unresolvable
+    // to a local TG, skipped fail-open), or the resolved ARN string. Resolve any of these to the
+    // TG's identities and mark them all as sibling-registered.
+    let tgLogicalId: string | undefined;
+    if (ref && typeof ref === 'object') {
+      if ('Ref' in ref && typeof (ref as { Ref: unknown }).Ref === 'string') {
+        tgLogicalId = (ref as { Ref: string }).Ref;
+      } else if ('Fn::GetAtt' in ref) {
+        const g = (ref as { 'Fn::GetAtt': unknown })['Fn::GetAtt'];
+        if (Array.isArray(g) && typeof g[0] === 'string') tgLogicalId = g[0];
+      }
+      // A `{Fn::ImportValue: ...}` (or any other intrinsic) does not resolve to a local TG → skip.
+    }
+    if (tgLogicalId !== undefined) {
+      const ids = tgIdentitiesByLogicalId.get(tgLogicalId);
+      if (ids) for (const id of ids) registered.add(id);
+      return;
+    }
+    // A resolved ARN string (== the TG's physical id) — mark it and its logicalId directly.
+    if (typeof ref === 'string' && ref) {
+      registered.add(ref);
+      const logicalId = tgLogicalIdByPhysicalId.get(ref);
+      if (logicalId) registered.add(logicalId);
+    }
+  };
+  for (const r of desired.resources) {
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const d = decl as Record<string, unknown>;
+    if (r.resourceType === ECS_SERVICE_TYPE) {
+      // An ECS service dynamically registers its tasks into each LoadBalancers[].TargetGroupArn.
+      const lbs = d.LoadBalancers;
+      if (Array.isArray(lbs)) {
+        for (const lb of lbs) {
+          if (lb && typeof lb === 'object') markTg((lb as Record<string, unknown>).TargetGroupArn);
+        }
+      }
+    } else if (r.resourceType === AUTO_SCALING_GROUP_TYPE) {
+      // An ASG dynamically registers its instances into each of its TargetGroupARNs.
+      const arns = d.TargetGroupARNs;
+      if (Array.isArray(arns)) for (const arn of arns) markTg(arn);
+    } else if (r.resourceType === TARGET_GROUP_TYPE && d.TargetType === 'lambda') {
+      // A lambda target group's membership is a lambda registration AWS manages — treat the TG's
+      // own lambda TargetType as a registrar so its live `Targets` folds.
+      const ids = tgIdentitiesByLogicalId.get(r.logicalId);
+      if (ids) for (const id of ids) registered.add(id);
+    }
+  }
+  return registered;
 }
 
 // Per Aurora DBInstance physical id, the parent DBCluster's live model — the source for the
@@ -1128,6 +1211,7 @@ export async function gatherFindings(
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     siblingListenerPorts: buildSiblingListenerPorts(desired),
     siblingEipAssociations: buildSiblingEipAssociations(desired),
+    siblingTargetGroupRegistrars: buildSiblingTargetGroupRegistrars(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
@@ -1230,6 +1314,7 @@ export async function regatherTouched(
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     siblingListenerPorts: buildSiblingListenerPorts(desired),
     siblingEipAssociations: buildSiblingEipAssociations(desired),
+    siblingTargetGroupRegistrars: buildSiblingTargetGroupRegistrars(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -87,6 +87,12 @@ export interface CorpusCase {
     // atDefault exactly as a real check does. Stored as an array (JSON has no Set); replay revives
     // it to a Set. Optional for back-compat (pre-#892 cases and non-EIP cases lack it).
     siblingEipAssociations?: string[];
+    // This TargetGroup's own identity (physicalId, else logicalId), present only when a declared
+    // sibling dynamically registers into it (an ECS Service, an ASG, or its own lambda TargetType),
+    // so replay reproduces the `generated` Targets fold and the case folds exactly as a real check
+    // does. Stored as an array (JSON has no Set); replay revives it to a Set. Optional for
+    // back-compat (pre-#891 cases and non-TargetGroup cases lack it).
+    siblingTargetGroupRegistrars?: string[];
     // The parent DBCluster's live model keyed by THIS instance's physical id — present only on a
     // CLUSTER_ECHO_CHILD case (an Aurora DBInstance echoing its cluster), so replay reproduces the
     // cluster-echo strip. Without it a fresh-harvested reader/writer replays the un-folded echo
@@ -133,6 +139,7 @@ export function buildCorpusCase(
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
     bucketNotificationManaged?: Set<string>;
     siblingEipAssociations?: Set<string>;
+    siblingTargetGroupRegistrars?: Set<string>;
     clusterEchoModel?: Record<string, Record<string, unknown>>;
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
     siblingListenerPorts?: Record<string, number>;
@@ -158,6 +165,15 @@ export function buildCorpusCase(
     resource.physicalId && opts.siblingEipAssociations?.has(resource.physicalId)
       ? resource.physicalId
       : opts.siblingEipAssociations?.has(resource.logicalId)
+        ? resource.logicalId
+        : undefined;
+  // Carry ONLY this TG's own identity from the stack-wide registrar set. classify keys the
+  // Targets `generated` fold on the physicalId first, else the logicalId — carry the same one that
+  // is present, so replay folds the same way the live check did.
+  const tgRegistrarId =
+    resource.physicalId && opts.siblingTargetGroupRegistrars?.has(resource.physicalId)
+      ? resource.physicalId
+      : opts.siblingTargetGroupRegistrars?.has(resource.logicalId)
         ? resource.logicalId
         : undefined;
   const echoModel =
@@ -215,6 +231,7 @@ export function buildCorpusCase(
         : {}),
       ...(bucketNotif ? { bucketNotificationManaged: bucketNotif } : {}),
       ...(eipSiblingId ? { siblingEipAssociations: [eipSiblingId] } : {}),
+      ...(tgRegistrarId ? { siblingTargetGroupRegistrars: [tgRegistrarId] } : {}),
       ...(echoModel && resource.physicalId
         ? { clusterEchoModel: { [resource.physicalId]: echoModel } }
         : {}),
@@ -246,23 +263,33 @@ export function reviveSchema(s: CorpusCase['schema']): SchemaInfo {
 }
 
 /** Revive a case's stored opts into the shape classifyResource expects: the JSON case stores
- *  `bucketNotificationManaged` / `siblingEipAssociations` as arrays (JSON has no Set) but classify
- *  wants Sets, so convert them; every other opts field passes through unchanged. Both replay call
- *  sites (corpus-replay + measure-noise) go through here so they stay in lockstep. */
+ *  `bucketNotificationManaged` / `siblingEipAssociations` / `siblingTargetGroupRegistrars` as arrays
+ *  (JSON has no Set) but classify wants Sets, so convert them; every other opts field passes through
+ *  unchanged. Both replay call sites (corpus-replay + measure-noise) go through here so they stay in
+ *  lockstep. */
 export function reviveOpts(o: CorpusCase['opts']): Omit<
   CorpusCase['opts'],
-  'bucketNotificationManaged' | 'siblingEipAssociations'
+  'bucketNotificationManaged' | 'siblingEipAssociations' | 'siblingTargetGroupRegistrars'
 > & {
   bucketNotificationManaged?: Set<string>;
   siblingEipAssociations?: Set<string>;
+  siblingTargetGroupRegistrars?: Set<string>;
 } {
-  const { bucketNotificationManaged, siblingEipAssociations, ...rest } = o;
+  const {
+    bucketNotificationManaged,
+    siblingEipAssociations,
+    siblingTargetGroupRegistrars,
+    ...rest
+  } = o;
   return {
     ...rest,
     ...(bucketNotificationManaged
       ? { bucketNotificationManaged: new Set(bucketNotificationManaged) }
       : {}),
     ...(siblingEipAssociations ? { siblingEipAssociations: new Set(siblingEipAssociations) } : {}),
+    ...(siblingTargetGroupRegistrars
+      ? { siblingTargetGroupRegistrars: new Set(siblingTargetGroupRegistrars) }
+      : {}),
   };
 }
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1708,6 +1708,15 @@ export function classifyResource(
     // `associate-address` HIJACK of the static IP and SURFACES (#892). The ENI value is AWS-assigned
     // at association time, so the fold is presence-gated (a declaring sibling explains any binding).
     siblingEipAssociations?: Set<string>;
+    // Identities (logicalId + physicalId == the TG ARN) of every AWS::ElasticLoadBalancingV2::
+    // TargetGroup a DECLARED sibling dynamically registers into — an AWS::ECS::Service
+    // (LoadBalancers[].TargetGroupArn), an AWS::AutoScaling::AutoScalingGroup (TargetGroupARNs), or
+    // the group's own TargetType: lambda (see buildSiblingTargetGroupRegistrars). A TG's live
+    // `Targets` reflects the registered membership; a sibling-registered group's membership is
+    // IaC-driven runtime churn (task IPs / instances recycle) and folds `generated`, but a NON-EMPTY
+    // membership on a TG NO registrar explains is an out-of-band `elbv2 register-targets` — traffic
+    // interception — and SURFACES (#891). Presence-gated (a registrar explains any membership).
+    siblingTargetGroupRegistrars?: Set<string>;
     // Bucket physical ids whose S3 notifications are managed by a Custom::S3BucketNotifications
     // custom resource (see buildBucketNotificationManaged): the live bucket reflects the
     // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
@@ -3638,6 +3647,21 @@ export function classifyResource(
     // and un-settable. Folded as `generated` (never drift, recorded, or reverted) so it
     // does not churn into false undeclared drift after any out-of-band API edit.
     if (GENERATED_TOPLEVEL_PATHS[resourceType]?.has(k)) {
+      findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
+      continue;
+    }
+    // A TargetGroup's undeclared live `Targets` is folded `generated` (runtime membership churn,
+    // never drift) ONLY when a DECLARED sibling dynamically registers into it — an ECS Service, an
+    // ASG, or its own lambda TargetType (see buildSiblingTargetGroupRegistrars). With NO such
+    // registrar the value is KEPT: a NON-EMPTY membership is an out-of-band `elbv2 register-targets`
+    // (traffic interception) and falls through to `undeclared` below; an EMPTY `Targets: []` is
+    // dropped by the shared trivial-empty rule. The old blanket generated fold hid both (#891).
+    if (
+      resourceType === 'AWS::ElasticLoadBalancingV2::TargetGroup' &&
+      k === 'Targets' &&
+      ((physicalId !== undefined && opts.siblingTargetGroupRegistrars?.has(physicalId)) ||
+        opts.siblingTargetGroupRegistrars?.has(logicalId))
+    ) {
       findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
       continue;
     }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2443,12 +2443,14 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // AWS-minted identity, not user intent; a Secret that DECLARES a Name carries it in the
   // template and never reaches this loop.
   'AWS::SecretsManager::Secret': new Set(['Name']),
-  // A target group's `Targets` that the template does not declare holds the targets AWS/ECS
-  // registered at RUNTIME (dynamic task IPs) — not template intent, and they churn as tasks
-  // recycle, so surfacing them as recordable drift is non-actionable (a record snapshot
-  // immediately re-drifts). A group that DECLARES static Targets carries them in the template
-  // and is compared normally, so a removed/changed static target still surfaces.
-  'AWS::ElasticLoadBalancingV2::TargetGroup': new Set(['Targets']),
+  // NOTE: AWS::ElasticLoadBalancingV2::TargetGroup.Targets is NOT folded here (#891). A blanket
+  // fold hid an out-of-band `elbv2 register-targets` pointing a listener's production traffic at
+  // an attacker-controlled instance/IP — a live (non-empty) Targets membership read CLEAN and
+  // survived record. Dynamic runtime churn (ECS task IPs / ASG instances) is real, but it only
+  // applies when a DECLARED sibling dynamically registers into the group (an ECS Service, an ASG,
+  // or a lambda TargetType). classify folds `Targets` via the sibling-derived registrar gate
+  // (opts.siblingTargetGroupRegistrars) and SURFACES a non-empty membership no registrar explains;
+  // an EMPTY live `Targets: []` is dropped by the shared trivial-empty rule either way.
   // An Application Auto Scaling policy attached to a target via ScalingTargetId (the CDK
   // pattern) reads back the target's ResourceId / ServiceNamespace / ScalableDimension,
   // which AWS derives from the target and the template never declares. They echo the

--- a/tests/classify-tg-targets-registrar-891.test.ts
+++ b/tests/classify-tg-targets-registrar-891.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildSiblingTargetGroupRegistrars } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #891 (SECURITY FN): AWS::ElasticLoadBalancingV2::TargetGroup `Targets` was folded `generated`
+// VALUE-INDEPENDENT for EVERY group, so an out-of-band `elbv2 register-targets` — pointing a
+// listener's production traffic at an attacker-controlled instance/IP — read CLEAN and survived
+// record. The blanket fold is replaced with a TIER-2 sibling-derived registrar gate: a group into
+// which a DECLARED sibling dynamically registers (an ECS Service, an ASG, or its own lambda
+// TargetType) FOLDS its live membership; a NON-EMPTY membership on a group NO registrar explains
+// SURFACES as [Potential Drift]. The registrar identities are built by
+// gather.buildSiblingTargetGroupRegistrars and consumed in classify via
+// opts.siblingTargetGroupRegistrars. An EMPTY live `Targets: []` is dropped either way (not a FP).
+
+const TG_ARN =
+  'arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/tg/1234567890abcdef';
+
+const tgSchema: SchemaInfo = {
+  readOnly: new Set([
+    'TargetGroupArn',
+    'TargetGroupName',
+    'TargetGroupFullName',
+    'LoadBalancerArns',
+  ]),
+  writeOnly: new Set([]),
+  createOnly: new Set(['Name', 'Port', 'Protocol', 'ProtocolVersion', 'TargetType', 'VpcId']),
+  readOnlyPaths: ['TargetGroupArn', 'TargetGroupName', 'TargetGroupFullName', 'LoadBalancerArns'],
+  writeOnlyPaths: [],
+  createOnlyPaths: ['Name', 'Port', 'Protocol', 'ProtocolVersion', 'TargetType', 'VpcId'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tgResource = (declared: Record<string, unknown> = {}): DesiredResource => ({
+  logicalId: 'Tg',
+  resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+  physicalId: TG_ARN,
+  declared,
+});
+
+// A group with a live non-empty registered membership (an undeclared Targets list).
+const registeredLive = (): Record<string, unknown> => ({
+  TargetGroupArn: TG_ARN,
+  Targets: [{ Id: 'i-0abc123def4567890', Port: 80 }],
+});
+
+const targetsFindings = (findings: Finding[], tier: string) =>
+  findings.filter((f) => f.tier === tier && f.path === 'Targets');
+
+describe('#891 TargetGroup Targets sibling-derived registrar gate', () => {
+  it('(map) marks a TG registered into by a declared ECS Service (LoadBalancers[].TargetGroupArn)', () => {
+    const desired: Desired = {
+      resources: [
+        tgResource(),
+        {
+          logicalId: 'Svc',
+          resourceType: 'AWS::ECS::Service',
+          declared: {
+            LoadBalancers: [
+              { TargetGroupArn: { Ref: 'Tg' }, ContainerName: 'app', ContainerPort: 80 },
+            ],
+          },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildSiblingTargetGroupRegistrars(desired);
+    expect(map.has('Tg')).toBe(true);
+    expect(map.has(TG_ARN)).toBe(true);
+  });
+
+  it('(map) marks a TG registered into by a declared ASG (TargetGroupARNs)', () => {
+    const desired: Desired = {
+      resources: [
+        tgResource(),
+        {
+          logicalId: 'Asg',
+          resourceType: 'AWS::AutoScaling::AutoScalingGroup',
+          declared: { TargetGroupARNs: [{ Ref: 'Tg' }] },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildSiblingTargetGroupRegistrars(desired);
+    expect(map.has('Tg')).toBe(true);
+    expect(map.has(TG_ARN)).toBe(true);
+  });
+
+  it('(map) marks a TG referenced by its resolved ARN string (not just {Ref})', () => {
+    const desired: Desired = {
+      resources: [
+        tgResource(),
+        {
+          logicalId: 'Asg',
+          resourceType: 'AWS::AutoScaling::AutoScalingGroup',
+          declared: { TargetGroupARNs: [TG_ARN] },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildSiblingTargetGroupRegistrars(desired);
+    expect(map.has('Tg')).toBe(true);
+    expect(map.has(TG_ARN)).toBe(true);
+  });
+
+  it('(map) marks a lambda-TargetType TG as its own registrar', () => {
+    const desired: Desired = {
+      resources: [tgResource({ TargetType: 'lambda' })],
+    } as unknown as Desired;
+    const map = buildSiblingTargetGroupRegistrars(desired);
+    expect(map.has('Tg')).toBe(true);
+    expect(map.has(TG_ARN)).toBe(true);
+  });
+
+  it('(map) a TG with NO registrar sibling is not marked', () => {
+    const desired: Desired = {
+      resources: [tgResource({ TargetType: 'instance' })],
+    } as unknown as Desired;
+    const map = buildSiblingTargetGroupRegistrars(desired);
+    expect(map.has('Tg')).toBe(false);
+    expect(map.has(TG_ARN)).toBe(false);
+  });
+
+  it('(map) a cross-stack Fn::ImportValue reference is skipped fail-open (not marked)', () => {
+    const desired: Desired = {
+      resources: [
+        tgResource(),
+        {
+          logicalId: 'Svc',
+          resourceType: 'AWS::ECS::Service',
+          declared: {
+            LoadBalancers: [{ TargetGroupArn: { 'Fn::ImportValue': 'OtherStack:TgArn' } }],
+          },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildSiblingTargetGroupRegistrars(desired);
+    expect(map.has('Tg')).toBe(false);
+  });
+
+  it('(1) a registrar-explained non-empty membership FOLDS (no Targets drift)', () => {
+    // A declared ECS/ASG registrar (or lambda TargetType) owns the membership → folded generated.
+    const siblingTargetGroupRegistrars = new Set(['Tg', TG_ARN]);
+    const findings = classifyResource(tgResource(), registeredLive(), tgSchema, {
+      siblingTargetGroupRegistrars,
+    });
+    expect(targetsFindings(findings, 'undeclared')).toEqual([]);
+    expect(targetsFindings(findings, 'generated').length).toBe(1);
+  });
+
+  it('(2) a registrar-LESS non-empty membership SURFACES (the OOB register-targets hijack)', () => {
+    // No declaring registrar → the live Targets membership is an out-of-band register-targets and
+    // must surface as undeclared drift.
+    const findings = classifyResource(tgResource(), registeredLive(), tgSchema, {
+      siblingTargetGroupRegistrars: new Set<string>(),
+    });
+    const surfaced = targetsFindings(findings, 'undeclared');
+    expect(surfaced.length).toBe(1);
+    expect(surfaced[0]?.actual).toEqual([{ Id: 'i-0abc123def4567890', Port: 80 }]);
+  });
+
+  it('(2b) with NO registrar map at all → a non-empty membership still SURFACES (fail-open to visible)', () => {
+    const findings = classifyResource(tgResource(), registeredLive(), tgSchema);
+    expect(targetsFindings(findings, 'undeclared').length).toBe(1);
+  });
+
+  it('(3) an EMPTY live Targets [] with no registrar produces NO finding (not a false undeclared)', () => {
+    const live: Record<string, unknown> = { TargetGroupArn: TG_ARN, Targets: [] };
+    const findings = classifyResource(tgResource(), live, tgSchema, {
+      siblingTargetGroupRegistrars: new Set<string>(),
+    });
+    expect(findings.some((f) => f.path === 'Targets')).toBe(false);
+  });
+
+  it('(3b) an EMPTY live Targets [] WITH a registrar also produces no undeclared drift', () => {
+    const live: Record<string, unknown> = { TargetGroupArn: TG_ARN, Targets: [] };
+    const findings = classifyResource(tgResource(), live, tgSchema, {
+      siblingTargetGroupRegistrars: new Set(['Tg', TG_ARN]),
+    });
+    expect(targetsFindings(findings, 'undeclared')).toEqual([]);
+  });
+});

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -9926,7 +9926,7 @@ describe('real-stack false-positive folds', () => {
     expect(t.undeclared).toEqual(['LoadBalancerAttributes[access_logs.s3.enabled]']);
   });
 
-  it('SecretsManager Secret generated Name (no stack prefix) + TargetGroup runtime Targets fold to generated', () => {
+  it('SecretsManager Secret generated Name (no stack prefix) + TargetGroup registrar-gated Targets fold (#891)', () => {
     const secret: DesiredResource = {
       logicalId: 'Sec',
       resourceType: 'AWS::SecretsManager::Secret',
@@ -9944,15 +9944,26 @@ describe('real-stack false-positive folds', () => {
       physicalId: 'tg-1',
       declared: {},
     };
-    const t = tiers(
-      classifyResource(
-        tg,
-        { Targets: [{ Port: 80, AvailabilityZone: 'ap-northeast-1a', Id: '10.0.0.1' }] },
-        mkSchema()
-      )
+    const liveTargets = {
+      Targets: [{ Port: 80, AvailabilityZone: 'ap-northeast-1a', Id: '10.0.0.1' }],
+    };
+    // #891: with a DECLARED registrar (ECS/ASG/lambda) the runtime membership folds `generated`.
+    const withRegistrar = tiers(
+      classifyResource(tg, liveTargets, mkSchema(), {
+        siblingTargetGroupRegistrars: new Set(['Tg', 'tg-1']),
+      })
     );
-    expect(t.generated).toEqual(['Targets']);
-    expect(t.undeclared).toEqual([]);
+    expect(withRegistrar.generated).toEqual(['Targets']);
+    expect(withRegistrar.undeclared).toEqual([]);
+    // #891: with NO registrar the same non-empty membership is an out-of-band register-targets and
+    // must SURFACE as undeclared drift (the blanket generated fold hid this traffic-interception FN).
+    const noRegistrar = tiers(
+      classifyResource(tg, liveTargets, mkSchema(), {
+        siblingTargetGroupRegistrars: new Set<string>(),
+      })
+    );
+    expect(noRegistrar.generated).toEqual([]);
+    expect(noRegistrar.undeclared).toEqual(['Targets']);
   });
 });
 

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.GrpcTgF27A0024.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.GrpcTgF27A0024.json
@@ -317,15 +317,6 @@
       "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
     },
     {
-      "tier": "generated",
-      "logicalId": "GrpcTgF27A0024",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "Targets",
-      "actual": [],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
-      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "GrpcTgF27A0024",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.InstTg162F7452.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.InstTg162F7452.json
@@ -316,15 +316,6 @@
       "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
     },
     {
-      "tier": "generated",
-      "logicalId": "InstTg162F7452",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "Targets",
-      "actual": [],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
-      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "InstTg162F7452",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgBB611D2A.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgBB611D2A.json
@@ -294,15 +294,6 @@
       "constructPath": "CdkRealDriftIntegAlbRich/Tg"
     },
     {
-      "tier": "generated",
-      "logicalId": "TgBB611D2A",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "Targets",
-      "actual": [],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
-      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "TgBB611D2A",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::ElasticLoadBalancingV2::TargetGroup model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::ElasticLoadBalancingV2::TargetGroup model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
   "resource": {
     "logicalId": "Web3C8945DB",
     "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
@@ -288,15 +288,6 @@
       "actual": {
         "HttpCode": "200"
       },
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
-      "constructPath": "CdkrdIntegHarvest4/Web"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "Web3C8945DB",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "Targets",
-      "actual": [],
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
       "constructPath": "CdkrdIntegHarvest4/Web"
     },


### PR DESCRIPTION
Closes #891. Replaces the blanket 'generated' fold (which hid OOB elbv2 register-targets traffic interception) with a tier-2 sibling-derived gate (#892 pattern): a TG registered by an ECS Service / ASG / lambda TargetType folds; a non-empty membership no registrar explains SURFACES; empty Targets stays trivial-dropped. Corpus opts carry siblingTargetGroupRegistrars. Unit-tested all three cases. See commit body.