### PR TITLE
fix(read): suppress spec-materialized Authorizer/Model/RequestValidator/GatewayResponse added on Body-defined RestApi (#1324)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -387,7 +387,7 @@ async function getAllResources(client: APIGatewayClient, apiId: string): Promise
   return out;
 }
 
-async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+export async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
   const { parent, desired, region } = ctx;
   const apiId = parent.physicalId;
   if (!apiId) return [];
@@ -400,12 +400,13 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     typeof restApiLive.RootResourceId === 'string' ? restApiLive.RootResourceId : undefined;
 
   // Body-defined (OpenAPI / SpecRestApi) RestApi: CloudFormation materializes its
-  // resources/methods FROM the declared `Body` / `BodyS3Location`, with no sibling
-  // AWS::ApiGateway::Resource / Method template resources to diff against. Skip enumerating
-  // (and flagging) them as `added` — otherwise every Body-materialized path/method is a
-  // first-run false positive on a clean deploy (issue #714). Authorizers / Models /
-  // RequestValidators / GatewayResponses that ARE declared as separate template resources
-  // still enumerate below.
+  // resources/methods AND its Authorizers / Models / RequestValidators / GatewayResponses FROM
+  // the declared `Body` / `BodyS3Location`, with no sibling AWS::ApiGateway::* template resources
+  // to diff against. Skip enumerating (and flagging) them all as `added` — otherwise every
+  // Body-materialized child is a first-run false positive on a clean deploy (Resources/Methods =
+  // #714; Authorizers/Models/RequestValidators/GatewayResponses = #1324, the v1 twin of #960).
+  // Stages are NOT spec-materialized (a REST Body import creates no stages), so stage diffing
+  // stays fully on below (#1044).
   const bodyDefined = isBodyDefinedRestApi(parent.declared);
 
   // Declared children of THIS api (Ref/GetAtt already resolved to physical ids by gather).
@@ -506,7 +507,16 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     bodyDefined,
   });
 
-  const authorizers = await getAllAuthorizers(client, apiId);
+  // Body-defined (OpenAPI / SpecRestApi) RestApi: its Authorizers / Models / RequestValidators /
+  // GatewayResponses are all materialized by CloudFormation FROM the spec (components.securitySchemes
+  // + x-amazon-apigateway-authorizer → Authorizers; components.schemas / definitions → Models;
+  // x-amazon-apigateway-request-validators → RequestValidators; x-amazon-apigateway-gateway-responses
+  // → GatewayResponses), with no sibling template resources to diff against. Skip enumerating (and
+  // flagging) them — otherwise every spec-materialized child is a first-run false positive on a clean
+  // deploy, each offering a DeleteResource that would strip the spec's auth / schemas (issue #1324,
+  // the v1 twin of #714's Resource/Method gate and #960's V2 gate). The `bodyDefined` flag is also
+  // threaded into each diff below as a fail-safe short-circuit.
+  const authorizers = bodyDefined ? [] : await getAllAuthorizers(client, apiId);
   const liveAuthorizers = authorizers
     .filter((a): a is ApiGwAuthorizer & { id: string } => typeof a.id === 'string')
     .map((a) => ({ id: a.id, label: a.name ?? a.id }));
@@ -514,15 +524,16 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     apiId,
     declaredAuthorizerIds,
     liveAuthorizers,
+    bodyDefined,
   });
 
-  const models = await getAllModels(client, apiId);
+  const models = bodyDefined ? [] : await getAllModels(client, apiId);
   const liveModels = models
     .filter((m): m is ApiGwModel & { name: string } => typeof m.name === 'string')
     .map((m) => ({ name: m.name, label: m.name }));
-  const modelAdded = diffApiGatewayModels({ apiId, declaredModelNames, liveModels });
+  const modelAdded = diffApiGatewayModels({ apiId, declaredModelNames, liveModels, bodyDefined });
 
-  const validators = await getAllRequestValidators(client, apiId);
+  const validators = bodyDefined ? [] : await getAllRequestValidators(client, apiId);
   const liveValidators = validators
     .filter((v): v is ApiGwRequestValidator & { id: string } => typeof v.id === 'string')
     .map((v) => ({ id: v.id, label: v.name ?? v.id }));
