### PR TITLE
fix(report): prefix-aware redaction masks secret VALUES in container-level findings (#1297)

### DIFF
--- a/src/report/redact.ts
+++ b/src/report/redact.ts
@@ -82,6 +82,47 @@ const maskMapValues = (value: unknown): unknown => {
   return maskPlaceholder(value);
 };
 
+// Mask the secret sub-tree of a CONTAINER-level value whose finding path is the highest
+// undeclared ANCESTOR of the secret (how classify emits the two most common leak scenarios,
+// #1297). #1234's leaf/per-key matchers cannot fire on such a container path (e.g. a Lambda
+// with no declared `Environment` surfaces ONE undeclared finding at path `Environment` whose
+// value is the whole `{Variables:{…}}` object), so the plaintext prints raw in text and
+// --json. These descend into the rendered value and mask at the remaining sub-path, keeping
+// every non-secret key/identity field visible. A shape that does not match falls through
+// unchanged (never whole-masks a container — that would hide non-secret siblings).
+
+// Lambda `Environment` container: mask every value inside a nested `Variables` map, keeping
+// the `Variables` key and each env-var KEY visible. Any sibling of `Variables` is untouched.
+const maskEnvironmentContainer = (value: unknown): unknown => {
+  if (value && typeof value === 'object' && !Array.isArray(value) && 'Variables' in value) {
+    return {
+      ...(value as Record<string, unknown>),
+      Variables: maskMapValues((value as Record<string, unknown>).Variables),
+    };
+  }
+  return value;
+};
+
+// Mask the `Value` field of every element of an `[{Name,Value,Type}]` array (a CodeBuild
+// `Environment.EnvironmentVariables` container emitted whole, or an array-delta element),
+// keeping each `Name`/`Type` identity field visible. A non-array or a non-`{Value}` element
+// is left unchanged.
+const maskEnvVarArrayElement = (element: unknown): unknown => {
+  if (element && typeof element === 'object' && !Array.isArray(element) && 'Value' in element) {
+    return {
+      ...(element as Record<string, unknown>),
+      Value: maskPlaceholder((element as Record<string, unknown>).Value),
+    };
+  }
+  return element;
+};
+// Mask a CodeBuild `Environment.EnvironmentVariables` value at its container path. The value
+// is EITHER the whole `[{Name,Value,Type}]` array (whole-container finding) OR a SINGLE element
+// (the text-report `formatArrayDelta` renders per-element via `redactValue` at the array path,
+// #1297 scenario 3) — mask both shapes so neither leaks. A non-matching value falls through.
+const maskEnvVarArray = (value: unknown): unknown =>
+  Array.isArray(value) ? value.map(maskEnvVarArrayElement) : maskEnvVarArrayElement(value);
+
 // The curated table: resourceType -> secret-bearing path matchers. A finding whose
 // resourceType + path matches has its DISPLAYED value masked; everything else prints in
 // full (subject to the existing 200-char cap). The paths mirror the secret-bearing
@@ -94,11 +135,20 @@ const REDACTED_VALUE_PATHS: Record<string, RedactMatcher[]> = {
   'AWS::Lambda::Function': [
     { pathRe: /(^|\.)Environment\.Variables\./, redact: maskWhole },
     { pathRe: /(^|\.)Environment\.Variables$/, redact: maskMapValues },
+    // #1297 container case: no declared `Environment` → ONE undeclared finding at path
+    // `Environment` whose value is the whole `{Variables:{…}}` object. Descend + mask each
+    // `Variables` value, keeping the keys. Ordered AFTER the leaf matchers so a leaf/whole-map
+    // path (which also ends in `Variables`/`Variables.<k>`) takes its more-specific matcher.
+    { pathRe: /(^|\.)Environment$/, redact: maskEnvironmentContainer },
   ],
   // CodeBuild PLAINTEXT env var: the reader projects `[{Name,Value,Type}]`, so a per-value
   // drift path is `Environment.EnvironmentVariables.<idx>.Value` (dot-indexed array).
   'AWS::CodeBuild::Project': [
     { pathRe: /(^|\.)Environment\.EnvironmentVariables\.\d+\.Value$/, redact: maskWhole },
+    // #1297 container case: `Environment` declared without `EnvironmentVariables` → finding at
+    // `Environment.EnvironmentVariables` whose value is the whole `[{Name,Value,Type}]` array.
+    // Mask each element's `Value`, keeping `Name`/`Type`. Ordered AFTER the leaf matcher.
+    { pathRe: /(^|\.)Environment\.EnvironmentVariables$/, redact: maskEnvVarArray },
   ],
   // EC2 LaunchTemplate UserData (base64 bootstrap script — may embed secrets). The
   // writeOnly strip is lifted for LaunchTemplateData so it is comparable; the UserData leaf
@@ -189,6 +239,12 @@ interface ArrayDeltaShape {
 }
 
 function redactArrayDelta(resourceType: string, path: string, d: ArrayDeltaShape): ArrayDeltaShape {
+  // Each delta entry's value is a SINGLE array ELEMENT, not the whole array — but `path` is the
+  // ARRAY path (e.g. CodeBuild `Environment.EnvironmentVariables`), so before #1297 a
+  // `redactValue` at the array path never masked a per-element `Value`. A secret-bearing
+  // array-container matcher (`maskEnvVarArray`) now accepts a single element too, so a per-element
+  // `redactValue` at the array path masks the element's `Value` — matching the text-report
+  // `formatArrayDelta` path, which likewise redacts per-element at the array path.
   const mv = (v: unknown): unknown => redactValue(resourceType, path, v);
   return {
     identityField: d.identityField,

--- a/tests/report-redact-798.test.ts
+++ b/tests/report-redact-798.test.ts
@@ -5,6 +5,7 @@ import {
   redactFinding,
   redactValue,
 } from '../src/report/redact.js';
+import type { ArrayDelta } from '../src/types.js';
 import { buildStackJson, formatFinding, report } from '../src/report/report.js';
 import type { Finding } from '../src/types.js';
 
@@ -141,6 +142,136 @@ describe('#798 report redaction — --json output masks secret VALUES', () => {
     const out = lines.join('\n');
     expect(out).not.toContain(SECRET);
     expect(out).toContain('<redacted:');
+  });
+});
+
+// #1297 — the secret surfaces inside a CONTAINER-level finding (the highest undeclared
+// ancestor), where #1234's leaf/per-key matchers cannot fire, so the plaintext printed raw
+// in both text and --json. The canary is the exact value from the issue evidence.
+const CANARY = 'HUNTY_SECRET_CANARY_0123456789';
+
+// Lambda with no declared `Environment`: ONE undeclared finding at path `Environment` whose
+// value is the whole `{Variables:{API_TOKEN:<secret>}}` object.
+const lambdaEnvContainerFinding = (): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'Fn',
+  resourceType: 'AWS::Lambda::Function',
+  path: 'Environment',
+  actual: { Variables: { API_TOKEN: CANARY } },
+  nested: true,
+});
+
+// CodeBuild with `Environment` declared but no `EnvironmentVariables`: finding at path
+// `Environment.EnvironmentVariables` whose value is the whole `[{Name,Value,Type}]` array.
+const codeBuildEnvVarsContainerFinding = (): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'Proj',
+  resourceType: 'AWS::CodeBuild::Project',
+  path: 'Environment.EnvironmentVariables',
+  actual: [{ Name: 'API_TOKEN', Value: CANARY, Type: 'PLAINTEXT' }],
+  nested: true,
+});
+
+describe('#1297 report redaction — CONTAINER-level findings mask secret VALUES', () => {
+  it('a Lambda whole-Environment container finding masks the nested Variables value (text)', () => {
+    const text = runText([lambdaEnvContainerFinding()]);
+    expect(text).not.toContain(CANARY); // plaintext never printed
+    expect(text).toContain('<redacted:'); // masked placeholder present
+    expect(text).toContain('API_TOKEN'); // the env-var KEY name stays visible
+    expect(text).toContain('Environment'); // the path stays visible
+  });
+
+  it('a Lambda whole-Environment container finding masks the nested Variables value (--json)', () => {
+    const { json } = buildStackJson([lambdaEnvContainerFinding()], 'stack (us-east-1)');
+    const serialized = JSON.stringify(json);
+    expect(serialized).not.toContain(CANARY);
+    expect(serialized).toContain('<redacted:');
+    expect(serialized).toContain('API_TOKEN'); // key preserved
+    expect(json.findings.length).toBe(1); // detection preserved
+  });
+
+  it('redactValue masks the nested Variables value at container path `Environment`, keeps keys', () => {
+    const masked = redactValue('AWS::Lambda::Function', 'Environment', {
+      Variables: { API_TOKEN: CANARY, KEEP_KEY: 'plain' },
+    }) as { Variables: Record<string, unknown> };
+    expect(masked.Variables.API_TOKEN).toMatch(
+      new RegExp(`^<redacted:${CANARY.length} chars:[0-9a-f]{8}>$`)
+    );
+    // every value masked, but the KEY names stay visible
+    expect(Object.keys(masked.Variables).sort()).toEqual(['API_TOKEN', 'KEEP_KEY']);
+    expect(String(masked.Variables.KEEP_KEY)).not.toContain('plain');
+  });
+
+  it('a CodeBuild whole-EnvironmentVariables container finding masks each element Value (text)', () => {
+    const text = runText([codeBuildEnvVarsContainerFinding()]);
+    expect(text).not.toContain(CANARY);
+    expect(text).toContain('<redacted:');
+    expect(text).toContain('API_TOKEN'); // Name identity stays visible
+    expect(text).toContain('PLAINTEXT'); // Type identity stays visible
+  });
+
+  it('a CodeBuild whole-EnvironmentVariables container finding masks each element Value (--json)', () => {
+    const { json } = buildStackJson([codeBuildEnvVarsContainerFinding()], 'stack (us-east-1)');
+    const serialized = JSON.stringify(json);
+    expect(serialized).not.toContain(CANARY);
+    expect(serialized).toContain('<redacted:');
+    expect(serialized).toContain('API_TOKEN'); // Name preserved
+    expect(serialized).toContain('PLAINTEXT'); // Type preserved
+  });
+
+  it('redactValue masks each element Value at container path, keeps Name/Type', () => {
+    const masked = redactValue('AWS::CodeBuild::Project', 'Environment.EnvironmentVariables', [
+      { Name: 'API_TOKEN', Value: CANARY, Type: 'PLAINTEXT' },
+      { Name: 'DEBUG', Value: 'true', Type: 'PLAINTEXT' },
+    ]) as Record<string, unknown>[];
+    expect(masked[0]?.Value).toMatch(new RegExp(`^<redacted:${CANARY.length} chars:[0-9a-f]{8}>$`));
+    expect(masked[0]?.Name).toBe('API_TOKEN'); // identity preserved
+    expect(masked[0]?.Type).toBe('PLAINTEXT');
+    expect(masked[1]?.Value).toMatch(/^<redacted:4 chars:[0-9a-f]{8}>$/);
+    expect(masked[1]?.Name).toBe('DEBUG');
+  });
+
+  it('isRedactedPath is true for the container paths (so redactFinding descends)', () => {
+    expect(isRedactedPath('AWS::Lambda::Function', 'Environment')).toBe(true);
+    expect(isRedactedPath('AWS::CodeBuild::Project', 'Environment.EnvironmentVariables')).toBe(
+      true
+    );
+  });
+
+  it('redactArrayDelta masks each CodeBuild EnvironmentVariables element Value, keeps Name/Type', () => {
+    // scenario 3: a recorded env-var array drifts → array-delta whose elements carry the
+    // secret in `Value`. The delta path is the ARRAY path, so #1234 masked nothing per-element.
+    const arrayDelta: ArrayDelta = {
+      identityField: 'Name',
+      added: [{ id: 'NEW_TOKEN', value: { Name: 'NEW_TOKEN', Value: CANARY, Type: 'PLAINTEXT' } }],
+      removed: [
+        { id: 'OLD', value: { Name: 'OLD', Value: 'old-secret-value', Type: 'PLAINTEXT' } },
+      ],
+      changed: [
+        {
+          id: 'API_TOKEN',
+          recorded: { Name: 'API_TOKEN', Value: 'recorded-secret', Type: 'PLAINTEXT' },
+          actual: { Name: 'API_TOKEN', Value: CANARY, Type: 'PLAINTEXT' },
+        },
+      ],
+    };
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Proj',
+      resourceType: 'AWS::CodeBuild::Project',
+      path: 'Environment.EnvironmentVariables',
+      arrayDelta,
+    };
+    const out = redactFinding(f);
+    const serialized = JSON.stringify(out.arrayDelta);
+    expect(serialized).not.toContain(CANARY);
+    expect(serialized).not.toContain('old-secret-value');
+    expect(serialized).not.toContain('recorded-secret');
+    // Name/Type identity fields stay visible on every entry
+    expect(serialized).toContain('NEW_TOKEN');
+    expect(serialized).toContain('API_TOKEN');
+    expect(serialized).toContain('PLAINTEXT');
+    expect(serialized).toContain('<redacted:');
   });
 });
 


