### PR TITLE
fix(baseline): baselineValueMatches preserves free-form-map ancestry so managed-named USER keys aren't stripped (#1267)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -775,10 +775,18 @@ export function carryForwardIgnored(
 // `canonicalizeBaselineForCompare` for which strips are (and are not) covered. `resourceType`
 // is optional: every call site has the recorded entry's / finding's type available and passes
 // it, but a type-less call stays correct (the type only tightens WAF/order-significant folds).
+// #1267: `path` (the entry's / finding's dotted property path) is threaded through so
+// `canonicalizeBaselineForCompare` can seed the AWS-managed-field strip's free-form flag
+// when a path segment is a free-form-map parent (UserPoolTags / Environment.Variables /
+// …). Without it, a recorded map fragment's USER key that collides with a managed-field
+// name (`CreatedBy`, …) is stripped from BOTH sides, hiding a real out-of-band change (an
+// FN). Every call site has the entry/finding path at hand and passes it; a path-less call
+// stays the pre-#1267 behavior (seed false), so no existing caller changes.
 export function baselineValueMatches(
   baselineValue: unknown,
   currentCanonicalValue: unknown,
-  resourceType?: string
+  resourceType?: string,
+  path?: string
 ): boolean {
   // #798 persistence half: a secret-bearing baseline value is a HASH SENTINEL (record stored
   // the hash of the canonicalized live value, never the plaintext). When either side is a
@@ -790,13 +798,13 @@ export function baselineValueMatches(
   if (isRedactedHashSentinel(baselineValue) || isRedactedHashSentinel(currentCanonicalValue)) {
     const asHash = (v: unknown): string =>
       redactedHashOf(
-        isRedactedHashSentinel(v) ? v : canonicalizeBaselineForCompare(v, resourceType)
+        isRedactedHashSentinel(v) ? v : canonicalizeBaselineForCompare(v, resourceType, path)
       );
     return asHash(baselineValue) === asHash(currentCanonicalValue);
   }
   return deepEqual(
-    canonicalizeBaselineForCompare(baselineValue, resourceType),
-    canonicalizeBaselineForCompare(currentCanonicalValue, resourceType)
+    canonicalizeBaselineForCompare(baselineValue, resourceType, path),
+    canonicalizeBaselineForCompare(currentCanonicalValue, resourceType, path)
   );
 }
 
@@ -892,7 +900,10 @@ export function splitRecordedByBaseline(
         a.path === entry.path &&
         a.resourceType === entry.resourceType
     );
-    if (baselineEntry && baselineValueMatches(baselineEntry.value, entry.value, entry.resourceType))
+    if (
+      baselineEntry &&
+      baselineValueMatches(baselineEntry.value, entry.value, entry.resourceType, entry.path)
+    )
       unchanged.push(entry);
     else changed.push(entry);
   }
@@ -1223,7 +1234,7 @@ export function applyBaseline(
         kept.push({ ...f, unrecorded: true });
         continue;
       }
