### PR TITLE
fix(synth): fail loudly when an --app command exits 0 without writing a fresh cloud assembly (#1323)

### DIFF
--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -3,7 +3,7 @@
 // pre-synthesized cloud-assembly DIRECTORY (`cdk.out`). Drift detection itself
 // does not need this — it is used for stack auto-discovery (and later clobber).
 import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import type { StackSelector } from '@aws-cdk/toolkit-lib';
 import {
   BaseCredentials,
@@ -160,6 +160,51 @@ function cleanupEmptyContextFile(file: string, existedBefore: boolean): void {
   }
 }
 
+// Filesystem-mtime slack for the freshness check (#1323). A genuine synth rewrites
+// manifest.json during `toolkit.synth`, so its mtime is >= the pre-synth timestamp. We
+// subtract this tolerance before comparing so coarse mtime granularity (some filesystems
+// round to whole seconds) or a clock that ticks backward a hair never falsely flags a real,
+// fast rewrite as stale. A no-op app that never wrote the manifest leaves an mtime from a
+// PRIOR run — seconds-to-minutes older — so 2s of slack cannot mask that genuine staleness.
+export const ASSEMBLY_FRESHNESS_TOLERANCE_MS = 2000;
+
+/**
+ * Verify the cloud assembly's manifest.json was (re)written by THIS synth run (#1323).
+ *
+ * Only meaningful on the `--app` COMMAND path (`isDir === false`): toolkit-lib runs the app
+ * subprocess, resolves the outdir to `<cwd>/cdk.out`, then reads whatever manifest.json is
+ * there — it never checks the subprocess actually WROTE one. An app that exits 0 without
+ * synthesizing (a no-op wrapper, a script that swallows a synth failure, a dropped
+ * `app.synth()`) makes cdkrd silently consume the STALE assembly a PRIOR run left behind.
+ * That stale template becomes the DESIRED state, so `check` reports false declared drift and
+ * `revert --yes` writes stale values back to AWS. Fail LOUDLY instead.
+ *
+ * The DIRECTORY path (`isDir === true`, `fromAssemblyDirectory`) is INTENTIONAL stale
+ * consumption (the user points at a pre-synth assembly), so this is a no-op there.
+ *
+ * `synthStart` is a `Date.now()` captured just BEFORE `toolkit.synth`. Staleness =
+ * `mtimeMs < synthStart - ASSEMBLY_FRESHNESS_TOLERANCE_MS`. A missing manifest is also treated
+ * as failure (toolkit-lib normally throws ENOENT first, but the defensive check keeps the
+ * loud, actionable message). Pure + exported so the freshness logic is unit-testable against a
+ * real temp file whose mtime we control, without driving a real assembly.
+ */
+export function assertAssemblyFresh(
+  manifestPath: string,
+  synthStart: number,
+  isDir: boolean
+): void {
+  if (isDir) return; // pre-synth directory path: stale consumption is intentional — no-op.
+  const stale = () => {
+    throw new Error(
+      `the --app command exited 0 but did not produce a cloud assembly (${manifestPath} was not ` +
+        'written by this run) — the app must synthesize a cloud assembly (did app.synth()/the ' +
+        'CDK app run?)'
+    );
+  };
+  if (!existsSync(manifestPath)) stale();
+  if (statSync(manifestPath).mtimeMs < synthStart - ASSEMBLY_FRESHNESS_TOLERANCE_MS) stale();
+}
+
 export async function synthApp(app: string, opts: SynthOptions = {}): Promise<SynthStack[]> {
   const { region, profile, context = {} } = opts;
   // #905: scope synth's metadata validation to the TARGET stacks, so a failing context
@@ -211,12 +256,20 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
 
   // Pass the selector only when scoped: an omitted `stacks` defaults to ALL_STACKS in
   // toolkit-lib, so no-scope discovery / --all keeps the exact pre-#905 call shape.
+  // #1323: timestamp captured just BEFORE synth so we can prove synth (re)wrote the manifest.
+  const synthStart = Date.now();
   const cached = await toolkit.synth(source, stackSelector ? { stacks: stackSelector } : undefined);
   // Best-effort: if synth just created an EMPTY cdk.context.json (every lookup failed → `{}`),
   // remove it so a read-only `check` does not dirty the user's git tree with a useless file.
   // Guarded to never touch a pre-existing or non-empty file (#906). Skipped on the dir path.
   if (!isDir) cleanupEmptyContextFile(contextFile, contextFileExistedBefore);
   try {
+    // #1323: on the COMMAND path only, verify the app subprocess actually WROTE a fresh
+    // manifest.json this run — else an app that exited 0 without synthesizing silently feeds us
+    // a PRIOR run's stale assembly as the desired state (false declared drift; a revert writes
+    // stale values back to AWS). Inside the try so `cached.dispose()` still releases the lock /
+    // temp dir when we throw. The dir path (fromAssemblyDirectory) is intentional stale reuse.
+    assertAssemblyFresh(join(cached.cloudAssembly.directory, 'manifest.json'), synthStart, isDir);
     // A CDK app whose context lookups are unresolved still synthesizes — CDK fills every
     // gap with a well-known DUMMY value (`vpc-12345`, ...) and records the gap in the
     // manifest's `missing` array. Surface that loudly (#907): a template carrying those

--- a/tests/synth-stale-assembly-1323.test.ts
+++ b/tests/synth-stale-assembly-1323.test.ts
@@ -1,0 +1,96 @@
+// #1323: on the `--app` COMMAND path, synthApp must verify the app subprocess actually
+// (re)WROTE the cloud assembly's manifest.json this run. An app that exits 0 without
+// synthesizing (a no-op wrapper, a swallowed synth failure, a dropped app.synth()) otherwise
+// makes cdkrd silently consume the STALE manifest a prior run left in cdk.out — which becomes
+// the DESIRED state (false declared drift; a revert writes stale values back to AWS).
+//
+// synthApp drives real toolkit-lib (heavy to mock), so we unit-test the extracted pure helper
+// assertAssemblyFresh against a real temp manifest.json whose mtime we control via
+// fs.utimesSync — mirroring how synth.ts extracts other pure, exported helpers so the synth
+// logic is testable without a real assembly.
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { ASSEMBLY_FRESHNESS_TOLERANCE_MS, assertAssemblyFresh } from '../src/synth/synth.js';
+
+describe('assertAssemblyFresh (#1323)', () => {
+  let dir: string;
+  let manifest: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cdkrd-synth-1323-'));
+    manifest = join(dir, 'manifest.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // Set the temp manifest's mtime to `ms` (an epoch-millis instant).
+  const setMtime = (ms: number) => {
+    const secs = ms / 1000;
+    utimesSync(manifest, secs, secs);
+  };
+
+  it('throws when the manifest is STALE (mtime older than synthStart minus tolerance)', () => {
+    writeFileSync(manifest, '{}');
+    const synthStart = Date.now();
+    // A prior run's manifest: mtime well before this run started (minutes old).
+    setMtime(synthStart - 60_000);
+    expect(() => assertAssemblyFresh(manifest, synthStart, false)).toThrow(
+      /did not produce a cloud assembly/
+    );
+  });
+
+  it('does NOT throw when the manifest is FRESH (rewritten at/after synthStart)', () => {
+    writeFileSync(manifest, '{}');
+    const synthStart = Date.now();
+    // A genuine synth rewrites the manifest during toolkit.synth → mtime >= synthStart.
+    setMtime(synthStart + 500);
+    expect(() => assertAssemblyFresh(manifest, synthStart, false)).not.toThrow();
+  });
+
+  it('does NOT throw for a fast rewrite whose mtime is a touch BEFORE synthStart (tolerance)', () => {
+    writeFileSync(manifest, '{}');
+    const synthStart = Date.now();
+    // Within the slack window: coarse mtime granularity / a tiny backward clock tick must not
+    // falsely flag a real, fast rewrite as stale.
+    setMtime(synthStart - (ASSEMBLY_FRESHNESS_TOLERANCE_MS - 500));
+    expect(() => assertAssemblyFresh(manifest, synthStart, false)).not.toThrow();
+  });
+
+  it('throws just OUTSIDE the tolerance window (mtime older than synthStart minus tolerance)', () => {
+    writeFileSync(manifest, '{}');
+    const synthStart = Date.now();
+    setMtime(synthStart - (ASSEMBLY_FRESHNESS_TOLERANCE_MS + 1000));
+    expect(() => assertAssemblyFresh(manifest, synthStart, false)).toThrow(
+      /did not produce a cloud assembly/
+    );
+  });
+
+  it('throws when the manifest does NOT exist at all (defensive)', () => {
+    // no writeFileSync — manifest.json is absent
+    const synthStart = Date.now();
+    expect(() => assertAssemblyFresh(manifest, synthStart, false)).toThrow(
+      /did not produce a cloud assembly/
+    );
+  });
+
+  it('is a NO-OP on the DIRECTORY path (isDir=true) even for a stale/absent manifest', () => {
+    // The dir path (fromAssemblyDirectory) is intentional stale consumption — never flagged.
+    const synthStart = Date.now();
+    // absent manifest, stale, whatever — isDir short-circuits before any stat.
+    expect(() => assertAssemblyFresh(manifest, synthStart, true)).not.toThrow();
+    writeFileSync(manifest, '{}');
+    setMtime(synthStart - 60_000);
+    expect(() => assertAssemblyFresh(manifest, synthStart, true)).not.toThrow();
+  });
+
+  it('includes the manifest path in the error message', () => {
+    writeFileSync(manifest, '{}');
+    const synthStart = Date.now();
+    setMtime(synthStart - 60_000);
+    expect(() => assertAssemblyFresh(manifest, synthStart, false)).toThrow(manifest);
+  });
+});


### PR DESCRIPTION
toolkit-lib runs the --app subprocess, resolves the outdir to <cwd>/cdk.out, then reads whatever manifest.json is present without verifying the subprocess wrote one. An app that exits 0 without synthesizing made cdkrd silently consume a PRIOR run's STALE assembly as the DESIRED state (false declared drift; revert --yes writes stale values back to AWS). After synth on the COMMAND path, assert manifest.json was (re)written this run (mtime >= synth start, 2s FS-granularity tolerance) via the pure, unit-tested assertAssemblyFresh helper, and throw a loud error otherwise. The directory path (fromAssemblyDirectory) is intentional stale reuse and stays a no-op. Adds tests/synth-stale-assembly-1323.test.ts. Closes #1323