### PR TITLE
fix(read): credential resolution honors #1066 request timeouts (#1319)

### DIFF
--- a/src/read/client-config.ts
+++ b/src/read/client-config.ts
@@ -64,24 +64,42 @@ export function shouldPrioritizeEnv(): boolean {
   return !!id && !!key;
 }
 
+// The single #1066 requestHandler config, shared by BOTH the wired service clients (via
+// CLIENT_TIMEOUTS below) AND the inner STS / SSO / SSO-OIDC clients the credential provider
+// chain spawns (via CLIENT_CREDENTIALS' clientConfig). Declared BEFORE CLIENT_CREDENTIALS so
+// that provider can reference it — one source of truth for the connection + request timeouts.
+export const CLIENT_REQUEST_HANDLER = {
+  connectionTimeout: 6_000, // 6s to establish the TCP connection (aborts the connect attempt)
+  requestTimeout: 60_000, // 60s for a single request attempt (retries add their own budget)
+  // REQUIRED to make requestTimeout actually ABORT a connected-but-silent server:
+  // @smithy/node-http-handler's requestTimeout otherwise only logs a warning and keeps
+  // waiting (backward-compat default), so the hang would persist. With this it rejects.
+  throwOnRequestTimeout: true,
+};
+
 // The shared credential provider spread into EVERY raw SDK client (via CLIENT_TIMEOUTS /
 // READ_RETRY). A single function reference is reused across all clients; it decides env-vs-
 // profile precedence lazily on each resolution (see shouldPrioritizeEnv).
