### PR TITLE
fix(read): AppSync GraphQLApi child enumerator surfaces out-of-band ApiKey (#1367)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -35,9 +35,11 @@ import {
   ListEnvironmentsCommand,
 } from '@aws-sdk/client-appconfig';
 import {
+  type ApiKey as AppSyncApiKey,
   AppSyncClient,
   type DataSource as AppSyncDataSource,
   type FunctionConfiguration as AppSyncFunctionConfiguration,
+  ListApiKeysCommand,
   ListDataSourcesCommand,
   ListFunctionsCommand as ListAppSyncFunctionsCommand,
   ListResolversCommand,
@@ -1913,16 +1915,17 @@ async function enumerateUserPoolChildren(ctx: EnumeratorContext): Promise<AddedC
 
 // ── AppSync ──────────────────────────────────────────────────────────────────
 // An `AWS::AppSync::GraphQLApi` owns DataSources (the DynamoDB / Lambda / HTTP / NONE
-// resolver backings), Resolvers (per type/field attachments), AND Functions (the
-// pipeline functions composed into a pipeline resolver), each a separate
-// CloudFormation resource. A console / CLI `create-data-source` / `create-resolver` /
-// `create-function` (someone wires a new backing, resolver, or function onto an api
-// out of band) is invisible to cdk drift / CFn drift detection. The GraphQLApi model
-// does NOT reflect its datasources, resolvers, or functions inline, so there is no
-// double-report to suppress. The CC primaryIdentifier for AWS::AppSync::DataSource is
-// the bare DataSourceArn, for AWS::AppSync::Resolver the bare ResolverArn, and for
-// AWS::AppSync::FunctionConfiguration the bare FunctionArn, which CC GetResource /
-// DeleteResource consume.
+// resolver backings), Resolvers (per type/field attachments), Functions (the pipeline
+// functions composed into a pipeline resolver), AND ApiKeys (the API_KEY-auth
+// credentials), each a separate CloudFormation resource. A console / CLI
+// `create-data-source` / `create-resolver` / `create-function` / `create-api-key`
+// (someone wires a new backing, resolver, function, or — security-relevant — a durable
+// API_KEY auth credential onto an api out of band) is invisible to cdk drift / CFn drift
+// detection. The GraphQLApi model does NOT reflect its datasources, resolvers, functions,
+// or api keys inline, so there is no double-report to suppress. The CC primaryIdentifier
+// for AWS::AppSync::DataSource is the bare DataSourceArn, for AWS::AppSync::Resolver the
+// bare ResolverArn, for AWS::AppSync::FunctionConfiguration the bare FunctionArn, and for
+// AWS::AppSync::ApiKey the bare ApiKeyId, which CC GetResource / DeleteResource consume.
 
 // Pure diff: declared datasource names + live inventory -> the added datasources.
 export interface GraphQLApiChildInput {
@@ -2055,6 +2058,66 @@ async function pageAppSyncFunctions(
   return out;
 }
 
+// An `AWS::AppSync::ApiKey` is a durable API_KEY-auth credential — a console / CLI
+// `appsync create-api-key` mints one out of band that cdk drift / CFn drift detection
+// cannot see (#1367; #965 covered only the DELETE direction of an api key). AppSync does
+// NOT auto-materialize a default key for a bare API_KEY-auth GraphQLApi — a key exists
+// ONLY via CreateApiKey or a declared AWS::AppSync::ApiKey (the CDK `GraphqlApi`
+// construct's auto-key IS a declared CfnApiKey in the template) — so a live key not
+// matching a declared one is genuinely out of band and needs no built-in default filter
+// (unlike the RestApi `Empty`/`Error` models). The CC primaryIdentifier is the SINGLE
+// `/properties/ApiKeyId` (confirmed via describe-type) whose runtime form is the BARE key
+// id — identical to ListApiKeys' `id`. A declared ApiKey's CFn physical id (Ref) is the
+// ARN `arn:...:apis/<apiId>/apikey[s]/<keyId>`, so declared keys are matched by the bare
+// key id extracted from that ARN (fall back to a bare id if gather resolved it as such).
+
+// Extract the BARE ApiKeyId (the ListApiKeys / CC primaryIdentifier form) from a declared
+// AWS::AppSync::ApiKey physical id: its ARN's trailing `apikey[s]/<keyId>` segment. A bare
+// id (no `/`) passes through unchanged in case gather resolved the Ref to the bare form.
+function bareApiKeyId(physicalId: string): string {
+  return physicalId.includes('/') ? physicalId.slice(physicalId.lastIndexOf('/') + 1) : physicalId;
+}
+
+// Pure diff: declared api key ids + live inventory -> the added api keys. A declared
+// AWS::AppSync::ApiKey is matched by its bare ApiKeyId; an added key's identifier is its
+// live bare ApiKeyId (the CC primaryIdentifier).
+export interface GraphQLApiApiKeyInput {
+  declaredApiKeyIds: string[]; // bare ApiKeyIds of AWS::AppSync::ApiKey declared on this api
+  liveApiKeys: { id: string; label?: string | undefined }[];
+  // Fail-safe (#1089): a declared api key's identity (the bare ApiKeyId, parsed from its
+  // physical-id ARN) was UNRESOLVED, so it could not be matched against the live keys —
+  // suppress ALL added for this api (a `revert --remove-unrecorded` would otherwise
+  // DeleteResource a declared api key).
+  hasUnresolvedDeclaredApiKey?: boolean;
+}
+
+export function diffGraphQLApiApiKeys(input: GraphQLApiApiKeyInput): AddedChild[] {
+  if (input.hasUnresolvedDeclaredApiKey) return [];
+  const declared = new Set(input.declaredApiKeyIds);
+  const added: AddedChild[] = [];
+  for (const k of input.liveApiKeys) {
+    if (declared.has(k.id)) continue;
+    added.push({
+      resourceType: 'AWS::AppSync::ApiKey',
+      identifier: k.id, // bare ApiKeyId IS the CC primaryIdentifier
+      label: k.label ?? k.id,
+      live: { ApiKeyId: k.id },
+    });
+  }
+  return added;
+}
+
+async function pageApiKeys(client: AppSyncClient, apiId: string): Promise<AppSyncApiKey[]> {
+  const out: AppSyncApiKey[] = [];
+  let next: string | undefined;
+  do {
+    const res = await client.send(new ListApiKeysCommand({ apiId, nextToken: next }));
+    out.push(...(res.apiKeys ?? []));
+    next = res.nextToken;
+  } while (next);
+  return out;
+}
+
 // A GraphQLApi's CFn physical id is its ARN (`arn:...:apis/<apiId>`), but `ListDataSources`
 // and a DataSource's declared `ApiId` (`Fn::GetAtt ApiId`) both use the BARE api id. Take
 // the trailing `apis/<id>` segment when the physical id is an ARN; otherwise it already IS
@@ -2138,6 +2201,33 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
     declaredFunctionArns.push(r.physicalId);
   }
 
+  // Declared api keys on THIS api. An AWS::AppSync::ApiKey's CFn physical id (Ref) is the
+  // ARN `arn:...:apis/<apiId>/apikey[s]/<keyId>`, so match DECLARED keys by the BARE
+  // ApiKeyId parsed from that ARN (= the ListApiKeys / CC primaryIdentifier form). A
+  // declared ApiKey's ApiId (Ref graphQlApiId, resolved by gather) is the bare api id;
+  // tolerate an ARN form too in case gather resolved it differently.
+  const declaredApiKeyIds: string[] = [];
+  // Fail-safe: a declared api key whose IDENTITY (physical id) is UNRESOLVED can't be matched
+  // against the live keys — suppress api-key added-reporting for this api rather than
+  // false-flag every live key as `added` with a DeleteResource offer (#1089).
+  let apiKeyIdUnresolved = false;
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::AppSync::ApiKey') continue;
+    // Fail-safe: an UNRESOLVED ApiId must not exclude a declared api key (#962).
+    const declaredApiId = r.declared.ApiId;
+    if (declaredApiId !== UNRESOLVED && !hasUnresolved(declaredApiId)) {
+      if (typeof declaredApiId !== 'string' || bareApiId(declaredApiId) !== apiId) continue;
+    }
+    // The identity of a declared ApiKey is its physical id (the CFn Ref ARN, from which the
+    // bare ApiKeyId is parsed). When gather could not resolve it (dynamic ref / no-default
+    // Param / degraded ImportValue), it is absent — fail safe: suppress ALL added for this api.
+    if (!r.physicalId) {
+      apiKeyIdUnresolved = true;
+      continue;
+    }
+    declaredApiKeyIds.push(bareApiKeyId(r.physicalId));
+  }
+
   const client = new AppSyncClient({ region, ...READ_RETRY });
   const dataSources = await pageDataSources(client, apiId);
   const liveDataSources = dataSources
