### PR TITLE
test(diff): pin the #828-class CORS dotted-key-map FP shape (corpus + keyed-array guard unit tests)

### DIFF
--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1387,8 +1387,8 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ]);
   });
 
-  it('LineLink first-run folds: GlobalTable WarmThroughput / ESM Enabled / Authorizer AuthType', () => {
-    // Three undeclared values a fresh dev LineLink stack reported with NO out-of-band
+  it('real-app first-run folds: GlobalTable WarmThroughput / ESM Enabled / Authorizer AuthType', () => {
+    // Three undeclared values a fresh real-app dev stack reported with NO out-of-band
     // edit — first-run noise that must fold to atDefault, while a meaningful change to
     // each still surfaces (equality-gated).
     const t = (rt: string, live: Record<string, unknown>) =>
@@ -1407,7 +1407,7 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ).toEqual(['WarmThroughput']);
 
     // The classic AWS::DynamoDB::Table (L1) reads back the SAME baseline warm throughput
-    // when on-demand — observed live on a dev reco-MailQueues stack — so it folds too;
+    // when on-demand — observed live on another real app's dev stack — so it folds too;
     // a warmed-up table still surfaces (equality-gated).
     expect(
       t('AWS::DynamoDB::Table', {
@@ -1432,7 +1432,7 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
 
     // AuthType is a derived, non-declarable read-back of the declared Type, so BOTH the
     // Cognito ("cognito_user_pools") and TOKEN/REQUEST ("custom", observed live on a
-    // my-app AimAssociation TOKEN authorizer) forms fold value-independently.
+    // a real app's TOKEN authorizer) forms fold value-independently.
     expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'cognito_user_pools' }).atDefault).toEqual([
       'AuthType',
     ]);
@@ -11837,6 +11837,122 @@ describe('#747 dotted map keys -> whole map at parent path (declared compare own
     };
     const findings = classifyResource(resource, live, bareSchema);
     expect(findings.map((f) => `${f.tier}:${f.path}`)).toEqual(['declared:TableInput.Parameters']);
+  });
+});
+
+// #747 follow-up regression net: the SAME path-unsafe-key guard fires on dotted-key maps
+// reached through a NESTED_ARRAY_IDENTITY keyed-array descent (ApiGateway Method
+// Integration.IntegrationResponses[<sc>].ResponseParameters / MethodResponses[<sc>].
+// ResponseParameters — `method.response.header.*`) and on a map nested in a declared object
+// (Integration.RequestParameters — `integration.request.header.*`). The #747 fix's own tests
+// cover only the Glue object shape, so a regression scoped to the keyed-array recursion
+// (as #828 was, FP'ing every CDK defaultCorsPreflightOptions method) would stay green there —
+// pin the CORS method shape explicitly. Asserted on the FULL tier:path list so a wrong-tier
+// or double-report can't hide behind a filtered subset.
+describe('#828 regression: CORS method dotted-key maps in StatusCode-keyed arrays', () => {
+  const corsSchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  // The standard CDK `defaultCorsPreflightOptions` OPTIONS mock method.
+  const corsDeclared = {
+    AuthorizationType: 'NONE',
+    HttpMethod: 'OPTIONS',
+    Integration: {
+      IntegrationResponses: [
+        {
+          ResponseParameters: {
+            'method.response.header.Access-Control-Allow-Headers': "'Content-Type,Authorization'",
+            'method.response.header.Access-Control-Allow-Methods': "'OPTIONS,POST'",
+            'method.response.header.Access-Control-Allow-Origin': "'*'",
+          },
+          StatusCode: '200',
+        },
+      ],
+      RequestTemplates: { 'application/json': '{"statusCode": 200}' },
+      Type: 'MOCK',
+    },
+    MethodResponses: [
+      {
+        ResponseParameters: {
+          'method.response.header.Access-Control-Allow-Headers': true,
+          'method.response.header.Access-Control-Allow-Methods': true,
+          'method.response.header.Access-Control-Allow-Origin': true,
+        },
+        StatusCode: '200',
+      },
+    ],
+    ResourceId: 'r1',
+    RestApiId: 'a1',
+  };
+  const mk = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'CorsOPTIONS',
+    resourceType: 'AWS::ApiGateway::Method',
+    physicalId: 'a1|r1|OPTIONS',
+    declared,
+  });
+
+  it('a clean live echo of the CORS method is ZERO findings (the #828 FP shape)', () => {
+    const findings = classifyResource(
+      mk(structuredClone(corsDeclared)),
+      structuredClone(corsDeclared),
+      corsSchema
+    );
+    expect(findings.map((f) => `${f.tier}:${f.path}`)).toEqual([]);
+  });
+
+  it('a declared Integration.RequestParameters (integration.request.*) echo is ZERO findings', () => {
+    const declared = {
+      HttpMethod: 'POST',
+      Integration: {
+        IntegrationHttpMethod: 'POST',
+        RequestParameters: {
+          'integration.request.header.Content-Type': "'application/x-www-form-urlencoded'",
+        },
+        Type: 'AWS',
+      },
+      ResourceId: 'r1',
+      RestApiId: 'a1',
+    };
+    const findings = classifyResource(
+      mk(structuredClone(declared)),
+      structuredClone(declared),
+      corsSchema
+    );
+    expect(findings.map((f) => `${f.tier}:${f.path}`)).toEqual([]);
+  });
+
+  // Detection must survive the fold: the guard suppresses only the DECLARED-echo FP, the
+  // declared whole-map compare still owns any real out-of-band change to the map.
+  it('an out-of-band header ADDED to a declared ResponseParameters surfaces as declared drift', () => {
+    const live = structuredClone(corsDeclared) as {
+      Integration: { IntegrationResponses: { ResponseParameters: Record<string, unknown> }[] };
+    };
+    live.Integration.IntegrationResponses[0].ResponseParameters['method.response.header.X-Rogue'] =
+      "'v'";
+    const findings = classifyResource(mk(structuredClone(corsDeclared)), live, corsSchema);
+    expect(findings.map((f) => `${f.tier}:${f.path}`)).toEqual([
+      'declared:Integration.IntegrationResponses.0.ResponseParameters',
+    ]);
+  });
+
+  it('an out-of-band VALUE change inside a declared ResponseParameters surfaces as declared drift', () => {
+    const live = structuredClone(corsDeclared) as {
+      MethodResponses: { ResponseParameters: Record<string, unknown> }[];
+    };
+    live.MethodResponses[0].ResponseParameters[
+      'method.response.header.Access-Control-Allow-Origin'
+    ] = false;
+    const findings = classifyResource(mk(structuredClone(corsDeclared)), live, corsSchema);
+    expect(findings.map((f) => `${f.tier}:${f.path}`)).toEqual([
+      'declared:MethodResponses.0.ResponseParameters',
+    ]);
   });
 });
 

