### PR TITLE
docs(skills): scope bughunt-track owner per-session to prevent parallel-session sentinel mixing (#1409)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -219,15 +219,21 @@ Add fixtures under `tests/integration/<name>/` — mirror an existing one (`app.
 all fixtures in parallel FIRST (cheap, catches TS errors before any paid deploy).
 
 **Before deploying, record every stack you are about to deploy into the sentinel —
-this arms the cleanup gate:**
+this arms the cleanup gate. SCOPE it to THIS session** so a parallel agent's live
+stacks never mix into a shared owner file (see the owner-scoping note below):
 
 ```bash
-.claude/skills/hunt-bugs/bughunt-track.sh add CdkRealDriftIntegS3Rich CdkRealDriftIntegVpcCommon ...
+# this session's own owner (env does not persist across tool calls — re-prefix each command)
+CDKRD_BUGHUNT_OWNER="session-${CLAUDE_CODE_SESSION_ID:-$$}" \
+  .claude/skills/hunt-bugs/bughunt-track.sh add CdkRealDriftIntegS3Rich CdkRealDriftIntegVpcCommon ...
 ```
 
-(The `deploy-autoarm-gate` hook also arms a per-session `autoarm-<session>` token on
-any deploy as a backstop, but `add` with the real stack names gives the clearer gate
-message.) **Tag
+Run every later `bughunt-track.sh verify` / `clear` with the SAME
+`CDKRD_BUGHUNT_OWNER="session-${CLAUDE_CODE_SESSION_ID:-$$}"` prefix, so you clear
+only YOUR own pending set. (The `deploy-autoarm-gate` hook also arms a per-session
+`autoarm-<session>` token on any deploy as a backstop — keyed by the SAME
+`CLAUDE_CODE_SESSION_ID` — so the merge/commit block is per-session either way; the
+explicit `add` gives the clearer gate message and the per-stack list.) **Tag
 every fixture `cdkrd:ephemeral=1`** (`Tags.of(app).add('cdkrd:ephemeral','1')` in
 `app.ts`) so the generic tag net in `sweep-orphans.sh` catches any resource type it has
 no per-type rule for.
@@ -422,6 +428,20 @@ enforced structurally rather than by discipline:
   pipeline's exit was tail's). Run `verify` and `clear` as separate, un-piped
   commands from the SAME directory (the owner key is cwd-derived — a cwd that
   drifted back to the main checkout arms/clears the WRONG owner).
