### PR TITLE
fix(read): Cognito auto-federated-group skip gates on bare RoleArn — a RoleArn-bearing OOB group surfaces (#1262)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -1723,7 +1723,19 @@ export interface UserPoolGroupInput {
   // out-of-band detection: an auto-group for an IdP the template never declared still
   // surfaces.
   declaredProviderNames: string[];
-  liveGroups: { name: string; label?: string | undefined }[];
+  // `roleArn` carries the live group's ListGroups `Group.RoleArn`. The genuine
+  // Cognito-auto-created federated group is created BARE (no RoleArn). An attacker with
+  // cognito-idp:CreateGroup can pre-create the exact `<userPoolId>_<ProviderName>` name WITH
+  // a RoleArn → every federated user of that IdP is auto-added to it on sign-in → via
+  // identity-pool `preferred_role` resolution they assume the attached role (federated
+  // privilege escalation). So the #961 auto-group skip is GATED on `roleArn === undefined` —
+  // a name-matched group that carries a RoleArn is NOT the benign auto-group and surfaces as
+  // added (#1262).
+  liveGroups: {
+    name: string;
+    label?: string | undefined;
+    roleArn?: string | undefined;
+  }[];
 }
 
 export function diffUserPoolGroups(input: UserPoolGroupInput): AddedChild[] {
@@ -1741,12 +1753,20 @@ export function diffUserPoolGroups(input: UserPoolGroupInput): AddedChild[] {
   const added: AddedChild[] = [];
   for (const g of liveGroups) {
     if (declared.has(g.name)) continue;
-    if (autoGroupNames.has(g.name)) continue; // Cognito-auto-created federated group (#961)
+    // Skip the Cognito-auto-created federated group (#961) ONLY when it looks auto-created:
+    // the genuine lazy auto-group is BARE (no RoleArn). A `<userPoolId>_<ProviderName>`-named
+    // group WITH a RoleArn is an out-of-band privilege-escalation group, not the benign
+    // auto-group → surface it as added (#1262).
+    if (autoGroupNames.has(g.name) && g.roleArn === undefined) continue;
     added.push({
       resourceType: 'AWS::Cognito::UserPoolGroup',
       identifier: `${userPoolId}|${g.name}`, // CC composite UserPoolId|GroupName
       label: g.label ?? g.name,
-      live: { GroupName: g.name, UserPoolId: userPoolId },
+      live: {
+        GroupName: g.name,
+        UserPoolId: userPoolId,
+        ...(g.roleArn !== undefined ? { RoleArn: g.roleArn } : {}),
+      },
     });
   }
   return added;
@@ -1931,7 +1951,7 @@ async function enumerateUserPoolChildren(ctx: EnumeratorContext): Promise<AddedC
   const groups = await pageUserPoolGroups(client, userPoolId);
   const liveGroups = groups
     .filter((g): g is GroupType & { GroupName: string } => typeof g.GroupName === 'string')
-    .map((g) => ({ name: g.GroupName }));
+    .map((g) => ({ name: g.GroupName, roleArn: g.RoleArn }));
   const groupAdded = diffUserPoolGroups({
     userPoolId,
     declaredGroupNames,

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1464,6 +1464,55 @@ describe('diffUserPoolGroups (Cognito user pool groups)', () => {
       },
     ]);
   });
+
+  // #1262: the #961 skip is NAME-only, but the genuine Cognito lazy auto-group is created
+  // BARE (no RoleArn). An attacker with cognito-idp:CreateGroup can pre-create the exact
+  // `<poolId>_<Provider>` name WITH a RoleArn → every federated user of that IdP is
+  // auto-added → via identity-pool `preferred_role` they assume the attached role
+  // (federated privilege escalation). Gate the auto-group skip on `roleArn === undefined`.
+  describe('#1262: RoleArn-bearing auto-named group is not the benign auto-group', () => {
+    const ESCALATION_ROLE = 'arn:aws:iam::123456789012:role/AdminEscalation';
+
+    it('surfaces a <poolId>_MySAML group that carries a RoleArn (privilege-escalation OOB group)', () => {
+      const added = diffUserPoolGroups({
+        userPoolId: POOL,
+        declaredGroupNames: [],
+        declaredProviderNames: ['MySAML'], // MySAML IdP IS declared -> #961 would skip by name
+        liveGroups: [{ name: `${POOL}_MySAML`, roleArn: ESCALATION_ROLE }],
+      });
+      expect(added).toEqual([
+        {
+          resourceType: 'AWS::Cognito::UserPoolGroup',
+          identifier: `${POOL}|${POOL}_MySAML`,
+          label: `${POOL}_MySAML`,
+          live: { GroupName: `${POOL}_MySAML`, UserPoolId: POOL, RoleArn: ESCALATION_ROLE },
+        },
+      ]);
+    });
+
+    it('still skips the SAME name when the group is BARE (no RoleArn) — the benign auto-group (no #961 regression)', () => {
+      const added = diffUserPoolGroups({
+        userPoolId: POOL,
+        declaredGroupNames: [],
+        declaredProviderNames: ['MySAML'],
+        liveGroups: [{ name: `${POOL}_MySAML` }], // roleArn undefined -> genuine auto-group
+      });
+      expect(added).toEqual([]);
+    });
+
+    it('a genuinely declared group is still matched/excluded regardless of RoleArn', () => {
+      const added = diffUserPoolGroups({
+        userPoolId: POOL,
+        declaredGroupNames: ['declared-group'],
+        declaredProviderNames: ['MySAML'],
+        liveGroups: [
+          { name: 'declared-group', roleArn: 'arn:aws:iam::123456789012:role/DeclaredRole' },
+          { name: `${POOL}_MySAML` }, // bare auto-group -> skipped
+        ],
+      });
+      expect(added).toEqual([]);
+    });
+  });
 });
 
 describe('diffUserPoolIdentityProviders (Cognito user pool IdPs)', () => {


### PR DESCRIPTION
Closes #1262

## The bug (security false negative — federated privilege escalation)

#1232 (#961) skips a live Cognito `UserPoolGroup` named `<userPoolId>_<ProviderName>` for any DECLARED IdP, because Cognito auto-creates that group on first federated sign-in. The predicate was NAME-only, and the enumerator dropped every other `ListGroups` field before the diff (it mapped only `GroupName`).

But the genuine lazy auto-group is created BARE (no `RoleArn`). An attacker with `cognito-idp:CreateGroup` can pre-create the exact `<userPoolId>_<ProviderName>` name WITH a `RoleArn` → Cognito adds every federated user of that IdP to the group on sign-in → via identity-pool role resolution (`preferred_role`) they assume the attached role. That out-of-band privilege-escalation group was skipped and `check` read CLEAN.

## Fix (detection-preserving tier-2 gate)

- Thread the live group's `RoleArn` (from `ListGroups` `Group.RoleArn`) through the `liveGroups` projection into `diffUserPoolGroups`.
- Gate the #961 auto-group skip on `nameMatchesAutoGroup && roleArn === undefined` — the genuine auto-group is bare. A name-matched group carrying a `RoleArn` is NOT the benign auto-group and now surfaces as `added` (with `RoleArn` in its `live` model).

No new IAM permission (`ListGroups` already used).

## Tests (`tests/child-enumerators.test.ts`, new `#1262` describe)

- FN fix: declared IdP `MySAML`, live `us-east-1_AbCdEf123_MySAML` WITH a `RoleArn` → SURFACES as added. (Verified this case FAILS without the src change.)
- Control: same name BARE → still skipped (no #961/#1232 regression).
- Control: a genuinely declared group → still matched/excluded.

## Gates
typecheck ✅ · build ✅ · full suite 4680 pass ✅ (including the #961/#1232 bare-auto-group regression tests). oxc/format clean on the changed files.