@@ -530,9 +541,10 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     apiId,
     declaredValidatorIds,
     liveValidators,
+    bodyDefined,
   });
 
-  const gatewayResponses = await getAllGatewayResponses(client, apiId);
+  const gatewayResponses = bodyDefined ? [] : await getAllGatewayResponses(client, apiId);
   const liveResponseTypes = gatewayResponses
     .filter(
       (g): g is ApiGwGatewayResponse & { responseType: string } =>
@@ -544,6 +556,7 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     declaredResponseTypes,
     liveResponseTypes,
     hasUnresolvedDeclaredResponseType: gatewayResponseTypeUnresolved,
+    bodyDefined,
   });
 
   // Stages — the V2 enumerator (enumerateHttpApiChildren) already sweeps + diffs Stages; the
@@ -605,10 +618,21 @@ export interface ApiGatewayAuthorizerInput {
   apiId: string;
   declaredAuthorizerIds: string[]; // physical ids (AuthorizerIds) of AWS::ApiGateway::Authorizer
   liveAuthorizers: { id: string; label?: string | undefined }[];
+  // The RestApi is Body-defined (OpenAPI / SpecRestApi): CloudFormation materializes its
+  // authorizers from the spec's `components.securitySchemes` + `x-amazon-apigateway-authorizer`
+  // entries, not from sibling AWS::ApiGateway::Authorizer template resources. There is therefore
+  // no per-child template declaration to diff against, so every spec-materialized authorizer
+  // would otherwise flag as an out-of-band `added` on a clean deploy — each offering a
+  // DeleteResource that would disable the API's auth. When set, authorizer diffing is skipped
+  // entirely (returns []) — the v1 twin of #960's `diffApiGatewayV2Authorizers` gate (issue #1324).
+  bodyDefined?: boolean | undefined;
 }
 
 export function diffApiGatewayAuthorizers(input: ApiGatewayAuthorizerInput): AddedChild[] {
-  const { apiId, declaredAuthorizerIds, liveAuthorizers } = input;
+  const { apiId, declaredAuthorizerIds, liveAuthorizers, bodyDefined } = input;
+  // Body-defined (OpenAPI / SpecRestApi) RestApi: authorizers come from the spec, not from
+  // sibling template resources, so there is nothing to diff them against (issue #1324).
+  if (bodyDefined) return [];
   const declared = new Set(declaredAuthorizerIds);
   const added: AddedChild[] = [];
   for (const a of liveAuthorizers) {
@@ -664,10 +688,19 @@ export interface ApiGatewayModelInput {
   apiId: string;
   declaredModelNames: string[]; // Names of AWS::ApiGateway::Model declared on this api
   liveModels: { name: string; label?: string | undefined }[];
+  // The RestApi is Body-defined (OpenAPI / SpecRestApi): CloudFormation materializes its models
+  // from the spec's `components.schemas` / `definitions`, not from sibling AWS::ApiGateway::Model
+  // template resources. There is therefore no per-child template declaration to diff against, so
+  // every spec-materialized model would otherwise flag as an out-of-band `added` on a clean deploy.
+  // When set, model diffing is skipped entirely (returns []) — the v1 twin of #960 (issue #1324).
+  bodyDefined?: boolean | undefined;
 }
 
 export function diffApiGatewayModels(input: ApiGatewayModelInput): AddedChild[] {
-  const { apiId, declaredModelNames, liveModels } = input;
+  const { apiId, declaredModelNames, liveModels, bodyDefined } = input;
+  // Body-defined (OpenAPI / SpecRestApi) RestApi: models come from the spec, not from sibling
+  // template resources, so there is nothing to diff them against (issue #1324).
+  if (bodyDefined) return [];
   const declared = new Set(declaredModelNames);
   const added: AddedChild[] = [];
   for (const m of liveModels) {
@@ -704,12 +737,22 @@ export interface ApiGatewayRequestValidatorInput {
   apiId: string;
   declaredValidatorIds: string[]; // physical ids (RequestValidatorIds) of AWS::ApiGateway::RequestValidator
   liveValidators: { id: string; label?: string | undefined }[];
+  // The RestApi is Body-defined (OpenAPI / SpecRestApi): CloudFormation materializes its request
+  // validators from the spec's `x-amazon-apigateway-request-validators`, not from sibling
+  // AWS::ApiGateway::RequestValidator template resources. There is therefore no per-child template
+  // declaration to diff against, so every spec-materialized validator would otherwise flag as an
+  // out-of-band `added` on a clean deploy. When set, validator diffing is skipped entirely
+  // (returns []) — the v1 twin of #960 (issue #1324).
+  bodyDefined?: boolean | undefined;
 }
 
 export function diffApiGatewayRequestValidators(
   input: ApiGatewayRequestValidatorInput
 ): AddedChild[] {
-  const { apiId, declaredValidatorIds, liveValidators } = input;
+  const { apiId, declaredValidatorIds, liveValidators, bodyDefined } = input;
+  // Body-defined (OpenAPI / SpecRestApi) RestApi: request validators come from the spec, not from
+  // sibling template resources, so there is nothing to diff them against (issue #1324).
+  if (bodyDefined) return [];
   const declared = new Set(declaredValidatorIds);
   const added: AddedChild[] = [];
   for (const v of liveValidators) {
@@ -764,11 +807,21 @@ export interface ApiGatewayGatewayResponseInput {
   // Fail-safe (#1089): a declared GatewayResponse's identity (ResponseType) was UNRESOLVED, so it
   // could not be matched against the live responses — suppress ALL added for this api.
   hasUnresolvedDeclaredResponseType?: boolean;
+  // The RestApi is Body-defined (OpenAPI / SpecRestApi): CloudFormation materializes its gateway
+  // responses from the spec's `x-amazon-apigateway-gateway-responses`, not from sibling
+  // AWS::ApiGateway::GatewayResponse template resources. There is therefore no per-child template
+  // declaration to diff against, so every spec-materialized gateway response would otherwise flag
+  // as an out-of-band `added` on a clean deploy. When set, gateway-response diffing is skipped
+  // entirely (returns []) — the v1 twin of #960 (issue #1324).
+  bodyDefined?: boolean | undefined;
 }
 
 export function diffApiGatewayGatewayResponses(
   input: ApiGatewayGatewayResponseInput
 ): AddedChild[] {
+  // Body-defined (OpenAPI / SpecRestApi) RestApi: gateway responses come from the spec, not from
+  // sibling template resources, so there is nothing to diff them against (issue #1324).
+  if (input.bodyDefined) return [];
   if (input.hasUnresolvedDeclaredResponseType) return [];
   const { apiId, declaredResponseTypes, liveResponseTypes } = input;
   const declared = new Set(declaredResponseTypes);

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1,4 +1,13 @@
 import {
+  APIGatewayClient,
+  GetAuthorizersCommand,
+  GetGatewayResponsesCommand,
+  GetModelsCommand,
+  GetRequestValidatorsCommand,
+  GetResourcesCommand,
+  GetStagesCommand as GetRestStagesCommand,
+} from '@aws-sdk/client-api-gateway';
+import {
   LambdaClient,
   ListAliasesCommand,
   ListEventSourceMappingsCommand,
@@ -19,6 +28,7 @@ import type { EnumeratorContext } from '../src/read/child-enumerators.js';
 import {
   enumerateLambdaFunctionChildren,
   enumerateRdsClusterChildren,
+  enumerateRestApiChildren,
   enumerateRoute53HostedZoneChildren,
   enumerateSnsTopicChildren,
   diffApiGatewayAuthorizers,
@@ -442,6 +452,124 @@ describe('diffApiGatewayGatewayResponses (REST API gateway responses)', () => {
       hasUnresolvedDeclaredResponseType: false,
     });
     expect(added.map((a) => a.identifier)).toEqual([`${API}:DEFAULT_5XX`]);
+  });
+});
+
+// #1324: a Body-defined (OpenAPI / SpecRestApi) RestApi materializes its Authorizers / Models /
+// RequestValidators / GatewayResponses FROM the spec (components.securitySchemes +
+// x-amazon-apigateway-authorizer → Authorizers; components.schemas / definitions → Models;
+// x-amazon-apigateway-request-validators → RequestValidators; x-amazon-apigateway-gateway-responses
+// → GatewayResponses), with no sibling AWS::ApiGateway::* template resources to diff against. Before
+// the fix, `bodyDefined` was passed ONLY to the Resources/Method diff (#714), leaving these four
+// diffs ungated — so every SpecRestApi with security schemes / schemas / validators / gateway-response
+// customizations surfaced first-run `[Added]` FPs, each offering a CC DeleteResource. This mirrors
+// the V2 gate (#960): thread `bodyDefined` into each diff and return [] when set.
+describe('Body-defined RestApi suppresses spec-materialized children (#1324)', () => {
+  it('diffApiGatewayAuthorizers returns [] when bodyDefined (spec-materialized authorizers)', () => {
+    const added = diffApiGatewayAuthorizers({
+      apiId: API,
+      declaredAuthorizerIds: [], // no sibling AWS::ApiGateway::Authorizer template resource
+      liveAuthorizers: [{ id: 'specAuth0', label: 'CognitoAuth' }],
+      bodyDefined: true,
+    });
+    expect(added).toEqual([]);
+  });
+
+  it('diffApiGatewayModels returns [] when bodyDefined (spec-materialized models)', () => {
+    const added = diffApiGatewayModels({
+      apiId: API,
+      declaredModelNames: [],
+      liveModels: [{ name: 'PetSchema' }, { name: 'ErrorSchema' }],
+      bodyDefined: true,
+    });
+    expect(added).toEqual([]);
+  });
+
+  it('diffApiGatewayRequestValidators returns [] when bodyDefined (spec-materialized validators)', () => {
+    const added = diffApiGatewayRequestValidators({
+      apiId: API,
+      declaredValidatorIds: [],
+      liveValidators: [{ id: 'specVal0', label: 'body-only' }],
+      bodyDefined: true,
+    });
+    expect(added).toEqual([]);
+  });
+
+  it('diffApiGatewayGatewayResponses returns [] when bodyDefined (spec-materialized responses)', () => {
+    const added = diffApiGatewayGatewayResponses({
+      apiId: API,
+      declaredResponseTypes: [],
+      liveResponseTypes: [{ type: 'UNAUTHORIZED' }, { type: 'ACCESS_DENIED' }],
+      bodyDefined: true,
+    });
+    expect(added).toEqual([]);
+  });
+
+  // End-to-end: a Body-defined RestApi with no sibling declared children, whose LIVE inventory
+  // holds one spec-materialized child of EACH kind (Authorizer, Model, RequestValidator,
+  // GatewayResponse). All four must be suppressed → `added` is EMPTY on a clean first check.
+  it('enumerateRestApiChildren suppresses ALL four spec-materialized child kinds on a Body-defined api', async () => {
+    const apigw = mockClient(APIGatewayClient);
+    apigw
+      // Body-defined: getAllResources is skipped by the enumerator, but stay realistic.
+      .on(GetResourcesCommand)
+      .resolves({ items: [{ id: 'root0', path: '/' }] })
+      .on(GetRestStagesCommand)
+      .resolves({ item: [] })
+      .on(GetAuthorizersCommand)
+      .resolves({ items: [{ id: 'specAuth0', name: 'CognitoAuth' }] })
+      .on(GetModelsCommand)
+      .resolves({ items: [{ name: 'Empty' }, { name: 'Error' }, { name: 'PetSchema' }] })
+      .on(GetRequestValidatorsCommand)
+      .resolves({ items: [{ id: 'specVal0', name: 'body-only' }] })
+      .on(GetGatewayResponsesCommand)
+      .resolves({ items: [{ responseType: 'UNAUTHORIZED', defaultResponse: false }] });
+    const ctx = {
+      parent: {
+        logicalId: 'SpecApi',
+        physicalId: 'specapi01',
+        declared: { Body: { openapi: '3.0.1', paths: {}, components: {} } },
+      },
+      desired: { resources: [], ctx: { liveAttrs: { SpecApi: { RootResourceId: 'root0' } } } },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateRestApiChildren(ctx);
+    expect(added).toEqual([]);
+    apigw.restore();
+  });
+
+  // Control: a NON-body RestApi (bodyDefined false) with genuine out-of-band live children still
+  // surfaces them — the gate is scoped to Body-defined apis, detection is preserved elsewhere.
+  it('a NON-body RestApi still surfaces a genuinely out-of-band Authorizer and Model', async () => {
+    const apigw = mockClient(APIGatewayClient);
+    apigw
+      .on(GetResourcesCommand)
+      .resolves({ items: [{ id: 'root0', path: '/' }] })
+      .on(GetRestStagesCommand)
+      .resolves({ item: [] })
+      .on(GetAuthorizersCommand)
+      .resolves({ items: [{ id: 'oobAuth1', name: 'oob-authorizer' }] })
+      .on(GetModelsCommand)
+      .resolves({ items: [{ name: 'Empty' }, { name: 'Error' }, { name: 'oobModel' }] })
+      .on(GetRequestValidatorsCommand)
+      .resolves({ items: [] })
+      .on(GetGatewayResponsesCommand)
+      .resolves({ items: [] });
+    const ctx = {
+      parent: {
+        logicalId: 'PlainApi',
+        physicalId: 'plainapi1',
+        declared: { Name: 'my-plain-api' }, // no Body / BodyS3Location
+      },
+      desired: { resources: [], ctx: { liveAttrs: { PlainApi: { RootResourceId: 'root0' } } } },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateRestApiChildren(ctx);
+    expect(added.map((a) => a.identifier).sort()).toEqual([
+      'plainapi1|oobAuth1',
+      'plainapi1|oobModel',
+    ]);
+    apigw.restore();
   });
 });
 


### PR DESCRIPTION
Closes #1324

## The bug (first-run false positive — violates the ZERO-first-run-drift core invariant)

For a Body-defined (OpenAPI) `AWS::ApiGateway::RestApi` (CDK `SpecRestApi` / raw-CFn `Body`), `enumerateRestApiChildren` computed `bodyDefined` but passed it ONLY to `diffApiGatewayChildren` (Resources/Methods, #714). The Authorizer / Model / RequestValidator / GatewayResponse diffs ran **ungated**.

An OpenAPI import materializes exactly those children from the spec:
- `components.securitySchemes` + `x-amazon-apigateway-authorizer` -> Authorizers
- `components.schemas` / `definitions` -> Models
- `x-amazon-apigateway-request-validators` -> RequestValidators
- `x-amazon-apigateway-gateway-responses` -> GatewayResponses

So every SpecRestApi with security schemes / schemas / validators / gateway-response customizations surfaced first-run `[Added]` FPs — each offering a CC `DeleteResource` (deleting the spec's authorizer would disable the API's auth). LIVE-CONFIRMED on real AWS.

## The fix (v1 twin of #960's V2 gate)

Thread `bodyDefined` into the four diff inputs (Authorizer / Model / RequestValidator / GatewayResponse) and `return []` when set, mirroring `diffApiGatewayV2Authorizers`. The enumerator also skips the corresponding SDK sweeps for a Body-defined api (matching the existing `items = bodyDefined ? []` pattern for Resources).

**Stages stay fully diffed** — a REST Body import materializes no stages, so #1044 is unaffected and stage gating is deliberately NOT added.

## Tests

New describe block in `tests/child-enumerators.test.ts`:
- Each of the four pure diffs returns `[]` when `bodyDefined: true`.
- End-to-end `enumerateRestApiChildren` on a Body-defined api with one live spec-materialized child of EACH kind -> `added` is empty.
- Control: a NON-body RestApi with genuine out-of-band live Authorizer + Model still surfaces both (detection preserved).

Verified the tests FAIL without the guard and PASS with it.

## Files changed
- `src/read/child-enumerators.ts`
- `tests/child-enumerators.test.ts`
