### PR TITLE
fix(noise): RDS GlobalCluster EngineVersion prefix fold + Route53 RecordSet Name case fold (#1360, #1361)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3918,7 +3918,14 @@ export const JSON_STRING_DEFAULT_FILLS: Record<string, Record<string, Record<str
 // case-insensitive). Observed-only entries. The drift path is the dotted path
 // from calculateResourceDrift (e.g. `AliasTarget.DNSName`).
 export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
-  'AWS::Route53::RecordSet': new Set(['AliasTarget.DNSName']),
+  // `Name` alongside `AliasTarget.DNSName`: Route53 stores/returns record names
+  // lowercased, but a raw-CFn / L1 record can declare a mixed-case `Name`
+  // (`MyApp.Example.Com.`). The reader already aligns the trailing dot to the
+  // declared value, so the only remaining difference is case — DNS names are
+  // case-insensitive, so the fold masks no real drift (a genuinely different name
+  // still differs after case-fold). The sibling `AliasTarget.DNSName` on this same
+  // type was case-folded for the identical reason.
+  'AWS::Route53::RecordSet': new Set(['Name', 'AliasTarget.DNSName']),
   // Batch ComputeEnvironment `Type` — CDK's `FargateComputeEnvironment` /
   // `ManagedComputeEnvironment` emits the value LOWERCASE (`managed`) in the
   // template, but the Batch API accepts it case-insensitively and the live read
@@ -4423,6 +4430,12 @@ export const VERSION_PREFIX_PATHS: Record<string, ReadonlySet<string>> = {
   // Aurora clusters resolve a partial track the same way (declared `"8.0"` /
   // `"5.7.mysql_aurora.2"` reads back the full provisioned patch version).
   'AWS::RDS::DBCluster': new Set(['EngineVersion']),
+  // Aurora GlobalCluster is the same partial->concrete Aurora family: it is
+  // FULLY_MUTABLE and CC-read-native (`rds:DescribeGlobalClusters`), and a declared
+  // partial `EngineVersion` (`"8.0"` / `"5.7.mysql_aurora.2"`) provisions and reads
+  // back the concrete patch version, false-drifting on every clean deploy without the
+  // fold. A genuine track change still differs (the leading-run check fails).
+  'AWS::RDS::GlobalCluster': new Set(['EngineVersion']),
   // Live-observed on a fresh neptune-rich deploy: Neptune accepts a major.minor
   // EngineVersion (declared `"1.3"`) and provisions the latest patch in that track,
   // reading back the concrete 4-segment version (`"1.3.5.0"`) — the same partial->

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3593,6 +3593,36 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 
+  // #1361: Route53 stores/returns record names lowercased, so a raw-CFn / L1 record
+  // declared with a mixed-case `Name` reads back lowercase — a case-only difference on
+  // the same DNS-name class as the already-folded sibling `AliasTarget.DNSName`. The
+  // reader aligns the trailing dot to the declared value, so case is the only residual.
+  describe('case-insensitive scalar path (Route53 RecordSet Name, #1361)', () => {
+    const T = 'AWS::Route53::RecordSet';
+
+    it('mixed-case declared Name vs lowercase live Name is NOT drift', () => {
+      expect(
+        classifyResource(
+          res(T, { Name: 'MyApp.Example.Com.' }),
+          { Name: 'myapp.example.com.' },
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('a genuinely different record name is still drift', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res(T, { Name: 'MyApp.Example.Com.' }),
+            { Name: 'other.example.com.' },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['Name']);
+    });
+  });
+
   // #502: ECR RepositoryCreationTemplate declares `Prefix: "cdkrd-hunt/"` (S3-prefix
   // habit) but the service stores `"cdkrd-hunt"` — after the CC_IDENTIFIER_ADAPTERS
   // read succeeds, the residual Prefix diff is pure trailing-slash noise.
@@ -6292,6 +6322,27 @@ describe('classifyResource RDS version-track + dynamic-reference (R130)', () => 
     // a genuine version change still differs
     expect(
       declaredPaths('AWS::DocDB::DBCluster', { EngineVersion: '4.0' }, { EngineVersion: '5.0.0' })
+    ).toEqual(['EngineVersion']);
+  });
+
+  // #1360: Aurora GlobalCluster is the same Aurora partial->concrete family and is CC-read-
+  // native + FULLY_MUTABLE, so a declared partial "8.0" reads back the concrete provisioned
+  // patch and false-drifts on every clean deploy without the VERSION_PREFIX_PATHS entry.
+  it('RDS GlobalCluster EngineVersion "8.0" resolved to live "8.0.mysql_aurora.3.08.0" is NOT declared drift', () => {
+    expect(
+      declaredPaths(
+        'AWS::RDS::GlobalCluster',
+        { EngineVersion: '8.0' },
+        { EngineVersion: '8.0.mysql_aurora.3.08.0' }
+      )
+    ).toEqual([]);
+    // a genuine track change still differs
+    expect(
+      declaredPaths(
+        'AWS::RDS::GlobalCluster',
+        { EngineVersion: '5.7' },
+        { EngineVersion: '8.0.mysql_aurora.3.08.0' }
+      )
     ).toEqual(['EngineVersion']);
   });
 


### PR DESCRIPTION
## Summary

Two file-disjoint clean-deploy declared-FP folds in `src/normalize/noise.ts`, each a sibling of an already-shipped fold on the same class.

### #1360 — RDS GlobalCluster EngineVersion → `VERSION_PREFIX_PATHS`
`AWS::RDS::GlobalCluster` is FULLY_MUTABLE and CC-read-native (`rds:DescribeGlobalClusters`). A declared partial Aurora `EngineVersion` (`"8.0"`) provisions and reads back the concrete patch, false-drifting on every clean deploy. Added the entry alongside its DBInstance/DBCluster/Neptune/DocDB siblings. Prefix-gated, so a genuine track change still differs.

### #1361 — Route53 RecordSet Name → `CASE_INSENSITIVE_PATHS`
Route53 stores/returns record names lowercased; a raw-CFn / L1 record declared with a mixed-case `Name` false-drifts permanently. The reader already aligns the trailing dot to the declared value, so case is the only residual. Added `Name` alongside the already-folded sibling `AliasTarget.DNSName` on the same type. DNS names are case-insensitive so no real drift is masked.

## Tests
- `tests/classify.test.ts`: GlobalCluster partial→concrete NOT drift + genuine track change IS drift; Route53 Name mixed-case NOT drift + genuinely different name IS drift.
- Full suite: 4692 passed.

## Verification
Offline deterministic table additions; each mirrors a live-proven sibling fold. Fresh-deploy live-test deferred (recommended-not-required per both issues); unit tests + sibling precedent stand as evidence.

Closes #1360
Closes #1361