### PR TITLE
fix(desired): getCrossRegionExports merges per-name across same-region stacks (#1282)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -356,8 +356,22 @@ export async function listExports(
 // Per-account+region cache of resolved `/cdk/exports/*` SSM parameters (name -> value), for
 // the CDK `crossRegionReferences: true` pattern. Like exportsCache, these parameters are scoped
 // to an account AND a region (they are written into the CONSUMER region by the reader), so the
-// cache key MUST carry BOTH axes. A single prefetch serves every reader GetAtt in the stack.
+// cache key MUST carry BOTH axes.
+//
+// Unlike exportsCache (backed by ListExports, which returns ALL exports so one fetch fully
+// determines the account:region content), getCrossRegionExports fetches only the names the
+// CURRENT stack's template references. The cached value is therefore a running MERGE across
+// every stack in the account:region — NOT a single stack's subset. Caching the first stack's
+// subset as the whole-key value starved every later same-region consumer stack of its own
+// (different) export names: they resolved UNRESOLVED though their parameters were live and
+// readable, re-hiding the out-of-band cert swap #741 was fixed to catch (#1282). The canonical
+// `crossRegionReferences: true` shape — several same-region stacks importing a us-east-1 ACM
+// cert — is exactly that population.
 const crossRegionExportsCache = new Map<string, Record<string, string>>();
+// Names already REQUESTED for a key (resolved OR confirmed-missing), so a name that came back
+// InvalidParameters is not re-fetched by every later stack. Without this tombstone a
+// confirmed-missing name would page ssm:GetParameters once per consumer stack forever.
+const crossRegionExportsFetched = new Map<string, Set<string>>();
 
 // The CDK cross-region-reference reader custom-resource type.
 const CROSS_REGION_EXPORT_READER_TYPE = 'Custom::CrossRegionExportReader';
@@ -420,7 +434,10 @@ export function collectCrossRegionExportNames(template: Record<string, any>): st
 // ssm:GetParameters (batched 10 at a time). Returns name -> value; a name that is missing /
 // unreadable is simply LEFT OUT (fail closed — resolveGetAtt then yields UNRESOLVED). Cached
 // per account:region so repeated gather runs in the same process don't re-fetch. Mirrors the
-// listExports prefetch/cache idiom.
+// listExports prefetch/cache idiom — but MERGES, fetching only the names not yet requested for
+// this key and accumulating results, because each stack references a DIFFERENT subset of the
+// account:region's exports (#1282). Fully-served requests (every name already attempted) return
+// the accumulated map with no SDK call.
 export async function getCrossRegionExports(
   ssm: SSMClient,
   accountId: string,
@@ -428,20 +445,30 @@ export async function getCrossRegionExports(
   names: string[]
 ): Promise<Record<string, string>> {
   const cacheKey = `${accountId}:${region}`;
-  const cached = crossRegionExportsCache.get(cacheKey);
-  if (cached) return cached;
-  const out: Record<string, string> = {};
-  for (let i = 0; i < names.length; i += 10) {
-    const batch = names.slice(i, i + 10);
+  const resolved = crossRegionExportsCache.get(cacheKey) ?? {};
+  const attempted = crossRegionExportsFetched.get(cacheKey) ?? new Set<string>();
+  const toFetch = names.filter((n) => !attempted.has(n));
+  if (toFetch.length === 0) return resolved;
+  // Accumulate into LOCAL copies and commit to the module cache only after every page
+  // succeeds: a throw mid-fetch must leave the cache untouched (no partial/poisoned map), the
+  // same all-or-nothing failure contract the previous throw-before-set had. On that throw the
+  // caller warns and every reader GetAtt in the stack falls back to UNRESOLVED for the run.
+  const nextResolved: Record<string, string> = { ...resolved };
+  const nextAttempted = new Set(attempted);
+  for (let i = 0; i < toFetch.length; i += 10) {
+    const batch = toFetch.slice(i, i + 10);
     const res = await ssm.send(new GetParametersCommand({ Names: batch }));
     for (const p of res.Parameters ?? []) {
-      if (p.Name && typeof p.Value === 'string') out[p.Name] = p.Value;
+      if (p.Name && typeof p.Value === 'string') nextResolved[p.Name] = p.Value;
     }
     // InvalidParameters (names that don't exist) are returned separately and intentionally
-    // dropped — the reader GetAtt for a missing name stays UNRESOLVED (fail closed).
+    // dropped from the value map — the reader GetAtt for a missing name stays UNRESOLVED (fail
+    // closed) — but the whole batch is marked attempted so it is not re-requested (tombstone).
+    for (const n of batch) nextAttempted.add(n);
   }
-  crossRegionExportsCache.set(cacheKey, out);
-  return out;
+  crossRegionExportsCache.set(cacheKey, nextResolved);
+  crossRegionExportsFetched.set(cacheKey, nextAttempted);
+  return nextResolved;
 }
 
 // Page ListStackResources (DescribeStackResources caps at 100; CDK stacks reach ~500).

--- a/tests/crossregion-exports-cache-1282.test.ts
+++ b/tests/crossregion-exports-cache-1282.test.ts
@@ -1,0 +1,126 @@
+// #1282 — getCrossRegionExports (#1236 crossRegionReferences `/cdk/exports/*` prefetch) caches
+// per account:region, but unlike listExports (which returns ALL exports) it fetches only the
+// names the CURRENT stack references. The pre-fix code cached that first-stack SUBSET as the
+// whole-key value and returned it verbatim to every later call:
+//   const cached = crossRegionExportsCache.get(cacheKey); if (cached) return cached;
+// so in a multi-stack run the SECOND same-region consumer stack — whose reader references
+// DIFFERENT export names — got stack A's map, its own names were absent, and every reader
+// GetAtt resolved UNRESOLVED (the out-of-band cert swap #741 catches went invisible again for
+// stacks 2..N). The fix keeps the account:region key but MERGES: it fetches only names not yet
+// requested for the key and accumulates, with a tombstone so a confirmed-missing name is not
+// re-paged by every stack, and commits to the cache only after a fully-successful fetch (the
+// throw-before-set poison-free failure contract is preserved).
+import { GetParametersCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { getCrossRegionExports } from '../src/desired/template-adapter.js';
+
+const REGION = 'eu-central-1';
+const CERT_A = '/cdk/exports/CertA';
+const CERT_B = '/cdk/exports/CertB';
+const ARN_A = 'arn:aws:acm:us-east-1:444455556666:certificate/aaaa';
+const ARN_B = 'arn:aws:acm:us-east-1:444455556666:certificate/bbbb';
+
+// Each test uses a UNIQUE account id so the process-level module cache (keyed account:region)
+// never bleeds one test's accumulation into another.
+let acctSeq = 0;
+function freshAccount(): string {
+  acctSeq += 1;
+  return String(100000000000 + acctSeq);
+}
+
+// An SSM stub that serves a fixed AVAILABLE map: a requested name present in it resolves; a name
+// absent from it comes back as InvalidParameters (dropped from Parameters), the "missing" shape.
+// Returns the raw stub (inferred type) so commandCalls(...) stays typed; cast to SSMClient at
+// the call site.
+function ssmServing(available: Record<string, string>) {
+  const stub = mockClient(SSMClient);
+  stub.on(GetParametersCommand).callsFake((input: { Names?: string[] }) => {
+    const names = input.Names ?? [];
+    return {
+      Parameters: names
+        .filter((n) => n in available)
+        .map((n) => ({ Name: n, Value: available[n] })),
+      InvalidParameters: names.filter((n) => !(n in available)),
+    };
+  });
+  return stub;
+}
+
+describe('getCrossRegionExports — per-name merge across same-region stacks (#1282)', () => {
+  beforeEach(() => {
+    acctSeq += 1000; // widen the gap between runs so a leaked key never coincides
+  });
+
+  it('a second stack’s DISTINCT export name on the same account:region is fetched and merged', async () => {
+    const acct = freshAccount();
+    const stub = ssmServing({ [CERT_A]: ARN_A, [CERT_B]: ARN_B });
+    const ssm = stub as unknown as SSMClient;
+
+    // Stack A references only CertA.
+    const a = await getCrossRegionExports(ssm, acct, REGION, [CERT_A]);
+    expect(a[CERT_A]).toBe(ARN_A);
+
+    // Stack B references only CertB — pre-fix it received A's cached subset ({CertA}) and CertB
+    // was absent → UNRESOLVED. The merge must fetch CertB and return it.
+    const b = await getCrossRegionExports(ssm, acct, REGION, [CERT_B]);
+    expect(b[CERT_B]).toBe(ARN_B);
+    // …and the accumulated map still carries A (a running merge, not a per-stack replace).
+    expect(b[CERT_A]).toBe(ARN_A);
+    // CertB was actually requested from SSM (pre-fix it never would be).
+    const requested = stub
+      .commandCalls(GetParametersCommand)
+      .flatMap((c) => c.args[0].input.Names ?? []);
+    expect(requested).toContain(CERT_B);
+  });
+
+  it('does NOT re-request a name already requested for the key (tombstone → cache hit)', async () => {
+    const acct = freshAccount();
+    const stub = ssmServing({ [CERT_A]: ARN_A });
+    const ssm = stub as unknown as SSMClient;
+
+    await getCrossRegionExports(ssm, acct, REGION, [CERT_A]);
+    const before = stub.commandCalls(GetParametersCommand).length;
+    const again = await getCrossRegionExports(ssm, acct, REGION, [CERT_A]);
+    const after = stub.commandCalls(GetParametersCommand).length;
+
+    expect(again[CERT_A]).toBe(ARN_A);
+    expect(after).toBe(before); // second call served entirely from cache, no SDK call
+  });
+
+  it('a first stack whose parameter is MISSING does not starve a later stack (no {} poison)', async () => {
+    const acct = freshAccount();
+    // CertA missing (its producer was deleted), CertB live.
+    const ssm = ssmServing({ [CERT_B]: ARN_B }) as unknown as SSMClient;
+
+    const a = await getCrossRegionExports(ssm, acct, REGION, [CERT_A]);
+    expect(a[CERT_A]).toBeUndefined(); // fail closed → UNRESOLVED downstream
+
+    // Pre-fix the empty {} was cached for the whole key and B got it → B was blinded too.
+    const b = await getCrossRegionExports(ssm, acct, REGION, [CERT_B]);
+    expect(b[CERT_B]).toBe(ARN_B);
+  });
+
+  it('a throw mid-fetch leaves the cache UNTOUCHED — the name is retried, not poisoned', async () => {
+    const acct = freshAccount();
+    const stub = mockClient(SSMClient);
+    let calls = 0;
+    stub.on(GetParametersCommand).callsFake((input: { Names?: string[] }) => {
+      calls += 1;
+      if (calls === 1) return Promise.reject(new Error('AccessDenied'));
+      return Promise.resolve({
+        Parameters: (input.Names ?? []).map((n) => ({ Name: n, Value: ARN_A })),
+        InvalidParameters: [],
+      });
+    });
+    const ssm = stub as unknown as SSMClient;
+
+    await expect(getCrossRegionExports(ssm, acct, REGION, [CERT_A])).rejects.toThrow(
+      'AccessDenied'
+    );
+    // The failed name was NOT tombstoned and no partial map was cached, so a later run retries it
+    // and resolves — the caller's warn+UNRESOLVED fallback for THIS run stays as before.
+    const retry = await getCrossRegionExports(ssm, acct, REGION, [CERT_A]);
+    expect(retry[CERT_A]).toBe(ARN_A);
+  });
+});


### PR DESCRIPTION
## Summary
#1236 prefetches the `/cdk/exports/*` SSM parameters a template references and caches per `account:region`. But unlike `exportsCache` (backed by `ListExports`, which returns ALL exports so `account:region` fully determines the content), `getCrossRegionExports` fetches only the names the CURRENT stack references — then cached that SUBSET as the whole-key value:
```ts
const cached = crossRegionExportsCache.get(cacheKey);
if (cached) return cached;   // returns stack A's subset to stack B
```
So in a multi-stack run the SECOND same-region consumer stack (different export names) got stack A's map, its own names were absent, and every `crossRegionReferences` reader GetAtt resolved UNRESOLVED — re-hiding the out-of-band cert swap #741 was fixed to catch for every stack after the first. A first stack whose producer was deleted also cached `{}`, blinding all later stacks.

## Fix
Keep the `account:region` key but **merge**: fetch only the names not yet requested for the key, accumulate results, tombstone attempted names (so a confirmed-missing name isn't re-paged by every stack), and commit to the cache only after a fully-successful fetch — preserving the throw-before-set poison-free failure contract.

## Test
`tests/crossregion-exports-cache-1282.test.ts` drives two `getCrossRegionExports` calls on the SAME `account:region` with distinct names and asserts the second stack's name is fetched and merged; plus tombstone (no re-fetch), no-{}-poison, and the failure contract (a throw leaves the cache untouched, the name is retried). Fails without the fix (merge + no-poison cases), passes with it. Full suite green (4693).

Closes #1282