### PR TITLE
fix(record): ignored declared/added findings no longer demote snapshot completeness — gate the #1078 guard on ignoredFrom (#1277)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -446,7 +446,16 @@ export function computeCompleteResources(
     if (f.tier === 'skipped' || f.tier === 'deleted' || f.tier === 'readGap')
       blocked.add(f.logicalId);
     if (f.tier === 'undeclared' && !recordedKeys.has(recordedKey(f))) blocked.add(f.logicalId);
-    if (f.tier === 'ignored' && !recordedKeys.has(recordedKey(f))) blockedByIgnore.add(f.logicalId);
+    // #1277: only DEMOTE for an ignored value that originated `undeclared`. `record`
+    // snapshots undeclared/added values only, so a never-recorded UNDECLARED value
+    // legitimately keeps its resource incomplete (the #1078 round-trip). A DECLARED (or
+    // `added`) path is NEVER in `recorded`, so without this gate the guard would fire
+    // UNCONDITIONALLY on every ignored declared drift — silently marking the resource
+    // not-snapshot-complete and downgrading a later out-of-band appearance from confirmed
+    // "appeared since record" drift to `unrecorded` (an FN). `applyIgnores` stamps the
+    // provenance on `ignoredFrom`.
+    if (f.tier === 'ignored' && f.ignoredFrom === 'undeclared' && !recordedKeys.has(recordedKey(f)))
+      blockedByIgnore.add(f.logicalId);
   }
   const all = new Set(allLogicalIds);
   const complete = new Set(

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -671,6 +671,15 @@ export function applyIgnores(
     // watching). The exit code was always safe (ignored is not a drift tier); this fixes
     // the spurious reporting that defeated the purpose of `ignore`.
     const { unrecorded: _unrecorded, ...rest } = f;
-    return { ...rest, tier: 'ignored', note: `ignored by config rule "${hit.raw}"` };
+    // Stamp the ORIGINAL tier (#1277): the `ignored` tier discards where the finding came
+    // from, but computeCompleteResources' #1078 demotion must only fire on an ignored value
+    // that originated `undeclared` (see Finding.ignoredFrom). Record it before we overwrite
+    // `tier`. `f.tier` is always defined here, so this never assigns undefined.
+    return {
+      ...rest,
+      tier: 'ignored',
+      note: `ignored by config rule "${hit.raw}"`,
+      ...(f.tier ? { ignoredFrom: f.tier } : {}),
+    };
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,16 @@ export interface Finding {
   // whole-array `add /<path>` replacement (converges deterministically regardless of live
   // order). The per-element REPORT is unaffected — this is revert-only metadata.
   wholeArrayRevert?: { path: string; value: unknown } | undefined;
+  // ignored tier only (#1277): the ORIGINAL tier this finding carried BEFORE applyIgnores
+  // re-tagged it to `ignored`. The `ignored` tier discards the source tier, but the #1078
+  // completeness demotion in computeCompleteResources must ONLY fire for an ignored value
+  // that originated as `undeclared` (record snapshots undeclared/added only, so a
+  // never-recorded undeclared value legitimately keeps its resource incomplete). An ignored
+  // DECLARED (or `added`) path is NEVER in `recorded`, so demoting on it would fire
+  // UNCONDITIONALLY and silently mark the resource not-snapshot-complete — a later
+  // out-of-band appearance would then read `unrecorded` instead of confirmed "appeared since
+  // record" drift (an FN downgrade). The provenance gates the demotion to the undeclared case.
+  ignoredFrom?: Tier | undefined;
 }
 
 // Element-level delta of a recorded-but-changed undeclared identity-keyed object

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -853,7 +853,16 @@ describe('baseline', () => {
       // stays complete even while an ignore rule suppresses reporting it. Preserves the
       // intended behavior for recorded values.
       const findings: Finding[] = [
-        { tier: 'ignored', logicalId: 'A', resourceType: 'T', path: 'P', actual: 1 },
+        // ignoredFrom (#1277): the demotion only applies to an ignored value that
+        // originated `undeclared`; applyIgnores stamps it. (Recovered via `recorded` here.)
+        {
+          tier: 'ignored',
+          ignoredFrom: 'undeclared',
+          logicalId: 'A',
+          resourceType: 'T',
+          path: 'P',
+          actual: 1,
+        },
       ];
       const recorded = [{ logicalId: 'A', resourceType: 'T', path: 'P', value: 1 }];
       expect(computeCompleteResources(['A'], findings, recorded)).toEqual(['A']);
@@ -864,14 +873,30 @@ describe('baseline', () => {
       // the value as known-absent, so deleting the rule (un-ignore) would false-surface the
       // untouched value as confirmed "appeared since record". It must stay INCOMPLETE.
       const findings: Finding[] = [
-        { tier: 'ignored', logicalId: 'A', resourceType: 'T', path: 'P', actual: 1 },
+        // ignoredFrom 'undeclared' (#1277): the demotion is scoped to the undeclared origin.
+        {
+          tier: 'ignored',
+          ignoredFrom: 'undeclared',
+          logicalId: 'A',
+          resourceType: 'T',
+          path: 'P',
+          actual: 1,
+        },
       ];
       expect(computeCompleteResources(['A'], findings, [])).toEqual([]);
     });
 
     it('#1078: an ignored-and-unrecorded value DEMOTES a previously-complete resource', () => {
       const findings: Finding[] = [
-        { tier: 'ignored', logicalId: 'A', resourceType: 'T', path: 'P', actual: 1 },
+        // ignoredFrom 'undeclared' (#1277): only the undeclared origin demotes.
+        {
+          tier: 'ignored',
+          ignoredFrom: 'undeclared',
+          logicalId: 'A',
+          resourceType: 'T',
+          path: 'P',
+          actual: 1,
+        },
       ];
       expect(computeCompleteResources(['A'], findings, [], ['A'])).toEqual([]);
     });

--- a/tests/ignore-completeness-1277.test.ts
+++ b/tests/ignore-completeness-1277.test.ts
@@ -1,0 +1,96 @@
+// #1277: an ignored DECLARED (or `added`) finding must NOT demote its resource's
+// snapshot completeness.
+//
+// #1210 (fix for #1078) made computeCompleteResources BLOCK/DEMOTE any resource with a
+// tier-`ignored` finding whose recordedKey is absent from the snapshot — so un-ignoring a
+// never-recorded UNDECLARED value lands at `unrecorded`, not false "appeared since record".
+//
+// But applyIgnores re-tags DECLARED (and `added`) findings to `ignored` too, discarding the
+// origin tier. A DECLARED path can NEVER be in `recorded` (record snapshots undeclared/added
+// only), so the completeness guard fired UNCONDITIONALLY for every ignored declared drift —
+// silently demoting the resource to not-snapshot-complete. A later out-of-band appearance on
+// that resource then read as `unrecorded` (excluded from --fail) instead of confirmed
+// "appeared since record" drift = an FN downgrade.
+//
+// The fix: applyIgnores stamps `ignoredFrom: <original tier>`; computeCompleteResources gates
+// its demotion on `ignoredFrom === 'undeclared'`. An ignored declared/added finding leaves
+// completeness untouched; the #1078 undeclared behavior is preserved.
+import { describe, expect, it } from 'vite-plus/test';
+import { computeCompleteResources, type RecordedEntry } from '../src/baseline/baseline-file.js';
+import { applyIgnores, type IgnoreScope } from '../src/config/config-file.js';
+import type { Finding } from '../src/types.js';
+
+const RES = { logicalId: 'Fn', resourceType: 'AWS::Lambda::Function', path: 'Timeout' };
+const scope: IgnoreScope = { stackName: 'S', accountId: '111122223333', region: 'us-east-1' };
+
+const declaredFinding = (): Finding => ({ tier: 'declared', ...RES, desired: 3, actual: 30 });
+const undeclaredFinding = (): Finding => ({ tier: 'undeclared', ...RES, actual: 30 });
+const addedFinding = (): Finding => ({
+  tier: 'added',
+  logicalId: 'Api',
+  resourceType: 'AWS::ApiGateway::RestApi',
+  path: '',
+});
+
+const ignoreCfg = (path: string) => ({ ignore: [{ path }] });
+
+describe('applyIgnores stamps ignoredFrom provenance (#1277)', () => {
+  it('records the original tier when re-tagging a DECLARED finding to ignored', () => {
+    const [out] = applyIgnores([declaredFinding()], scope, ignoreCfg('Fn.Timeout'));
+    expect(out?.tier).toBe('ignored');
+    expect(out?.ignoredFrom).toBe('declared');
+  });
+
+  it('records the original tier when re-tagging an UNDECLARED finding to ignored', () => {
+    const [out] = applyIgnores([undeclaredFinding()], scope, ignoreCfg('Fn.Timeout'));
+    expect(out?.tier).toBe('ignored');
+    expect(out?.ignoredFrom).toBe('undeclared');
+  });
+
+  it('records the original tier when re-tagging an ADDED finding to ignored', () => {
+    const [out] = applyIgnores([addedFinding()], scope, ignoreCfg('Api'));
+    expect(out?.tier).toBe('ignored');
+    expect(out?.ignoredFrom).toBe('added');
+  });
+
+  it('leaves ignoredFrom unset on a non-matching finding (still its own tier)', () => {
+    const [out] = applyIgnores([declaredFinding()], scope, ignoreCfg('Fn.SomethingElse'));
+    expect(out?.tier).toBe('declared');
+    expect(out?.ignoredFrom).toBeUndefined();
+  });
+});
+
+describe('computeCompleteResources: ignored DECLARED finding leaves completeness untouched (#1277)', () => {
+  it('marks the resource complete when a DECLARED finding is ignored (no false demotion)', () => {
+    // The bug: this ignored declared path is absent from `recorded` (record never snapshots
+    // declared values), so the pre-fix guard demoted Fn to incomplete -> returned [].
+    const ignored = applyIgnores([declaredFinding()], scope, ignoreCfg('Fn.Timeout'));
+    expect(computeCompleteResources(['Fn'], ignored, [], ['Fn'])).toEqual(['Fn']);
+  });
+
+  it('keeps the resource complete even without previousComplete', () => {
+    const ignored = applyIgnores([declaredFinding()], scope, ignoreCfg('Fn.Timeout'));
+    expect(computeCompleteResources(['Fn'], ignored, [])).toEqual(['Fn']);
+  });
+
+  it('marks the resource complete when an ADDED finding is ignored (added origin does not demote)', () => {
+    const ignored = applyIgnores([addedFinding()], scope, ignoreCfg('Api'));
+    expect(computeCompleteResources(['Api'], ignored, [], ['Api'])).toEqual(['Api']);
+  });
+});
+
+describe('computeCompleteResources: #1078 UNDECLARED demotion preserved (#1277)', () => {
+  it('still DEMOTES for an ignored UNDECLARED value absent from the snapshot', () => {
+    const ignored = applyIgnores([undeclaredFinding()], scope, ignoreCfg('Fn.Timeout'));
+    expect(ignored[0]?.ignoredFrom).toBe('undeclared');
+    // The #1078 round-trip: a never-recorded ignored undeclared path keeps its resource
+    // incomplete, so un-ignoring lands the untouched value at `unrecorded`, not false drift.
+    expect(computeCompleteResources(['Fn'], ignored, [], ['Fn'])).toEqual([]);
+  });
+
+  it('KEEPS complete when the ignored UNDECLARED path IS recorded (carried forward)', () => {
+    const ignored = applyIgnores([undeclaredFinding()], scope, ignoreCfg('Fn.Timeout'));
+    const recorded: RecordedEntry[] = [{ ...RES, value: 30 }];
+    expect(computeCompleteResources(['Fn'], ignored, recorded, ['Fn'])).toEqual(['Fn']);
+  });
+});

--- a/tests/ignore-record-unignore-1078.test.ts
+++ b/tests/ignore-record-unignore-1078.test.ts
@@ -42,6 +42,9 @@ const ignoredFinding = (actual: unknown): Finding => ({
   ...RES,
   actual,
   note: 'ignored by config rule "Res.OwnershipControls"',
+  // applyIgnores stamps the origin tier (#1277); this path is an ignored UNDECLARED value,
+  // so the #1078 completeness demotion applies to it (a declared origin would NOT demote).
+  ignoredFrom: 'undeclared',
 });
 
 // -------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Bug

`computeCompleteResources` demotes a resource to "not snapshot-complete" whenever an ignored finding is not in `recorded` (the #1078 round-trip guard). But `record` only ever snapshots `undeclared`/`added` values, so a DECLARED (or `added`) path is NEVER in `recorded`. That made the guard fire UNCONDITIONALLY on every ignored declared drift — silently marking the resource not-snapshot-complete and downgrading a later out-of-band appearance from confirmed "appeared since record" drift to `unrecorded` (a false negative).

## Fix

Gate the #1078 completeness demotion so it only fires for an ignored value that originated as `undeclared` — the one case where a never-recorded value legitimately keeps its resource incomplete.

- `applyIgnores` now stamps the ORIGINAL tier on a new `Finding.ignoredFrom` field before overwriting `tier` to `ignored` (the `ignored` tier otherwise discards provenance).
- `computeCompleteResources` checks `f.ignoredFrom === 'undeclared'` before adding to `blockedByIgnore`.

Unit tests added in `tests/ignore-completeness-1277.test.ts` plus updates to `tests/baseline.test.ts` and `tests/ignore-record-unignore-1078.test.ts`.

Closes #1277
