### PR TITLE
fix(schema): top-level variant-wrapped default folds via defaultPaths in classify (#1328)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -3593,6 +3593,15 @@ export function classifyResource(
     // the default no longer matches here and falls through to the `undeclared` tier.
     if (
       (k in schema.defaults && matchesKnownDefault(v, schema.defaults[k])) ||
+      // The authoritative top-level default source: `collectDefaultPaths` records the
+      // annotated `default` for EVERY top-level property keyed by its bare name — direct,
+      // `$ref`'d, AND variant-wrapped (`allOf`/`oneOf`/`anyOf`) shapes uniformly. `schema.defaults`
+      // is populated only via `resolveRefNode`, which does not descend variant branches, so a
+      // variant-wrapped default (e.g. BedrockAgentCore Gateway `ProtocolType` written as
+      // `allOf: [ { $ref }, { default: "MCP" } ]`) is absent from `schema.defaults` yet present
+      // in `defaultPaths`. Consult it here too, still equality-gated (a value CHANGED away from
+      // the default falls through to `undeclared` — out-of-band detection preserved) (#1328).
+      (k in schema.defaultPaths && matchesKnownDefault(v, schema.defaultPaths[k])) ||
       (k in knownDef && matchesKnownDefault(v, knownDef[k])) ||
       // A live value equal to ONE OF several stable-constant AWS defaults for this key (e.g.
       // an ApiGatewayV2 Integration's protocol-specific TimeoutInMillis, 29000 for WebSocket

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -272,11 +272,18 @@ async function fetch(client: CloudFormationClient, resourceType: string): Promis
 // (guarding a circular / unresolvable ref → undefined). A node with no `$ref` is
 // returned as-is. Used to reach a top-level property's annotated `default` when the
 // property is written as a bare `$ref` to a definition that carries it (#1068).
+// A property may also wrap its `default` in a TRANSPARENT variant branch —
+// `"allOf": [ { "$ref": … }, { "default": "MCP" } ]` (BedrockAgentCore Gateway
+// `ProtocolType`) — so if the resolved node carries no `default` of its own, descend
+// its `oneOf`/`anyOf`/`allOf` branches (each resolved through the same $ref chain) and
+// return the first branch that carries a `default`. Non-variant schemas keep their exact
+// prior behavior (no variant branches → the resolved node is returned unchanged) (#1328).
 function resolveRefNode(
   node: SchemaNode | undefined,
-  definitions: Record<string, SchemaNode>
+  definitions: Record<string, SchemaNode>,
+  depth = 0
 ): SchemaNode | undefined {
-  if (!node || typeof node !== 'object') return undefined;
+  if (!node || typeof node !== 'object' || depth > MAX_VARIANT_DEPTH) return undefined;
   let n: SchemaNode | undefined = node;
   const seen = new Set<string>();
   while (n?.$ref) {
@@ -284,6 +291,12 @@ function resolveRefNode(
     if (seen.has(name)) return undefined; // circular — unresolvable
     seen.add(name);
     n = definitions[name];
+  }
+  if (n && !('default' in n)) {
+    for (const branch of variantBranches(n)) {
+      const resolved = resolveRefNode(branch, definitions, depth + 1);
+      if (resolved && 'default' in resolved) return resolved;
+    }
   }
   return n;
 }

--- a/tests/schema-variant-default-1328.test.ts
+++ b/tests/schema-variant-default-1328.test.ts
@@ -1,0 +1,71 @@
+// #1328 — a variant-WRAPPED top-level default (a property written as
+// `"allOf": [ { "$ref": … }, { "default": "MCP" } ]`, e.g. an
+// AWS::BedrockAgentCore::Gateway `ProtocolType`) must fold to atDefault on a clean
+// first check, not surface as a first-run [Potential Drift] false positive.
+//
+// `collectDefaultPaths` already records the wrapped default under `schema.defaultPaths`
+// (it descends variant branches), but the top-level undeclared fold in classify only
+// consulted `schema.defaults` — which is built via `resolveRefNode` and, before this fix,
+// did not descend variant branches, so it stayed absent for this shape. The fix teaches
+// the fold to ALSO match `schema.defaultPaths[k]` (the authoritative per-top-level-key
+// source) and, defense-in-depth, teaches `resolveRefNode` to descend variant branches so
+// `schema.defaults` picks the wrapped default up too. Both stay EQUALITY-GATED: a value
+// CHANGED away from the default still surfaces (out-of-band detection preserved).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { parseSchema } from '../src/schema/schema-strip.js';
+import type { DesiredResource, Finding } from '../src/types.js';
+
+// The real BedrockAgentCore Gateway shape: ProtocolType is a variant wrapper carrying the
+// annotated default, so `schema.defaults` (pre-fix) missed it while `defaultPaths` had it.
+const GATEWAY_SCHEMA_JSON = JSON.stringify({
+  typeName: 'AWS::BedrockAgentCore::Gateway',
+  properties: {
+    Name: { type: 'string' },
+    ProtocolType: {
+      allOf: [{ $ref: '#/definitions/GatewayProtocolType' }, { default: 'MCP' }],
+    },
+  },
+  definitions: {
+    GatewayProtocolType: { type: 'string', enum: ['MCP'] },
+  },
+});
+
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Gateway',
+  resourceType: 'AWS::BedrockAgentCore::Gateway',
+  physicalId: 'test-gateway',
+  declared,
+});
+
+describe('#1328 variant-wrapped top-level default folds via defaultPaths', () => {
+  it('parseSchema records the allOf-wrapped default under defaultPaths (and defaults)', () => {
+    const info = parseSchema(GATEWAY_SCHEMA_JSON);
+    // The authoritative source — always populated for a top-level key.
+    expect(info.defaultPaths.ProtocolType).toBe('MCP');
+    // Defense-in-depth: resolveRefNode now descends the allOf branch, so `defaults` has it too.
+    expect(info.defaults.ProtocolType).toBe('MCP');
+  });
+
+  it('does NOT surface an undeclared ProtocolType equal to the schema default (folds atDefault)', () => {
+    const schema = parseSchema(GATEWAY_SCHEMA_JSON);
+    const res = mk({ Name: 'my-gw' }); // ProtocolType OMITTED (undeclared)
+    const f = classifyResource(res, { Name: 'my-gw', ProtocolType: 'MCP' }, schema, {});
+    expect(tier(f, 'atDefault')).toContain('ProtocolType');
+    expect(tier(f, 'undeclared')).not.toContain('ProtocolType');
+  });
+
+  it('STILL surfaces an out-of-band ProtocolType away from the default — detection preserved', () => {
+    const schema = parseSchema(GATEWAY_SCHEMA_JSON);
+    const res = mk({ Name: 'my-gw' }); // ProtocolType OMITTED (undeclared)
+    const f = classifyResource(res, { Name: 'my-gw', ProtocolType: 'SOMETHING_ELSE' }, schema, {});
+    expect(tier(f, 'undeclared')).toContain('ProtocolType');
+    expect(tier(f, 'atDefault')).not.toContain('ProtocolType');
+  });
+});


### PR DESCRIPTION
Closes #1328

## The bug (first-run false positive)

A freshly deployed `AWS::BedrockAgentCore::Gateway` that does NOT declare `ProtocolType` reads back the schema's own annotated default (`MCP`) and surfaced it as `[Potential Drift]` on the first `check`, violating the core invariant (a clean deploy must have ZERO potential drift).

The schema writes the property as a variant wrapper:

    "ProtocolType": { "allOf": [ { "$ref": "#/definitions/GatewayProtocolType" }, { "default": "MCP" } ] }

Root cause: (1) `resolveRefNode` did not descend variant branches, so `schema.defaults` stayed empty for this shape; and (2) the top-level undeclared fold in `classify.ts` checked `schema.defaults` but never consulted `schema.defaultPaths[k]`, even though `collectDefaultPaths` correctly recorded `defaultPaths.ProtocolType === "MCP"`.

## Fix (tier-1, equality-gated)

1. **Primary** — the top-level undeclared fold now ALSO matches against `schema.defaultPaths[k]`, the authoritative per-top-level-key default source (populated uniformly for direct, `$ref`'d, AND variant-wrapped defaults). Still equality-gated: a value CHANGED away from the default falls through to `undeclared`, so out-of-band detection is preserved.
2. **Defense-in-depth** — `resolveRefNode` now descends `allOf`/`oneOf`/`anyOf` branches to find a wrapped `default`, so `schema.defaults` picks it up too. Non-variant schemas keep their exact prior behavior.

## Test

New `tests/schema-variant-default-1328.test.ts`: builds the real BedrockAgentCore Gateway shape, asserts `parseSchema` records `defaultPaths.ProtocolType === "MCP"`, asserts an undeclared `ProtocolType: "MCP"` folds to `atDefault` (no potential drift), and a control asserting `ProtocolType: "SOMETHING_ELSE"` still surfaces as `undeclared` (detection preserved). Fails without the fix (2/3), passes with it.

## Gates

- `vp run typecheck` pass
- `vp check --fix` / `vp run check` pass (0 errors)
- `vp pack` pass
- `vp test run` pass (192 files, 4656 tests, incl. the #1068/#1069 schema tests)
