### PR TITLE
fix(diff): rdsMaterializedDefault resolves the option name from the sorted diff index, not the raw declared array (#1318)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1152,22 +1152,30 @@ function isIdentityOnlyHusk(el: Record<string, unknown>, idField: string): boole
 }
 
 // The gather-resolved catalog default for `settingName` under the OptionConfiguration at `path`'s
-// array index (its OptionName read from the declared side). Returns the DefaultValue string, `null`
-// for a catalog husk, or `undefined` when unresolvable (no catalog, unknown option/setting) — in
-// which case the value-bearing fold does not apply.
+// array index. Returns the DefaultValue string, `null` for a catalog husk, or `undefined` when
+// unresolvable (no catalog, unknown option/setting) — in which case the value-bearing fold does
+// not apply.
+//
+// `OptionConfigurations` is `insertionOrder:false`, so classify sorts BOTH sides by canonical JSON
+// before the positional diff — `path`'s array index is the SORTED index, NOT the raw template
+// index. The owning option NAME must therefore be resolved from the array the diff index actually
+// refers to: the diff was computed over the sorted `liveVal`, whose element at the diff index is
+// order-aligned with `path` and carries the same `OptionName` as its declared counterpart. Reading
+// the name from the RAW, unsorted declared model would pick the WRONG option whenever raw order ≠
+// sorted order (a multi-option group whose template order differs from canonical sort), silently
+// dropping the fold and surfacing every catalog default as first-run undeclared drift (#1318).
 function rdsMaterializedDefault(
   catalog: Record<string, Record<string, Record<string, string | null>>> | undefined,
   physicalId: string | undefined,
-  declared: unknown,
+  aligned: unknown,
   path: string,
   settingName: string
 ): string | null | undefined {
   if (!catalog || physicalId === undefined) return undefined;
   const m = /OptionConfigurations\.(\d+)\.OptionSettings$/.exec(path);
   if (!m) return undefined;
-  const configs = (declared as { OptionConfigurations?: unknown } | undefined)
-    ?.OptionConfigurations;
-  const optName = Array.isArray(configs)
+  const configs = Array.isArray(aligned) ? aligned : undefined;
+  const optName = configs
     ? (configs[Number(m[1])] as { OptionName?: unknown } | undefined)?.OptionName
     : undefined;
   if (typeof optName !== 'string') return undefined;
@@ -3187,10 +3195,14 @@ export function classifyResource(
               if (isIdentityOnlyHusk(loRec, nvSubsetSpec.nameField)) {
                 isRdsOptionDefault = true;
               } else {
+                // Resolve the owning option NAME from the SORTED, index-aligned array the diff
+                // index refers to (`liveVal`) — NOT the raw declared model, whose order can differ
+                // from the sorted diff index (#1318). The live element at the diff index carries
+                // the same `OptionName` as its declared counterpart.
                 const matDefault = rdsMaterializedDefault(
                   opts.rdsOptionSettingDefaults,
                   physicalId,
-                  declaredIn,
+                  liveVal,
                   d.path,
                   loName
                 );

--- a/tests/classify-978-rds-optiongroup-default-fill.test.ts
+++ b/tests/classify-978-rds-optiongroup-default-fill.test.ts
@@ -162,3 +162,112 @@ describe('#978 RDS OptionGroup default-fill folds to atDefault via the live cata
     expect(atDefault).toContain(p('SERVER_AUDIT_FILE_ROTATIONS'));
   });
 });
