### PR TITLE
fix(read): project Tags in DLM/ServiceDiscovery/ElastiCache-PG/DAX/Glue-Workflow/MediaConvert readers (#1362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,7 +802,9 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   handlers),
   `dlm:GetLifecyclePolicy` (reads an `AWS::DLM::LifecyclePolicy` — a Data
   Lifecycle Manager EBS-snapshot / AMI backup-schedule policy, NON_PROVISIONABLE
-  with no Cloud Control handlers; the physical id IS the policy id),
+  with no Cloud Control handlers; the physical id IS the policy id, and the same
+  `GetLifecyclePolicy` response carries the policy's `Tags` — no extra call — so a
+  declared `Tags` is not false-flagged as drift),
   `dms:DescribeEndpoints` + `dms:DescribeReplicationSubnetGroups` +
   `dms:DescribeReplicationInstances` + `dms:DescribeReplicationTasks` +
   `dms:ListTagsForResource` (read an `AWS::DMS::Endpoint` /
@@ -815,21 +817,27 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   registered S3 data location whose Cloud Control `GetResource` returns
   `UnsupportedActionException`; the physical id IS the location `ResourceArn`, and
   the reader projects `RoleArn` / `WithFederation` / `HybridAccessEnabled`),
-  `mediaconvert:GetQueue` + `mediaconvert:GetJobTemplate` (read an
+  `mediaconvert:GetQueue` + `mediaconvert:GetJobTemplate` +
+  `mediaconvert:ListTagsForResource` (read an
   `AWS::MediaConvert::Queue` / `AWS::MediaConvert::JobTemplate` — a video-pipeline
   staple, NON_PROVISIONABLE with no Cloud Control handlers; the physical id IS the
-  resource name),
+  resource name, and `ListTagsForResource` reads each resource's tags, which the
+  `Get*` responses omit — without it a declared `Tags` false-flagged as drift on
+  every tagged MediaConvert resource),
   `ssm:DescribeParameters` (supplements the Cloud Control read of an
   `AWS::SSM::Parameter` with its writeOnly `Description` / `AllowedPattern`),
   `elasticache:DescribeReplicationGroups` + `elasticache:DescribeCacheClusters`
   (supplement an `AWS::ElastiCache::ReplicationGroup` with its writeOnly
   `PreferredMaintenanceWindow` / `NotificationTopicArn` / `EngineVersion`, read
   from the member cache cluster),
-  `elasticache:DescribeCacheParameterGroups` + `elasticache:DescribeCacheParameters`
+  `elasticache:DescribeCacheParameterGroups` + `elasticache:DescribeCacheParameters` +
+  `elasticache:ListTagsForResource`
   (read an `AWS::ElastiCache::ParameterGroup`'s `Properties` as the `Source=user`
   MODIFIED set only — the Cloud Control read returns the full effective set, so the
   ~60 inherited engine defaults would otherwise surface as first-run drift; an
-  out-of-band parameter change is `Source=user` and still detected),
+  out-of-band parameter change is `Source=user` and still detected;
+  `ListTagsForResource` reads the group's tags, which the `Describe*` responses
+  omit — without it a declared `Tags` false-flagged as drift on every tagged group),
   `ecs:DescribeServices` (supplements an
   `AWS::ECS::Service` with its writeOnly `ServiceConnectConfiguration` /
   `VolumeConfigurations`, read from the PRIMARY deployment),
@@ -856,10 +864,13 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   full resolved option set; an out-of-band console edit to any environment option
   is otherwise invisible, and the service-filled default options fold to
   `atDefault`),
