### PR TITLE
fix(read): project CodeBuild Triggers/SecondarySources/SecondaryArtifacts/BuildBatchConfig (#1299)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -2300,12 +2300,7 @@ const readCodeBuildProject: OverrideReader = async ({ physicalId, declared, regi
   // absent unless set, so no noise. FileSystemLocations — EFS mounts into the build
   // (Identifier/Type/Location/MountPoint/MountOptions are all USER-specified, no server
   // default), absent unless the project mounts a file system. Both were omitted, so an
-  // out-of-band change was invisible. (secondarySources / secondaryArtifacts /
-  // buildBatchConfig / autoRetryLimit are deliberately NOT projected yet: the read shapes
-  // diverge from the declared CFn shapes [secondaryArtifacts reads as BuildArtifacts —
-  // missing Type/Name/NamespaceType/Packaging], carry server defaults [autoRetryLimit=0,
-  // batch nested defaults], or are order-sensitive arrays — each needs its own FP-safe
-  // handling, added when a real gap surfaces per the "widen coverage as gaps surface" rule.)
+  // out-of-band change was invisible.
   if (p.resourceAccessRole !== undefined) model.ResourceAccessRole = p.resourceAccessRole;
   if (p.fileSystemLocations !== undefined && p.fileSystemLocations.length > 0)
     model.FileSystemLocations = p.fileSystemLocations.map((f) => ({
@@ -2381,6 +2376,97 @@ const readCodeBuildProject: OverrideReader = async ({ physicalId, declared, regi
   // on non-empty so an untagged project emits no `Tags` and stays clean.
   if (Array.isArray(p.tags) && p.tags.length > 0)
     model.Tags = p.tags.map((t) => ({ Key: t.key, Value: t.value }));
+  // Secondary sources / artifacts / source versions — CFn-declarable COLLECTION props
+  // that BatchGetProjects returns but the projection omitted. For a project that DECLARES
+  // any of them (e.g. `SecondarySources: [...]`), the live read carried NO counterpart,
+  // so the classify "removed collection" branch emitted a false DECLARED drift
+  // (actual=undefined) on every clean deploy (#1299). AWS echoes exactly the declared
+  // members, so projecting them makes the declared compare match; guarded on non-empty so
+  // a single-source project emits nothing and stays clean. The SDK shapes are the SAME
+  // ProjectSource / ProjectArtifacts used for the primary Source / Artifacts above (each
+  // gains a SourceIdentifier / ArtifactIdentifier that CFn requires for a secondary), so
+  // mirror those PascalCase mappings.
+  if (Array.isArray(p.secondarySources) && p.secondarySources.length > 0)
+    model.SecondarySources = p.secondarySources.map((s) => ({
+      ...(s.type !== undefined && { Type: s.type }),
+      ...(s.location !== undefined && { Location: s.location }),
+      ...(s.buildspec !== undefined && { BuildSpec: s.buildspec }),
+      ...(s.gitCloneDepth !== undefined && { GitCloneDepth: s.gitCloneDepth }),
+      ...(s.insecureSsl !== undefined && { InsecureSsl: s.insecureSsl }),
+      ...(s.reportBuildStatus !== undefined && { ReportBuildStatus: s.reportBuildStatus }),
+      ...(s.sourceIdentifier !== undefined && { SourceIdentifier: s.sourceIdentifier }),
+    }));
+  if (Array.isArray(p.secondaryArtifacts) && p.secondaryArtifacts.length > 0)
+    model.SecondaryArtifacts = p.secondaryArtifacts.map((a) => ({
+      ...(a.type !== undefined && { Type: a.type }),
+      ...(a.location !== undefined && { Location: a.location }),
+      ...(a.name !== undefined && { Name: a.name }),
+      ...(a.namespaceType !== undefined && { NamespaceType: a.namespaceType }),
+      ...(a.packaging !== undefined && { Packaging: a.packaging }),
+      ...(a.path !== undefined && { Path: a.path }),
+      ...(a.artifactIdentifier !== undefined && { ArtifactIdentifier: a.artifactIdentifier }),
+      ...(a.overrideArtifactName !== undefined && { OverrideArtifactName: a.overrideArtifactName }),
+      ...(a.encryptionDisabled !== undefined && { EncryptionDisabled: a.encryptionDisabled }),
+    }));
+  if (Array.isArray(p.secondarySourceVersions) && p.secondarySourceVersions.length > 0)
+    model.SecondarySourceVersions = p.secondarySourceVersions.map((v) => ({
+      ...(v.sourceIdentifier !== undefined && { SourceIdentifier: v.sourceIdentifier }),
+      ...(v.sourceVersion !== undefined && { SourceVersion: v.sourceVersion }),
+    }));
+  // BuildBatchConfig — the batch-build config object; absent unless the project enables
+  // batch builds, so no noise when unused. When set, the template declares it and AWS
+  // echoes exactly the configured shape; each nested field is projected only when present
+  // so a partial config matches its template (a live-added default nested field would fold
+  // via nested-undeclared handling, not surface a declared FP).
+  const batch = p.buildBatchConfig;
+  if (batch) {
+    const restrictions = batch.restrictions;
+    model.BuildBatchConfig = {
+      ...(batch.serviceRole !== undefined && { ServiceRole: batch.serviceRole }),
+      ...(batch.combineArtifacts !== undefined && { CombineArtifacts: batch.combineArtifacts }),
+      ...(batch.timeoutInMins !== undefined && { TimeoutInMins: batch.timeoutInMins }),
+      ...(batch.batchReportMode !== undefined && { BatchReportMode: batch.batchReportMode }),
+      ...(restrictions && {
+        Restrictions: {
+          ...(restrictions.maximumBuildsAllowed !== undefined && {
+            MaximumBuildsAllowed: restrictions.maximumBuildsAllowed,
+          }),
+          ...(restrictions.computeTypesAllowed !== undefined && {
+            ComputeTypesAllowed: restrictions.computeTypesAllowed,
+          }),
+        },
+      }),
+    };
+  }
+  // AutoRetryLimit — max additional automatic retries after a failed build; projected only
+  // when present so a project that never set it emits nothing and stays clean, while a
+  // declared value matches its template and an out-of-band change surfaces.
+  if (p.autoRetryLimit !== undefined) model.AutoRetryLimit = p.autoRetryLimit;
+  // Triggers — the CFn `ProjectTriggers` shape mirrors the SDK `webhook` OBJECT: a project
+  // that declares `Triggers` (a webhook) reads back `webhook: {...}`, but the projection
+  // omitted it, so `Triggers` had NO live counterpart → a false DECLARED drift
+  // (actual=undefined) on every clean deploy of a webhook project (#1299). The CFn
+  // `Triggers.Webhook` is a BOOLEAN meaning "a webhook is configured" — the presence of the
+  // SDK `webhook` object IS that boolean, so map it to `Webhook: true`; `FilterGroups`
+  // (WebhookFilter[][]) and `BuildType` come straight from the object. `url` / `secret` /
+  // `payloadUrl` etc. are AWS-managed webhook attributes, not CFn-declarable, so omitted.
+  const webhook = p.webhook;
+  if (webhook)
+    model.Triggers = {
+      Webhook: true,
+      ...(webhook.buildType !== undefined && { BuildType: webhook.buildType }),
+      ...(webhook.filterGroups !== undefined && {
+        FilterGroups: webhook.filterGroups.map((group) =>
+          group.map((f) => ({
+            ...(f.type !== undefined && { Type: f.type }),
+            ...(f.pattern !== undefined && { Pattern: f.pattern }),
+            ...(f.excludeMatchedPattern !== undefined && {
+              ExcludeMatchedPattern: f.excludeMatchedPattern,
+            }),
+          }))
+        ),
+      }),
+    };
   return model;
 };
 

--- a/tests/codebuild-reader-1299.test.ts
+++ b/tests/codebuild-reader-1299.test.ts
@@ -1,0 +1,172 @@
+import { BatchGetProjectsCommand, CodeBuildClient } from '@aws-sdk/client-codebuild';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+// #1299 — readCodeBuildProject projected Tags (#1056) but OMITTED the other writable
+// COLLECTION / config props BatchGetProjects returns: Triggers (from webhook),
+// SecondarySources, SecondaryArtifacts, SecondarySourceVersions, BuildBatchConfig,
+// AutoRetryLimit. For a project that DECLARES any of them, the live read carried NO
+// counterpart, so the classify "removed collection" branch emitted a false DECLARED
+// drift (actual=undefined) on every clean deploy. These tests FAIL without the
+// projection (the model lacks the props) and PASS with it.
+const codebuild = mockClient(CodeBuildClient);
+
+const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId,
+});
+
+beforeEach(() => {
+  codebuild.reset();
+});
+
+describe('CodeBuild Project reader (#1299) — writable collection / config projection', () => {
+  it('projects Triggers from webhook, SecondarySources/Artifacts/SourceVersions, BuildBatchConfig, AutoRetryLimit', async () => {
+    codebuild.on(BatchGetProjectsCommand).resolves({
+      projects: [
+        {
+          name: 'p',
+          arn: 'arn:aws:codebuild:us-east-1:1:project/p',
+          source: { type: 'GITHUB', location: 'https://github.com/o/r.git' },
+          artifacts: { type: 'NO_ARTIFACTS' },
+          secondarySources: [
+            {
+              type: 'GITHUB',
+              location: 'https://github.com/o/lib.git',
+              sourceIdentifier: 'lib',
+              gitCloneDepth: 1,
+              insecureSsl: false,
+            },
+          ],
+          secondaryArtifacts: [
+            {
+              type: 'S3',
+              location: 'bkt',
+              path: 'out',
+              namespaceType: 'BUILD_ID',
+              packaging: 'ZIP',
+              name: 'lib.zip',
+              artifactIdentifier: 'libArtifact',
+            },
+          ],
+          secondarySourceVersions: [{ sourceIdentifier: 'lib', sourceVersion: 'main' }],
+          buildBatchConfig: {
+            serviceRole: 'arn:aws:iam::1:role/batch',
+            combineArtifacts: true,
+            timeoutInMins: 60,
+            batchReportMode: 'REPORT_INDIVIDUAL_BUILDS',
+            restrictions: {
+              maximumBuildsAllowed: 10,
+              computeTypesAllowed: ['BUILD_GENERAL1_SMALL'],
+            },
+          },
+          autoRetryLimit: 2,
+          webhook: {
+            url: 'https://api.github.com/hook/1', // AWS-managed, must NOT appear
+            buildType: 'BUILD',
+            filterGroups: [
+              [
+                { type: 'EVENT', pattern: 'PUSH' },
+                { type: 'HEAD_REF', pattern: '^refs/heads/main$', excludeMatchedPattern: false },
+              ],
+            ],
+          },
+        },
+      ],
+    });
+    const out = (await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'p'))) as Record<
+      string,
+      unknown
+    >;
+
+    // The core #1299 assertions: each collection now has a live counterpart so classify
+    // sees actual != undefined and does NOT report a false declared drift.
+    expect(out.SecondarySources).toEqual([
+      {
+        Type: 'GITHUB',
+        Location: 'https://github.com/o/lib.git',
+        SourceIdentifier: 'lib',
+        GitCloneDepth: 1,
+        InsecureSsl: false,
+      },
+    ]);
+    expect(out.SecondaryArtifacts).toEqual([
+      {
+        Type: 'S3',
+        Location: 'bkt',
+        Path: 'out',
+        NamespaceType: 'BUILD_ID',
+        Packaging: 'ZIP',
+        Name: 'lib.zip',
+        ArtifactIdentifier: 'libArtifact',
+      },
+    ]);
+    expect(out.SecondarySourceVersions).toEqual([
+      { SourceIdentifier: 'lib', SourceVersion: 'main' },
+    ]);
+    expect(out.BuildBatchConfig).toEqual({
+      ServiceRole: 'arn:aws:iam::1:role/batch',
+      CombineArtifacts: true,
+      TimeoutInMins: 60,
+      BatchReportMode: 'REPORT_INDIVIDUAL_BUILDS',
+      Restrictions: {
+        MaximumBuildsAllowed: 10,
+        ComputeTypesAllowed: ['BUILD_GENERAL1_SMALL'],
+      },
+    });
+    expect(out.AutoRetryLimit).toBe(2);
+    // The CFn Triggers.Webhook boolean IS the presence of the SDK webhook object; the
+    // AWS-managed webhook url is NOT a CFn-declarable field, so it must not leak.
+    expect(out.Triggers).toEqual({
+      Webhook: true,
+      BuildType: 'BUILD',
+      FilterGroups: [
+        [
+          { Type: 'EVENT', Pattern: 'PUSH' },
+          { Type: 'HEAD_REF', Pattern: '^refs/heads/main$', ExcludeMatchedPattern: false },
+        ],
+      ],
+    });
+  });
+
+  it('emits none of the collection / config props for a plain project (no first-run noise)', async () => {
+    codebuild.on(BatchGetProjectsCommand).resolves({
+      projects: [{ name: 'p', source: { type: 'NO_SOURCE' }, artifacts: { type: 'NO_ARTIFACTS' } }],
+    });
+    const out = (await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'p'))) as Record<
+      string,
+      unknown
+    >;
+    expect(out.Triggers).toBeUndefined();
+    expect(out.SecondarySources).toBeUndefined();
+    expect(out.SecondaryArtifacts).toBeUndefined();
+    expect(out.SecondarySourceVersions).toBeUndefined();
+    expect(out.BuildBatchConfig).toBeUndefined();
+    expect(out.AutoRetryLimit).toBeUndefined();
+  });
+
+  it('an EMPTY secondary array emits nothing (guarded on non-empty)', async () => {
+    codebuild.on(BatchGetProjectsCommand).resolves({
+      projects: [
+        {
+          name: 'p',
+          source: { type: 'NO_SOURCE' },
+          artifacts: { type: 'NO_ARTIFACTS' },
+          secondarySources: [],
+          secondaryArtifacts: [],
+          secondarySourceVersions: [],
+        },
+      ],
+    });
+    const out = (await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'p'))) as Record<
+      string,
+      unknown
+    >;
+    expect(out.SecondarySources).toBeUndefined();
+    expect(out.SecondaryArtifacts).toBeUndefined();
+    expect(out.SecondarySourceVersions).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1299

## Problem

`readCodeBuildProject` (src/read/overrides.ts) projected `Tags` (#1056) but OMITTED the other writable COLLECTION / config properties that `BatchGetProjects` returns and the `AWS::CodeBuild::Project` schema marks writable (readOnly = Id/Arn only):

- `Triggers` (from `p.webhook`)
- `SecondarySources`
- `SecondaryArtifacts`
- `SecondarySourceVersions`
- `BuildBatchConfig`
- `AutoRetryLimit`

For a project that DECLARES any of these (a webhook / secondary-source / batch project), the live read carried NO counterpart, so the classify "removed collection" branch emitted a **declared-tier false positive** (`actual=undefined`) on every clean deploy. The old deferral comment (claiming the read shapes diverge / carry server defaults) and the "benign readGap" framing were wrong for non-empty collections.

## Fix

Project the missing fields **present-only** (set only when the SDK returns them), mapping SDK camelCase to CFn PascalCase, mirroring the existing `Source` / `Artifacts` / `Tags` idiom:

- Secondary sources / artifacts / source-versions reuse the primary `ProjectSource` / `ProjectArtifacts` mapping (plus the `SourceIdentifier` / `ArtifactIdentifier` CFn requires for a secondary), guarded on non-empty so a single-source project stays clean.
- `BuildBatchConfig` maps the batch object (incl. nested `Restrictions`) only when present (absent unless batch builds are enabled).
- `AutoRetryLimit` is projected only when set.
- `Triggers` — the CFn `Triggers.Webhook` boolean IS the presence of the SDK `webhook` object, so map its presence to `Webhook: true` and carry `FilterGroups` / `BuildType`; AWS-managed webhook `url` / `secret` are not CFn-declarable so are omitted.

Removed the misleading deferral comment.

## Tests

New `tests/codebuild-reader-1299.test.ts`:
- projection test (FAILS without the fix, PASSES with it) — asserts each collection/config prop is projected so classify sees `actual != undefined`, and the AWS-managed webhook `url` does not leak.
- a plain project emits none of the new props (no first-run noise).
- an EMPTY secondary array emits nothing (guarded on non-empty).

All gates green: typecheck, `vp run check` (non-fix, 0 errors), build, full suite (4633 tests / 190 files).