### PR TITLE
fix(revert): EC2 Modify*Attribute siblings write set-default so revert converges (#1366)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -241,6 +241,22 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   'AWS::EC2::Subnet\0AssignIpv6AddressOnCreation',
   'AWS::EC2::Subnet\0PrivateDnsNameOptionsOnLaunch',
   'AWS::EC2::Subnet\0EnableDns64',
+  // The #651 EC2 Modify*Attribute silent-no-op class through its siblings (#1366): each
+  // of these mutable attributes is set by a one-attribute-per-call Modify*Attribute API
+  // (ModifyVpcAttribute / ModifyInstanceAttribute / ModifyNetworkInterfaceAttribute), the
+  // exact contract #651 live-proved for Subnet EnableDns64 — a `remove` revert drops the
+  // property from the desired model, the CC patch carries no op for that attribute, the
+  // handler never issues the Modify*Attribute call, and the live value persists though CC
+  // reports SUCCESS (revert loops forever). Each already folds `atDefault` from the
+  // top-level KNOWN_DEFAULTS (VPC EnableDnsSupport:true, Instance/ENI SourceDestCheck:true,
+  // Instance InstanceInitiatedShutdownBehavior:'stop'), so writing that default explicitly
+  // converges. SourceDestCheck:false is a security-relevant OOB flip (turns the interface
+  // into a forwarding/NAT pivot) — detected by the equality gate but silently unrevertable
+  // without the explicit write.
+  'AWS::EC2::VPC\0EnableDnsSupport',
+  'AWS::EC2::NetworkInterface\0SourceDestCheck',
+  'AWS::EC2::Instance\0SourceDestCheck',
+  'AWS::EC2::Instance\0InstanceInitiatedShutdownBehavior',
   // EC2 ModifyClientVpnEndpoint is a SELECTIVE-update API routed through an SDK writer
   // (CLIENT_VPN_SCALAR_PARAMS): a `remove` deletes the key from the desired model, the
   // writer skips the now-undefined param, and nothing is sent — Cloud Control-style

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -554,6 +554,79 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#1366: undeclared EC2 VPC EnableDnsSupport -> add op writing the true KNOWN_DEFAULTS default', () => {
+    // Same #651 EC2 Modify*Attribute silent-no-op class: ModifyVpcAttribute leaves an
+    // omitted EnableDnsSupport unchanged, so a bare `remove` of an out-of-band `false` is a
+    // no-op. The `true` default is sourced from the top-level KNOWN_DEFAULTS.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::VPC',
+      path: 'EnableDnsSupport',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/EnableDnsSupport',
+      value: true,
+      prior: false,
+    });
+  });
+
+  it('#1366: undeclared EC2 NetworkInterface SourceDestCheck -> add op writing the true default (security)', () => {
+    // ModifyNetworkInterfaceAttribute one-attribute-per-call: a `remove` of an out-of-band
+    // `false` (turns the ENI into a forwarding/NAT pivot) is a silent no-op. Write the `true`
+    // KNOWN_DEFAULTS default explicitly so the security-relevant flip actually reverts.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::NetworkInterface',
+      path: 'SourceDestCheck',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SourceDestCheck',
+      value: true,
+      prior: false,
+    });
+  });
+
+  it('#1366: undeclared EC2 Instance SourceDestCheck -> add op writing the true default (security)', () => {
+    // ModifyInstanceAttribute sibling of the ENI case — same one-attribute-per-call no-op.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::Instance',
+      path: 'SourceDestCheck',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SourceDestCheck',
+      value: true,
+      prior: false,
+    });
+  });
+
+  it('#1366: undeclared EC2 Instance InstanceInitiatedShutdownBehavior -> add op writing the "stop" default', () => {
+    // ModifyInstanceAttribute leaves an omitted InstanceInitiatedShutdownBehavior unchanged;
+    // write the "stop" KNOWN_DEFAULTS default explicitly so an out-of-band "terminate" reverts.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::Instance',
+      path: 'InstanceInitiatedShutdownBehavior',
+      actual: 'terminate',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/InstanceInitiatedShutdownBehavior',
+      value: 'stop',
+      prior: 'terminate',
+    });
+  });
+
   it('#912: undeclared ClientVpnEndpoint VpnPort -> add op writing the 443 KNOWN_DEFAULTS default, not a no-op remove', () => {
     // AWS::EC2::ClientVpnEndpoint VpnPort is a CLIENT_VPN_SCALAR_PARAMS writer prop: a bare
     // `remove` deletes the key from the desired model, the selective ModifyClientVpnEndpoint


### PR DESCRIPTION
## Summary

The #651 EC2 `Modify*Attribute` silent-no-op revert class through its siblings. Each of these mutable attributes is set by a one-attribute-per-call `Modify*Attribute` API — the exact contract #651 live-proved for Subnet `EnableDns64`: a bare `remove` revert drops the property from the desired model, the Cloud Control patch carries no op for that attribute, the handler never issues the `Modify*Attribute` call, and the live value persists though CC reports SUCCESS (revert loops forever).

Added to `REVERT_SET_DEFAULT_PATHS` in `src/revert/plan.ts` (each already folds `atDefault` from the top-level `KNOWN_DEFAULTS`, so the explicit set-default value resolves from there):

| Type | Property | Default | ModifyX API |
|---|---|---|---|
| `AWS::EC2::VPC` | `EnableDnsSupport` | `true` | ModifyVpcAttribute |
| `AWS::EC2::NetworkInterface` | `SourceDestCheck` | `true` | ModifyNetworkInterfaceAttribute |
| `AWS::EC2::Instance` | `SourceDestCheck` | `true` | ModifyInstanceAttribute |
| `AWS::EC2::Instance` | `InstanceInitiatedShutdownBehavior` | `stop` | ModifyInstanceAttribute |

`SourceDestCheck: false` is a security-relevant OOB flip (turns the interface into a forwarding/NAT pivot) — detected by the equality gate but silently unrevertable without the explicit write.

## Tests
- `tests/revert-plan.test.ts`: four new cases asserting each produces an `add` op writing the KNOWN_DEFAULTS default (mirrors the shipped #651 Subnet tests).
- Full suite: 4693 passed.

## Verification
Offline deterministic table addition riding the proven #651 `Modify*Attribute` contract; plan-op unit tests assert the converging write. Fresh-deploy live-confirm deferred (recommended-not-required per the issue).

Closes #1366