### PR TITLE
fix(diff): SFN object-Definition fold applies DefinitionSubstitutions + non-ASCII-mask readGap tolerance (#1301)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -3923,8 +3923,48 @@ export function classifyResource(
       } catch {
         liveDefParsed = undefined;
       }
-      if (liveDefParsed !== undefined && deepEqual(liveDefParsed, sfnDefinitionObject)) {
+      // #712 (symptom B) for the OBJECT form: `DefinitionSubstitutions` apply to BOTH
+      // definition forms in CloudFormation, but the resolution above only rewrites the
+      // declared `DefinitionString` STRING. For the object form the declared object still
+      // carries the literal `${token}` placeholders while the live compiled `DefinitionString`
+      // is already SUBSTITUTED — so serialize the declared object, resolve the tokens through
+      // the SAME `applyDefinitionSubstitutions` helper #712 uses for the string form, and
+      // re-parse before comparing. A genuine out-of-band definition edit still fails the
+      // compares below.
+      let declaredDef: unknown = sfnDefinitionObject;
+      if (sfnDefinitionSubstitutions !== undefined) {
+        try {
+          declaredDef = JSON.parse(
+            applyDefinitionSubstitutions(
+              JSON.stringify(sfnDefinitionObject),
+              sfnDefinitionSubstitutions
+            )
+          );
+        } catch {
+          declaredDef = sfnDefinitionObject;
+        }
+      }
+      if (liveDefParsed !== undefined && deepEqual(liveDefParsed, declaredDef)) {
         findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+        continue;
+      }
+      // #1301 (residue of #1247): GetTemplate masks every non-ASCII character in a stored
+      // string literal as `?`, so a declared object `Definition` carrying non-ASCII text (a
+      // Japanese `Cause` message) arrives `?`-masked while the live compiled `DefinitionString`
+      // is intact — the strict compare above can never match, and letting the whole live
+      // definition surface as undeclared drift on a clean deploy is a false positive. This
+      // mirrors the declared `DefinitionString` branch (#1247): when the two definitions differ
+      // ONLY at such masked leaves, the declared value is unknowable from GetTemplate
+      // (CloudFormation itself reports it IN_SYNC), so emit the SAME readGap instead of a false
+      // undeclared. A genuine out-of-band edit still fails the mask-tolerant compare and surfaces.
+      if (liveDefParsed !== undefined && deepEqualModuloNonAsciiMask(declaredDef, liveDefParsed)) {
+        findings.push({
+          tier: 'readGap',
+          logicalId,
+          resourceType,
+          path: 'Definition',
+          note: GETTEMPLATE_MASK_NOTE,
+        });
         continue;
       }
     }

--- a/tests/classify-sfn-definition-712.test.ts
+++ b/tests/classify-sfn-definition-712.test.ts
@@ -206,3 +206,94 @@ describe('GetTemplate non-ASCII mask inside a DefinitionString — readGap, not 
     expect(tier(f, 'declared')).toContain('DefinitionString');
   });
 });
