### PR TITLE
fix(read): Cognito IdentityPool GetCognitoEvents failure surfaces a counted readGap (#1326)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -202,6 +202,37 @@ export interface OverrideCtx {
   // UpdateResource ValidationException. Falls back to `physicalId` when no adapter applies.
   identifier?: string;
 }
+// An override that COULD read the base model but hit a partial read-gap (an enrichment call it
+// depends on failed) reports the affected paths so the router can surface them as counted
+// `readGap` findings — exactly like the SDK_SUPPLEMENTS path (collectSupplementReadGaps →
+// ReadResult.readGapPaths → classifyResource, #849). Branded with a Symbol so the router can
+// tell it apart from a bare live model that might coincidentally carry a `model` key (#1326).
+const OVERRIDE_READ_GAP = Symbol.for('cdkrd.overrideReadGap');
+// A `type` (not `interface`) so it carries an implicit index signature and stays assignable to
+// Record<string, unknown> — that is what lets OverrideReader keep its narrow bare-model return
+// type while a reader can still hand back this branded variant.
+export type OverrideReadResult = {
+  [OVERRIDE_READ_GAP]: true;
+  model: Record<string, unknown>;
+  readGapPaths: string[];
+};
+export function overrideReadGap(
+  model: Record<string, unknown>,
+  readGapPaths: string[]
+): OverrideReadResult {
+  return { [OVERRIDE_READ_GAP]: true, model, readGapPaths };
+}
+export function isOverrideReadResult(
+  x: Record<string, unknown> | undefined
+): x is OverrideReadResult {
+  return (
+    typeof x === 'object' && x !== null && (x as OverrideReadResult)[OVERRIDE_READ_GAP] === true
+  );
+}
+// An OverrideReadResult is structurally a Record<string, unknown> (a symbol brand key plus the
+// `model` / `readGapPaths` string keys), so the reader return type stays narrow — the revert path
+// and every other override caller keep seeing a bare model, and only the router (via
+// isOverrideReadResult) unwraps the read-gap variant.
 export type OverrideReader = (ctx: OverrideCtx) => Promise<Record<string, unknown> | undefined>;
 
 const str = (v: unknown): string | undefined =>
