### PR TITLE
fix(read): Lambda child matchers accept the partial-ARN FunctionName form (#1281)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -174,6 +174,13 @@ export function unqualifiedFunctionRef(ref: unknown): unknown {
     if (seg.length >= 8 && seg[5] === 'function') return seg.slice(0, 7).join(':');
     return ref;
   }
+  // Partial ARN `<accountId>:function:NAME[:QUALIFIER]` — a documented FunctionName form that
+  // is NOT prefixed `arn:`, so without this it falls into the short-form truncation below and
+  // collapses to the account id (`123456789012`), matching neither the parent's bare name nor
+  // its full ARN → the declared child is dropped and falsely flagged `added` (#1281). The bare
+  // function name is the segment after `function:`.
+  const partial = ref.match(/^\d{12}:function:([^:]+)/);
+  if (partial) return partial[1];
   // Short forms: `NAME:QUALIFIER` (single colon) → `NAME`. A bare `NAME` has no colon.
   const i = ref.indexOf(':');
   return i === -1 ? ref : ref.slice(0, i);
@@ -1392,7 +1399,9 @@ export async function enumerateLambdaFunctionChildren(
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::Url') continue;
     const target = r.declared.TargetFunctionArn;
-    const targetsThis = parentRefMatches(target, functionName, fnArn);
+    // Normalize BOTH sides to the unqualified function identity so the documented partial-ARN
+    // FunctionName form (`123456789012:function:my-fn`) matches this parent (#1281, #803).
+    const targetsThis = lambdaFunctionRefMatches(target, functionName, fnArn);
     if (targetsThis) {
       // The URL's FunctionArn (its primaryIdentifier) is the function's bare ARN for an
       // unqualified URL; prefer the resolved live function ARN, else the declared physicalId.
@@ -1412,7 +1421,10 @@ export async function enumerateLambdaFunctionChildren(
   const declaredAliasArns: string[] = [];
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::Alias' || !r.physicalId) continue;
-    if (parentRefMatches(r.declared.FunctionName, functionName, fnArn)) {
+    // Same unqualified-identity match as the ESM/Version paths: an alias whose declared
+    // FunctionName is a partial ARN (`123456789012:function:my-fn`) or a qualified ref still
+    // targets this parent function (#1281, #803). Keeps the UNRESOLVED fail-safe.
+    if (lambdaFunctionRefMatches(r.declared.FunctionName, functionName, fnArn)) {
       declaredAliasArns.push(r.physicalId);
     }
   }

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -2801,6 +2801,157 @@ describe('Lambda alias/version-bound children match on unqualified function iden
   });
 });
 
+// #1281: the documented partial-ARN FunctionName form `<accountId>:function:<name>[:qualifier]`
+// does NOT start with `arn:`, so the short-form truncation collapsed it to the account id —
+// matching neither the parent's bare name nor its full ARN, so a DECLARED ESM/Version/Alias/Url
+// using this form was dropped from the declared set and its live counterpart falsely flagged
+// `added` (with a destructive DeleteResource offer). unqualifiedFunctionRef must extract the bare
+// name; the Alias/Url matchers must normalize both sides like the ESM/Version paths already do.
+describe('Lambda children match on the partial-ARN FunctionName form (#1281)', () => {
+  const fnArn = 'arn:aws:lambda:us-east-1:111122223333:function:my-fn';
+  const partial = '111122223333:function:my-fn';
+
+  it('unqualifiedFunctionRef extracts the bare name from a partial ARN (± qualifier)', () => {
+    expect(unqualifiedFunctionRef(partial)).toBe('my-fn');
+    expect(unqualifiedFunctionRef(`${partial}:prod`)).toBe('my-fn');
+    expect(unqualifiedFunctionRef(`${partial}:$LATEST`)).toBe('my-fn');
+  });
+
+  it('a declared ESM with a partial-ARN FunctionName is NOT flagged added', async () => {
+    const declaredUuid = '11111111-2222-3333-4444-555555555555';
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [{ UUID: declaredUuid, EventSourceArn: 'q' }] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::EventSourceMapping',
+            physicalId: declaredUuid,
+            declared: { FunctionName: partial },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added).toEqual([]);
+    lambda.restore();
+  });
+
+  it('a declared Alias with a partial-ARN FunctionName is NOT flagged added', async () => {
+    const aliasArn = `${fnArn}:live`;
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [{ AliasArn: aliasArn, Name: 'live' }] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::Alias',
+            physicalId: aliasArn,
+            declared: { FunctionName: partial },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added).toEqual([]);
+    lambda.restore();
+  });
+
+  it('a declared function URL with a partial-ARN TargetFunctionArn is NOT flagged added', async () => {
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({
+        FunctionUrlConfigs: [
+          {
+            FunctionArn: fnArn,
+            AuthType: 'NONE',
+            FunctionUrl: 'https://abc.lambda-url.us-east-1.on.aws/',
+            CreationTime: '2020-01-01T00:00:00Z',
+            LastModifiedTime: '2020-01-01T00:00:00Z',
+          },
+        ],
+      })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::Url',
+            physicalId: fnArn,
+            declared: { TargetFunctionArn: partial },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added).toEqual([]);
+    lambda.restore();
+  });
+
+  it('a genuinely out-of-band alias (no declared partial-ARN counterpart) IS still flagged added', async () => {
+    const rogueArn = `${fnArn}:rogue`;
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [{ AliasArn: rogueArn, Name: 'rogue' }] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        // A DIFFERENT function is declared by partial ARN; the rogue alias is not in the template.
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::Alias',
+            physicalId: `${fnArn}:other`,
+            declared: { FunctionName: '111122223333:function:other-fn' },
+          },
+        ],
+        ctx: { liveAttrs: { Fn: { Arn: fnArn } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added.map((a) => a.identifier)).toEqual([rogueArn]);
+    lambda.restore();
+  });
+});
+
 describe('diffRoute53HostedZoneChildren (Route53 hosted zone record sets, #1042)', () => {
   const ZONE = 'Z1234567890ABC';
   const APEX = 'example.com';


### PR DESCRIPTION
## Summary
The documented partial-ARN `FunctionName` form `123456789012:function:my-fn[:qualifier]` (accepted on `AWS::Lambda::EventSourceMapping`/`.Version`/`.Alias`/`.Url`) does NOT start with `arn:`, so `unqualifiedFunctionRef` fell into the short-form branch that truncates at the FIRST colon → `123456789012`. That matched neither the parent's bare name nor its full ARN, so a **declared** ESM/Version/Alias/Url using this form was dropped from the declared set and its live counterpart falsely flagged `[Added]` — with a destructive Cloud Control `DeleteResource` offer against a template-declared resource (#803 sibling form).

## Fix (`src/read/child-enumerators.ts`)
- `unqualifiedFunctionRef`: recognize `<accountId>:function:NAME[:QUALIFIER]` and return the bare `NAME`.
- The Alias and Url matchers now use `lambdaFunctionRefMatches` (normalizes BOTH sides to the unqualified identity), matching the ESM/Version paths — so all four child matchers handle the partial-ARN form. The UNRESOLVED (#962) fail-safe is preserved.

## Tests (`tests/child-enumerators.test.ts`)
- `unqualifiedFunctionRef` extracts the bare name from a partial ARN (± qualifier).
- A declared ESM / Alias / function-URL with a partial-ARN `FunctionName`/`TargetFunctionArn` is NOT flagged `added`.
- A genuinely out-of-band alias (no declared counterpart) IS still flagged — over-fold guard.

Offline / deterministic (mocked `LambdaClient`). Full suite green.

Closes #1281