### PR TITLE
fix(baseline): fold an adopted out-of-band added resource instead of phantom-deleting it

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -1036,6 +1036,41 @@ function addedChildParentLogicalId(logicalId: string): string | undefined {
   return slash < 0 ? undefined : logicalId.slice(0, slash);
 }
 
+// #1279: the IDENTIFIER portion of an out-of-band `added` child id — everything AFTER the
+// first `/` (the parent is everything before it, see `addedChildParentLogicalId`). For
+// `Api/res456` -> `res456`; for a COMPOSITE CC identifier `Api/RestApiId|ResourceId` ->
+// `RestApiId|ResourceId`. Returns undefined for a top-level property entry (no `/`).
+function addedChildIdentifier(logicalId: string): string | undefined {
+  const slash = logicalId.indexOf('/');
+  return slash < 0 ? undefined : logicalId.slice(slash + 1);
+}
+
+// #1279: was a recorded out-of-band `added` child ADOPTED into the template since record
+// (via `cdk import`, or re-declared + deployed)? Once adopted, the child enumerator sees it
+// in the template and stops emitting `added` for it while the parent reads clean — so the
+// #791 "removed since record" branch would wrongly fire a phantom `deleted` drift forever
+// for a resource that is alive and now IaC-managed. Adoption is proven when the child's
+// identifier matches a template resource's LIVE physical id: compare the FULL composite
+// identifier (`RestApiId|ResourceId`) AND its trailing segment (`ResourceId`, the resource's
+// own id within the composite) against every live physical id in `physicalIdByLogical`. A
+// match on either means the resource is now a template resource — fold it (join the
+// replacedStale / removedFromTemplate fold family), never report a phantom deletion. When
+// no physical-id map is passed (a caller without #674 wiring) this is a no-op, so today's
+// behavior is unchanged.
+function addedChildWasAdopted(
+  childLogicalId: string,
+  physicalIdByLogical: Map<string, string> | undefined
+): boolean {
+  if (physicalIdByLogical === undefined || physicalIdByLogical.size === 0) return false;
+  const identifier = addedChildIdentifier(childLogicalId);
+  if (identifier === undefined) return false;
+  const trailing = identifier.slice(identifier.lastIndexOf('|') + 1);
+  for (const livePhysicalId of physicalIdByLogical.values()) {
+    if (livePhysicalId === identifier || livePhysicalId === trailing) return true;
+  }
+  return false;
+}
+
 // Descend one segment into a declared node. Object: index by key. Array: index by the
 // element's identity-field value (the `[<id>]` grammar) when an element carries a matching
 // identity field, else fall back to a numeric index. Returns undefined when the segment
