### PR TITLE
fix(ignore): ignore verb passes constructPathByLogical so removed-since-record findings match constructPath-form rules (#1285)

### DIFF
--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -7,11 +7,14 @@
 import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
+  type ApplyBaselineOptions,
   checkBaselineAccount,
+  constructPathsByLogical,
   declaredKeysByLogical,
   loadBaseline,
   physicalIdsByLogical,
 } from '../baseline/baseline-file.js';
+import type { Desired } from '../desired/template-adapter.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { resolveStacks } from './resolve-stacks.js';
@@ -19,6 +22,23 @@ import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
 import { ignoreStack, warnStackStatus } from './stack-actions.js';
 import { emitJsonArray, type IgnoreJson, stackLabel } from './verb-json.js';
+
+// Build the applyBaseline options the `ignore` verb reconciles with. Extracted +
+// exported so a unit test can assert the opts include `constructPathByLogical`
+// (#1285): the ignore verb was the ONLY applyBaseline caller that omitted it, so a
+// synthetic "baseline value removed since record" finding carried no constructPath
+// and the constructPath-form ignore rule check.ts writes by preference never matched
+// it — `ignore --yes` then appended a duplicate, logicalId-form rule. Mirrors the
+// opts check.ts / stack-actions.ts / interactive-resolve.ts already build.
+export function ignoreApplyBaselineOpts(desired: Pick<Desired, 'resources'>): ApplyBaselineOptions {
+  return {
+    declaredByLogical: declaredKeysByLogical(desired.resources),
+    constructPathByLogical: constructPathsByLogical(desired.resources),
+    physicalIdByLogical: physicalIdsByLogical(desired.resources),
+    allLogicalIds: desired.resources.map((r) => r.logicalId),
+    warn: console.error,
+  };
+}
 
 export async function runIgnore(args: string[]): Promise<number> {
   const a = parseCommonArgs(args, 'ignore');
@@ -77,12 +97,7 @@ export async function runIgnore(args: string[]): Promise<number> {
       const baseline = await loadBaseline(stackName, desired.accountId, region);
       if (baseline) checkBaselineAccount(baseline, desired.accountId, stackName);
       const reconciled = applyIgnores(
-        applyBaseline(findings, baseline, {
-          declaredByLogical: declaredKeysByLogical(desired.resources),
-          physicalIdByLogical: physicalIdsByLogical(desired.resources),
-          allLogicalIds: desired.resources.map((r) => r.logicalId),
-          warn: console.error,
-        }),
+        applyBaseline(findings, baseline, ignoreApplyBaselineOpts(desired)),
         { stackName, accountId: desired.accountId, region },
         config
       );

--- a/tests/ignore-constructpath-1285.test.ts
+++ b/tests/ignore-constructpath-1285.test.ts
@@ -1,0 +1,119 @@
+// #1285: the `ignore` verb reconciles findings via applyBaseline but OMITTED
+// `constructPathByLogical` from the opts — it was the only applyBaseline caller
+// that did. A synthetic "baseline value removed since record" finding therefore
+// carried no `constructPath` in the ignore verb, so the constructPath-form ignore
+// rule that `check` writes by preference never matched it: the finding was
+// re-offered in the multiselect and `ignore <stack> --yes` appended a second,
+// logicalId-form rule that mergeIgnoreRules could not dedupe.
+//
+// This is an OFFLINE round-trip of that bug. It drives the ACTUAL opts the ignore
+// verb builds (`ignoreApplyBaselineOpts`, extracted from runIgnore) so the test
+// fails if that opts builder ever drops `constructPathByLogical` again — then feeds
+// those opts through applyBaseline + a constructPath-form rule + applyIgnores to
+// assert the synthetic "removed since record" finding is re-tagged `ignored`.
+import { describe, expect, it } from 'vite-plus/test';
+import { applyBaseline, type BaselineFile } from '../src/baseline/baseline-file.js';
+import { ignoreApplyBaselineOpts } from '../src/commands/ignore.js';
+import { applyIgnores, ignoreRuleFor } from '../src/config/config-file.js';
+import type { DesiredResource, Finding } from '../src/types.js';
+
+const STACK = 'MyStack';
+const ACCOUNT = '111122223333';
+const REGION = 'us-east-1';
+const LOGICAL = 'Bucket';
+const CONSTRUCT_PATH = `${STACK}/Bucket/Resource`;
+
+// A resource whose value was recorded, then removed out of band since record.
+const RESOURCES: DesiredResource[] = [
+  {
+    logicalId: LOGICAL,
+    resourceType: 'AWS::S3::Bucket',
+    physicalId: 'my-bucket',
+    constructPath: CONSTRUCT_PATH,
+    declared: {},
+  },
+];
+
+const desired: Pick<import('../src/desired/template-adapter.js').Desired, 'resources'> = {
+  resources: RESOURCES,
+};
+
+function baselineWithRecordedEntry(): BaselineFile {
+  return {
+    schemaVersion: 1,
+    stackName: STACK,
+    region: REGION,
+    accountId: ACCOUNT,
+    capturedAt: '',
+    templateHash: '',
+    recorded: [
+      {
+        logicalId: LOGICAL,
+        resourceType: 'AWS::S3::Bucket',
+        path: 'AccelerateConfiguration',
+        value: { AccelerationStatus: 'Enabled' },
+      },
+    ],
+  };
+}
+
+// The live findings do NOT contain the recorded path (removed since record) and the
+// resource was NOT skipped/deleted, so applyBaseline synthesizes a single undeclared
+// "baseline value removed since record" finding.
+const LIVE_FINDINGS: Finding[] = [];
+
+describe('#1285: ignore verb applyBaseline opts include constructPathByLogical', () => {
+  it('ignoreApplyBaselineOpts populates constructPathByLogical from desired.resources', () => {
+    // The regression guard on the actual opts builder: drop the line in ignore.ts and
+    // this map is empty, so the assertions below fail.
+    const opts = ignoreApplyBaselineOpts(desired);
+    expect(opts.constructPathByLogical?.get(LOGICAL)).toBe(CONSTRUCT_PATH);
+  });
+
+  it('the synthetic "removed since record" finding carries the constructPath under the verb opts', () => {
+    const out = applyBaseline(
+      LIVE_FINDINGS,
+      baselineWithRecordedEntry(),
+      ignoreApplyBaselineOpts(desired)
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.note).toBe('baseline value removed since record');
+    expect(out[0]!.constructPath).toBe(CONSTRUCT_PATH);
+  });
+
+  it('a constructPath-form ignore rule re-tags the finding to `ignored` (no re-offer / no duplicate rule)', () => {
+    // The rule check.ts writes by preference: derived from a finding WITH a
+    // constructPath, so it targets the within-stack construct path — NOT the logicalId.
+    const rule = ignoreRuleFor(
+      {
+        tier: 'undeclared',
+        logicalId: LOGICAL,
+        resourceType: 'AWS::S3::Bucket',
+        path: 'AccelerateConfiguration',
+        constructPath: CONSTRUCT_PATH,
+        desired: { AccelerationStatus: 'Enabled' },
+        actual: undefined,
+      },
+      STACK,
+      ACCOUNT,
+      REGION
+    );
+    expect(rule.path).toBe('Bucket/Resource.AccelerateConfiguration');
+
+    const config = { ignore: [rule] };
+    const scope = { stackName: STACK, accountId: ACCOUNT, region: REGION };
+
+    // Drive the ACTUAL ignore-verb opts: the synthetic finding gets its constructPath,
+    // so the constructPath-form rule matches and applyIgnores re-tags it `ignored`.
+    // (Without the fix, ignoreApplyBaselineOpts would omit constructPathByLogical, the
+    // finding would carry no constructPath, the rule would miss, and the finding would
+    // stay `undeclared` — re-offered, appending a duplicate logicalId-form rule.)
+    const reconciled = applyIgnores(
+      applyBaseline(LIVE_FINDINGS, baselineWithRecordedEntry(), ignoreApplyBaselineOpts(desired)),
+      scope,
+      config
+    );
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]!.tier).toBe('ignored');
+  });
+});

