### PR TITLE
test(corpus): pin the dot-key map + S3 transition-default regressions with harvested cases

### DIFF
--- a/tests/corpus/AWS__Glue__Database.LogsDatabase.json
+++ b/tests/corpus/AWS__Glue__Database.LogsDatabase.json
@@ -1,0 +1,68 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LogsDatabase",
+    "resourceType": "AWS::Glue::Database",
+    "physicalId": "cdkrd_hunt_dotkey_logs_db",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseInput": {
+        "Name": "cdkrd_hunt_dotkey_logs_db"
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_hunt_dotkey_logs_db",
+    "DatabaseInput": {
+      "CreateTableDefaultPermissions": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "Parameters": {},
+      "Name": "cdkrd_hunt_dotkey_logs_db"
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DatabaseName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DatabaseName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["DatabaseInput.CreateTableDefaultPermissions"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "LogsDatabase",
+      "resourceType": "AWS::Glue::Database",
+      "path": "DatabaseInput.CreateTableDefaultPermissions",
+      "actual": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "nested": true,
+      "physicalId": "cdkrd_hunt_dotkey_logs_db"
+    }
+  ],
+  "description": "Companion database of the dot-key projection table case (same harvest)."
+}

--- a/tests/corpus/AWS__Glue__Table.LogsTable.json
+++ b/tests/corpus/AWS__Glue__Table.LogsTable.json
@@ -1,0 +1,153 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LogsTable",
+    "resourceType": "AWS::Glue::Table",
+    "physicalId": "cdkrd_hunt_dotkey_access_logs",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseName": "cdkrd_hunt_dotkey_logs_db",
+      "TableInput": {
+        "Name": "cdkrd_hunt_dotkey_access_logs",
+        "Parameters": {
+          "skip.header.line.count": 2,
+          "projection.enabled": true,
+          "projection.date.type": "date",
+          "projection.date.range": "2024/04/01/00, NOW",
+          "projection.date.format": "yyyy/MM/dd/HH",
+          "projection.date.interval": "1",
+          "projection.date.interval.unit": "HOURS",
+          "storage.location.template": "s3://cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups/${date}"
+        },
+        "PartitionKeys": [
+          {
+            "Name": "date",
+            "Type": "string"
+          }
+        ],
+        "StorageDescriptor": {
+          "Columns": [
+            {
+              "Name": "request_time",
+              "Type": "string"
+            },
+            {
+              "Name": "edge_location",
+              "Type": "string"
+            },
+            {
+              "Name": "status",
+              "Type": "int"
+            }
+          ],
+          "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+          "Location": "s3://cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups/",
+          "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+          "SerdeInfo": {
+            "Parameters": {
+              "field.delim": "\t",
+              "serialization.format": "\t"
+            },
+            "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+          }
+        },
+        "TableType": "EXTERNAL_TABLE"
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_hunt_dotkey_logs_db",
+    "TableInput": {
+      "Name": "cdkrd_hunt_dotkey_access_logs",
+      "Retention": 0,
+      "TableType": "EXTERNAL_TABLE",
+      "Parameters": {
+        "skip.header.line.count": "2",
+        "projection.date.type": "date",
+        "projection.date.format": "yyyy/MM/dd/HH",
+        "projection.date.interval": "1",
+        "projection.date.interval.unit": "HOURS",
+        "projection.enabled": "true",
+        "projection.date.range": "2024/04/01/00, NOW",
+        "storage.location.template": "s3://cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups/${date}"
+      },
+      "PartitionKeys": [
+        {
+          "Name": "date",
+          "Type": "string"
+        }
+      ],
+      "StorageDescriptor": {
+        "Columns": [
+          {
+            "Name": "request_time",
+            "Type": "string"
+          },
+          {
+            "Name": "edge_location",
+            "Type": "string"
+          },
+          {
+            "Name": "status",
+            "Type": "int"
+          }
+        ],
+        "Location": "s3://cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups/",
+        "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+        "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+        "Compressed": false,
+        "NumberOfBuckets": 0,
+        "SerdeInfo": {
+          "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+          "Parameters": {
+            "serialization.format": "\t",
+            "field.delim": "\t"
+          }
+        },
+        "SortColumns": [],
+        "StoredAsSubDirectories": false
+      }
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["CatalogId", "DatabaseName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["CatalogId", "DatabaseName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "LogsTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.Retention",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_hunt_dotkey_access_logs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LogsTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.StorageDescriptor.NumberOfBuckets",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_hunt_dotkey_access_logs"
+    }
+  ],
+  "description": "Athena partition-projection access-log table: free-form TableInput.Parameters / StorageDescriptor.SerdeInfo.Parameters with DOT-containing keys, CDK-typed declared values (boolean projection.enabled, numeric skip.header.line.count) vs the all-string live echo, plus a Ref-resolved storage.location.template. Locks the twice-regressed FP to zero findings beyond the two constant atDefaults: #300 (declared-tier whole-map coercion) and #828/PR #1249 (undeclared-tier unconditional unsafe-key emit)."
+}

