### PR TITLE
fix(config): addIgnoreRules dedupes against the same snapshot it writes from (#1290)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -142,6 +142,20 @@ export async function loadConfig(): Promise<CdkrdConfig> {
     if ((e as NodeJS.ErrnoException).code === 'ENOENT') return { ignore: [] };
     throw e;
   }
+  return parseConfigRaw(raw);
+}
+
+/**
+ * Validate-and-parse the decoded `.cdkrd/ignore.yaml` text into a `CdkrdConfig`. This is
+ * loadConfig's body AFTER the read+decode, factored out so a caller that ALREADY holds the
+ * raw bytes (addIgnoreRules' pre-write `existingRaw`) can derive the same validated config
+ * from the SAME snapshot — without a second `readFile`. Sharing one snapshot between the
+ * write basis and the dedupe basis is the #1290 fix: a peer rule that landed on disk between
+ * two separate reads would otherwise be in the dedupe basis but not the write basis, and get
+ * clobbered. Applies every guard loadConfig applied on read (syntax errors, alias/anchor,
+ * non-mapping, unknown top-level key, `ignore` typed as an array, per-entry validation).
+ */
+export function parseConfigRaw(raw: string): CdkrdConfig {
   let parsed: unknown;
   // parseDocument collects syntax problems in `doc.errors` (it does NOT throw), so check
   // them explicitly to fail fast. YAML is a JSON superset, so this also reads a legacy
@@ -431,6 +445,10 @@ async function atomicWrite(dest: string, content: string): Promise<void> {
  * a concurrent `cdkrd` process, the on-disk config is RE-READ immediately before the write
  * and the incoming rules merged against THAT fresh state — so a rule another process
  * appended between our initial `loadConfig` and our write is preserved, not clobbered.
+ * The re-read is a SINGLE snapshot: both the write basis (`existingRaw`, re-emitted with its
+ * comments) and the dedupe basis (`parseConfigRaw(existingRaw)`) come from those same bytes,
+ * so a peer rule on disk is BOTH carried forward AND deduped against — never in one but not
+ * the other (#1290).
  */
 export async function addIgnoreRules(
   newRules: IgnoreRuleObject[]
@@ -456,8 +474,7 @@ export async function addIgnoreRules(
   // merge the requested rules against THAT fresh on-disk state. If a concurrent process
   // appended rules between our initial `loadConfig` and here, its rules are in `existingRaw`
   // and are carried forward (we append to them) instead of being clobbered by a write built
-  // from the stale first read. Re-run the dedupe against the fresh existing rules so a rule
-  // the other process ALSO just added is not written twice.
+  // from the stale first read.
   let existingRaw: string | undefined;
   try {
     // Same BOM/UTF-16 decode as loadConfig (#1291): this raw text is re-parsed by
@@ -467,8 +484,16 @@ export async function addIgnoreRules(
   } catch (e) {
     if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
   }
+  // Derive the dedupe basis from the SAME `existingRaw` bytes the write is built from —
+  // `parseConfigRaw(existingRaw)`, NOT a second `loadConfig()` read (#1290). A separate
+  // re-read could observe a peer's just-appended rule that `existingRaw` did not: the peer
+  // rule would then be in the dedupe basis but absent from the write basis, so our rules
+  // still count as new and we'd write `existingRaw + ours`, silently clobbering the peer's
+  // rule that WAS on disk. One snapshot for both bases keeps the carried-forward claim true.
   const existingRules =
-    existingRaw !== undefined && existingRaw.trim() !== '' ? (await loadConfig()).ignore : [];
+    existingRaw !== undefined && existingRaw.trim() !== ''
+      ? parseConfigRaw(existingRaw).ignore
+      : [];
   const { added, alreadyPresent } = mergeIgnoreRules(existingRules, newRules);
   if (added.length === 0) {
     // A concurrent writer already added every rule we wanted between our two reads — report

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { buildRecorded } from '../src/baseline/baseline-file.js';
 import {
   addIgnoreRules,
@@ -18,6 +18,27 @@ import {
 } from '../src/config/config-file.js';
 import { buildRevertPlan } from '../src/revert/plan.js';
 import type { Finding } from '../src/types.js';
+
+// #1290 — deterministically reproduce a concurrent-append interleave by scripting the bytes
+// each `readFile('.cdkrd/ignore.yaml')` returns. ESM export namespaces are frozen so `readFile`
+// cannot be `vi.spyOn`-ed; instead mock `node:fs/promises` with a factory that DELEGATES every
+// call to the real module (so all other tests keep hitting the real temp filesystem) and only
+// overrides ignore.yaml reads WHEN `readScript` is set (null by default = pure pass-through).
+const { readScript } = vi.hoisted(() => ({ readScript: { seq: null as string[] | null, i: 0 } }));
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const real = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...real,
+    readFile: (async (path: unknown, ...args: unknown[]) => {
+      if (readScript.seq !== null && typeof path === 'string' && path.endsWith('ignore.yaml')) {
+        const next = readScript.seq[Math.min(readScript.i, readScript.seq.length - 1)];
+        readScript.i++;
+        return Buffer.from(next, 'utf8');
+      }
+      return (real.readFile as (...a: unknown[]) => unknown)(path, ...args);
+    }) as typeof real.readFile,
+  };
+});
 
 const ACCT = '111111111111';
 const cfg = (ignore: IgnoreRuleObject[]): CdkrdConfig => ({ ignore });
@@ -1148,6 +1169,47 @@ describe('addIgnoreRules', () => {
     // both the peer's rule and ours land — the write was built from the re-read, not a write
     // that overwrote the file with only our rule.
     expect((await loadConfig()).ignore).toEqual([{ path: 'Peer.appended' }, { path: 'Mine.z' }]);
+  });
+
+  it('builds the write AND the dedupe from ONE re-read snapshot — a peer rule already on disk is not re-appended as a duplicate (#1290)', async () => {
+    // The #759 re-read narrowing is only sound when the WRITE basis (`existingRaw`, re-emitted
+    // with comments) and the DEDUPE basis come from the SAME snapshot. The old code did TWO
+    // separate reads before writing: `existingRaw` = one readFile, then a SECOND `loadConfig()`
+    // (another readFile) used ONLY for dedupe. When those two reads observe DIFFERENT bytes —
+    // a concurrent `cdkrd` appending a rule between them — the dedupe basis and the write basis
+    // disagree, and the merge decision (what counts as "new") is computed against a snapshot
+    // that is not the one being written. Here a peer appends OUR rule (`Mine.z`) to disk: it is
+    // present in `existingRaw` (the write basis) but ABSENT from the stale second read (the
+    // dedupe basis), so the old code judged `Mine.z` new and appended it ON TOP of the copy
+    // that already had it — a DUPLICATE. The fix derives the dedupe basis from
+    // `parseConfigRaw(existingRaw)` (one snapshot), so the peer's `Mine.z` is seen as present
+    // and the write is a no-op. We script the sequence of on-disk-config reads to reproduce the
+    // exact interleave the issue names.
+    await mkdir('.cdkrd', { recursive: true });
+    const raw1 = 'ignore:\n  - path: Base.x\n';
+    // The peer process, racing us, appends OUR rule to disk in the window between our reads.
+    const raw2 = `${raw1}  - path: Mine.z\n`;
+    // Seed the REAL file with the peer-included state (raw2) so the final loadConfig assertion
+    // reads the true on-disk result after the spy is restored.
+    await writeFile('.cdkrd/ignore.yaml', raw2, 'utf8');
+    // Read order in addIgnoreRules: (1) top loadConfig, (2) existingRaw = the write basis,
+    // (3) OLD-ONLY second loadConfig = the dedupe basis. Scripting existingRaw to see the
+    // peer (raw2) but the stale dedupe read to miss it (raw1) is the divergence the issue
+    // describes. The NEW code never does read (3), so its dedupe basis IS raw2 and the write
+    // is a no-op. After the scripted reads are exhausted, later reads (the assertion's
+    // loadConfig) fall through to the LAST scripted value; we clear the script instead so the
+    // final assertion reads the true on-disk file.
+    readScript.seq = [raw1, raw2, raw1];
+    readScript.i = 0;
+    try {
+      await addIgnoreRules([p('Mine.z')]);
+    } finally {
+      readScript.seq = null;
+      readScript.i = 0;
+    }
+    // Exactly one Mine.z — the peer's rule is deduped against the SAME snapshot the write is
+    // built from, so the stale second read can no longer make us re-append a duplicate.
+    expect((await loadConfig()).ignore).toEqual([{ path: 'Base.x' }, { path: 'Mine.z' }]);
   });
 
   it('appends to a UTF-16 LE existing file without mojibaking its prior rules (#1291 re-read)', async () => {


### PR DESCRIPTION
## Problem

The #759 race-narrowing in `addIgnoreRules` (`src/config/config-file.ts`) reads `.cdkrd/ignore.yaml` **twice** right before writing:

1. `existingRaw = decodeConfig(await readFile(CONFIG_PATH))` — the bytes the new file is built from (`appendRulesToYaml(existingRaw, added)`);
2. `(await loadConfig()).ignore` — a **second** read, used only as the dedupe basis.

A concurrent `cdkrd` appending a rule **between** read 1 and read 2 lands its rule in the dedupe basis but not in the write basis (or vice versa). The two bases then disagree, and the merge decision ("what counts as new") is computed against a snapshot that is not the one being written — so the write built from `existingRaw` can clobber a peer rule the dedupe basis saw, or re-append a duplicate of a rule already on disk. The in-code comment claimed the peer's rules "are in `existingRaw` and are carried forward", which only holds when both reads observe identical bytes.

## Fix

Extract `loadConfig`'s validate-and-parse body (syntax-error check, alias/anchor, non-mapping, unknown-key, `ignore`-is-array, per-entry validation — everything after the read+decode; the #1076/#1291 UTF-16/BOM decode stays in `loadConfig`'s read step) into an exported **`parseConfigRaw(raw)`** helper. `loadConfig` = read + decode + `parseConfigRaw`.

In `addIgnoreRules`, derive the dedupe basis from `parseConfigRaw(existingRaw)` — the **same** bytes the write is built from — removing the second `loadConfig()` read. Both the write basis and the dedupe basis now come from one snapshot, so a peer rule on disk is both carried forward **and** deduped against. Stale comment corrected.

The remaining write-vs-write race (two processes writing simultaneously) is what #759 explicitly left un-locked; this PR does not touch that.

## Test

`tests/config-file.test.ts` — new case "builds the write AND the dedupe from ONE re-read snapshot — a peer rule already on disk is not re-appended as a duplicate (#1290)". A hoisted `vi.mock('node:fs/promises')` (delegates every call to the real module; only scripts ignore.yaml reads when a per-test flag is set, so the other 94 tests are unaffected) reproduces the interleave: `existingRaw` sees the peer's `Mine.z`, the stale second read misses it. Verified **fails on the unpatched source** (duplicate `Mine.z` appended) and passes with the fix.

Closes #1290
