### PR TITLE
fix(read): supplementTrustStore fetch honors the #1066 timeout contract via AbortSignal.timeout (#1321)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -182,7 +182,7 @@ import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { ResourceGoneError } from '../aws-errors.js';
 import { partitionForRegion } from '../desired/template-adapter.js';
-import { READ_RETRY } from './client-config.js';
+import { CLIENT_REQUEST_HANDLER, READ_RETRY } from './client-config.js';
 import { isDefinitiveDenial } from './kms-aliases.js';
 import { hashCaBundle, sha256Hex } from './pem.js';
 
@@ -3467,10 +3467,26 @@ const supplementTrustStore: SupplementReader = async ({ physicalId, region }) =>
   const r = await c.send(new GetTrustStoreCaCertificatesBundleCommand({ TrustStoreArn: arn }));
   const url = str(r.Location);
   if (!url) return undefined;
-  const resp = await fetch(url);
-  if (!resp.ok) return undefined;
-  const hash = hashCaBundle(await resp.text());
-  return hash !== undefined ? { CaCertificatesBundleSha256: hash } : undefined;
+  try {
+    // The ONLY non-SDK HTTP call on the read path — the global undici `fetch`, which
+    // predates #1066 and so bypassed its timeout contract: undici bounds headers only
+    // at 300s, so a trickling / never-completing body hung `check` FOREVER (#1321).
+    // Bound it with the SAME #1066 requestTimeout the wired SDK clients use
+    // (CLIENT_REQUEST_HANDLER.requestTimeout) via AbortSignal.timeout — the one signal
+    // aborts BOTH the fetch and the subsequent `resp.text()` body read. On timeout the
+    // AbortError falls into this catch and DEGRADES to the documented best-effort skip
+    // (keep the CC model), never a fatal hang or a false-flag.
+    const resp = await fetch(url, {
+      signal: AbortSignal.timeout(CLIENT_REQUEST_HANDLER.requestTimeout),
+    });
+    if (!resp.ok) return undefined;
+    const hash = hashCaBundle(await resp.text());
+    return hash !== undefined ? { CaCertificatesBundleSha256: hash } : undefined;
+  } catch {
+    // Fetch/read failed (timeout/abort, network error, non-PEM body): the CA-bundle
+    // digest is a best-effort integrity signal — skip the field rather than propagate.
+    return undefined;
+  }
 };
 
 // AWS::Lambda::Function — the function `Code` is writeOnly (Cloud Control returns a

