### PR TITLE
fix(report): escape bidi/zero-width Unicode in live drift VALUES, not just keys (#1307)

### DIFF
--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -733,9 +733,29 @@ function stringifySymbolSafe(v: unknown): string | undefined {
   return JSON.stringify(v, symbolReplacer);
 }
 
+// #1307: JSON.stringify escapes only C0 controls / quote / backslash / lone surrogates —
+// it emits the Unicode bidi/format controls (U+202A-U+202E, U+2066-U+2069) and the
+// zero-width set (U+200B-U+200F, U+FEFF) RAW inside the quoted string. A drift VALUE is
+// live-controlled, so a stringified value still carries the spoof onto the terminal (an RLO
+// visually reorders the `actual =` line; a zero-width char makes two different values render
+// identically). Post-process the already-stringified value with the SAME visible `\u{XXXX}`
+// escape the KEY path uses (sanitizeForTerminal / isBidiOrZeroWidth). TEXT path only — the
+// `--json` payload is built structurally in buildStackJson and never routes through j()/jPair(),
+// so its bytes stay faithful for parsers. Pure; the C0 range is already escaped by
+// JSON.stringify, so this only needs the bidi/zero-width tier.
+function escapeBidiZeroWidth(s: string): string {
+  let out = '';
+  for (const ch of s) {
+    const code = ch.charCodeAt(0);
+    out += isBidiOrZeroWidth(code) ? `\\u{${code.toString(16).toUpperCase()}}` : ch;
+  }
+  return out;
+}
+
 function j(v: unknown): string {
   const s = stringifySymbolSafe(v);
-  return s && s.length > VALUE_CAP ? safeSlice(s, 0, VALUE_CAP) + '…' : (s ?? String(v));
+  const raw = s && s.length > VALUE_CAP ? safeSlice(s, 0, VALUE_CAP) + '…' : (s ?? String(v));
+  return escapeBidiZeroWidth(raw);
 }
 
 // #829: drift VALUES are JSON.stringify-escaped (via j()/jPair()), but several live-derived
@@ -793,7 +813,10 @@ function isBidiOrZeroWidth(code: number): boolean {
 export function jPair(a: unknown, b: unknown): { a: string; b: string } {
   const as = stringifySymbolSafe(a) ?? String(a);
   const bs = stringifySymbolSafe(b) ?? String(b);
-  if (as.length <= VALUE_CAP && bs.length <= VALUE_CAP) return { a: as, b: bs };
+  // #1307: escape bidi/zero-width controls JSON.stringify left raw in the VALUE (TEXT path
+  // only) — the same visible `\u{XXXX}` form the key path uses. Applied at both return sites.
+  if (as.length <= VALUE_CAP && bs.length <= VALUE_CAP)
+    return { a: escapeBidiZeroWidth(as), b: escapeBidiZeroWidth(bs) };
   let i = 0;
   const min = Math.min(as.length, bs.length);
   while (i < min && as[i] === bs[i]) i++; // first index at which they differ
@@ -803,7 +826,7 @@ export function jPair(a: unknown, b: unknown): { a: string; b: string } {
     let out = safeSlice(s, start, start + VALUE_CAP);
     if (start > 0) out = `…${out}`;
     if (start + VALUE_CAP < s.length) out = `${out}…`;
-    return out;
+    return escapeBidiZeroWidth(out);
   };
   return { a: window(as), b: window(bs) };
 }

--- a/tests/report-value-bidi-1307.test.ts
+++ b/tests/report-value-bidi-1307.test.ts
@@ -1,0 +1,104 @@
+// #1307: #1058 escaped bidi/zero-width controls in report KEYS/ids/notes via
+// sanitizeForTerminal, but closed on the FALSE premise that VALUES were safe because they go
+// through JSON.stringify. JSON.stringify escapes only C0 controls / quote / backslash / lone
+// surrogates — it emits U+202E / U+200B / U+2066-2069 RAW inside the quoted string. So a
+// live-controlled string VALUE still carried the spoof onto the terminal (an RLO visually
+// reorders the `actual =` line; a zero-width char makes two different values render
+// identically). Fix: post-process the stringified value in j()/jPair() with the same visible
+// `\u{XXXX}` escape the key path uses — TEXT path only. The `--json` payload must stay
+// byte-faithful (it is parsed, not rendered on a terminal).
+
+import { describe, expect, it } from 'vite-plus/test';
+import { buildStackJson, formatFinding, jPair } from '../src/report/report.js';
+import type { Finding } from '../src/types.js';
+
+// The issue's evidence example: an SNS Topic DisplayName undeclared finding whose live VALUE
+// carries a RIGHT-TO-LEFT OVERRIDE (U+202E) — which visually renders `desired=SAFE` inside an
+// `actual =` line — and a trailing ZERO-WIDTH SPACE (U+200B).
+const RLO = '‮'; // RIGHT-TO-LEFT OVERRIDE
+const ZWSP = '​'; // ZERO-WIDTH SPACE
+const HOSTILE_VALUE = `abc${RLO}desired=SAFE${ZWSP}`;
+
+const snsFinding: Finding = {
+  tier: 'undeclared',
+  logicalId: 'Topic',
+  resourceType: 'AWS::SNS::Topic',
+  path: 'DisplayName',
+  actual: HOSTILE_VALUE,
+};
+
+describe('#1307 report VALUE bidi/zero-width escaping (TEXT path)', () => {
+  it('formatFinding escapes a raw U+202E / U+200B in an undeclared VALUE to \\u{...}', () => {
+    const out = formatFinding(snsFinding);
+    // the raw controls MUST NOT reach the terminal
+    expect(out).not.toContain(RLO);
+    expect(out).not.toContain(ZWSP);
+    // they survive VISIBLY as the same escape form the key path (sanitizeForTerminal) uses
+    expect(out).toContain('\\u{202E}');
+    expect(out).toContain('\\u{200B}');
+    // the escaped value is on the `actual =` line, benign text preserved
+    expect(out).toContain('actual =');
+    expect(out).toContain('abc\\u{202E}desired=SAFE\\u{200B}');
+  });
+
+  it('escapes bidi/zero-width in a declared desired/actual scalar PAIR (jPair path)', () => {
+    const declared: Finding = {
+      tier: 'declared',
+      logicalId: 'Topic',
+      resourceType: 'AWS::SNS::Topic',
+      path: 'DisplayName',
+      desired: 'safe',
+      actual: HOSTILE_VALUE,
+    };
+    const out = formatFinding(declared);
+    expect(out).not.toContain(RLO);
+    expect(out).not.toContain(ZWSP);
+    expect(out).toContain('\\u{202E}');
+    expect(out).toContain('\\u{200B}');
+  });
+
+  it('jPair escapes bidi/zero-width in both the short and windowed (long-value) branches', () => {
+    // short branch (both <= cap)
+    const short = jPair('safe', HOSTILE_VALUE);
+    expect(short.b).not.toContain(RLO);
+    expect(short.b).not.toContain(ZWSP);
+    expect(short.b).toContain('\\u{202E}');
+    expect(short.b).toContain('\\u{200B}');
+
+    // long branch (forces the windowing path): a long shared prefix + a hostile divergence
+    const prefix = 'x'.repeat(300);
+    const long = jPair(`${prefix}safe`, `${prefix}${RLO}evil${ZWSP}`);
+    expect(long.b).not.toContain(RLO);
+    expect(long.b).not.toContain(ZWSP);
+    expect(long.b).toContain('\\u{202E}');
+    expect(long.b).toContain('\\u{200B}');
+  });
+
+  it('a benign VALUE (CJK, emoji, printable) is NOT over-escaped', () => {
+    const benign: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Topic',
+      resourceType: 'AWS::SNS::Topic',
+      path: 'DisplayName',
+      actual: '日本語-héllo \u{1F600}',
+    };
+    const out = formatFinding(benign);
+    expect(out).toContain('日本語-héllo \u{1F600}');
+    expect(out).not.toContain('\\u{'); // nothing to escape
+  });
+
+  it('the --json payload stays byte-faithful (raw controls preserved, NOT escaped)', () => {
+    const { json } = buildStackJson([snsFinding], 'MyStack');
+    const serialized = JSON.stringify(json);
+    const parsed = JSON.parse(serialized) as {
+      findings: { actual: string }[];
+    };
+    // the parsed value round-trips to the ORIGINAL raw string — no \u{...} visible-escape leaked in
+    expect(parsed.findings[0].actual).toBe(HOSTILE_VALUE);
+    expect(parsed.findings[0].actual).toContain(RLO);
+    expect(parsed.findings[0].actual).toContain(ZWSP);
+    // the visible key-path escape form must NOT appear in the JSON payload
+    expect(serialized).not.toContain('\\u{202E}');
+    expect(serialized).not.toContain('\\u{200B}');
+  });
+});


### PR DESCRIPTION
Closes #1307.

## Problem
#1058 escaped bidi/zero-width Unicode in report KEYS/ids/notes but assumed VALUES were safe because they route through `JSON.stringify`. That premise is false: `JSON.stringify` escapes only C0 controls / quote / backslash / lone surrogates — it emits U+202E (RLO), U+200B (ZWSP), and the bidi isolates U+2066–2069 **raw** inside the quoted value. So a live-controlled drift VALUE still carried the terminal spoof (RLO reorders the rendered `actual =` line; zero-width chars make two different values render identically).

## Fix
Post-process the stringified value in `j()` / `jPair()` (both the short and windowed branches) with the already-defined `isBidiOrZeroWidth` escape — the same visible `\u{XXXX}` form the key path uses. **TEXT path only**: the `--json` payload is built structurally in `buildStackJson` and never routes through `j()`/`jPair()`, so its bytes stay byte-faithful for parsers (asserted in the test).

## Tests
`tests/report-value-bidi-1307.test.ts` — escapes raw U+202E/U+200B in undeclared values and declared value-pairs (short + windowed branches), does not over-escape benign CJK/emoji, and confirms `--json` output round-trips the raw bytes unchanged. Fails without the fix, passes with it.