-  `servicediscovery:GetNamespace` + `servicediscovery:GetService` (read a Cloud Map
+  `servicediscovery:GetNamespace` + `servicediscovery:GetService` +
+  `servicediscovery:ListTagsForResource` (read a Cloud Map
   `HttpNamespace` / `PrivateDnsNamespace` / `PublicDnsNamespace` — incl. the Arn an
   ECS Service Connect namespace `Fn::GetAtt` resolves against — and a Cloud Map
-  `Service`),
+  `Service`; `ListTagsForResource` reads each resource's tags, which the `Get*`
+  responses omit — without it a declared `Tags` false-flagged as drift on every
+  tagged Cloud Map resource),
   `docdb:DescribeDBClusters` + `docdb:DescribeDBInstances` +
   `rds:ListTagsForResource` (read an `AWS::DocDB::DBCluster` /
   `AWS::DocDB::DBInstance` — the whole DocumentDB family is a Cloud Control read
@@ -873,8 +884,10 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `codebuild:BatchGetProjects` (reads an `AWS::CodeBuild::Project`) +
   `codebuild:BatchGetReportGroups` (reads an `AWS::CodeBuild::ReportGroup`),
   `dax:DescribeClusters` + `dax:DescribeParameterGroups` + `dax:DescribeParameters` +
-  `dax:DescribeSubnetGroups` (read an `AWS::DAX::Cluster` / `ParameterGroup` /
-  `SubnetGroup` — the DynamoDB Accelerator family),
+  `dax:DescribeSubnetGroups` + `dax:ListTags` (read an `AWS::DAX::Cluster` /
+  `ParameterGroup` / `SubnetGroup` — the DynamoDB Accelerator family; `ListTags`
+  reads a cluster's tags, which `DescribeClusters` omits — without it a declared
+  `Tags` false-flagged as drift on every tagged DAX cluster),
   `ec2:DescribeClientVpnEndpoints` + `ec2:DescribeClientVpnAuthorizationRules` +
   `ec2:DescribeClientVpnTargetNetworks` (read an `AWS::EC2::ClientVpnEndpoint` /
   `ClientVpnAuthorizationRule` / `ClientVpnTargetNetworkAssociation`),
@@ -883,10 +896,12 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `appsync:ListApiKeys` (reads an `AWS::AppSync::ApiKey` — a Cloud Control gap),
   `cognito-sync:GetCognitoEvents` (enriches the Cloud Control read of an
   `AWS::Cognito::IdentityPool` with its writeOnly `CognitoEvents` Sync trigger),
-  `glue:GetClassifier` + `glue:GetWorkflow` + `glue:GetConnection`
+  `glue:GetClassifier` + `glue:GetWorkflow` + `glue:GetConnection` + `glue:GetTags`
   (`glue:GetConnection` is issued with `HidePassword` so NO credential enters the
   baseline — read an `AWS::Glue::Classifier` / `Workflow` / `Connection`, the rest
-  of the Glue family that has no Cloud Control handler),
+  of the Glue family that has no Cloud Control handler; `glue:GetTags` reads a
+  workflow's tags, which `GetWorkflow` omits — without it a declared `Tags`
+  false-flagged as drift on every tagged Glue workflow),
   `rds:DescribeOptionGroupOptions` (reads an `AWS::RDS::OptionGroup`'s option-default
   catalog — the `DefaultValue` AWS materializes for every plugin setting the template
   did not declare — so the service default-fill folds to `atDefault` instead of

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -52,6 +52,7 @@ import {
   DescribeParameterGroupsCommand,
   DescribeParametersCommand as DescribeDaxParametersCommand,
   DescribeSubnetGroupsCommand,
+  ListTagsCommand as DaxListTagsCommand,
 } from '@aws-sdk/client-dax';
 import {
   GetClassifierCommand,
@@ -59,6 +60,7 @@ import {
   GetJobCommand,
   GetSecurityConfigurationCommand,
   GetTableCommand,
+  GetTagsCommand as GlueGetTagsCommand,
   GetWorkflowCommand,
   GlueClient,
 } from '@aws-sdk/client-glue';
@@ -92,6 +94,7 @@ import {
   DescribeReplicationGroupsCommand,
   DescribeUsersCommand as DescribeCacheUsersCommand,
   ElastiCacheClient,
+  ListTagsForResourceCommand as ElastiCacheListTagsForResourceCommand,
 } from '@aws-sdk/client-elasticache';
 import {
   DescribeParameterGroupsCommand as DescribeMemoryDbParameterGroupsCommand,
@@ -121,6 +124,7 @@ import {
 import {
   GetJobTemplateCommand,
   GetQueueCommand,
+  ListTagsForResourceCommand as MediaConvertListTagsForResourceCommand,
   MediaConvertClient,
 } from '@aws-sdk/client-mediaconvert';
 import {
@@ -166,6 +170,7 @@ import {
 import {
   GetNamespaceCommand,
   GetServiceCommand,
+  ListTagsForResourceCommand as ServiceDiscoveryListTagsForResourceCommand,
   ServiceDiscoveryClient,
 } from '@aws-sdk/client-servicediscovery';
 import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
@@ -243,6 +248,50 @@ function mirrorDeclaredTags(declaredTags: unknown): { Key: string; Value: string
     .filter((t) => str(t.Key) !== undefined)
     .map((t) => ({ Key: t.Key as string, Value: str(t.Value) ?? '' }));
   return out.length > 0 ? out : undefined;
+}
+
+// The map-shape twin of projectTagList: a live tag MAP ({ k: v }) — how DLM / DAX / Glue /
+// MediaConvert model tags — cleaned to a plain { k: v } for the CFn map-shape `Tags` those
+// types declare. Values are coerced to '' when null/missing (parity with projectTagList).
+// Returns undefined when there are no keys so the caller can OMIT `Tags` (absent stays
+// absent = FP-safe). Some SDKs (DAX ListTags) return the tags as a LIST even though CFn
+// declares the map shape — pass the tags through tagListToMap first.
+function projectTagMap(
+  tags: Record<string, string | undefined> | undefined
+): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(tags ?? {})) {
+    if (str(k) === undefined) continue;
+    out[k] = v ?? '';
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+// A live tag LIST ([{Key?, Value?}, ...]) folded to a { k: v } map — DAX ListTags returns a
+// list even though AWS::DAX::Cluster declares the map-shape `Tags`.
+function tagListToMap(
+  tags: { Key?: string | undefined; Value?: string | undefined }[] | undefined
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const t of tags ?? []) {
+    const k = str(t.Key);
+    if (k !== undefined) out[k] = t.Value ?? '';
+  }
+  return out;
+}
+
+// The map-shape twin of mirrorDeclaredTags: mirror a declared map-shape `Tags` ({ k: v })
+// on the degrade path when a map-shape type's tag fetch FAILS, so an omission does not
+// false-flag a `declared`-tier Tags drift. Returns undefined when nothing was declared.
+function mirrorDeclaredTagsMap(declaredTags: unknown): Record<string, string> | undefined {
+  if (typeof declaredTags !== 'object' || declaredTags === null || Array.isArray(declaredTags))
+    return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(declaredTags as Record<string, unknown>)) {
+    if (str(k) === undefined) continue;
+    out[k] = str(v) ?? '';
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 const readS3BucketPolicy: OverrideReader = async ({ declared, region }) => {
@@ -739,6 +788,15 @@ const readDlmLifecyclePolicy: OverrideReader = async ({ physicalId, declared, re
   } else if (Object.keys(details).length > 0) {
     model.PolicyDetails = details;
   }
+  // Tags — AWS::DLM::LifecyclePolicy declares the LIST shape ([{Key, Value}]), but
+  // GetLifecyclePolicy already returns the policy's tags as a { k: v } MAP on `Policy.Tags`
+  // (no extra call / IAM perm). Convert to the CFn list shape so a declared `Tags` value has
+  // a live counterpart — without it a tagged policy false-flagged `Tags desired=[…]
+  // actual=undefined` on every check, surviving record (#1362 / #1056 class).
+  const dlmTags = projectTagList(
+    Object.entries(p.Tags ?? {}).map(([Key, Value]) => ({ Key, Value }))
+  );
+  if (dlmTags) model.Tags = dlmTags;
   return model;
 };
 
@@ -1018,7 +1076,34 @@ const readLakeFormationResource: OverrideReader = async ({ physicalId, region })
 // ReservationPlan/*JobsCount/ServiceOverrides/Type) are dropped — not user-declarable scalars,
 // pure noise. Read-ONLY (UpdateQueue deferred). A deleted queue surfaces as
 // NotFoundException → the router maps it to `deleted`.
-const readMediaConvertQueue: OverrideReader = async ({ physicalId, region }) => {
+// Fetch a MediaConvert resource's live tags via mediaconvert:ListTagsForResource (the Arn
+// is the tag address) and project them onto the map-shape `Tags` the CFn schema declares,
+// degrading — mirror declared Tags + warn — on failure so a tag-fetch permission gap /
+// throttle does not false-flag a `declared`-tier Tags drift (#1362 / #1056 class). GetQueue
+// / GetJobTemplate do NOT carry Tags, so without this any MediaConvert resource in a
+// `Tags.of(app)` app false-flagged `Tags desired={…} actual=undefined` on every check.
+async function attachMediaConvertTags(
+  c: MediaConvertClient,
+  arn: string,
+  declared: Record<string, unknown>,
+  model: Record<string, unknown>,
+  label: string
+): Promise<void> {
+  try {
+    const t = await c.send(new MediaConvertListTagsForResourceCommand({ Arn: arn }));
+    const tags = projectTagMap(t.ResourceTags?.Tags);
+    if (tags) model.Tags = tags;
+  } catch (err) {
+    const mirrored = mirrorDeclaredTagsMap(declared.Tags);
+    if (mirrored) model.Tags = mirrored;
+    const call = (err as Error)?.name || 'unknown error';
+    process.stderr.write(
+      `[cdkrd] warning: MediaConvert ListTagsForResource for ${label} (${arn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant mediaconvert:ListTagsForResource to detect out-of-band tag changes\n`
+    );
+  }
+}
+
+const readMediaConvertQueue: OverrideReader = async ({ physicalId, declared, region }) => {
   const name = str(physicalId);
   if (!name) return undefined;
   const c = new MediaConvertClient({ region, ...READ_RETRY });
@@ -1029,6 +1114,8 @@ const readMediaConvertQueue: OverrideReader = async ({ physicalId, region }) => 
   if (str(q.Description)) model.Description = q.Description;
   if (str(q.PricingPlan)) model.PricingPlan = q.PricingPlan;
   if (str(q.Status)) model.Status = q.Status;
+  if (str(q.Arn))
+    await attachMediaConvertTags(c, q.Arn as string, declared, model, `Queue ${name}`);
   return model;
 };
 
@@ -1040,7 +1127,7 @@ const readMediaConvertQueue: OverrideReader = async ({ physicalId, region }) => 
 // AccelerationSettings/HopDestinations/StatusUpdateInterval/Category/Queue/Priority mirror the
 // CFn shape 1:1. Computed/managed fields (Arn/CreatedAt/LastUpdated/Type) are dropped. Read-ONLY
 // (UpdateJobTemplate deferred). A deleted template surfaces as NotFoundException → `deleted`.
-const readMediaConvertJobTemplate: OverrideReader = async ({ physicalId, region }) => {
+const readMediaConvertJobTemplate: OverrideReader = async ({ physicalId, declared, region }) => {
   const name = str(physicalId);
   if (!name) return undefined;
   const c = new MediaConvertClient({ region, ...READ_RETRY });
@@ -1060,6 +1147,8 @@ const readMediaConvertJobTemplate: OverrideReader = async ({ physicalId, region 
   // `Settings` object. Faithful passthrough so a console-side transcode-settings change is
   // detectable.
   if (t.Settings !== undefined) model.SettingsJson = t.Settings;
+  if (str(t.Arn))
+    await attachMediaConvertTags(c, t.Arn as string, declared, model, `JobTemplate ${name}`);
   return model;
 };
 
@@ -1337,7 +1426,7 @@ const readEc2ClientVpnTargetNetworkAssociation: OverrideReader = async ({
 // from ParameterGroup.ParameterGroupName, NotificationTopicARN from
 // NotificationConfiguration.TopicArn, SSESpecification from SSEDescription.Status). Read-ONLY.
 // Empty result -> ResourceGoneError so the router maps it to `deleted`.
-const readDaxCluster: OverrideReader = async ({ physicalId, region }) => {
+const readDaxCluster: OverrideReader = async ({ physicalId, declared, region }) => {
   const name = str(physicalId);
   if (!name) return undefined;
   const c = new DAXClient({ region, ...READ_RETRY });
@@ -1362,6 +1451,25 @@ const readDaxCluster: OverrideReader = async ({ physicalId, region }) => {
   if (cl.NotificationConfiguration && str(cl.NotificationConfiguration.TopicArn))
     model.NotificationTopicARN = cl.NotificationConfiguration.TopicArn;
   if (cl.SSEDescription?.Status === 'ENABLED') model.SSESpecification = { SSEEnabled: true };
+  // Tags — AWS::DAX::Cluster declares the map-shape `Tags`, but DAX ListTags returns a
+  // LIST; fold it to the map shape. DescribeClusters does NOT carry tags, so without this a
+  // tagged cluster false-flagged `Tags desired={…} actual=undefined` every check (#1362 /
+  // #1056 class). Degrade (mirror declared + warn) on a tag-fetch failure.
+  const daxArn = str(cl.ClusterArn);
+  if (daxArn) {
+    try {
+      const t = await c.send(new DaxListTagsCommand({ ResourceName: daxArn }));
+      const tags = projectTagMap(tagListToMap(t.Tags));
+      if (tags) model.Tags = tags;
+    } catch (err) {
+      const mirrored = mirrorDeclaredTagsMap(declared.Tags);
+      if (mirrored) model.Tags = mirrored;
+      const call = (err as Error)?.name || 'unknown error';
+      process.stderr.write(
+        `[cdkrd] warning: DAX ListTags for Cluster ${name} (${daxArn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant dax:ListTags to detect out-of-band tag changes\n`
+      );
+    }
+  }
   return model;
 };
 
@@ -1406,7 +1514,12 @@ const readDaxParameterGroup: OverrideReader = async ({ physicalId, region }) => 
 // divergence still surfaces — only the untouched inherited defaults fold away. The CFn
 // physical id (Ref) IS the CacheParameterGroupName. Read-ONLY. Empty group -> ResourceGoneError
 // so the router maps it to `deleted`.
-const readElastiCacheParameterGroup: OverrideReader = async ({ physicalId, region }) => {
+const readElastiCacheParameterGroup: OverrideReader = async ({
+  physicalId,
+  declared,
+  region,
+  accountId,
+}) => {
   const name = str(physicalId);
   if (!name) return undefined;
   const c = new ElastiCacheClient({ region, ...READ_RETRY });
@@ -1437,6 +1550,26 @@ const readElastiCacheParameterGroup: OverrideReader = async ({ physicalId, regio
     marker = str(p.Marker);
   } while (marker !== undefined);
   if (Object.keys(values).length > 0) model.Properties = values;
+  // Tags — AWS::ElastiCache::ParameterGroup declares the LIST shape ([{Key, Value}]).
+  // DescribeCacheParameterGroups does NOT carry tags; fetch via ListTagsForResource on the
+  // group ARN (built from region/account) so a tagged group has a live counterpart —
+  // without it a declared `Tags` false-flagged `desired=[…] actual=undefined` every check
+  // (#1362 / #1056 class). Degrade (mirror declared + warn) on a tag-fetch failure.
+  if (accountId) {
+    const arn = `arn:${partitionForRegion(region).partition}:elasticache:${region}:${accountId}:parametergroup:${name}`;
+    try {
+      const t = await c.send(new ElastiCacheListTagsForResourceCommand({ ResourceName: arn }));
+      const tags = projectTagList(t.TagList);
+      if (tags) model.Tags = tags;
+    } catch (err) {
+      const mirrored = mirrorDeclaredTags(declared.Tags);
+      if (mirrored) model.Tags = mirrored;
+      const call = (err as Error)?.name || 'unknown error';
+      process.stderr.write(
+        `[cdkrd] warning: ElastiCache ListTagsForResource for ParameterGroup ${name} (${arn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant elasticache:ListTagsForResource to detect out-of-band tag changes\n`
+      );
+    }
+  }
   return model;
 };
 
@@ -1705,7 +1838,7 @@ const readGlueClassifier: OverrideReader = async ({ physicalId, declared, region
 // CFn physical id is the workflow name; project the CFn-modeled scalar/map props, dropping
 // AWS-managed run/graph state (CreatedOn / LastModifiedOn / LastRun / Graph) and `Tags`
 // (handled by the shared aws:* tag strip). MaxConcurrentRuns is a number CFn declares.
-const readGlueWorkflow: OverrideReader = async ({ physicalId, declared, region }) => {
+const readGlueWorkflow: OverrideReader = async ({ physicalId, declared, region, accountId }) => {
   const name = str(physicalId) ?? str(declared.Name);
   if (!name) return undefined;
   const c = new GlueClient({ region, ...READ_RETRY });
@@ -1716,6 +1849,26 @@ const readGlueWorkflow: OverrideReader = async ({ physicalId, declared, region }
   if (w.Description !== undefined) out.Description = w.Description;
   if (w.DefaultRunProperties !== undefined) out.DefaultRunProperties = w.DefaultRunProperties;
   if (w.MaxConcurrentRuns !== undefined) out.MaxConcurrentRuns = w.MaxConcurrentRuns;
+  // Tags — AWS::Glue::Workflow declares the map-shape `Tags`. GetWorkflow does NOT carry
+  // tags; fetch via glue:GetTags on the workflow ARN (built from region/account) so a
+  // declared `Tags` has a live counterpart — without it a tagged workflow false-flagged
+  // `Tags desired={…} actual=undefined` every check (#1362 / #1056 class). Degrade (mirror
+  // declared + warn) on a tag-fetch failure.
+  if (accountId) {
+    const arn = `arn:${partitionForRegion(region).partition}:glue:${region}:${accountId}:workflow/${name}`;
+    try {
+      const t = await c.send(new GlueGetTagsCommand({ ResourceArn: arn }));
+      const tags = projectTagMap(t.Tags);
+      if (tags) out.Tags = tags;
+    } catch (err) {
+      const mirrored = mirrorDeclaredTagsMap(declared.Tags);
+      if (mirrored) out.Tags = mirrored;
+      const call = (err as Error)?.name || 'unknown error';
+      process.stderr.write(
+        `[cdkrd] warning: Glue GetTags for Workflow ${name} (${arn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant glue:GetTags to detect out-of-band tag changes\n`
+      );
+    }
+  }
   return out;
 };
 
@@ -2241,7 +2394,34 @@ const readCodeBuildProject: OverrideReader = async ({ physicalId, declared, regi
 // type), so without the namespace's Arn in liveAttrs the whole ServiceConnect config
 // resolves to UNRESOLVED and its drift is never detected. (ServiceCount / CreateDate /
 // Properties / a DNS namespace's Vpc stay readGaps — not projected.)
-const readServiceDiscoveryNamespace: OverrideReader = async ({ physicalId, region }) => {
+// Fetch a Cloud Map resource's live tags via servicediscovery:ListTagsForResource (the Arn
+// is the tag address) and project them onto the list-shape `Tags` the CFn schema declares,
+// degrading — mirror declared Tags + warn — on failure so a tag-fetch permission gap /
+// throttle does not false-flag a `declared`-tier Tags drift (#1362 / #1056 class). GetNamespace
+// / GetService do NOT carry Tags, so without this any ServiceDiscovery resource in a
+// `Tags.of(app)` app false-flagged `Tags desired=[…] actual=undefined` on every check.
+async function attachServiceDiscoveryTags(
+  c: ServiceDiscoveryClient,
+  arn: string,
+  declared: Record<string, unknown>,
+  model: Record<string, unknown>,
+  label: string
+): Promise<void> {
+  try {
+    const t = await c.send(new ServiceDiscoveryListTagsForResourceCommand({ ResourceARN: arn }));
+    const tags = projectTagList(t.Tags);
+    if (tags) model.Tags = tags;
+  } catch (err) {
+    const mirrored = mirrorDeclaredTags(declared.Tags);
+    if (mirrored) model.Tags = mirrored;
+    const call = (err as Error)?.name || 'unknown error';
+    process.stderr.write(
+      `[cdkrd] warning: ServiceDiscovery ListTagsForResource for ${label} (${arn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant servicediscovery:ListTagsForResource to detect out-of-band tag changes\n`
+    );
+  }
+}
+
+const readServiceDiscoveryNamespace: OverrideReader = async ({ physicalId, declared, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const c = new ServiceDiscoveryClient({ region, ...READ_RETRY });
@@ -2253,6 +2433,8 @@ const readServiceDiscoveryNamespace: OverrideReader = async ({ physicalId, regio
   if (ns.Description !== undefined) model.Description = ns.Description;
   if (ns.Arn !== undefined) model.Arn = ns.Arn; // readOnly: stripped from compare, kept for GetAtt
   if (ns.Id !== undefined) model.Id = ns.Id; // readOnly: ditto (a GetAtt [ns, Id] consumer)
+  if (str(ns.Arn))
+    await attachServiceDiscoveryTags(c, ns.Arn as string, declared, model, `Namespace ${id}`);
   return model;
 };
 
@@ -2262,7 +2444,7 @@ const readServiceDiscoveryNamespace: OverrideReader = async ({ physicalId, regio
 // deprecated/read-only echo, deliberately not projected (a service in an HTTP
 // namespace has no DnsConfig at all). HealthCheck* are projected only when present
 // so an HTTP service stays CLEAN. Id / Arn / InstanceCount / CreateDate are noise.
-const readServiceDiscoveryService: OverrideReader = async ({ physicalId, region }) => {
+const readServiceDiscoveryService: OverrideReader = async ({ physicalId, declared, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const c = new ServiceDiscoveryClient({ region, ...READ_RETRY });
@@ -2297,6 +2479,8 @@ const readServiceDiscoveryService: OverrideReader = async ({ physicalId, region 
         FailureThreshold: s.HealthCheckCustomConfig.FailureThreshold,
       }),
     };
+  if (str(s.Arn))
+    await attachServiceDiscoveryTags(c, s.Arn as string, declared, model, `Service ${id}`);
   return model;
 };
 

--- a/tests/overrides-reader-tags-1362.test.ts
+++ b/tests/overrides-reader-tags-1362.test.ts
@@ -1,0 +1,332 @@
+import {
+  DescribeClustersCommand,
+  DAXClient,
+  ListTagsCommand as DaxListTagsCommand,
+} from '@aws-sdk/client-dax';
+import { GetLifecyclePolicyCommand, DLMClient } from '@aws-sdk/client-dlm';
+import {
+  DescribeCacheParameterGroupsCommand,
+  DescribeCacheParametersCommand,
+  ElastiCacheClient,
+  ListTagsForResourceCommand as ElastiCacheListTagsForResourceCommand,
+} from '@aws-sdk/client-elasticache';
+import {
+  GetTagsCommand as GlueGetTagsCommand,
+  GetWorkflowCommand,
+  GlueClient,
+} from '@aws-sdk/client-glue';
+import {
+  GetJobTemplateCommand,
+  GetQueueCommand,
+  ListTagsForResourceCommand as MediaConvertListTagsForResourceCommand,
+  MediaConvertClient,
+} from '@aws-sdk/client-mediaconvert';
+import {
+  GetNamespaceCommand,
+  GetServiceCommand,
+  ListTagsForResourceCommand as ServiceDiscoveryListTagsForResourceCommand,
+  ServiceDiscoveryClient,
+} from '@aws-sdk/client-servicediscovery';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+// #1362 — several SDK_OVERRIDES readers never projected the resource's live `Tags`, so a
+// declared `Tags` value had no live counterpart (actual=undefined) → a FALSE `declared`-tier
+// drift on every check that SURVIVES record, and an out-of-band tag change was invisible. This
+// is the #1056 class already fixed for CodeBuild/ACM/DMS/DocDB. Each fixed reader now fetches
+// the live tags and, on a tag-fetch FAILURE, MIRRORS the declared Tags + warns (so an omission
+// is not a silent FP). List-shape CFn types produce [{Key, Value}]; map-shape produce {k:v}.
+
+const dax = mockClient(DAXClient);
+const dlm = mockClient(DLMClient);
+const elasticache = mockClient(ElastiCacheClient);
+const glue = mockClient(GlueClient);
+const mediaconvert = mockClient(MediaConvertClient);
+const servicediscovery = mockClient(ServiceDiscoveryClient);
+
+const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId,
+});
+
+let warn: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  dax.reset();
+  dlm.reset();
+  elasticache.reset();
+  glue.reset();
+  mediaconvert.reset();
+  servicediscovery.reset();
+  warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+});
+afterEach(() => {
+  warn.mockRestore();
+});
+
+describe('DLM LifecyclePolicy Tags (#1362)', () => {
+  it('projects Policy.Tags (map) as the CFn list shape so a declared Tags is not false drift', async () => {
+    dlm.on(GetLifecyclePolicyCommand).resolves({
+      Policy: {
+        Description: 'p',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        PolicyDetails: {},
+        Tags: { env: 'prod', team: 'data' },
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::DLM::LifecyclePolicy'](
+      ctx(
+        {
+          Tags: [
+            { Key: 'env', Value: 'prod' },
+            { Key: 'team', Value: 'data' },
+          ],
+        },
+        'policy-abc'
+      )
+    );
+    expect(out?.Tags).toEqual([
+      { Key: 'env', Value: 'prod' },
+      { Key: 'team', Value: 'data' },
+    ]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('omits Tags when the policy carries none (untagged stays clean)', async () => {
+    dlm.on(GetLifecyclePolicyCommand).resolves({
+      Policy: { Description: 'p', State: 'ENABLED', PolicyDetails: {} },
+    });
+    const out = await SDK_OVERRIDES['AWS::DLM::LifecyclePolicy'](ctx({}, 'policy-abc'));
+    expect(out?.Tags).toBeUndefined();
+  });
+});
+
+describe('ServiceDiscovery Namespace Tags (#1362)', () => {
+  it('projects live tags (list shape) via ListTagsForResource so no false drift', async () => {
+    servicediscovery.on(GetNamespaceCommand).resolves({
+      Namespace: {
+        Name: 'ns',
+        Arn: 'arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-x',
+        Id: 'ns-x',
+      },
+    });
+    servicediscovery
+      .on(ServiceDiscoveryListTagsForResourceCommand)
+      .resolves({ Tags: [{ Key: 'env', Value: 'prod' }] });
+    const out = await SDK_OVERRIDES['AWS::ServiceDiscovery::PrivateDnsNamespace'](
+      ctx({ Tags: [{ Key: 'env', Value: 'prod' }] }, 'ns-x')
+    );
+    expect(out?.Tags).toEqual([{ Key: 'env', Value: 'prod' }]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('mirrors declared Tags + warns when ListTagsForResource fails', async () => {
+    servicediscovery.on(GetNamespaceCommand).resolves({
+      Namespace: {
+        Name: 'ns',
+        Arn: 'arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-x',
+        Id: 'ns-x',
+      },
+    });
+    servicediscovery
+      .on(ServiceDiscoveryListTagsForResourceCommand)
+      .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+    const out = await SDK_OVERRIDES['AWS::ServiceDiscovery::PrivateDnsNamespace'](
+      ctx({ Tags: [{ Key: 'env', Value: 'prod' }] }, 'ns-x')
+    );
+    expect(out?.Tags).toEqual([{ Key: 'env', Value: 'prod' }]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('servicediscovery:ListTagsForResource');
+  });
+});
+
+describe('ServiceDiscovery Service Tags (#1362)', () => {
+  it('projects live tags (list shape) so no false drift', async () => {
+    servicediscovery.on(GetServiceCommand).resolves({
+      Service: {
+        Name: 'svc',
+        Arn: 'arn:aws:servicediscovery:us-east-1:123456789012:service/srv-x',
+        Type: 'HTTP',
+      },
+    });
+    servicediscovery
+      .on(ServiceDiscoveryListTagsForResourceCommand)
+      .resolves({ Tags: [{ Key: 'app', Value: 'web' }] });
+    const out = await SDK_OVERRIDES['AWS::ServiceDiscovery::Service'](
+      ctx({ Tags: [{ Key: 'app', Value: 'web' }] }, 'srv-x')
+    );
+    expect(out?.Tags).toEqual([{ Key: 'app', Value: 'web' }]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('mirrors declared Tags + warns on failure', async () => {
+    servicediscovery.on(GetServiceCommand).resolves({
+      Service: {
+        Name: 'svc',
+        Arn: 'arn:aws:servicediscovery:us-east-1:123456789012:service/srv-x',
+        Type: 'HTTP',
+      },
+    });
+    servicediscovery.on(ServiceDiscoveryListTagsForResourceCommand).rejects(new Error('boom'));
+    const out = await SDK_OVERRIDES['AWS::ServiceDiscovery::Service'](
+      ctx({ Tags: [{ Key: 'app', Value: 'web' }] }, 'srv-x')
+    );
+    expect(out?.Tags).toEqual([{ Key: 'app', Value: 'web' }]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ElastiCache ParameterGroup Tags (#1362)', () => {
+  it('projects live tags (list shape) via ListTagsForResource so no false drift', async () => {
+    elasticache.on(DescribeCacheParameterGroupsCommand).resolves({
+      CacheParameterGroups: [
+        {
+          CacheParameterGroupName: 'pg',
+          CacheParameterGroupFamily: 'redis7',
+          Description: 'd',
+        },
+      ],
+    });
+    elasticache.on(DescribeCacheParametersCommand).resolves({ Parameters: [] });
+    elasticache
+      .on(ElastiCacheListTagsForResourceCommand)
+      .resolves({ TagList: [{ Key: 'env', Value: 'prod' }] });
+    const out = await SDK_OVERRIDES['AWS::ElastiCache::ParameterGroup'](
+      ctx({ Tags: [{ Key: 'env', Value: 'prod' }] }, 'pg')
+    );
+    expect(out?.Tags).toEqual([{ Key: 'env', Value: 'prod' }]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('mirrors declared Tags + warns when ListTagsForResource fails', async () => {
+    elasticache.on(DescribeCacheParameterGroupsCommand).resolves({
+      CacheParameterGroups: [{ CacheParameterGroupName: 'pg', Description: 'd' }],
+    });
+    elasticache.on(DescribeCacheParametersCommand).resolves({ Parameters: [] });
+    elasticache
+      .on(ElastiCacheListTagsForResourceCommand)
+      .rejects(Object.assign(new Error('nope'), { name: 'AccessDeniedException' }));
+    const out = await SDK_OVERRIDES['AWS::ElastiCache::ParameterGroup'](
+      ctx({ Tags: [{ Key: 'env', Value: 'prod' }] }, 'pg')
+    );
+    expect(out?.Tags).toEqual([{ Key: 'env', Value: 'prod' }]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('elasticache:ListTagsForResource');
+  });
+});
+
+describe('DAX Cluster Tags (#1362)', () => {
+  it('projects live tags (SDK list) folded to the CFn map shape so no false drift', async () => {
+    dax.on(DescribeClustersCommand).resolves({
+      Clusters: [
+        {
+          ClusterName: 'c',
+          NodeType: 'dax.r4.large',
+          ClusterArn: 'arn:aws:dax:us-east-1:123456789012:cache/c',
+        },
+      ],
+    });
+    dax.on(DaxListTagsCommand).resolves({
+      Tags: [
+        { Key: 'env', Value: 'prod' },
+        { Key: 'team', Value: 'data' },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::DAX::Cluster'](
+      ctx({ Tags: { env: 'prod', team: 'data' } }, 'c')
+    );
+    expect(out?.Tags).toEqual({ env: 'prod', team: 'data' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('mirrors declared Tags (map) + warns when ListTags fails', async () => {
+    dax.on(DescribeClustersCommand).resolves({
+      Clusters: [
+        {
+          ClusterName: 'c',
+          NodeType: 'dax.r4.large',
+          ClusterArn: 'arn:aws:dax:us-east-1:123456789012:cache/c',
+        },
+      ],
+    });
+    dax
+      .on(DaxListTagsCommand)
+      .rejects(Object.assign(new Error('x'), { name: 'AccessDeniedException' }));
+    const out = await SDK_OVERRIDES['AWS::DAX::Cluster'](ctx({ Tags: { env: 'prod' } }, 'c'));
+    expect(out?.Tags).toEqual({ env: 'prod' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('dax:ListTags');
+  });
+});
+
+describe('Glue Workflow Tags (#1362)', () => {
+  it('projects live tags (map shape) via GetTags so no false drift', async () => {
+    glue.on(GetWorkflowCommand).resolves({ Workflow: { Name: 'wf', Description: 'd' } });
+    glue.on(GlueGetTagsCommand).resolves({ Tags: { env: 'prod' } });
+    const out = await SDK_OVERRIDES['AWS::Glue::Workflow'](ctx({ Tags: { env: 'prod' } }, 'wf'));
+    expect(out?.Tags).toEqual({ env: 'prod' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('mirrors declared Tags (map) + warns when GetTags fails', async () => {
+    glue.on(GetWorkflowCommand).resolves({ Workflow: { Name: 'wf', Description: 'd' } });
+    glue
+      .on(GlueGetTagsCommand)
+      .rejects(Object.assign(new Error('x'), { name: 'AccessDeniedException' }));
+    const out = await SDK_OVERRIDES['AWS::Glue::Workflow'](ctx({ Tags: { env: 'prod' } }, 'wf'));
+    expect(out?.Tags).toEqual({ env: 'prod' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('glue:GetTags');
+  });
+});
+
+describe('MediaConvert Queue / JobTemplate Tags (#1362)', () => {
+  it('Queue: projects live tags (map shape) via ListTagsForResource so no false drift', async () => {
+    mediaconvert.on(GetQueueCommand).resolves({
+      Queue: { Name: 'q', Arn: 'arn:aws:mediaconvert:us-east-1:123456789012:queues/q' },
+    });
+    mediaconvert
+      .on(MediaConvertListTagsForResourceCommand)
+      .resolves({ ResourceTags: { Tags: { env: 'prod' } } });
+    const out = await SDK_OVERRIDES['AWS::MediaConvert::Queue'](
+      ctx({ Tags: { env: 'prod' } }, 'q')
+    );
+    expect(out?.Tags).toEqual({ env: 'prod' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('JobTemplate: projects live tags (map shape) so no false drift', async () => {
+    mediaconvert.on(GetJobTemplateCommand).resolves({
+      JobTemplate: {
+        Name: 'jt',
+        Arn: 'arn:aws:mediaconvert:us-east-1:123456789012:jobTemplates/jt',
+      },
+    } as never);
+    mediaconvert
+      .on(MediaConvertListTagsForResourceCommand)
+      .resolves({ ResourceTags: { Tags: { app: 'web' } } });
+    const out = await SDK_OVERRIDES['AWS::MediaConvert::JobTemplate'](
+      ctx({ Tags: { app: 'web' } }, 'jt')
+    );
+    expect(out?.Tags).toEqual({ app: 'web' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('mirrors declared Tags (map) + warns when ListTagsForResource fails', async () => {
+    mediaconvert.on(GetQueueCommand).resolves({
+      Queue: { Name: 'q', Arn: 'arn:aws:mediaconvert:us-east-1:123456789012:queues/q' },
+    });
+    mediaconvert
+      .on(MediaConvertListTagsForResourceCommand)
+      .rejects(Object.assign(new Error('x'), { name: 'AccessDeniedException' }));
+    const out = await SDK_OVERRIDES['AWS::MediaConvert::Queue'](
+      ctx({ Tags: { env: 'prod' } }, 'q')
+    );
+    expect(out?.Tags).toEqual({ env: 'prod' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('mediaconvert:ListTagsForResource');
+  });
+});

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -1299,7 +1299,7 @@ describe('SDK overrides', () => {
           State: 'ENABLED',
           ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
           PolicyDetails: livePolicyDetails,
-          Tags: { team: 'ops' }, // map shape — deliberately NOT projected
+          Tags: { team: 'ops' },
         },
       } as never);
       const out = await SDK_OVERRIDES['AWS::DLM::LifecyclePolicy'](
@@ -1310,6 +1310,7 @@ describe('SDK overrides', () => {
         State: 'ENABLED',
         ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
         PolicyDetails: livePolicyDetails,
+        Tags: [{ Key: 'team', Value: 'ops' }],
       });
       const call = dlm.commandCalls(GetLifecyclePolicyCommand)[0]!;
       expect(call.args[0].input).toEqual({ PolicyId: 'policy-0abc' });


### PR DESCRIPTION
These SDK_OVERRIDES readers never projected Tags, so a declared Tags value had no live counterpart (actual=undefined) and false-flagged as declared-tier drift on every check (surviving record) while an out-of-band tag change was invisible — the #1056 class already fixed for CodeBuild/ACM/DMS/DocDB. Project Tags in each reader's CFn schema shape (list for DLM/ServiceDiscovery/ElastiCache-ParameterGroup; map for DAX/Glue-Workflow/MediaConvert). DLM's tags ride on the existing GetLifecyclePolicy response (no extra call); the rest fetch via ListTags*/GetTags, degrading by mirroring declared Tags + a stderr warning on failure (the DMS/DocDB pattern). New read permissions documented in the README IAM section. Adds tests/overrides-reader-tags-1362.test.ts. Closes #1362