@@ -2186,7 +2276,20 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
     .map((f) => ({ arn: f.functionArn, label: f.name ?? f.functionArn }));
   const functionAdded = diffGraphQLApiFunctions({ declaredFunctionArns, liveFunctions });
 
-  return [...datasourceAdded, ...resolverAdded, ...functionAdded];
+  // Api keys are listed per api. A live key not matching a declared AWS::AppSync::ApiKey is
+  // an out-of-band `appsync create-api-key` (#1367). Label with the key's description when it
+  // carries one (AWS returns none/"" for an undescribed key), else the bare id.
+  const apiKeys = await pageApiKeys(client, apiId);
+  const liveApiKeys = apiKeys
+    .filter((k): k is AppSyncApiKey & { id: string } => typeof k.id === 'string')
+    .map((k) => ({ id: k.id, label: k.description ? `${k.id} (${k.description})` : k.id }));
+  const apiKeyAdded = diffGraphQLApiApiKeys({
+    declaredApiKeyIds,
+    liveApiKeys,
+    hasUnresolvedDeclaredApiKey: apiKeyIdUnresolved,
+  });
+
+  return [...datasourceAdded, ...resolverAdded, ...functionAdded, ...apiKeyAdded];
 }
 
 // ── CloudWatch Logs ────────────────────────────────────────────────────────────

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -35,6 +35,7 @@ import {
   diffEcsClusterChildren,
   diffEfsFileSystemChildren,
   diffEventBusChildren,
+  diffGraphQLApiApiKeys,
   diffGraphQLApiChildren,
   diffGraphQLApiFunctions,
   diffGraphQLApiResolvers,
@@ -1677,6 +1678,70 @@ describe('diffGraphQLApiFunctions (AppSync functions)', () => {
         liveFunctions: [{ arn: FN('a') }, { arn: FN('b') }],
       })
     ).toEqual([]);
