### PR TITLE
fix(read+diff): DMS::Endpoint *Settings blobs become a counted readGap, not false declared drift (#1293)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -5074,6 +5074,37 @@ export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
   // (live-observed on a clean ClientVpnEndpoint, us-east-1, 2026-07-10; #1102 F3). A true readGap:
   // the declared input shape is simply not part of the live model.
   'AWS::EC2::ClientVpnEndpoint': new Set(['TagSpecifications']),
+  // The per-engine `*Settings` connection blobs (S3Settings/KinesisSettings/…) — a
+  // NON_PROVISIONABLE type read via DMS DescribeEndpoints (overrides.ts readDmsEndpoint).
+  // The SDK returns these under DIFFERENT key casing than the CFn schema AND AWS
+  // default-fills them, so a verbatim passthrough would false-flag; the reader deliberately
+  // projects only the scalars and NEVER these blobs. Without this denylist a declared
+  // `S3Settings` (REQUIRED for an S3 endpoint) — a non-empty object — hits classify's
+  // removed-collection branch as `[CFn-Declared Drift] S3Settings desired={…} actual=undefined`
+  // on every S3/Kinesis/Kafka/MongoDB/… endpoint, survives record, and revert offers a bogus
+  // whole-property add. A true readGap: the live model genuinely never carries the declared
+  // shape. The 17 keys are the full AWS::DMS::Endpoint `*Settings` set (describe-type,
+  // us-east-1, 2026-07-10). Full field-by-field projection (restoring out-of-band detection)
+  // needs per-engine live default-fill analysis and is a deferred follow-up (#1293).
+  'AWS::DMS::Endpoint': new Set([
+    'DocDbSettings',
+    'DynamoDbSettings',
+    'ElasticsearchSettings',
+    'GcpMySQLSettings',
+    'IbmDb2Settings',
+    'KafkaSettings',
+    'KinesisSettings',
+    'MicrosoftSqlServerSettings',
+    'MongoDbSettings',
+    'MySqlSettings',
+    'NeptuneSettings',
+    'OracleSettings',
+    'PostgreSqlSettings',
+    'RedisSettings',
+    'RedshiftSettings',
+    'S3Settings',
+    'SybaseSettings',
+  ]),
 };
 
 // SCALAR_RETURNED_WHEN_SET is the ALLOWLIST inverse of the collection default in the

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -816,7 +816,12 @@ const readDlmLifecyclePolicy: OverrideReader = async ({ physicalId, declared, re
 // (S3Settings/KinesisSettings/…) are NOT projected: the SDK returns them under DIFFERENT key
 // casing than the CFn schema (e.g. CFn MongoDbSettings vs API MongoDbSettings sub-field
 // drift) and AWS default-fills them, so a passthrough would false-flag; scalar coverage is
-// the deliverable. Read-ONLY: a ModifyEndpoint writer is deferred to a follow-up (revert of
+// the deliverable. A declared *Settings would otherwise hit classify's removed-collection
+// branch (desired={…} actual=undefined) as a false declared drift on essentially every S3/
+// Kinesis/Mongo/… endpoint, so the 17 *Settings keys are an honest counted readGap via
+// READGAP_COLLECTION_PATHS['AWS::DMS::Endpoint'] (normalize/noise.ts); field-by-field
+// projection to restore out-of-band settings detection is a deferred follow-up (#1293).
+// Read-ONLY: a ModifyEndpoint writer is deferred to a follow-up (revert of
 // connection settings needs per-engine care). A deleted endpoint surfaces as
 // ResourceNotFoundFault → the router maps it to `deleted`.
 // Fetch a resource's live tags via DMS dms:ListTagsForResource (the ARN is the tag

--- a/tests/dms-endpoint-readgap-1293.test.ts
+++ b/tests/dms-endpoint-readgap-1293.test.ts
@@ -1,0 +1,103 @@
+// #1293 — AWS::DMS::Endpoint per-engine `*Settings` blobs (S3Settings/KinesisSettings/…) are
+// NOT projected by readDmsEndpoint (the SDK key-casing drifts from the CFn schema and AWS
+// default-fills them, so a passthrough would false-flag). Without the readGap denylist, a
+// declared `S3Settings` (a REQUIRED, non-empty object for an S3 endpoint) hits classify's
+// removed-collection branch as `[CFn-Declared Drift] S3Settings desired={…} actual=undefined`
+// on essentially every S3/Kinesis/Mongo/… endpoint, survives record, and revert offers a
+// bogus whole-property add. READGAP_COLLECTION_PATHS['AWS::DMS::Endpoint'] makes it an honest
+// counted readGap instead.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { READGAP_COLLECTION_PATHS } from '../src/normalize/noise.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+
+// No writeOnly on the *Settings, so they survive schema-strip into the declared model — the
+// condition under which the removed-collection branch would fire.
+const schema: SchemaInfo = {
+  readOnly: new Set(['Id']),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: ['Id'],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Endpoint',
+  resourceType: 'AWS::DMS::Endpoint',
+  physicalId: 'arn:aws:dms:us-east-1:123456789012:endpoint:ABCDEF0123456789',
+  declared,
+});
+
+describe('#1293 DMS::Endpoint *Settings readGap denylist', () => {
+  it('a declared S3Settings absent from the live read stays readGap, not declared drift', () => {
+    const findings = classifyResource(
+      mk({
+        EndpointType: 'target',
+        EngineName: 's3',
+        S3Settings: {
+          BucketName: 'my-bucket',
+          ServiceAccessRoleArn: 'arn:aws:iam::123456789012:role/dms',
+        },
+      }),
+      // the reader projects only the scalars; S3Settings is never in the live model
+      { EndpointType: 'target', EngineName: 's3' },
+      schema
+    );
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'S3Settings')).toBe(false);
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'S3Settings')).toBe(true);
+  });
+
+  it('a declared KinesisSettings likewise stays readGap, not declared drift', () => {
+    const findings = classifyResource(
+      mk({
+        EndpointType: 'target',
+        EngineName: 'kinesis',
+        KinesisSettings: {
+          StreamArn: 'arn:aws:kinesis:us-east-1:123456789012:stream/s',
+          MessageFormat: 'json',
+        },
+      }),
+      { EndpointType: 'target', EngineName: 'kinesis' },
+      schema
+    );
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'KinesisSettings')).toBe(false);
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'KinesisSettings')).toBe(true);
+  });
+
+  it('denylist covers the full 17-key AWS::DMS::Endpoint *Settings set', () => {
+    const keys = READGAP_COLLECTION_PATHS['AWS::DMS::Endpoint'];
+    expect(keys?.size).toBe(17);
+    for (const k of [
+      'DocDbSettings',
+      'DynamoDbSettings',
+      'ElasticsearchSettings',
+      'GcpMySQLSettings',
+      'IbmDb2Settings',
+      'KafkaSettings',
+      'KinesisSettings',
+      'MicrosoftSqlServerSettings',
+      'MongoDbSettings',
+      'MySqlSettings',
+      'NeptuneSettings',
+      'OracleSettings',
+      'PostgreSqlSettings',
+      'RedisSettings',
+      'RedshiftSettings',
+      'S3Settings',
+      'SybaseSettings',
+    ]) {
+      expect(keys?.has(k)).toBe(true);
+    }
+  });
+
+  it('a real out-of-band change to a projected SCALAR is still detected (no over-suppression)', () => {
+    const findings = classifyResource(
+      mk({ EndpointType: 'target', EngineName: 's3', ServerName: 'declared.example.com' }),
+      { EndpointType: 'target', EngineName: 's3', ServerName: 'changed.example.com' },
+      schema
+    );
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'ServerName')).toBe(true);
+  });
+});


### PR DESCRIPTION
`readDmsEndpoint` deliberately does not project the per-engine `*Settings` blobs (S3Settings/KinesisSettings/…) — the SDK key-casing drifts from the CFn schema and AWS default-fills them, so a verbatim passthrough would false-flag. But omitting them false-flags the other way: a declared `*Settings` is a non-empty object, so classify's removed-collection branch reports declared drift (`desired={…} actual=undefined`) on essentially every S3/Kinesis/Kafka/MongoDB/… endpoint (S3 targets REQUIRE `S3Settings`), it survives `record`, and `revert` offers a bogus whole-property add.

This implements the issue's tier-1 fix: add the 17 `AWS::DMS::Endpoint` `*Settings` keys (the full `describe-type` set, us-east-1) to `READGAP_COLLECTION_PATHS` so a declared `*Settings` classifies as an honest counted readGap instead. The reader comment is updated to reference it. Full field-by-field projection to restore out-of-band settings detection needs per-engine live default-fill analysis (per the reader's own comment) and is a deferred follow-up.

Adds tests/dms-endpoint-readgap-1293.test.ts (declared S3Settings/KinesisSettings → readGap not declared; full 17-key set asserted; a projected scalar OOB change still detected).

Closes #1293