@@ -1343,6 +1378,7 @@ export function applyBaseline(
   const removedFromTemplate: string[] = []; // #675
   const replacedStale: string[] = []; // #674
   const typeMismatchStale: string[] = []; // #793
+  const adoptedStale: string[] = []; // #1279
   for (const a of recorded) {
     // #791: an `added`-resource entry has an empty path (the WHOLE resource is the value)
     // and is reconciled in the loop above when its live child is still enumerated. When it
@@ -1367,6 +1403,18 @@ export function applyBaseline(
       // carryForwardUnreadable preserves it (Gap 2), so DO NOT report a false deletion here.
       const parentRead = parent !== undefined && readParentLogical.has(parent);
       if (!parentRead) continue; // unread / no-signal parent -> not "removed" (Gap 2 carries it)
+      // #1279: a child disappears from the `added` enumeration for TWO reasons — it was
+      // DELETED out of band (#791, the deletion above) OR it was ADOPTED into the template
+      // (`cdk import`, or re-declared + deployed), which makes the enumerator stop emitting
+      // `added` for it while the parent reads clean. In the adoption case the resource is
+      // alive and now IaC-managed, so a synthetic `deleted` drift is a phantom. Distinguish
+      // by identifier: if the child's identifier matches a template resource's live physical
+      // id, it was adopted — fold it (like replacedStale / removedFromTemplate), never a
+      // phantom deletion. The next `record` prunes the entry via the drop-candidate flow.
+      if (addedChildWasAdopted(a.logicalId, opts.physicalIdByLogical)) {
+        adoptedStale.push(a.logicalId);
+        continue;
+      }
       kept.push({
         tier: 'deleted',
         logicalId: a.logicalId,
@@ -1447,6 +1495,7 @@ export function applyBaseline(
     opts.warn?.(formatRemovedFromTemplateNote(removedFromTemplate));
   if (replacedStale.length > 0) opts.warn?.(formatReplacedStaleNote(replacedStale));
   if (typeMismatchStale.length > 0) opts.warn?.(formatTypeMismatchStaleNote(typeMismatchStale));
+  if (adoptedStale.length > 0) opts.warn?.(formatAdoptedStaleNote(adoptedStale));
   return kept;
 }
 
@@ -1494,6 +1543,22 @@ export function formatTypeMismatchStaleNote(paths: string[]): string {
   const n = paths.length;
   const subject = n === 1 ? `baseline entry (${paths[0]}) was` : `${n} baseline entries were`;
   return `note: ${subject} recorded against a resource whose logicalId now has a DIFFERENT type — re-run \`cdkrd record\`.`;
+}
+
+/**
+ * #1279: the folded one-line note for recorded out-of-band `added` resources that have since
+ * been ADOPTED into the template (`cdk import`, or re-declared + deployed) — the child is no
+ * longer enumerated as `added`, but its identifier matches a template resource's live physical
+ * id, so it is alive and now IaC-managed, not deleted. Mirror of formatReplacedStaleNote. Pure
+ * + exported for unit tests.
+ */
+export function formatAdoptedStaleNote(logicalIds: string[]): string {
+  const n = logicalIds.length;
+  const subject =
+    n === 1
+      ? `recorded added resource (${logicalIds[0]}) was`
+      : `${n} recorded added resources were`;
+  return `note: ${subject} adopted into the template (now IaC-managed) — re-run \`cdkrd record\` to clean up the baseline.`;
 }
 
 /**

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -12,6 +12,7 @@ import {
   carryForwardUnreadable,
   constructPathsByLogical,
   physicalIdsByLogical,
+  formatAdoptedStaleNote,
   formatPromotedStaleNote,
   formatRemovedFromTemplateNote,
   formatReplacedStaleNote,
@@ -606,6 +607,92 @@ describe('baseline', () => {
       ]);
       const out = applyBaseline([], b);
       expect(out).toHaveLength(0);
+    });
+  });
+
+  describe('#1279 — a recorded added resource ADOPTED into the template is not a phantom deletion', () => {
+    // gather.ts synthesizes an added child id as `${parent.logicalId}/${identifier}`. When the
+    // resource is later adopted (`cdk import` / re-declared + deployed) the child enumerator
+    // stops emitting `added` for it while the parent reads clean — so the #791 removed-since-
+    // record branch fires a phantom `deleted` drift. The fix: if the child's identifier matches
+    // a template resource's LIVE physical id (`physicalIdByLogical`, #674), it was adopted -> fold.
+    const parentRead = (): Finding => ({
+      tier: 'undeclared',
+      logicalId: 'Api',
+      resourceType: 'AWS::ApiGateway::RestApi',
+      path: 'ApiKeySourceType',
+      actual: 'HEADER',
+    });
+    const recordedAddedChild = (childLogicalId: string): BaselineFile['recorded'] => [
+      {
+        logicalId: childLogicalId,
+        resourceType: 'AWS::ApiGateway::Resource',
+        path: '',
+        value: { PathPart: 'orders' },
+      },
+    ];
+
+    it('bare-id child now present as a template resource physical id -> folded, NO deleted finding', () => {
+      // Recorded added child `Api/res456`; the resource is now the template resource
+      // `OrdersResource` whose live physical id is `res456` -> adopted.
+      const b = baseline(recordedAddedChild('Api/res456'));
+      const warnings: string[] = [];
+      const out = applyBaseline([parentRead()], b, {
+        physicalIdByLogical: new Map([['OrdersResource', 'res456']]),
+        warn: (s) => warnings.push(s),
+      });
+      expect(out.find((f) => f.tier === 'deleted')).toBeUndefined();
+      expect(
+        out.find((f) => f.note === 'recorded added resource removed since record')
+      ).toBeUndefined();
+      expect(warnings.join('\n')).toContain('adopted into the template');
+    });
+
+    it('COMPOSITE-identifier child adopted (full composite OR trailing segment matches) -> folded', () => {
+      // Composite id `RestApiId|ResourceId`; the template resource physical id is the trailing
+      // segment `ResourceId` (the resource-Resource case where the composite includes its parent).
+      const b = baseline(recordedAddedChild('Api/RestApiId|res456'));
+      const out = applyBaseline([parentRead()], b, {
+        physicalIdByLogical: new Map([['OrdersResource', 'res456']]),
+      });
+      expect(out.find((f) => f.tier === 'deleted')).toBeUndefined();
+    });
+
+    it('full composite matches a live physical id -> folded', () => {
+      const b = baseline(recordedAddedChild('Api/RestApiId|res456'));
+      const out = applyBaseline([parentRead()], b, {
+        physicalIdByLogical: new Map([['Something', 'RestApiId|res456']]),
+      });
+      expect(out.find((f) => f.tier === 'deleted')).toBeUndefined();
+    });
+
+    it('regression (#791): a GENUINELY DELETED child (no matching physical id) STILL surfaces as deleted', () => {
+      // No template resource has the child identifier as its physical id -> genuine deletion.
+      const b = baseline(recordedAddedChild('Api/res456'));
+      const out = applyBaseline([parentRead()], b, {
+        physicalIdByLogical: new Map([['Unrelated', 'other-phys-id']]),
+      });
+      const removed = out.find(
+        (f) => f.tier === 'deleted' && f.note === 'recorded added resource removed since record'
+      );
+      expect(removed).toBeDefined();
+      expect(removed!.logicalId).toBe('Api/res456');
+    });
+
+    it('regression (#791): genuine deletion with NO physicalIdByLogical passed at all STILL surfaces', () => {
+      const b = baseline(recordedAddedChild('Api/res456'));
+      const out = applyBaseline([parentRead()], b);
+      expect(
+        out.find(
+          (f) => f.tier === 'deleted' && f.note === 'recorded added resource removed since record'
+        )
+      ).toBeDefined();
+    });
+
+    it('formatAdoptedStaleNote reads singular/plural and names the resource', () => {
+      expect(formatAdoptedStaleNote(['Api/res456'])).toContain('(Api/res456)');
+      expect(formatAdoptedStaleNote(['Api/res456'])).toContain('adopted into the template');
+      expect(formatAdoptedStaleNote(['a', 'b'])).toContain('2 recorded added resources');
     });
   });
 


### PR DESCRIPTION
## Problem (#1279)

The #791 fix surfaces an endorsed (recorded) out-of-band `added` resource that disappears from the `added` enumeration as `deleted`-tier drift (note `recorded added resource removed since record`). But a child disappears from the enumeration for **two** causes, and the `a.path === ''` branch in `src/baseline/baseline-file.ts` only modeled one:

1. the resource was **deleted** out of band (#791 case — correct), or
2. the resource was **ADOPTED** into the template (`cdk import`, or re-declared + deployed) — the child enumerator now sees it in the template and stops emitting `added` for it, while the parent reads clean.

In case 2 the branch still fired: every subsequent `check` reported a **phantom** `deleted` drift for a resource that is alive and now IaC-managed, so `--fail` exited 1 forever.

## Fix

`applyBaseline` already receives the template resources' live physical ids (`physicalIdByLogical`, #674). Before synthesizing the `deleted` finding, test whether the child id's **identifier portion** matches a template resource's live physical id — comparing both:

- the **full composite** identifier (`RestApiId|ResourceId`), and
- its **trailing segment** (`ResourceId`, the resource's own id within the composite)

against every value of `physicalIdByLogical`. A match means the resource was **adopted** → fold it (join the `replacedStale` / `removedFromTemplate` fold family, emit a stderr note via `formatAdoptedStaleNote`), never report a phantom deletion. The next `record` prunes the stale entry via the existing drop-candidate flow.

A **genuine deletion** (no matching physical id, or no `physicalIdByLogical` passed) still surfaces as a `deleted` finding exactly as before — the #791 behavior is preserved.

## Scope

Touches only `src/baseline/baseline-file.ts` and `tests/baseline.test.ts`.

## Tests

New tests in `tests/baseline.test.ts` (verified to FAIL without the fix, pass with it):

- adoption folds a **bare-id** child (`Api/res456`, live physical id `res456`) — no `deleted` finding, stderr note emitted
- adoption folds a **composite-identifier** child (`Api/RestApiId|res456`) when the trailing segment matches
- adoption folds when the **full composite** matches a live physical id
- regression: a genuinely **deleted** child (no matching physical id) STILL surfaces as `deleted`
- regression: genuine deletion with **no `physicalIdByLogical`** at all STILL surfaces
- `formatAdoptedStaleNote` singular/plural

Full suite green (4533 tests; one unrelated subprocess-timing flake in `tests/json-empty-on-error.test.ts` that passes in isolation).

Closes #1279