+  });
+});
+
+// #1367: an `appsync create-api-key` mints a durable, undeclared API_KEY auth credential
+// invisible to the `added` tier (#965 covered only the DELETE direction). A live key not
+// matching a declared AWS::AppSync::ApiKey is out of band; matched by its bare ApiKeyId (the
+// CC primaryIdentifier `/properties/ApiKeyId`), which equals ListApiKeys' `id`.
+describe('diffGraphQLApiApiKeys (AppSync api keys)', () => {
+  it('flags an out-of-band api key added via the console (not in the template)', () => {
+    const added = diffGraphQLApiApiKeys({
+      declaredApiKeyIds: ['da2-declared'],
+      liveApiKeys: [
+        { id: 'da2-declared', label: 'da2-declared' },
+        { id: 'da2-console', label: 'da2-console (backdoor)' },
+      ],
+    });
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::AppSync::ApiKey',
+        identifier: 'da2-console',
+        label: 'da2-console (backdoor)',
+        live: { ApiKeyId: 'da2-console' },
+      },
+    ]);
+  });
+
+  it('identifier is the bare ApiKeyId (CC primaryIdentifier)', () => {
+    const added = diffGraphQLApiApiKeys({
+      declaredApiKeyIds: [],
+      liveApiKeys: [{ id: 'da2-x' }],
+    });
+    expect(added[0]!.identifier).toBe('da2-x');
+  });
+
+  it('no drift when every live api key is declared', () => {
+    expect(
+      diffGraphQLApiApiKeys({
+        declaredApiKeyIds: ['da2-a', 'da2-b'],
+        liveApiKeys: [{ id: 'da2-a' }, { id: 'da2-b' }],
+      })
+    ).toEqual([]);
+  });
+
+  // #1089: a declared ApiKey is matched ONLY by its bare ApiKeyId. When that identity is
+  // UNRESOLVED (its physical-id ARN could not be resolved) the enumerator raises
+  // hasUnresolvedDeclaredApiKey — the diff must FAIL SAFE (no live key flagged added, since a
+  // `revert --remove-unrecorded` would DeleteResource a declared api key).
+  it('fails safe: an UNRESOLVED declared ApiKeyId suppresses ALL added for this api (#1089)', () => {
+    expect(
+      diffGraphQLApiApiKeys({
+        declaredApiKeyIds: [], // the UNRESOLVED key never reached the list
+        liveApiKeys: [{ id: 'da2-console' }],
+        hasUnresolvedDeclaredApiKey: true,
+      })
+    ).toEqual([]);
+  });
+
+  it('with no UNRESOLVED declared api key, a genuine out-of-band key is STILL added (#1089)', () => {
+    const added = diffGraphQLApiApiKeys({
+      declaredApiKeyIds: ['da2-declared'],
+      liveApiKeys: [{ id: 'da2-declared' }, { id: 'da2-console' }],
+      hasUnresolvedDeclaredApiKey: false,
+    });
+    expect(added.map((a) => a.identifier)).toEqual(['da2-console']);
   });
 });
 


