### PR TITLE
fix(revert): refuse to write GetTemplate-masked declared values back to AWS

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -39,6 +39,7 @@ import { applyRevertDelete, applyRevertDeletes, applyRevertItem } from '../rever
 import {
   buildRevertPlan,
   isContractOp,
+  maskReadGapKeysOf,
   rejectedEmptyStripOps,
   type RevertItem,
   type RevertPlan,
@@ -1204,6 +1205,10 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     // raw live models so a CC revert patch can strip a bare-null array husk out of CC's
     // server-side model (#641 symptom 2), else the unrelated-property revert fails validation.
     liveByLogical: gathered.liveByLogical,
+    // computed over the FULL reconciled findings — `drifted` may be the picked subset,
+    // which never includes the (unpickable) GetTemplate-masked readGaps the whole-array
+    // mask guard correlates against.
+    maskReadGapKeys: maskReadGapKeysOf(reconciled),
   });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -11,10 +11,12 @@
 // CC-gap types (revert for those is a follow-up).
 import type { BaselineFile } from '../baseline/baseline-file.js';
 import { withinStackPath } from '../construct-path.js';
+import { GETTEMPLATE_MASK_NOTE } from '../diff/classify.js';
 import { TAG_PROPERTY_NAMES } from '../normalize/cc-api-strip.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
   awsManagedTags,
+  isCfnTemplateNonAsciiMask,
   JSON_STRING_PROPS,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
@@ -448,6 +450,82 @@ export interface NotRevertable {
   reason: string;
 }
 
