### PR TITLE
fix(noise): fold LakeFormation PrincipalPermissions undeclared Catalog=<account> (#930)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2291,6 +2291,15 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string
   // account id; equality-gated, so a Tag pointed at another account's catalog still surfaces.
   // Live-confirmed (#914).
   'AWS::LakeFormation::Tag': { CatalogId: '{accountId}' },
+  // A LakeFormation PrincipalPermissions that declares no `Catalog` reads back the deploying
+  // account id — the same own-account Data Catalog default as the Tag echo above (its optional
+  // top-level `Catalog` property defaults to the account id per the registry schema, and CC's
+  // read handler echoes it). `Catalog` is createOnly (IMMUTABLE type — no update handler), so it
+  // cannot drift out of band; equality-gated `{accountId}`, so a grant pointed at another
+  // account's catalog still surfaces. #930 (part 1 — the Tag-sibling family; DataCellsFilter's
+  // TableCatalogId is REQUIRED so always declared, and TagAssociation carries CatalogId only in
+  // nested sub-refs — both out of scope here).
+  'AWS::LakeFormation::PrincipalPermissions': { Catalog: '{accountId}' },
   // An S3 Access Point that declares no BucketAccountId reads back the deploying account id —
   // the default bucket-owner account. The bare `{accountId}` placeholder substitutes to the
   // account id; equality-gated, so an AccessPoint pointed at a cross-account bucket owner still

--- a/tests/noise-folds-910-914.test.ts
+++ b/tests/noise-folds-910-914.test.ts
@@ -110,3 +110,34 @@ describe('#914 LakeFormation Tag undeclared CatalogId=<account>', () => {
     expect(pathsByTier(f, 'undeclared')).toContain('CatalogId');
   });
 });
+
+describe('#930 LakeFormation PrincipalPermissions undeclared Catalog=<account>', () => {
+  const res: DesiredResource = {
+    logicalId: 'LfPerm',
+    resourceType: 'AWS::LakeFormation::PrincipalPermissions',
+    physicalId: 'perm',
+    declared: {
+      Principal: { DataLakePrincipalIdentifier: 'arn:aws:iam::111122223333:role/analyst' },
+      Resource: { Database: { CatalogId: '111122223333', Name: 'sales' } },
+      Permissions: ['DESCRIBE'],
+      PermissionsWithGrantOption: [],
+    },
+  };
+  const opts = { accountId: '111122223333', region: 'us-east-1' };
+  it('folds Catalog equal to the deploying account id to atDefault', () => {
+    const f = classifyResource(res, { Catalog: '111122223333' }, emptySchema, opts);
+    expect(pathsByTier(f, 'atDefault')).toContain('Catalog');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Catalog');
+  });
+  it('surfaces a Catalog pointed at another account as undeclared', () => {
+    const f = classifyResource(res, { Catalog: '999988887777' }, emptySchema, opts);
+    expect(pathsByTier(f, 'undeclared')).toContain('Catalog');
+  });
+  it('leaves Catalog undeclared (recordable) when the account is unresolved', () => {
+    const f = classifyResource(res, { Catalog: '111122223333' }, emptySchema, {
+      region: 'us-east-1',
+    });
+    expect(pathsByTier(f, 'atDefault')).not.toContain('Catalog');
+    expect(pathsByTier(f, 'undeclared')).toContain('Catalog');
+  });
+});


### PR DESCRIPTION
Addresses #930 part 1 for `AWS::LakeFormation::PrincipalPermissions`.

Its optional top-level `Catalog` (createOnly) defaults to the deploying account id (own-account Data Catalog) when undeclared — the same per-account-constant echo #914 folded for `LakeFormation::Tag` CatalogId. `describe-type` confirms the type is IMMUTABLE with a `read` handler (CC echoes it). Folded via `CONTEXT_ARN_DEFAULTS { Catalog: '{accountId}' }`, equality-gated so a grant pointed at another account's catalog still surfaces; `Catalog` is createOnly so it cannot drift out of band.

**Scope narrowed by schema evidence:** DataCellsFilter's `TableCatalogId` is REQUIRED (always declared — no undeclared echo, skipped); TagAssociation carries CatalogId only in nested sub-refs (deferred — needs live). Part 2 (the `LakeFormation::Resource` CC read gap) already landed via #1245.

**Live note:** a fresh LakeFormation-admin deploy is deferred (it mutates account-wide Lake Formation settings — risky to leave); the fold rests on describe-type CC-readability + the schema's documented account default + the live-proven #914 Tag precedent, and the equality gate on a createOnly property makes an over-fold impossible (a different-account or user-set value still surfaces).