### PR TITLE
fix(normalize): add missing registry tag property names to TAG_PROPERTY_NAMES + map-shaped names to FREE_FORM_MAP_PARENTS (#1300)

### DIFF
--- a/src/normalize/cc-api-strip.ts
+++ b/src/normalize/cc-api-strip.ts
@@ -48,6 +48,10 @@ export const FREE_FORM_MAP_PARENTS = new Set([
   'BackupPlanTags', // AWS::Backup::BackupPlan
   'BackupVaultTags', // AWS::Backup::BackupVault
   'RecoveryPointTags', // AWS::Backup::* recovery points
+  // #1300: additional MAP-shaped primary tag properties from the CFn registry's
+  // tagInformation.tagPropertyName metadata (keys are user strings, must not name-strip).
+  'TieringConfigurationTags', // AWS::Backup::TieringConfiguration
+  'TestAliasTags', // AWS::Bedrock::Agent / AWS::Bedrock::Flow
 ]);
 
 // Tag-property names that carry the same semantics as `Tags` but live under a
@@ -72,6 +76,18 @@ export const TAG_PROPERTY_NAMES: ReadonlySet<string> = new Set([
   'ResourceTags', // AWS::CE::AnomalySubscription (list)
   'FileSystemTags', // AWS::EFS::FileSystem (list)
   'HostedZoneTags', // AWS::Route53::HostedZone (list)
+  // #1300: additional primary/secondary tag property names sourced from the CFn
+  // registry's tagInformation.tagPropertyName metadata (misses caused #862 first-run
+  // map-key FPs and #952 revert drops of live aws:* managed tags).
+  'TieringConfigurationTags', // AWS::Backup::TieringConfiguration (map)
+  'FrameworkTags', // AWS::Backup::Framework (list)
+  'ReportPlanTags', // AWS::Backup::ReportPlan (list)
+  'PipelineTags', // AWS::DataPipeline::Pipeline (list)
+  'AccessPointTags', // AWS::EFS::AccessPoint (list)
+  'BotAliasTags', // AWS::Lex::BotAlias (list)
+  'HealthCheckTags', // AWS::Route53::HealthCheck (list)
+  'TestBotAliasTags', // AWS::Lex::Bot secondary (list)
+  'TestAliasTags', // AWS::Bedrock::Agent / AWS::Bedrock::Flow secondary (map)
 ]);
 
 export function stripCcApiAwsManagedFields(

--- a/tests/tag-property-names-1300.test.ts
+++ b/tests/tag-property-names-1300.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { FREE_FORM_MAP_PARENTS, TAG_PROPERTY_NAMES } from '../src/normalize/cc-api-strip.js';
+import { stripAwsTagsDeep } from '../src/normalize/noise.js';
+
+// #1300: primary/secondary tag property names from the CFn registry's
+// tagInformation.tagPropertyName metadata were missing from TAG_PROPERTY_NAMES,
+// causing (a) #862 first-run map-key FPs (aws:cloudformation:* keys surfacing) and
+// (b) #952 revert drops of live aws:* managed tags.
+describe('#1300 registry tag property names', () => {
+  const NEW_NAMES = [
+    'TieringConfigurationTags', // AWS::Backup::TieringConfiguration (map)
+    'FrameworkTags', // AWS::Backup::Framework
+    'ReportPlanTags', // AWS::Backup::ReportPlan
+    'PipelineTags', // AWS::DataPipeline::Pipeline
+    'AccessPointTags', // AWS::EFS::AccessPoint
+    'BotAliasTags', // AWS::Lex::BotAlias
+    'HealthCheckTags', // AWS::Route53::HealthCheck
+    'TestBotAliasTags', // AWS::Lex::Bot secondary
+    'TestAliasTags', // AWS::Bedrock::Agent / Flow secondary (map)
+  ];
+
+  it('membership gate: every new name is in TAG_PROPERTY_NAMES (revert preservation + aws:* strip)', () => {
+    for (const name of NEW_NAMES) {
+      expect(TAG_PROPERTY_NAMES.has(name)).toBe(true);
+    }
+  });
+
+  it('map-shaped names are also in FREE_FORM_MAP_PARENTS (name-strip exemption)', () => {
+    expect(FREE_FORM_MAP_PARENTS.has('TieringConfigurationTags')).toBe(true);
+    expect(FREE_FORM_MAP_PARENTS.has('TestAliasTags')).toBe(true);
+  });
+
+  it('map-shaped strip: aws:cloudformation:* keys are stripped, user keys survive', () => {
+    const live = {
+      TieringConfigurationTags: {
+        'aws:cloudformation:stack-name': 'x',
+        'aws:cloudformation:logical-id': 'y',
+        UserKey: 'z',
+      },
+    };
+    const stripped = stripAwsTagsDeep(live) as {
+      TieringConfigurationTags: Record<string, unknown>;
+    };
+    expect(stripped.TieringConfigurationTags).toEqual({ UserKey: 'z' });
+  });
+});


### PR DESCRIPTION
## Summary

Several primary/secondary tag property names present in the CloudFormation
registry's `tagInformation.tagPropertyName` metadata were missing from the
normalizer's tag tables. Because they were not recognized as tag properties,
their live values were treated like ordinary properties — user-supplied tag
keys were name-stripped, producing first-run map-key false positives (#862
class) and reverts that dropped live `aws:*` managed tags (#952 class).

## Fix

- Add the missing list-shaped tag property names to `TAG_PROPERTY_NAMES`
  (`FrameworkTags`, `ReportPlanTags`, `PipelineTags`, `AccessPointTags`,
  `BotAliasTags`, `HealthCheckTags`, `TestBotAliasTags`, plus the map-shaped
  `TieringConfigurationTags` / `TestAliasTags`).
- Add the map-shaped names (`TieringConfigurationTags`,
  `TestAliasTags`) to `FREE_FORM_MAP_PARENTS` so their user-string keys are
  not name-stripped.
- Add unit tests covering the new entries.

Closes #1300