### PR TITLE
fix(report): break GetTemplate-masked readGaps out of "not returned by AWS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ that folds everything informational.
 result: 1 drift(s) (declared=1)
 ───────────────────────────────
 info:
-  - readGap=1 (declared but unverifiable — AWS doesn't return them on read, not drift: 1 write-only)
+  - readGap=1 (declared but unverifiable — not drift: 1 write-only)
   - skipped=2 (custom resource 2)
   run with --verbose for the list
 ```

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -20,6 +20,7 @@
 // sections (below result, as a footer). 0-count tiers are never printed. The
 // "surfaced, never silently dropped" invariant is preserved by the counts.
 import { withinStackPath } from '../construct-path.js';
+import { GETTEMPLATE_MASK_NOTE } from '../diff/classify.js';
 import { deepEqual } from '../diff/drift-calculator.js';
 import { annotateHints } from '../diff/hints.js';
 import { UNRESOLVED } from '../normalize/intrinsic-resolver.js';
@@ -316,6 +317,7 @@ function reasonKey(f: Finding): string {
   const n = f.note ?? '';
   if (f.tier === 'ignored') return n.replace(/^ignored by config rule /, '') || 'ignored';
   if (f.tier === 'unresolved') return 'intrinsic unresolved';
+  if (n === GETTEMPLATE_MASK_NOTE) return 'non-ASCII masked by GetTemplate';
   if (n.includes('write-only')) return 'write-only';
   if (n.startsWith('custom resource')) return 'custom resource';
   if (n.includes('target not resolvable')) return 'override target unresolved';
@@ -600,12 +602,17 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
     // the cause (write-only props are never readable by design vs simply not returned).
     if (t === 'readGap') {
       const writeOnly = items.filter((f) => (f.note ?? '').includes('write-only')).length;
-      const notReturned = items.length - writeOnly;
+      // GetTemplate-masked values ARE returned on read — it is the DECLARED side that is
+      // unreadable (GetTemplate corrupts non-ASCII to "?") — so break them out instead of
+      // miscounting them under "not returned by AWS".
+      const masked = items.filter((f) => f.note === GETTEMPLATE_MASK_NOTE).length;
+      const notReturned = items.length - writeOnly - masked;
       const parts = [
         ...(notReturned > 0 ? [`${notReturned} not returned by AWS`] : []),
         ...(writeOnly > 0 ? [`${writeOnly} write-only`] : []),
+        ...(masked > 0 ? [`${masked} non-ASCII masked by GetTemplate`] : []),
       ];
-      return `readGap=${items.length} (declared but unverifiable — AWS doesn't return them on read, not drift: ${parts.join(', ')})`;
+      return `readGap=${items.length} (declared but unverifiable — not drift: ${parts.join(', ')})`;
     }
     // unresolved is jargon too: these are declared values whose CloudFormation intrinsic
     // cdkrd could not resolve to a concrete value, so there is nothing concrete to compare

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -489,13 +489,31 @@ describe('report', () => {
       const infoIdx = lines.indexOf('info:');
       expect(infoIdx).toBeGreaterThan(-1);
       expect(lines[infoIdx + 1]).toBe(
-        "  - readGap=1 (declared but unverifiable — AWS doesn't return them on read, not drift: 1 write-only)"
+        '  - readGap=1 (declared but unverifiable — not drift: 1 write-only)'
       );
       expect(lines[infoIdx + 2]).toMatch(
         /^ {2}- skipped=2 — NOT checked \(coverage incomplete: .*custom resource 1.*override target unresolved 1.*\)$/
       );
       expect(lines[infoIdx + 3]).toBe('  run with --verbose for the list');
       expect(text.match(/--verbose/g)).toHaveLength(1);
+    });
+
+    it('breaks GetTemplate-masked readGaps out of "not returned by AWS" in the info: summary', () => {
+      // A masked value IS returned on read — the DECLARED side is what GetTemplate
+      // corrupted — so it must not inflate the "not returned by AWS" count.
+      const findings: Finding[] = [
+        reason('readGap', 'declared but not returned by live read'),
+        reason('readGap', 'write-only — cannot be read back'),
+        reason(
+          'readGap',
+          'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"'
+        ),
+        reason('skipped', 'custom resource — no cloud-side model to read', 'Custom::Foo'),
+      ];
+      const { text } = run(findings);
+      expect(text).toContain(
+        '  - readGap=3 (declared but unverifiable — not drift: 1 not returned by AWS, 1 write-only, 1 non-ASCII masked by GetTemplate)'
+      );
     });
 
     it('result: appears ABOVE the info: footer', () => {


### PR DESCRIPTION
Follow-up to #1247/#1341 (display-only).

## Why

The readGap `info:` breakdown counted everything non-write-only as "not returned by AWS". A GetTemplate-masked readGap is the opposite case — the LIVE read returns the value fine; it is the DECLARED side GetTemplate corrupted (non-ASCII masked to `?`) — so it was miscounted under a wrong cause (observed: the demoted DefinitionString showed up as "2 not returned by AWS").

## What

- `summaryFor`: count `GETTEMPLATE_MASK_NOTE` findings as their own bucket ("non-ASCII masked by GetTemplate") and subtract them from "not returned by AWS"; drop the now-inaccurate blanket "AWS doesn't return them on read" phrasing (the per-bucket labels carry the cause).
- `reasonKey`: matching short key for the `--verbose` reason list.
- README sample output updated to the new line.

## Verification

- New unit test: 3 mixed readGaps (not-returned / write-only / masked) render `readGap=3 (declared but unverifiable — not drift: 1 not returned by AWS, 1 write-only, 1 non-ASCII masked by GetTemplate)`.
- Full suite: 175 files / 4491 tests pass; typecheck + lint/format + build pass.
