### PR TITLE
fix(noise): fold S3 AccelerateConfiguration Suspended off-state (#1288)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -118,6 +118,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // {Status:"Suspended"} re-reports forever and revert can never converge (R46).
   'AWS::S3::Bucket': {
     VersioningConfiguration: { Status: 'Suspended' },
+    // Transfer acceleration has identical semantics to versioning (R46): the API
+    // (PutBucketAccelerateConfiguration) accepts only Enabled|Suspended, there is no
+    // delete, and once ever touched GetBucketAccelerateConfiguration returns Suspended
+    // forever — Suspended IS the off/default state, not user intent, and a revert
+    // "remove" of an OOB Enabled lands on Suspended. Without this entry an undeclared
+    // {AccelerationStatus:"Suspended"} re-reports forever and revert can never converge
+    // (#1288). Equality-gated: an OOB Enabled — the cost/security-meaningful direction,
+    // a new world-reachable accelerate endpoint — no longer matches the folded constant
+    // and still surfaces as real undeclared drift.
+    AccelerateConfiguration: { AccelerationStatus: 'Suspended' },
     AbacStatus: 'Disabled', // R66
     // R86 (account-wide S3 defaults AWS has applied to every new bucket since 2023):
     // Block Public Access fully on (Apr 2023), ACLs disabled / BucketOwnerEnforced

--- a/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
+++ b/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (mutation-matrix integ run, final state): a real versioned+encrypted bucket; raw classify (pre-baseline) surfaces exactly the 3 real undeclared values (AccelerateConfiguration left Suspended by M3, PublicAccessBlockConfiguration, OwnershipControls) while encryption struct extras (BucketKeyEnabled/BlockedEncryptionTypes), aws:* tags, generated names and readOnly fields stay quiet.",
+  "description": "RECORDED LIVE (mutation-matrix integ run, final state): a real versioned+encrypted bucket; raw classify (pre-baseline) folds the AWS-default values to atDefault (AccelerateConfiguration left Suspended by M3 — the off/default state, #1288; PublicAccessBlockConfiguration; OwnershipControls; AbacStatus) while encryption struct extras (BucketKeyEnabled/BlockedEncryptionTypes), aws:* tags, generated names and readOnly fields stay quiet.",
   "resource": {
     "logicalId": "Data666C94C7",
     "resourceType": "AWS::S3::Bucket",
@@ -135,7 +135,7 @@
       "constructPath": "CdkdriftIntegBasic/Data"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::S3::Bucket",
       "path": "AccelerateConfiguration",

--- a/tests/noise-s3-accelerate-1288.test.ts
+++ b/tests/noise-s3-accelerate-1288.test.ts
@@ -1,0 +1,55 @@
+// #1288 S3 AccelerateConfiguration Suspended off-state fold. Transfer acceleration has
+// identical semantics to versioning (R46): PutBucketAccelerateConfiguration accepts only
+// Enabled|Suspended, there is no delete, and once ever touched Suspended is returned
+// forever — it IS the off/default state, not user intent. Without the fold an undeclared
+// {AccelerationStatus:"Suspended"} re-reports on every first check and revert of an OOB
+// Enabled can never converge. Equality-gated: an OOB Enabled still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const bucket = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType: 'AWS::S3::Bucket',
+  physicalId: 'phys',
+  declared,
+});
+
+describe('#1288 S3 AccelerateConfiguration Suspended off-state', () => {
+  const res = bucket({ BucketName: 'b' });
+
+  it('folds an undeclared {AccelerationStatus:"Suspended"} to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { AccelerateConfiguration: { AccelerationStatus: 'Suspended' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('AccelerateConfiguration');
+    expect(tier(f, 'undeclared')).not.toContain('AccelerateConfiguration');
+  });
+
+  it('surfaces an out-of-band Enabled as undeclared (detection preserved)', () => {
+    const f = classifyResource(
+      res,
+      { AccelerateConfiguration: { AccelerationStatus: 'Enabled' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('AccelerateConfiguration');
+    expect(tier(f, 'atDefault')).not.toContain('AccelerateConfiguration');
+  });
+});


### PR DESCRIPTION
Closes #1288

Adds `AccelerateConfiguration: { AccelerationStatus: 'Suspended' }` to KNOWN_DEFAULTS['AWS::S3::Bucket'], mirroring the R46 VersioningConfiguration fold. Equality-gated: an out-of-band `Enabled` still surfaces. Corpus AWS__S3__Bucket.Data666C94C7.json expected updated (undeclared → atDefault); unit test added.