### PR TITLE
fix(report): hash secret-bearing values in the baseline, not plaintext (#798)

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,11 @@ Elastic Beanstalk env-namespace `OptionSettings`, EC2 LaunchTemplate `UserData` 
 are masked as `<redacted:NN chars>` in both text and `--json` output, so a rotated
 secret surfacing as drift does not leak its plaintext into CI logs. The finding
 still surfaces (detection is preserved) and the property/key name stays visible —
-only the value is hidden (#798).
+only the value is hidden. The same protection covers persistence: `record` writes a
+**hash** of these values into the git-committed baseline instead of the plaintext, so
+the secret never lands in a committed file while a later change still re-surfaces as
+drift (an unchanged one stays recorded). Older baselines holding a plaintext value keep
+comparing correctly and migrate to the hashed form on the next `record` (#798).
 
 A **stack that errored or was skipped** before it could be checked still appears as an
 element so a consumer sees which stacks ran: it carries `"error": "<reason>"` alongside

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -28,6 +28,12 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { deepEqual } from '../diff/drift-calculator.js';
 import { canonicalizeBaselineForCompare, canonicalizeForCompare } from '../normalize/pipeline.js';
+import {
+  isRedactedHashSentinel,
+  isRedactedPath,
+  redactedHashOf,
+  redactedHashSentinel,
+} from '../report/redact.js';
 import type { ArrayDelta, Finding } from '../types.js';
 
 export interface RecordedEntry {
@@ -583,7 +589,16 @@ export function buildRecorded(findings: Finding[]): RecordedEntry[] {
         logicalId: f.logicalId,
         resourceType: f.resourceType,
         path: f.path,
-        value: f.actual,
+        // #798 persistence half: a secret-bearing value (a Lambda/CodeBuild env var, EC2
+        // LaunchTemplate UserData, EB env option) must NOT be written in plaintext into the
+        // git-committed baseline. Store a HASH SENTINEL of the CANONICALIZED value instead —
+        // `baselineValueMatches` re-hashes the canonicalized live value to compare, so an
+        // unchanged secret stays recorded (record→check clean) while a rotated one re-surfaces
+        // as drift. The plaintext never reaches `.cdkrd/baselines/*.json`. Hash the same
+        // canonical form the compare path derives so the two hashes align.
+        value: isRedactedPath(f.resourceType, f.path)
+          ? redactedHashSentinel(canonicalizeBaselineForCompare(f.actual, f.resourceType))
+          : f.actual,
       }))
   );
 }
