### PR TITLE
fix(added): SNS subscription foreign Owner/Endpoint gates the sibling-stack ValidationError to unverified (#1322)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -253,6 +253,24 @@ export function isDefinitiveNotManaged(
   return true;
 }
 
+// The child may carry EXPLICIT foreign-scope metadata that the physical-id ARN parse cannot see
+// (#1322). An AWS::SNS::Subscription's physical id is `<topicArn>:<uuid>` — always minted under
+// the TOPIC's (= this check's) account+region, so `isDefinitiveNotManaged` always reads it LOCAL
+// even when a FOREIGN subscriber stack owns it. `ListSubscriptionsByTopic` DOES return the true
+// scope: `Owner` (the subscription's owning account) and, for a cross-account / cross-region
+// fan-out, an ARN `Endpoint` carrying the subscriber's account+region. When either signals a
+// foreign scope, a ValidationError from the local DescribeStackResources is UNVERIFIABLE (the
+// owning stack is simply unreachable from here), so it must NOT be a definitive not-managed.
+export function hasForeignScopeSignal(c: AddedChild, accountId: string, region: string): boolean {
+  const owner = c.ownerAccountId;
+  if (typeof owner === 'string' && owner !== '' && owner !== accountId) {
+    return true;
+  }
+  return (c.scopeArns ?? []).some(
+    (arn) => arn.startsWith('arn:') && !isDefinitiveNotManaged(arn, accountId, region)
+  );
+}
+
 // Probe ONE candidate CloudFormation physical id against the run's account+region: does a
 // stack own a resource of THIS child's type (`c.resourceType`) with this exact physical id?
 // Returns the tri-state and memoizes any DEFINITIVE answer per physical id (a transient