### PR DESCRIPTION
Closes #1367

## Problem

The AppSync child enumerator in CHILD_ENUMERATORS (src/read/child-enumerators.ts) enumerates DataSource, Resolver, and FunctionConfiguration under a declared AWS::AppSync::GraphQLApi, but OMITS AWS::AppSync::ApiKey. An out-of-band `appsync create-api-key` mints a durable, undeclared API_KEY auth credential that is invisible to the `added` tier — a false negative. #965 covered only the DELETE direction of an api key; the ADD direction was uncovered.

## Fix

Add an AWS::AppSync::ApiKey child enumerator under AWS::AppSync::GraphQLApi, mirroring the existing DataSource/Resolver/Function shape exactly (pagination via ListApiKeys nextToken, the #1089 fail-safe on an UNRESOLVED declared identity, the #962 fail-safe on an UNRESOLVED parent ApiId):

- `pageApiKeys` — paginates appsync:ListApiKeys for the api id (apiKeys[].id).
- `diffGraphQLApiApiKeys` — pure diff, matches declared keys by bare ApiKeyId, emits each out-of-band key with resourceType AWS::AppSync::ApiKey and identifier = the bare key id.
- `bareApiKeyId` — extracts the bare ApiKeyId from a declared ApiKey's CFn physical-id ARN (arn:...:apis/<apiId>/apikey[s]/<keyId>); the Ref for AWS::AppSync::ApiKey returns that ARN.

### CC primaryIdentifier

Confirmed via describe-type AWS::AppSync::ApiKey: the primaryIdentifier is the SINGLE /properties/ApiKeyId, whose runtime form is the BARE key id — identical to ListApiKeys id. So the added-tier identifier (which feeds the CC DeleteResource revert) is the bare key id.

### FP check: no auto-created default key

AppSync does NOT auto-materialize a default API key for a bare API_KEY-auth GraphQLApi. A key exists ONLY via CreateApiKey (console/CLI) or a declared AWS::AppSync::ApiKey (the CDK GraphqlApi construct's auto-key IS a declared CfnApiKey in the template, so it is matched in the declared set). Confirmed from the CFn resource reference (ApiKey is a separate resource created explicitly) and the existing readAppSyncApiKey override. Therefore a live key not matching a declared one is genuinely out of band and needs no built-in default filter (unlike the RestApi Empty/Error models or the V2 quick-create $default stage).

## Tests

tests/child-enumerators.test.ts — new diffGraphQLApiApiKeys describe block mirroring the DataSource/Resolver/Function pattern: an out-of-band key surfaces as an AWS::AppSync::ApiKey added child; a declared key is excluded; identifier is the bare ApiKeyId; the #1089 fail-safe suppresses all added when a declared identity is UNRESOLVED.

## Gates

typecheck / vp check (0 errors) / build / 4635 unit tests — all green.

## IAM note

appsync:ListApiKeys is already enumerated in the README IAM section (the AWS::AppSync::ApiKey reader override uses it), so no NEW permission is required. The GraphQLApi child-enumerator sub-list in the README could add appsync:ListApiKeys for completeness (README was out of scope for this PR).
