### PR TITLE
fix(commands): add the account axis to named/glob stack dedup + pre-deploy synth key (#1320)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -56,10 +56,19 @@ import { resolveInteractively } from './interactive-resolve.js';
 // synth (not deployed) declared set, so all three are excluded. --declared-only
 // reuses the same filter against the DEPLOYED template (R59) — its "undeclared
 // values are not compared" contract must hold for the `atDefault` footer too, else
-// Key a synth template by stack name + region (a CFn stack name is region-scoped, so
-// the same name can recur across regions in one app). Exported (pure) for unit testing.
-export function synthKey(stackName: string, region: string | undefined): string {
-  return `${stackName}\0${region ?? ''}`;
+// Key a synth template by stack name + region + account (a CFn stack name is
+// region-scoped, so the same name can recur across regions in one app; #1320: it can
+// also recur across ACCOUNTS — a #740 multi-account app defines a fixed stackName in
+// the SAME region with env.account varying per stage. Keyed by name+region alone, the
+// second-synthesized template would OVERWRITE the first and both stacks would compare
+// against the wrong account's synth template — false declared drift / masked real
+// drift). Exported (pure) for unit testing.
+export function synthKey(
+  stackName: string,
+  region: string | undefined,
+  account: string | undefined
+): string {
+  return `${stackName}\0${region ?? ''}\0${account ?? ''}`;
 }
 
 // Reconcile classified findings against the baseline for the report. Exported (pure)
@@ -529,13 +538,15 @@ export async function runCheck(args: string[]): Promise<number> {
       emitEmptyJsonOnError();
       return 2;
     }
-    // Key by stackName + region, NOT stackName alone: a stack name is region-scoped in
-    // CloudFormation, so an app can define two same-named stacks in different regions.
-    // Keyed by name alone, the second would overwrite the first and BOTH would then be
-    // compared against the wrong (last-synthesized) template. The region resolution
-    // mirrors resolveStacks (`s.region ?? a.region`) so the loop's lookup key matches.
+    // Key by stackName + region + account, NOT stackName alone: a stack name is
+    // region-scoped in CloudFormation, so an app can define two same-named stacks in
+    // different regions (#884) — AND #1320: a #740 multi-account app can define the same
+    // name in the SAME region for two accounts. Keyed by name (+region) alone, the second
+    // would overwrite the first and BOTH would then be compared against the wrong
+    // (last-synthesized) template. The region resolution mirrors resolveStacks
+    // (`s.region ?? a.region`) so the loop's lookup key matches.
     synthTemplates = new Map(
-      synthed.map((s) => [synthKey(s.stackName, s.region ?? a.region), s.template])
+      synthed.map((s) => [synthKey(s.stackName, s.region ?? a.region, s.account), s.template])
     );
     console.error('(--pre-deploy) comparing live state against the LOCAL synth template');
   }
@@ -616,7 +627,7 @@ export async function runCheck(args: string[]): Promise<number> {
         worst = Math.max(worst, a.strict ? 1 : 0);
         continue;
       }
-      const sKey = synthKey(stackName, region);
+      const sKey = synthKey(stackName, region, account);
       if (synthTemplates && !synthTemplates.has(sKey)) {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
         jsonError(stackName, region, 'not in the synth output — skipped (--pre-deploy)');

--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -196,7 +196,15 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
     account: string | undefined, // #740: the stack's own env.account (concrete, else undefined)
     template: Record<string, unknown>
   ): void => {
-    const key = `${stackName}\0${region ?? ''}`;
+    // #1320: dedup on name + region + ACCOUNT. #884 added the region axis but not
+    // the account axis, so a #740 multi-account app that defines the SAME stackName
+    // in the SAME region for TWO different accounts (a fixed stackName with env.account
+    // varying per stage — the multi-account CI staple) had its SECOND instance silently
+    // dropped when selected by name or glob, while --all (no dedup) returned both — the
+    // two selection forms then disagreed (the prod stack never checked by any named leg).
+    // A same-name/same-region/same-account duplicate (or env-agnostic account undefined)
+    // still collapses, so #884's behavior is unchanged.
+    const key = `${stackName}\0${region ?? ''}\0${account ?? ''}`;
     if (seen.has(key)) return;
     seen.add(key);
     out.push({ stackName, region, account, template });

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -416,15 +416,39 @@ describe('coverageWarning / hasCoverageGap (--strict + loud coverage gap)', () =
   });
 });
 
