### PR TITLE
fix(normalize): Fn::Select indexes the compacted list; dynamic-ref elements in produced containers fail closed (#1329, #1331)

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -52,8 +52,22 @@ export function containsDynamicReference(v: string): boolean {
 // Use the contains-form so an EMBEDDED token in a larger produced string is muted too
 // (see #722); a whole-string token is a subset of it.
 // See #1073 (the indirect siblings of the direct-literal guard #722).
+// A produced CONTAINER (a CommaDelimitedList/List<> parameter value split by
+// buildResolverContext.toParam, an Fn::FindInMap list value) may carry the token as
+// an ELEMENT — a string-only gate would let it through uninspected, the same leak one
+// level down. Fail closed on the WHOLE container when ANY string leaf carries a
+// token: per-element muting would fabricate a list whose shape differs from live,
+// so whole-value muting matches the scalar precedent. See #1331.
+function containsDynamicReferenceDeep(v: unknown): boolean {
+  if (typeof v === 'string') return containsDynamicReference(v);
+  if (Array.isArray(v)) return v.some(containsDynamicReferenceDeep);
+  if (v !== null && typeof v === 'object') {
+    return Object.values(v).some(containsDynamicReferenceDeep);
+  }
+  return false;
+}
 function checkResolvedDynamicRef(r: unknown): unknown {
-  return typeof r === 'string' && containsDynamicReference(r) ? UNRESOLVED : r;
+  return containsDynamicReferenceDeep(r) ? UNRESOLVED : r;
 }
 
 // A value safe to interpolate into a joined / substituted STRING: a primitive
@@ -154,6 +168,13 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
         const [idxRaw, list] = v as [unknown, unknown];
         const arr = resolve(list, ctx);
         if (!Array.isArray(arr)) return UNRESOLVED;
+        // CloudFormation REMOVES a list element whose value resolves to AWS::NoValue,
+        // so the list COMPACTS and indices shift BEFORE Fn::Select runs — mirror the
+        // compaction Fn::Join already does, else an index after the NoValue slot
+        // selects the WRONG element (a fabricated declared value) and an index AT the
+        // slot leaks the NOVALUE symbol (pruneNoValue then deletes the whole declared
+        // property). See #1329.
+        const compacted = arr.filter((x) => x !== NOVALUE);
         // The index may itself be an intrinsic (CFn allows e.g. { Ref: SomeParam } /
         // Fn::FindInMap as the index) — resolve it before coercing. (Number() on the
         // raw UNRESOLVED symbol would throw, so guard it first.)
@@ -163,8 +184,8 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
         // Fail-closed: out-of-range index (or a NaN index) would otherwise yield
         // `undefined` and report false `desired: undefined` drift. The selected
         // element itself being UNRESOLVED also propagates.
-        if (!Number.isInteger(i) || i < 0 || i >= arr.length) return UNRESOLVED;
-        const sel = arr[i];
+        if (!Number.isInteger(i) || i < 0 || i >= compacted.length) return UNRESOLVED;
+        const sel = compacted[i];
         return sel === UNRESOLVED ? UNRESOLVED : checkResolvedDynamicRef(sel);
       }
       case 'Fn::FindInMap': {

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -689,6 +689,94 @@ describe('intrinsic resolver', () => {
     ).toBe(UNRESOLVED);
   });
 
+  // #1329: CloudFormation REMOVES a list element whose value resolves to AWS::NoValue,
+  // so the list COMPACTS and later indices shift BEFORE Fn::Select runs. The resolver
+  // already mirrors that compaction in Fn::Join and pruneNoValue, but Fn::Select
+  // indexed the RAW resolved array: an index after the NoValue slot selected the WRONG
+  // element (a fabricated declared value → false [Declared Drift], and revert writes
+  // the wrong value back), and an index AT the slot returned the NOVALUE symbol, which
+  // pruneNoValue then deleted as the whole declared property.
+  it('#1329: Fn::Select indexes the COMPACTED list (AWS::NoValue elements removed first)', () => {
+    const c = ctx({
+      params: { Env: 'dev' }, // IsProd=false → the Fn::If element resolves to NOVALUE
+      conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } },
+    });
+    // index AFTER the NoValue slot: CFn compacts to ['b','c'], so index 1 is 'c' (was 'b')
+    expect(
+      resolve(
+        {
+          'Fn::Select': [
+            1,
+            [{ 'Fn::If': ['IsProd', 'prod-only', { Ref: 'AWS::NoValue' }] }, 'b', 'c'],
+          ],
+        },
+        c
+      )
+    ).toBe('c');
+    // index AT the NoValue slot: compacted[0] is 'y' — previously the NOVALUE symbol
+    // leaked out and pruneNoValue deleted the whole declared property.
+    expect(
+      resolveProperties(
+        {
+          Port: {
+            'Fn::Select': [0, [{ 'Fn::If': ['IsProd', 'x', { Ref: 'AWS::NoValue' }] }, 'y']],
+          },
+        },
+        c
+      )
+    ).toEqual({ Port: 'y' });
+    // the bounds check runs against the COMPACTED length: selecting past it fails
+    // closed (previously the raw length let a wrong element through).
+    expect(resolve({ 'Fn::Select': [1, [{ Ref: 'AWS::NoValue' }, 'only']] }, ctx())).toBe(
+      UNRESOLVED
+    );
+    // a list WITHOUT NoValue is unchanged (regression guard; Fn::Join compaction is
+    // pinned separately above).
+    expect(resolve({ 'Fn::Select': [1, ['a', 'b']] }, ctx())).toBe('b');
+  });
+
+  // #1331: the #1073 re-check of an intrinsic-PRODUCED value was gated on
+  // `typeof r === 'string'`, so a produced ARRAY passed through with its elements
+  // uninspected — a `{{resolve:…}}` ELEMENT inside a CommaDelimitedList/List<>
+  // parameter value or an Fn::FindInMap list value leaked out (false declared drift
+  // that prints the secret token and, on revert, writes the literal token to AWS).
+  // The whole container fails closed to UNRESOLVED (per-element muting would
+  // fabricate a list whose shape differs from live), matching the scalar precedent.
+  it('#1331: a dynamic-ref ELEMENT inside a produced list → whole value UNRESOLVED', () => {
+    const ssm = '{{resolve:ssm:/prod/extra-sg}}';
+    // (a) Ref to a CommaDelimitedList/List<> parameter carrying a token element
+    //     (buildResolverContext.toParam splits 'sg-aaa,{{resolve:…}}' into this array).
+    expect(resolve({ Ref: 'SgList' }, ctx({ params: { SgList: ['sg-aaa', ssm] } }))).toBe(
+      UNRESOLVED
+    );
+    // (b) Fn::FindInMap whose looked-up value is a LIST with a token element.
+    expect(
+      resolve(
+        { 'Fn::FindInMap': ['M', 'top', 'key'] },
+        ctx({ mappings: { M: { top: { key: ['sg-aaa', ssm] } } } })
+      )
+    ).toBe(UNRESOLVED);
+    // controls: the SCALAR cases stay muted exactly as before (#1073).
+    expect(
+      resolve(
+        { 'Fn::FindInMap': ['M', 'top', 'key'] },
+        ctx({ mappings: { M: { top: { key: ssm } } } })
+      )
+    ).toBe(UNRESOLVED);
+    expect(resolve({ Ref: 'Secret' }, ctx({ params: { Secret: ssm } }))).toBe(UNRESOLVED);
+    // controls: plain lists WITHOUT tokens still resolve normally (no over-muting).
+    expect(resolve({ Ref: 'SgList' }, ctx({ params: { SgList: ['sg-aaa', 'sg-bbb'] } }))).toEqual([
+      'sg-aaa',
+      'sg-bbb',
+    ]);
+    expect(
+      resolve(
+        { 'Fn::FindInMap': ['M', 'top', 'key'] },
+        ctx({ mappings: { M: { top: { key: ['a', 'b'] } } } })
+      )
+    ).toEqual(['a', 'b']);
+  });
+
   it('#722 NEGATIVE: a literal that merely contains `{{resolve` without a valid token is NOT muted', () => {
     // no valid <service> + closing `}}` completion → stays a literal declared value.
     expect(resolve('see {{resolve later}}', ctx())).toBe('see {{resolve later}}');


### PR DESCRIPTION
## Summary

Two intrinsic-resolver fixes in `src/normalize/intrinsic-resolver.ts` (bundled: same file, same class).

### #1329 — Fn::Select indexed the RAW (uncompacted) resolved list
CloudFormation removes a list element whose value resolves to `AWS::NoValue`, so the list compacts and indices shift **before** `Fn::Select` runs. The resolver already mirrored that in `Fn::Join` and `pruneNoValue`, but the `Fn::Select` branch indexed the raw array:
- index **after** the NoValue slot → wrong element selected → fabricated declared value → false `[Declared Drift]` on a clean stack, and `revert` writes the wrong element's value.
- index **at** the slot → `NOVALUE` symbol leaked → `pruneNoValue` silently deletes the whole declared property (declared comparison lost).

Fix: compact before bounds-checking/indexing, mirroring `Fn::Join`. All existing fail-closed guards stay.

### #1331 — a `{{resolve:…}}` ELEMENT inside a produced container bypassed the #1073 re-check
`checkResolvedDynamicRef` was gated on `typeof r === 'string'`, so a produced ARRAY passed through uninspected. Real producers: a CommaDelimitedList/List<> parameter value carrying a dynamic-reference element (split by `buildResolverContext.toParam`), and an `Fn::FindInMap` list value. Consequences: false declared drift on every clean deploy, live-resolved secret printed beside the token, and `revert` writing the literal `{{resolve:…}}` string to AWS.

Fix: deep-walk containers and fail the WHOLE value closed to `UNRESOLVED` when any string leaf carries a token (per-element muting would fabricate a list whose shape differs from live) — one change covers both the `Ref` branch and the raw `Fn::FindInMap` list return.

## Tests
- `#1329: Fn::Select indexes the COMPACTED list` — pins the issue's repro (wrong-element, at-slot property-vanish, compacted-length bounds, no-NoValue regression guard). Fails without the fix.
- `#1331: a dynamic-ref ELEMENT inside a produced list → whole value UNRESOLVED` — pins both leak producers + scalar/no-token controls (no over-muting). Fails without the fix.
- Full suite: 175 files / 4493 tests green; existing #1073 / Fn::Join compaction controls unchanged.

Both issues are offline/deterministic (resolver-direct repros from the /hunt-bugs offline audit) — the new unit tests ARE the authoritative repro; no live deploy involved.

Closes #1329
Closes #1331