### PR TITLE
fix(config): decode UTF-16/BOM ignore.yaml (#1291)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -79,6 +79,47 @@ const FILE_HEADER =
   '# "<constructPath|logicalId>.<property>" glob, the scopes narrow WHERE it applies.\n' +
   '# Add a comment above a rule to record WHY it is ignored.\n';
 
+// Decode an ignore.yaml buffer via the same BOM/UTF-16 sniff resolveApp gained for cdk.json
+// (#1076) and the baseline reader got in #1137 — the config reader is the remaining sibling
+// (#1291). A UTF-16 LE file (FF FE — Windows PowerShell 5.1's DEFAULT for `Out-File` / `>`)
+// or UTF-16 BE (FE FF) decoded with Node's `readFile(…, 'utf8')` becomes NUL-interleaved
+// mojibake that the YAML parser reads as a SINGLE scalar, so a perfectly valid mapping is
+// mis-diagnosed as "must be a YAML mapping". A default TextDecoder consumes the BOM
+// (`ignoreBOM` defaults to false), so a UTF-8 BOM (EF BB BF) is also stripped here — the
+// yaml parser already tolerates a UTF-8 BOM, so this only makes the two paths agree; the
+// UTF-16 cases are the ones Node's 'utf8' decode genuinely mangles.
+//
+// Beyond the BOM sniff (resolveApp's cdk.json only ever sees BOM-prefixed UTF-16), we also
+// detect BOM-LESS UTF-16 from the NUL-interleaving the issue calls out: ignore.yaml is a
+// hand-edited file, and some editors write UTF-16 without a BOM. UTF-16-LE ASCII-range text
+// is `<byte> 00 <byte> 00 …` and UTF-16-BE is `00 <byte> 00 <byte> …`; a legitimate UTF-8
+// ignore.yaml contains no NUL bytes at all, so a NUL at every odd (LE) or even (BE) index in
+// the leading window is an unambiguous UTF-16 signal.
+function looksUtf16(buf: Buffer, nulAtOddIndex: boolean): boolean {
+  const n = Math.min(buf.length, 64);
+  if (n < 2) return false;
+  let pairs = 0;
+  for (let i = nulAtOddIndex ? 1 : 0; i < n; i += 2) {
+    if (buf[i] !== 0x00) return false;
+    pairs++;
+  }
+  return pairs > 0;
+}
+
+function decodeConfig(buf: Buffer): string {
+  const encoding =
+    buf[0] === 0xff && buf[1] === 0xfe
+      ? 'utf-16le'
+      : buf[0] === 0xfe && buf[1] === 0xff
+        ? 'utf-16be'
+        : looksUtf16(buf, /* nulAtOddIndex (LE) */ true)
+          ? 'utf-16le'
+          : looksUtf16(buf, /* nulAtEvenIndex (BE) */ false)
+            ? 'utf-16be'
+            : 'utf-8';
+  return new TextDecoder(encoding).decode(buf);
+}
+
 /**
  * Load `.cdkrd/ignore.yaml` (cwd-relative). Absent file -> empty config (no migration
  * needed). A comments-only / empty file parses to null -> empty config too. Invalid
@@ -91,7 +132,12 @@ const FILE_HEADER =
 export async function loadConfig(): Promise<CdkrdConfig> {
   let raw: string;
   try {
-    raw = await readFile(CONFIG_PATH, 'utf8');
+    // Read as a Buffer (no encoding) and decode via the BOM/UTF-16 sniff (#1291): a
+    // Windows-authored UTF-16 file decoded as 'utf8' becomes mojibake the YAML parser
+    // mis-reads as a single scalar, throwing the misleading "must be a YAML mapping" on a
+    // file that IS a valid mapping. `decodeConfig` strips a BOM / handles UTF-16 like the
+    // real `cdk` CLI does for cdk.json (resolveApp, #1076) and the baseline reader (#1137).
+    raw = decodeConfig(await readFile(CONFIG_PATH));
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code === 'ENOENT') return { ignore: [] };
     throw e;
@@ -414,7 +460,10 @@ export async function addIgnoreRules(
   // the other process ALSO just added is not written twice.
   let existingRaw: string | undefined;
   try {
-    existingRaw = await readFile(CONFIG_PATH, 'utf8');
+    // Same BOM/UTF-16 decode as loadConfig (#1291): this raw text is re-parsed by
+    // appendRulesToYaml to preserve the user's comments/layout, so it must be decoded the
+    // same way — a UTF-16 file read as 'utf8' here would corrupt the append.
+    existingRaw = decodeConfig(await readFile(CONFIG_PATH));
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
   }

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -732,6 +732,46 @@ describe('loadConfig', () => {
     await write('ignore: []\nconcurency: 4\n');
     await expect(loadConfig()).rejects.toThrow(/unknown key\(s\) "concurency"/);
   });
+
+  // #1291 — a Windows-authored UTF-16 ignore.yaml (PowerShell 5.1 `Out-File` / `> file`
+  // default) read as 'utf8' becomes NUL-interleaved mojibake the YAML parser reads as a
+  // single scalar, so a valid mapping was mis-diagnosed as "must be a YAML mapping". The
+  // BOM/UTF-16 sniff (mirroring resolveApp #1076) now decodes these correctly.
+  const YAML = 'ignore:\n  - path: Res.Prop\n';
+  const EXPECTED = { ignore: [{ path: 'Res.Prop' }] };
+  // write a raw Buffer (bypasses the utf8 `write` helper) at .cdkrd/ignore.yaml
+  const writeBytes = async (buf: Buffer) => {
+    await mkdir('.cdkrd', { recursive: true });
+    await writeFile('.cdkrd/ignore.yaml', buf);
+  };
+  const toUtf16be = (le: Buffer): Buffer => {
+    const be = Buffer.alloc(le.length);
+    for (let i = 0; i < le.length; i += 2) {
+      be[i] = le[i + 1]!;
+      be[i + 1] = le[i]!;
+    }
+    return be;
+  };
+
+  it('reads a UTF-16 LE ignore.yaml with a BOM (PowerShell 5.1 `Out-File` default)', async () => {
+    await writeBytes(Buffer.from(`﻿${YAML}`, 'utf16le'));
+    expect(await loadConfig()).toEqual(EXPECTED);
+  });
+
+  it('reads a UTF-16 LE ignore.yaml without a BOM', async () => {
+    await writeBytes(Buffer.from(YAML, 'utf16le'));
+    expect(await loadConfig()).toEqual(EXPECTED);
+  });
+
+  it('reads a UTF-16 BE ignore.yaml (with a BOM)', async () => {
+    await writeBytes(toUtf16be(Buffer.from(`﻿${YAML}`, 'utf16le')));
+    expect(await loadConfig()).toEqual(EXPECTED);
+  });
+
+  it('reads a UTF-8 BOM ignore.yaml (BOM stripped, uniform with cdk.json)', async () => {
+    await writeBytes(Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(YAML, 'utf8')]));
+    expect(await loadConfig()).toEqual(EXPECTED);
+  });
 });
 
 describe('ignoreRuleFor', () => {
@@ -1108,5 +1148,15 @@ describe('addIgnoreRules', () => {
     // both the peer's rule and ours land — the write was built from the re-read, not a write
     // that overwrote the file with only our rule.
     expect((await loadConfig()).ignore).toEqual([{ path: 'Peer.appended' }, { path: 'Mine.z' }]);
+  });
+
+  it('appends to a UTF-16 LE existing file without mojibaking its prior rules (#1291 re-read)', async () => {
+    // The pre-write re-read (existingRaw) must decode with the same BOM/UTF-16 sniff as
+    // loadConfig, else a Windows-authored UTF-16 ignore.yaml would parse to mojibake here
+    // and its existing rules would be dropped on append.
+    await mkdir('.cdkrd', { recursive: true });
+    await writeFile('.cdkrd/ignore.yaml', Buffer.from('﻿ignore:\n  - path: Prior.x\n', 'utf16le'));
+    await addIgnoreRules([p('Mine.z')]);
+    expect((await loadConfig()).ignore).toEqual([{ path: 'Prior.x' }, { path: 'Mine.z' }]);
   });
 });


### PR DESCRIPTION
Closes #1291

`loadConfig` read `.cdkrd/ignore.yaml` with `readFile(path, 'utf8')`. A Windows-authored UTF-16 file (PowerShell 5.1 `Out-File` / `>` default) decodes to NUL-interleaved mojibake, which the YAML parser reads as a single scalar → the misleading `.cdkrd/ignore.yaml must be a YAML mapping` error on a file that IS a valid mapping.

Fix: read the file as a Buffer and decode via a BOM/UTF-16 sniff, mirroring the approach `resolveApp` gained for cdk.json (#1076) and the baseline reader got (#1137). A local `decodeConfig` helper in config-file.ts:
- sniffs a UTF-16 LE (FF FE) / BE (FE FF) BOM and decodes with `TextDecoder`;
- additionally detects **BOM-less** UTF-16 from the NUL-interleaving the issue calls out (a legit UTF-8 ignore.yaml has no NUL bytes), covering editors that write UTF-16 without a BOM;
- a UTF-8 BOM is stripped by `TextDecoder` too, so the two paths agree (the yaml parser already tolerated a UTF-8 BOM — no regression).

The same decode is applied to the pre-write re-read in `addIgnoreRules` so an append to a UTF-16 file preserves its prior rules/comments instead of mojibaking them.

Scope: only `src/config/config-file.ts` + `tests/config-file.test.ts`.

Tests: UTF-16 LE (BOM + BOM-less), UTF-16 BE (BOM), UTF-8 BOM, plain UTF-8 regression guard, and a UTF-16 `addIgnoreRules` re-read/append case.