### PR DESCRIPTION
Closes #1297

## The bug — a real SECRET LEAK
#1234 (the #798 CI-log-leak fix) masks secret VALUES for Lambda / CodeBuild / EB / LaunchTemplate, but its `REDACTED_VALUE_PATHS` matchers key on **leaf / per-key** finding-path shapes only. When the secret surfaces inside a **container-level** finding (the highest undeclared ancestor — how classify actually emits the two most common leak scenarios) no matcher fires and plaintext prints raw in BOTH the text report and `--json`:

1. **Lambda, no declared `Environment`**: operator console-adds a token → one undeclared finding at path `Environment` whose value is the whole `{Variables:{API_TOKEN:<secret>}}` object. Matchers `Environment\.Variables\.` / `Environment\.Variables$` both miss path `Environment`.
2. **CodeBuild, `Environment` declared without `EnvironmentVariables`**: operator adds a PLAINTEXT var → finding at `Environment.EnvironmentVariables` whose value is the whole `[{Name,Value,Type}]` array. Matcher `Environment\.EnvironmentVariables\.\d+\.Value$` cannot fire.
3. Same gap in `redactArrayDelta`: elements were masked via `redactValue(rt, f.path, element)` at the **array** path, so no per-element `Value` was ever masked.

## Fix
Prefix-aware container matchers in `src/report/redact.ts` that descend into the rendered value and mask at the remaining sub-path, keeping every non-secret key/identity field visible:

