### PR TITLE
fix(desired): --pre-deploy unpreviewable-param warning also scans Conditions (#1296)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -177,7 +177,11 @@ export function unpreviewableParamInfo(
     })
     .map(([k]) => k);
   if (noValue.length === 0) return null;
+  // #1296: a no-value param referenced ONLY through a Condition (e.g. `Fn::If`-fed property or a
+  // resource-level `Condition:` attribute) is still unpreviewable — union in the Conditions bodies
+  // so its Refs are counted, not just those under Resources.
   const referenced = collectReferencedNames(template.Resources ?? {});
+  collectReferencedNames(template.Conditions ?? {}, referenced);
   const unpreviewable = noValue.filter((k) => referenced.has(k)).sort();
   if (unpreviewable.length === 0) return null;
   const shown = unpreviewable.slice(0, 10);

--- a/tests/template-adapter-conditions-1296.test.ts
+++ b/tests/template-adapter-conditions-1296.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { unpreviewableParamInfo } from '../src/desired/template-adapter.js';
+
+// #1296 — unpreviewableParamInfo scoped the "referenced by a declared property" set to
+// template.Resources ONLY, so a no-value param referenced only through template.Conditions
+// (a `Fn::If`-fed property, or a resource-level `Condition:` attribute) was never counted →
+// the loud --pre-deploy warning silently returned null and the property fell into the generic
+// unresolved footer. The fix unions the Conditions bodies into the referenced-name set.
+describe('#1296 — unpreviewableParamInfo counts params referenced through Conditions', () => {
+  it('warns for a no-value param referenced ONLY through a Condition (Fn::If)', () => {
+    // `Env` has no Default and no deployed value; it is referenced only inside a Condition body
+    // (`IsProd: Env == prod`), which then feeds a property via `Fn::If`. Before the fix, the
+    // referenced set (Resources only) did not include `Env`, so this returned null.
+    const template = {
+      Parameters: { Env: { Type: 'String' } },
+      Conditions: {
+        IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] },
+      },
+      Resources: {
+        Fn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            MemorySize: { 'Fn::If': ['IsProd', 1024, 128] },
+          },
+        },
+      },
+    };
+    const note = unpreviewableParamInfo(template, {}, 'MyStack');
+    expect(note).not.toBeNull();
+    expect(note).toContain('Env');
+    expect(note).toContain('MyStack');
+  });
+
+  it('control: a param referenced ONLY in Resources still warns (regression guard)', () => {
+    const template = {
+      Parameters: { BucketName: { Type: 'String' } },
+      Resources: {
+        Bkt: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { BucketName: { Ref: 'BucketName' } },
+        },
+      },
+    };
+    const note = unpreviewableParamInfo(template, {}, 'MyStack');
+    expect(note).not.toBeNull();
+    expect(note).toContain('BucketName');
+  });
+
+  it('control: a param with a Default is excluded even if referenced through a Condition', () => {
+    const template = {
+      Parameters: { Env: { Type: 'String', Default: 'dev' } },
+      Conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } },
+      Resources: {
+        Fn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: { MemorySize: { 'Fn::If': ['IsProd', 1024, 128] } },
+        },
+      },
+    };
+    expect(unpreviewableParamInfo(template, {}, 'MyStack')).toBeNull();
+  });
+
+  it('control: a NoEcho param referenced through a Condition is excluded (#744 treatment)', () => {
+    const template = {
+      Parameters: { Env: { Type: 'String', NoEcho: true } },
+      Conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } },
+      Resources: {
+        Fn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: { MemorySize: { 'Fn::If': ['IsProd', 1024, 128] } },
+        },
+      },
+    };
+    expect(unpreviewableParamInfo(template, {}, 'MyStack')).toBeNull();
+  });
+
+  it('control: an SSM Parameter::Value-typed param referenced through a Condition is excluded (#882)', () => {
+    const template = {
+      Parameters: { Env: { Type: 'AWS::SSM::Parameter::Value<String>' } },
+      Conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } },
+      Resources: {
+        Fn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: { MemorySize: { 'Fn::If': ['IsProd', 1024, 128] } },
+        },
+      },
+    };
+    expect(unpreviewableParamInfo(template, {}, 'MyStack')).toBeNull();
+  });
+});


### PR DESCRIPTION
collectReferencedNames walked template.Resources only, so a no-value local param referenced ONLY through a Condition body (an Fn::If-fed property, or a resource-level Condition: attribute) was not counted as unpreviewable — the property resolved UNRESOLVED and was silently uncompared under --pre-deploy while the #1221 root-cause warning never fired. Union the referenced-name walk over template.Conditions. Adds tests/template-adapter-conditions-1296.test.ts. Closes #1296