### PR TITLE
fix(diff): applyDefinitionSubstitutions resolves in a single pass (#1305)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -761,23 +761,30 @@ function twinOverlapEchoes(
   return true;
 }
 
-// #712: apply an AWS::StepFunctions::StateMachine `DefinitionSubstitutions` map into a declared
-// `DefinitionString`, mirroring how CloudFormation resolves `${token}` placeholders at deploy time
-// (the live read echoes the substituted string). Each `${key}` for a declared substitution key is
-// replaced with its value (scalars stringified; a non-scalar value is left untouched, since Step
-// Functions substitutions are scalar). Text that is not a declared `${key}` token is preserved, so
-// a genuine out-of-band definition change still surfaces as declared drift.
-function applyDefinitionSubstitutions(
+// #712 / #1305: apply an AWS::StepFunctions::StateMachine `DefinitionSubstitutions` map into a
+// declared `DefinitionString`, mirroring how CloudFormation resolves `${token}` placeholders at
+// deploy time (the live read echoes the substituted string). This is a SINGLE Fn::Sub-like pass:
+// the ORIGINAL definition text is scanned once for `${key}` tokens and each is replaced with its
+// substitution value — injected text is NEVER re-scanned (#1305). A per-key sequential
+// split/join re-substituted a value that itself contained a literal `${otherKey}` and made the
+// result depend on template key order; CloudFormation's provider resolves in one pass, so the
+// live definition keeps that literal while the naive resolver mis-resolved the declared side into
+// a permanent false declared drift (and a mis-resolved revert write).
+//
+// Each `${key}` whose `key` is a declared substitution with a scalar value is replaced (stringified
+// with `String(value)`). A `${key}` whose key is NOT in the map, or whose value is null/object
+// (Step Functions substitutions are scalar), is left VERBATIM — so a genuine out-of-band definition
+// change still surfaces as declared drift.
+export function applyDefinitionSubstitutions(
   definitionString: string,
   substitutions: Record<string, unknown>
 ): string {
-  let out = definitionString;
-  for (const [key, value] of Object.entries(substitutions)) {
-    if (value === null || typeof value === 'object') continue;
-    const token = `\${${key}}`;
-    out = out.split(token).join(String(value));
-  }
-  return out;
+  return definitionString.replace(/\$\{([^}]+)\}/g, (match, key: string) => {
+    if (!(key in substitutions)) return match;
+    const value = substitutions[key];
+    if (value === null || typeof value === 'object') return match;
+    return String(value);
+  });
 }
 
 // Per-type attachment-list properties handled by tier rather than a positional compare.

