### PR TITLE
fix(diff): EIP self-declared InstanceId/NetworkInterfaceId folds reflected NetworkInterfaceId (#1261)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1939,11 +1939,20 @@ export function classifyResource(
   // explains is an out-of-band `associate-address` HIJACK of the allocated static IP (#892), which
   // the old blanket value-independent fold silenced. `NetworkInterfaceId` is only ever present when
   // an association exists (an unassociated EIP has no such key), so no fold is needed when absent.
+  // The association can also be SELF-declared on THIS same EIP: a classic `new ec2.CfnEIP({ instanceId })`
+  // (or a declared `NetworkInterfaceId`) binds the address to a target, and AWS reflects that target's
+  // primary ENI onto the live `NetworkInterfaceId` with NO sibling to explain it (#1261). That
+  // reflected id is IaC intent too, so fold it when the EIP declares its own `InstanceId` or
+  // `NetworkInterfaceId` — an out-of-band re-associate still surfaces because the declared
+  // `InstanceId`/`NetworkInterfaceId` would then mismatch in the declared loop (detection preserved).
   if (resourceType === 'AWS::EC2::EIP' && 'NetworkInterfaceId' in live) {
     const explained =
       (physicalId !== undefined && opts.siblingEipAssociations?.has(physicalId)) ||
       opts.siblingEipAssociations?.has(logicalId);
-    if (explained) delete live.NetworkInterfaceId;
+    const declaresTarget = (v: unknown): boolean => v !== undefined && v !== null && v !== '';
+    const selfDeclared =
+      declaresTarget(declared.InstanceId) || declaresTarget(declared.NetworkInterfaceId);
+    if (explained || selfDeclared) delete live.NetworkInterfaceId;
   }
   // A bucket whose notifications are managed by a Custom::S3BucketNotifications CR reflects
   // the CR-applied NotificationConfiguration it never declares itself (CDK renders

--- a/tests/classify-eip-associate-892.test.ts
+++ b/tests/classify-eip-associate-892.test.ts
@@ -127,4 +127,51 @@ describe('#892 EIP NetworkInterfaceId sibling-derived association gate', () => {
     });
     expect(findings.some((f) => f.path === 'NetworkInterfaceId')).toBe(false);
   });
+
+  // #1261 (self-declared-target FN): #892's sibling gate misses the classic
+  // `new ec2.CfnEIP({ instanceId })` (or a declared NetworkInterfaceId) that binds the address on
+  // the EIP itself — NO sibling EIPAssociation / NatGateway exists, yet AWS reflects the target's
+  // primary ENI onto the live NetworkInterfaceId, so the empty sibling set surfaced it as a
+  // first-run FALSE POSITIVE (these EIPs folded pre-#892). The EIP's OWN declared InstanceId /
+  // NetworkInterfaceId is a self-explained association → fold.
+  it('(4) a self-declared InstanceId FOLDS the reflected NetworkInterfaceId (no sibling)', () => {
+    const eipWithInstance: DesiredResource = {
+      logicalId: 'Ip',
+      resourceType: 'AWS::EC2::EIP',
+      physicalId: '52.4.97.166',
+      declared: { Domain: 'vpc', InstanceId: 'i-0abc123def456789a' },
+    };
+    const findings = classifyResource(eipWithInstance, associatedLive(), eipSchema, {
+      siblingEipAssociations: new Set<string>(),
+    });
+    expect(findings.some((f) => f.path === 'NetworkInterfaceId')).toBe(false);
+    expect(niiFindings(findings, 'undeclared')).toEqual([]);
+    expect(niiFindings(findings, 'atDefault')).toEqual([]);
+  });
+
+  it('(4b) a self-declared NetworkInterfaceId FOLDS the reflected NetworkInterfaceId (no sibling)', () => {
+    const eipWithEni: DesiredResource = {
+      logicalId: 'Ip',
+      resourceType: 'AWS::EC2::EIP',
+      physicalId: '52.4.97.166',
+      declared: { Domain: 'vpc', NetworkInterfaceId: 'eni-0f1c51db64ee88129' },
+    };
+    const findings = classifyResource(eipWithEni, associatedLive(), eipSchema, {
+      siblingEipAssociations: new Set<string>(),
+    });
+    // Declared == live here, so it must not surface as undeclared drift either.
+    expect(niiFindings(findings, 'undeclared')).toEqual([]);
+    expect(niiFindings(findings, 'atDefault')).toEqual([]);
+  });
+
+  it('(4c) CONTROL: no self-declared target and no sibling → NetworkInterfaceId still SURFACES', () => {
+    // Unchanged #892 behavior: an association neither a sibling nor the EIP itself declares is a
+    // genuine out-of-band hijack and must remain visible.
+    const findings = classifyResource(eipResource, associatedLive(), eipSchema, {
+      siblingEipAssociations: new Set<string>(),
+    });
+    const surfaced = niiFindings(findings, 'undeclared');
+    expect(surfaced.length).toBe(1);
+    expect(surfaced[0]?.actual).toBe('eni-0f1c51db64ee88129');
+  });
 });


### PR DESCRIPTION
Closes #1261

## Problem
#892 replaced the blanket value-independent fold of `AWS::EC2::EIP.NetworkInterfaceId` with a sibling-derived gate: the reflected live ENI id folds only when a declared sibling `AWS::EC2::EIPAssociation` or `AWS::EC2::NatGateway` explains the association.

But an EIP can bind an address via its OWN declared `InstanceId` (classic `new ec2.CfnEIP({ instanceId })`) or its own `NetworkInterfaceId`, with NO sibling. AWS reflects the target's primary ENI onto the live `NetworkInterfaceId`, the sibling set is empty, and classify surfaced `NetworkInterfaceId` as undeclared [Potential Drift] on a clean first check — a first-run FALSE POSITIVE that #892 introduced (these EIPs folded pre-#892). Violates the core invariant (a clean deploy must have ZERO potential drift).

## Fix (tier-2 self-derived)
In `src/diff/classify.ts`, at the #892 EIP gate, ALSO treat the EIP's OWN declared `InstanceId` or `NetworkInterfaceId` (a non-empty value) as a self-explained association — drop the reflected live `NetworkInterfaceId` when either is declared on this same EIP.

Detection preserved: an out-of-band re-associate still surfaces because the declared `InstanceId`/`NetworkInterfaceId` then mismatches in the declared loop. Distinct from #892's sibling-explained case.

## Tests
Added to `tests/classify-eip-associate-892.test.ts`:
- (4) self-declared `InstanceId` (empty sibling set) → `NetworkInterfaceId` folds (FAILS without the fix).
- (4b) self-declared `NetworkInterfaceId` folds.
- (4c) CONTROL: no self-declared target and no sibling → `NetworkInterfaceId` still surfaces (unchanged #892 behavior).

## Gates
typecheck / vp check --fix / vp run check (0 errors) / vp pack / vp test run (4633 passed) all green. #892 sibling-case tests unchanged and passing. gather.ts NOT touched.

Files changed: `src/diff/classify.ts`, `tests/classify-eip-associate-892.test.ts`.