### PR TITLE
fix(record): redact + terminal-sanitize the record picker changed-value preview (#1302)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -31,6 +31,8 @@ import {
   ignoreRuleFor,
 } from '../config/config-file.js';
 import { withinStackPath } from '../construct-path.js';
+import { sanitizeForTerminal } from '../report/report.js';
+import { redactValue } from '../report/redact.js';
 import { style } from '../report/style.js';
 import { bulkMultiselect } from './bulk-multiselect.js';
 import { CLIENT_TIMEOUTS } from '../read/client-config.js';
@@ -207,15 +209,30 @@ export function recordDropMessage(stackName: string, region: string): string {
  * so a `changed since record` row can show `recorded → live` and the user can see WHAT they
  * are blessing (instead of a bare `Res.Path`). JSON-encoded (scalars stay bare-ish), then
  * truncated to keep the multiselect row on one line. Pure + exported for unit tests.
+ *
+ * #1302: this row prints straight to an interactive terminal (the clack multiselect), so it
+ * needs the two hardening layers the report path applies to displayed VALUES:
+ *   (a) REDACTION — a secret-bearing path (Lambda/CodeBuild env var, the #798/#1234 masked
+ *       set) must not print its recorded/rotated plaintext into the terminal; mask it via the
+ *       same `redactValue(resourceType, path, v)` the text + --json renderers use, BEFORE
+ *       truncation.
+ *   (b) TERMINAL SANITIZING — a live string is charset-permissive and could carry `\r` / ESC
+ *       sequences (the #829 injection class); report.ts values are C0-safe only because they
+ *       route through `JSON.stringify`. Here a string was returned verbatim, so route EVERY
+ *       displayed form (string AND JSON-encoded) through `sanitizeForTerminal`.
+ * DISPLAY-ONLY — the recorded value itself is unchanged; only what the picker prints is masked
+ * and sanitized.
  */
-export function previewValue(v: unknown, max = 40): string {
+export function previewValue(resourceType: string, path: string, v: unknown, max = 40): string {
+  const masked = redactValue(resourceType, path, v);
   let s: string;
   try {
-    s = typeof v === 'string' ? v : JSON.stringify(v);
+    s = typeof masked === 'string' ? masked : JSON.stringify(masked);
   } catch {
-    s = String(v);
+    s = String(masked);
   }
-  if (s === undefined) s = String(v); // JSON.stringify(undefined) === undefined
+  if (s === undefined) s = String(masked); // JSON.stringify(undefined) === undefined
+  s = sanitizeForTerminal(s);
   return s.length > max ? `${s.slice(0, max - 1)}…` : s;
 }
 
@@ -227,14 +244,18 @@ export function previewValue(v: unknown, max = 40): string {
  * value under a bare label. Pure + exported for unit tests.
  */
 export function changedRecordLabel(
-  entry: { logicalId: string; path: string; value: unknown },
+  entry: { logicalId: string; path: string; value: unknown; resourceType: string },
   recordedValue: { hasRecorded: boolean; recordedValue: unknown }
 ): string {
   const id = entry.path
     ? `${entry.logicalId}.${entry.path}`
     : `${entry.logicalId} (added resource)`;
   if (!recordedValue.hasRecorded) return id; // genuinely NEW path — plain row
-  return `${id} (changed since record: ${previewValue(recordedValue.recordedValue)} → ${previewValue(entry.value)})`;
+  // #1302: thread the finding's resourceType + path so the preview can redact a secret-bearing
+  // path and sanitize control chars — both the recorded and live sides.
+  const recorded = previewValue(entry.resourceType, entry.path, recordedValue.recordedValue);
+  const live = previewValue(entry.resourceType, entry.path, entry.value);
+  return `${id} (changed since record: ${recorded} → ${live})`;
 }
 
 /**

--- a/tests/picker-redact-1302.test.ts
+++ b/tests/picker-redact-1302.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { changedRecordLabel, previewValue } from '../src/commands/stack-actions.js';
+
+// #1302 — the record interactive multiselect row for a value CHANGED since record
+// (`changedRecordLabel` / `previewValue`, src/commands/stack-actions.ts) prints straight to
+// the terminal. It was missing the two hardening layers the report path applies to displayed
+// VALUES:
+//   1. NO REDACTION — a secret-bearing path (a Lambda/CodeBuild env var, the #798/#1234 masked
+//      set) printed both the recorded and the rotated live secret in PLAINTEXT.
+//   2. NO TERMINAL SANITIZING — a live STRING was returned verbatim, so a hostile value
+//      carrying `\r` / ESC sequences (#829 class) was emitted raw inside the clack prompt.
+// The fix routes every displayed value through `redactValue` (masking) AND `sanitizeForTerminal`
+// (C0/ESC escaping), matching the report path. It is DISPLAY-ONLY — recording is unchanged.
+
+const LAMBDA = 'AWS::Lambda::Function';
+const SECRET_PATH = 'Environment.Variables.API_TOKEN';
+
+describe('#1302 record-picker changed-value preview is redacted + terminal-sanitized', () => {
+  it('redacts a secret-bearing path so neither the recorded nor the live plaintext prints', () => {
+    const recorded = 'OLD_SECRET_abcdef';
+    const live = 'NEW_SECRET_ghijkl';
+    const label = changedRecordLabel(
+      { logicalId: 'Fn', path: SECRET_PATH, value: live, resourceType: LAMBDA },
+      { hasRecorded: true, recordedValue: recorded }
+    );
+    // The path/key name stays visible (it is not secret) but the plaintext values do not.
+    expect(label).toContain('Fn.Environment.Variables.API_TOKEN');
+    expect(label).not.toContain(recorded);
+    expect(label).not.toContain(live);
+    // Masked to the same `<redacted:N chars:…>` placeholder the report renderers use.
+    expect(label).toMatch(/<redacted:\d+ chars:[0-9a-f]+>/);
+
+    // previewValue on the same secret path masks the plaintext directly, too.
+    const preview = previewValue(LAMBDA, SECRET_PATH, live);
+    expect(preview).not.toContain(live);
+    expect(preview).toMatch(/<redacted:\d+ chars:[0-9a-f]+>/);
+  });
+
+  it('sanitizes control chars (ESC + CR) out of a hostile live string value', () => {
+    // A live value carrying an ANSI erase-line + CR — the #829 injection class. Use a
+    // NON-secret path so the raw string reaches the sanitizer (a secret path would mask first).
+    const hostile = 'plainvalue\x1b[2K\rspoof';
+    const preview = previewValue('AWS::S3::Bucket', 'SomeProp', hostile);
+    // No raw ESC (\x1b) or CR (\r) byte survives — they are escaped to a visible \xNN form.
+    expect(preview).not.toContain('\x1b');
+    expect(preview).not.toContain('\r');
+    expect(preview).toContain('\\x1b');
+    expect(preview).toContain('\\x0d');
+
+    // Same guarantee through the full label builder.
+    const label = changedRecordLabel(
+      { logicalId: 'B', path: 'SomeProp', value: hostile, resourceType: 'AWS::S3::Bucket' },
+      { hasRecorded: true, recordedValue: 'OLD' }
+    );
+    expect(label).not.toContain('\x1b');
+    expect(label).not.toContain('\r');
+  });
+
+  it('leaves a normal (non-secret, control-free) value label shape unchanged', () => {
+    const label = changedRecordLabel(
+      { logicalId: 'A', path: 'P', value: 'NEW', resourceType: 'AWS::S3::Bucket' },
+      { hasRecorded: true, recordedValue: 'OLD' }
+    );
+    expect(label).toBe('A.P (changed since record: OLD → NEW)');
+    // A plain new-path row (no recorded value) is still a bare id.
+    const plain = changedRecordLabel(
+      { logicalId: 'A', path: 'P', value: 'NEW', resourceType: 'AWS::S3::Bucket' },
+      { hasRecorded: false, recordedValue: undefined }
+    );
+    expect(plain).toBe('A.P');
+  });
+});

--- a/tests/record-lifecycle-790-758.test.ts
+++ b/tests/record-lifecycle-790-758.test.ts
@@ -164,20 +164,22 @@ describe('recordedValueForChanged (#758 — old recorded value for a changed row
 
 describe('record labels (#758 / #790)', () => {
   it('previewValue truncates a long value to one line', () => {
-    expect(previewValue('short')).toBe('short');
-    expect(previewValue('x'.repeat(60), 10)).toBe(`${'x'.repeat(9)}…`);
-    expect(previewValue({ a: 1 })).toBe('{"a":1}');
+    // #1302: previewValue now takes (resourceType, path, value, max) — a non-secret path
+    // renders unchanged (redactValue is a no-op off the curated table).
+    expect(previewValue('AWS::S3::Bucket', 'P', 'short')).toBe('short');
+    expect(previewValue('AWS::S3::Bucket', 'P', 'x'.repeat(60), 10)).toBe(`${'x'.repeat(9)}…`);
+    expect(previewValue('AWS::S3::Bucket', 'P', { a: 1 })).toBe('{"a":1}');
   });
   it('changedRecordLabel shows recorded → live for a CHANGED entry', () => {
     const label = changedRecordLabel(
-      { logicalId: 'A', path: 'P', value: 'NEW' },
+      { logicalId: 'A', path: 'P', value: 'NEW', resourceType: 'AWS::S3::Bucket' },
       { hasRecorded: true, recordedValue: 'OLD' }
     );
     expect(label).toBe('A.P (changed since record: OLD → NEW)');
   });
   it('changedRecordLabel is a plain row for a NEW path (no recorded value)', () => {
     const label = changedRecordLabel(
-      { logicalId: 'A', path: 'P', value: 'NEW' },
+      { logicalId: 'A', path: 'P', value: 'NEW', resourceType: 'AWS::S3::Bucket' },
       { hasRecorded: false, recordedValue: undefined }
     );
     expect(label).toBe('A.P');


### PR DESCRIPTION
Closes #1302

## Problem (security)

The `record` interactive multiselect row for a value CHANGED since record —
built by `previewValue` / `changedRecordLabel` (src/commands/stack-actions.ts) —
printed straight to the terminal while MISSING the two hardening layers the report
path applies to displayed VALUES:

1. **No redaction** — a secret-bearing path (Lambda/CodeBuild env var, the #798/#1234
   masked set) printed BOTH the recorded and the rotated live secret in plaintext into
   the terminal.
2. **No terminal sanitizing** — a live STRING was returned verbatim
   (`typeof v === 'string' ? v : JSON.stringify(v)`), so a hostile live value carrying
   `\r` / ESC sequences (the #829 injection class) was emitted raw inside the clack
   prompt. report.ts values are C0-safe only because they route through JSON.stringify;
   this path skipped that for strings.

## Fix (DISPLAY-ONLY — recording behavior unchanged)

`previewValue` now takes `(resourceType, path, value)` and:
- applies `redactValue(resourceType, path, v)` (report/redact.ts) BEFORE truncation, masking
  a secret-bearing path to the same `<redacted:N chars:sig>` placeholder the text + --json
  renderers use;
- routes EVERY displayed form (string AND JSON-encoded) through `sanitizeForTerminal`
  (report/report.ts), escaping C0/ESC/CR + bidi controls.

`changedRecordLabel` threads the finding's `resourceType` + `path` (available on the
Finding at every call site) into both the recorded and live previews. Neither
`sanitizeForTerminal` nor `redactValue` needed re-exporting — both were already exported.

## Tests

- `tests/picker-redact-1302.test.ts` — secret path is masked (no plaintext), a hostile
  `\x1b[2K\r` value is sanitized (no raw ESC/CR), a normal value keeps its label shape.
  Fails without the fix, passes with it.
- `tests/record-lifecycle-790-758.test.ts` — 3 existing call sites updated to the new
  signature (mechanical, intent preserved; a non-secret path renders unchanged).

Gates: typecheck / lint+format / build / 4656 unit tests all green.