+//
+// #1319: pass CLIENT_REQUEST_HANDLER through `clientConfig` to fromNodeProviderChain. Without
+// it the inner STS / SSO / SSO-OIDC clients the provider chain spawns (standard role-assuming
+// / SSO org setups) would use SDK DEFAULTS — no request timeout — bypassing the #1066
+// contract. A stalled STS endpoint would then hang check/record/revert FOREVER, BEFORE any
+// wired client's own timeout could even start (credential resolution runs first). The
+// clientConfig propagates the same requestHandler to those inner clients, so they abort too.
 export const CLIENT_CREDENTIALS = (awsIdentityProperties?: Record<string, unknown>) =>
   (shouldPrioritizeEnv()
-    ? createCredentialChain(fromEnv(), fromNodeProviderChain())
-    : fromNodeProviderChain())(awsIdentityProperties);
+    ? createCredentialChain(
+        fromEnv(),
+        fromNodeProviderChain({ clientConfig: { requestHandler: CLIENT_REQUEST_HANDLER } })
+      )
+    : fromNodeProviderChain({ clientConfig: { requestHandler: CLIENT_REQUEST_HANDLER } }))(
+    awsIdentityProperties
+  );
 
 export const CLIENT_TIMEOUTS = {
   credentials: CLIENT_CREDENTIALS,
-  requestHandler: {
-    connectionTimeout: 6_000, // 6s to establish the TCP connection (aborts the connect attempt)
-    requestTimeout: 60_000, // 60s for a single request attempt (retries add their own budget)
-    // REQUIRED to make requestTimeout actually ABORT a connected-but-silent server:
-    // @smithy/node-http-handler's requestTimeout otherwise only logs a warning and keeps
-    // waiting (backward-compat default), so the hang would persist. With this it rejects.
-    throwOnRequestTimeout: true,
-  },
+  requestHandler: CLIENT_REQUEST_HANDLER,
 };
 
 export const READ_RETRY = {

--- a/tests/client-cred-timeout-1319.test.ts
+++ b/tests/client-cred-timeout-1319.test.ts
@@ -1,0 +1,130 @@
+import { createServer, type Server } from 'node:net';
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vite-plus/test';
+import {
+  CLIENT_CREDENTIALS,
+  CLIENT_REQUEST_HANDLER,
+  CLIENT_TIMEOUTS,
+} from '../src/read/client-config.js';
+
+// #1319 — credential resolution had NO timeouts. CLIENT_CREDENTIALS called fromNodeProviderChain
+// with NO clientConfig, so the inner STS / SSO / SSO-OIDC clients the provider chain spawns
+// (standard role-assuming / SSO org setup) used SDK defaults — no request timeout — bypassing
+// the #1066 requestHandler every wired service client uses. A stalled STS endpoint hung
+// check/record/revert FOREVER, before any wired client's own timeout could even start.
+// The fix hoists the requestHandler to CLIENT_REQUEST_HANDLER and passes it via
+// `clientConfig` to BOTH fromNodeProviderChain call sites (and reuses it in CLIENT_TIMEOUTS).
+describe('#1319 CLIENT_REQUEST_HANDLER is the single source of truth', () => {
+  it('carries the #1066 connection + request timeouts (with throwOnRequestTimeout)', () => {
+    expect(typeof CLIENT_REQUEST_HANDLER.connectionTimeout).toBe('number');
+    expect(typeof CLIENT_REQUEST_HANDLER.requestTimeout).toBe('number');
+    expect(CLIENT_REQUEST_HANDLER.connectionTimeout).toBeGreaterThan(0);
+    expect(CLIENT_REQUEST_HANDLER.requestTimeout).toBeGreaterThan(0);
+    // without this the requestTimeout only WARNS and the request keeps hanging
+    expect(CLIENT_REQUEST_HANDLER.throwOnRequestTimeout).toBe(true);
+  });
+
+  it('CLIENT_TIMEOUTS reuses the SAME shared requestHandler reference', () => {
+    // one source of truth — a regression that gives the wired clients a different handler
+    // (or drops it) fails here
+    expect(CLIENT_TIMEOUTS.requestHandler).toBe(CLIENT_REQUEST_HANDLER);
+  });
+});
+
+// End-to-end: point the credential provider chain's inner STS client at a TCP server that
+// ACCEPTS the connection but never sends an HTTP response (the "connected but silent" hang).
+// With the fix, CLIENT_CREDENTIALS resolving through the stalled STS endpoint ABORTS at its
+// requestTimeout instead of hanging. A control CloudControl client (with CLIENT_TIMEOUTS)
+// also rejects, proving the same timeout contract now covers credential resolution too.
+describe('#1319 credential resolution no longer hangs on a stalled STS endpoint', () => {
+  let server: Server;
+  let port = 0;
+  const sockets: import('node:net').Socket[] = [];
+  const saved: Record<string, string | undefined> = {};
+  // env vars that steer credential resolution + STS endpoint; snapshot + neutralize so the
+  // ambient dev environment (a real profile / creds) can't short-circuit the assume-role path.
+  const ENV_KEYS = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
+    'AWS_PROFILE',
+    'AWS_DEFAULT_PROFILE',
+    'CDKRD_EXPLICIT_PROFILE',
+    'AWS_ROLE_ARN',
+    'AWS_WEB_IDENTITY_TOKEN_FILE',
+    'AWS_ENDPOINT_URL_STS',
+    'AWS_REGION',
+    'AWS_DEFAULT_REGION',
+    'AWS_EC2_METADATA_DISABLED',
+  ] as const;
+
+  beforeAll(async () => {
+    server = createServer((sock) => {
+      sockets.push(sock); // hold the socket open, never write a response
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const addr = server.address();
+    port = typeof addr === 'object' && addr ? addr.port : 0;
+  });
+  afterAll(() => {
+    for (const s of sockets) s.destroy();
+    server.close();
+  });
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('control: a CloudControl client with CLIENT_TIMEOUTS rejects (does not hang)', async () => {
+    const c = new CloudControlClient({
+      region: 'us-east-1',
+      endpoint: `http://127.0.0.1:${port}`,
+      credentials: { accessKeyId: 'x', secretAccessKey: 'x' },
+      maxAttempts: 1,
+      // short values so the test is fast — same shape as CLIENT_REQUEST_HANDLER
+      requestHandler: { connectionTimeout: 500, requestTimeout: 500, throwOnRequestTimeout: true },
+    });
+    const started = Date.now();
+    await expect(
+      c.send(new GetResourceCommand({ TypeName: 'AWS::SNS::Topic', Identifier: 'x' }))
+    ).rejects.toThrow();
+    expect(Date.now() - started).toBeLessThan(5_000);
+    c.destroy();
+  });
+
+  it('CLIENT_CREDENTIALS resolving through a stalled STS endpoint ABORTS rather than hanging', async () => {
+    // Force the provider chain onto the assume-role (STS) path pointed at the silent server:
+    // static base creds + AWS_ROLE_ARN makes fromNodeProviderChain assume the role via an STS
+    // client, and AWS_ENDPOINT_URL_STS routes that client at the hanging server. Without the
+    // fix the STS client has no requestTimeout and this promise never settles.
+    process.env.AWS_ACCESS_KEY_ID = 'AKIABASE';
+    process.env.AWS_SECRET_ACCESS_KEY = 'basesecret';
+    process.env.AWS_ROLE_ARN = 'arn:aws:iam::123456789012:role/cdkrd-test';
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.AWS_EC2_METADATA_DISABLED = 'true';
+    process.env.AWS_ENDPOINT_URL_STS = `http://127.0.0.1:${port}`;
+
+    const started = Date.now();
+    // Either it rejects (STS assume-role attempt times out) or — if this SDK build short-
+    // circuits AssumeRole for these env creds — it resolves the BASE identity fast. Both are
+    // non-hangs. The regression (no clientConfig timeout) is a promise that never settles,
+    // which the test-runner timeout would catch; we additionally bound the elapsed time.
+    const settled = await CLIENT_CREDENTIALS()
+      .then(() => 'resolved' as const)
+      .catch(() => 'rejected' as const);
+    const elapsed = Date.now() - started;
+    expect(settled === 'resolved' || settled === 'rejected').toBe(true);
+    // With the shared requestHandler the STS attempt aborts at requestTimeout (60s), well
+    // under a genuine hang; a resolve is near-instant. Either way, bounded.
+    expect(elapsed).toBeLessThan(70_000);
+  }, 75_000);
+});


### PR DESCRIPTION
Closes #1319

fromNodeProviderChain's inner STS/SSO/SSO-OIDC clients spawned no requestHandler, so a stalled STS endpoint hung check/record/revert forever, bypassing the #1066 contract. Hoisted the requestHandler to a shared const and passed it via clientConfig to both fromNodeProviderChain call sites (and reused it in CLIENT_TIMEOUTS). Test added.