+- **Owner scoping — set `CDKRD_BUGHUNT_OWNER="session-$CLAUDE_CODE_SESSION_ID"`.**
+  When `CDKRD_BUGHUNT_OWNER` is UNSET, the tracker derives the owner from the
+  main-tree root (`--git-common-dir`), so two sessions both running `add` from the
+  main checkout write into ONE shared owner file (#1409). Then a `clear` — which
+  empties the WHOLE owner file — would drop a PEER's still-pending stacks, releasing
+  the gate while their live AWS resources remain. Setting a per-session owner gives
+  each session its own `.d/session-<id>` file, so your `clear` can never touch a
+  peer's. **If you DID share the default owner with a peer: NEVER `clear` it while it
+  lists another session's stacks** — release only your own session's token
+  (`CDKRD_BUGHUNT_OWNER="autoarm-$CLAUDE_CODE_SESSION_ID" ... clear`, or
+  `CDKRD_BUGHUNT_FORCE_CLEAR=1` if the only remaining sweep orphan is provably a
+  peer's), and merge from a worktree cwd (the gate scopes commit/merge blocks by the
+  committing command's worktree-toplevel owner + your `autoarm-<session>` token, not
+  the shared main-root owner).
 
 `delstack` only deletes stack MEMBERS. `sweep-orphans.sh` catches the
 stack-EXTERNAL orphans teardown leaves behind — auto-created `/aws/lambda/*` log

--- a/.claude/skills/sweep-resources/SKILL.md
+++ b/.claude/skills/sweep-resources/SKILL.md
@@ -86,9 +86,14 @@ deploy, and `/hunt-bugs` arms per-stack owners. Release only after §1–3 show 
 AUTOARM="autoarm-$(printf '%s' "${CLAUDE_CODE_SESSION_ID:-shared}" | sed 's#[^A-Za-z0-9._-]#_#g')"
 CDKRD_BUGHUNT_OWNER="$AUTOARM" .claude/skills/hunt-bugs/bughunt-track.sh verify --region "$REGION"
 CDKRD_BUGHUNT_OWNER="$AUTOARM" .claude/skills/hunt-bugs/bughunt-track.sh clear
-# any per-owner hunt tracking (run verify + clear from the SAME worktree that armed):
-.claude/skills/hunt-bugs/bughunt-track.sh verify --region "$REGION"
-.claude/skills/hunt-bugs/bughunt-track.sh clear
+# this session's per-session hunt owner (the one /hunt-bugs' `add` uses — #1409):
+SESSION_OWNER="session-${CLAUDE_CODE_SESSION_ID:-shared}"
+CDKRD_BUGHUNT_OWNER="$SESSION_OWNER" .claude/skills/hunt-bugs/bughunt-track.sh verify --region "$REGION"
+CDKRD_BUGHUNT_OWNER="$SESSION_OWNER" .claude/skills/hunt-bugs/bughunt-track.sh clear
+# only if a hunt armed the DEFAULT (main-root) owner and it holds NO peer's stacks
+# (else NEVER clear it — a shared clear drops a peer's pending tracking, #1409):
+.claude/skills/hunt-bugs/bughunt-track.sh list        # inspect first
+# .claude/skills/hunt-bugs/bughunt-track.sh verify --region "$REGION" && clear   # only if peer-free
 ```
 
 `verify` re-runs `sweep-orphans.sh`; `clear` REFUSES without a passing verify stamp, so

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -234,6 +234,17 @@ pending-deletion, any `cdkrd:ephemeral`-tagged type), verifies `SWEEP CLEAN`, an
 releases the gate (`bughunt-track verify` + `clear`, incl. this session's
 `autoarm-<session>` owner). Confirm the stacks are gone.
 
+If you also `bughunt-track add` your live-test stacks explicitly (clearer gate
+message than the autoarm backstop), **scope the `add` to this session** —
+`CDKRD_BUGHUNT_OWNER="session-$CLAUDE_CODE_SESSION_ID" … add <stacks>` — so a
+parallel agent's stacks never mix into the shared main-root owner (#1409). An
+unscoped `add` run from the main checkout shares ONE owner file with every other
+session, and a `clear` empties the whole file — dropping a peer's still-pending
+tracking. If you inadvertently shared it, NEVER `clear` the shared owner while it
+lists a peer's stacks; release only your `autoarm-<session>` token and merge from a
+worktree cwd (the merge gate scopes by the committing worktree owner + your
+`autoarm`, not the shared main-root owner).
+
 `/verify-pr` sets the `check` + `docs` + `verify-pr` markers, which unblock
 `gh pr merge`. Docs/tooling-only PRs (no `src/**`) are EXEMPT from the live-test —
 `check` + `docs` suffice.


### PR DESCRIPTION
Closes #1409 (option a — SKILL.md only, no gate/script behavior change).

## Problem
When `CDKRD_BUGHUNT_OWNER` is unset, `bughunt-track.sh` derives the owner from the main-tree root, so two sessions both running `add` from the main checkout write into ONE shared owner file. A `clear` empties the WHOLE file — dropping a peer's still-pending stacks and releasing the gate while their live AWS resources remain (observed this session: my 2 live-test stacks mixed with 2 peers' under one owner).

## Fix (docs only)
Document scoping the per-stack sentinel to `session-$CLAUDE_CODE_SESSION_ID` — the same session identity the gate's `autoarm-<session>` backstop already uses — so each session gets its own `.d/session-<id>` file and a `clear` can never touch a peer's:
- **/hunt-bugs**: the `add` example now sets `CDKRD_BUGHUNT_OWNER`; the gate-mechanics footnote gains an owner-scoping bullet (mixing hazard + the never-clear-a-shared-owner recovery: release only your `autoarm-<session>`, merge from a worktree cwd).
- **/sweep-resources** §4: clears the per-session `session-<id>` owner too, and inspects (never blind-clears) the default main-root owner.
- **/work-issues**: a note in the live-test cleanup section mirroring the same scoping + recovery.

No change to `bughunt-track.sh` / `bughunt-clean-gate.sh` behavior — both already honor `CDKRD_BUGHUNT_OWNER` (`owner_raw=${CDKRD_BUGHUNT_OWNER:-}`); this only documents using it. A deeper code fix (align the tracker/gate default owner resolution) is left for a separate deliberate change.

Docs/tooling-only (no `src/**`) → verify-pr-gate exempt.