### PR TITLE
fix(noise): subtract CFn stack-level tags propagated onto resources (#683)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,7 +30,10 @@ un-deployed code edits would show as false "drift".
      - cc-api strip   (timestamps, revision ids, ...)
      - policy canonical (Action/Resource/Principal scalar-vs-array unify, statement
        sort, account-id<->root-ARN; Version kept only when declared — never fabricated)
-     - aws:* tags (list + map); schema-defaults (at ANY depth, via $ref-resolved
+     - aws:* tags (list + map); CFn STACK-level tags (`cdk deploy --tags`, propagated
+       by CFN onto every resource, never in the template — subtracted from each
+       resource's live `Tags` except keys the resource itself declares; #683);
+       schema-defaults (at ANY depth, via $ref-resolved
        nested `default` extraction; R103) + per-type known-defaults are NOT dropped
        but tagged `atDefault` (folded, never drift; R86); auto-generated identifiers
        AWS assigns at deploy and absent from the template, keyed by the resource's

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -382,6 +382,7 @@ interface ClassifyOpts {
   accountId: string;
   region: string;
   kmsAliasTargets: Record<string, string>;
+  stackTags: Record<string, string>; // CFn stack-level tags (cdk deploy --tags), subtracted from live Tags (#683)
   oaiCanonicalIds: Record<string, string>;
   siblingSgRules: Record<string, { ingress: unknown[]; egress: unknown[] }>;
   siblingEventBusPolicies: Record<string, unknown[]>;
@@ -1206,6 +1207,7 @@ export async function gatherFindings(
     region,
     kmsAliasTargets,
     defaultSgIds,
+    stackTags: desired.stackTags,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
@@ -1309,6 +1311,7 @@ export async function regatherTouched(
     region,
     kmsAliasTargets,
     defaultSgIds,
+    stackTags: desired.stackTags,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -21,6 +21,11 @@ export interface Desired {
   region: string;
   accountId: string;
   resources: DesiredResource[];
+  // CloudFormation STACK-level tags (`cdk deploy --tags`, `create-stack --tags`, StackSets,
+  // Service Catalog) as key->value — from DescribeStacks. CFN propagates these onto every
+  // taggable resource without them appearing in the template, so classify subtracts them from
+  // each resource's live `Tags` to avoid a first-run / declared-tier tag FP (#683).
+  stackTags: Record<string, string>;
   rawTemplate: string; // verbatim deployed template body (for baseline templateHash)
   ctx: ResolverContext; // exposed so gather can re-resolve GetAtt once live attrs are read
   // set when the stack's StackStatus is mid-operation / failed (a comparison still runs
@@ -508,6 +513,13 @@ export async function loadDesired(
   const stackId = stack?.StackId ?? '';
   const accountId = stackId.split(':')[4] ?? '';
 
+  // #683 — the stack's own tags (from `cdk deploy --tags` etc.). CFN propagates these onto
+  // every taggable resource without them appearing in the template; classify subtracts them.
+  const stackTags: Record<string, string> = {};
+  for (const t of stack?.Tags ?? []) {
+    if (typeof t.Key === 'string' && typeof t.Value === 'string') stackTags[t.Key] = t.Value;
+  }
+
   const stackParams: Record<string, string> = {};
   for (const p of stack?.Parameters ?? []) {
     if (!p.ParameterKey) continue;
@@ -701,7 +713,21 @@ export async function loadDesired(
           : undefined,
     });
   }
-  return { stackName, region, accountId, resources, rawTemplate, ctx, stackStatusWarning };
+  // NOTE: build the result as an explicitly-typed `Desired` rather than returning an inline
+  // shorthand literal — a large shorthand return literal here degraded tsgolint's type-aware
+  // analysis (types dropped to `error`/`any`, cascading false lint errors across UNRELATED
+  // files); the annotation resolves the object type deterministically. tsgo accepts either. (#683)
+  const desired: Desired = {
+    stackName,
+    region,
+    accountId,
+    resources,
+    stackTags,
+    rawTemplate,
+    ctx,
+    stackStatusWarning,
+  };
+  return desired;
 }
 
 // The IAM principal types an AWS::IAM::Policy can attach an inline policy to, via its

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -101,6 +101,7 @@ import { MANAGED_KEY_ALIAS_PATHS, shouldFoldManagedServiceKey } from '../read/km
 import { deepStripPaths } from '../normalize/path-strip.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
 import { canonicalizePolicy, rewriteOaiPrincipalsDeep } from '../normalize/policy-canonical.js';
+import { declaredTagKeys, subtractPropagatedStackTags } from '../normalize/stack-tags.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../types.js';
 import { calculateResourceDrift, deepEqual } from './drift-calculator.js';
 
@@ -1694,6 +1695,9 @@ export function classifyResource(
     // DERIVED equality gate rather than a value-independent one: a single default SG folds, a
     // 2+-element APPEND or a single non-default SG SWAP surfaces. Undefined/empty → fail open (fold).
     defaultSgIds?: ReadonlySet<string>;
+    // CFn STACK-level tags (`cdk deploy --tags`) — subtracted from each resource's live `Tags`
+    // (except keys the resource declares) to avoid a first-run / declared-tier tag FP (#683).
+    stackTags?: Record<string, string>;
     oaiCanonicalIds?: Record<string, string>; // OAI id -> S3CanonicalUserId, for CloudFront OAI principal match
     // Rules declared by SIBLING standalone AWS::EC2::SecurityGroupIngress/::SecurityGroupEgress
     // resources, keyed by the target SG's resolved GroupId (== the SG's physical id). Subtracted
@@ -1791,10 +1795,13 @@ export function classifyResource(
   const liveForCompare = structuredClone(liveRaw);
   const declaredForCompare = cloneDeepWithSymbols(declaredIn) as Record<string, unknown>;
   stripAsymmetricIdentityFields(declaredForCompare, liveForCompare);
-  const live = normalizeLiveModel(liveForCompare, schema, {
-    oaiCanonicalIds: oaiMap,
-    resourceType,
-  });
+  // #683 — subtract CFn stack-level tags (`cdk deploy --tags`) propagated onto this resource's
+  // live `Tags`, keeping any key the resource itself declares (compared normally).
+  const live = subtractPropagatedStackTags(
+    normalizeLiveModel(liveForCompare, schema, { oaiCanonicalIds: oaiMap, resourceType }),
+    opts.stackTags ?? {},
+    declaredTagKeys(declaredForCompare)
+  );
   const declared = canonicalizeForCompare(
     rewriteOaiPrincipalsDeep(declaredForCompare, oaiMap),
     resourceType

--- a/src/normalize/stack-tags.ts
+++ b/src/normalize/stack-tags.ts
@@ -1,0 +1,54 @@
+// #683 — CloudFormation STACK-level tag helpers.
+//
+// NOTE: these are `const` ARROW functions, NOT `function` declarations. Adding even a single
+// new top-level `function` to this codebase tips tsgolint (`vp check`) over an analysis budget
+// where it degrades types to `error`/`any` and cascades false type-aware lint errors across
+// UNRELATED files (tsgo typecheck stays clean). A `const` arrow binding does not trip it.
+// (Verified on main e58704d; see the #683 issue thread.)
+
+// The set of Tag KEYS a resource DECLARES on its top-level `Tags` list (a `{Key,Value}[]`).
+// Used to protect a declared tag key from the stack-tag subtraction below: a key the resource
+// itself declares is real intent and must stay in the live model so the declared loop compares
+// it (a value change on it still surfaces).
+export const declaredTagKeys = (declared: unknown): ReadonlySet<string> => {
+  const out = new Set<string>();
+  const tags = (declared as Record<string, unknown> | null | undefined)?.Tags;
+  if (Array.isArray(tags)) {
+    for (const t of tags) {
+      const k = (t as Record<string, unknown> | null | undefined)?.Key;
+      if (typeof k === 'string') out.add(k);
+    }
+  }
+  return out;
+};
+
+// CloudFormation STACK-level tags (`cdk deploy --tags k=v`, `create-stack --tags`, StackSets,
+// Service Catalog) are propagated by CFN onto every taggable resource WITHOUT ever appearing in
+// the template. `stripAwsTagsDeep` only removes `aws:*` tags, so these propagated USER tags
+// surface on a clean deploy — a declared-tier tag FP on resources that declare Tags (their
+// declared list is a strict subset of the live list) and a first-run undeclared `Tags` FP on
+// resources that declare none. Subtract a propagated stack tag from the resource's top-level
+// live `Tags` list UNLESS the resource itself declares that key (declared → real intent,
+// compared normally). Only an EXACT {Key,Value} match to a stack tag is dropped, so a
+// resource-level tag that merely shares a key with a stack tag but has a different value is
+// preserved (and its divergence still surfaces). Scoped to the standard top-level `Tags` list
+// (where CFN propagates them); map-shaped / differently-named tag properties are out of scope (#862).
+export const subtractPropagatedStackTags = (
+  live: Record<string, unknown>,
+  stackTags: Record<string, string>,
+  declaredKeys: ReadonlySet<string>
+): Record<string, unknown> => {
+  if (Object.keys(stackTags).length === 0) return live;
+  const tags = live.Tags;
+  if (!Array.isArray(tags)) return live;
+  const filtered = tags.filter((t) => {
+    if (!t || typeof t !== 'object') return true;
+    const key = (t as Record<string, unknown>).Key;
+    const value = (t as Record<string, unknown>).Value;
+    if (typeof key !== 'string') return true;
+    if (declaredKeys.has(key)) return true; // declared intent — keep it, compared normally
+    return !(key in stackTags && stackTags[key] === value); // drop the propagated stack tag
+  });
+  if (filtered.length === tags.length) return live; // nothing removed — preserve identity
+  return { ...live, Tags: filtered };
+};

--- a/tests/noise-stacktags-683.test.ts
+++ b/tests/noise-stacktags-683.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { declaredTagKeys, subtractPropagatedStackTags } from '../src/normalize/stack-tags.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #683 — CloudFormation STACK-level tags (`cdk deploy --tags k=v`) are propagated by CFN onto
+// every taggable resource WITHOUT appearing in the template. stripAwsTagsDeep only removes
+// aws:* tags, so the propagated USER tags surfaced as a clean-deploy tag FP: a declared-tier FP
+// on resources that declare Tags (declared list ⊂ live list) and a first-run undeclared `Tags`
+// FP on resources with none. classify subtracts them from the live top-level Tags (keeping any
+// key the resource itself declares).
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string): string[] =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const stackTags = { team: 'platform', costcenter: '1234' };
+
+describe('#683 subtractPropagatedStackTags / declaredTagKeys (pure)', () => {
+  it('declaredTagKeys extracts the declared top-level Tag keys', () => {
+    const keys = declaredTagKeys({
+      Tags: [
+        { Key: 'app', Value: 'x' },
+        { Key: 'tier', Value: 'storage' },
+      ],
+    });
+    expect([...keys].sort()).toEqual(['app', 'tier']);
+  });
+
+  it('drops a propagated stack tag the resource does not declare', () => {
+    const out = subtractPropagatedStackTags(
+      {
+        Tags: [
+          { Key: 'app', Value: 'x' },
+          { Key: 'team', Value: 'platform' },
+        ],
+      },
+      stackTags,
+      new Set(['app'])
+    );
+    expect(out.Tags).toEqual([{ Key: 'app', Value: 'x' }]);
+  });
+
+  it('KEEPS a stack-tag key the resource DECLARES (compared normally)', () => {
+    const live = { Tags: [{ Key: 'team', Value: 'platform' }] };
+    const out = subtractPropagatedStackTags(live, stackTags, new Set(['team']));
+    expect(out).toEqual(live);
+  });
+
+  it('KEEPS a same-key tag whose VALUE differs from the stack tag (real divergence surfaces)', () => {
+    const live = { Tags: [{ Key: 'team', Value: 'attacker' }] };
+    const out = subtractPropagatedStackTags(live, stackTags, new Set());
+    expect(out).toEqual(live);
+  });
+
+  it('no stack tags → identity (no-op)', () => {
+    const live = { Tags: [{ Key: 'team', Value: 'platform' }] };
+    expect(subtractPropagatedStackTags(live, {}, new Set())).toBe(live);
+  });
+});
+
+describe('#683 classifyResource end-to-end (zero tag FP on a --tags deploy)', () => {
+  const declaredTags = [
+    { Key: 'app', Value: 'cdkrd-hunt' },
+    { Key: 'tier', Value: 'storage' },
+  ];
+  const liveTags = [
+    { Key: 'costcenter', Value: '1234' },
+    { Key: 'app', Value: 'cdkrd-hunt' },
+    { Key: 'team', Value: 'platform' },
+    { Key: 'tier', Value: 'storage' },
+  ];
+
+  it('a bucket WITH declared Tags shows no declared-tier Tags FP', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Data',
+      resourceType: 'AWS::S3::Bucket',
+      physicalId: 'data-bucket',
+      declared: { Tags: declaredTags },
+    };
+    const f = classifyResource(resource, { Tags: liveTags }, emptySchema, { stackTags });
+    expect(tier(f, 'declared')).not.toContain('Tags');
+  });
+
+  it('a queue WITHOUT declared Tags shows no first-run undeclared Tags FP', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Work',
+      resourceType: 'AWS::SQS::Queue',
+      physicalId: 'work-queue',
+      declared: {},
+    };
+    const f = classifyResource(
+      resource,
+      {
+        Tags: [
+          { Key: 'costcenter', Value: '1234' },
+          { Key: 'team', Value: 'platform' },
+        ],
+      },
+      emptySchema,
+      { stackTags }
+    );
+    expect(tier(f, 'undeclared')).not.toContain('Tags');
+  });
+
+  it('detection preserved: an out-of-band tag that is NOT a stack tag still surfaces undeclared', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Work',
+      resourceType: 'AWS::SQS::Queue',
+      physicalId: 'work-queue',
+      declared: {},
+    };
+    const f = classifyResource(
+      resource,
+      {
+        Tags: [
+          { Key: 'rogue', Value: 'evil' },
+          { Key: 'team', Value: 'platform' },
+        ],
+      },
+      emptySchema,
+      { stackTags }
+    );
+    expect(tier(f, 'undeclared')).toContain('Tags');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #683. (Rebased re-issue of #1250 after peer #889 touched the same `classifyResource` opts region.)

CloudFormation **stack-level tags** (`cdk deploy --tags k=v`, `create-stack --tags`, StackSets, Service Catalog) are propagated by CFN onto every taggable resource **without ever appearing in the template**. cdkrd's live-side tag subtraction only stripped `aws:*` tags, so the propagated USER tags surfaced on a clean deploy — a **declared-tier** tag FP on resources that declare Tags (declared list ⊂ live list) and a **first-run undeclared** `Tags` FP on resources that declare none. Both violate the zero-first-run invariant, and the declared-tier symptom survives `record`.

## Fix
Thread the stack's own tags (`DescribeStacks`) → `Desired.stackTags` → gather `ClassifyOpts` → `classifyResource` opts, and subtract each propagated `{Key,Value}` from a resource's top-level live `Tags` list **unless the resource itself declares that key** (declared = real intent, compared normally). Only an EXACT `{Key,Value}` match is dropped, so a resource-level tag sharing a key but with a different value is preserved and still surfaces.

## Test
`tests/noise-stacktags-683.test.ts` — pure helper tests + `classifyResource` end-to-end (tagged bucket → no declared FP, untagged queue → no undeclared FP, rogue non-stack tag still surfaces). Helpers in new `src/normalize/stack-tags.ts`.

## Live verification (A/B, real AWS — Cdkrd683Verify, us-east-1)
A tagged S3 bucket + untagged SQS queue deployed with `aws cloudformation deploy --tags team=platform costcenter=1234`:
- **prior release 0.11.1**: `[CFn-Declared Drift: 1] Data.Tags` + `[Potential Drift: 1] Work.Tags`.
- **this build**: `result: CLEAN`.

## Lint note
`tsgo` typecheck + `vp lint` on the 5 changed files are clean; all unit tests pass (4381). Whole-program `vp check` (tsgolint) cascades false type-aware errors onto unrelated pre-existing `String(...)` calls when the type-graph grows — a tsgolint budget artifact (reproducible by adding two trivial `function` declarations to a clean tree), independent of this change. Helpers are `const` arrows and the `loadDesired` return is an explicitly-typed `Desired` to minimise the trigger. See the #683 thread.