+
+// #1318 — a group declaring TWO+ options whose TEMPLATE order differs from the canonical SORT
+// order. `OptionConfigurations` is `insertionOrder:false`, so classify sorts BOTH sides by
+// canonical JSON before the positional diff — the drift record's index is the SORTED index. The
+// fold must resolve each option's NAME from the array the diff index actually refers to (the sorted
+// live element's `OptionName`), NOT the raw declared model — else the wrong catalog entry is
+// consulted and every value-bearing default of the misaligned option surfaces as first-run
+// undeclared drift. Reverse-sorted repro: raw order [MARIADB_AUDIT_PLUGIN, A_DUMMY_PLUGIN] with
+// A_DUMMY_PLUGIN sorting BEFORE MARIADB_AUDIT_PLUGIN.
+describe('#1318 multi-option group whose template order differs from canonical sort order', () => {
+  // Declared in raw order [MARIADB_AUDIT_PLUGIN, A_DUMMY_PLUGIN]; A_DUMMY_PLUGIN sorts first.
+  const declaredTwo = {
+    EngineName: 'mariadb',
+    MajorEngineVersion: '10.11',
+    OptionConfigurations: [
+      {
+        OptionName: 'MARIADB_AUDIT_PLUGIN',
+        OptionSettings: [
+          { Name: 'SERVER_AUDIT_EVENTS', Value: 'CONNECT,QUERY' },
+          { Name: 'SERVER_AUDIT_QUERY_LOG_LIMIT', Value: '2048' },
+        ],
+      },
+      {
+        OptionName: 'A_DUMMY_PLUGIN',
+        OptionSettings: [{ Name: 'DUMMY_MODE', Value: 'STRICT' }],
+      },
+    ],
+  };
+
+  // Live reads both options back with RDS's default-fill (raw live order also differs from sort).
+  const liveTwo = () => ({
+    EngineName: 'mariadb',
+    MajorEngineVersion: '10.11',
+    OptionConfigurations: [
+      {
+        OptionName: 'MARIADB_AUDIT_PLUGIN',
+        VpcSecurityGroupMemberships: [],
+        OptionSettings: [
+          { Name: 'SERVER_AUDIT_EVENTS', Value: 'CONNECT,QUERY' },
+          { Name: 'SERVER_AUDIT_QUERY_LOG_LIMIT', Value: '2048' },
+          { Name: 'SERVER_AUDIT_LOGGING', Value: 'ON' },
+          { Name: 'SERVER_AUDIT', Value: 'FORCE_PLUS_PERMANENT' },
+          { Name: 'SERVER_AUDIT_INCL_USERS' },
+        ],
+      },
+      {
+        OptionName: 'A_DUMMY_PLUGIN',
+        VpcSecurityGroupMemberships: [],
+        OptionSettings: [
+          { Name: 'DUMMY_MODE', Value: 'STRICT' },
+          { Name: 'DUMMY_LEVEL', Value: '5' },
+          { Name: 'DUMMY_FLAG', Value: 'OFF' },
+          { Name: 'DUMMY_UNSET' },
+        ],
+      },
+    ],
+  });
+
+  const catalogTwo = () => ({
+    rdsOptionSettingDefaults: {
+      [PHYS]: {
+        MARIADB_AUDIT_PLUGIN: {
+          SERVER_AUDIT_EVENTS: 'CONNECT,QUERY',
+          SERVER_AUDIT_QUERY_LOG_LIMIT: '1024',
+          SERVER_AUDIT_LOGGING: 'ON',
+          SERVER_AUDIT: 'FORCE_PLUS_PERMANENT',
+          SERVER_AUDIT_INCL_USERS: null,
+        },
+        A_DUMMY_PLUGIN: {
+          DUMMY_MODE: 'LENIENT',
+          DUMMY_LEVEL: '5',
+          DUMMY_FLAG: 'OFF',
+          DUMMY_UNSET: null,
+        },
+      },
+    },
+  });
+
+  it('folds every catalog default of BOTH options despite raw-order != sort-order (#1318)', () => {
+    const f = classifyResource(mk(declaredTwo), liveTwo(), emptySchema, catalogTwo());
+    // Both options full-fold: zero first-run undeclared drift.
+    expect(tier(f, 'undeclared')).toEqual([]);
+    const atDefault = tier(f, 'atDefault');
+    // MARIADB_AUDIT_PLUGIN default-fills.
+    for (const name of ['SERVER_AUDIT_LOGGING', 'SERVER_AUDIT', 'SERVER_AUDIT_INCL_USERS']) {
+      expect(atDefault.some((path) => path.endsWith(`[${name}]`))).toBe(true);
+    }
+    // A_DUMMY_PLUGIN default-fills (the misaligned option — the one that regressed pre-fix).
+    for (const name of ['DUMMY_LEVEL', 'DUMMY_FLAG', 'DUMMY_UNSET']) {
+      expect(atDefault.some((path) => path.endsWith(`[${name}]`))).toBe(true);
+    }
+  });
+
+  it('control: raw order == sort order (single option) still folds', () => {
+    const f = classifyResource(mk(declared), liveOptionSettings(), emptySchema, catalogOpts());
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('preserves out-of-band detection on the misaligned option — equality gating unchanged', () => {
+    // A_DUMMY_PLUGIN.DUMMY_FLAG flipped OFF -> ON diverges from its catalog default.
+    const live = liveTwo();
+    (live.OptionConfigurations[1].OptionSettings as Record<string, unknown>[]).find(
+      (s) => s.Name === 'DUMMY_FLAG'
+    )!.Value = 'ON';
+    const f = classifyResource(mk(declaredTwo), live, emptySchema, catalogTwo());
+    expect(tier(f, 'undeclared').some((path) => path.endsWith('[DUMMY_FLAG]'))).toBe(true);
+    expect(tier(f, 'atDefault').some((path) => path.endsWith('[DUMMY_FLAG]'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1318

## The bug (first-run FALSE POSITIVE — violates the zero-first-run-drift invariant)

The #978/#1200 live-catalog fold for `AWS::RDS::OptionGroup` default-fill settings broke when a group declared 2+ options whose TEMPLATE order differed from the canonical SORT order. `OptionConfigurations` is `insertionOrder:false`, so classify sorts BOTH sides by canonical JSON before the positional diff — the drift record's `d.path` index is the SORTED index. But `rdsMaterializedDefault` resolved the owning option NAME by indexing the RAW, unsorted `declaredIn.OptionConfigurations[i]`. When raw order ≠ sorted order it read the WRONG option's name, consulted the wrong catalog entry, found no matching setting, and the fold silently did not apply → every value-bearing catalog default of the misaligned option surfaced as `[Potential Drift] undeclared` on a clean first `check`.

## Fix (surgical)

Resolve the option name from the array the diff index actually refers to — the SORTED, index-aligned `liveVal` array — reading `OptionName` from the live element at the diff index (order-aligned with `d.path`, and carrying the same `OptionName` as its declared counterpart). Equality gating is unchanged: only a value equal to the catalog default folds, so out-of-band detection is preserved.

- `src/diff/classify.ts` — `rdsMaterializedDefault` now takes the aligned array; call site passes `liveVal` instead of `declaredIn`.
- `tests/classify-978-rds-optiongroup-default-fill.test.ts` — reverse-sorted two-option repro `[MARIADB_AUDIT_PLUGIN, A_DUMMY_PLUGIN]` (A_DUMMY_PLUGIN sorts first): all catalog defaults of BOTH options fold to atDefault (NONE undeclared); + control (single option) + out-of-band-detection-preserved case. FAILS pre-fix, PASSES with it.

## Gates

typecheck / lint+format (oxc, 0 errors) / build / full unit suite (4667 pass) all green. #978/#1200 RDS OptionGroup suites (classify-978-*, gather-rds-optiongroup-catalog-978 = 13) and corpus-replay/record (691) stay green.