### PR TITLE
fix(diff): pin SSMContacts/Scheduler/AppSync order-significant arrays so an OOB reorder surfaces (#880)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -76,6 +76,7 @@ import {
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
   ORDER_SIGNIFICANT_ARRAY_KEYS,
+  ORDER_SIGNIFICANT_PATHS,
   READGAP_COLLECTION_PATHS,
   SCALAR_RETURNED_WHEN_SET,
   READ_NORMALIZED_DECLARED_PATHS,
@@ -1505,7 +1506,13 @@ function sortUnorderedSetProps(
   // reorder at compare time — an asymmetry that false-flagged a nested set AWS re-ordered as
   // "changed since record". Sorting nested paths here too makes the live normalizer's output
   // symmetric with the declared-compare tolerance.
+  // A SCALAR path whose ORDER is semantically significant (AppSync Resolver
+  // `PipelineConfig.Functions` — pipeline functions execute in array order) must NOT be
+  // sorted even when the schema marks it insertionOrder:false: sorting the live side would
+  // fold an out-of-band execution-order change to equality, hiding real drift (#880).
+  const orderSigPaths = ORDER_SIGNIFICANT_PATHS[resourceType];
   for (const path of [...(UNORDERED_ARRAY_PROPS[resourceType] ?? []), ...schemaScalarPaths]) {
+    if (orderSigPaths?.has(path)) continue;
     if (path.includes('.')) sortScalarSetAtNestedPath(model, path.split('.'));
     // Guard on presence — assigning `model[path]` for an absent top-level key would
     // MATERIALIZE it as `undefined`, injecting a phantom key into the live model that
@@ -2926,10 +2933,16 @@ export function classifyResource(
     // ContentPolicyConfig.FiltersConfig etc.): sort the reordered set on both sides so
     // a positional diff doesn't false-flag it.
     const nestedUnordered = UNORDERED_NESTED_OBJECT_ARRAY_PATHS[resourceType];
+    // A NESTED object-array path whose ORDER is semantically significant (Scheduler::Schedule
+    // `Target.EcsParameters.PlacementStrategy` — strategies are evaluated in order) must NOT be
+    // sorted even when the schema marks it insertionOrder:false: sortNestedObjectArrays would
+    // fold an out-of-band reorder to equality, hiding real drift. Compare the FULL path
+    // (`${k}.${subPath}`) since nestedSubPaths are stored RELATIVE to the top-level key k (#880).
+    const orderSigPathsForType = ORDER_SIGNIFICANT_PATHS[resourceType];
     const nestedSubPaths = [
       ...new Set(
         [...(nestedUnordered ?? []), ...(schema.unorderedObjectArrayPaths ?? [])]
-          .filter((p) => p.startsWith(`${k}.`))
+          .filter((p) => p.startsWith(`${k}.`) && !orderSigPathsForType?.has(p))
           .map((p) => p.slice(k.length + 1))
       ),
     ];
@@ -3314,6 +3327,11 @@ export function classifyResource(
           // `Triggers.0.GitConfiguration.Push.0.Branches.Includes` -> `Triggers.*.…Push.*.…`).
           UNORDERED_ARRAY_PROPS[resourceType]?.has(d.path.replace(/\.\d+(?=\.|$)/g, '.*')) ||
           schema.unorderedScalarPaths?.includes(d.path)) &&
+        // An ORDER-significant scalar path (AppSync Resolver `PipelineConfig.Functions` —
+        // functions execute in array order) must NOT fold a reorder to equality: exclude it so
+        // an out-of-band execution-order change surfaces even though the schema lies with
+        // insertionOrder:false (#880).
+        !ORDER_SIGNIFICANT_PATHS[resourceType]?.has(d.path) &&
         isEqualUnorderedScalarSet(d.stateValue, d.awsValue)
       )
         continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3602,6 +3602,28 @@ export const ORDER_SIGNIFICANT_ARRAY_KEYS: Record<string, ReadonlySet<string>> =
   // addresses the RAW live model, so `revert` failed with `noSuchPath //TransformerConfig/0/...`.
   // Pinning it order-significant keeps both compare sides in raw order so the index aligns.
   'AWS::Logs::Transformer': new Set(['TransformerConfig']),
+  // SSMContacts escalation Plan: `Stages` engage IN ARRAY ORDER (stage 1 pages first,
+  // stage 2 after its duration, ...), and its items carry no identity key, so a live
+  // reorder (`update-contact`) that swaps who is paged first must SURFACE, not fold. The
+  // schema marks it insertionOrder:false (a lie); pin it here so the top-level object-array
+  // wiring (canonicalizeTagLists + sortUnorderedSetProps + the declared object-array loop)
+  // keeps it in raw order and a reorder differs positionally (#880).
+  'AWS::SSMContacts::Plan': new Set(['Stages']),
+};
+// Dotted paths (NESTED object arrays and NESTED scalar sets) whose ORDER is semantically
+// significant even though the registry schema marks the array insertionOrder:false — a
+// reorder IS real drift and must surface, not fold. The single-property-name
+// ORDER_SIGNIFICANT_ARRAY_KEYS twin above handles TOP-LEVEL object arrays; this table
+// handles NESTED object arrays AND NESTED scalar sets, keyed by resourceType -> the set of
+// full DOTTED paths whose array must stay in raw order (#880):
+//   - Scheduler::Schedule `Target.EcsParameters.PlacementStrategy` — ECS placement strategies
+//     are EVALUATED IN ORDER (spread-then-binpack != binpack-then-spread); nested object array,
+//     items `{Type, Field}` with no identity key. Mutable out of band via UpdateSchedule.
+//   - AppSync::Resolver `PipelineConfig.Functions` — pipeline functions EXECUTE IN ARRAY ORDER;
+//     a nested SCALAR array (list of function-id strings). Mutable out of band via UpdateResolver.
+export const ORDER_SIGNIFICANT_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::Scheduler::Schedule': new Set(['Target.EcsParameters.PlacementStrategy']),
+  'AWS::AppSync::Resolver': new Set(['PipelineConfig.Functions']),
 };
 export function canonicalizeTagListsDeep(v: unknown, orderSig?: ReadonlySet<string>): unknown {
   return canonicalizeTagLists(v, orderSig, undefined);

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2102,6 +2102,122 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       ).toEqual(['HealthCheckConfig.Regions']);
     });
 