--- a/tests/corpus/AWS__S3__Bucket.DestLogBucketE7485D81.json
+++ b/tests/corpus/AWS__S3__Bucket.DestLogBucketE7485D81.json
@@ -1,0 +1,204 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DestLogBucketE7485D81",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups",
+    "declared": {
+      "LifecycleConfiguration": {
+        "Rules": [
+          {
+            "ExpirationInDays": 730,
+            "Status": "Enabled"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups",
+    "RegionalDomainName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3-website-us-east-1.amazonaws.com",
+    "LifecycleConfiguration": {
+      "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+      "Rules": [
+        {
+          "Status": "Enabled",
+          "ExpirationInDays": 730,
+          "Id": "ZjhhYmI1NmMtYzI4NC00YmZmLThkMDctYTFmZjllNmI0OWQz",
+          "Prefix": ""
+        }
+      ]
+    },
+    "DualStackDomainName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups",
+    "Tags": [
+      {
+        "Value": "CdkrdHuntGlueDotkeyParams",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "DestLogBucketE7485D81",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntGlueDotkeyParams/c2b14830-7c67-11f1-936c-0ea7cdc24351",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketE7485D81",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketE7485D81",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketE7485D81",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketE7485D81",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketE7485D81",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "LifecycleConfiguration.TransitionDefaultMinimumObjectSize",
+      "actual": "all_storage_classes_128K",
+      "nested": true,
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    }
+  ],
+  "description": "Lifecycle bucket declaring only Rules: a FRESH lifecycle configuration reads back TransitionDefaultMinimumObjectSize=all_storage_classes_128K (the post-2024 AWS default) \u2014 folds atDefault via the KNOWN_DEFAULT_ONE_OF_PATHS two-constant set (PR #1249)."
+}

--- a/tests/corpus/AWS__S3__Bucket.DestLogBucketLegacyTransition.json
+++ b/tests/corpus/AWS__S3__Bucket.DestLogBucketLegacyTransition.json
@@ -1,0 +1,204 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DestLogBucketLegacyTransition",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups",
+    "declared": {
+      "LifecycleConfiguration": {
+        "Rules": [
+          {
+            "ExpirationInDays": 730,
+            "Status": "Enabled"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups",
+    "RegionalDomainName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3-website-us-east-1.amazonaws.com",
+    "LifecycleConfiguration": {
+      "TransitionDefaultMinimumObjectSize": "varies_by_storage_class",
+      "Rules": [
+        {
+          "Status": "Enabled",
+          "ExpirationInDays": 730,
+          "Id": "ZjhhYmI1NmMtYzI4NC00YmZmLThkMDctYTFmZjllNmI0OWQz",
+          "Prefix": ""
+        }
+      ]
+    },
+    "DualStackDomainName": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups",
+    "Tags": [
+      {
+        "Value": "CdkrdHuntGlueDotkeyParams",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "DestLogBucketE7485D81",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntGlueDotkeyParams/c2b14830-7c67-11f1-936c-0ea7cdc24351",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketLegacyTransition",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketLegacyTransition",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketLegacyTransition",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketLegacyTransition",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DestLogBucketLegacyTransition",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "LifecycleConfiguration.TransitionDefaultMinimumObjectSize",
+      "actual": "varies_by_storage_class",
+      "nested": true,
+      "physicalId": "cdkrdhuntgluedotkeyparams-destlogbuckete7485d81-p68wsfq2xups"
+    }
+  ],
+  "description": "HAND-CURATED variant of DestLogBucketE7485D81: identical harvested case with TransitionDefaultMinimumObjectSize swapped to varies_by_storage_class \u2014 the documented LEGACY enum value AWS returns for lifecycle configurations created before the late-2024 default change (observed live on a real pre-change bucket; a fresh deploy cannot reproduce it). Locks the second constant of the KNOWN_DEFAULT_ONE_OF_PATHS set (PR #1249): must fold atDefault, never surface."
+}

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -179,6 +179,22 @@ resource_gone() {
       printf '%s' "$err" | grep -q 'ResourceNotFoundException' && return 0
       return 1
       ;;
+    ec2)
+      # arn:aws:ec2:<region>:<acct>:vpc-endpoint/vpce-<id> — the second type observed
+      # lingering in the RGT index after deletion (2026-07-10): DescribeVpcEndpoints
+      # returned InvalidVpcEndpointId.NotFound while the tag filter still listed it,
+      # keeping an unrelated agent's gate RED. Only the vpc-endpoint subtype gets a
+      # probe; every other ec2 resource stays fail-safe (return 1 → ORPHAN stays RED).
+      case "$arn" in
+        *:vpc-endpoint/vpce-*)
+          id="${arn##*/}"
+          err="$(aws ec2 describe-vpc-endpoints --vpc-endpoint-ids "$id" --region "$REGION" 2>&1 >/dev/null)" && return 1
+          printf '%s' "$err" | grep -q 'InvalidVpcEndpointId.NotFound' && return 0
+          return 1
+          ;;
+        *) return 1 ;;
+      esac
+      ;;
     *)
       return 1 ;;
   esac


### PR DESCRIPTION
## Summary

Permanent regression net for the two PR #1249 false positives — requested because the dot-key map FP had **regressed once already**: #300 fixed the declared-tier coercion FP (2026-06-22), then #828 reintroduced the same user-visible first-run FP through the *undeclared* tier (2026-07-09). Both prior fixes had tests, but they asserted tier-filtered subsets, and the existing Glue corpus tables carry only path-safe `Parameters` keys — so every net stayed green while the FP migrated tiers.

## What's added

Four golden-corpus cases harvested from a fresh fictional-name deploy (`CDKRD_CORPUS_DIR` during a real `check`, stack deleted + swept afterwards):

- **`AWS__Glue__Table.LogsTable`** — the canonical Athena partition-projection access-log table: dot-containing keys in `TableInput.Parameters` / `StorageDescriptor.SerdeInfo.Parameters`, CDK-typed declared values (`projection.enabled: true`, `skip.header.line.count: 2`) vs the all-string live echo, and a Ref-resolved `storage.location.template`. Expected findings pin **zero beyond two constant atDefaults** — replay runs the real live model through the whole normalize→classify pipeline, so the FP cannot come back through *any* tier unseen.
- **`AWS__S3__Bucket.DestLogBucketE7485D81`** — fresh lifecycle config reads back `all_storage_classes_128K` → `atDefault` via the `KNOWN_DEFAULT_ONE_OF_PATHS` set.
- **`AWS__S3__Bucket.DestLogBucketLegacyTransition`** — hand-curated variant pinning the *other* documented enum value, `varies_by_storage_class` (returned for lifecycle configs created before the late-2024 default change; a fresh deploy cannot reproduce it — observed live on a real pre-change bucket). Locks the second constant of the ONE_OF set.
- **`AWS__Glue__Database.LogsDatabase`** — companion case from the same harvest.

**Regression-net proof:** temporarily reverting each #1249 fix makes exactly the corresponding case fail replay (`AWS__Glue__Table.LogsTable` for the classify guard, `DestLogBucketLegacyTransition` for the ONE_OF entry); restoring turns it green.

## Also

`sweep-orphans.sh` `resource_gone()` gains an `ec2` `vpc-endpoint` probe: a deleted vpce lingering in the RGT tag index (same lag class as the existing `cognito-idp` probe, observed live during this harvest's teardown) false-flagged as ORPHAN and kept the bughunt gate RED for an unrelated owner. Only the `vpc-endpoint/vpce-*` subtype is probed; all other ec2 types stay fail-safe RED.

## Verification

- Full suite green: 173 files / 4473 tests (replay includes the 4 new cases).
- Teardown verified: `bughunt-track.sh verify` → stack GONE + SWEEP CLEAN, gate released.
- No `src/**` in the diff (tests/tooling only).
