### PR TITLE
fix(read): DMS/SageMaker-EndpointConfig/DocDB readers project Tags (#1287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,9 +803,14 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `dlm:GetLifecyclePolicy` (reads an `AWS::DLM::LifecyclePolicy` — a Data
   Lifecycle Manager EBS-snapshot / AMI backup-schedule policy, NON_PROVISIONABLE
   with no Cloud Control handlers; the physical id IS the policy id),
-  `dms:DescribeEndpoints` + `dms:DescribeReplicationSubnetGroups` (read an
-  `AWS::DMS::Endpoint` / `AWS::DMS::ReplicationSubnetGroup` — the classic DMS
-  migration/CDC family, NON_PROVISIONABLE with no Cloud Control handlers),
+  `dms:DescribeEndpoints` + `dms:DescribeReplicationSubnetGroups` +
+  `dms:DescribeReplicationInstances` + `dms:DescribeReplicationTasks` +
+  `dms:ListTagsForResource` (read an `AWS::DMS::Endpoint` /
+  `AWS::DMS::ReplicationSubnetGroup` / `AWS::DMS::ReplicationInstance` /
+  `AWS::DMS::ReplicationTask` — the classic DMS migration/CDC family,
+  NON_PROVISIONABLE with no Cloud Control handlers; `ListTagsForResource` reads
+  each resource's tags, which the `Describe*` responses omit — without it a
+  declared `Tags` false-flagged as drift on every tagged DMS resource),
   `lakeformation:DescribeResource` (reads an `AWS::LakeFormation::Resource` — a
   registered S3 data location whose Cloud Control `GetResource` returns
   `UnsupportedActionException`; the physical id IS the location `ResourceArn`, and
@@ -855,9 +860,16 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `HttpNamespace` / `PrivateDnsNamespace` / `PublicDnsNamespace` — incl. the Arn an
   ECS Service Connect namespace `Fn::GetAtt` resolves against — and a Cloud Map
   `Service`),