+// Keys (`logicalId\0path`) of the GetTemplate-masked readGap findings classify demoted
+// (#1341) — the positive record of WHERE the declared template carries `?`-masked
+// non-ASCII text. Used to refuse a whole-array revert whose declared array contains such
+// a masked element: the finding's own desired/actual pair can't reveal it (desired is
+// the whole array, actual just the edited leaf), but a sibling masked readGap UNDER the
+// same array path proves the write would stamp `?`s over intact live text. Exported so
+// stack-actions can compute the keys over the FULL reconciled findings and pass them via
+// RevertOptions.maskReadGapKeys — the interactive per-finding flow narrows the plan
+// input to the picked findings only, which never include (unpickable) readGaps.
+export function maskReadGapKeysOf(findings: readonly Finding[]): Set<string> {
+  const keys = new Set<string>();
+  for (const f of findings) {
+    if (f.tier === 'readGap' && f.note === GETTEMPLATE_MASK_NOTE) {
+      keys.add(`${f.logicalId}\0${f.path}`);
+    }
+  }
+  return keys;
+}
+
+// Does the DECLARED (desired) value carry a GetTemplate non-ASCII `?`-mask anywhere,
+// judged against the intact live value? A declared drift whose desired came from
+// GetTemplate with non-ASCII text masked to `?` (and no local-synth recovery — see
+// desired/recover-nonascii.ts) can still surface when a GENUINE edit exists alongside
+// the masks (a mask-ONLY difference is demoted to readGap in classify and never reaches
+// the plan). Writing that desired back would fix the edited leaf but CORRUPT every
+// masked leaf — stamping literal `?` runs over the live non-ASCII text — so the plan
+// must refuse it. Walk desired and live in parallel and report true when ANY aligned
+// string-leaf pair is a mask (isCfnTemplateNonAsciiMask: exact ASCII skeleton + length,
+// >=1 non-ASCII — a legit literal `?` never matches an ASCII live value); when both
+// leaves are JSON documents (an SFN DefinitionString, a JSON-string prop), parse and
+// walk INSIDE them, since the masked leaf hides within the encoded text. Structurally
+// divergent branches (the genuine edit) simply don't align — fail-open by design: a
+// masked leaf whose OWN text was also edited is undetectable in principle (the intact
+// declared text is unrecoverable), and blocking must only fire on positive evidence.
+// Unlike the #1225 write-time guard this compares f.desired vs f.actual — BOTH from
+// classify's one normalized domain, never a fresh live read — so there is no
+// writer-shape mismatch to false-abort on (the trap that sank #1225 → revert #1243).
+export function hasGetTemplateMaskedLeaf(desired: unknown, live: unknown): boolean {
+  if (typeof desired === 'string' && typeof live === 'string') {
+    if (isCfnTemplateNonAsciiMask(desired, live)) return true;
+    // Not mask-aligned as raw strings — if both encode JSON documents, the mask may sit
+    // on a leaf inside them (alongside a genuine edit that broke whole-string alignment).
+    try {
+      return hasGetTemplateMaskedLeaf(JSON.parse(desired), JSON.parse(live));
+    } catch {
+      return false;
+    }
+  }
+  if (Array.isArray(desired) && Array.isArray(live)) {
+    const n = Math.min(desired.length, live.length);
+    for (let i = 0; i < n; i++) if (hasGetTemplateMaskedLeaf(desired[i], live[i])) return true;
+    return false;
+  }
+  if (
+    typeof desired === 'object' &&
+    desired !== null &&
+    typeof live === 'object' &&
+    live !== null &&
+    !Array.isArray(desired) &&
+    !Array.isArray(live)
+  ) {
+    for (const key of Object.keys(desired as Record<string, unknown>)) {
+      if (!Object.hasOwn(live, key)) continue;
+      if (
+        hasGetTemplateMaskedLeaf(
+          (desired as Record<string, unknown>)[key],
+          (live as Record<string, unknown>)[key]
+        )
+      )
+        return true;
+    }
+    return false;
+  }
+  return false;
+}
+
 export interface RevertPlan {
   items: RevertItem[];
   notRevertable: NotRevertable[];
@@ -572,6 +650,11 @@ export interface RevertOptions {
   // resourceType -> schema, so create-only property drift is reported as
   // notRevertable up front (an in-place patch would fail at apply time).
   schemas?: Map<string, SchemaInfo>;
+  // `logicalId\0path` keys of GetTemplate-masked readGaps (maskReadGapKeysOf) computed
+  // over the FULL reconciled findings. buildRevertPlan also collects them from its own
+  // input, but the interactive per-finding flow narrows that input to the picked
+  // findings (readGaps are unpickable), so the caller passes the full-set keys here.
+  maskReadGapKeys?: ReadonlySet<string>;
   // The stack name — used to strip the stack/Stage prefix off each finding's construct path
   // for display (`withinStackPath`), matching what `cdkrd check` shows. Absent (unit calls) =
   // no strip, the full construct path.
@@ -642,6 +725,11 @@ export function buildRevertPlan(
   const itemsByLogical = new Map<string, RevertItem>();
   const notRevertable: NotRevertable[] = [];
   const recorded = baseline?.recorded ?? [];
+  // Where the declared template carries GetTemplate-masked non-ASCII text: the demoted
+  // readGaps in this plan's own input plus the caller-supplied full-set keys (the
+  // interactive flow narrows the input to picked findings, which exclude readGaps).
+  const maskGapKeys = maskReadGapKeysOf(findings);
+  for (const k of opts.maskReadGapKeys ?? []) maskGapKeys.add(k);
   // Collapse the per-element findings of an UNORDERED_OBJECT_ARRAY into ONE whole-array
   // replacement (see Finding.wholeArrayRevert): classify sorted both sides before the diff,
   // so each finding's array index is a SORTED position that does NOT map to the live raw
@@ -768,6 +856,43 @@ export function buildRevertPlan(
       continue;
     }
     if (!DRIFT_TIERS.has(f.tier)) continue; // only declared/undeclared are drift to revert
+    // A declared desired that carries GetTemplate `?`-masked non-ASCII text (judged
+    // against the intact live value) must NOT be written back: the write would stamp
+    // literal `?` runs over the live text wherever the template's non-ASCII literals
+    // were masked. Only the declared tier is at risk — undeclared reverts write baseline
+    // values recorded from the intact LIVE read. Two detections (see
+    // hasGetTemplateMaskedLeaf / maskReadGapKeysOf):
+    //   1. the finding's own desired/actual pair walks to a masked leaf, or
+    //   2. WHOLE-ARRAY reverts only: a sibling GetTemplate-masked readGap sits under the
+    //      same array path — the whole declared array being written contains that masked
+    //      element even though this finding's own pair (whole array vs one edited leaf)
+    //      cannot align to reveal it. Gated on wholeArrayRevert so a per-key writer that
+    //      sends ONLY the edited attribute (ELB bags) is never false-blocked by a masked
+    //      SIBLING it does not write.
+    const maskedSiblingUnderPath = (): boolean => {
+      if (maskGapKeys.size === 0) return false;
+      for (const key of maskGapKeys) {
+        const sep = key.indexOf('\0');
+        if (key.slice(0, sep) !== f.logicalId) continue;
+        const p = key.slice(sep + 1);
+        if (p === f.path || p.startsWith(`${f.path}.`)) return true;
+      }
+      return false;
+    };
+    if (
+      f.tier === 'declared' &&
+      (hasGetTemplateMaskedLeaf(f.desired, f.actual) ||
+        (f.wholeArrayRevert !== undefined && maskedSiblingUnderPath()))
+    ) {
+      notRevertable.push({
+        displayId,
+        resourceType: f.resourceType,
+        path: f.path,
+        reason:
+          'declared value is non-ASCII-masked by GetTemplate ("?") — writing it back would corrupt the live text; redeploy from your CDK app instead',
+      });
+      continue;
+    }
     // A SYNTHETIC integrity signal an SDK_SUPPLEMENTS reader computes (ELBv2 TrustStore
     // `CaCertificatesBundleSha256`, a digest of the live CA bundle content — #505) is not a
     // real AWS property, so it has no write target: a `remove` would fail. It exists only to

--- a/tests/revert-plan-mask-guard.test.ts
+++ b/tests/revert-plan-mask-guard.test.ts
@@ -1,0 +1,173 @@
+// Revert guard for GetTemplate `?`-masked declared values (#1247 follow-up). A declared
+// drift can carry masks in `desired` even after the classify-side demotion (#1341): when
+// a GENUINE out-of-band edit exists ALONGSIDE the masks, the finding rightly stays
+// declared drift — but writing that desired back would stamp literal `?` runs over the
+// live non-ASCII text wherever the template's literals were masked. The plan must refuse
+// it (notRevertable with an actionable reason), never emit the corrupting write. Unlike
+// the #1225 write-time guard (reverted in #1243 for false-aborting on writer-shape
+// mismatches), this compares finding.desired vs finding.actual — both from classify's
+// one normalized domain — and fires only on positive per-leaf mask evidence.
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildRevertPlan,
+  hasGetTemplateMaskedLeaf,
+  maskReadGapKeysOf,
+} from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+const mask = (s: string): string =>
+  [...s].map((ch) => ((ch.codePointAt(0) ?? 0) > 0x7f ? '?' : ch)).join('');
+
+// Generic fixture text (not from any real environment).
+const LIVE_CAUSE = '入力値 item.<type>.<size> が不正です';
+
+const F = (over: Partial<Finding>): Finding => ({
+  tier: 'declared',
+  logicalId: 'Machine',
+  physicalId: 'arn:aws:states:us-east-1:111111111111:stateMachine:m',
+  resourceType: 'AWS::StepFunctions::StateMachine',
+  path: 'DefinitionString',
+  ...over,
+});
+
+describe('hasGetTemplateMaskedLeaf', () => {
+  it('finds a masked leaf INSIDE a JSON string even when a genuine edit broke whole-string alignment', () => {
+    const live = `{"States":{"Bad":{"Cause":"${LIVE_CAUSE}","Error":"InvalidFormat"}}}`;
+    // Out-of-band edit changed Error (so raw strings are not mask-aligned), Cause is masked.
+    const desired = `{"States":{"Bad":{"Cause":"${mask(LIVE_CAUSE)}","Error":"WrongCode"}}}`;
+    expect(hasGetTemplateMaskedLeaf(desired, live)).toBe(true);
+  });
+
+  it('does NOT fire on a legit literal "?" against an ASCII live value', () => {
+    expect(hasGetTemplateMaskedLeaf('is it ok?', 'is it ok!')).toBe(false);
+    expect(hasGetTemplateMaskedLeaf({ a: 'x?' }, { a: 'y!' })).toBe(false);
+  });
+
+  it('does NOT fire when the values are plain non-JSON strings that differ genuinely', () => {
+    expect(hasGetTemplateMaskedLeaf('Enabled', 'Suspended')).toBe(false);
+  });
+
+  it('walks objects and arrays in parallel and ignores unaligned branches', () => {
+    const desired = { list: [{ label: mask(LIVE_CAUSE) }], extraOnlyInDesired: '???' };
+    const live = { list: [{ label: LIVE_CAUSE }], other: 1 };
+    expect(hasGetTemplateMaskedLeaf(desired, live)).toBe(true);
+    // The masked leaf gone -> nothing aligned masks -> false.
+    expect(hasGetTemplateMaskedLeaf({ extraOnlyInDesired: '???' }, { other: 1 })).toBe(false);
+  });
+});
+
+describe('buildRevertPlan — masked declared desired is refused, not written', () => {
+  it('reports notRevertable (with the mask reason) instead of emitting a write op', () => {
+    const live = `{"States":{"Bad":{"Cause":"${LIVE_CAUSE}","Error":"InvalidFormat"}}}`;
+    const desired = `{"States":{"Bad":{"Cause":"${mask(LIVE_CAUSE)}","Error":"WrongCode"}}}`;
+    const plan = buildRevertPlan([F({ desired, actual: live })], undefined);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0].reason).toContain('non-ASCII-masked by GetTemplate');
+  });
+
+  it('still plans a normal declared revert when no mask is involved', () => {
+    const plan = buildRevertPlan(
+      [
+        F({
+          resourceType: 'AWS::S3::Bucket',
+          path: 'VersioningConfiguration.Status',
+          desired: 'Enabled',
+          actual: 'Suspended',
+        }),
+      ],
+      undefined
+    );
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+  });
+
+  it('refuses a WHOLE-ARRAY revert whose declared array contains a masked sibling element', () => {
+    // A tag list where one value was genuinely edited out of band (declared drift with a
+    // whole-array revert) while ANOTHER tag's value is non-ASCII (its own leaf demoted to
+    // a masked readGap). The whole-array write would stamp the masked element too — the
+    // sibling readGap (correlated via maskReadGapKeys) is the evidence.
+    const maskedTagList = [
+      { Key: 'purpose', Value: mask('検証用') },
+      { Key: 'team', Value: 'edited-out-of-band' },
+    ];
+    const declared = F({
+      resourceType: 'AWS::S3::Bucket',
+      path: 'Tags',
+      desired: 'team-orig',
+      actual: 'edited-out-of-band',
+      wholeArrayRevert: { path: 'Tags', value: maskedTagList },
+    });
+    const maskGap: Finding = {
+      tier: 'readGap',
+      logicalId: 'Machine',
+      resourceType: 'AWS::S3::Bucket',
+      path: 'Tags.0.Value',
+      note: 'declared value unverifiable — CloudFormation GetTemplate masks non-ASCII characters as "?"',
+    };
+    // Full-list input (standalone revert): the readGap rides along in findings.
+    const plan = buildRevertPlan([declared, maskGap], undefined);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable.map((n) => n.reason).join()).toContain(
+      'non-ASCII-masked by GetTemplate'
+    );
+    // Subset input (interactive picked-finding flow): the readGap is NOT in findings —
+    // the caller passes the keys computed over the full reconciled list instead.
+    const subset = buildRevertPlan([declared], undefined, {
+      maskReadGapKeys: maskReadGapKeysOf([maskGap]),
+    });
+    expect(subset.items).toHaveLength(0);
+    expect(subset.notRevertable).toHaveLength(1);
+  });
+
+  it('does NOT block a per-key attribute revert over a masked SIBLING it never writes', () => {
+    // ELB attribute bags revert per Key=Value (no wholeArrayRevert): a masked sibling
+    // attribute must not block reverting a different, genuinely edited attribute.
+    const declared = F({
+      resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+      physicalId: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/tg/1',
+      path: 'TargetGroupAttributes',
+      attributeKey: 'deregistration_delay.timeout_seconds',
+      desired: '300',
+      actual: '60',
+    });
+    const plan = buildRevertPlan([declared], undefined, {
+      maskReadGapKeys: new Set(['Machine\0TargetGroupAttributes']),
+    });
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+  });
+
+  it('does not gate the undeclared tier (baseline values come from the intact live read)', () => {
+    // An undeclared restore whose baseline value legitimately contains "?" must not be
+    // blocked: the guard is declared-only by design.
+    const plan = buildRevertPlan(
+      [
+        F({
+          tier: 'undeclared',
+          resourceType: 'AWS::S3::Bucket',
+          path: 'Description',
+          desired: undefined,
+          actual: 'now-live',
+        }),
+      ],
+      {
+        schemaVersion: 1,
+        stackName: 's',
+        region: 'r',
+        accountId: '111122223333',
+        capturedAt: '',
+        templateHash: '',
+        recorded: [
+          {
+            logicalId: 'Machine',
+            resourceType: 'AWS::S3::Bucket',
+            path: 'Description',
+            value: 'was: ok?',
+          },
+        ],
+      }
+    );
+    expect(plan.notRevertable.filter((n) => n.reason.includes('non-ASCII-masked'))).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Final follow-up in the GetTemplate non-ASCII mask series (#1247 → #1337 → #1341 → #1345): close the AWS-mutating hole.

## Why

A declared drift can carry GetTemplate `?`-masked non-ASCII text in `desired` even after the classify-side demotion (#1341): when a genuine out-of-band edit exists ALONGSIDE the masks, the finding rightly stays declared drift — but revert writes `finding.desired`, stamping literal `?` runs over the live non-ASCII text wherever the template's string literals were masked (an SFN definition's non-ASCII Cause message, a non-ASCII tag value). Fixing the edited leaf would silently corrupt every masked one.

## What

Plan-time guard (surfaces in `--dry-run`; never a mid-write abort), two positive-evidence-only detections:

1. **Per-finding walk** — `hasGetTemplateMaskedLeaf(desired, actual)`: parallel walk of the finding's own pair; a string-leaf pair matching `isCfnTemplateNonAsciiMask` is proof, and when both sides encode JSON documents it parses and walks inside them (the SFN mixed-edit case, where the genuine edit breaks whole-string mask alignment). Unaligned branches fail open — a masked leaf whose own text was also edited is undetectable in principle.
2. **Whole-array correlation** — whole-array reverts only: a sibling GetTemplate-masked readGap under the same array path proves the declared array being written contains a masked element the finding's own pair (whole array vs one edited leaf) cannot reveal. Keys come from `maskReadGapKeysOf` over the plan's own input plus `RevertOptions.maskReadGapKeys` computed by the caller over the FULL reconciled findings (the interactive picked-finding flow narrows the plan input, and readGaps are unpickable). Gated on `wholeArrayRevert` so per-key writers (ELB attribute bags) that send only the edited attribute are never false-blocked.

Refused findings surface as `notRevertable` with an actionable reason (redeploy from the CDK app). Undeclared reverts are exempt by design — their values come from the baseline, recorded from the intact live read.

## Why this is not another #1225

The #1225 write-time guard (reverted in #1243) false-aborted deterministically because it compared classify-normalized `op.prior` against a FRESH live read in the writer's shape. This guard never touches a live read: both sides of every comparison are the finding's own `desired`/`actual` from classify's one normalized domain, it runs at plan time (dry-run visible), and it fires only on exact per-leaf mask evidence (ASCII skeleton + length match + >=1 non-ASCII), never on shape.

## Verification

- 7 new unit tests: helper walk (JSON-embedded mask + genuine edit, literal `?` never excused, unaligned branches fail open), plan refusal (string form, whole-array via in-list readGap AND via caller-passed keys), per-key sibling non-block, undeclared exemption.
- Full suite: 176 files / 4500 tests pass; typecheck + lint/format + build pass.
