### PR TITLE
fix(noise): RDS GlobalCluster EngineLifecycleSupport folds value-independent (#1406)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3045,6 +3045,14 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'PreferredBackupWindow',
     'EngineLifecycleSupport',
   ]),
+  // Aurora GlobalCluster carries the SAME `EngineLifecycleSupport` RDS Extended Support
+  // enrollment as its DBCluster/DBInstance siblings above, with the identical creation-era-
+  // dependent, restore-resets-the-timestamp non-reconstructability (see the full note above) —
+  // so it folds value-independent too. Live-observed first-run on a fresh headless GlobalCluster
+  // (`open-source-rds-extended-support`, #1406). A DECLARED enrollment is compared in the
+  // declared loop (detected). GlobalCluster has no KmsKeyId / AZ / window props of its own
+  // (those live on the member cluster), so this is the only value-independent entry it needs.
+  'AWS::RDS::GlobalCluster': new Set(['EngineLifecycleSupport']),
   //   AWS::EKS::AccessEntry.Username is NO LONGER value-independent (#890): the undeclared
   //   default is a DETERMINISTIC transform of the declared PrincipalArn, so it is folded by a
   //   tier-2 derived equality gate in classify.ts (which STILL surfaces an out-of-band RBAC

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6469,6 +6469,11 @@ describe('RDS AWS-assigned values fold value-independent (KmsKeyId/AZ/windows)',
       expect(t('AWS::RDS::DBInstance', {}, { EngineLifecycleSupport: v }).atDefault).toContain(
         'EngineLifecycleSupport'
       );
+      // #1406: Aurora GlobalCluster carries the same enrollment with the same creation-era
+      // non-reconstructability — live-observed first-run undeclared on a fresh headless deploy.
+      expect(t('AWS::RDS::GlobalCluster', {}, { EngineLifecycleSupport: v }).atDefault).toContain(
+        'EngineLifecycleSupport'
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

Discovered live while verifying #1360: a clean, un-mutated headless Aurora `AWS::RDS::GlobalCluster` surfaces the undeclared `EngineLifecycleSupport = "open-source-rds-extended-support"` as a first-run `[Potential Drift]` — a core-invariant violation.

## Correction to the filed issue's fix direction
The issue proposed a tier-1 `KNOWN_DEFAULTS` constant. That is **wrong**: the DBCluster/DBInstance siblings already fold this exact property **value-independent** (tier-3), because the value is set by the resource's ORIGINAL creation era (`-disabled` for a pre-Extended-Support lineage, `-extended-support` otherwise) and a RESTORE resets the readable `ClusterCreateTime` — the live model exposes no signal to reconstruct it, so no single constant folds both forms without a false positive. GlobalCluster carries the identical enrollment and shares that non-reconstructability, so it belongs in `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` alongside its siblings, NOT `KNOWN_DEFAULTS`.

GlobalCluster has no KmsKeyId / AZ / window props of its own (those live on the member cluster), so `EngineLifecycleSupport` is the only value-independent entry it needs.

A DECLARED enrollment stays user intent — compared in the declared loop (detected).

## Tests
- `tests/classify.test.ts`: extended the existing value-independent EngineLifecycleSupport case to assert GlobalCluster folds BOTH the enabled and disabled forms to `atDefault` (mirrors the DBCluster/DBInstance assertions).
- Full suite: 4730 passed.

Closes #1406