### PR TITLE
fix(schema): pointerToDotted tolerates a no-leading-slash properties/ pointer (#1311)

### DIFF
--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -298,8 +298,14 @@ function pointerToDotted(p: string): string {
   // and drop a trailing `/properties`, so the dotted path matches the actual model key
   // (`EncryptionAtRestOptions`, `AdvancedSecurityOptions.Enabled`) instead of keeping a
   // literal `properties` segment that matches nothing.
+  //
+  // The leading slash is OPTIONAL (`/?`): some registry schemas ship a
+  // `propertyTransform` key with NO leading slash — `AWS::SimSpaceWeaver::Simulation`
+  // emits `"properties/MaximumDuration"`. Without tolerating that, the key would land
+  // under the dead `properties.MaximumDuration` and the transform would never be
+  // consulted — a permanent declared false positive (#1311).
   return p
-    .replace(/^\/properties\//, '')
+    .replace(/^\/?properties\//, '')
     .replace(/\/properties\//g, '/')
     .replace(/\/properties$/, '')
     .replace(/\//g, '.');

--- a/tests/schema-proptransform-881.test.ts
+++ b/tests/schema-proptransform-881.test.ts
@@ -26,6 +26,27 @@ describe('#881 parseSchema honors propertyTransform', () => {
     });
   });
 
+  it('tolerates a NO-leading-slash `properties/` key (SimSpaceWeaver) while keeping the slashed form (#1311)', () => {
+    // `AWS::SimSpaceWeaver::Simulation` ships `"properties/MaximumDuration"` with NO
+    // leading `/`. Without the `/?` tolerance the key lands under the dead
+    // `properties.MaximumDuration` and the transform is never consulted → a permanent
+    // declared FP. The slashed nested/array form must still normalize as before.
+    const info = parseSchema(
+      JSON.stringify({
+        typeName: 'AWS::SimSpaceWeaver::Simulation',
+        properties: {},
+        propertyTransform: {
+          'properties/MaximumDuration': '$uppercase(MaximumDuration)',
+          '/properties/A/*/B': '$lowercase(B)',
+        },
+      })
+    );
+    expect(info.propertyTransforms).toEqual({
+      MaximumDuration: '$uppercase(MaximumDuration)',
+      'A.*.B': '$lowercase(B)',
+    });
+  });
+
   it('omits propertyTransforms entirely when the schema has no propertyTransform block', () => {
     const info = parseSchema(JSON.stringify({ typeName: 'AWS::Test::Type', properties: {} }));
     expect(info.propertyTransforms).toBeUndefined();

--- a/tests/schema-strip.test.ts
+++ b/tests/schema-strip.test.ts
@@ -96,3 +96,59 @@ describe('getSchemaInfo DescribeType failure handling (#751)', () => {
     expect(msg).toContain('cloudformation:DescribeType');
   });
 });
+
+// #1311: `AWS::SimSpaceWeaver::Simulation` ships a `propertyTransform` whose KEY has NO
+// leading slash — `"properties/MaximumDuration": "$uppercase(MaximumDuration)"`. The
+// pointerToDotted helper only stripped a LEADING `/properties/`, so the transform landed
+// under the dead dotted key `properties.MaximumDuration` and was never consulted; a
+// template declaring `MaximumDuration: 5d` (service echoes `5D`) was a permanent declared
+// false positive. The fix tolerates the optional leading slash — exercised here through
+// the public getSchemaInfo, which keys propertyTransforms via pointerToDotted, plus the
+// readOnly/writeOnly/createOnly strip that shares the same helper.
+describe('pointerToDotted tolerates a no-leading-slash properties/ pointer (#1311)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keys a no-leading-slash propertyTransform under the real model path, not `properties.*`', async () => {
+    const resourceType = 'AWS::SimSpaceWeaver::Simulation1311';
+    const region = 'us-east-1';
+    const schema = {
+      properties: { MaximumDuration: { type: 'string' } },
+      // The typo'd registry key: `properties/MaximumDuration` with NO leading slash.
+      propertyTransform: { 'properties/MaximumDuration': '$uppercase(MaximumDuration)' },
+    };
+    const send = vi.fn().mockResolvedValue({ Schema: JSON.stringify(schema) });
+    const client = fakeClient(region, send as unknown as () => Promise<unknown>);
+
+    const info = await getSchemaInfo(client, resourceType);
+
+    // The transform is now reachable under the real dotted key...
+    expect(info.propertyTransforms?.['MaximumDuration']).toBe('$uppercase(MaximumDuration)');
+    // ...and NOT stranded under the dead `properties.MaximumDuration` key (the pre-fix bug).
+    expect(info.propertyTransforms?.['properties.MaximumDuration']).toBeUndefined();
+  });
+
+  it('still strips a normal leading-slash `/properties/Foo` readOnly/writeOnly pointer', async () => {
+    const resourceType = 'AWS::Foo::Slash1311';
+    const region = 'eu-west-1';
+    const schema = {
+      properties: { Id: { type: 'string' }, Secret: { type: 'string' } },
+      readOnlyProperties: ['/properties/Id'],
+      writeOnlyProperties: ['/properties/Secret'],
+      // A no-leading-slash variant also folds correctly via the shared helper.
+      createOnlyProperties: ['properties/Id'],
+    };
+    const send = vi.fn().mockResolvedValue({ Schema: JSON.stringify(schema) });
+    const client = fakeClient(region, send as unknown as () => Promise<unknown>);
+
+    const info = await getSchemaInfo(client, resourceType);
+
+    // Leading-slash pointers keep working (no regression).
+    expect(info.readOnly.has('Id')).toBe(true);
+    expect(info.writeOnly.has('Secret')).toBe(true);
+    // The no-leading-slash createOnly pointer also lands on the real key, not `properties`.
+    expect(info.createOnly.has('Id')).toBe(true);
+    expect(info.createOnly.has('properties')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1311

`AWS::SimSpaceWeaver::Simulation` ships `"propertyTransform": { "properties/MaximumDuration": "$uppercase(MaximumDuration)" }` — with NO leading `/`. `pointerToDotted` only stripped a LEADING `/properties/`, so the transform key landed under the dead dotted key `properties.MaximumDuration` and was never consulted; a template declaring `MaximumDuration: 5d` (service echoes `5D`) was a permanent declared false positive.

## Fix
In `pointerToDotted`, tolerate an optional leading slash: the leading strip becomes `/^\/?properties\//`, so both `/properties/X` and `properties/X` yield `X` (and nested `.../Y` → `X.Y`). The same helper feeds readOnly/writeOnly/createOnly stripping, so this also hardens those against the same registry typo. The normal `/properties/Foo/Bar` → `Foo.Bar` case is unaffected.

## Tests
- `tests/schema-strip.test.ts`: a no-leading-slash `propertyTransform` now keys under the real `MaximumDuration` (not the dead `properties.MaximumDuration`); leading-slash readOnly/writeOnly and a no-leading-slash createOnly still land on the real key.
- `tests/schema-proptransform-881.test.ts`: `parseSchema` normalizes both the no-leading-slash `properties/MaximumDuration` and the slashed nested/array `/properties/A/*/B` form.

Both new assertions FAIL without the fix and PASS with it.