### PR TITLE
fix(diff): demote non-ASCII-masked JSON_STRING_PROPS values to readGap, not declared drift

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -2743,6 +2743,23 @@ export function classifyResource(
       const dv = parseJson(v);
       const lv = parseJson(live[k]);
       if (!deepEqual(dv, lv) && !isStringlyEqualDeep(dv, lv)) {
+        // Same GetTemplate `?`-mask bypass as the SFN DefinitionString branch above
+        // (#1247): the declared side arrives with every non-ASCII character in a string
+        // literal masked to `?` while the live read is intact, and pushing here would
+        // skip the general mask→readGap demotion the plain string-diff path applies.
+        // When the parsed documents differ ONLY at masked string leaves, the declared
+        // value is unknowable from GetTemplate — a readGap, not drift; a genuine edit
+        // still fails the mask-tolerant compare and is reported.
+        if (deepEqualModuloNonAsciiMask(dv, lv)) {
+          findings.push({
+            tier: 'readGap',
+            logicalId,
+            resourceType,
+            path: k,
+            note: 'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"',
+          });
+          continue;
+        }
         findings.push({
           tier: 'declared',
           logicalId,

--- a/tests/classify-json-string-nonascii-mask.test.ts
+++ b/tests/classify-json-string-nonascii-mask.test.ts
@@ -1,0 +1,79 @@
+// Follow-up to #1247: the JSON_STRING_PROPS whole-unit compare (ConfigRule
+// InputParameters) pushed a `declared` finding directly when the structural compare
+// failed — bypassing the GetTemplate non-ASCII `?`-mask → readGap demotion the plain
+// string-diff path applies (the same bypass the SFN DefinitionString branch had).
+// A declared JSON-string / object property whose string leaves carry non-ASCII text
+// arrives masked from GetTemplate while the live read is intact, so a clean deploy
+// false-flagged as declared drift with a `????…` desired. When the two parsed values
+// differ ONLY at masked leaves, demote to readGap; a genuine edit still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (fs: Finding[]): string[] => fs.map((f) => `${f.tier}:${f.path}`).sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Rule',
+  resourceType: 'AWS::Config::ConfigRule',
+  physicalId: 'example-rule',
+  declared,
+});
+
+// Generic non-ASCII fixture text (NOT copied from any real environment): a label a
+// user might legitimately put in a rule parameter, with ASCII interleaved so the
+// mask must align around it.
+const LIVE_LABEL = 'サンプル説明 tag.<key> を確認';
+// Mask exactly as GetTemplate does: every non-ASCII codepoint becomes one `?`.
+const MASKED_LABEL = [...LIVE_LABEL]
+  .map((ch) => ((ch.codePointAt(0) ?? 0) > 0x7f ? '?' : ch))
+  .join('');
+
+describe('JSON_STRING_PROPS GetTemplate non-ASCII mask — readGap, not declared drift', () => {
+  it('demotes to readGap when the declared JSON string differs from live ONLY at masked leaves', () => {
+    const res = mk({
+      InputParameters: `{"label":"${MASKED_LABEL}","maxAge":"90"}`,
+    });
+    const live = { InputParameters: { label: LIVE_LABEL, maxAge: '90' } };
+    const f = classifyResource(res, live, emptySchema);
+    // Full tier:path assertion — the demotion must not leave a declared twin behind.
+    expect(tierPaths(f)).toEqual(['readGap:InputParameters']);
+    expect(f[0].note).toContain('masks non-ASCII');
+  });
+
+  it('demotes to readGap for the object-declared form too (CDK object vs live parsed)', () => {
+    const res = mk({
+      InputParameters: { label: MASKED_LABEL, maxAge: 90 },
+    });
+    const live = { InputParameters: { label: LIVE_LABEL, maxAge: 90 } };
+    const f = classifyResource(res, live, emptySchema);
+    expect(tierPaths(f)).toEqual(['readGap:InputParameters']);
+  });
+
+  it('still reports declared drift when a genuine change exists alongside the masks', () => {
+    const res = mk({
+      InputParameters: { label: MASKED_LABEL, maxAge: 90 },
+    });
+    // Out-of-band: maxAge weakened 90 -> 365 in addition to the masked label.
+    const live = { InputParameters: { label: LIVE_LABEL, maxAge: '365' } };
+    const f = classifyResource(res, live, emptySchema);
+    expect(tierPaths(f)).toEqual(['declared:InputParameters']);
+  });
+
+  it('does NOT demote a pure-ASCII change even when the declared value contains a literal "?"', () => {
+    const res = mk({ InputParameters: { pattern: 'item.<type>.<size>?' } });
+    const live = { InputParameters: { pattern: 'item.<type>.<size>!' } };
+    const f = classifyResource(res, live, emptySchema);
+    expect(tierPaths(f)).toEqual(['declared:InputParameters']);
+  });
+});

--- a/tests/classify-sfn-definition-712.test.ts
+++ b/tests/classify-sfn-definition-712.test.ts
@@ -144,7 +144,7 @@ describe('GetTemplate non-ASCII mask inside a DefinitionString — readGap, not 
   // drift whose desired shows `????…` (observed live: two Japanese Cause runs of 13 and
   // 24 chars masked 1:1 while CloudFormation's own drift detection reported IN_SYNC).
   const LIVE_JP =
-    '{"StartAt":"Check","States":{"Check":{"Type":"Choice","Choices":[{"Condition":"{% $ok %}","Next":"Done"}],"Default":"Bad"},"Bad":{"Type":"Fail","Cause":"復元先インスタンスクラスが db.<family>.<size> 形式ではない","Error":"InvalidInstanceClass"},"Done":{"Type":"Pass","End":true}}}';
+    '{"StartAt":"Check","States":{"Check":{"Type":"Choice","Choices":[{"Condition":"{% $ok %}","Next":"Done"}],"Default":"Bad"},"Bad":{"Type":"Fail","Cause":"入力された値 item.<type>.<size> の形式が正しくありません","Error":"InvalidFormat"},"Done":{"Type":"Pass","End":true}}}';
   const mask = (s: string): string => s.replace(/[^\x00-\x7f]/gu, '?');
 
   it('demotes to readGap when the declared definition differs from live ONLY at masked non-ASCII leaves', () => {
@@ -163,8 +163,8 @@ describe('GetTemplate non-ASCII mask inside a DefinitionString — readGap, not 
     // Byte-alignment breaks (Cause/Error/Type reordered), so the raw-string mask check
     // cannot fire — only the structural mask-tolerant compare can.
     const liveReordered = LIVE_JP.replace(
-      '"Type":"Fail","Cause":"復元先インスタンスクラスが db.<family>.<size> 形式ではない","Error":"InvalidInstanceClass"',
-      '"Cause":"復元先インスタンスクラスが db.<family>.<size> 形式ではない","Error":"InvalidInstanceClass","Type":"Fail"'
+      '"Type":"Fail","Cause":"入力された値 item.<type>.<size> の形式が正しくありません","Error":"InvalidFormat"',
+      '"Cause":"入力された値 item.<type>.<size> の形式が正しくありません","Error":"InvalidFormat","Type":"Fail"'
     );
     const res = mk({
       DefinitionString: mask(LIVE_JP),
@@ -179,7 +179,7 @@ describe('GetTemplate non-ASCII mask inside a DefinitionString — readGap, not 
   it('still reports declared drift when a genuine ASCII edit exists alongside the masks (fail-toward-reporting)', () => {
     // An out-of-band edit changed an ASCII leaf (Error code) — masks alone no longer
     // explain the difference, so the finding must surface as declared drift.
-    const liveEdited = LIVE_JP.replace('"Error":"InvalidInstanceClass"', '"Error":"SomethingElse"');
+    const liveEdited = LIVE_JP.replace('"Error":"InvalidFormat"', '"Error":"SomethingElse"');
     const res = mk({
       DefinitionString: mask(LIVE_JP),
       RoleArn: 'arn:aws:iam::111111111111:role/r',
@@ -195,10 +195,10 @@ describe('GetTemplate non-ASCII mask inside a DefinitionString — readGap, not 
     // isCfnTemplateNonAsciiMask requires the live side to carry non-ASCII at the masked
     // positions, so an ASCII-vs-ASCII difference always surfaces.
     const declared =
-      '{"StartAt":"P","States":{"P":{"Type":"Fail","Cause":"expected db.<family>.<size>?","Error":"E"}}}';
+      '{"StartAt":"P","States":{"P":{"Type":"Fail","Cause":"expected item.<type>.<size>?","Error":"E"}}}';
     const live = {
       DefinitionString:
-        '{"StartAt":"P","States":{"P":{"Type":"Fail","Cause":"expected db.<family>.<size>!","Error":"E"}}}',
+        '{"StartAt":"P","States":{"P":{"Type":"Fail","Cause":"expected item.<type>.<size>!","Error":"E"}}}',
       RoleArn: 'arn:aws:iam::111111111111:role/r',
     };
     const res = mk({ DefinitionString: declared, RoleArn: 'arn:aws:iam::111111111111:role/r' });


### PR DESCRIPTION
Follow-up to #1247 (same bug class, second instance).

## Root cause

The JSON_STRING_PROPS whole-unit compare (AWS::Config::ConfigRule InputParameters) pushes a declared finding directly when its structural compare fails — bypassing the general GetTemplate non-ASCII mask -> readGap demotion gate, exactly like the SFN DefinitionString branch fixed in #1247. GetTemplate returns every non-ASCII character in a stored string literal as a literal question mark, so a declared JSON-string / object value whose string leaves carry non-ASCII text arrives corrupted while the live read is intact: a clean deploy false-flags as permanent declared drift with a masked desired.

## Fix

When the structural compare fails, demote to readGap (same note as the general gate) when the parsed values are deep-equal modulo per-leaf non-ASCII masks (reusing deepEqualModuloNonAsciiMask from #1247). A genuine edit — changed ASCII char, changed sibling value, re-typed leaf — still fails the mask-tolerant compare and surfaces as declared drift.

Also replaces incidental fixture strings in the #1247 test with generic text (test-only; no behavior change).

## Verification

- 4 new unit tests (string-declared and object-declared masked forms -> readGap with full tier:path assertions; genuine change alongside masks -> declared drift; literal question mark in pure-ASCII value -> never excused).
- Full suite: 170 files / 4419 tests pass; typecheck + lint/format + build pass.
- The mask mechanics were live-proven in #1247 against a real stack; this branch reuses the identical comparator on the remaining bypass.

Reviewed the other direct declared-push sites for the same class: declared-but-live-missing (no live value to mask), ManagedPolicy attachment members and ELB attribute bags (ASCII-constrained values), and the general diff loop (already gated) — no further instances.