@@ -2809,23 +2840,31 @@ const readCognitoIdentityPool: OverrideReader = async ({ physicalId, declared, r
     // which must stay absent (declared) so a clean pool never reports false drift.
     if (ev.Events && Object.keys(ev.Events).length > 0) model.CognitoEvents = ev.Events;
   } catch (e) {
-    // Re-fold a DECLARED CognitoEvents to a readGap (mirror declared -> live) so it never
-    // false-flags as declared drift against the (now unread) live value. An UNDECLARED
-    // CognitoEvents has nothing to compare, so nothing is mirrored — a clean pool stays clean.
-    if ('CognitoEvents' in declared && !('CognitoEvents' in model))
-      model.CognitoEvents = declared.CognitoEvents;
-    // Only a genuine region-unavailability is silent; a permission/throttle/other transient
-    // failure is a fixable coverage gap and warns LOUDLY on stderr.
-    if (!isCognitoSyncRegionUnavailable(e)) {
-      const call = (e as Error)?.name || 'unknown error';
-      const gap =
-        'CognitoEvents' in declared
-          ? ' — treating CognitoEvents as an unverifiable read-gap (declared value assumed unchanged; grant cognito-sync:GetCognitoEvents to detect out-of-band drift on it)'
-          : '';
-      process.stderr.write(
-        `[cdkrd] warning: cognito-sync:GetCognitoEvents for ${id} failed (${call})${gap}\n`
-      );
+    // A genuine region-unavailability of the (deprecated) cognito-sync service is SILENT: the
+    // service cannot exist here, so there is no coverage gap to report. Mirror a DECLARED value
+    // (declared == live → no false drift); an undeclared one has nothing to compare, so a clean
+    // pool stays clean. No readGap, no warning.
+    if (isCognitoSyncRegionUnavailable(e)) {
+      if ('CognitoEvents' in declared && !('CognitoEvents' in model))
+        model.CognitoEvents = declared.CognitoEvents;
+      return model;
     }
+    // A permission/throttle/other transient failure IS a fixable coverage gap. Report
+    // CognitoEvents as a COUNTED readGap (footer + snapshot-completeness-blocking, #849/#1182)
+    // rather than mirroring the declared value: mirroring (pre-#1326) silenced BOTH cases —
+    // a DECLARED value read as verified when it was never read, and an UNDECLARED out-of-band
+    // Sync trigger behind the denial (the #482-class event this reader exists to catch) stayed
+    // fully invisible. A readGap covers both: no false declared-tier drift (#752 preserved) AND
+    // the undeclared path is surfaced as unread. classifyResource handles declared + undeclared
+    // readGap paths uniformly, so the model keeps CognitoEvents ABSENT and the router translates
+    // the reported path into ReadResult.readGapPaths.
+    const call = (e as Error)?.name || 'unknown error';
+    process.stderr.write(
+      `[cdkrd] warning: cognito-sync:GetCognitoEvents for ${id} failed (${call}) — treating ` +
+        `CognitoEvents as an unverifiable read-gap (grant cognito-sync:GetCognitoEvents to ` +
+        `detect out-of-band drift on it)\n`
+    );
+    return overrideReadGap(model, ['CognitoEvents']);
   }
   return model;
 };

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -6,7 +6,7 @@ import { isResourceNotFoundError } from '../aws-errors.js';
 import { partitionForRegion } from '../desired/template-adapter.js';
 import { OVERRIDE_READABLE_WRITEONLY } from '../schema/schema-strip.js';
 import type { DesiredResource } from '../types.js';
-import { SDK_OVERRIDES, SDK_SUPPLEMENTS } from './overrides.js';
+import { isOverrideReadResult, SDK_OVERRIDES, SDK_SUPPLEMENTS } from './overrides.js';
 
 export interface ReadResult {
   live?: Record<string, unknown>; // un-stripped property model
@@ -551,10 +551,16 @@ export async function readLive(
   const override = SDK_OVERRIDES[resourceType];
   if (override) {
     try {
-      const live = await override({ physicalId: physicalId ?? '', declared, region, accountId });
-      return live
-        ? { live }
-        : { skippedReason: 'SDK override: target not resolvable from template' };
+      const result = await override({ physicalId: physicalId ?? '', declared, region, accountId });
+      if (result === undefined)
+        return { skippedReason: 'SDK override: target not resolvable from template' };
+      // An override that read the base model but hit a partial read-gap (an enrichment call it
+      // depends on failed) returns a branded { model, readGapPaths } so those paths surface as
+      // counted readGap findings — the same ReadResult.readGapPaths channel the SDK_SUPPLEMENTS
+      // path uses (#1326, e.g. Cognito IdentityPool CognitoEvents on a GetCognitoEvents denial).
+      if (isOverrideReadResult(result))
+        return { live: result.model, readGapPaths: result.readGapPaths };
+      return { live: result };
     } catch (e) {
       if (isResourceNotFoundError(e)) return { deleted: true };
       return { skippedReason: `SDK override (${resourceType}): ${(e as Error).name}` };

--- a/tests/cognito-identity-pool-events-1085.test.ts
+++ b/tests/cognito-identity-pool-events-1085.test.ts
@@ -2,7 +2,11 @@ import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcon
 import { CognitoSyncClient, GetCognitoEventsCommand } from '@aws-sdk/client-cognito-sync';
 import { mockClient } from 'aws-sdk-client-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import {
+  isOverrideReadResult,
+  type OverrideReadResult,
+  SDK_OVERRIDES,
+} from '../src/read/overrides.js';
 
 const cc = mockClient(CloudControlClient);
 const sync = mockClient(CognitoSyncClient);
@@ -18,6 +22,13 @@ const ctx = (
 ) => ({ physicalId, declared, region, accountId });
 
 const read = (c: ReturnType<typeof ctx>) => SDK_OVERRIDES['AWS::Cognito::IdentityPool'](c);
+
+// Assert-and-cast: the reader's loud-failure return is a branded readGap result. Casting after
+// the assertion keeps each expect at the top level (avoids vitest/no-conditional-expect).
+const gapOf = (out: Awaited<ReturnType<typeof read>>): OverrideReadResult => {
+  expect(isOverrideReadResult(out)).toBe(true);
+  return out as unknown as OverrideReadResult;
+};
 
 // The CC base-model GetResource that always succeeds (a live pool). CognitoEvents is a
 // writeOnly prop that Cloud Control never echoes, so it is absent from the CC model.
@@ -58,11 +69,12 @@ describe('AWS::Cognito::IdentityPool GetCognitoEvents failure handling (#1085)',
     expect(out).not.toHaveProperty('CognitoEvents');
   });
 
-  // The core #1085 regression: an AccessDenied (missing cognito-sync:GetCognitoEvents)
-  // must NOT silently drop a DECLARED CognitoEvents. Before the fix, the reader returned a
-  // model with CognitoEvents omitted -> the exempted-from-writeOnly-strip prop compared
-  // against absent live -> a FALSE declared-tier "removed out of band" finding.
-  it('does NOT drop a DECLARED CognitoEvents on AccessDenied — mirrors it to a readGap + warns', async () => {
+  // The core #1085 regression: an AccessDenied (missing cognito-sync:GetCognitoEvents) must NOT
+  // silently drop a DECLARED CognitoEvents. #1326 upgrades the #1085 mirror to a real COUNTED
+  // readGap: the reader now returns a branded { model, readGapPaths } with CognitoEvents ABSENT
+  // from the model, so classify emits a readGap finding (footer + completeness) instead of a
+  // silent mirror — and NO false declared-tier "removed out of band" drift.
+  it('reports a DECLARED CognitoEvents as a readGap on AccessDenied (no mirror) + warns', async () => {
     okBaseModel();
     const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     sync
@@ -70,8 +82,11 @@ describe('AWS::Cognito::IdentityPool GetCognitoEvents failure handling (#1085)',
       .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
 
     const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
-    // The declared value is mirrored into live (declared == live -> no false drift).
-    expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
+    // A branded readGap result: CognitoEvents is NOT mirrored into the model (so it is not read
+    // as verified), and the path is reported so classify counts it as a readGap.
+    const gap = gapOf(out);
+    expect(gap.model).not.toHaveProperty('CognitoEvents');
+    expect(gap.readGapPaths).toContain('CognitoEvents');
     // AND it warns LOUDLY on stderr — a fixable coverage gap, not a silent drop.
     expect(warn).toHaveBeenCalled();
     const msg = warn.mock.calls.map((c) => String(c[0])).join('');
@@ -79,7 +94,7 @@ describe('AWS::Cognito::IdentityPool GetCognitoEvents failure handling (#1085)',
     expect(msg).toContain('AccessDeniedException');
   });
 
-  it('does NOT drop a DECLARED CognitoEvents on throttling — mirrors it to a readGap + warns', async () => {
+  it('reports a DECLARED CognitoEvents as a readGap on throttling (no mirror) + warns', async () => {
     okBaseModel();
     const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     sync
@@ -87,12 +102,12 @@ describe('AWS::Cognito::IdentityPool GetCognitoEvents failure handling (#1085)',
       .rejects(Object.assign(new Error('rate exceeded'), { name: 'ThrottlingException' }));
 
     const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
-    expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
+    expect(gapOf(out).readGapPaths).toContain('CognitoEvents');
     expect(warn).toHaveBeenCalled();
     expect(warn.mock.calls.map((c) => String(c[0])).join('')).toContain('ThrottlingException');
   });
 
-  it('an UNDECLARED CognitoEvents stays absent on AccessDenied (nothing to false-flag) but still warns', async () => {
+  it('reports an UNDECLARED CognitoEvents as a readGap on AccessDenied (OOB Sync trigger no longer silent) + warns', async () => {
     okBaseModel();
     const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
     sync
@@ -100,8 +115,11 @@ describe('AWS::Cognito::IdentityPool GetCognitoEvents failure handling (#1085)',
       .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
 
     const out = await read(ctx(POOL_ID, {}));
-    // No declared CognitoEvents -> nothing to mirror -> stays absent (a clean pool).
-    expect(out).not.toHaveProperty('CognitoEvents');
+    // Pre-#1326 an undeclared CognitoEvents stayed absent + uncounted, so an out-of-band Sync
+    // trigger behind the denial was fully invisible. Now the path is reported as a readGap.
+    const gap = gapOf(out);
+    expect(gap.model).not.toHaveProperty('CognitoEvents');
+    expect(gap.readGapPaths).toContain('CognitoEvents');
     expect(warn).toHaveBeenCalled();
   });
 
@@ -113,9 +131,10 @@ describe('AWS::Cognito::IdentityPool GetCognitoEvents failure handling (#1085)',
       .rejects(Object.assign(new Error('endpoint not resolvable'), { name: 'UnknownEndpoint' }));
 
     const out = await read(ctx(POOL_ID, { CognitoEvents: DECLARED_EVENTS }));
-    // Still no false declared-tier drift: the declared value is folded to a readGap.
+    // Region-unavailability stays QUIET (not a coverage gap — the service can't exist here), so
+    // it keeps the #1085 mirror (declared == live → no false drift), NOT the #1326 loud readGap.
     expect(out).toMatchObject({ CognitoEvents: DECLARED_EVENTS });
-    // But it is SILENT — the deprecated cognito-sync service simply cannot exist there.
+    // And it is SILENT — the deprecated cognito-sync service simply cannot exist there.
     expect(warn).not.toHaveBeenCalled();
   });
 

--- a/tests/cognito-identity-pool-readgap-1326.test.ts
+++ b/tests/cognito-identity-pool-readgap-1326.test.ts
@@ -1,0 +1,103 @@
+// #1326 — the Cognito IdentityPool reader (SDK_OVERRIDES, not a supplement) was left on the OLD
+// #1085 mirror on a GetCognitoEvents failure: it copied the DECLARED CognitoEvents into the live
+// model, producing ZERO findings. So the read-gap footer claimed the pool fully verified, a
+// `record` during an outage blessed an unverified value, and an out-of-band-added Sync trigger
+// (undeclared) behind the denial was fully invisible. The fix routes an override's partial
+// read-gap through the SAME ReadResult.readGapPaths channel the SDK_SUPPLEMENTS path uses
+// (#849/#1182): readCognitoIdentityPool returns a branded { model, readGapPaths:['CognitoEvents'] }
+// on a LOUD failure, the router translates it, and classifyResource emits a counted readGap for
+// BOTH the declared and the undeclared case. This drives readLive end to end (CC GetResource
+// mocked OK, GetCognitoEvents → AccessDenied) and then classifyResource.
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { CognitoSyncClient, GetCognitoEventsCommand } from '@aws-sdk/client-cognito-sync';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { readLive } from '../src/read/router.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const cc = mockClient(CloudControlClient);
+const sync = mockClient(CognitoSyncClient);
+
+const POOL_ID = 'us-east-1:12345678-1234-1234-1234-123456789012';
+const EVENTS = { SyncTrigger: 'arn:aws:lambda:us-east-1:123456789012:function:MyTrigger' };
+const REGION = 'us-east-1';
+const ACCOUNT = '123456789012';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const resource = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Pool',
+  resourceType: 'AWS::Cognito::IdentityPool',
+  physicalId: POOL_ID,
+  declared,
+});
+
+const tierOf = (findings: Finding[], path: string) => findings.find((f) => f.path === path)?.tier;
+
+beforeEach(() => {
+  cc.reset();
+  sync.reset();
+  cc.on(GetResourceCommand).resolves({
+    ResourceDescription: {
+      Identifier: POOL_ID,
+      Properties: JSON.stringify({
+        IdentityPoolName: 'mypool',
+        AllowUnauthenticatedIdentities: false,
+      }),
+    },
+  });
+  sync
+    .on(GetCognitoEventsCommand)
+    .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('#1326 Cognito IdentityPool GetCognitoEvents denial → counted readGap (not a silent mirror)', () => {
+  it('readLive reports CognitoEvents in ReadResult.readGapPaths and leaves it absent from live', async () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const res = await readLive(
+      cc as unknown as CloudControlClient,
+      resource({ CognitoEvents: EVENTS }),
+      REGION,
+      ACCOUNT
+    );
+    expect(res.readGapPaths).toContain('CognitoEvents');
+    // The declared value is NOT mirrored into live (pre-#1326 it was), so it is not read as verified.
+    expect(res.live).toBeDefined();
+    expect(res.live).not.toHaveProperty('CognitoEvents');
+  });
+
+  it('a DECLARED CognitoEvents classifies as readGap (footer + completeness), NOT a false declared removal', async () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const dr = resource({ CognitoEvents: EVENTS });
+    const res = await readLive(cc as unknown as CloudControlClient, dr, REGION, ACCOUNT);
+    const findings = classifyResource(dr, res.live ?? {}, emptySchema, {
+      supplementReadGapPaths: res.readGapPaths,
+    });
+    expect(tierOf(findings, 'CognitoEvents')).toBe('readGap');
+  });
+
+  it('an UNDECLARED CognitoEvents classifies as readGap — the OOB Sync trigger behind the denial is no longer invisible', async () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const dr = resource({});
+    const res = await readLive(cc as unknown as CloudControlClient, dr, REGION, ACCOUNT);
+    expect(res.readGapPaths).toContain('CognitoEvents');
+    const findings = classifyResource(dr, res.live ?? {}, emptySchema, {
+      supplementReadGapPaths: res.readGapPaths,
+    });
+    expect(tierOf(findings, 'CognitoEvents')).toBe('readGap');
+  });
+});


### PR DESCRIPTION
## Summary
The Cognito IdentityPool reader (`SDK_OVERRIDES`, not a supplement) was left on the old #1085 mechanism: on any `cognito-sync:GetCognitoEvents` failure it mirrored the DECLARED `CognitoEvents` into the live model, producing ZERO findings. Consequences:
- the read-gap footer claimed the pool fully verified;
- a `record` during an outage blessed an unverified declared value;
- an out-of-band-added Sync trigger (a Lambda wired to the pool — the #482-class event this reader exists to catch) that is **undeclared** and behind the denial was fully invisible.

Root cause: `ReadResult.readGapPaths` was populated only in the router's `SDK_SUPPLEMENTS` catch; the `OverrideReader` contract returned a bare model, so an override enriching a CC base read had no way to signal a per-prop read gap (#849/#1182 follow-up).

## Fix
- Add a **branded** `OverrideReadResult` `{ model, readGapPaths }`. It is a `type` (structurally still a `Record<string, unknown>`, with a `Symbol` brand), so `OverrideReader`'s return type stays narrow — the revert path and every other override caller keep seeing a bare model; only the router unwraps it via `isOverrideReadResult`.
- `readCognitoIdentityPool` returns `{ model, readGapPaths: ['CognitoEvents'] }` on a **loud** failure (no mirror; model keeps CognitoEvents absent). A genuine region-unavailability stays **quiet** and keeps the #1085 mirror.
- The router translates the branded result into `ReadResult.readGapPaths` — the same channel `SDK_SUPPLEMENTS` uses — so `classifyResource` emits a counted `readGap` for BOTH the declared (no false #752 removal) and the undeclared case. No classify change needed.

## Tests
- `tests/cognito-identity-pool-readgap-1326.test.ts` — drives `readLive` end to end (CC GetResource OK, GetCognitoEvents → AccessDenied) → asserts `ReadResult.readGapPaths` carries CognitoEvents and the model omits it, then `classifyResource` → `readGap` for declared AND undeclared.
- `tests/cognito-identity-pool-events-1085.test.ts` — updated the loud-failure cases to the new readGap contract (region-unavailability quiet-mirror unchanged).
- 6 tests fail without the fix. Full suite green (4733).

Closes #1326