### PR TITLE
fix(report): sha256 distinguisher for masked values + redacted json marker (#1308)

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,9 +634,19 @@ valid JSON value nor JSONL; multi-stack `--json` was unparseable — issue #755.
 **Secret redaction.** Values on known secret-bearing properties — Lambda
 `Environment.Variables`, CodeBuild `Environment.EnvironmentVariables[].Value`,
 Elastic Beanstalk env-namespace `OptionSettings`, EC2 LaunchTemplate `UserData` —
-are masked as `<redacted:NN chars>` in both text and `--json` output, so a rotated
-secret surfacing as drift does not leak its plaintext into CI logs. The finding
-still surfaces (detection is preserved) and the property/key name stays visible —
+are masked as `<redacted:NN chars:HHHHHHHH>` in both text and `--json` output, so a rotated
+secret surfacing as drift does not leak its plaintext into CI logs. The `NN` is the
+value's char length and `HHHHHHHH` is the first 8 hex of its sha256 — a **deterministic,
+stable distinguisher** (#1308): the same secret masks to the same placeholder across runs,
+so a consumer diffing two consecutive `--json` runs compares them correctly, while a
+**rotated same-length** secret now masks to a **different** placeholder instead of a
+byte-identical one (the length-only mask erased that change). The hash is non-reversible for
+a high-entropy value; a low-entropy value's short hash is brute-forceable, so it is a
+change-distinguisher, not a confidentiality guarantee — but the plaintext itself is never
+printed. In `--json` a masked finding additionally carries a `"redacted": true` sibling, an
+**out-of-band marker** so a consumer can tell a masked value from a literal live string that
+happens to look like the placeholder (a non-secret finding has no `redacted` field). The
+finding still surfaces (detection is preserved) and the property/key name stays visible —
 only the value is hidden. The same protection covers persistence: `record` writes a
 **hash** of these values into the git-committed baseline instead of the plaintext, so
 the secret never lands in a committed file while a later change still re-surfaces as

--- a/src/report/redact.ts
+++ b/src/report/redact.ts
@@ -22,10 +22,22 @@ import { createHash } from 'node:crypto';
 // paths and nothing else. Classification and folding are unchanged.
 
 // The masked placeholder. Keeps the char length as a signal (a rotated 40-char token vs a
-// blanked env var reads differently) without revealing any plaintext. A non-string value
-// (an object/array/number that slipped a matcher) masks to the length-less form.
+// blanked env var reads differently) AND appends a short sha256 prefix of the plaintext as a
+// DISTINGUISHER (#1308): without it, a rotated same-length secret renders as a byte-identical
+// `<redacted:N chars>` on both the desired/actual sides and across consecutive `--json` runs,
+// so a human diff shows zero signal and a bot diffing two runs treats two DIFFERENT secrets as
+// EQUAL (change-suppression on the machine channel). The hash is DETERMINISTIC and stable
+// across runs (same plaintext → same placeholder), so consecutive `--json` runs compare
+// correctly, and non-reversible for a high-entropy value. CAVEAT: for a LOW-entropy value (a
+// short/guessable env var) the truncated hash is brute-forceable — it is a change-DISTINGUISHER,
+// not a confidentiality guarantee; the plaintext (not the hash) is what must never be printed,
+// which it never is. A non-string value (an object/array/number that slipped a matcher) masks
+// to the length-less form (no stable byte string to hash).
 export function maskPlaceholder(value: unknown): string {
-  if (typeof value === 'string') return `<redacted:${value.length} chars>`;
+  if (typeof value === 'string') {
+    const sig = createHash('sha256').update(value).digest('hex').slice(0, 8);
+    return `<redacted:${value.length} chars:${sig}>`;
+  }
   return '<redacted>';
 }
 
@@ -136,6 +148,14 @@ export function isRedactedPath(resourceType: string, path: string): boolean {
 // where the leaf path extends the finding path (a whole free-form map, an identity-keyed
 // array), the mask is applied at the finding-path level (maskMapValues / maskEntryValueField
 // handle the sub-key masking), which covers the shapes the report renders.
+//
+// #1308: a masked copy additionally carries an out-of-band `redacted: true` marker so a
+// `--json` consumer can tell a MASKED value from a literal live string — the mask is an
+// in-band string (`<redacted:…>`) that a live property could in principle hold verbatim, so
+// without the sibling flag a bot cannot distinguish "this value was withheld" from "the live
+// value literally is that string". Non-secret findings are returned unchanged (no marker). The
+// return type is widened (not the shared `Finding` type) so the flag is optional and only
+// present on masked findings.
 export function redactFinding<
   T extends {
     resourceType: string;
@@ -144,9 +164,9 @@ export function redactFinding<
     actual?: unknown;
     arrayDelta?: unknown;
   },
->(f: T): T {
+>(f: T): T & { redacted?: true } {
   if (!isRedactedPath(f.resourceType, f.path)) return f;
-  const out: T = { ...f };
+  const out: T & { redacted?: true } = { ...f, redacted: true };
   if ('desired' in f && f.desired !== undefined)
     out.desired = redactValue(f.resourceType, f.path, f.desired);
   if ('actual' in f && f.actual !== undefined)

--- a/tests/report-redact-798.test.ts
+++ b/tests/report-redact-798.test.ts
@@ -145,18 +145,20 @@ describe('#798 report redaction — --json output masks secret VALUES', () => {
 });
 
 describe('#798 redact module unit behavior', () => {
-  it('maskPlaceholder keeps the char length for a string, length-less for non-string', () => {
-    expect(maskPlaceholder('abcd')).toBe('<redacted:4 chars>');
+  it('maskPlaceholder keeps the char length + a sha256 distinguisher for a string, length-less for non-string', () => {
+    // #1308: `<redacted:<len> chars:<sha8>>` — the 8-hex sha256 prefix distinguishes two
+    // same-length secrets. length-less form for a non-string (no stable byte string to hash).
+    expect(maskPlaceholder('abcd')).toMatch(/^<redacted:4 chars:[0-9a-f]{8}>$/);
     expect(maskPlaceholder({ x: 1 })).toBe('<redacted>');
   });
 
   it('redactValue masks the secret paths and passes non-secret paths through unchanged', () => {
-    expect(redactValue('AWS::Lambda::Function', 'Environment.Variables.T', SECRET)).toBe(
-      `<redacted:${SECRET.length} chars>`
+    expect(redactValue('AWS::Lambda::Function', 'Environment.Variables.T', SECRET)).toMatch(
+      new RegExp(`^<redacted:${SECRET.length} chars:[0-9a-f]{8}>$`)
     );
     expect(
       redactValue('AWS::EC2::LaunchTemplate', 'LaunchTemplateData.UserData', '#!/bin/bash secret')
-    ).toBe('<redacted:18 chars>');
+    ).toMatch(/^<redacted:18 chars:[0-9a-f]{8}>$/);
     // non-secret path / type -> unchanged
     expect(redactValue('AWS::Lambda::Function', 'Timeout', 900)).toBe(900);
     expect(redactValue('AWS::S3::Bucket', 'Environment.Variables.X', 'x')).toBe('x');
@@ -173,7 +175,7 @@ describe('#798 redact module unit behavior', () => {
       'OptionSettings[aws:elasticbeanstalk:application:environment|DB_PASSWORD]',
       entry
     ) as Record<string, unknown>;
-    expect(masked.Value).toBe(`<redacted:${SECRET.length} chars>`);
+    expect(masked.Value).toMatch(new RegExp(`^<redacted:${SECRET.length} chars:[0-9a-f]{8}>$`));
     expect(masked.Namespace).toBe('aws:elasticbeanstalk:application:environment');
     expect(masked.OptionName).toBe('DB_PASSWORD');
     // a NON-env-namespace option value is not a secret path -> unchanged

--- a/tests/report-redact-distinguisher-1308.test.ts
+++ b/tests/report-redact-distinguisher-1308.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { maskPlaceholder, redactFinding } from '../src/report/redact.js';
+import { buildStackJson } from '../src/report/report.js';
+import type { Finding } from '../src/types.js';
+
+// #1308 — #1234's length-only mask (`<redacted:N chars>`) had two gaps:
+//   (1) a rotated SAME-LENGTH secret rendered byte-identical on both the desired/actual
+//       sides and across consecutive `--json` runs — zero distinguishing signal (a human
+//       sees no change; a bot diffing two runs treats two DIFFERENT secrets as EQUAL and
+//       suppresses the change on the machine channel).
+//   (2) the mask is an in-band string with no `redacted: true` sibling in `--json`, so a
+//       consumer can't tell a masked value from a literal live string.
+// Fix: append a deterministic sha256 distinguisher to the placeholder, and stamp
+// `redacted: true` on the masked --json finding.
+
+// Two DIFFERENT secrets that happen to be the SAME LENGTH — the exact worst case #1234's
+// length-only mask erased (both were `<redacted:36 chars>`).
+const SECRET_A = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'; // 36 chars
+const SECRET_B = 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'; // 36 chars
+
+const lambdaEnvFinding = (value: string): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'Fn',
+  resourceType: 'AWS::Lambda::Function',
+  path: 'Environment.Variables.API_TOKEN',
+  actual: value,
+  nested: true,
+  freeFormKey: true,
+});
+
+describe('#1308 sha256 distinguisher for masked values', () => {
+  it('two DIFFERENT same-length secrets produce DIFFERENT placeholders', () => {
+    expect(SECRET_A.length).toBe(SECRET_B.length); // guard: the erased worst case
+    const a = maskPlaceholder(SECRET_A);
+    const b = maskPlaceholder(SECRET_B);
+    // both carry the same length prefix (the length is not secret) …
+    expect(a.startsWith('<redacted:36 chars:')).toBe(true);
+    expect(b.startsWith('<redacted:36 chars:')).toBe(true);
+    // … but the sha256 distinguisher differs, so a rotation is now visible (this is the
+    // assertion that FAILS under the old length-only mask, where a === b).
+    expect(a).not.toBe(b);
+  });
+
+  it('the SAME secret produces a STABLE placeholder across calls (deterministic across runs)', () => {
+    // determinism is what lets a bot compare two consecutive `--json` runs correctly.
+    expect(maskPlaceholder(SECRET_A)).toBe(maskPlaceholder(SECRET_A));
+  });
+
+  it('the placeholder never leaks the plaintext', () => {
+    expect(maskPlaceholder(SECRET_A)).not.toContain(SECRET_A);
+  });
+});
+
+describe('#1308 redacted:true json marker', () => {
+  it('a redacted --json finding carries redacted: true (out-of-band marker)', () => {
+    const { json } = buildStackJson([lambdaEnvFinding(SECRET_A)], 'stack (us-east-1)');
+    const el = json.findings[0] as Finding & { redacted?: true };
+    expect(el.redacted).toBe(true);
+    // and the marker survives serialization (the machine channel a consumer reads)
+    expect(JSON.stringify(json)).toContain('"redacted":true');
+  });
+
+  it('a NON-secret finding carries NO redacted marker', () => {
+    const normal: Finding = {
+      tier: 'declared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Timeout',
+      desired: 30,
+      actual: 900,
+    };
+    const { json } = buildStackJson([normal], 'stack (us-east-1)');
+    const el = json.findings[0] as Finding & { redacted?: true };
+    expect(el.redacted).toBeUndefined();
+    expect(JSON.stringify(json)).not.toContain('"redacted"');
+  });
+
+  it('redactFinding sets redacted: true on the masked copy and leaves non-secret findings untouched', () => {
+    const secret = redactFinding(lambdaEnvFinding(SECRET_A));
+    expect(secret.redacted).toBe(true);
+    const nonSecret = redactFinding({
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Timeout',
+      actual: 900,
+    });
+    // non-secret path returns the input unchanged (same reference, no marker)
+    expect((nonSecret as { redacted?: true }).redacted).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1308

## Problem
#1234's `maskPlaceholder` is length-only (`<redacted:N chars>`). Two gaps:
1. A rotated **same-length** secret renders byte-identical on both desired/actual and across consecutive `--json` runs — zero distinguishing signal (a human sees no change; a bot diffing two runs treats two DIFFERENT secrets as EQUAL → change-suppression on the machine channel).
2. In `--json` the mask is an in-band string with no out-of-band marker, so a consumer can't tell a masked value from a literal live string.

## Fix
- `maskPlaceholder(v)` → `<redacted:${len} chars:${sha256(v).slice(0,8)}>` — deterministic + stable across runs (consecutive `--json` runs compare correctly), non-reversible for high-entropy values. Reuses node `crypto.createHash('sha256')` (same style as the existing #798 baseline hash sentinel in the same module). Code comment notes the low-entropy brute-force caveat (it is a change-distinguisher, not a confidentiality guarantee — the plaintext is never printed).
- `redactFinding` stamps `redacted: true` on the masked copy so `--json` consumers get an out-of-band marker. The return type is **widened locally** (`T & { redacted?: true }`) — the shared `Finding` type in `src/types.ts` was NOT modified (out of scope, and not needed: the extra optional prop is assignable to `StackJsonReport.findings: Finding[]` and serializes fine).
- README JSON-output-contract section documents both.

## Tests
New `tests/report-redact-distinguisher-1308.test.ts`: (a) two DIFFERENT same-length secrets → DIFFERENT placeholders (fails under old length-only mask), (b) same secret → STABLE placeholder, (c) redacted finding carries `redacted: true` in its json shape (+ non-secret has no marker). Existing `report-redact-798.test.ts` assertions updated to the new `<redacted:N chars:HHHHHHHH>` format.

## Gates
typecheck / `vp check --fix` / `vp pack` / `vp test run` (4471 pass) / `vp run check` (0 errors) — all green.

## Scope note
Fix is entirely in `src/report/redact.ts`; `src/report/report.ts` already routes through `redactFinding`/`redactValue` so needed no change.