- **Lambda** `(^|\.)Environment$` → `maskEnvironmentContainer`: mask each nested `Variables` value, keep the `Variables` key + env-var KEY names.
- **CodeBuild** `(^|\.)Environment\.EnvironmentVariables$` → `maskEnvVarArray`: mask each element's `Value`, keep `Name`/`Type`. `maskEnvVarArray` accepts a **single element** too, so the text-report `formatArrayDelta` path (per-element `redactValue` at the array path) and the JSON `redactArrayDelta` both mask element `Value`s.

Container matchers are ordered **after** the existing leaf matchers so a leaf / whole-map path still takes its more-specific matcher. Detection is unaffected (mask is display-only, post-compare); keys/identity stay visible. Only `src/report/redact.ts` is touched — no other src file.

## Tests
7 new cases in `tests/report-redact-798.test.ts` using the issue's exact `HUNTY_SECRET_CANARY_0123456789` evidence shapes — each asserts the canary is **absent** from the masked text + `--json` output and non-secret keys/identity remain:
- Lambda whole-`Environment` container masked in text and `--json` (+ `redactValue` unit).
- CodeBuild whole-`EnvironmentVariables` container masked in text and `--json` (+ `redactValue` unit).
- `redactArrayDelta` masks each element `Value` across added/removed/changed, keeps `Name`/`Type`.
- `isRedactedPath` true for the container paths.

All 23 tests in the redact file pass; full suite green (176/176 files, the pre-existing `interrupt-exit-950` process.exit teardown flake is unrelated). `vp run check` (CI non-fix) reports 0 errors.