### PR TITLE
fix(revert): ClientVpnEndpoint SessionTimeoutHours revert converges via set-default (#1289)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -241,13 +241,14 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // (CLIENT_VPN_SCALAR_PARAMS): a `remove` deletes the key from the desired model, the
   // writer skips the now-undefined param, and nothing is sent — Cloud Control-style
   // "converge on omit" never applies (#912). Write the KNOWN_DEFAULTS defaults back
-  // explicitly so an out-of-band change converges. VpnPort (443) and
-  // DisconnectOnSessionTimeout (true) pull their values from KNOWN_DEFAULTS. SplitTunnel
-  // folds `atDefault` as a trivial-empty `false` (no KNOWN_DEFAULTS value), so an OOB
-  // `true` is otherwise unrevertable — its `false` default comes from
-  // REVERT_SET_DEFAULT_VALUES below, the EnableDns64 pattern.
+  // explicitly so an out-of-band change converges. VpnPort (443),
+  // DisconnectOnSessionTimeout (true), and SessionTimeoutHours (24) pull their values
+  // from KNOWN_DEFAULTS. SplitTunnel folds `atDefault` as a trivial-empty `false` (no
+  // KNOWN_DEFAULTS value), so an OOB `true` is otherwise unrevertable — its `false`
+  // default comes from REVERT_SET_DEFAULT_VALUES below, the EnableDns64 pattern.
   'AWS::EC2::ClientVpnEndpoint\0VpnPort',
   'AWS::EC2::ClientVpnEndpoint\0DisconnectOnSessionTimeout',
+  'AWS::EC2::ClientVpnEndpoint\0SessionTimeoutHours',
   'AWS::EC2::ClientVpnEndpoint\0SplitTunnel',
   // DocDB ModifyDBCluster / ModifyDBInstance are SELECTIVE-update APIs routed through SDK
   // writers whose allowlists include these props: a `remove` empties the desired model and

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -574,6 +574,27 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#1289: undeclared ClientVpnEndpoint SessionTimeoutHours -> add op writing the 24 KNOWN_DEFAULTS default, not a no-op remove', () => {
+    // AWS::EC2::ClientVpnEndpoint SessionTimeoutHours folds atDefault at its constant
+    // KNOWN_DEFAULTS default (24, #1102). It is a CLIENT_VPN_SCALAR_PARAMS writer prop, so a
+    // bare `remove` is un-expressible (the writer throws "cannot be cleared … update it
+    // manually") — exactly the VpnPort selective-writer no-op class. Revert of an out-of-band
+    // ModifyClientVpnEndpoint --session-timeout-hours must write the 24 default explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::ClientVpnEndpoint',
+      path: 'SessionTimeoutHours',
+      actual: 12,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SessionTimeoutHours',
+      value: 24,
+      prior: 12,
+    });
+  });
+
   it('#912: undeclared ClientVpnEndpoint DisconnectOnSessionTimeout -> add op writing the true KNOWN_DEFAULTS default', () => {
     // Same selective-writer no-op class as VpnPort; write the `true` KNOWN_DEFAULTS default.
     const f = F({


### PR DESCRIPTION
Closes #1289

## Problem
`AWS::EC2::ClientVpnEndpoint.SessionTimeoutHours` folds `atDefault` at its constant KNOWN_DEFAULTS default (`24`, #1102) and is mutable out of band (`ModifyClientVpnEndpoint --session-timeout-hours 12`; not create-only). But it had **no** `REVERT_SET_DEFAULT_PATHS` entry, so reverting an OOB change planned a bare `{op:remove,path:/SessionTimeoutHours}`. The `CLIENT_VPN_SCALAR_PARAMS` SDK writer classifies a `SessionTimeoutHours` remove as un-expressible and throws `cannot be cleared via ModifyClientVpnEndpoint ...; update it manually` — the revert **fails**, even though the same writer converges an explicit `add SessionTimeoutHours=24` in one call (exactly how the sibling `VpnPort` entry works, #912/#1019).

## Fix
Add `'AWS::EC2::ClientVpnEndpoint\\0SessionTimeoutHours'` to `REVERT_SET_DEFAULT_PATHS`. The `24` write value is sourced from `KNOWN_DEFAULTS` (the VpnPort pattern), so revert now plans `{op:add,path:/SessionTimeoutHours,value:24}`.

## Test
`revert-plan.test.ts`: new #1289 case asserts an undeclared `SessionTimeoutHours=12` reverts to `{op:add, value:24, prior:12}`, not a no-op `remove`.

## Verification
Offline-proven (issue carries the deterministic `buildRevertPlan` repro). Surgical table entry mirroring the live-proven VpnPort/#912 sibling — no new live deploy.