### PR TITLE
fix(diff): dot-key empty {} double-report + GA HealthCheckPort string FromPort (#1275, #1268)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -643,7 +643,15 @@ export function buildSiblingListenerPorts(desired: Desired): Record<string, numb
     const first = Array.isArray(ranges) ? ranges[0] : undefined;
     const from =
       first && typeof first === 'object' ? (first as Record<string, unknown>).FromPort : undefined;
-    if (typeof from === 'number') map[r.physicalId] = from;
+    // A raw-CFn / YAML template can carry FromPort as a quoted all-digit string ("80") that CFn
+    // coerces to a number; accept it so the EndpointGroup HealthCheckPort still folds (#1268).
+    const port =
+      typeof from === 'number'
+        ? from
+        : typeof from === 'string' && /^\d+$/.test(from)
+          ? Number(from)
+          : undefined;
+    if (port !== undefined) map[r.physicalId] = port;
   }
   return map;
 }

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1316,7 +1316,12 @@ function collectNestedUndeclared(
   // it those arrays are identity-LESS to the generic check below and the descent is skipped —
   // hiding a live-only sub-key added to a declared element (a silent FN). See
   // NESTED_ARRAY_IDENTITY.
-  nestedArrayIdentity?: Record<string, string>
+  nestedArrayIdentity?: Record<string, string>,
+  // True only when this map/property has NO declared twin at all (the #555 fully-undeclared
+  // descend passes an empty `{}` sentinel). A DECLARED-empty `{}` (dv passed from the declared
+  // loop) is NOT absent — its whole-map compare already owns any unsafe-key divergence, so the
+  // path-unsafe emit below must fire on genuine ABSENCE, not zero-length (#1275).
+  declaredAbsent = false
 ): void {
   if (Array.isArray(declaredVal) && Array.isArray(liveVal)) {
     if (declaredVal.length === 0 || liveVal.length === 0) return;
@@ -1410,7 +1415,10 @@ function collectNestedUndeclared(
   // stringly-equal fold collapses the CDK typed-JSON vs AWS string coercion. Emitting it
   // here too false-flagged every declared dot-key map as first-run undeclared drift.
   if (Object.keys(liveVal).some((k) => PATH_UNSAFE_KEY.test(k))) {
-    if (Object.keys(declaredVal).length === 0) emit(path, liveVal);
+    // Emit only when the map is genuinely LIVE-ONLY (no declared twin). A DECLARED-empty `{}`
+    // (declaredAbsent === false, Object.keys length 0) is owned by the declared whole-map
+    // compare; emitting here too double-reported it as declared + undeclared (#1275).
+    if (declaredAbsent) emit(path, liveVal);
     return;
   }
   for (const [k, val] of Object.entries(liveVal)) {
@@ -3800,7 +3808,9 @@ export function classifyResource(
     // trivially-empty) and only the non-default residue surfaces (nested, at `k.sub`). Curated
     // per (type, path) so objects with no foldable defaults are never fragmented into noise.
     if (isNestedObject(v) && DESCEND_UNDECLARED_OBJECT_PATHS[resourceType]?.has(k)) {
-      collectNestedUndeclared({}, v, k, emitNested, NESTED_ARRAY_IDENTITY[resourceType]);
+      // Fully-undeclared property (no declared twin): pass declaredAbsent so an unsafe-key
+      // sub-map still surfaces whole here (the declared loop won't, #1275).
+      collectNestedUndeclared({}, v, k, emitNested, NESTED_ARRAY_IDENTITY[resourceType], true);
       continue;
     }
     // #629: a FULLY-undeclared identity-keyed SUBSET array (a bare Cognito UserPool's `Schema`

--- a/tests/classify-dotkey-empty-map-1275.test.ts
+++ b/tests/classify-dotkey-empty-map-1275.test.ts
@@ -1,0 +1,57 @@
+// #1275 — a path-unsafe-key (dotted) map DECLARED as an explicit empty `{}` was double-reported:
+// the declared whole-map compare owns it, but the undeclared nested descent ALSO emitted it whole
+// (the #1249 guard fired on zero-length, not genuine absence). Assert a declared-empty dot-key map
+// with a live-only `projection.*` key surfaces ONCE (declared), never a duplicate undeclared; and
+// that a map with NO declared twin still surfaces (live-only detection preserved).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Tbl',
+  resourceType: 'AWS::Glue::Table',
+  physicalId: 'db|t',
+  declared,
+});
+
+describe('#1275 dot-key map declared as explicit empty {} does not double-report', () => {
+  it('emits the declared-empty Parameters ONCE (declared), no duplicate undeclared', () => {
+    const res = mk({ Name: 't', Parameters: {} });
+    const f = classifyResource(
+      res,
+      { Name: 't', Parameters: { 'projection.enabled': 'true' } },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toContain('Parameters');
+    expect(tier(f, 'undeclared')).not.toContain('Parameters');
+  });
+
+  it('still surfaces a wholly-undeclared dot-key map (live-only detection preserved)', () => {
+    // Parameters NOT declared at all, present live with a dot-key: the top-level undeclared loop
+    // owns it and emits it whole as undeclared — the change must not suppress genuine live-only maps.
+    const res = mk({ Name: 't' });
+    const f = classifyResource(
+      res,
+      { Name: 't', Parameters: { 'projection.enabled': 'true' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('Parameters');
+    expect(tier(f, 'declared')).not.toContain('Parameters');
+  });
+});

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -1766,4 +1766,32 @@ describe('buildSiblingListenerPorts (#975)', () => {
     );
     expect(map).toEqual({});
   });
+
+  it('coerces an all-digit string FromPort ("80") from a raw-CFn/YAML template (#1268)', () => {
+    const map = buildSiblingListenerPorts(
+      desiredWith([
+        {
+          logicalId: 'Listener',
+          resourceType: 'AWS::GlobalAccelerator::Listener',
+          physicalId: 'arn:...:listener/str',
+          declared: { PortRanges: [{ FromPort: '80', ToPort: '80' }] },
+        } as DesiredResource,
+      ])
+    );
+    expect(map['arn:...:listener/str']).toBe(80);
+  });
+
+  it('still skips a non-numeric-string FromPort (fail-open, #1268)', () => {
+    const map = buildSiblingListenerPorts(
+      desiredWith([
+        {
+          logicalId: 'Listener',
+          resourceType: 'AWS::GlobalAccelerator::Listener',
+          physicalId: 'arn:...:listener/bad',
+          declared: { PortRanges: [{ FromPort: '8x' }] },
+        } as DesiredResource,
+      ])
+    );
+    expect(map).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary
Two file-disjoint first-run false-positive folds in `src/diff/classify.ts` (+ `src/commands/gather.ts`), bundled because they share `classify.ts`.

### #1275 — dot-key map declared as explicit empty `{}` double-reported
The #1249 undeclared-descent guard emitted a path-unsafe (dotted) live-only map whenever the declared twin was **zero-length**. That also fired when the map was **declared as an explicit empty `{}`** (owned by the declared whole-map compare), producing a duplicate `declared` + `undeclared` finding. Fixed by threading a `declaredAbsent` flag through `collectNestedUndeclared`: the unsafe-key emit now fires on genuine ABSENCE (the #555 fully-undeclared descend), not zero-length. A declared-empty `{}` no longer double-reports; a wholly-undeclared dot-key map still surfaces.

### #1268 — GA EndpointGroup HealthCheckPort skipped a string FromPort
#975 derives an undeclared `HealthCheckPort` from the sibling Listener's first `PortRanges.FromPort`, but `buildSiblingListenerPorts` only accepted a JS `number`. A raw-CFn / YAML template can carry `FromPort: "80"` (CFn-coerced string), which skipped the entry and surfaced the port as a first-run FP. Now an all-digit string is coerced; a non-numeric string is still skipped (fail-open).

## Tests
- `tests/classify-dotkey-empty-map-1275.test.ts` — declared-empty `{}` emits once (declared), no duplicate undeclared; wholly-undeclared map still surfaces.
- `tests/gather.test.ts` — `buildSiblingListenerPorts` coerces `"80"`, still skips `"8x"`.

Offline / deterministic (unit-proven). Full suite green.

Closes #1275
Closes #1268