+    // #880: schemas that LIE about insertionOrder:false — the array's order is
+    // semantically significant, so a real out-of-band REORDER must SURFACE (not fold).
+    // These are the ORDER_SIGNIFICANT_ARRAY_KEYS / ORDER_SIGNIFICANT_PATHS pins.
+    it('ORDER_SIGNIFICANT_ARRAY_KEYS: SSMContacts::Plan Stages reorder IS drift, non-reorder is CLEAN (#880)', () => {
+      // The schema marks Stages insertionOrder:false (a lie); escalation stages engage in
+      // array order (stage 1 pages first), so a swap changes who is paged first.
+      const schema: SchemaInfo = {
+        ...emptySchema,
+        unorderedObjectArrayPaths: ['Stages'],
+      };
+      const stages = [
+        { DurationInMinutes: 5, Targets: [{ ChannelTargetInfo: { ContactChannelId: 'chan-a' } }] },
+        { DurationInMinutes: 10, Targets: [{ ChannelTargetInfo: { ContactChannelId: 'chan-b' } }] },
+      ];
+      const plan = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Plan',
+        resourceType: 'AWS::SSMContacts::Plan',
+        physicalId: 'plan-1',
+        declared,
+      });
+      // clean deploy (same order) -> no drift
+      expect(classifyResource(plan({ Stages: stages }), { Stages: stages }, schema)).toEqual([]);
+      // an out-of-band reorder swaps who is paged first -> MUST surface
+      expect(
+        tiers(
+          classifyResource(plan({ Stages: stages }), { Stages: [stages[1], stages[0]] }, schema)
+        ).declared.length
+      ).toBeGreaterThan(0);
+      // WITHOUT the pin the schema flag would fold the reorder — proving the pin drives
+      // the surface. (A hypothetical un-pinned type folds the same reorder.)
+      const unpinned = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Plan',
+        resourceType: 'AWS::Fake::UnpinnedPlan',
+        physicalId: 'plan-1',
+        declared,
+      });
+      expect(
+        classifyResource(unpinned({ Stages: stages }), { Stages: [stages[1], stages[0]] }, schema)
+      ).toEqual([]);
+    });
+
+    it('ORDER_SIGNIFICANT_PATHS: Scheduler::Schedule Target.EcsParameters.PlacementStrategy reorder IS drift, non-reorder is CLEAN (#880)', () => {
+      // The schema marks the nested PlacementStrategy object array insertionOrder:false (a
+      // lie); ECS evaluates strategies in order (spread-then-binpack != binpack-then-spread).
+      const schema: SchemaInfo = {
+        ...emptySchema,
+        unorderedObjectArrayPaths: ['Target.EcsParameters.PlacementStrategy'],
+      };
+      const strat = [
+        { Type: 'spread', Field: 'attribute:ecs.availability-zone' },
+        { Type: 'binpack', Field: 'memory' },
+      ];
+      const model = (s: unknown[]): Record<string, unknown> => ({
+        Target: { EcsParameters: { PlacementStrategy: s } },
+      });
+      const sched = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Sched',
+        resourceType: 'AWS::Scheduler::Schedule',
+        physicalId: 'sched-1',
+        declared,
+      });
+      // clean deploy (same order) -> no drift
+      expect(classifyResource(sched(model(strat)), model(strat), schema)).toEqual([]);
+      // an out-of-band reorder flips the placement priority -> MUST surface
+      expect(
+        tiers(classifyResource(sched(model(strat)), model([strat[1], strat[0]]), schema)).declared
+          .length
+      ).toBeGreaterThan(0);
+      // WITHOUT the pin the schema flag folds the same nested reorder — proving the pin.
+      const unpinned = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Sched',
+        resourceType: 'AWS::Fake::UnpinnedSched',
+        physicalId: 'sched-1',
+        declared,
+      });
+      expect(classifyResource(unpinned(model(strat)), model([strat[1], strat[0]]), schema)).toEqual(
+        []
+      );
+    });
+
+    it('ORDER_SIGNIFICANT_PATHS: AppSync::Resolver PipelineConfig.Functions (scalar) reorder IS drift, non-reorder is CLEAN (#880)', () => {
+      // The schema marks the nested SCALAR Functions list insertionOrder:false (a lie);
+      // pipeline functions EXECUTE in array order, so a reorder changes the execution order.
+      const schema: SchemaInfo = {
+        ...emptySchema,
+        unorderedScalarPaths: ['PipelineConfig.Functions'],
+      };
+      const fns = ['fn-authz', 'fn-fetch', 'fn-transform'];
+      const model = (f: unknown[]): Record<string, unknown> => ({
+        PipelineConfig: { Functions: f },
+      });
+      const resolver = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Resolver',
+        resourceType: 'AWS::AppSync::Resolver',
+        physicalId: 'resolver-1',
+        declared,
+      });
+      // clean deploy (same order) -> no drift
+      expect(classifyResource(resolver(model(fns)), model(fns), schema)).toEqual([]);
+      // an out-of-band reorder changes the execution order -> MUST surface the nested path
+      expect(
+        tiers(classifyResource(resolver(model(fns)), model([fns[2], fns[0], fns[1]]), schema))
+          .declared
+      ).toEqual(['PipelineConfig.Functions']);
+      // WITHOUT the pin the schema flag folds the same scalar reorder — proving the pin.
+      const unpinned = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Resolver',
+        resourceType: 'AWS::Fake::UnpinnedResolver',
+        physicalId: 'resolver-1',
+        declared,
+      });
+      expect(
+        classifyResource(unpinned(model(fns)), model([fns[2], fns[0], fns[1]]), schema)
+      ).toEqual([]);
+    });
+
     // Live-observed FP (rds-logexports-reorder fixture): RDS echoes a DB instance's
     // EnableCloudwatchLogsExports log-type set SORTED alphabetically (declared
     // [slowquery, general, error] read back [error, general, slowquery]). The same


