### PR TITLE
fix(normalize): canonicalize bare IPv6 addresses, not only CIDRs (#1273)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -4696,14 +4696,22 @@ export function canonicalizeIdArraysDeep(v: unknown): unknown {
 // spelling compares equal, while a GENUINELY different CIDR (`2001:db8::/32` vs
 // `2001:dead::/32`) still lands on distinct canonical forms and surfaces.
 //
-// FP-safety: this only transforms a string that passes a STRICT IPv6-CIDR parse gate
-// (`canonicalIpv6Cidr` returns undefined otherwise) — an IPv4 CIDR, an ARN (colon-
-// heavy but not a valid hextet structure), or any arbitrary string passes through
-// UNCHANGED. The embedded-IPv4 tail form (`::ffff:1.2.3.4`) is handled
-// conservatively: `parseIpv6Groups` rejects it (an IPv4 dotted tail is not a hextet),
-// so it is left unchanged. Because the gate is a strict parse, this is FP-safe to
-// apply UNSCOPED (deep over the whole model), exactly like the other deep
-// canonicalizers — no path table needed.
+// This folds BOTH the CIDR form (`<addr>/<prefix>`, via `canonicalIpv6Cidr`) AND the
+// BARE-ADDRESS form (no prefix, via `canonicalIpv6Address`) — #1273. Bare IPv6
+// addresses appear in `AWS::EC2::Instance.Ipv6Addresses[].Ipv6Address`,
+// `AWS::EC2::NetworkInterface.Ipv6Addresses[].Ipv6Address`, and Route53 AAAA
+// `ResourceRecords`, and AWS echoes them RFC 5952-canonical too, so the CIDR-only
+// fold left them false-drifting exactly like CIDRs did before #981.
+//
+// FP-safety: this only transforms a string that passes the STRICT `parseIpv6Groups`
+// gate (both `canonicalIpv6Cidr` and `canonicalIpv6Address` return undefined
+// otherwise) — an IPv4 CIDR, an ARN (colon-heavy but not a valid hextet structure),
+// a MAC, a plain word, or any arbitrary string passes through UNCHANGED. The gate
+// rejects embedded-IPv4 tails (`::ffff:1.2.3.4`), non-hex groups, the wrong group
+// count, multiple `::`, and a `::` that elides zero groups, so it only ever matches
+// an unambiguous 8-group IPv6 address. Because the gate is a strict parse, BOTH the
+// CIDR and bare-address folds are FP-safe to apply UNSCOPED (deep over the whole
+// model), exactly like the other deep canonicalizers — no path table needed.
 
 // Parse an IPv6 address literal into its 8 16-bit groups, or undefined if it is not a
 // valid, unambiguous IPv6 address. Rejects: embedded-IPv4 tails, non-hex groups,
@@ -4753,19 +4761,12 @@ function parseIpv6Groups(addr: string): number[] | undefined {
   return [...headGroups, ...new Array(missing).fill(0), ...tailGroups];
 }
 
-// RFC 5952-canonicalize an IPv6 CIDR string (`<addr>/<prefix>`), or undefined if it is
-// not a valid IPv6 CIDR. Lowercase hex, strip leading zeros per group, compress the
-// LONGEST run of ≥1 all-zero groups to `::` (leftmost on ties), reattach `/prefix`.
-export function canonicalIpv6Cidr(s: string): string | undefined {
-  const slash = s.indexOf('/');
-  if (slash === -1) return undefined; // must be a CIDR, not a bare address
-  const addr = s.slice(0, slash);
-  const prefixStr = s.slice(slash + 1);
-  if (!/^\d{1,3}$/.test(prefixStr)) return undefined;
-  const prefix = Number.parseInt(prefixStr, 10);
-  if (prefix < 0 || prefix > 128) return undefined;
-  const groups = parseIpv6Groups(addr);
-  if (!groups) return undefined;
+// RFC 5952-format an already-parsed IPv6 address (its 8 16-bit groups) into the one
+// canonical string: lowercase hex, leading zeros stripped per group, the LONGEST run
+// of ≥2 all-zero groups compressed to `::` (leftmost on ties). No prefix — callers
+// reattach `/prefix` for CIDRs. Shared by `canonicalIpv6Cidr` and
+// `canonicalIpv6Address` so both emit identical formatting.
+function formatCanonicalIpv6(groups: number[]): string {
   // Find the longest run of consecutive all-zero groups (length ≥ 2 to compress).
   let bestStart = -1;
   let bestLen = 0;
@@ -4785,23 +4786,48 @@ export function canonicalIpv6Cidr(s: string): string | undefined {
     }
   }
   const hex = groups.map((g) => g.toString(16));
-  let addrOut: string;
   if (bestLen >= 2) {
     const before = hex.slice(0, bestStart).join(':');
     const after = hex.slice(bestStart + bestLen).join(':');
-    addrOut = `${before}::${after}`;
-  } else {
-    addrOut = hex.join(':');
+    return `${before}::${after}`;
   }
-  return `${addrOut}/${prefix}`;
+  return hex.join(':');
+}
+
+// RFC 5952-canonicalize an IPv6 CIDR string (`<addr>/<prefix>`), or undefined if it is
+// not a valid IPv6 CIDR. Lowercase hex, strip leading zeros per group, compress the
+// LONGEST run of ≥1 all-zero groups to `::` (leftmost on ties), reattach `/prefix`.
+export function canonicalIpv6Cidr(s: string): string | undefined {
+  const slash = s.indexOf('/');
+  if (slash === -1) return undefined; // must be a CIDR, not a bare address
+  const addr = s.slice(0, slash);
+  const prefixStr = s.slice(slash + 1);
+  if (!/^\d{1,3}$/.test(prefixStr)) return undefined;
+  const prefix = Number.parseInt(prefixStr, 10);
+  if (prefix < 0 || prefix > 128) return undefined;
+  const groups = parseIpv6Groups(addr);
+  if (!groups) return undefined;
+  return `${formatCanonicalIpv6(groups)}/${prefix}`;
+}
+
+// RFC 5952-canonicalize a BARE IPv6 address (no `/prefix`), or undefined if it is not a
+// valid IPv6 address — the bare-address twin of `canonicalIpv6Cidr` (#1273). Returns
+// undefined for a CIDR (that carries a `/`, handled by `canonicalIpv6Cidr`), then runs
+// the same STRICT `parseIpv6Groups` gate, so an IPv4 dotted address, an ARN, a MAC, or
+// any arbitrary string passes through unchanged — FP-safe to apply unscoped.
+export function canonicalIpv6Address(s: string): string | undefined {
+  if (s.includes('/')) return undefined; // a CIDR — handled by canonicalIpv6Cidr
+  const groups = parseIpv6Groups(s);
+  if (!groups) return undefined;
+  return formatCanonicalIpv6(groups);
 }
 
 // Deep-walk every string value, RFC 5952-canonicalizing any that unambiguously parses
-// as an IPv6 CIDR and passing everything else through unchanged (see block comment
-// above). Applied to BOTH compare sides in `canonicalizeForCompare` so equivalent
-// spellings fold, mirroring `canonicalizeIdArraysDeep`'s structure.
+// as an IPv6 CIDR or a bare IPv6 address and passing everything else through unchanged
+// (see block comment above). Applied to BOTH compare sides in `canonicalizeForCompare`
+// so equivalent spellings fold, mirroring `canonicalizeIdArraysDeep`'s structure.
 export function canonicalizeIpv6CidrsDeep(v: unknown): unknown {
-  if (typeof v === 'string') return canonicalIpv6Cidr(v) ?? v;
+  if (typeof v === 'string') return canonicalIpv6Cidr(v) ?? canonicalIpv6Address(v) ?? v;
   if (Array.isArray(v)) return v.map(canonicalizeIpv6CidrsDeep);
   if (v && typeof v === 'object') {
     const out: Record<string, unknown> = {};

--- a/tests/ipv6-bare-address-1273.test.ts
+++ b/tests/ipv6-bare-address-1273.test.ts
@@ -1,0 +1,157 @@
+// #1273 — the #981 RFC 5952 IPv6 canonicalization was CIDR-only: `canonicalIpv6Cidr`
+// requires a `/prefix` and returns undefined for a BARE address, so every property
+// whose value is a bare IPv6 address that AWS echoes canonical (EC2 Instance /
+// NetworkInterface `Ipv6Addresses[].Ipv6Address`, Route53 AAAA `ResourceRecords`)
+// still false-flagged `declared` drift on a non-canonical template spelling (uppercase
+// hex, uncompressed zeros), survived record, and the offered revert wrote the
+// non-canonical string back → EC2 re-canonicalizes → the revert never converges. The
+// fix adds `canonicalIpv6Address` (same strict `parseIpv6Groups` gate) and has
+// `canonicalizeIpv6CidrsDeep` try CIDR then bare, folding both compare sides to the one
+// RFC 5952 form. A genuinely different address still surfaces; the strict parse keeps
+// it FP-safe unscoped.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { canonicalIpv6Address, canonicalizeIpv6CidrsDeep } from '../src/normalize/noise.js';
+import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+
+describe('#1273 canonicalIpv6Address — RFC 5952 bare-address canonicalization', () => {
+  it('lowercases uppercase hex', () => {
+    expect(canonicalIpv6Address('2001:DB8::1')).toBe('2001:db8::1');
+  });
+
+  it('compresses an uncompressed all-zero run', () => {
+    expect(canonicalIpv6Address('2001:db8:0:0:0:0:0:1')).toBe('2001:db8::1');
+    expect(canonicalIpv6Address('2001:db8:0:0::1')).toBe('2001:db8::1');
+  });
+
+  it('strips leading zeros per group', () => {
+    expect(canonicalIpv6Address('2001:0db8::0001')).toBe('2001:db8::1');
+    expect(canonicalIpv6Address('2001:0DB8:0000:0000::1')).toBe('2001:db8::1');
+  });
+
+  it('canonicalizes the all-zero address', () => {
+    expect(canonicalIpv6Address('0:0:0:0:0:0:0:0')).toBe('::');
+    expect(canonicalIpv6Address('::')).toBe('::');
+  });
+
+  it('compresses the LEFTMOST longest zero run on ties', () => {
+    expect(canonicalIpv6Address('2001:0:0:1:2:0:0:3')).toBe('2001::1:2:0:0:3');
+  });
+
+  it('preserves a genuinely different bare address as a distinct canonical form', () => {
+    expect(canonicalIpv6Address('2001:db8::1')).not.toBe(canonicalIpv6Address('2001:db8::2'));
+    expect(canonicalIpv6Address('2001:db8::2')).toBe('2001:db8::2');
+  });
+
+  it('returns undefined for a CIDR (that is canonicalIpv6Cidr territory)', () => {
+    expect(canonicalIpv6Address('2001:db8::/32')).toBeUndefined();
+    expect(canonicalIpv6Address('2001:db8::1/128')).toBeUndefined();
+  });
+
+  it('returns undefined for non-IPv6 strings (pass-through gate)', () => {
+    // IPv4 dotted address.
+    expect(canonicalIpv6Address('10.0.0.1')).toBeUndefined();
+    // ARN — colon-heavy but not a valid hextet structure.
+    expect(canonicalIpv6Address('arn:aws:iam::123456789012:role/MyRole')).toBeUndefined();
+    // Arbitrary strings.
+    expect(canonicalIpv6Address('hello')).toBeUndefined();
+    expect(canonicalIpv6Address('not an address')).toBeUndefined();
+    // Embedded-IPv4 tail form — rejected (an IPv4 dotted tail is not a hextet).
+    expect(canonicalIpv6Address('::ffff:1.2.3.4')).toBeUndefined();
+    // Too many / too few groups.
+    expect(canonicalIpv6Address('2001:db8:0:0:0:0:0:0:1')).toBeUndefined();
+    expect(canonicalIpv6Address('2001:db8')).toBeUndefined();
+    // Group with > 4 hex digits.
+    expect(canonicalIpv6Address('2001:db8:00000::1')).toBeUndefined();
+  });
+});
+
+describe('#1273 canonicalizeIpv6CidrsDeep — folds bare addresses AND CIDRs', () => {
+  it('canonicalizes bare IPv6 addresses nested in objects and arrays', () => {
+    const model = {
+      Ipv6Addresses: [{ Ipv6Address: '2001:DB8:0:0::1' }, { Ipv6Address: '2001:0db8::2' }],
+      // A CIDR sibling still folds via the CIDR path.
+      CidrIpv6: '2001:DB8:0:0::/32',
+    };
+    expect(canonicalizeIpv6CidrsDeep(model)).toEqual({
+      Ipv6Addresses: [{ Ipv6Address: '2001:db8::1' }, { Ipv6Address: '2001:db8::2' }],
+      CidrIpv6: '2001:db8::/32',
+    });
+  });
+
+  it('leaves IPv4 addresses, ARNs, and arbitrary strings unchanged', () => {
+    const model = {
+      Ip: '10.0.0.1',
+      Arn: 'arn:aws:iam::123456789012:role/MyRole',
+      Other: 'just a string',
+      Nested: { deep: ['a:b:c', 'foo/bar'] },
+    };
+    expect(canonicalizeIpv6CidrsDeep(model)).toEqual(model);
+  });
+});
+
+describe('#1273 canonicalizeForCompare — folds equivalent bare IPv6-address spellings', () => {
+  it('folds a non-canonical declared bare address to the canonical live form', () => {
+    const declared = { Ipv6Address: '2001:DB8::1' };
+    const live = { Ipv6Address: '2001:db8::1' };
+    expect(canonicalizeForCompare(declared)).toEqual(canonicalizeForCompare(live));
+  });
+
+  it('still surfaces a genuinely different bare IPv6 address', () => {
+    const declared = { Ipv6Address: '2001:db8::1' };
+    const live = { Ipv6Address: '2001:db8::2' };
+    expect(canonicalizeForCompare(declared)).not.toEqual(canonicalizeForCompare(live));
+  });
+});
+
+// Mirror the issue's repro through a real classifyResource run: a declared
+// non-canonical bare IPv6 address vs the RFC 5952 live echo must fold to NO declared
+// drift, while a genuinely different live address still surfaces.
+const schema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+function instanceResource(declaredAddr: string): DesiredResource {
+  return {
+    logicalId: 'I',
+    resourceType: 'AWS::EC2::Instance',
+    physicalId: 'i-1',
+    constructPath: 'Stack/I',
+    declared: { Ipv6Addresses: [{ Ipv6Address: declaredAddr }] },
+  } as DesiredResource;
+}
+
+function instanceLive(liveAddr: string): Record<string, unknown> {
+  return { Ipv6Addresses: [{ Ipv6Address: liveAddr }] };
+}
+
+describe('#1273 classifyResource — EC2 Instance bare Ipv6Address', () => {
+  it('non-canonical declared vs canonical live folds to NO declared drift', () => {
+    const findings = classifyResource(
+      instanceResource('2001:DB8::1'),
+      instanceLive('2001:db8::1'),
+      schema
+    );
+    const declared = findings.filter((f) => f.tier === 'declared');
+    expect(declared).toEqual([]);
+  });
+
+  it('a genuinely different live IPv6 address still surfaces as declared drift', () => {
+    const findings = classifyResource(
+      instanceResource('2001:db8::1'),
+      instanceLive('2001:db8::2'),
+      schema
+    );
+    const declared = findings.filter((f) => f.tier === 'declared');
+    expect(declared.length).toBeGreaterThan(0);
+    expect(declared.some((f) => f.path.includes('Ipv6Address'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1273

Extends the RFC 5952 IPv6 fold to BARE addresses (no /prefix), not just CIDRs, via a new canonicalIpv6Address using the existing strict parseIpv6Groups gate; canonicalizeIpv6CidrsDeep now tries CIDR then bare. Kills the permanent declared FP (and revert non-convergence loop) on EC2 Instance / NetworkInterface Ipv6Addresses and Route53 AAAA records whose template spells an address non-canonically. A genuinely different address still surfaces; the strict parse keeps it FP-safe unscoped.