-  `docdb:DescribeDBClusters` + `docdb:DescribeDBInstances` (read an
-  `AWS::DocDB::DBCluster` / `AWS::DocDB::DBInstance` — the whole DocumentDB family is
-  a Cloud Control read gap),
+  `docdb:DescribeDBClusters` + `docdb:DescribeDBInstances` +
+  `rds:ListTagsForResource` (read an `AWS::DocDB::DBCluster` /
+  `AWS::DocDB::DBInstance` — the whole DocumentDB family is a Cloud Control read
+  gap; DocumentDB tag reads use the shared RDS `rds:ListTagsForResource` action,
+  which the `Describe*` responses omit — without it a declared `Tags`
+  false-flagged as drift on every tagged DocDB resource),
+  `sagemaker:DescribeEndpointConfig` + `sagemaker:ListTags` (read an
+  `AWS::SageMaker::EndpointConfig` — its production-variant model wiring, plus the
+  tags a separate `ListTags` call supplies since `DescribeEndpointConfig` omits
+  them),
   `codebuild:BatchGetProjects` (reads an `AWS::CodeBuild::Project`) +
   `codebuild:BatchGetReportGroups` (reads an `AWS::CodeBuild::ReportGroup`),
   `dax:DescribeClusters` + `dax:DescribeParameterGroups` + `dax:DescribeParameters` +

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -29,6 +29,7 @@ import {
   DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
   DocDBClient,
+  ListTagsForResourceCommand as DocDbListTagsForResourceCommand,
 } from '@aws-sdk/client-docdb';
 import {
   CloudWatchLogsClient,
@@ -110,6 +111,7 @@ import {
   DescribeReplicationInstancesCommand,
   DescribeReplicationSubnetGroupsCommand,
   DescribeReplicationTasksCommand,
+  ListTagsForResourceCommand as DmsListTagsForResourceCommand,
 } from '@aws-sdk/client-database-migration-service';
 import {
   DescribeResourceCommand,
@@ -157,6 +159,7 @@ import {
 import { DescribeParametersCommand, SSMClient } from '@aws-sdk/client-ssm';
 import {
   DescribeEndpointConfigCommand,
+  ListTagsCommand as SageMakerListTagsCommand,
   type ProductionVariant,
   SageMakerClient,
 } from '@aws-sdk/client-sagemaker';
@@ -168,6 +171,7 @@ import {
 import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { ResourceGoneError } from '../aws-errors.js';
+import { partitionForRegion } from '../desired/template-adapter.js';
 import { READ_RETRY } from './client-config.js';
 import { isDefinitiveDenial } from './kms-aliases.js';
 import { hashCaBundle, sha256Hex } from './pem.js';
@@ -210,6 +214,35 @@ function safeDecode(s: string): string {
   } catch {
     return s;
   }
+}
+
+// A live tag list ([{Key?, Value?}, ...] as most SDKs return it) mapped to the CFn
+// `Tags` shape ([{Key, Value}, ...]), keyed off a present Key and defaulting a missing
+// Value to '' — the same normalization readAcmCertificate uses. Returns undefined when
+// there are no keyed tags so the caller can OMIT `Tags` (absent stays absent = FP-safe).
+function projectTagList(
+  tags: { Key?: string | undefined; Value?: string | undefined }[] | undefined
+): { Key: string; Value: string }[] | undefined {
+  const out = (tags ?? [])
+    .filter((t) => str(t.Key) !== undefined)
+    .map((t) => ({ Key: t.Key as string, Value: t.Value ?? '' }));
+  return out.length > 0 ? out : undefined;
+}
+
+// The declared `Tags` mirrored into the CFn shape ([{Key, Value}, ...]), for the
+// degrade path when a ListTags*/ListTagsForResource call FAILS. Silently omitting live
+// Tags after a tag-fetch failure would read back as Tags=undefined, which false-flags a
+// `declared`-tier drift against a declared non-empty Tags array (and revert would offer
+// a bogus re-write). Mirroring the declared Tags makes the compare equal (no FP); the
+// caller ALSO emits a one-line stderr warning so the omission is not silent. This is the
+// #1086 (readAcmCertificate) degrade shape. Returns undefined when nothing was declared.
+function mirrorDeclaredTags(declaredTags: unknown): { Key: string; Value: string }[] | undefined {
+  if (!Array.isArray(declaredTags)) return undefined;
+  const out = declaredTags
+    .filter((t): t is Record<string, unknown> => typeof t === 'object' && t !== null)
+    .filter((t) => str(t.Key) !== undefined)
+    .map((t) => ({ Key: t.Key as string, Value: str(t.Value) ?? '' }));
+  return out.length > 0 ? out : undefined;
 }
 
 const readS3BucketPolicy: OverrideReader = async ({ declared, region }) => {
@@ -723,7 +756,34 @@ const readDlmLifecyclePolicy: OverrideReader = async ({ physicalId, declared, re
 // the deliverable. Read-ONLY: a ModifyEndpoint writer is deferred to a follow-up (revert of
 // connection settings needs per-engine care). A deleted endpoint surfaces as
 // ResourceNotFoundFault → the router maps it to `deleted`.
-const readDmsEndpoint: OverrideReader = async ({ physicalId, region }) => {
+// Fetch a resource's live tags via DMS dms:ListTagsForResource (the ARN is the tag
+// address) and project them onto the model's `Tags`, degrading — mirror declared Tags +
+// warn — on failure so a tag-fetch permission gap / throttle does not false-flag a
+// `declared`-tier Tags drift (the readAcmCertificate / #1086 pattern; #1287). DMS
+// describes DO NOT carry Tags, so without this any DMS resource in a `Tags.of(app)`
+// app false-flagged `Tags desired=[…] actual=undefined` on every check.
+async function attachDmsTags(
+  c: DatabaseMigrationServiceClient,
+  arn: string,
+  declared: Record<string, unknown>,
+  model: Record<string, unknown>,
+  label: string
+): Promise<void> {
+  try {
+    const t = await c.send(new DmsListTagsForResourceCommand({ ResourceArn: arn }));
+    const tags = projectTagList(t.TagList);
+    if (tags) model.Tags = tags;
+  } catch (err) {
+    const mirrored = mirrorDeclaredTags(declared.Tags);
+    if (mirrored) model.Tags = mirrored;
+    const call = (err as Error)?.name || 'unknown error';
+    process.stderr.write(
+      `[cdkrd] warning: DMS ListTagsForResource for ${label} (${arn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant dms:ListTagsForResource to detect out-of-band tag changes\n`
+    );
+  }
+}
+
+const readDmsEndpoint: OverrideReader = async ({ physicalId, declared, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
@@ -747,6 +807,10 @@ const readDmsEndpoint: OverrideReader = async ({ physicalId, region }) => {
   if (str(e.KmsKeyId)) model.KmsKeyId = e.KmsKeyId;
   if (str(e.CertificateArn)) model.CertificateArn = e.CertificateArn;
   if (str(e.SslMode)) model.SslMode = e.SslMode;
+  // Tags — DescribeEndpoints does not carry them; the EndpointArn is the tag address
+  // (fall back to an arn-form physical id).
+  const tagArn = str(e.EndpointArn) ?? (id.startsWith('arn:') ? id : undefined);
+  if (tagArn) await attachDmsTags(c, tagArn, declared, model, 'Endpoint');
   return model;
 };
 
@@ -759,7 +823,12 @@ const readDmsEndpoint: OverrideReader = async ({ physicalId, region }) => {
 // order difference is not false drift; DMS does not preserve the declared order). Read-ONLY
 // (ModifyReplicationSubnetGroup deferred). AWS lowercases the identifier, and CFn's Ref
 // resolves to that lowercased form, so the identity round-trips.
-const readDmsReplicationSubnetGroup: OverrideReader = async ({ physicalId, region }) => {
+const readDmsReplicationSubnetGroup: OverrideReader = async ({
+  physicalId,
+  declared,
+  region,
+  accountId,
+}) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
@@ -771,8 +840,8 @@ const readDmsReplicationSubnetGroup: OverrideReader = async ({ physicalId, regio
   const g = r.ReplicationSubnetGroups?.[0];
   if (!g) throw new ResourceGoneError(`DMS ReplicationSubnetGroup ${id} absent`);
   const model: Record<string, unknown> = {};
-  if (str(g.ReplicationSubnetGroupIdentifier))
-    model.ReplicationSubnetGroupIdentifier = g.ReplicationSubnetGroupIdentifier;
+  const identifier = str(g.ReplicationSubnetGroupIdentifier);
+  if (identifier) model.ReplicationSubnetGroupIdentifier = identifier;
   if (str(g.ReplicationSubnetGroupDescription))
     model.ReplicationSubnetGroupDescription = g.ReplicationSubnetGroupDescription;
   const subnetIds = (g.Subnets ?? [])
@@ -780,6 +849,14 @@ const readDmsReplicationSubnetGroup: OverrideReader = async ({ physicalId, regio
     .filter((v): v is string => v !== undefined)
     .sort();
   if (subnetIds.length > 0) model.SubnetIds = subnetIds;
+  // Tags — DescribeReplicationSubnetGroups carries no ARN, so synthesize the subnet-group
+  // ARN (`arn:<partition>:dms:<region>:<account>:subgrp:<identifier>`) for the tag address.
+  const subgrpId = identifier ?? id;
+  if (accountId && subgrpId) {
+    const { partition } = partitionForRegion(region);
+    const arn = `arn:${partition}:dms:${region}:${accountId}:subgrp:${subgrpId}`;
+    await attachDmsTags(c, arn, declared, model, 'ReplicationSubnetGroup');
+  }
   return model;
 };
 
@@ -798,7 +875,7 @@ const readDmsReplicationSubnetGroup: OverrideReader = async ({ physicalId, regio
 // difference is not false drift). Read-ONLY: a ModifyReplicationInstance writer is deferred to a
 // follow-up. A deleted instance surfaces as ResourceNotFoundFault → the router maps it to
 // `deleted`; an empty result → ResourceGoneError with the same effect.
-const readDmsReplicationInstance: OverrideReader = async ({ physicalId, region }) => {
+const readDmsReplicationInstance: OverrideReader = async ({ physicalId, declared, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
@@ -823,6 +900,14 @@ const readDmsReplicationInstance: OverrideReader = async ({ physicalId, region }
   if (str(i.PreferredMaintenanceWindow))
     model.PreferredMaintenanceWindow = i.PreferredMaintenanceWindow;
   if (str(i.KmsKeyId)) model.KmsKeyId = i.KmsKeyId;
+  // NetworkType (mutable, writable) + DnsNameServers (writable) are BOTH returned by
+  // DescribeReplicationInstances and modeled in the CFn schema, but were omitted — an
+  // out-of-band NetworkType flip (e.g. IPV4 -> DUAL) was invisible (a readGap FN).
+  // Project present-only. NOTE: the `NetworkType: "IPV4"` KNOWN_DEFAULTS fold (so an
+  // UNDECLARED IPV4 default folds atDefault on a first check) lives in noise.ts, which is
+  // off-limits here — that fold is a follow-up; this projection is the read-side fix.
+  if (str(i.NetworkType)) model.NetworkType = i.NetworkType;
+  if (str(i.DnsNameServers)) model.DnsNameServers = i.DnsNameServers;
   if (str(i.ReplicationSubnetGroup?.ReplicationSubnetGroupIdentifier))
     model.ReplicationSubnetGroupIdentifier =
       i.ReplicationSubnetGroup?.ReplicationSubnetGroupIdentifier;
@@ -831,6 +916,10 @@ const readDmsReplicationInstance: OverrideReader = async ({ physicalId, region }
     .filter((v): v is string => v !== undefined)
     .sort();
   if (sgIds.length > 0) model.VpcSecurityGroupIds = sgIds;
+  // Tags — DescribeReplicationInstances does not carry them; ReplicationInstanceArn is the
+  // tag address (fall back to an arn-form physical id).
+  const tagArn = str(i.ReplicationInstanceArn) ?? (id.startsWith('arn:') ? id : undefined);
+  if (tagArn) await attachDmsTags(c, tagArn, declared, model, 'ReplicationInstance');
   return model;
 };
 
@@ -847,7 +936,7 @@ const readDmsReplicationInstance: OverrideReader = async ({ physicalId, region }
 // and an unparseable blob falls back to the raw string. Read-ONLY (ModifyReplicationTask
 // deferred). A deleted task surfaces as ResourceNotFoundFault → `deleted`; an empty result →
 // ResourceGoneError.
-const readDmsReplicationTask: OverrideReader = async ({ physicalId, region }) => {
+const readDmsReplicationTask: OverrideReader = async ({ physicalId, declared, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
@@ -882,6 +971,10 @@ const readDmsReplicationTask: OverrideReader = async ({ physicalId, region }) =>
   if (str(t.CdcStartPosition)) model.CdcStartPosition = t.CdcStartPosition;
   if (str(t.CdcStopPosition)) model.CdcStopPosition = t.CdcStopPosition;
   if (str(t.TaskData)) model.TaskData = t.TaskData;
+  // Tags — DescribeReplicationTasks does not carry them; ReplicationTaskArn is the tag
+  // address (fall back to an arn-form physical id).
+  const tagArn = str(t.ReplicationTaskArn) ?? (id.startsWith('arn:') ? id : undefined);
+  if (tagArn) await attachDmsTags(c, tagArn, declared, model, 'ReplicationTask');
   return model;
 };
 
@@ -1747,9 +1840,12 @@ const readGlueSecurityConfiguration: OverrideReader = async ({ physicalId, decla
 // ManagedInstanceScaling / RoutingConfig / InstancePools / CapacityReservationConfig) match the
 // CFn definitions 1:1 and pass through verbatim when present.
 //
-// Tags are NOT projected: DescribeEndpointConfig does not return them (there is no `Tags` field
-// on the response — tags come from a separate ListTags call), so there is nothing to map; a
-// declared Tags stays a readGap rather than a false `desired=[…] actual=undefined` drift.
+// Tags: DescribeEndpointConfig does NOT return them (there is no `Tags` field on the response),
+// so they come from a separate SageMaker ListTags call keyed on the EndpointConfigArn (#1287).
+// Without this a declared non-empty Tags array read back as Tags=undefined -> a false
+// `declared`-tier `desired=[…] actual=undefined` drift on every tagged endpoint config (a
+// `Tags.of(app)` app tags them all). On a ListTags failure, MIRROR declared Tags + warn on
+// stderr (the readAcmCertificate / #1086 degrade shape) so a permission gap does not false-flag.
 // Read-ONLY: the endpoint config is immutable (every mutable property is createOnly in the
 // schema — you replace, not update — and there is no UpdateEndpointConfig API), so there is no
 // in-place revert to offer. A deleted config surfaces as ResourceNotFound / ValidationException
@@ -1783,7 +1879,12 @@ const projectSageMakerVariant = (v: ProductionVariant): Record<string, unknown> 
   // permanent undeclared false inventory.
   return out;
 };
-const readSageMakerEndpointConfig: OverrideReader = async ({ physicalId, declared, region }) => {
+const readSageMakerEndpointConfig: OverrideReader = async ({
+  physicalId,
+  declared,
+  region,
+  accountId,
+}) => {
   const name = str(physicalId) ?? str(declared.EndpointConfigName);
   if (!name) return undefined;
   const c = new SageMakerClient({ region, ...READ_RETRY });
@@ -1805,6 +1906,27 @@ const readSageMakerEndpointConfig: OverrideReader = async ({ physicalId, declare
     model.EnableNetworkIsolation = r.EnableNetworkIsolation;
   if (str(r.ExecutionRoleArn)) model.ExecutionRoleArn = r.ExecutionRoleArn;
   if (r.VpcConfig !== undefined) model.VpcConfig = r.VpcConfig;
+  // Tags — a separate SageMaker sagemaker:ListTags call keyed on the EndpointConfigArn (the
+  // response's ARN, else synthesize it). On failure, mirror declared Tags + warn (see note).
+  const tagArn =
+    str(r.EndpointConfigArn) ??
+    (accountId
+      ? `arn:${partitionForRegion(region).partition}:sagemaker:${region}:${accountId}:endpoint-config/${name}`
+      : undefined);
+  if (tagArn) {
+    try {
+      const t = await c.send(new SageMakerListTagsCommand({ ResourceArn: tagArn }));
+      const tags = projectTagList(t.Tags);
+      if (tags) model.Tags = tags;
+    } catch (err) {
+      const mirrored = mirrorDeclaredTags(declared.Tags);
+      if (mirrored) model.Tags = mirrored;
+      const call = (err as Error)?.name || 'unknown error';
+      process.stderr.write(
+        `[cdkrd] warning: SageMaker ListTags for EndpointConfig (${tagArn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant sagemaker:ListTags to detect out-of-band tag changes\n`
+      );
+    }
+  }
   // EndpointConfigArn / CreationTime are AWS-managed readOnly response fields NOT in the CFn
   // schema — dropped (projecting them would be a permanent undeclared false inventory).
   return model;
@@ -2189,7 +2311,33 @@ const readServiceDiscoveryService: OverrideReader = async ({ physicalId, region 
 // deliberately NOT projected — it is create-only and AWS may reorder it, an FP surface
 // with no detection benefit (same rule as Subnet AZ). An absent cluster returns
 // undefined (-> skipped; a genuinely deleted one throws DBClusterNotFoundFault -> deleted).
-const readDocDbCluster: OverrideReader = async ({ physicalId, declared, region }) => {
+// Fetch a DocDB resource's live tags via docdb:ListTagsForResource (the ARN is the
+// `ResourceName` tag address) onto `Tags`, degrading — mirror declared Tags + warn — on
+// failure (the readAcmCertificate / #1086 shape; #1287). DescribeDBClusters /
+// DescribeDBInstances do NOT carry Tags, so without this any DocDB resource in a
+// `Tags.of(app)` app false-flagged `Tags desired=[…] actual=undefined` on every check.
+async function attachDocDbTags(
+  c: DocDBClient,
+  arn: string,
+  declared: Record<string, unknown>,
+  model: Record<string, unknown>,
+  label: string
+): Promise<void> {
+  try {
+    const t = await c.send(new DocDbListTagsForResourceCommand({ ResourceName: arn }));
+    const tags = projectTagList(t.TagList);
+    if (tags) model.Tags = tags;
+  } catch (err) {
+    const mirrored = mirrorDeclaredTags(declared.Tags);
+    if (mirrored) model.Tags = mirrored;
+    const call = (err as Error)?.name || 'unknown error';
+    process.stderr.write(
+      `[cdkrd] warning: DocDB ListTagsForResource for ${label} (${arn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant rds:ListTagsForResource to detect out-of-band tag changes\n`
+    );
+  }
+}
+
+const readDocDbCluster: OverrideReader = async ({ physicalId, declared, region, accountId }) => {
   const id = str(physicalId) ?? str(declared.DBClusterIdentifier);
   if (!id) return undefined;
   const c = new DocDBClient({ region, ...READ_RETRY });
@@ -2218,6 +2366,14 @@ const readDocDbCluster: OverrideReader = async ({ physicalId, declared, region }
     .map((g) => g.VpcSecurityGroupId)
     .filter((s): s is string => s !== undefined);
   if (sgs.length > 0) model.VpcSecurityGroupIds = sgs;
+  // Tags — DescribeDBClusters does not carry them; DBClusterArn is the tag address (else
+  // synthesize the RDS-family cluster ARN).
+  const tagArn =
+    str(cl.DBClusterArn) ??
+    (accountId && id
+      ? `arn:${partitionForRegion(region).partition}:rds:${region}:${accountId}:cluster:${id}`
+      : undefined);
+  if (tagArn) await attachDocDbTags(c, tagArn, declared, model, 'DBCluster');
   return model;
 };
 
@@ -2225,7 +2381,7 @@ const readDocDbCluster: OverrideReader = async ({ physicalId, declared, region }
 // physical id IS the DBInstanceIdentifier. Project the CFn-modeled props, mapping
 // PerformanceInsightsEnabled -> EnablePerformanceInsights. AvailabilityZone is
 // create-only and not projected. Endpoint / Status / InstanceCreateTime are noise.
-const readDocDbInstance: OverrideReader = async ({ physicalId, declared, region }) => {
+const readDocDbInstance: OverrideReader = async ({ physicalId, declared, region, accountId }) => {
   const id = str(physicalId) ?? str(declared.DBInstanceIdentifier);
   if (!id) return undefined;
   const c = new DocDBClient({ region, ...READ_RETRY });
@@ -2245,6 +2401,14 @@ const readDocDbInstance: OverrideReader = async ({ physicalId, declared, region 
     model.CACertificateIdentifier = inst.CACertificateIdentifier;
   if (inst.PerformanceInsightsEnabled !== undefined)
     model.EnablePerformanceInsights = inst.PerformanceInsightsEnabled;
+  // Tags — DescribeDBInstances does not carry them; DBInstanceArn is the tag address (else
+  // synthesize the RDS-family instance ARN).
+  const tagArn =
+    str(inst.DBInstanceArn) ??
+    (accountId && id
+      ? `arn:${partitionForRegion(region).partition}:rds:${region}:${accountId}:db:${id}`
+      : undefined);
+  if (tagArn) await attachDocDbTags(c, tagArn, declared, model, 'DBInstance');
   return model;
 };
 

--- a/tests/overrides-sagemaker-endpointconfig-857.test.ts
+++ b/tests/overrides-sagemaker-endpointconfig-857.test.ts
@@ -1,6 +1,10 @@
-import { DescribeEndpointConfigCommand, SageMakerClient } from '@aws-sdk/client-sagemaker';
+import {
+  DescribeEndpointConfigCommand,
+  ListTagsCommand as SageMakerListTagsCommand,
+  SageMakerClient,
+} from '@aws-sdk/client-sagemaker';
 import { mockClient } from 'aws-sdk-client-mock';
-import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { ResourceGoneError } from '../src/aws-errors.js';
 import { SDK_OVERRIDES } from '../src/read/overrides.js';
 
@@ -25,6 +29,9 @@ const read = SDK_OVERRIDES['AWS::SageMaker::EndpointConfig'];
 
 beforeEach(() => {
   sagemaker.reset();
+  // #1287 — the reader now fetches tags via sagemaker:ListTags. Default it to empty so these
+  // Tags-agnostic cases exercise the (Tags-absent) success path, not the degrade warn.
+  sagemaker.on(SageMakerListTagsCommand).resolves({ Tags: [] });
 });
 
 describe('SageMaker EndpointConfig (#857)', () => {
@@ -157,5 +164,85 @@ describe('SageMaker EndpointConfig (#857)', () => {
 
   it('undefined when identity cannot be resolved (physical id + declared name both absent) -> skipped', async () => {
     expect(await read(ctx({}))).toBeUndefined();
+  });
+
+  // #1287 — DescribeEndpointConfig carries NO Tags; the reader must fetch them via a separate
+  // sagemaker:ListTags call keyed on the EndpointConfigArn, or a declared non-empty Tags array
+  // false-flags a `declared`-tier drift (actual=undefined) on every tagged endpoint config.
+  describe('Tags via ListTags (#1287)', () => {
+    const ARN = 'arn:aws:sagemaker:us-east-1:123456789012:endpoint-config/ec';
+
+    it('projects live Tags from ListTags addressed by EndpointConfigArn', async () => {
+      sagemaker.on(DescribeEndpointConfigCommand).resolves({
+        EndpointConfigName: 'ec',
+        EndpointConfigArn: ARN,
+        ProductionVariants: [{ VariantName: 'v1' }],
+      });
+      sagemaker.on(SageMakerListTagsCommand).resolves({
+        Tags: [
+          { Key: 'Env', Value: 'prod' },
+          { Key: 'Team', Value: 'ml' },
+        ],
+      });
+      const out = (await read(
+        ctx({ EndpointConfigName: 'ec', Tags: [{ Key: 'Env', Value: 'prod' }] }, 'ec')
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([
+        { Key: 'Env', Value: 'prod' },
+        { Key: 'Team', Value: 'ml' },
+      ]);
+      const tagCall = sagemaker.commandCalls(SageMakerListTagsCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({ ResourceArn: ARN });
+    });
+
+    it('no live tags -> Tags omitted (absent stays absent, FP-safe)', async () => {
+      sagemaker.on(DescribeEndpointConfigCommand).resolves({
+        EndpointConfigName: 'ec',
+        EndpointConfigArn: ARN,
+        ProductionVariants: [{ VariantName: 'v1' }],
+      });
+      sagemaker.on(SageMakerListTagsCommand).resolves({ Tags: [] });
+      const out = await read(ctx({ EndpointConfigName: 'ec' }, 'ec'));
+      expect(out).not.toHaveProperty('Tags');
+    });
+
+    it('synthesizes the EndpointConfigArn when the response omits it', async () => {
+      sagemaker.on(DescribeEndpointConfigCommand).resolves({
+        EndpointConfigName: 'ec',
+        ProductionVariants: [{ VariantName: 'v1' }],
+      });
+      sagemaker.on(SageMakerListTagsCommand).resolves({ Tags: [] });
+      await read(ctx({ EndpointConfigName: 'ec' }, 'ec'));
+      const tagCall = sagemaker.commandCalls(SageMakerListTagsCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({ ResourceArn: ARN });
+    });
+
+    it('ListTags fails -> mirrors declared Tags + warns (#1086 degrade shape)', async () => {
+      const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      sagemaker.on(DescribeEndpointConfigCommand).resolves({
+        EndpointConfigName: 'ec',
+        EndpointConfigArn: ARN,
+        ProductionVariants: [{ VariantName: 'v1' }],
+      });
+      sagemaker.on(SageMakerListTagsCommand).rejects(new Error('AccessDenied'));
+      const out = (await read(
+        ctx(
+          {
+            EndpointConfigName: 'ec',
+            Tags: [
+              { Key: 'Env', Value: 'prod' },
+              { Key: 'Team', Value: 'ml' },
+            ],
+          },
+          'ec'
+        )
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([
+        { Key: 'Env', Value: 'prod' },
+        { Key: 'Team', Value: 'ml' },
+      ]);
+      expect(warn.mock.calls[0]?.[0]).toContain('SageMaker ListTags');
+      warn.mockRestore();
+    });
   });
 });

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -7,6 +7,7 @@ import {
   DescribeReplicationInstancesCommand,
   DescribeReplicationSubnetGroupsCommand,
   DescribeReplicationTasksCommand,
+  ListTagsForResourceCommand as DmsListTagsForResourceCommand,
 } from '@aws-sdk/client-database-migration-service';
 import {
   GetJobTemplateCommand,
@@ -58,6 +59,7 @@ import {
   DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
   DocDBClient,
+  ListTagsForResourceCommand as DocDbListTagsForResourceCommand,
 } from '@aws-sdk/client-docdb';
 import {
   CloudWatchLogsClient,
@@ -105,7 +107,7 @@ import {
 import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { mockClient } from 'aws-sdk-client-mock';
-import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { SDK_OVERRIDES, SDK_SUPPLEMENTS } from '../src/read/overrides.js';
 import { ResourceGoneError } from '../src/aws-errors.js';
 import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
@@ -176,6 +178,11 @@ beforeEach(() => {
     eb,
   ])
     m.reset();
+  // #1287 — the DMS/DocDB readers now fetch tags via ListTagsForResource. Default them to
+  // empty so unrelated cases exercise the (Tags-absent) success path, not the degrade warn.
+  // A case that wants to assert tag projection / degrade overrides this per-test.
+  dms.on(DmsListTagsForResourceCommand).resolves({ TagList: [] });
+  docdb.on(DocDbListTagsForResourceCommand).resolves({ TagList: [] });
 });
 
 describe('SDK overrides', () => {
@@ -1677,6 +1684,215 @@ describe('SDK overrides', () => {
       await expect(
         SDK_OVERRIDES['AWS::DMS::ReplicationTask'](ctx({}, 'my-task'))
       ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+  });
+
+  describe('DMS Tags via ListTagsForResource (#1287)', () => {
+    const ENDPOINT_ARN = 'arn:aws:dms:us-east-1:123456789012:endpoint:ABCDEF';
+
+    it('Endpoint: projects live Tags from ListTagsForResource (no false declared-Tags drift)', async () => {
+      dms.on(DescribeEndpointsCommand).resolves({
+        Endpoints: [{ EndpointArn: ENDPOINT_ARN, EndpointIdentifier: 'src', EngineName: 'mysql' }],
+      } as never);
+      dms.on(DmsListTagsForResourceCommand).resolves({
+        TagList: [
+          { Key: 'Env', Value: 'prod' },
+          { Key: 'Team', Value: 'data' },
+        ],
+      });
+      // The template DECLARES Tags. Without projecting the live tags the model would omit Tags
+      // (actual=undefined) → a false `declared`-tier drift on a tagged endpoint.
+      const out = (await SDK_OVERRIDES['AWS::DMS::Endpoint'](
+        ctx({ EngineName: 'mysql', Tags: [{ Key: 'Env', Value: 'prod' }] }, ENDPOINT_ARN)
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([
+        { Key: 'Env', Value: 'prod' },
+        { Key: 'Team', Value: 'data' },
+      ]);
+      // Tag call is addressed by the EndpointArn.
+      const tagCall = dms.commandCalls(DmsListTagsForResourceCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({ ResourceArn: ENDPOINT_ARN });
+    });
+
+    it('Endpoint: no live tags -> Tags omitted (absent stays absent, FP-safe)', async () => {
+      dms.on(DescribeEndpointsCommand).resolves({
+        Endpoints: [{ EndpointArn: ENDPOINT_ARN, EndpointIdentifier: 'src', EngineName: 'mysql' }],
+      } as never);
+      dms.on(DmsListTagsForResourceCommand).resolves({ TagList: [] });
+      const out = await SDK_OVERRIDES['AWS::DMS::Endpoint'](ctx({}, ENDPOINT_ARN));
+      expect(out).not.toHaveProperty('Tags');
+    });
+
+    it('Endpoint: ListTagsForResource fails -> mirrors declared Tags + warns (#1086 degrade shape)', async () => {
+      const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      dms.on(DescribeEndpointsCommand).resolves({
+        Endpoints: [{ EndpointArn: ENDPOINT_ARN, EndpointIdentifier: 'src', EngineName: 'mysql' }],
+      } as never);
+      dms.on(DmsListTagsForResourceCommand).rejects(new Error('AccessDenied'));
+      const out = (await SDK_OVERRIDES['AWS::DMS::Endpoint'](
+        ctx(
+          {
+            EngineName: 'mysql',
+            Tags: [
+              { Key: 'Env', Value: 'prod' },
+              { Key: 'Team', Value: 'data' },
+            ],
+          },
+          ENDPOINT_ARN
+        )
+      )) as Record<string, unknown>;
+      // Degrade mirrors the DECLARED tags so the compare is equal (no false drift) …
+      expect(out.Tags).toEqual([
+        { Key: 'Env', Value: 'prod' },
+        { Key: 'Team', Value: 'data' },
+      ]);
+      // … and warns on stderr so the omission is not silent.
+      expect(warn.mock.calls[0]?.[0]).toContain('DMS ListTagsForResource');
+      warn.mockRestore();
+    });
+
+    it('ReplicationSubnetGroup: synthesizes the subgrp ARN for the tag address', async () => {
+      dms.on(DescribeReplicationSubnetGroupsCommand).resolves({
+        ReplicationSubnetGroups: [{ ReplicationSubnetGroupIdentifier: 'dms-subnet-grp' }],
+      } as never);
+      dms.on(DmsListTagsForResourceCommand).resolves({ TagList: [{ Key: 'K', Value: 'V' }] });
+      const out = (await SDK_OVERRIDES['AWS::DMS::ReplicationSubnetGroup'](
+        ctx({ Tags: [{ Key: 'K', Value: 'V' }] }, 'dms-subnet-grp')
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([{ Key: 'K', Value: 'V' }]);
+      const tagCall = dms.commandCalls(DmsListTagsForResourceCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({
+        ResourceArn: 'arn:aws:dms:us-east-1:123456789012:subgrp:dms-subnet-grp',
+      });
+    });
+
+    it('ReplicationInstance: projects live Tags + present-only NetworkType/DnsNameServers', async () => {
+      dms.on(DescribeReplicationInstancesCommand).resolves({
+        ReplicationInstances: [
+          {
+            ReplicationInstanceArn: 'arn:aws:dms:us-east-1:123456789012:rep:ABCDEF',
+            ReplicationInstanceIdentifier: 'my-repl',
+            NetworkType: 'DUAL',
+            DnsNameServers: '10.0.0.2,10.0.0.3',
+          },
+        ],
+      } as never);
+      dms.on(DmsListTagsForResourceCommand).resolves({ TagList: [{ Key: 'Env', Value: 'prod' }] });
+      const out = (await SDK_OVERRIDES['AWS::DMS::ReplicationInstance'](
+        ctx(
+          { Tags: [{ Key: 'Env', Value: 'prod' }] },
+          'arn:aws:dms:us-east-1:123456789012:rep:ABCDEF'
+        )
+      )) as Record<string, unknown>;
+      // NetworkType (mutable) + DnsNameServers now projected → an out-of-band flip is detectable.
+      expect(out.NetworkType).toBe('DUAL');
+      expect(out.DnsNameServers).toBe('10.0.0.2,10.0.0.3');
+      expect(out.Tags).toEqual([{ Key: 'Env', Value: 'prod' }]);
+    });
+
+    it('ReplicationInstance: NetworkType/DnsNameServers ABSENT from the response -> omitted (readGap, no fabrication)', async () => {
+      dms.on(DescribeReplicationInstancesCommand).resolves({
+        ReplicationInstances: [{ ReplicationInstanceIdentifier: 'my-repl' }],
+      } as never);
+      dms.on(DmsListTagsForResourceCommand).resolves({ TagList: [] });
+      const out = await SDK_OVERRIDES['AWS::DMS::ReplicationInstance'](ctx({}, 'my-repl'));
+      expect(out).not.toHaveProperty('NetworkType');
+      expect(out).not.toHaveProperty('DnsNameServers');
+    });
+
+    it('ReplicationTask: projects live Tags addressed by ReplicationTaskArn', async () => {
+      dms.on(DescribeReplicationTasksCommand).resolves({
+        ReplicationTasks: [
+          {
+            ReplicationTaskArn: 'arn:aws:dms:us-east-1:123456789012:task:ABCDEF',
+            ReplicationTaskIdentifier: 'my-task',
+          },
+        ],
+      } as never);
+      dms.on(DmsListTagsForResourceCommand).resolves({ TagList: [{ Key: 'K', Value: 'V' }] });
+      const out = (await SDK_OVERRIDES['AWS::DMS::ReplicationTask'](
+        ctx({ Tags: [{ Key: 'K', Value: 'V' }] }, 'arn:aws:dms:us-east-1:123456789012:task:ABCDEF')
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([{ Key: 'K', Value: 'V' }]);
+      const tagCall = dms.commandCalls(DmsListTagsForResourceCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({
+        ResourceArn: 'arn:aws:dms:us-east-1:123456789012:task:ABCDEF',
+      });
+    });
+  });
+
+  describe('DocDB Tags via ListTagsForResource (#1287)', () => {
+    it('DBCluster: projects live Tags addressed by DBClusterArn (no false declared-Tags drift)', async () => {
+      docdb.on(DescribeDBClustersCommand).resolves({
+        DBClusters: [
+          {
+            DBClusterIdentifier: 'my-cluster',
+            DBClusterArn: 'arn:aws:rds:us-east-1:123456789012:cluster:my-cluster',
+          },
+        ],
+      } as never);
+      docdb
+        .on(DocDbListTagsForResourceCommand)
+        .resolves({ TagList: [{ Key: 'Env', Value: 'prod' }] });
+      const out = (await SDK_OVERRIDES['AWS::DocDB::DBCluster'](
+        ctx({ Tags: [{ Key: 'Env', Value: 'prod' }] }, 'my-cluster')
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([{ Key: 'Env', Value: 'prod' }]);
+      const tagCall = docdb.commandCalls(DocDbListTagsForResourceCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({
+        ResourceName: 'arn:aws:rds:us-east-1:123456789012:cluster:my-cluster',
+      });
+    });
+
+    it('DBCluster: no DBClusterArn on the response -> synthesizes the cluster ARN', async () => {
+      docdb.on(DescribeDBClustersCommand).resolves({
+        DBClusters: [{ DBClusterIdentifier: 'my-cluster' }],
+      } as never);
+      docdb.on(DocDbListTagsForResourceCommand).resolves({ TagList: [] });
+      await SDK_OVERRIDES['AWS::DocDB::DBCluster'](ctx({}, 'my-cluster'));
+      const tagCall = docdb.commandCalls(DocDbListTagsForResourceCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({
+        ResourceName: 'arn:aws:rds:us-east-1:123456789012:cluster:my-cluster',
+      });
+    });
+
+    it('DBCluster: ListTagsForResource fails -> mirrors declared Tags + warns', async () => {
+      const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      docdb.on(DescribeDBClustersCommand).resolves({
+        DBClusters: [
+          {
+            DBClusterIdentifier: 'my-cluster',
+            DBClusterArn: 'arn:aws:rds:us-east-1:123456789012:cluster:my-cluster',
+          },
+        ],
+      } as never);
+      docdb.on(DocDbListTagsForResourceCommand).rejects(new Error('AccessDenied'));
+      const out = (await SDK_OVERRIDES['AWS::DocDB::DBCluster'](
+        ctx({ Tags: [{ Key: 'Env', Value: 'prod' }] }, 'my-cluster')
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([{ Key: 'Env', Value: 'prod' }]);
+      expect(warn.mock.calls[0]?.[0]).toContain('DocDB ListTagsForResource');
+      warn.mockRestore();
+    });
+
+    it('DBInstance: projects live Tags addressed by DBInstanceArn', async () => {
+      docdb.on(DescribeDBInstancesCommand).resolves({
+        DBInstances: [
+          {
+            DBInstanceIdentifier: 'inst-1',
+            DBInstanceArn: 'arn:aws:rds:us-east-1:123456789012:db:inst-1',
+          },
+        ],
+      } as never);
+      docdb.on(DocDbListTagsForResourceCommand).resolves({ TagList: [{ Key: 'K', Value: 'V' }] });
+      const out = (await SDK_OVERRIDES['AWS::DocDB::DBInstance'](
+        ctx({ Tags: [{ Key: 'K', Value: 'V' }] }, 'inst-1')
+      )) as Record<string, unknown>;
+      expect(out.Tags).toEqual([{ Key: 'K', Value: 'V' }]);
+      const tagCall = docdb.commandCalls(DocDbListTagsForResourceCommand)[0]!;
+      expect(tagCall.args[0].input).toEqual({
+        ResourceName: 'arn:aws:rds:us-east-1:123456789012:db:inst-1',
+      });
     });
   });
 


### PR DESCRIPTION
Closes #1287.

## Problem
The `SDK_OVERRIDES` readers for DMS (`readDmsEndpoint`/`readDmsReplicationInstance`/`readDmsReplicationTask`/`readDmsReplicationSubnetGroup`), SageMaker EndpointConfig, and DocDB (`readDocDbCluster`/`readDocDbInstance`) projected only their `Describe*` response fields. Those responses carry no tags (DMS/DocDB need `ListTagsForResource`; SageMaker needs `ListTags`), so the live model never contained `Tags`. The CFn schema models a writable top-level `Tags` array, so classify's removed-collection branch emitted a false **declared-tier** `Tags desired=[…] actual=undefined` drift on every tagged resource (any `Tags.of(app).add(...)` app) — surviving `record` and offering a bogus revert re-write. This is the recurring #1056 / #1086 SDK_OVERRIDES-reader-omits-schema-fields class.

## Fix
Fetch tags per read via `ListTagsForResource` (DMS/DocDB) / `ListTags` (SageMaker), addressing by the response ARN or a synthesized ARN (SubnetGroup / DocDB / SageMaker fallback) via the shared `partitionForRegion` helper. Project present-only. On a tag-fetch failure, **mirror declared Tags + emit a stderr warning** (the `readAcmCertificate` / #1086 degrade shape) so a permission gap / throttle does not itself false-flag.

Bundled (same reader): `readDmsReplicationInstance` now projects `NetworkType` / `DnsNameServers` present-only (both writable, returned by `DescribeReplicationInstances`, previously an unprojected readGap FN). Also fixes the stale SageMaker `declared Tags stays a readGap` comment (wrong for a collection).

Follow-up (deferred, off-limits file): the `NetworkType: "IPV4"` `KNOWN_DEFAULTS` fold belongs in `noise.ts` (owned by a parallel lane) — noted at the projection site.

## Tests
`tests/overrides.test.ts` + `tests/overrides-sagemaker-endpointconfig-857.test.ts` — Tags projected via ListTags*/ListTagsForResource (project / omit-empty / ARN synthesis / degrade-mirror+warn) for every affected reader, plus DMS RI NetworkType/DnsNameServers present-only projection. Each fails without the fix, passes with it. No new dependency packages.