-describe('synthKey (--pre-deploy template keyed by name + region, WAVE21)', () => {
+describe('synthKey (--pre-deploy template keyed by name + region + account, WAVE21 / #1320)', () => {
   it('distinguishes the same stack name across regions (no template collision)', () => {
-    expect(synthKey('MyStack', 'us-east-1')).not.toBe(synthKey('MyStack', 'eu-west-1'));
+    expect(synthKey('MyStack', 'us-east-1', undefined)).not.toBe(
+      synthKey('MyStack', 'eu-west-1', undefined)
+    );
   });
-  it('is stable for the same name + region', () => {
-    expect(synthKey('MyStack', 'us-east-1')).toBe(synthKey('MyStack', 'us-east-1'));
+  it('is stable for the same name + region + account', () => {
+    expect(synthKey('MyStack', 'us-east-1', '111111111111')).toBe(
+      synthKey('MyStack', 'us-east-1', '111111111111')
+    );
   });
   it('treats an undefined (env-agnostic) region as a distinct, stable key', () => {
-    expect(synthKey('MyStack', undefined)).toBe(synthKey('MyStack', undefined));
-    expect(synthKey('MyStack', undefined)).not.toBe(synthKey('MyStack', 'us-east-1'));
+    expect(synthKey('MyStack', undefined, undefined)).toBe(
+      synthKey('MyStack', undefined, undefined)
+    );
+    expect(synthKey('MyStack', undefined, undefined)).not.toBe(
+      synthKey('MyStack', 'us-east-1', undefined)
+    );
+  });
+  it('#1320: distinguishes the same name + SAME region across different accounts (no overwrite)', () => {
+    // the multi-account staple: a fixed stackName in one region, env.account per stage.
+    // Keyed by name+region alone these collided and the second synth template overwrote
+    // the first — both stacks then compared against the wrong account's template.
+    expect(synthKey('MyStack', 'us-east-1', '111111111111')).not.toBe(
+      synthKey('MyStack', 'us-east-1', '222222222222')
+    );
+  });
+  it('#1320: an env-agnostic (undefined account) key is distinct from a pinned one, and stable', () => {
+    expect(synthKey('MyStack', 'us-east-1', undefined)).not.toBe(
+      synthKey('MyStack', 'us-east-1', '111111111111')
+    );
+    expect(synthKey('MyStack', 'us-east-1', undefined)).toBe(
+      synthKey('MyStack', 'us-east-1', undefined)
+    );
   });
 });

--- a/tests/multiaccount-dup-1320.test.ts
+++ b/tests/multiaccount-dup-1320.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+// resolveStacks synthesizes a CDK app (resolveApp) and discovers its stacks
+// (discoverStacks) — both heavy. Mock them the same way the #884 multi-REGION
+// test does: resolveApp returns a truthy app, discoverStacks returns a fixed set
+// so exact-name / glob matching can be exercised in isolation. Here the app
+// defines the SAME stackName in the SAME region for TWO different ACCOUNTS — the
+// #740 multi-account staple (a fixed stackName, env.account varying per stage).
+// #884 added the region dedup axis but NOT the account axis, so the second
+// same-name/same-region/different-account instance was silently dropped when
+// selected by exact name or glob, while --all (no dedup) returned both — the two
+// selection forms disagreed and the prod stack was never checked by any named leg.
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+
+const discovered = [
+  { stackName: 'App', region: 'us-east-1', account: '111111111111', template: { dev: true } },
+  { stackName: 'App', region: 'us-east-1', account: '222222222222', template: { prod: true } },
+  { stackName: 'Solo', region: 'us-east-1', account: '111111111111', template: {} },
+];
+vi.mock('../src/synth/synth.js', () => ({
+  discoverStacks: () => Promise.resolve(discovered),
+}));
+
+import type { CommonArgs } from '../src/cli-args.js';
+import { resolveStacks } from '../src/commands/resolve-stacks.js';
+
+function args(overrides: Partial<CommonArgs>): CommonArgs {
+  return {
+    stackNames: [],
+    all: false,
+    region: 'us-east-1',
+    profile: undefined,
+    app: undefined,
+    context: {},
+    json: false,
+    showAll: false,
+    yes: false,
+    preDeploy: false,
+    undeclaredOnly: false,
+    declaredOnly: false,
+    fail: false,
+    strict: false,
+    removeUnrecorded: false,
+    force: false,
+    verbose: false,
+    waitMs: undefined,
+    ...overrides,
+  };
+}
+
+describe('resolveStacks — exact name / glob select EVERY same-name+region account instance (#1320)', () => {
+  it('exact name returns BOTH accounts (not just the first)', async () => {
+    const out = await resolveStacks(args({ stackNames: ['App'] }));
+    expect(out.map((s) => s.account).sort()).toEqual(['111111111111', '222222222222']);
+    // each instance carries its OWN synth template — the drop bug would have lost prod
+    expect(out.map((s) => s.template)).toEqual(
+      expect.arrayContaining([{ dev: true }, { prod: true }])
+    );
+  });
+
+  it('glob returns BOTH accounts', async () => {
+    const out = await resolveStacks(args({ stackNames: ['App*'] }));
+    expect(out.map((s) => s.account).sort()).toEqual(['111111111111', '222222222222']);
+  });
+
+  it('--all returns BOTH accounts (parity with named selection)', async () => {
+    const out = await resolveStacks(args({ all: true }));
+    const app = out.filter((s) => s.stackName === 'App');
+    expect(app.map((s) => s.account).sort()).toEqual(['111111111111', '222222222222']);
+  });
+
+  it('exact-name and glob resolve the SAME set (the two forms must not disagree)', async () => {
+    const exact = await resolveStacks(args({ stackNames: ['App'] }));
+    const glob = await resolveStacks(args({ stackNames: ['App*'] }));
+    expect(exact.map((s) => s.account).sort()).toEqual(glob.map((s) => s.account).sort());
+  });
+
+  it('a TRUE duplicate (same name + region + account) still collapses to one', async () => {
+    // `App App` (exact name twice) must not multiply the per-account instances:
+    // add() dedups on name+region+account, so each account still appears exactly once.
+    const out = await resolveStacks(args({ stackNames: ['App', 'App'] }));
+    const app = out.filter((s) => s.stackName === 'App');
+    expect(app).toHaveLength(2); // two ACCOUNTS, once each — NOT four
+    expect(app.map((s) => s.account).sort()).toEqual(['111111111111', '222222222222']);
+  });
+});


### PR DESCRIPTION
Closes #1320.

## Problem
`resolveStacks`' named/glob selection deduped on `${stackName}\0${region}`. #884 added the region axis but never the account axis; #740/#1195 carried `env.account` through discovery but the dedup key never got it. A #740 **multi-account** app defining the same `stackName` in the **same region** for two accounts (fixed name, `env.account` per stage) had its second instance **silently dropped** on name/glob selection, while `--all` (no dedup) returned both — the two selection forms disagreed, and the prod stack was never checked by any named CI leg (its kept entry is the dev pin, which #740's cross-account gate then skips). Same root, secondary FP: `check --all --pre-deploy` keyed the synth-template map by name+region, so the second-synthesized template overwrote the first across accounts.

## Fix
- Add the account axis to the `add()` dedup key: `${stackName}\0${region ?? ''}\0${account ?? ''}` (mirrors #884, covers both the exact-name and glob branches).
- Thread `account` into `synthKey` (check.ts) and its two call sites for the `--pre-deploy` template map.

A same-name/same-region/same-account (or env-agnostic `account: undefined`) duplicate still collapses — #884 behavior unchanged.

## Tests
`tests/multiaccount-dup-1320.test.ts` (mirrors the #884 pattern): same name + region + different account → exact-name, glob, and `--all` all return both; a true duplicate collapses. `tests/check.test.ts` `synthKey` block migrated to the 3-arg signature with #1320 no-overwrite cases. Fails without the fix, passes with it.