### PR TITLE
fix(revert): pre-classify added AWS::EC2::NetworkAclEntry as not-revertable (#1405)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -735,6 +735,18 @@ function isUnderCreateOnly(findingPath: string, createOnlyPaths: readonly string
   return false;
 }
 
+// #1405: resource types whose out-of-band `added` finding CANNOT be reverted by a Cloud
+// Control DeleteResource — the CC registry has NO delete handler for the type, so a
+// `delete`-kind item would be built and then FAIL only at apply with
+// `UnsupportedActionException: Resource type <T> does not support DELETE action`. Pre-classify
+// them as `notRevertable` up front — the honest twin of the `deleted` / `no physical id`
+// gates — instead of offering a delete that loudly fails. Detection + record / ignore still
+// work; a type-specific SDK writer could later make it actually revertable.
+//   - AWS::EC2::NetworkAclEntry: live-proven (#1315/#1405). CC GetResource reads it via the
+//     SDK override (`readEc2NetworkAclEntry`), but DeleteResource returns the unsupported-action
+//     error above (its CFn delete flows through the parent NetworkAcl's EC2 API, not CC).
+const CC_DELETE_UNSUPPORTED_ADDED_TYPES = new Set<string>(['AWS::EC2::NetworkAclEntry']);
+
 export function buildRevertPlan(
   findings: Finding[],
   baseline: BaselineFile | undefined,
@@ -833,6 +845,18 @@ export function buildRevertPlan(
           resourceType: f.resourceType,
           path: f.path,
           reason: 'no physical id',
+        });
+        continue;
+      }
+      // #1405: Cloud Control has no DeleteResource handler for this type — a `delete` item
+      // would fail only at apply (UnsupportedActionException). Report it honestly up front.
+      if (CC_DELETE_UNSUPPORTED_ADDED_TYPES.has(f.resourceType)) {
+        notRevertable.push({
+          displayId,
+          resourceType: f.resourceType,
+          path: f.path,
+          reason:
+            'out-of-band resource of a type Cloud Control cannot delete (no DeleteResource handler) — remove it manually',
         });
         continue;
       }

--- a/tests/revert-plan-naclentry-1405.test.ts
+++ b/tests/revert-plan-naclentry-1405.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+// #1405: an out-of-band `added` AWS::EC2::NetworkAclEntry (surfaced by #1315) must be
+// reported as notRevertable UP FRONT — Cloud Control has no DeleteResource handler for the
+// type, so a `delete`-kind item would fail only at apply with UnsupportedActionException
+// (live-observed: "Resource type AWS::EC2::NetworkAclEntry does not support DELETE action").
+const addedFinding = (over: Partial<Finding>): Finding => ({
+  tier: 'added',
+  logicalId: 'Rogue',
+  physicalId: 'acl-0decc27dd4a85e726|50|false',
+  resourceType: 'AWS::EC2::NetworkAclEntry',
+  path: '',
+  unrecorded: true,
+  ...over,
+});
+
+describe('buildRevertPlan — #1405 CC-delete-unsupported added types', () => {
+  it('an added NetworkAclEntry is notRevertable up front under --remove-unrecorded (no delete op)', () => {
+    const f = addedFinding({});
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('Cloud Control cannot delete');
+    expect(plan.notRevertable[0]!.resourceType).toBe('AWS::EC2::NetworkAclEntry');
+  });
+
+  it('without --remove-unrecorded it is the ordinary unrecorded gate (never a silent delete)', () => {
+    const f = addedFinding({});
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('unrecorded');
+  });
+
+  it('a CC-deletable added sibling (SubnetRouteTableAssociation) STILL builds a delete item', () => {
+    // control: the gate must be scoped to the unsupported type only — the other #1315
+    // sub-resources revert cleanly via CC DeleteResource.
+    const f = addedFinding({
+      logicalId: 'RogueAssoc',
+      resourceType: 'AWS::EC2::SubnetRouteTableAssociation',
+      physicalId: 'rtbassoc-09eeac6b454391d81',
+    });
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('delete');
+  });
+});


### PR DESCRIPTION
Closes #1405. Follow-up to #1315 (#1312/#1386 honesty class).

## Problem
An out-of-band `added` `AWS::EC2::NetworkAclEntry` (surfaced by #1315) was OFFERED a DELETE op in the revert plan and only FAILED at apply — live-observed while verifying #1315:

```
FAILED: Nacl ▸ #50 ingress allow 0.0.0.0/0 — UnsupportedActionException: Resource type AWS::EC2::NetworkAclEntry does not support DELETE action
```

Cloud Control has no DeleteResource handler for the type (its CFn delete flows through the parent NetworkAcl's EC2 API, not CC), so the plan should say so up front instead of a loud apply-time failure. The other three #1315 sub-resources (SubnetRouteTableAssociation, VPCGatewayAttachment, VPCCidrBlock) revert cleanly via CC and are unaffected.

## Fix
`src/revert/plan.ts`: a small `CC_DELETE_UNSUPPORTED_ADDED_TYPES` set, checked in the `added`-delete branch right after the `no physical id` gate and before building the `delete` item — a matching type is pushed to `notRevertable` with an honest reason (the twin of the `deleted` / `no physical id` / `unrecorded` gates). Detection + record / ignore still work; a type-specific SDK writer could later make it actually revertable.

## Scope / collision
Disjoint from the open #1348 (which touches `REVERT_SET_DEFAULT_PATHS` @L241); this edit is in the added-delete branch (~L840) + a NEW test file `tests/revert-plan-naclentry-1405.test.ts` (no overlap with revert-plan.test.ts).

## Tests
New file: NACLEntry added → notRevertable up front (no delete op); the ordinary unrecorded gate without `--remove-unrecorded`; and a CC-deletable sibling (SubnetRouteTableAssociation) STILL builds a delete item (gate scoped to the unsupported type only).

Offline-deterministic; the live UnsupportedActionException was observed this session verifying #1315 (0.12.43).