### PR DESCRIPTION
Closes #880.

## Problem
The schema-driven unordered-array fold trusts `insertionOrder: false`, but some registry schemas **lie** — the array order is semantically significant, so a real out-of-band **reorder** folds to equality and is invisible (FN). Three confirmed liars:
- `AWS::SSMContacts::Plan` **Stages** — escalation stages engage in array order.
- `AWS::Scheduler::Schedule` **Target.EcsParameters.PlacementStrategy** — ECS strategies are evaluated in order.
- `AWS::AppSync::Resolver` **PipelineConfig.Functions** — pipeline functions execute in array order.

## Fix
- `Stages` (top-level object array) → added to the existing `ORDER_SIGNIFICANT_ARRAY_KEYS`.
- New dotted-path table `ORDER_SIGNIFICANT_PATHS` for the two **nested** cases, threaded into all three nested fold sites: the scalar sort loop, the `nestedSubPaths` object-array sort, and the declared-loop scalar fold (`isEqualUnorderedScalarSet` guard).

A reorder now surfaces positionally; a clean (non-reordered) deploy stays CLEAN (AWS echoes these arrays in configured order → no first-`check` false positive).

## Tests
Added tests proving each of the three paths surfaces a reordered live array as drift while an identically-ordered array stays clean. New tests fail against old source, pass with the fix. No corpus impact (existing Scheduler/AppSync corpus cases carry no such arrays).