--- a/tests/corpus/AWS__ApiGateway__Method.ApiitemsOPTIONS0467E25A.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiitemsOPTIONS0467E25A.json
@@ -1,0 +1,163 @@
+{
+  "corpusVersion": 1,
+  "description": "CORS preflight mock method (the standard CDK defaultCorsPreflightOptions shape): declared Integration.IntegrationResponses[200].ResponseParameters and MethodResponses[200].ResponseParameters are dotted-key maps (method.response.header.*) inside StatusCode-keyed arrays. Regression net for the #828-class FP (fixed in #1249): collectNestedUndeclared's path-unsafe-key guard must NOT emit a DECLARED dotted-key map as undeclared \u2014 a clean first check on this method folds to zero drift.",
+  "resource": {
+    "logicalId": "ApiitemsOPTIONS0467E25A",
+    "resourceType": "AWS::ApiGateway::Method",
+    "physicalId": "a1b2c3d4e5|it3ms9|OPTIONS",
+    "constructPath": "CorpusDemo/Api/Default/items/OPTIONS",
+    "declared": {
+      "AuthorizationType": "NONE",
+      "HttpMethod": "OPTIONS",
+      "Integration": {
+        "IntegrationResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+              "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'",
+              "method.response.header.Access-Control-Allow-Origin": "'*'"
+            },
+            "ResponseTemplates": {
+              "application/json": "\n#set($origin = $input.params().header.get('origin'))\n#set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)\n"
+            },
+            "StatusCode": "200"
+          }
+        ],
+        "PassthroughBehavior": "WHEN_NO_MATCH",
+        "RequestTemplates": {
+          "application/json": "{\"statusCode\": 200}"
+        },
+        "Type": "MOCK"
+      },
+      "MethodResponses": [
+        {
+          "ResponseModels": {
+            "application/json": "Empty"
+          },
+          "ResponseParameters": {
+            "method.response.header.Access-Control-Allow-Headers": true,
+            "method.response.header.Access-Control-Allow-Methods": true,
+            "method.response.header.Access-Control-Allow-Origin": true
+          },
+          "StatusCode": "200"
+        }
+      ],
+      "ResourceId": "it3ms9",
+      "RestApiId": "a1b2c3d4e5"
+    }
+  },
+  "liveRaw": {
+    "MethodResponses": [
+      {
+        "ResponseParameters": {
+          "method.response.header.Access-Control-Allow-Methods": true,
+          "method.response.header.Access-Control-Allow-Headers": true,
+          "method.response.header.Access-Control-Allow-Origin": true
+        },
+        "StatusCode": "200",
+        "ResponseModels": {
+          "application/json": "Empty"
+        }
+      }
+    ],
+    "Integration": {
+      "CacheNamespace": "it3ms9",
+      "Type": "MOCK",
+      "IntegrationResponses": [
+        {
+          "ResponseTemplates": {
+            "application/json": "\n#set($origin = $input.params().header.get('origin'))\n#set($context.responseOverride.header.Access-Control-Allow-Origin = $origin)\n"
+          },
+          "ResponseParameters": {
+            "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,POST'",
+            "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+            "method.response.header.Access-Control-Allow-Origin": "'*'"
+          },
+          "StatusCode": "200"
+        }
+      ],
+      "RequestTemplates": {
+        "application/json": "{\"statusCode\": 200}"
+      },
+      "ResponseTransferMode": "BUFFERED",
+      "TimeoutInMillis": 29000,
+      "PassthroughBehavior": "WHEN_NO_MATCH"
+    },
+    "ResourceId": "it3ms9",
+    "RestApiId": "a1b2c3d4e5",
+    "ApiKeyRequired": false,
+    "AuthorizationType": "NONE",
+    "HttpMethod": "OPTIONS"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["HttpMethod", "ResourceId", "RestApiId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HttpMethod", "ResourceId", "RestApiId"],
+    "defaults": {},
+    "defaultPaths": {
+      "Integration.ResponseTransferMode": "BUFFERED"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "Integration.IntegrationResponses.*.ResponseParameters",
+      "Integration.IntegrationResponses.*.ResponseTemplates",
+      "Integration.RequestParameters",
+      "Integration.RequestTemplates",
+      "MethodResponses.*.ResponseModels",
+      "MethodResponses.*.ResponseParameters",
+      "RequestModels",
+      "RequestParameters"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "ap-northeast-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsOPTIONS0467E25A",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "a1b2c3d4e5|it3ms9|OPTIONS",
+      "constructPath": "CorpusDemo/Api/Default/items/OPTIONS"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "ApiitemsOPTIONS0467E25A",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.CacheNamespace",
+      "actual": "it3ms9",
+      "nested": true,
+      "physicalId": "a1b2c3d4e5|it3ms9|OPTIONS",
+      "constructPath": "CorpusDemo/Api/Default/items/OPTIONS"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsOPTIONS0467E25A",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.ResponseTransferMode",
+      "actual": "BUFFERED",
+      "nested": true,
+      "physicalId": "a1b2c3d4e5|it3ms9|OPTIONS",
+      "constructPath": "CorpusDemo/Api/Default/items/OPTIONS"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsOPTIONS0467E25A",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.TimeoutInMillis",
+      "actual": 29000,
+      "nested": true,
+      "physicalId": "a1b2c3d4e5|it3ms9|OPTIONS",
+      "constructPath": "CorpusDemo/Api/Default/items/OPTIONS"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__Method.ApiqueuePOST69F945C0.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiqueuePOST69F945C0.json
@@ -1,0 +1,194 @@
+{
+  "corpusVersion": 1,
+  "description": "AWS-type SQS integration method: declared Integration.RequestParameters is a dotted-key map (integration.request.header.Content-Type). Regression net for the #828-class FP (fixed in #1249): the declared map echoed by the live read must fold to zero undeclared findings. Also carries a real declared drift (IntegrationResponses pruned out of band) so the whole-array declared compare is replayed too.",
+  "resource": {
+    "logicalId": "ApiqueuePOST69F945C0",
+    "resourceType": "AWS::ApiGateway::Method",
+    "physicalId": "a1b2c3d4e5|qu3ue7|POST",
+    "constructPath": "CorpusDemo/Api/Default/queue/POST",
+    "declared": {
+      "AuthorizationType": "AWS_IAM",
+      "HttpMethod": "POST",
+      "Integration": {
+        "Credentials": "arn:aws:iam::111111111111:role/CorpusDemo-ApiIntegrationRole-Zy9xWvUt87Kj",
+        "IntegrationHttpMethod": "POST",
+        "IntegrationResponses": [
+          {
+            "StatusCode": "200"
+          },
+          {
+            "StatusCode": "400"
+          },
+          {
+            "StatusCode": "500"
+          }
+        ],
+        "RequestParameters": {
+          "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'"
+        },
+        "RequestTemplates": {
+          "application/json": "Action=SendMessage&MessageBody=$util.urlEncode($input.body)"
+        },
+        "Type": "AWS",
+        "Uri": "arn:aws:apigateway:ap-northeast-1:sqs:path//CorpusDemo-QueueB6722424-Ab3dEfGh12Xy"
+      },
+      "MethodResponses": [
+        {
+          "StatusCode": "200"
+        },
+        {
+          "StatusCode": "400"
+        },
+        {
+          "StatusCode": "500"
+        }
+      ],
+      "ResourceId": "qu3ue7",
+      "RestApiId": "a1b2c3d4e5"
+    }
+  },
+  "liveRaw": {
+    "MethodResponses": [
+      {
+        "StatusCode": "200"
+      },
+      {
+        "StatusCode": "400"
+      },
+      {
+        "StatusCode": "500"
+      }
+    ],
+    "Integration": {
+      "CacheNamespace": "qu3ue7",
+      "Type": "AWS",
+      "IntegrationResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "RequestTemplates": {
+        "application/json": "Action=SendMessage&MessageBody=$util.urlEncode($input.body)"
+      },
+      "IntegrationHttpMethod": "POST",
+      "ResponseTransferMode": "BUFFERED",
+      "TimeoutInMillis": 29000,
+      "Uri": "arn:aws:apigateway:ap-northeast-1:sqs:path//CorpusDemo-QueueB6722424-Ab3dEfGh12Xy",
+      "Credentials": "arn:aws:iam::111111111111:role/CorpusDemo-ApiIntegrationRole-Zy9xWvUt87Kj",
+      "PassthroughBehavior": "WHEN_NO_MATCH",
+      "RequestParameters": {
+        "integration.request.header.Content-Type": "'application/x-www-form-urlencoded'"
+      }
+    },
+    "ResourceId": "qu3ue7",
+    "RestApiId": "a1b2c3d4e5",
+    "ApiKeyRequired": false,
+    "AuthorizationType": "AWS_IAM",
+    "HttpMethod": "POST"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["HttpMethod", "ResourceId", "RestApiId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HttpMethod", "ResourceId", "RestApiId"],
+    "defaults": {},
+    "defaultPaths": {
+      "Integration.ResponseTransferMode": "BUFFERED"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "Integration.IntegrationResponses.*.ResponseParameters",
+      "Integration.IntegrationResponses.*.ResponseTemplates",
+      "Integration.RequestParameters",
+      "Integration.RequestTemplates",
+      "MethodResponses.*.ResponseModels",
+      "MethodResponses.*.ResponseParameters",
+      "RequestModels",
+      "RequestParameters"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "ap-northeast-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "ApiqueuePOST69F945C0",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.IntegrationResponses",
+      "desired": [
+        {
+          "StatusCode": "200"
+        },
+        {
+          "StatusCode": "400"
+        },
+        {
+          "StatusCode": "500"
+        }
+      ],
+      "actual": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "physicalId": "a1b2c3d4e5|qu3ue7|POST",
+      "constructPath": "CorpusDemo/Api/Default/queue/POST"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiqueuePOST69F945C0",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "a1b2c3d4e5|qu3ue7|POST",
+      "constructPath": "CorpusDemo/Api/Default/queue/POST"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "ApiqueuePOST69F945C0",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.CacheNamespace",
+      "actual": "qu3ue7",
+      "nested": true,
+      "physicalId": "a1b2c3d4e5|qu3ue7|POST",
+      "constructPath": "CorpusDemo/Api/Default/queue/POST"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiqueuePOST69F945C0",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.ResponseTransferMode",
+      "actual": "BUFFERED",
+      "nested": true,
+      "physicalId": "a1b2c3d4e5|qu3ue7|POST",
+      "constructPath": "CorpusDemo/Api/Default/queue/POST"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiqueuePOST69F945C0",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.TimeoutInMillis",
+      "actual": 29000,
+      "nested": true,
+      "physicalId": "a1b2c3d4e5|qu3ue7|POST",
+      "constructPath": "CorpusDemo/Api/Default/queue/POST"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiqueuePOST69F945C0",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.PassthroughBehavior",
+      "actual": "WHEN_NO_MATCH",
+      "nested": true,
+      "physicalId": "a1b2c3d4e5|qu3ue7|POST",
+      "constructPath": "CorpusDemo/Api/Default/queue/POST"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Regression net for the #828-class false positive (fixed in #1249): a **declared** dotted-key map (`method.response.header.*` / `integration.request.header.*`) emitted whole as `[Potential Drift]` by `collectNestedUndeclared`'s path-unsafe-key guard.

#1249's own tests cover only the Glue **object** shape (`TableInput.Parameters`). The reported real-world FP hit a different recursion path — dotted-key maps inside **StatusCode-keyed arrays** (`NESTED_ARRAY_IDENTITY`): `Integration.IntegrationResponses[200].ResponseParameters` / `MethodResponses[200].ResponseParameters` on every CDK `defaultCorsPreflightOptions` method — and **no corpus fixture carried a dotted-key declared map at all**, which is why #828 shipped with a green corpus.

## Changes (tests only)

- **2 corpus golden cases** (harvested from a real deployed stack via `CDKRD_CORPUS_DIR`, then anonymized): a CORS preflight mock method and an AWS-type SQS integration method (`Integration.RequestParameters`; keeps a real declared drift so the whole-array declared compare is replayed too).
- **`#828 regression` describe in classify.test.ts**: clean CORS echo ⇒ ZERO findings (full `tier:path` list assertion); declared `Integration.RequestParameters` echo ⇒ ZERO findings; out-of-band added/changed header inside a declared dotted-key map still surfaces as **declared** drift (detection preserved).
- Scrub real app names from pre-existing test comments (generic wording, no behavior change).

## Verification

Mutation-checked both nets: temporarily reverting the #1249 guard fix (back to the #828 bug) fails exactly the 2 new corpus replays and all 4 new unit tests; with the fix restored the full suite passes (173 files / 4475 tests).

Gates: `check` + `docs` markers set (tests-only diff — verify-pr exempt).