@@ -317,10 +335,15 @@ async function probeSiblingPhysicalId(
     // sweep, AccessDenied without cloudformation:DescribeStackResources, a network blip) is also
     // 'unverified' and NOT memoized (a transient throttle must not poison the run). The foreign-
     // scope determination IS deterministic per physical id, so caching it as 'notManaged' is not
-    // done — we leave it un-cached like the other unverifiable cases for uniform handling.
+    // done — we leave it un-cached like the other unverifiable cases for uniform handling. The
+    // ARN parse is a GENERIC backstop, but it MISREADS a child whose physical id is always local
+    // to its parent yet may be foreign-owned (an SNS Subscription arn is `<topicArn>:<uuid>`),
+    // so an EXPLICIT foreign-scope metadata signal (`Owner` / ARN `Endpoint`) overrides it and
+    // also downgrades this to `unverified` (#1322).
     if (
       (e as { name?: string }).name === 'ValidationError' &&
-      isDefinitiveNotManaged(physicalId, accountId, region)
+      isDefinitiveNotManaged(physicalId, accountId, region) &&
+      !hasForeignScopeSignal(c, accountId, region)
     ) {
       cache.set(physicalId, 'notManaged');
       return 'notManaged';

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -225,6 +225,18 @@ export interface AddedChild {
   // misses and a sibling-managed rule is falsely reported `added` (#895). Only the sibling
   // lookup id changes; the CC read / DeleteResource path still uses `identifier`.
   siblingLookupId?: string | undefined;
+  // Extra foreign-scope signals that OVERRIDE the identifier-ARN scope parse for the
+  // sibling-stack membership check (#1322). `isDefinitiveNotManaged` decides whether a
+  // `ValidationError` from the run's own (account+region-scoped) DescribeStackResources is a
+  // DEFINITIVE not-managed by parsing the child's physical-id ARN's account+region. That parse
+  // LIES for an AWS::SNS::Subscription: its physical id is `<topicArn>:<uuid>`, always minted
+  // under the TOPIC's (= this check's) account+region, so it always looks LOCAL even when a
+  // FOREIGN subscriber stack owns it (the canonical cross-account / cross-region fan-out) —
+  // making the ValidationError a false definitive not-managed and offering a DESTRUCTIVE
+  // DeleteResource on another stack's resource. These carry the child's TRUE scope so that
+  // signal wins: a foreign owner / endpoint ARN downgrades the ValidationError to `unverified`.
+  ownerAccountId?: string | undefined; // the child's OWNING account (SNS subscription `Owner`)
+  scopeArns?: string[] | undefined; // extra ARNs carrying the child's true account/region (SNS `Endpoint` when an ARN)
 }
 
 export interface EnumeratorContext {
@@ -1185,7 +1197,12 @@ const CHATBOT_SUBSCRIPTION_ENDPOINT = 'https://global.sns-api.chatbot.amazonaws.
 // Pure diff: declared subscription arns + live inventory -> the added subscriptions.
 export interface SnsTopicChildInput {
   declaredSubscriptionArns: string[]; // physical ids of AWS::SNS::Subscription in the template
-  liveSubscriptions: { arn: string; label?: string | undefined; endpoint?: string | undefined }[];
+  liveSubscriptions: {
+    arn: string;
+    label?: string | undefined;
+    endpoint?: string | undefined;
+    owner?: string | undefined; // the subscription's owning account (SNS `Owner`)
+  }[];
 }
 
 export function diffSnsTopicChildren(input: SnsTopicChildInput): AddedChild[] {
@@ -1199,6 +1216,13 @@ export function diffSnsTopicChildren(input: SnsTopicChildInput): AddedChild[] {
       identifier: s.arn, // SubscriptionArn IS the CC primaryIdentifier
       label: s.label ?? s.arn,
       live: { SubscriptionArn: s.arn },
+      // Foreign-scope signals for the sibling-stack check (#1322): a subscription's physical id
+      // is always local to the topic, so its `Owner` (owning account) and an ARN `Endpoint`
+      // (subscriber's account+region for a cross-account / cross-region fan-out) are the only
+      // hints that a FOREIGN stack manages it — carry them so a ValidationError downgrades to
+      // `unverified` rather than a destructive `notManaged` delete.
+      ownerAccountId: s.owner,
+      scopeArns: s.endpoint?.startsWith('arn:') ? [s.endpoint] : undefined,
     });
   }
   return added;
@@ -1249,6 +1273,7 @@ export async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise
       arn: s.SubscriptionArn,
       label: s.Protocol ? `${s.Protocol} ${s.Endpoint ?? ''}`.trim() : s.SubscriptionArn,
       endpoint: s.Endpoint,
+      owner: s.Owner, // owning account — foreign-scope signal for the sibling-stack check (#1322)
     }));
 
   return diffSnsTopicChildren({ declaredSubscriptionArns, liveSubscriptions });

