### PR TITLE
fix(read): fold RDS cluster implicit members by name signature so a rogue OOB instance surfaces (#985)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -3256,16 +3256,32 @@ async function enumerateEfsFileSystemChildren(ctx: EnumeratorContext): Promise<A
 
 // Pure diff: declared instance ids + live inventory -> the added DB instances.
 export interface RdsClusterChildInput {
+  clusterId: string; // the parent DBClusterIdentifier — anchors the implicit-member name signature
   declaredInstanceIds: string[]; // physical ids (DBInstanceIdentifiers) of AWS::RDS::DBInstance
   liveInstances: { id: string; label?: string | undefined }[];
   // DBInstanceIdentifiers the PARENT cluster reports as its own members (DBClusterMembers).
-  // These are AWS-managed cluster membership, NOT out-of-band additions: a Multi-AZ DB cluster
-  // (non-Aurora, DBClusterInstanceClass set) implicitly materializes its writer + reader
-  // instances (`<cluster>-instance-1/2/3`) that the template never declares, so they must fold
-  // (else 3 false `[Added]` on every clean deploy — the #801-class ZERO-drift violation, #896).
-  // The cluster itself is the authoritative source of truth for membership, so this needs no
-  // name-marker guess and still surfaces a genuinely out-of-band instance (one NOT a member).
+  // WARNING: membership ALONE cannot discriminate AWS-managed from out-of-band (#985). Every
+  // instance in a cluster is a member, AND our live inventory source (`DescribeDBInstances`
+  // filtered by `db-cluster-id`) enumerates the IDENTICAL set — so an out-of-band
+  // `create-db-instance --db-cluster-identifier <cluster>` instance is a member too. Folding
+  // on bare membership therefore drops EVERY instance and disables OOB detection (silent FN).
+  // Instead we fold only the AWS-managed implicit members by their creation SIGNATURE: a
+  // Multi-AZ DB cluster (non-Aurora, DBClusterInstanceClass set) materializes writer + reader
+  // instances named `<clusterId>-instance-<N>` (AWS's documented deterministic naming). Those
+  // must fold (else 3 false `[Added]` on every clean deploy — the #801-class ZERO-drift
+  // violation, #896). Membership is kept as a NECESSARY condition (fold only if the id IS a
+  // member AND matches the signature) — defensive: a non-member never folds by name alone.
+  // (Aurora autoscaling readers `application-autoscaling-<uuid>` are excluded UPSTREAM in
+  // enumerateRdsClusterChildren before the diff, so they do not reach here.)
   clusterMemberIds: string[];
+}
+
+// AWS's deterministic name for a Multi-AZ DB cluster's implicitly-materialized member instances:
+// `<clusterId>-instance-<N>` (N = 1, 2, 3). Anchored + regex-escape the clusterId so a cluster id
+// containing regex-special chars matches literally and an unrelated suffix does not slip through.
+function isImplicitClusterMemberName(clusterId: string, instanceId: string): boolean {
+  const escaped = clusterId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escaped}-instance-\\d+$`).test(instanceId);
 }
 
 export function diffRdsClusterChildren(input: RdsClusterChildInput): AddedChild[] {
@@ -3273,7 +3289,14 @@ export function diffRdsClusterChildren(input: RdsClusterChildInput): AddedChild[
   const clusterMembers = new Set(input.clusterMemberIds);
   const added: AddedChild[] = [];
   for (const i of input.liveInstances) {
-    if (declared.has(i.id) || clusterMembers.has(i.id)) continue;
+    // Fold a declared instance, OR an AWS-managed implicit member — the latter ONLY when it is
+    // both a reported cluster member AND matches the `<clusterId>-instance-<N>` signature (#985:
+    // bare membership can't discriminate an out-of-band member from a managed one).
+    if (
+      declared.has(i.id) ||
+      (clusterMembers.has(i.id) && isImplicitClusterMemberName(input.clusterId, i.id))
+    )
+      continue;
     added.push({
       resourceType: 'AWS::RDS::DBInstance',
       identifier: i.id, // DBInstanceIdentifier IS the CC primaryIdentifier
@@ -3358,7 +3381,12 @@ export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promi
     )
     .map((i) => ({ id: i.DBInstanceIdentifier, label: i.DBInstanceIdentifier }));
 
-  return diffRdsClusterChildren({ declaredInstanceIds, liveInstances, clusterMemberIds });
+  return diffRdsClusterChildren({
+    clusterId,
+    declaredInstanceIds,
+    liveInstances,
+    clusterMemberIds,
+  });
 }
 
 // ── Route53 ──────────────────────────────────────────────────────────────────

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1932,6 +1932,7 @@ describe('diffVpcNaclChildren (EC2 VPC network ACLs) — #1045', () => {
 describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
   it('flags an out-of-band DB instance added via the console (not in the template)', () => {
     const added = diffRdsClusterChildren({
+      clusterId: 'c1',
       declaredInstanceIds: ['cluster-writer'],
       liveInstances: [
         { id: 'cluster-writer', label: 'cluster-writer' },
@@ -1951,6 +1952,7 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
 
   it('identifier is the bare DBInstanceIdentifier (CC primaryIdentifier, not a composite)', () => {
     const added = diffRdsClusterChildren({
+      clusterId: 'c1',
       declaredInstanceIds: [],
       liveInstances: [{ id: 'reader-1', label: 'reader-1' }],
       clusterMemberIds: [],
@@ -1961,6 +1963,7 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
   it('no drift when every live DB instance is declared', () => {
     expect(
       diffRdsClusterChildren({
+        clusterId: 'c1',
         declaredInstanceIds: ['writer', 'reader'],
         liveInstances: [
           { id: 'writer', label: 'writer' },
@@ -1971,19 +1974,20 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
     ).toEqual([]);
   });
 
-  // #896: a Multi-AZ DB cluster implicitly materializes its writer + 2 reader instances
-  // (undeclared) — folded because the parent cluster reports them in DBClusterMembers; a
-  // genuinely out-of-band instance (NOT a member) still surfaces.
-  it('folds implicit cluster members (in DBClusterMembers) but still flags a non-member instance', () => {
+  // #985: the REALISTIC production state — `liveInstances` and `clusterMemberIds` are the SAME
+  // set (every instance in a cluster IS a member, and `DescribeDBInstances(db-cluster-id)`
+  // enumerates exactly the members). A rogue OOB instance (`aws rds create-db-instance
+  // --db-cluster-identifier`) is a member too, so folding on bare membership would drop it. We
+  // fold only the AWS-managed implicit members by their `<clusterId>-instance-<N>` signature; the
+  // rogue member, which matches neither a declared id nor the signature, must still surface.
+  it('folds `<cluster>-instance-N` managed members but surfaces a rogue member in the SAME set (#985)', () => {
+    const members = ['c1-instance-1', 'c1-instance-2', 'rogue-oob'];
     const added = diffRdsClusterChildren({
+      clusterId: 'c1',
       declaredInstanceIds: [],
-      liveInstances: [
-        { id: 'c1-instance-1', label: 'c1-instance-1' },
-        { id: 'c1-instance-2', label: 'c1-instance-2' },
-        { id: 'c1-instance-3', label: 'c1-instance-3' },
-        { id: 'rogue-oob', label: 'rogue-oob' },
-      ],
-      clusterMemberIds: ['c1-instance-1', 'c1-instance-2', 'c1-instance-3'],
+      liveInstances: members.map((id) => ({ id, label: id })),
+      // liveInstances and clusterMemberIds are the SAME set (the reachable production state).
+      clusterMemberIds: members,
     });
     expect(added).toEqual([
       {
@@ -1994,10 +1998,61 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
       },
     ]);
   });
+
+  // A declared instance still folds even though it is (like every instance) a cluster member.
+  it('folds a declared instance that is also a cluster member (#985)', () => {
+    const added = diffRdsClusterChildren({
+      clusterId: 'c1',
+      declaredInstanceIds: ['my-writer'],
+      liveInstances: [{ id: 'my-writer', label: 'my-writer' }],
+      clusterMemberIds: ['my-writer'],
+    });
+    expect(added).toEqual([]);
+  });
+
+  // The signature is only honored as a fold when the id IS a reported member — a
+  // `<cluster>-instance-N`-named instance that is NOT a member (defensive/unreachable) surfaces.
+  it('folds a signature-matching name only when it IS a cluster member (#985)', () => {
+    // Member + signature match → folded.
+    expect(
+      diffRdsClusterChildren({
+        clusterId: 'c1',
+        declaredInstanceIds: [],
+        liveInstances: [{ id: 'c1-instance-1', label: 'c1-instance-1' }],
+        clusterMemberIds: ['c1-instance-1'],
+      })
+    ).toEqual([]);
+    // Signature match but NOT a member → surfaces.
+    expect(
+      diffRdsClusterChildren({
+        clusterId: 'c1',
+        declaredInstanceIds: [],
+        liveInstances: [{ id: 'c1-instance-1', label: 'c1-instance-1' }],
+        clusterMemberIds: [],
+      }).map((a) => a.identifier)
+    ).toEqual(['c1-instance-1']);
+  });
+
+  // A member whose name does not match the `<clusterId>-instance-N` signature (a rogue attached
+  // via create-db-instance with an arbitrary id) surfaces even though it is a member — this is
+  // the core #985 FN: bare membership used to fold it.
+  it('surfaces a member whose name is not the managed signature (#985)', () => {
+    expect(
+      diffRdsClusterChildren({
+        clusterId: 'c1',
+        declaredInstanceIds: [],
+        liveInstances: [{ id: 'exfil-reader', label: 'exfil-reader' }],
+        clusterMemberIds: ['exfil-reader'],
+      }).map((a) => a.identifier)
+    ).toEqual(['exfil-reader']);
+  });
 });
 
-describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896)', () => {
-  it('folds the Multi-AZ cluster member instances the parent reports, flags a non-member', async () => {
+describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896/#985)', () => {
+  // #985: `DescribeDBInstances(db-cluster-id)` and `DBClusterMembers` enumerate the IDENTICAL
+  // set — the rogue instance is a member too. The managed `c1-instance-N` members fold by
+  // signature; the rogue member, whose name is not the signature, must still surface.
+  it('folds the Multi-AZ `c1-instance-N` members but surfaces a rogue member in the SAME set', async () => {
     const rds = mockClient(RDSClient);
     rds
       .on(DescribeDBInstancesCommand)
@@ -2013,10 +2068,13 @@ describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896)', () => {
       .resolves({
         DBClusters: [
           {
+            // The rogue instance is a member too (create-db-instance --db-cluster-identifier
+            // makes it one immediately) — the realistic state the #985 fix must handle.
             DBClusterMembers: [
               { DBInstanceIdentifier: 'c1-instance-1' },
               { DBInstanceIdentifier: 'c1-instance-2' },
               { DBInstanceIdentifier: 'c1-instance-3' },
+              { DBInstanceIdentifier: 'rogue-oob' },
             ],
           },
         ],


### PR DESCRIPTION
Closes #985.

## Problem
`diffRdsClusterChildren` folded any instance the parent cluster reports in `DBClusterMembers`. But the enumerator's live inventory (`DescribeDBInstances` filtered by `db-cluster-id`) returns the **identical** set — every instance in a cluster is a member. So the `added` set was always empty and a genuinely out-of-band instance (`aws rds create-db-instance --db-cluster-identifier <cluster> --db-instance-identifier rogue …`) was silently invisible — the headline out-of-band-resource detection was fully disabled for RDS clusters (high-severity FN, survives `record`).

## Fix
Fold only the AWS-**managed** implicit members by their creation **signature**, not by bare membership: a Multi-AZ DB cluster materializes `<clusterId>-instance-<N>` (AWS's documented deterministic naming). Membership is kept as a necessary condition (fold only if the id IS a member AND matches the signature). Aurora AAS readers (`application-autoscaling-*`) are still excluded upstream. Anything else — a rogue member — now surfaces as `[Added]`.

## Tests
Replaced the test that asserted an **unreachable** state (`liveInstances` ⊋ `clusterMemberIds`) with the realistic production case where both sources are the SAME set, and added coverage: managed `<clusterId>-instance-N` members fold, a rogue member surfaces, a declared instance folds, a signature name folds only when it IS a member. New tests fail against old source, pass with the fix.