--- a/tests/truststore-timeout-1321.test.ts
+++ b/tests/truststore-timeout-1321.test.ts
@@ -1,0 +1,115 @@
+// #1321 — supplementTrustStore (ELBv2 TrustStore CA-bundle content-hash supplement) fetches
+// the presigned CA-bundle URL. Before the fix that fetch was a BARE `await fetch(url)` (the
+// global undici fetch, no AbortController/signal/timeout) and the body read `await
+// resp.text()` was unbounded — the ONLY non-SDK HTTP call on the read path, predating #1066,
+// so it bypassed the #1066 timeout contract. undici bounds HEADERS only at 300s, so a
+// trickling / never-completing body hung `check` FOREVER. The fix bounds it with
+// AbortSignal.timeout(CLIENT_REQUEST_HANDLER.requestTimeout) — the same #1066 request timeout
+// the wired SDK clients use — and degrades a timeout/abort to the documented best-effort skip
+// (keep the CC model), never a fatal hang.
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import {
+  ElasticLoadBalancingV2Client,
+  GetTrustStoreCaCertificatesBundleCommand,
+} from '@aws-sdk/client-elastic-load-balancing-v2';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { CLIENT_REQUEST_HANDLER } from '../src/read/client-config.js';
+import { readLive } from '../src/read/router.js';
+import type { DesiredResource } from '../src/types.js';
+
+const cc = mockClient(CloudControlClient);
+const elbv2 = mockClient(ElasticLoadBalancingV2Client);
+
+const arn = 'arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-ts/abc';
+const bundle = '-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n';
+
+const ts = (): DesiredResource => ({
+  logicalId: 'L',
+  resourceType: 'AWS::ElasticLoadBalancingV2::TrustStore',
+  physicalId: arn,
+  declared: { Name: 'cdkrd-ts' },
+});
+
+beforeEach(() => {
+  cc.reset();
+  elbv2.reset();
+  cc.on(GetResourceCommand).resolves({
+    ResourceDescription: { Properties: `{"TrustStoreArn":"${arn}","Name":"cdkrd-ts"}` },
+  });
+  elbv2
+    .on(GetTrustStoreCaCertificatesBundleCommand)
+    .resolves({ Location: 'https://s3.example.com/presigned' });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('supplementTrustStore CA-bundle fetch honors the #1066 timeout contract (#1321)', () => {
+  it('passes an AbortSignal to fetch (the #1066 timeout guard, previously absent)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(bundle) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const r = await readLive(cc as unknown as CloudControlClient, ts(), 'us-east-1', '1');
+
+    // Success still projects the digest (behavior unchanged for the happy path).
+    expect(r.live?.CaCertificatesBundleSha256).toMatch(/^[0-9a-f]{64}$/);
+
+    // The fix: the fetch call now carries an abort signal. Before the fix it was
+    // `fetch(url)` with NO second argument, so this assertion FAILS without the fix.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe('https://s3.example.com/presigned');
+    expect(opts?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('uses the shared #1066 request timeout as the abort deadline', async () => {
+    // AbortSignal.timeout(ms) schedules the abort; assert the timeout VALUE reused is the
+    // shared CLIENT_REQUEST_HANDLER.requestTimeout (not a bare hardcoded literal).
+    const spy = vi.spyOn(AbortSignal, 'timeout');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(bundle) })
+    );
+
+    await readLive(cc as unknown as CloudControlClient, ts(), 'us-east-1', '1');
+
+    expect(spy).toHaveBeenCalledWith(CLIENT_REQUEST_HANDLER.requestTimeout);
+    spy.mockRestore();
+  });
+
+  it('degrades to the non-fatal skip when the fetch aborts/times out (keeps the CC model, no throw)', async () => {
+    // A rejecting fetch models the AbortSignal.timeout firing (undici throws a
+    // TimeoutError/AbortError). It must NOT propagate out of the reader as a fatal hang —
+    // the CA-bundle digest is best-effort, so the supplement keeps the CC model.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(Object.assign(new Error('timed out'), { name: 'TimeoutError' }))
+    );
+
+    const r = await readLive(cc as unknown as CloudControlClient, ts(), 'us-east-1', '1');
+
+    // The read did NOT throw and the CC model is preserved WITHOUT the synthetic digest.
+    expect(r.live).toEqual({ TrustStoreArn: arn, Name: 'cdkrd-ts' });
+    expect(r.live?.CaCertificatesBundleSha256).toBeUndefined();
+    expect(r.skippedReason).toBeUndefined();
+  });
+
+  it('degrades when the body read (resp.text) rejects under the same signal', async () => {
+    // The single signal also aborts the body read — a text() that rejects (aborted mid-body)
+    // must fall into the same best-effort skip, not throw.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+      })
+    );
+
+    const r = await readLive(cc as unknown as CloudControlClient, ts(), 'us-east-1', '1');
+
+    expect(r.live).toEqual({ TrustStoreArn: arn, Name: 'cdkrd-ts' });
+    expect(r.skippedReason).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1321

## Problem

`supplementTrustStore` (ELBv2 TrustStore CA-bundle content-hash supplement in src/read/overrides.ts) fetched the presigned CA-bundle URL with a **bare** `await fetch(url)` — the global undici fetch, no AbortController/signal/timeout — and the body read `await resp.text()` was also unbounded. This is the ONLY non-SDK HTTP call on the read path and it predated #1066, so it bypassed the #1066 timeout contract. undici bounds HEADERS only at 300s, so a trickling / never-completing body hung `check` FOREVER.

## Fix

`fetch(url, { signal: AbortSignal.timeout(CLIENT_REQUEST_HANDLER.requestTimeout) })` — reusing the SHARED #1066 request timeout (`CLIENT_REQUEST_HANDLER.requestTimeout`, 60s) the wired SDK clients already use, rather than a hardcoded literal. The single signal aborts BOTH the fetch and the subsequent `resp.text()` body read.

On timeout the AbortError falls into a local try/catch that DEGRADES to the documented best-effort skip (keep the CC model, no synthetic digest) — matching the existing "any failure skips the field" contract for this reader (same shape as `supplementGlueJob`'s S3 fetch guard). Never a fatal hang, never a false-flag.

## Tests

New `tests/truststore-timeout-1321.test.ts` (drives the real `readLive` router path):
- asserts fetch is now called WITH an AbortSignal (FAILS without the fix — previously `fetch(url)` had no 2nd arg)
- asserts the timeout VALUE reused is the shared `CLIENT_REQUEST_HANDLER.requestTimeout` (not a bare literal)
- a rejecting fetch (timeout/abort) degrades to the non-fatal skip (keeps the CC model, no throw, no `skippedReason`)
- a rejecting `resp.text()` under the same signal degrades identically

Verified the two signal-assertions FAIL on pre-fix bare-fetch and PASS with the fix.

Gates: typecheck / `vp check --fix` / build / `vp test run` (4668 pass) / `vp run check` (0 errors) all green. Regression: pem/router/clientvpn/new = 143 pass.