--- a/tests/sns-foreign-scope-1322.test.ts
+++ b/tests/sns-foreign-scope-1322.test.ts
@@ -1,0 +1,124 @@
+import {
+  CloudFormationClient,
+  DescribeStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, expect, it } from 'vite-plus/test';
+import { isManagedBySiblingStack } from '../src/commands/gather.js';
+import { type AddedChild, diffSnsTopicChildren } from '../src/read/child-enumerators.js';
+
+// #1322: an AWS::SNS::Subscription's physical id is `<topicArn>:<uuid>` — always minted under the
+// TOPIC's (= this check's) account+region, so the identifier-ARN scope parse in
+// `isDefinitiveNotManaged` always reads it LOCAL, even when a FOREIGN subscriber stack (the
+// canonical cross-account / cross-region SNS fan-out) legitimately owns it. That made a
+// DescribeStackResources `ValidationError` a false-definitive `notManaged` -> a false `[Added]`
+// with a DESTRUCTIVE DeleteResource revert offer on another stack's resource. Threading the
+// subscription's `Owner` (owning account) and ARN `Endpoint` (subscriber scope) onto AddedChild
+// lets a foreign signal downgrade that ValidationError to `unverified` (fail-safe, never a delete).
+describe('#1322: SNS subscription foreign Owner/Endpoint gates the sibling-stack ValidationError', () => {
+  // The check-run's OWN account+region — the subscription ARN below is minted here (topic-local),
+  // so absent a foreign signal a ValidationError is a DEFINITIVE local not-managed.
+  const LOCAL_ACCOUNT = '111122223333';
+  const LOCAL_REGION = 'us-east-1';
+  const FOREIGN_ACCOUNT = '999988887777';
+  // Topic-local subscription arn (its account+region ALWAYS equals the topic's = the check's).
+  const subArn = `arn:aws:sns:${LOCAL_REGION}:${LOCAL_ACCOUNT}:NotifTopic:0000-1111-2222`;
+
+  const rejectValidationError = (cfn: ReturnType<typeof mockClient>) => {
+    const notFound = new Error(`Stack for ${subArn} does not exist`);
+    notFound.name = 'ValidationError';
+    cfn.on(DescribeStackResourcesCommand).rejects(notFound);
+  };
+
+  const subChild = (extra: Partial<AddedChild>): AddedChild => ({
+    resourceType: 'AWS::SNS::Subscription',
+    identifier: subArn,
+    label: subArn,
+    live: { SubscriptionArn: subArn },
+    ...extra,
+  });
+
+  it('a FOREIGN-account owner (Owner !== run account) -> unverified, NOT notManaged', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    rejectValidationError(cfn);
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      subChild({ ownerAccountId: FOREIGN_ACCOUNT }),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('unverified');
+  });
+
+  it('a FOREIGN-scope endpoint ARN (cross-region subscriber) -> unverified, NOT notManaged', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    rejectValidationError(cfn);
+    // Endpoint is a Lambda in a DIFFERENT region -> the subscription is declared in that
+    // subscriber's foreign stack; the local DescribeStackResources cannot see it.
+    const foreignEndpoint = `arn:aws:lambda:eu-west-1:${FOREIGN_ACCOUNT}:function:Consumer`;
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      subChild({ scopeArns: [foreignEndpoint] }),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('unverified');
+  });
+
+  it('a LOCAL owner + no foreign endpoint -> notManaged (unchanged genuine out-of-band behavior)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    rejectValidationError(cfn);
+    // Owner is this account, endpoint (if any) is same-account+region -> a real local addition.
+    const localEndpoint = `arn:aws:lambda:${LOCAL_REGION}:${LOCAL_ACCOUNT}:function:Consumer`;
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      subChild({ ownerAccountId: LOCAL_ACCOUNT, scopeArns: [localEndpoint] }),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('notManaged');
+  });
+
+  it('no metadata at all -> notManaged (generic ARN backstop preserved)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    rejectValidationError(cfn);
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      subChild({}),
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('notManaged');
+  });
+});
+
+describe('diffSnsTopicChildren threads Owner/Endpoint onto the AddedChild (#1322)', () => {
+  const subArn = 'arn:aws:sns:us-east-1:111122223333:Topic:abcd-uuid';
+
+  it('carries a foreign Owner as ownerAccountId and an ARN Endpoint as scopeArns', () => {
+    const endpoint = 'arn:aws:lambda:eu-west-1:999988887777:function:Consumer';
+    const added = diffSnsTopicChildren({
+      declaredSubscriptionArns: [],
+      liveSubscriptions: [{ arn: subArn, label: 'lambda', endpoint, owner: '999988887777' }],
+    });
+    expect(added).toHaveLength(1);
+    expect(added[0]!.ownerAccountId).toBe('999988887777');
+    expect(added[0]!.scopeArns).toEqual([endpoint]);
+  });
+
+  it('leaves scopeArns undefined for a non-ARN endpoint (e.g. an email/https subscription)', () => {
+    const added = diffSnsTopicChildren({
+      declaredSubscriptionArns: [],
+      liveSubscriptions: [
+        { arn: subArn, label: 'email', endpoint: 'ops@example.com', owner: '111122223333' },
+      ],
+    });
+    expect(added).toHaveLength(1);
+    expect(added[0]!.ownerAccountId).toBe('111122223333');
+    expect(added[0]!.scopeArns).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1322

Threads the SNS subscription's Owner (owning account) and Endpoint (foreign-scope ARN) through AddedChild so a foreign-managed cross-account/cross-region subscription's DescribeStackResources ValidationError is treated as 'unverified' (coverage-incomplete) rather than a definitive 'notManaged' — no more false [Added] + destructive DeleteResource offer on a subscriber stack's CFn-managed subscription. The identifier-ARN gate stays as a generic backstop.