### PR TITLE
fix(read): fold RDS cluster implicit members by name signature, not membership (#985)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -117,7 +117,6 @@ import {
 } from '@aws-sdk/client-lambda';
 import {
   type DBInstance as RdsDBInstance,
-  DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
   RDSClient,
 } from '@aws-sdk/client-rds';
@@ -3258,22 +3257,35 @@ async function enumerateEfsFileSystemChildren(ctx: EnumeratorContext): Promise<A
 export interface RdsClusterChildInput {
   declaredInstanceIds: string[]; // physical ids (DBInstanceIdentifiers) of AWS::RDS::DBInstance
   liveInstances: { id: string; label?: string | undefined }[];
-  // DBInstanceIdentifiers the PARENT cluster reports as its own members (DBClusterMembers).
-  // These are AWS-managed cluster membership, NOT out-of-band additions: a Multi-AZ DB cluster
-  // (non-Aurora, DBClusterInstanceClass set) implicitly materializes its writer + reader
-  // instances (`<cluster>-instance-1/2/3`) that the template never declares, so they must fold
-  // (else 3 false `[Added]` on every clean deploy — the #801-class ZERO-drift violation, #896).
-  // The cluster itself is the authoritative source of truth for membership, so this needs no
-  // name-marker guess and still surfaces a genuinely out-of-band instance (one NOT a member).
-  clusterMemberIds: string[];
+  clusterId: string; // the parent DBClusterIdentifier — anchors the implicit-member name pattern
+  // The parent declares `DBClusterInstanceClass` → it is a Multi-AZ DB cluster (non-Aurora),
+  // which IMPLICITLY materializes its writer + reader instances (`<clusterId>-instance-N`) that
+  // the template never declares. Those (and ONLY those) AWS-managed implicit members must fold
+  // (#896: else 3 false `[Added]` on every clean deploy — the #801-class ZERO-drift violation).
+  // Aurora clusters have no implicit members: every instance is either declared or an AAS reader.
+  isMultiAzCluster: boolean;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// A Multi-AZ DB cluster names its AWS-created implicit members `<clusterId>-instance-N` (N ≥ 1),
+// a reserved shape the user cannot pick for an out-of-band `create-db-instance`. Match that exact
+// shape — NOT bare cluster membership (every instance a `db-cluster-id` query returns IS a member,
+// so membership folds EVERYTHING and disables OOB detection, #985). A rogue instance with any
+// other name still surfaces as `[Added]`.
+function isMultiAzImplicitMember(instanceId: string, clusterId: string): boolean {
+  return new RegExp(`^${escapeRegExp(clusterId)}-instance-\\d+$`).test(instanceId);
 }
 
 export function diffRdsClusterChildren(input: RdsClusterChildInput): AddedChild[] {
   const declared = new Set(input.declaredInstanceIds);
-  const clusterMembers = new Set(input.clusterMemberIds);
   const added: AddedChild[] = [];
   for (const i of input.liveInstances) {
-    if (declared.has(i.id) || clusterMembers.has(i.id)) continue;
+    if (declared.has(i.id)) continue;
+    // Fold ONLY the Multi-AZ AWS-managed implicit members (by name signature), not membership.
+    if (input.isMultiAzCluster && isMultiAzImplicitMember(i.id, input.clusterId)) continue;
     added.push({
       resourceType: 'AWS::RDS::DBInstance',
       identifier: i.id, // DBInstanceIdentifier IS the CC primaryIdentifier
@@ -3310,21 +3322,16 @@ async function pageDbInstances(client: RDSClient, clusterId: string): Promise<Rd
   return out;
 }
 
-// The cluster's OWN live description authoritatively lists its members (each DBClusterMembers
-// entry carries a DBInstanceIdentifier). Instances it claims are AWS-managed membership, not
-// out-of-band additions — folded by diffRdsClusterChildren (see #896).
-async function describeClusterMemberIds(client: RDSClient, clusterId: string): Promise<string[]> {
-  const res = await client.send(new DescribeDBClustersCommand({ DBClusterIdentifier: clusterId }));
-  const cluster = res.DBClusters?.[0];
-  return (cluster?.DBClusterMembers ?? [])
-    .map((m) => m.DBInstanceIdentifier)
-    .filter((id): id is string => typeof id === 'string');
-}
-
 export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
   const { parent, desired, region } = ctx;
   const clusterId = parent.physicalId; // a DBCluster's physical id IS its DBClusterIdentifier
   if (!clusterId) return [];
+
+  // A Multi-AZ DB cluster (non-Aurora) is the one that implicitly materializes undeclared
+  // member instances; the CFn `DBClusterInstanceClass` property is its required marker (Aurora
+  // clusters never declare it). Deriving the marker from the DECLARED parent needs no extra API
+  // call — and NOT gating fold on live membership is exactly the #985 fix (membership folds all).
+  const isMultiAzCluster = parent.declared.DBClusterInstanceClass != null;
 
   // Declared instances of THIS cluster (Ref/GetAtt DBClusterIdentifier already resolved to
   // the physical id by gather). A DBInstance's CFn physical id (Ref) IS its DBInstanceIdentifier.
@@ -3340,10 +3347,7 @@ export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promi
   }
 
   const client = new RDSClient({ region, ...READ_RETRY });
-  const [instances, clusterMemberIds] = await Promise.all([
-    pageDbInstances(client, clusterId),
-    describeClusterMemberIds(client, clusterId),
-  ]);
+  const instances = await pageDbInstances(client, clusterId);
   const liveInstances = instances
     .filter(
       (i): i is RdsDBInstance & { DBInstanceIdentifier: string } =>
@@ -3358,7 +3362,12 @@ export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promi
     )
     .map((i) => ({ id: i.DBInstanceIdentifier, label: i.DBInstanceIdentifier }));
 
-  return diffRdsClusterChildren({ declaredInstanceIds, liveInstances, clusterMemberIds });
+  return diffRdsClusterChildren({
+    declaredInstanceIds,
+    liveInstances,
+    clusterId,
+    isMultiAzCluster,
+  });
 }
 
 // ── Route53 ──────────────────────────────────────────────────────────────────

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -5,11 +5,7 @@ import {
   ListFunctionUrlConfigsCommand,
   ListVersionsByFunctionCommand,
 } from '@aws-sdk/client-lambda';
-import {
-  DescribeDBClustersCommand,
-  DescribeDBInstancesCommand,
-  RDSClient,
-} from '@aws-sdk/client-rds';
+import { DescribeDBInstancesCommand, RDSClient } from '@aws-sdk/client-rds';
 import { ListResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { ListSubscriptionsByTopicCommand, SNSClient } from '@aws-sdk/client-sns';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -1937,7 +1933,8 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
         { id: 'cluster-writer', label: 'cluster-writer' },
         { id: 'cdkrd-integ-oob', label: 'cdkrd-integ-oob' },
       ],
-      clusterMemberIds: [],
+      clusterId: 'cluster',
+      isMultiAzCluster: false,
     });
     expect(added).toEqual([
       {
@@ -1953,7 +1950,8 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
     const added = diffRdsClusterChildren({
       declaredInstanceIds: [],
       liveInstances: [{ id: 'reader-1', label: 'reader-1' }],
-      clusterMemberIds: [],
+      clusterId: 'cluster',
+      isMultiAzCluster: false,
     });
     expect(added[0]!.identifier).toBe('reader-1');
   });
@@ -1966,24 +1964,29 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
           { id: 'writer', label: 'writer' },
           { id: 'reader', label: 'reader' },
         ],
