### PR TITLE
fix(diff): funnel every declared-drift push through a central GetTemplate-mask guard

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1681,6 +1681,42 @@ function resolveParentObject(root: unknown, dottedPath: string): unknown {
   return node;
 }
 
+export const GETTEMPLATE_MASK_NOTE =
+  'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"';
+
+// The SINGLE funnel every `declared`-drift emission must flow through. CloudFormation's
+// GetTemplate masks every non-ASCII character in a stored string literal as `?` (see
+// isCfnTemplateNonAsciiMask), so any compare of a GetTemplate-sourced desired against an
+// intact live value can false-flag; the plain string-diff path demotes such a mask-only
+// difference to a readGap, but a special-case branch that pushed its `declared` finding
+// DIRECTLY bypassed that demotion — exactly how #712's SFN DefinitionString branch
+// regressed into a guaranteed false drift (#1247), and JSON_STRING_PROPS repeated it
+// (#1337). Funnelling the push applies the demotion structurally, so a future branch
+// cannot reintroduce the bypass; a companion meta-test asserts no direct
+// `tier: 'declared'` push exists outside this function. Branches that compare PARSED
+// forms (SFN / JSON_STRING_PROPS) still run their own mask-tolerant structural checks
+// first — this funnel is the raw-value backstop, not a replacement.
+function pushDeclaredFinding(findings: Finding[], finding: Omit<Finding, 'tier'>): void {
+  // Demote ONLY when the mask is what makes the two sides differ (mask-tolerant equal,
+  // strictly unequal) — a site that pushes two genuinely equal values keeps its
+  // (buggy) declared finding visible instead of being silently relabelled a readGap.
+  if (
+    !deepEqual(finding.desired, finding.actual) &&
+    deepEqualModuloNonAsciiMask(finding.desired, finding.actual)
+  ) {
+    findings.push({
+      tier: 'readGap',
+      logicalId: finding.logicalId,
+      resourceType: finding.resourceType,
+      path: finding.path,
+      ...(finding.attributeKey !== undefined ? { attributeKey: finding.attributeKey } : {}),
+      note: GETTEMPLATE_MASK_NOTE,
+    });
+    return;
+  }
+  findings.push({ tier: 'declared', ...finding });
+}
+
 export function classifyResource(
   resource: DesiredResource,
   liveRaw: Record<string, unknown>,
@@ -2654,8 +2690,7 @@ export function classifyResource(
         (isNonEmptyCollection && !READGAP_COLLECTION_PATHS[resourceType]?.has(k)) ||
         isClearedAllowlistedScalar
       ) {
-        findings.push({
-          tier: 'declared',
+        pushDeclaredFinding(findings, {
           logicalId,
           resourceType,
           path: k,
@@ -2715,12 +2750,11 @@ export function classifyResource(
           logicalId,
           resourceType,
           path: k,
-          note: 'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"',
+          note: GETTEMPLATE_MASK_NOTE,
         });
         continue;
       }
-      findings.push({
-        tier: 'declared',
+      pushDeclaredFinding(findings, {
         logicalId,
         resourceType,
         path: k,
@@ -2790,12 +2824,11 @@ export function classifyResource(
             logicalId,
             resourceType,
             path: k,
-            note: 'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"',
+            note: GETTEMPLATE_MASK_NOTE,
           });
           continue;
         }
-        findings.push({
-          tier: 'declared',
+        pushDeclaredFinding(findings, {
           logicalId,
           resourceType,
           path: k,
@@ -2824,8 +2857,7 @@ export function classifyResource(
         if (typeof member !== 'string' && typeof member !== 'number') continue;
         declaredSet.add(String(member));
         if (liveSet.has(String(member))) continue;
-        findings.push({
-          tier: 'declared',
+        pushDeclaredFinding(findings, {
           logicalId,
           resourceType,
           path: k,
@@ -2864,8 +2896,7 @@ export function classifyResource(
         const liveValue = lEl ? (lEl as { Value: unknown }).Value : undefined;
         if (deepEqual(dEl.Value, liveValue)) continue;
         if (isStringlyEqualScalar(dEl.Value, liveValue)) continue;
-        findings.push({
-          tier: 'declared',
+        pushDeclaredFinding(findings, {
           logicalId,
           resourceType,
           path: k,
@@ -3246,7 +3277,7 @@ export function classifyResource(
           logicalId,
           resourceType,
           path: d.path,
-          note: 'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"',
+          note: GETTEMPLATE_MASK_NOTE,
         });
         continue;
       }
@@ -3433,8 +3464,7 @@ export function classifyResource(
           : tagListWhole
             ? { wholeArrayRevert: { path: k, value: v } }
             : {};
-      findings.push({
-        tier: 'declared',
+      pushDeclaredFinding(findings, {
         logicalId,
         resourceType,
         path: d.path,

--- a/tests/classify-declared-push-funnel.test.ts
+++ b/tests/classify-declared-push-funnel.test.ts
@@ -1,0 +1,80 @@
+// Regression guard for the GetTemplate `?`-mask bypass CLASS (#1247/#1337): the
+// mask → readGap demotion lived only on the plain string-diff path, so any special-case
+// branch that pushed its `declared` finding directly bypassed it — #712's SFN
+// DefinitionString branch reintroduced the false drift that way, and JSON_STRING_PROPS
+// repeated it. Two structural defenses, both pinned here:
+//   1. Every declared emission flows through the pushDeclaredFinding funnel, which
+//      demotes a mask-only difference to readGap centrally.
+//   2. A source-level meta-test asserts NO direct `tier: 'declared'` push exists in
+//      classify.ts outside the funnel — a future branch that bypasses it fails this
+//      test instead of shipping the regression.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (fs: Finding[]): string[] => fs.map((f) => `${f.tier}:${f.path}`).sort();
+
+describe('declared-push funnel meta-test (source-level)', () => {
+  it("classify.ts contains no direct tier: 'declared' push outside pushDeclaredFinding", () => {
+    const src = readFileSync(new URL('../src/diff/classify.ts', import.meta.url), 'utf8');
+    expect(src).toContain('function pushDeclaredFinding');
+    // Strip line comments so the funnel's own doc comment doesn't count, then require
+    // exactly ONE code occurrence — the funnel body. A new special-case branch that
+    // pushes `tier: 'declared'` directly (the #712-style bypass) adds a second
+    // occurrence and fails here: route it through pushDeclaredFinding instead.
+    const code = src
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('//'))
+      .join('\n');
+    const occurrences = code.split("tier: 'declared'").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});
+
+describe('funnel behavior — a site with no branch-local mask handling is still guarded', () => {
+  // ELB attribute bags compare BY KEY and push per-attribute declared findings with no
+  // mask logic of their own; the funnel must demote a mask-only Value difference. ELB
+  // attribute values are ASCII-constrained in practice — this exercises the FUNNEL,
+  // guarding every present and future push site, not an observed ELB false positive.
+  const mask = (s: string): string =>
+    [...s].map((ch) => ((ch.codePointAt(0) ?? 0) > 0x7f ? '?' : ch)).join('');
+  const LIVE_VALUE = 'ラベル tag.<key> 付き';
+
+  const mk = (attrs: unknown): DesiredResource => ({
+    logicalId: 'TG',
+    resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+    physicalId: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/tg/1',
+    declared: { TargetGroupAttributes: attrs },
+  });
+
+  it('demotes a mask-only attribute Value difference to readGap (carrying the attributeKey)', () => {
+    const res = mk([{ Key: 'a.b', Value: mask(LIVE_VALUE) }]);
+    const live = { TargetGroupAttributes: [{ Key: 'a.b', Value: LIVE_VALUE }] };
+    const f = classifyResource(res, live, emptySchema);
+    expect(tierPaths(f).filter((t) => t.startsWith('declared:'))).toEqual([]);
+    const gap = f.find((x) => x.tier === 'readGap' && x.path === 'TargetGroupAttributes');
+    expect(gap?.note).toContain('masks non-ASCII');
+    expect(gap?.attributeKey).toBe('a.b');
+  });
+
+  it('still reports a genuine ASCII attribute change as declared drift', () => {
+    const res = mk([{ Key: 'a.b', Value: 'true' }]);
+    const live = { TargetGroupAttributes: [{ Key: 'a.b', Value: 'false' }] };
+    const f = classifyResource(res, live, emptySchema);
+    const declared = f.filter((x) => x.tier === 'declared' && x.path === 'TargetGroupAttributes');
+    expect(declared).toHaveLength(1);
+    expect(declared[0].attributeKey).toBe('a.b');
+  });
+});


### PR DESCRIPTION
Regression-proofing follow-up to #1247 / #1337 (closes out the bug CLASS, not another instance).

## Why

The GetTemplate non-ASCII mask -> readGap demotion lived only on the plain string-diff path. Any special-case branch that pushed its declared finding directly bypassed it — that is exactly how #712's SFN DefinitionString branch REGRESSED into a guaranteed false declared drift (worked on <= 0.10.0, broken from 0.10.1), and how JSON_STRING_PROPS repeated the same bypass. Per-site unit tests (#1247, #1337) pin the two fixed sites but cannot protect a future new branch from reintroducing the bypass.

## What

Two structural defenses:

1. **Funnel**: all six declared-finding emissions in classifyResource now flow through a single `pushDeclaredFinding` helper that demotes a mask-only difference (mask-tolerant deep-equal AND strictly unequal) to readGap centrally. Branch-local parsed-form mask checks (SFN, JSON_STRING_PROPS) stay as the precise first line; the funnel is the raw-value backstop. The demotion condition requires the values to be strictly unequal, so a site that (buggily) pushes two equal values is not silently relabelled.
2. **Meta-test**: a source-level unit test asserts classify.ts contains no direct tier-declared push outside the funnel — a future bypass branch fails the unit suite instead of shipping the regression. Plus behavior tests exercising the funnel through a site that had no branch-local mask handling at all (ELB attribute bags), proving the guard applies to every present and future site.

The shared note string becomes the exported `GETTEMPLATE_MASK_NOTE` constant (3 duplicated literals removed).

## Verification

- Full suite: 174 files / 4472 tests pass (new meta-test + 2 funnel behavior tests; all pre-existing declared-drift tests unchanged and green — the funnel does not alter genuine-drift behavior).
- typecheck + lint/format + build pass.
- The mask mechanics themselves were live-proven in #1247 against a real stack; this PR only changes WHERE the guard is applied (centrally), covered by the offline suite.