+
+describe('#1301 — object Definition parity with the string form (non-ASCII mask + DefinitionSubstitutions)', () => {
+  // Both fixes live in the OBJECT-`Definition` fold of the undeclared loop, which #1247's
+  // declared-`DefinitionString` non-ASCII demotion and #712-B's substitution resolution never
+  // reached. The SAME machine declared with the STRING form already behaved correctly; these
+  // assert the object form now matches, so a clean un-mutated stack has ZERO potential drift.
+
+  it('Case A: object Definition with non-ASCII leaves demotes to readGap at Definition, not undeclared DefinitionString', () => {
+    // The declared object's string leaf arrives `?`-masked from GetTemplate while the live
+    // compiled DefinitionString is intact, so the strict structural fold can never match.
+    // Mirror the STRING form: emit a readGap (at Definition), never surface the whole
+    // definition as undeclared drift on a clean deploy.
+    const DEF_OBJECT_JP = {
+      StartAt: 'Bad',
+      States: {
+        Bad: { Type: 'Fail', Cause: '入力された値が正しくありません', Error: 'InvalidFormat' },
+      },
+    };
+    const mask = (v: unknown): unknown =>
+      JSON.parse(JSON.stringify(v).replace(/[^\x00-\x7f]/gu, '?'));
+    const res = mk({
+      Definition: mask(DEF_OBJECT_JP),
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    });
+    const live = {
+      DefinitionString: JSON.stringify(DEF_OBJECT_JP),
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    };
+    const f = classifyResource(res, live, sfnSchema);
+    expect(tier(f, 'undeclared')).not.toContain('DefinitionString');
+    // The mask readGap (the #1301 fix) is emitted at `Definition` with the GetTemplate-mask
+    // note — distinct from the always-present writeOnly `Definition` readGap.
+    const maskGap = f.find(
+      (x) => x.tier === 'readGap' && x.path === 'Definition' && x.note?.includes('masks non-ASCII')
+    );
+    expect(maskGap).toBeDefined();
+  });
+
+  it('Case B: object Definition with a ${token} + DefinitionSubstitutions folds against the live substituted definition', () => {
+    // Substitutions apply to BOTH definition forms; the declared object still carries the
+    // literal `${greeting}` while the live compiled DefinitionString echoes the substituted
+    // value. Resolving the object leaves through applyDefinitionSubstitutions makes it fold.
+    const DEF_OBJECT_TOKEN = {
+      StartAt: 'P',
+      States: { P: { Type: 'Pass', Result: { v: '${greeting}' }, End: true } },
+    };
+    const res = mk({
+      Definition: DEF_OBJECT_TOKEN,
+      DefinitionSubstitutions: { greeting: 'hello-world' },
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    });
+    const live = {
+      DefinitionString:
+        '{"StartAt":"P","States":{"P":{"End":true,"Result":{"v":"hello-world"},"Type":"Pass"}}}',
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    };
+    const f = classifyResource(res, live, sfnSchema);
+    expect(tier(f, 'atDefault')).toContain('DefinitionString');
+    expect(tier(f, 'undeclared')).not.toContain('DefinitionString');
+  });
+
+  it('Control: a genuine ASCII-visible out-of-band edit to the object Definition still surfaces as undeclared', () => {
+    // Detection preserved: the live definition diverges by an ASCII leaf that neither the
+    // substitution nor the non-ASCII mask can explain, so it fails BOTH compares.
+    const DEF_OBJECT_TOKEN = {
+      StartAt: 'P',
+      States: { P: { Type: 'Pass', Result: { v: '${greeting}' }, End: true } },
+    };
+    const res = mk({
+      Definition: DEF_OBJECT_TOKEN,
+      DefinitionSubstitutions: { greeting: 'hello-world' },
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    });
+    // Substituted the token BUT also flipped Pass -> Wait: a genuine out-of-band edit.
+    const live = {
+      DefinitionString:
+        '{"StartAt":"P","States":{"P":{"End":true,"Result":{"v":"hello-world"},"Seconds":5,"Type":"Wait"}}}',
+      RoleArn: 'arn:aws:iam::111111111111:role/r',
+    };
+    const f = classifyResource(res, live, sfnSchema);
+    // The live compiled definition diverges by an ASCII leaf → surfaces as undeclared drift,
+    // NOT folded and NOT demoted to a mask readGap (the #1301 mask branch must not swallow it;
+    // the writeOnly `Definition` readGap that always accompanies the object form is unrelated).
+    expect(tier(f, 'undeclared')).toContain('DefinitionString');
+    expect(tier(f, 'atDefault')).not.toContain('DefinitionString');
+    const maskGap = f.find(
+      (x) => x.tier === 'readGap' && x.path === 'Definition' && x.note?.includes('masks non-ASCII')
+    );
+    expect(maskGap).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1301

## Problem

Two first-run FALSE POSITIVES on a clean, un-mutated `AWS::StepFunctions::StateMachine` stack (violating the ZERO-potential-drift core invariant) in the object-`Definition` fold of the undeclared loop (`sfnDefinitionObject`). The SAME machine declared with the STRING form already behaved correctly; the object form never reached the two prior fixes:

- **A. Object `Definition` + non-ASCII text (residue of #1247).** #1247 demoted the non-ASCII-masked compare to `readGap`, but only in the DECLARED `DefinitionString` branch. The #1209 object-`Definition` fold still used strict `deepEqual`; the declared object's string leaves arrive `?`-masked from GetTemplate while the live `DefinitionString` is intact, so the fold never matched and the WHOLE definition surfaced as `[Potential Drift]` undeclared.
- **B. Object `Definition` + `DefinitionSubstitutions`.** Substitutions apply to BOTH definition forms, but #1209 resolved them only into a declared `DefinitionString` STRING. With the object form the fold compared the live SUBSTITUTED definition against the declared object still carrying literal `${token}` placeholders → strict `deepEqual` failed → whole-definition undeclared FP.

## Fix

In the `sfnDefinitionObject` fold (`src/diff/classify.ts`):

1. Serialize the declared object and resolve `${token}` placeholders through the SAME `applyDefinitionSubstitutions` helper #1209 uses for the string form, then re-parse, BEFORE the compare.
2. When strict `deepEqual` fails, RETRY with `deepEqualModuloNonAsciiMask` (the helper #1247 used in the declared branch) and emit the SAME `readGap` finding (`GETTEMPLATE_MASK_NOTE`) instead of falling through to `undeclared`.

A genuine out-of-band definition edit (any ASCII-visible difference) still fails BOTH compares and surfaces — detection preserved.

## Tests

Added to `tests/classify-sfn-definition-712.test.ts`:
- Case A: object Definition with `?`-masked non-ASCII leaves vs intact live → asserts the mask `readGap` at `Definition` (fails without fix).
- Case B: object Definition with a `${token}` + `DefinitionSubstitutions` matching the live substituted definition → asserts it FOLDS (fails without fix).
- Control: a genuine ASCII-visible out-of-band edit → STILL surfaces as undeclared, no mask readGap swallow (detection preserved).

## Gates

typecheck / `vp check --fix` (0 errors) / pack / `vp test run` (4680 passed) / `vp run check` (0 errors) all green. #712/#1209/#1247 SFN tests + full corpus regression stay green.
