### PR TITLE
test: scrub remaining real app names from test comments and fixture ids

### DIFF
--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -834,8 +834,8 @@ describe('sibling-managed inline Policies (IAM User / Group)', () => {
       { Effect: 'Allow', Action: ['s3:GetBucket*', 's3:GetObject*', 's3:List*'], Resource: '*' },
     ],
   };
-  // db2bq's real live shape: PolicyName === the sibling AWS::IAM::Policy's literal name.
-  const sibling = { PolicyName: 'DataTransferIamUserDefaultPolicy758350EB', PolicyDocument: DOC };
+  // a real app's live shape: PolicyName === the sibling AWS::IAM::Policy's literal name.
+  const sibling = { PolicyName: 'MyIamUserDefaultPolicy758350EB', PolicyDocument: DOC };
   const rogue = { PolicyName: 'rogue-inline', PolicyDocument: DOC };
   const principal = (
     resourceType: string,
@@ -852,7 +852,7 @@ describe('sibling-managed inline Policies (IAM User / Group)', () => {
   it('IAM User: Path:/ folds atDefault and the sibling-owned Policies entry is filtered out', () => {
     const t = tiers(
       classifyResource(
-        principal('AWS::IAM::User', ['DataTransferIamUserDefaultPolicy758350EB']),
+        principal('AWS::IAM::User', ['MyIamUserDefaultPolicy758350EB']),
         { Path: '/', Policies: [sibling] },
         noSchema
       )
@@ -864,7 +864,7 @@ describe('sibling-managed inline Policies (IAM User / Group)', () => {
   it('IAM Group: Path:/ folds atDefault and the sibling-owned Policies entry is filtered out', () => {
     const t = tiers(
       classifyResource(
-        principal('AWS::IAM::Group', ['DataTransferIamUserDefaultPolicy758350EB']),
+        principal('AWS::IAM::Group', ['MyIamUserDefaultPolicy758350EB']),
         { Path: '/', Policies: [sibling] },
         noSchema
       )
@@ -875,7 +875,7 @@ describe('sibling-managed inline Policies (IAM User / Group)', () => {
 
   it('IAM User: an out-of-band inline policy next to a sibling still surfaces as undeclared', () => {
     const findings = classifyResource(
-      principal('AWS::IAM::User', ['DataTransferIamUserDefaultPolicy758350EB']),
+      principal('AWS::IAM::User', ['MyIamUserDefaultPolicy758350EB']),
       { Policies: [sibling, rogue] },
       noSchema
     );
@@ -922,7 +922,7 @@ describe('ECS Cluster sibling capacity providers + ClusterSettings default (my-a
     declared: {},
     hasSiblingCapacityProviders,
   });
-  // the exact live model db2bq's cluster read back (key order as CC returned it)
+  // the exact live model a real app's cluster read back (key order as CC returned it)
   const live = {
     ClusterSettings: [{ Value: 'disabled', Name: 'containerInsights' }],
     CapacityProviders: ['FARGATE', 'FARGATE_SPOT'],
@@ -6336,7 +6336,7 @@ describe('classifyResource RDS version-track + dynamic-reference (R130)', () => 
 // AWS-ASSIGNED RDS values a user never declared: the KMS key, AZ placement, and randomly-
 // assigned maintenance/backup windows AWS picks at creation. Undeclared → AWS's choice, not
 // user intent → folded value-independent (atDefault). A DECLARED value is user intent →
-// compared in the declared loop (detected). Observed live on my-app-Rds / DbUsers-DB.
+// compared in the declared loop (detected). Observed live on two real apps' RDS instances.
 describe('RDS AWS-assigned values fold value-independent (KmsKeyId/AZ/windows)', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/construct-path.test.ts
+++ b/tests/construct-path.test.ts
@@ -7,7 +7,7 @@ describe('withinStackPath (strip the stack/Stage prefix off a construct path)', 
   });
 
   it('a stack id composed with the stage (e.g. `${stage}-Name`) strips as ONE segment', () => {
-    // the common manual pattern: `new Stack(app, `${stage}-AuroraDB`)` — the whole first
+    // the common manual pattern: `new Stack(app, `${stage}-MyDb`)` — the whole first
     // segment IS the stack name, so it strips even though it contains a hyphen.
     expect(withinStackPath('my-app-Rds/Database/ParameterGroup', 'my-app-Rds')).toBe(
       'Database/ParameterGroup'
@@ -31,9 +31,9 @@ describe('withinStackPath (strip the stack/Stage prefix off a construct path)', 
   });
 
   it('overridden stackName that no longer mirrors the construct ids: returns UNCHANGED (safe)', () => {
-    // `new Stack(app, 'AuroraDB', { stackName: 'prod-db' })` — construct path leads with the
-    // construct id `AuroraDB`, not `prod-db`, so nothing strips rather than stripping wrongly.
-    expect(withinStackPath('AuroraDB/Database/PG', 'prod-db')).toBe('AuroraDB/Database/PG');
+    // `new Stack(app, 'MyDb', { stackName: 'prod-db' })` — construct path leads with the
+    // construct id `MyDb`, not `prod-db`, so nothing strips rather than stripping wrongly.
+    expect(withinStackPath('MyDb/Database/PG', 'prod-db')).toBe('MyDb/Database/PG');
   });
 
   it('empty stackName (direct/unit call): returns UNCHANGED (no strip)', () => {

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -83,7 +83,7 @@ describe('collectPrincipalsWithSiblingPolicies', () => {
     ]);
   });
 
-  it('also maps Users and Groups a sibling policy attaches to (db2bq IAM User pattern)', () => {
+  it('also maps Users and Groups a sibling policy attaches to (real-app IAM User pattern)', () => {
     const resources = {
       MyUser: { Type: 'AWS::IAM::User' },
       MyGroup: { Type: 'AWS::IAM::Group' },


### PR DESCRIPTION
## Summary

Sweep follow-up to #1340 / #1342: replace the remaining private app/stack names in `tests/**` with generic wording — comments in `classify.test.ts` / `template-adapter.test.ts`, and example fixture ids in `construct-path.test.ts` (plus one fixture policy name derived from a real construct).

**Comment/fixture-string only — no behavior change.** All gates pass (typecheck / lint+format / build / 4491 unit tests). Tests-only diff — verify-pr exempt.