-      if (entry && baselineValueMatches(entry.value, f.actual, f.resourceType)) continue; // recorded, unchanged
+      if (entry && baselineValueMatches(entry.value, f.actual, f.resourceType, f.path)) continue; // recorded, unchanged
       if (entry) {
         kept.push({
           ...f,
@@ -1257,7 +1268,7 @@ export function applyBaseline(
     // (f.actual is already canonical from classify): a baseline recorded under older
     // normalization rules still matches today's live, so a cdkrd version bump alone
     // never resurfaces a suppressed value as false drift.
-    if (entry && baselineValueMatches(entry.value, f.actual, f.resourceType)) continue; // recorded, unchanged
+    if (entry && baselineValueMatches(entry.value, f.actual, f.resourceType, f.path)) continue; // recorded, unchanged
     if (entry) {
       // recorded value CHANGED -> drift. This takes PRIORITY over the at-default fold
       // below: a recorded NON-default value reset out of band to the AWS default is a

--- a/src/normalize/cc-api-strip.ts
+++ b/src/normalize/cc-api-strip.ts
@@ -90,10 +90,20 @@ export const TAG_PROPERTY_NAMES: ReadonlySet<string> = new Set([
   'TestAliasTags', // AWS::Bedrock::Agent / AWS::Bedrock::Flow secondary (map)
 ]);
 
+// `freeFormSeed` seeds the strip walk's free-form flag at the ROOT of `awsProps`.
+// Normally `false` (the top-level live model root is never itself free-form user data),
+// but the BASELINE compare (#1267) passes a bare undeclared FRAGMENT whose root IS the
+// content of a free-form map (a recorded `UserPoolTags` / `Environment.Variables` value):
+// there is no ancestor key left in the fragment for `FREE_FORM_MAP_PARENTS` to match, so
+// the caller — which still knows the entry's dotted PATH — seeds `true` to restore the
+// same protection the full-model live walk gets from seeing the parent key. A user key
+// colliding with a managed-field name (`CreatedBy`, `OwnerId`, an #1251 timestamp variant)
+// then survives on both compare sides, so an out-of-band change to it still surfaces.
 export function stripCcApiAwsManagedFields(
-  awsProps: Record<string, unknown>
+  awsProps: Record<string, unknown>,
+  freeFormSeed = false
 ): Record<string, unknown> {
-  return stripWalk(awsProps, false) as Record<string, unknown>;
+  return stripWalk(awsProps, freeFormSeed) as Record<string, unknown>;
 }
 
 // `freeForm` = this subtree lives under a free-form USER map (Lambda env Variables, Glue

--- a/src/normalize/pipeline.ts
+++ b/src/normalize/pipeline.ts
@@ -10,7 +10,7 @@
 // lists (unordered set -> sorted by Key), then AWS-id arrays (unordered set ->
 // sorted). It does NOT strip AWS-managed fields / aws:* tags / schema paths — those
 // are live-only concerns the caller applies before this.
-import { stripCcApiAwsManagedFields } from './cc-api-strip.js';
+import { FREE_FORM_MAP_PARENTS, stripCcApiAwsManagedFields } from './cc-api-strip.js';
 import {
   canonicalizeIdArraysDeep,
   canonicalizeIpv6CidrsDeep,
@@ -84,7 +84,37 @@ function sortObjectArraysDeep(v: unknown): unknown {
 // model-root-less compare cannot supply. In practice those two already ran on both sides at
 // record/read time via `normalizeLiveModel` (the recorded value came from a normalized model),
 // so only a NEW schema readOnly/writeOnly path added in a later version is left uncovered.
-export function canonicalizeBaselineForCompare(v: unknown, resourceType?: string): unknown {
-  const stripped = stripAwsTagsDeep(stripCcApiAwsManagedFields(v as Record<string, unknown>));
+//
+// #1267: a stored baseline value is a bare FRAGMENT rooted AT its entry path — it has no
+// ancestor keys left, so the strip walk (which normally engages free-form protection on
+// SEEING a `FREE_FORM_MAP_PARENTS` parent key) never protects a fragment whose root IS the
+// map content. A recorded undeclared free-form-map value (`UserPoolTags`,
+// `Environment.Variables`, `Parameters`, `DockerLabels`, map `Tags`, …) containing a USER
+// key that collides with a managed-field name (`CreatedBy`, `OwnerId`, an #1251 timestamp
+// variant) then has that key stripped from BOTH compare sides, so an out-of-band change /
+// add / remove of it can never surface (an FN #1205 introduced). The caller passes the
+// entry's dotted `path`; if ANY of its segments is a free-form-map parent, the fragment
+// content is user data, so seed the walk `freeForm=true` — mirroring the protection the
+// full-model live walk gets from seeing that same parent key. `path` is optional: a
+// path-less call stays the pre-#1267 behavior (seed false), keeping every non-free-form
+// caller identical (so the #766/#1205 managed-field strip is preserved).
+function seedFreeFormFromPath(path: string | undefined): boolean {
+  if (!path) return false;
+  const segments = path
+    .replace(/\[([^\]]*)\]/g, '.$1')
+    .split('.')
+    .filter((s) => s.length > 0);
+  return segments.some((s) => FREE_FORM_MAP_PARENTS.has(s));
+}
+
+export function canonicalizeBaselineForCompare(
+  v: unknown,
+  resourceType?: string,
+  path?: string
+): unknown {
+  const freeFormSeed = seedFreeFormFromPath(path);
+  const stripped = stripAwsTagsDeep(
+    stripCcApiAwsManagedFields(v as Record<string, unknown>, freeFormSeed)
+  );
   return sortObjectArraysDeep(canonicalizeForCompare(stripped, resourceType));
 }

--- a/tests/baseline-restrip-1267.test.ts
+++ b/tests/baseline-restrip-1267.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { baselineValueMatches } from '../src/baseline/baseline-file.js';
+
+// #1267 (an FN regression introduced by #1205): `baselineValueMatches` re-applies
+// `stripCcApiAwsManagedFields` to BOTH compare sides via `canonicalizeBaselineForCompare`.
+// But a stored baseline value is a bare FRAGMENT rooted AT its entry path, so the strip
+// walk starts with `freeForm=false` and the `FREE_FORM_MAP_PARENTS` protection (which
+// engages on SEEING the parent key — UserPoolTags, Environment.Variables, Parameters,
+// DockerLabels, map Tags, …) never fires for a fragment whose root IS the map content. A
+// recorded undeclared free-form-map fragment holding a USER key that collides with an
+// AWS-managed-field name (`CreatedBy`, `OwnerId`, an #1251 MANAGED_TIMESTAMP_NAME variant)
+// then has that key deleted from BOTH sides → an out-of-band change / add / remove of it can
+// never surface. The fix threads the entry `path` into `baselineValueMatches` and seeds the
+// strip walk `freeForm=true` when a path segment is a free-form-map parent, mirroring #807's
+// ancestry restoration. Without the fix these change-detection cases return `true` (FN).
+describe('#1267 baselineValueMatches preserves free-form-map ancestry (managed-named user keys not stripped)', () => {
+  it('(FN) detects an out-of-band change to a UserPoolTags user key colliding with a managed name', () => {
+    // The recorded fragment IS the content of a Cognito UserPool's UserPoolTags map.
+    const recorded = { CreatedBy: 'alice', Team: 'platform' };
+    // Out of band, someone changed the user tag `CreatedBy` from alice -> mallory.
+    const live = { CreatedBy: 'mallory', Team: 'platform' };
+    // WITHOUT the fix: `CreatedBy` is stripped from both sides (it collides with the managed
+    // `CreatedBy` field name), so the fragments compare EQUAL and the drift is hidden (FN).
+    // WITH the fix: the `UserPoolTags` path segment seeds free-form, `CreatedBy` survives on
+    // both sides, and the change surfaces.
+    expect(baselineValueMatches(recorded, live, 'AWS::Cognito::UserPool', 'UserPoolTags')).toBe(
+      false
+    );
+  });
+
+  it('(FN) detects an out-of-band change to a Lambda Environment.Variables user key', () => {
+    const recorded = { OwnerId: '111', LOG_LEVEL: 'info' };
+    const live = { OwnerId: '222', LOG_LEVEL: 'info' };
+    expect(
+      baselineValueMatches(recorded, live, 'AWS::Lambda::Function', 'Environment.Variables')
+    ).toBe(false);
+  });
+
+  it('(FN) detects an out-of-band ADD of a managed-named user key under a free-form map', () => {
+    const recorded = { Team: 'platform' };
+    const live = { Team: 'platform', UpdatedAt: 'someone-set-this' };
+    expect(baselineValueMatches(recorded, live, 'AWS::Cognito::UserPool', 'UserPoolTags')).toBe(
+      false
+    );
+  });
+
+  it('(FN) detects an out-of-band REMOVE of a managed-named user key under a free-form map', () => {
+    const recorded = { CreatedBy: 'alice', Team: 'platform' };
+    const live = { Team: 'platform' };
+    expect(baselineValueMatches(recorded, live, 'AWS::Cognito::UserPool', 'UserPoolTags')).toBe(
+      false
+    );
+  });
+
+  it('an UNCHANGED free-form-map fragment still compares equal (reflexive, no false drift)', () => {
+    const v = { CreatedBy: 'alice', Team: 'platform', UpdatedAt: '2024-01-01' };
+    expect(baselineValueMatches(v, v, 'AWS::Cognito::UserPool', 'UserPoolTags')).toBe(true);
+  });
+
+  // POSITIVE CONTROL — must NOT regress #766/#1205: a genuine AWS-managed field at a
+  // NON-free-form path is still stripped, so a baseline recorded WITH the managed echo
+  // matches the freshly-stripped live value (a pure cdkrd upgrade never resurfaces it).
+  it('(#766/#1205 preserved) a managed field at a NON-free-form path is still stripped', () => {
+    // Recorded under an older cdkrd that kept the raw managed echoes at the model root.
+    const recordedOldShape = {
+      Runtime: 'nodejs20.x',
+      LastModified: '2024-01-01T00:00:00Z',
+      RevisionId: 'abc-123',
+    };
+    // Today's live value: classify strips those managed fields before f.actual — a DIFFERENT
+    // managed value proves the field is genuinely ignored (stripped), not compared.
+    const liveStripped = { Runtime: 'nodejs20.x' };
+    // No free-form-map segment in the path -> seed stays false -> managed strip runs, matches.
+    expect(
+      baselineValueMatches(recordedOldShape, liveStripped, 'AWS::Lambda::Function', 'Runtime')
+    ).toBe(true);
+  });
+
+  it('(#766/#1205 preserved) a managed field is still stripped when NO path is passed', () => {
+    const recordedOldShape = { Runtime: 'nodejs20.x', LastModified: '2024-01-01T00:00:00Z' };
+    const liveStripped = { Runtime: 'nodejs20.x' };
+    expect(baselineValueMatches(recordedOldShape, liveStripped, 'AWS::Lambda::Function')).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
Closes #1267

## The bug (FN regression introduced by #1205)

`baselineValueMatches` re-applies `stripCcApiAwsManagedFields` + `stripAwsTagsDeep` to BOTH compare sides via `canonicalizeBaselineForCompare`. But a stored baseline value is a bare **fragment** rooted AT its entry path: the strip walk starts with `freeForm=false`, so `FREE_FORM_MAP_PARENTS` protection (which engages on *seeing* the parent key — `UserPoolTags`, `Environment.Variables`, `Parameters`, `DockerLabels`, map `Tags`, …) never fires for a fragment whose root IS the map content.

A recorded undeclared free-form-map fragment holding a USER key that collides with a managed-field name (`CreatedBy`, `OwnerId`, an #1251 `MANAGED_TIMESTAMP_NAME` variant) had that key deleted from **both** sides → an out-of-band change / add / remove of it could never surface (FN). Pre-#1205 it correctly surfaced as "changed since record".

## The fix (mirrors #807's ancestry restoration)

Thread the entry `path` into `baselineValueMatches` → `canonicalizeBaselineForCompare`, and seed the strip walk `freeForm=true` when any path segment is a `FREE_FORM_MAP_PARENTS` key. All 3 production call sites pass the entry/finding `path`. A path-less call keeps the pre-#1267 behavior (seed `false`), so no existing caller changes and the #766/#1205 managed-field strip is preserved.

## Tests

`tests/baseline-restrip-1267.test.ts`: the `CreatedBy` change/add/remove cases now return `false` (drift detected) under a free-form path — these FAIL without the fix. Positive controls confirm a managed field at a NON-free-form path (and with no path) is still stripped, so #766/#1205 is not re-opened. Full suite green (4637 tests); baseline-recanon-766 / reflexive-767 / reflexive-807 / redact-798 all pass.