### PR TITLE
fix(diff): fold EventBusPolicy Statement Sid == declared StatementId (#1314)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -2560,7 +2560,20 @@ export function classifyResource(
         false) ||
       // #627: a GSI's undeclared WarmThroughput echoing that GSI's effective capacity
       // (on-demand constant or its own ProvisionedThroughput) — a per-GSI derived default.
-      dynamoGsiWarmThroughputAtDefault(resourceType, path, value, live);
+      dynamoGsiWarmThroughputAtDefault(resourceType, path, value, live) ||
+      // #1314: an AWS::Events::EventBusPolicy's live `Statement[n].Sid` (the resource's OWN
+      // read) is the service stamping the declared top-level `StatementId` into the stored
+      // statement — the registry `propertyTransform` `Statement: $merge([{"Sid":StatementId},
+      // Statement])`. That transform gate (#881) only runs in the DECLARED loop, so when the
+      // template omits `Sid` on `Statement`, this live-only value lands here as nested-
+      // undeclared inventory (Statement[0].Sid) and floods a first-run FP on EVERY policy.
+      // Tier-2 DERIVED fold: equality-gate the live Sid against the declared StatementId — a
+      // Sid that DIFFERS (a real out-of-band statement swap) still surfaces (detection preserved).
+      // This is the policy's own read; the sibling-EventBus reflection (#699) is a separate path.
+      (resourceType === 'AWS::Events::EventBusPolicy' &&
+        schemaPath === 'Statement.*.Sid' &&
+        typeof value === 'string' &&
+        value === declared['StatementId']);
     const tier = atDefault
       ? 'atDefault'
       : // R142: a GENERATED_PATHS value folds as `generated` ONLY when it echoes a

--- a/tests/classify-eventbus-sid-1314.test.ts
+++ b/tests/classify-eventbus-sid-1314.test.ts
@@ -1,0 +1,80 @@
+// #1314 — an AWS::Events::EventBusPolicy's OWN read carries a live-only `Statement[n].Sid`
+// that the service STAMPS from the declared top-level `StatementId` (the registry
+// propertyTransform `Statement: $merge([{"Sid": StatementId}, Statement])`). That transform
+// gate (#881) only runs in the DECLARED findings loop; when the template declares a `Statement`
+// WITHOUT an inline `Sid`, the stamped value is live-only and lands in the nested-undeclared
+// inventory as `Statement[0].Sid` — a first-run [Potential Drift] on EVERY EventBusPolicy,
+// violating the zero-first-run-drift invariant. Tier-2 DERIVED fold: the live Sid folds
+// atDefault when it equals the declared StatementId; a Sid that DIFFERS (a real out-of-band
+// statement swap) still surfaces as undeclared (detection preserved).
+//
+// This is the policy resource's OWN read — the sibling-EventBus reflection (#699) is a
+// separate, already-handled path and is not exercised here.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// The real registry schema shape for AWS::Events::EventBusPolicy (from the corpus fixture):
+// Action/Condition/Principal are writeOnly, EventBusName/StatementId createOnly.
+const schema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(['Action', 'Condition', 'Principal']),
+  createOnly: new Set(['EventBusName', 'StatementId']),
+  readOnlyPaths: [],
+  writeOnlyPaths: ['Action', 'Condition', 'Principal'],
+  createOnlyPaths: ['EventBusName', 'StatementId'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const stmt = {
+  Effect: 'Allow',
+  Principal: { AWS: 'arn:aws:iam::111111111111:root' },
+  Action: 'events:PutEvents',
+  Resource: 'arn:aws:events:us-east-1:111111111111:event-bus/mybus',
+};
+
+// A declared model that DECLARES a top-level StatementId but NO inline Sid on Statement.
+const res: DesiredResource = {
+  logicalId: 'BusPolicy',
+  resourceType: 'AWS::Events::EventBusPolicy',
+  physicalId: 'mybus|AllowPartner',
+  declared: {
+    EventBusName: 'mybus',
+    StatementId: 'AllowPartner',
+    Statement: stmt,
+  },
+};
+
+const sidFindings = (fs: Finding[]) => fs.filter((f) => f.path === 'Statement[0].Sid');
+
+describe('#1314 EventBusPolicy live Statement Sid == declared StatementId', () => {
+  it('folds Statement[n].Sid to atDefault when it equals the declared StatementId', () => {
+    // The service stamped StatementId into the stored statement as Sid — live-only.
+    const live = {
+      EventBusName: 'mybus',
+      StatementId: 'AllowPartner',
+      Statement: { ...stmt, Sid: 'AllowPartner' },
+    };
+    const f = classifyResource(res, live, schema);
+    const sid = sidFindings(f);
+    expect(sid).toHaveLength(1);
+    expect(sid[0]?.tier).toBe('atDefault');
+    // Zero first-run potential drift: nothing on this policy surfaces as undeclared.
+    expect(f.filter((x) => x.tier === 'undeclared')).toHaveLength(0);
+  });
+
+  it('surfaces Statement[n].Sid as undeclared when it DIFFERS from the declared StatementId (detection preserved)', () => {
+    // A real out-of-band statement swap: the live Sid no longer matches the declared StatementId.
+    const live = {
+      EventBusName: 'mybus',
+      StatementId: 'AllowPartner',
+      Statement: { ...stmt, Sid: 'OutOfBandSwap' },
+    };
+    const f = classifyResource(res, live, schema);
+    const sid = sidFindings(f);
+    expect(sid).toHaveLength(1);
+    expect(sid[0]?.tier).toBe('undeclared');
+    expect(sid[0]?.actual).toBe('OutOfBandSwap');
+  });
+});


### PR DESCRIPTION
Closes #1314

The service stamps declared top-level StatementId into the stored statement as Sid; this live-only value landed in nested-undeclared inventory (Statement[n].Sid) with no transform consulted, a first-run FP on every EventBusPolicy. Tier-2 derived fold: undeclared Statement[n].Sid folds atDefault when it equals the declared StatementId; a differing Sid (real OOB swap) still surfaces. Unit test added.