@@ -732,6 +747,20 @@ export function baselineValueMatches(
   currentCanonicalValue: unknown,
   resourceType?: string
 ): boolean {
+  // #798 persistence half: a secret-bearing baseline value is a HASH SENTINEL (record stored
+  // the hash of the canonicalized live value, never the plaintext). When either side is a
+  // sentinel, compare by HASH: reduce each side to its hash (a sentinel yields its stored
+  // hash; a raw value is canonicalized then hashed the same way record did). An unchanged
+  // secret hashes equal in every mix — recorded-set-vs-recorded-set (re-record), sentinel-vs-
+  // live (check/applyBaseline), and old-plaintext-vs-new-sentinel (the first re-record after
+  // upgrade migrates without churn) — while a rotated secret hashes differently and surfaces.
+  if (isRedactedHashSentinel(baselineValue) || isRedactedHashSentinel(currentCanonicalValue)) {
+    const asHash = (v: unknown): string =>
+      redactedHashOf(
+        isRedactedHashSentinel(v) ? v : canonicalizeBaselineForCompare(v, resourceType)
+      );
+    return asHash(baselineValue) === asHash(currentCanonicalValue);
+  }
   return deepEqual(
     canonicalizeBaselineForCompare(baselineValue, resourceType),
     canonicalizeBaselineForCompare(currentCanonicalValue, resourceType)

--- a/src/report/redact.ts
+++ b/src/report/redact.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 // #798 — report-layer redaction of secret-bearing live-readable property VALUES.
 //
 // Several CC/SDK-readable properties routinely carry live secrets (a Lambda env var
@@ -10,10 +12,14 @@
 // preserved), the path/key name stays visible (it is not secret), and the plaintext never
 // reaches the output.
 //
-// SCOPE: OUTPUT ONLY. This layer is consulted by the report renderers (text + --json). It
-// does NOT change classification, folding, or what `record` writes to the baseline (that
-// persistence half is a separate deferred lane, #798). A non-secret property's value is
-// NEVER masked — the table is curated to the secret-bearing paths and nothing else.
+// SCOPE: two halves, ONE curated table. (1) OUTPUT — the report renderers (text + --json)
+// mask the displayed value. (2) PERSISTENCE — `record` writes a HASH SENTINEL (not the
+// plaintext) into the git-committed baseline for the same secret-bearing paths, and
+// `baselineValueMatches` re-hashes the live side to compare (change-detection survives; the
+// plaintext never reaches `.cdkrd/baselines/*.json`). Both halves consult the same
+// `REDACTED_VALUE_PATHS` table, so a path is secret in exactly one place. A non-secret
+// property's value is NEVER masked or hashed — the table is curated to the secret-bearing
+// paths and nothing else. Classification and folding are unchanged.
 
 // The masked placeholder. Keeps the char length as a signal (a rotated 40-char token vs a
 // blanked env var reads differently) without revealing any plaintext. A non-string value
@@ -107,6 +113,10 @@ const REDACTED_VALUE_PATHS: Record<string, RedactMatcher[]> = {
 export function redactValue(resourceType: string, path: string, value: unknown): unknown {
   const matchers = REDACTED_VALUE_PATHS[resourceType];
   if (!matchers) return value;
+  // A baseline-side value at a secret path is already a HASH SENTINEL (record wrote a hash,
+  // not the plaintext). It carries no secret, but render it as a plain `<redacted>` rather
+  // than dumping the raw `{__cdkrdRedactedSha256__: …}` object into the report.
+  if (isRedactedHashSentinel(value)) return '<redacted>';
   for (const m of matchers) {
     if (m.pathRe.test(path)) return m.redact(value);
   }
@@ -166,4 +176,77 @@ function redactArrayDelta(resourceType: string, path: string, d: ArrayDeltaShape
     removed: d.removed.map((r) => ({ id: r.id, value: mv(r.value) })),
     changed: d.changed.map((c) => ({ id: c.id, recorded: mv(c.recorded), actual: mv(c.actual) })),
   };
+}
+
+// ── #798 persistence half — baseline HASH SENTINEL for secret-bearing recorded values ──
+//
+// The output half masks values in the REPORT; this half stops `record` from writing a live
+// secret in PLAINTEXT into the git-committed baseline. When `buildRecorded` snapshots a
+// finding whose (resourceType, path) `isRedactedPath`, it stores this SENTINEL — a single
+// reserved key holding the SHA-256 of the (already-canonicalized) live value — instead of
+// the raw value. `baselineValueMatches` recognizes the sentinel STRUCTURALLY (no path
+// threading needed) and re-hashes the live side to compare: an unchanged secret hashes
+// equal (record→check stays clean), a rotated secret hashes differently (re-surfaces as
+// drift). The plaintext never reaches the baseline file or a diff of it.
+//
+// The caller hashes the value AFTER running the same `canonicalizeBaselineForCompare` the
+// compare path uses, so record-then-check is reflexive; hashing here is order-stable via a
+// deep key-sort (arrays keep their already-canonical order).
+
+const REDACTION_HASH_KEY = '__cdkrdRedactedSha256__';
+
+// Deterministic serialization for hashing: deep-sort object keys so two structurally-equal
+// values hash identically regardless of key insertion order. Arrays keep order (the caller
+// passes an already-canonicalized value whose unordered arrays are sorted). `undefined`
+// (which `JSON.stringify` drops) hashes to a stable literal so it never collides with a
+// real value.
+function stableStringify(v: unknown): string {
+  const sortDeep = (x: unknown): unknown => {
+    if (Array.isArray(x)) return x.map(sortDeep);
+    if (x && typeof x === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(x as Record<string, unknown>).sort())
+        out[k] = sortDeep((x as Record<string, unknown>)[k]);
+      return out;
+    }
+    return x;
+  };
+  return JSON.stringify(sortDeep(v)) ?? 'null';
+}
+
+// Build the hash sentinel for an ALREADY-CANONICALIZED value. The caller (buildRecorded)
+// runs `canonicalizeBaselineForCompare` first so the stored hash matches the compare-time
+// hash of the freshly-canonicalized live value.
+function hashOfCanonical(canonicalValue: unknown): string {
+  return 'sha256:' + createHash('sha256').update(stableStringify(canonicalValue)).digest('hex');
+}
+
+export function redactedHashSentinel(canonicalValue: unknown): Record<string, string> {
+  return { [REDACTION_HASH_KEY]: hashOfCanonical(canonicalValue) };
+}
+
+// True if a baseline `value` is a redaction hash sentinel (a single reserved key mapping to
+// a string). An older baseline holding a plaintext value is NOT a sentinel, so it keeps
+// comparing via the normal deepEqual path — this change is backward-compatible.
+export function isRedactedHashSentinel(v: unknown): v is Record<string, string> {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    !Array.isArray(v) &&
+    Object.keys(v as object).length === 1 &&
+    typeof (v as Record<string, unknown>)[REDACTION_HASH_KEY] === 'string'
+  );
+}
+
+// Reduce EITHER a hash sentinel OR an already-canonicalized value to its hash string, so a
+// caller can compare two values whatever mix of {sentinel, raw-canonical} they are:
+//   - both sentinels (re-record: two built recorded sets)        → compare stored hashes
+//   - baseline sentinel vs raw live (check / applyBaseline)      → stored vs hash(live)
+//   - old PLAINTEXT baseline vs new sentinel (first re-record)   → hash(plaintext) vs stored
+// An unchanged secret yields the same hash in every case (record→check stays clean and the
+// plaintext→sentinel migration does not churn); a rotated secret yields a different hash.
+export function redactedHashOf(sentinelOrCanonical: unknown): string {
+  return isRedactedHashSentinel(sentinelOrCanonical)
+    ? (sentinelOrCanonical[REDACTION_HASH_KEY] ?? hashOfCanonical(sentinelOrCanonical))
+    : hashOfCanonical(sentinelOrCanonical);
 }

--- a/tests/baseline-redact-798.test.ts
+++ b/tests/baseline-redact-798.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  baselineValueMatches,
+  buildRecorded,
+  type BaselineFile,
+  splitRecordedByBaseline,
+} from '../src/baseline/baseline-file.js';
+import { isRedactedHashSentinel, redactedHashSentinel } from '../src/report/redact.js';
+import type { Finding } from '../src/types.js';
+
+// #798 (persistence half) — `record` must NOT write a live secret in plaintext into the
+// git-committed baseline. A secret-bearing recorded value is stored as a HASH SENTINEL, and
+// `baselineValueMatches` re-hashes the live side so change-detection survives (an unchanged
+// secret stays recorded; a rotated one re-surfaces as drift) with no plaintext in the file.
+
+const SECRET = 'super-secret-token-abcdef0123456789';
+const ROTATED = 'rotated-secret-token-9876543210fedcba';
+
+const lambdaEnvFinding = (value: unknown): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'Fn',
+  resourceType: 'AWS::Lambda::Function',
+  path: 'Environment.Variables.API_TOKEN',
+  actual: value,
+  nested: true,
+  freeFormKey: true,
+});
+
+const normalFinding = (): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'Fn',
+  resourceType: 'AWS::Lambda::Function',
+  // a non-secret undeclared prop on the SAME resource type — must be recorded in plaintext
+  path: 'MemorySize',
+  actual: 512,
+  nested: false,
+});
+
+describe('#798 buildRecorded hashes secret-bearing values, keeps others plaintext', () => {
+  it('a Lambda env-var value is stored as a hash sentinel, not the plaintext', () => {
+    const [entry] = buildRecorded([lambdaEnvFinding(SECRET)]);
+    expect(entry).toBeDefined();
+    expect(isRedactedHashSentinel(entry?.value)).toBe(true);
+    // the plaintext secret appears NOWHERE in the serialized baseline entry
+    expect(JSON.stringify(entry)).not.toContain(SECRET);
+    expect(JSON.stringify(entry)).toContain('sha256:');
+  });
+
+  it('a non-secret value on the same resource type is recorded in plaintext (no over-redaction)', () => {
+    const [entry] = buildRecorded([normalFinding()]);
+    expect(entry?.value).toBe(512);
+    expect(isRedactedHashSentinel(entry?.value)).toBe(false);
+  });
+
+  it('two DIFFERENT secrets hash to DIFFERENT sentinels (change is detectable)', () => {
+    const a = buildRecorded([lambdaEnvFinding(SECRET)])[0]?.value;
+    const b = buildRecorded([lambdaEnvFinding(ROTATED)])[0]?.value;
+    expect(a).not.toEqual(b);
+  });
+});
+
+describe('#798 baselineValueMatches compares secrets by hash (detection preserved)', () => {
+  const rt = 'AWS::Lambda::Function';
+  const sentinel = buildRecorded([lambdaEnvFinding(SECRET)])[0]?.value;
+
+  it('sentinel vs the SAME live secret -> matches (record->check stays clean)', () => {
+    expect(baselineValueMatches(sentinel, SECRET, rt)).toBe(true);
+  });
+
+  it('sentinel vs a ROTATED live secret -> does NOT match (re-surfaces as drift)', () => {
+    expect(baselineValueMatches(sentinel, ROTATED, rt)).toBe(false);
+  });
+
+  it('reflexive across two built recorded sets (re-record of an unchanged secret)', () => {
+    // splitRecordedByBaseline compares a freshly-built recorded set (also a sentinel) against
+    // the prior baseline's sentinel — both sides hashed, must still read as unchanged.
+    const prior: BaselineFile = {
+      schemaVersion: 2,
+      recorded: buildRecorded([lambdaEnvFinding(SECRET)]).map((e) => ({ ...e })),
+    } as BaselineFile;
+    const fresh = buildRecorded([lambdaEnvFinding(SECRET)]);
+    const { unchanged, changed } = splitRecordedByBaseline(fresh, prior);
+    expect(unchanged.length).toBe(1);
+    expect(changed.length).toBe(0);
+  });
+
+  it('a rotated secret across two built recorded sets reads as CHANGED', () => {
+    const prior: BaselineFile = {
+      schemaVersion: 2,
+      recorded: buildRecorded([lambdaEnvFinding(SECRET)]).map((e) => ({ ...e })),
+    } as BaselineFile;
+    const fresh = buildRecorded([lambdaEnvFinding(ROTATED)]);
+    const { unchanged, changed } = splitRecordedByBaseline(fresh, prior);
+    expect(unchanged.length).toBe(0);
+    expect(changed.length).toBe(1);
+  });
+
+  it('backward-compatible: an OLD PLAINTEXT baseline of the same secret still matches', () => {
+    // baselines written before this change hold the plaintext value — an unchanged secret must
+    // not falsely re-surface (and must migrate to a sentinel without churn on re-record).
+    expect(baselineValueMatches(SECRET, SECRET, rt)).toBe(true);
+    expect(baselineValueMatches(SECRET, ROTATED, rt)).toBe(false);
+  });
+
+  it('a NON-secret sentinel-shaped baseline value still uses the sentinel hash path safely', () => {
+    // Sanity: redactedHashSentinel/​isRedactedHashSentinel round-trip for a canonical value.
+    const s = redactedHashSentinel({ a: 1, b: [2, 3] });
+    expect(isRedactedHashSentinel(s)).toBe(true);
+    // key order in the source object does not change the hash (deep key-sort is stable)
+    expect(redactedHashSentinel({ b: [2, 3], a: 1 })).toEqual(s);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **persistence half** of #798. The output half (PR #1234) already masks secret-bearing live values in the text + `--json` report, but `record` still wrote the raw value into the git-committed `.cdkrd/baselines/*.json`: a Lambda / CodeBuild env var, EC2 LaunchTemplate `UserData`, or EB env-namespace `OptionSetting` landed in git in **plaintext**.

## What changed

- `buildRecorded` (baseline write) now stores a self-describing **hash sentinel** — `{__cdkrdRedactedSha256__: "sha256:…"}` of the *canonicalized* value — for the same curated secret-bearing paths (`isRedactedPath`) instead of the plaintext.
- `baselineValueMatches` (compare) compares **by hash** whenever either side is a sentinel: reduce each side to its hash (a sentinel yields its stored hash; a raw value is canonicalized then hashed the same way `record` did). This handles all mixes — sentinel-vs-live (check/applyBaseline), sentinel-vs-sentinel (re-record via `splitRecordedByBaseline`), and old-plaintext-vs-new-sentinel (migration).
- One curated table (`REDACTED_VALUE_PATHS` in `report/redact.ts`) now drives **both** halves, so a path is secret in exactly one place.

## Guarantees

- **No plaintext in git** — the secret never reaches the baseline file or a diff of it.
- **Detection preserved** — an unchanged secret hashes equal (record→check stays clean, the core invariant); a **rotated** secret hashes differently and re-surfaces as drift.
- **Backward compatible** — an older plaintext baseline still compares via the `deepEqual` path and migrates to the hashed form on the next `record` **without churn** (an unchanged secret's plaintext hashes equal to the new sentinel).
- Classification / folding unchanged; non-secret values are never hashed.

## Tests

`tests/baseline-redact-798.test.ts` — hash-on-record + no-plaintext-in-entry, non-secret-stays-plaintext, same/rotated compare, the two-built-recorded-sets (re-record) unchanged/changed paths, and plaintext-baseline backward compatibility. Full suite: 172 files / 4456 tests green; typecheck + `vp check` clean.

## Scope note

Follows the display half's curated-path scope (the enumerated undeclared sub-paths); deep redaction of a whole out-of-band `added` resource model is out of scope, same as the display layer.