--- a/tests/ignore-footer-949.test.ts
+++ b/tests/ignore-footer-949.test.ts
@@ -37,6 +37,9 @@ vi.mock('../src/baseline/baseline-file.js', () => ({
   checkBaselineAccount: () => {},
   applyBaseline: (findings: unknown) => findings,
   declaredKeysByLogical: () => ({}),
+  // #1285: ignore.ts's ignoreApplyBaselineOpts now also calls this — stub it so the
+  // opts builder does not throw on an undefined import under this module mock.
+  constructPathsByLogical: () => new Map(),
   physicalIdsByLogical: () => ({}),
 }));
 


### PR DESCRIPTION
## Bug

The `ignore` verb was the only `applyBaseline` caller that omitted `constructPathByLogical` from its options (unlike `check.ts`, `stack-actions.ts`, and `interactive-resolve.ts`). As a result, a synthetic "baseline value removed since record" finding carried no `constructPath`, so the constructPath-form ignore rule that `check.ts` writes by preference never matched it. `ignore --yes` then appended a duplicate, logicalId-form rule.

## Fix

Extract and export `ignoreApplyBaselineOpts(desired)`, which builds the full `ApplyBaselineOptions` — including `constructPathByLogical: constructPathsByLogical(desired.resources)` — mirroring the opts the other `applyBaseline` callers already construct. The `ignore` verb now reconciles with the same constructPath context, so removed-since-record findings match the constructPath-form rules and no duplicate is appended.

Adds a unit test (`tests/ignore-constructpath-1285.test.ts`) asserting the opts include `constructPathByLogical`, plus a small addition to `tests/ignore-footer-949.test.ts`.

Closes #1285