-        clusterMemberIds: [],
+        clusterId: 'cluster',
+        isMultiAzCluster: false,
       })
     ).toEqual([]);
   });
 
-  // #896: a Multi-AZ DB cluster implicitly materializes its writer + 2 reader instances
-  // (undeclared) — folded because the parent cluster reports them in DBClusterMembers; a
-  // genuinely out-of-band instance (NOT a member) still surfaces.
-  it('folds implicit cluster members (in DBClusterMembers) but still flags a non-member instance', () => {
+  // #896: a Multi-AZ DB cluster implicitly materializes its writer + 2 reader instances named
+  // `<clusterId>-instance-N` (undeclared) — folded by that reserved name signature.
+  // #985: the fold must key on the name signature, NOT bare cluster membership — a
+  // `create-db-instance --db-cluster-identifier <cluster>` attaches a member (so it appears in
+  // both the `db-cluster-id` inventory AND DBClusterMembers), and a membership-keyed fold would
+  // silently drop it. With a name-signature fold, the rogue member still surfaces as `[Added]`.
+  it('folds Multi-AZ implicit members by name signature but flags a rogue member (#985)', () => {
     const added = diffRdsClusterChildren({
       declaredInstanceIds: [],
       liveInstances: [
         { id: 'c1-instance-1', label: 'c1-instance-1' },
         { id: 'c1-instance-2', label: 'c1-instance-2' },
         { id: 'c1-instance-3', label: 'c1-instance-3' },
-        { id: 'rogue-oob', label: 'rogue-oob' },
+        { id: 'rogue-oob', label: 'rogue-oob' }, // a real cluster member added out of band
       ],
-      clusterMemberIds: ['c1-instance-1', 'c1-instance-2', 'c1-instance-3'],
+      clusterId: 'c1',
+      isMultiAzCluster: true,
     });
     expect(added).toEqual([
       {
@@ -1994,35 +1997,42 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
       },
     ]);
   });
+
+  // #985: on an Aurora cluster (no DBClusterInstanceClass → isMultiAzCluster false) there are no
+  // AWS-managed implicit members; an instance that merely mimics the `<clusterId>-instance-N`
+  // shape is NOT folded, so an out-of-band member still surfaces.
+  it('does not fold the implicit-member name shape on a non-Multi-AZ (Aurora) cluster (#985)', () => {
+    const added = diffRdsClusterChildren({
+      declaredInstanceIds: ['writer'],
+      liveInstances: [
+        { id: 'writer', label: 'writer' },
+        { id: 'c1-instance-1', label: 'c1-instance-1' },
+      ],
+      clusterId: 'c1',
+      isMultiAzCluster: false,
+    });
+    expect(added.map((a) => a.identifier)).toEqual(['c1-instance-1']);
+  });
 });
 
-describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896)', () => {
-  it('folds the Multi-AZ cluster member instances the parent reports, flags a non-member', async () => {
+describe('enumerateRdsClusterChildren (Multi-AZ implicit-member fold, #896/#985)', () => {
+  // The realistic live shape: `DescribeDBInstances(db-cluster-id)` returns EXACTLY the cluster's
+  // members, so the AWS-managed implicit members (`c1-instance-N`) AND a rogue out-of-band member
+  // both appear in the same list. A name-signature fold drops only the implicit members; the
+  // rogue member (any other name) still surfaces — the #985 fix (membership alone folds all).
+  it('folds implicit `<clusterId>-instance-N` members but flags a rogue member on a Multi-AZ cluster', async () => {
     const rds = mockClient(RDSClient);
-    rds
-      .on(DescribeDBInstancesCommand)
-      .resolves({
-        DBInstances: [
-          { DBInstanceIdentifier: 'c1-instance-1' },
-          { DBInstanceIdentifier: 'c1-instance-2' },
-          { DBInstanceIdentifier: 'c1-instance-3' },
-          { DBInstanceIdentifier: 'rogue-oob' },
-        ],
-      })
-      .on(DescribeDBClustersCommand)
-      .resolves({
-        DBClusters: [
-          {
-            DBClusterMembers: [
-              { DBInstanceIdentifier: 'c1-instance-1' },
-              { DBInstanceIdentifier: 'c1-instance-2' },
-              { DBInstanceIdentifier: 'c1-instance-3' },
-            ],
-          },
-        ],
-      });
+    rds.on(DescribeDBInstancesCommand).resolves({
+      DBInstances: [
+        { DBInstanceIdentifier: 'c1-instance-1' },
+        { DBInstanceIdentifier: 'c1-instance-2' },
+        { DBInstanceIdentifier: 'c1-instance-3' },
+        { DBInstanceIdentifier: 'rogue-oob' },
+      ],
+    });
     const ctx = {
-      parent: { physicalId: 'c1' },
+      // A Multi-AZ DB cluster declares DBClusterInstanceClass (required for that mode).
+      parent: { physicalId: 'c1', declared: { DBClusterInstanceClass: 'db.r6g.large' } },
       desired: { resources: [] },
       region: 'us-east-1',
     } as unknown as EnumeratorContext;
@@ -2037,28 +2047,16 @@ describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896)', () => {
   // permanent first-run false positive; revert would offer to delete an autoscaler reader).
   it('excludes Application Auto Scaling readers (application-autoscaling-*) while keeping normal instances', async () => {
     const rds = mockClient(RDSClient);
-    rds
-      .on(DescribeDBInstancesCommand)
-      .resolves({
-        DBInstances: [
-          { DBInstanceIdentifier: 'cluster-writer' },
-          { DBInstanceIdentifier: 'cluster-reader' },
-          { DBInstanceIdentifier: 'application-autoscaling-4d1e2f3a-0b5c-6789-abcd-ef0123456789' },
-        ],
-      })
-      .on(DescribeDBClustersCommand)
-      .resolves({
-        DBClusters: [
-          {
-            DBClusterMembers: [
-              { DBInstanceIdentifier: 'cluster-writer' },
-              { DBInstanceIdentifier: 'cluster-reader' },
-            ],
-          },
-        ],
-      });
+    rds.on(DescribeDBInstancesCommand).resolves({
+      DBInstances: [
+        { DBInstanceIdentifier: 'cluster-writer' },
+        { DBInstanceIdentifier: 'cluster-reader' },
+        { DBInstanceIdentifier: 'application-autoscaling-4d1e2f3a-0b5c-6789-abcd-ef0123456789' },
+      ],
+    });
     const ctx = {
-      parent: { physicalId: 'c1' },
+      // Aurora cluster (no DBClusterInstanceClass) — instances are declared, AAS reader filtered.
+      parent: { physicalId: 'c1', declared: {} },
       // Both normal instances are declared in the template.
       desired: {
         resources: [
@@ -2086,15 +2084,11 @@ describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896)', () => {
   // prefix) is still flagged if out of band.
   it('does not fold an instance whose identifier only contains application-autoscaling- as a substring', async () => {
     const rds = mockClient(RDSClient);
-    rds
-      .on(DescribeDBInstancesCommand)
-      .resolves({
-        DBInstances: [{ DBInstanceIdentifier: 'my-application-autoscaling-reader' }],
-      })
-      .on(DescribeDBClustersCommand)
-      .resolves({ DBClusters: [{ DBClusterMembers: [] }] });
+    rds.on(DescribeDBInstancesCommand).resolves({
+      DBInstances: [{ DBInstanceIdentifier: 'my-application-autoscaling-reader' }],
+    });
     const ctx = {
-      parent: { physicalId: 'c1' },
+      parent: { physicalId: 'c1', declared: {} },
       desired: { resources: [] },
       region: 'us-east-1',
     } as unknown as EnumeratorContext;


### PR DESCRIPTION
Closes #985

## Problem

The #896/#935 fold (fold Multi-AZ DB cluster implicit member instances, not `added`) keyed on the parent cluster's `DBClusterMembers` list. But the enumerator's OWN inventory source — `DescribeDBInstances` filtered by `db-cluster-id` — returns **exactly** the cluster's member set. So every live instance was a member, and `clusterMembers.has(id)` folded **all** of them: the `added` set was always empty for any real cluster state.

An out-of-band `aws rds create-db-instance --db-cluster-identifier <cluster> --db-instance-identifier rogue …` attaches a read replica that immediately becomes a member, so it appears in BOTH `DescribeDBInstances(db-cluster-id)` AND `DBClusterMembers` → folded → **silently invisible** and survives `record`. This disabled cdkrd's headline out-of-band-`added` detection for every RDS cluster (a rogue reader = cost bomb / data-exfil vector).

The passing unit test asserted an **unreachable** state (a live instance in `liveInstances` but absent from `clusterMemberIds`), giving false confidence.

## Fix

Membership is not the discriminator (all cluster instances are members). Fold only the **AWS-managed Multi-AZ implicit members** by their reserved name signature `<clusterId>-instance-N`, gated on the parent declaring `DBClusterInstanceClass` (the Multi-AZ-cluster marker, read from the **declared** template — no extra API call).

- Aurora clusters have no implicit members (every instance is declared or an `application-autoscaling-` reader, already filtered before the diff), so `isMultiAzCluster` is false and nothing is folded by name there.
- A member with any other name still surfaces as `[Added]`.
- Drops the now-redundant `DescribeDBClusters` call.

This is the tier-2 "AWS-managed child predicate" #801/#896 asked for — a signature match, not a membership match — preserving both the #896 zero-drift invariant and out-of-band detection.

## Tests

- `diffRdsClusterChildren`: the **realistic same-set case** (implicit members `c1-instance-1..3` + a rogue member `rogue-oob`, all in the live list) now surfaces the rogue; a non-Multi-AZ (Aurora) cluster does not fold an instance that merely mimics the `<clusterId>-instance-N` shape.
- `enumerateRdsClusterChildren`: updated to the realistic live shape (no `DescribeDBClusters` mock; Multi-AZ parent declares `DBClusterInstanceClass`); AAS-reader and substring cases preserved.

Full suite green (4439 tests), typecheck + `vp run check` clean.