--- a/tests/def-substitution-singlepass-1305.test.ts
+++ b/tests/def-substitution-singlepass-1305.test.ts
@@ -1,0 +1,94 @@
+// #1305 — applyDefinitionSubstitutions must resolve DefinitionSubstitutions in a SINGLE
+// Fn::Sub-like pass. The old per-key sequential split/join re-scanned text injected by an
+// earlier key, so a substitution VALUE containing a literal `${otherKey}` got re-substituted and
+// the result depended on template JSON key order. CloudFormation's StepFunctions provider resolves
+// in one pass (injected `${...}` is NEVER re-scanned), so cdkrd folding the declared side to the
+// re-substituted text produced a permanent false declared drift (and a mis-resolved revert write).
+import { describe, expect, it } from 'vite-plus/test';
+import { applyDefinitionSubstitutions, classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+describe('#1305 applyDefinitionSubstitutions — single Fn::Sub-like pass', () => {
+  it('does NOT re-substitute a value that contains a literal ${otherKey}', () => {
+    // ${a} -> '${b}' (injected), and that injected ${b} must NOT be re-substituted to 'X'.
+    const out = applyDefinitionSubstitutions('{"Result":"${a}"}', { a: '${b}', b: 'X' });
+    expect(out).toBe('{"Result":"${b}"}');
+  });
+
+  it('is independent of substitution key insertion order', () => {
+    const ab = applyDefinitionSubstitutions('{"Result":"${a}"}', { a: '${b}', b: 'X' });
+    const ba = applyDefinitionSubstitutions('{"Result":"${a}"}', { b: 'X', a: '${b}' });
+    expect(ab).toBe(ba);
+    expect(ab).toBe('{"Result":"${b}"}');
+  });
+
+  it('resolves a plain substitution', () => {
+    expect(applyDefinitionSubstitutions('${Name}', { Name: 'Foo' })).toBe('Foo');
+  });
+
+  it('preserves an unknown ${token} verbatim', () => {
+    expect(applyDefinitionSubstitutions('${Unknown}', { Name: 'Foo' })).toBe('${Unknown}');
+  });
+
+  it('leaves a null / object-valued substitution token verbatim', () => {
+    expect(applyDefinitionSubstitutions('${N} ${O}', { N: null, O: { x: 1 } })).toBe('${N} ${O}');
+  });
+
+  it('stringifies scalar substitution values', () => {
+    expect(applyDefinitionSubstitutions('${A}-${B}-${C}', { A: 1, B: true, C: 'z' })).toBe(
+      '1-true-z'
+    );
+  });
+});
+
+// End-to-end: a state machine whose substitution value keeps a literal ${b} must NOT surface a
+// declared drift, since the live definition also keeps that literal (CFn single-pass).
+const sfnSchema: SchemaInfo = {
+  readOnly: new Set(['Arn', 'Name', 'StateMachineRevisionId']),
+  writeOnly: new Set(['Definition', 'DefinitionS3Location', 'DefinitionSubstitutions']),
+  createOnly: new Set(['StateMachineName', 'StateMachineType']),
+  readOnlyPaths: ['Arn', 'Name', 'StateMachineRevisionId'],
+  writeOnlyPaths: ['Definition', 'DefinitionS3Location', 'DefinitionSubstitutions'],
+  createOnlyPaths: ['StateMachineName', 'StateMachineType'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tier = (fs: Finding[], t: string): string[] =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Machine',
+  resourceType: 'AWS::StepFunctions::StateMachine',
+  physicalId: 'arn:aws:states:us-east-1:111111111111:stateMachine:m',
+  declared,
+});
+
+describe('#1305 classifyResource — no false declared drift when a substitution value holds ${literal}', () => {
+  const DECLARED_WITH_TOKEN =
+    '{"StartAt":"P","States":{"P":{"Type":"Pass","Result":{"v":"${a}"},"End":true}}}';
+
+  for (const [label, subs] of [
+    ['{a,b} order', { a: '${b}', b: 'X' }],
+    ['{b,a} order', { b: 'X', a: '${b}' }],
+  ] as const) {
+    it(`no declared drift with substitutions in ${label}`, () => {
+      const res = mk({
+        DefinitionString: DECLARED_WITH_TOKEN,
+        DefinitionSubstitutions: subs,
+        RoleArn: 'arn:aws:iam::111111111111:role/r',
+      });
+      // ${a} -> '${b}' single pass; live keeps the literal ${b} (CFn provider does not re-scan).
+      const live = {
+        DefinitionString:
+          '{"StartAt":"P","States":{"P":{"End":true,"Result":{"v":"${b}"},"Type":"Pass"}}}',
+        RoleArn: 'arn:aws:iam::111111111111:role/r',
+      };
+      const f = classifyResource(res, live, sfnSchema);
+      expect(tier(f, 'declared')).not.toContain('DefinitionString');
+    });
+  }
+});


### PR DESCRIPTION
Closes #1305

Rewrites the StepFunctions DefinitionSubstitutions resolver to a single Fn::Sub-like pass so a substitution value containing a literal ${otherKey} is not re-substituted and the result is no longer template key-order dependent — matching CloudFormation's provider. Kills the permanent declared FP (and mis-resolved revert write) on state machines whose substitution values contain ${...} literals. Unknown/non-scalar tokens are still preserved so genuine out-of-band definition changes surface.