### PR TITLE
fix(report): --json baseline flag omitted when not consulted; record's path field renamed baselinePath (#1335, #1336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,14 +670,19 @@ If the whole invocation fails before any stack is reached (bad config, an
 un-synthesizable app, or a zero-stack app), stdout is still a valid empty array
 `[]` (exit code non-zero, the reason on stderr) — never empty bytes.
 
-Every successfully-checked stack element carries a `"baseline": <bool>` flag —
+Every successfully-checked stack element of a baseline-consulting `check` carries a
+`"baseline": <bool>` flag —
 `true` when the stack has a committed `.cdkrd` baseline (its undeclared dimension is
 **watched**), `false` when it has never been recorded. Without a baseline the
 classification shifts: appeared-since-record out-of-band values read as `unrecorded`
 and are excluded from `drifted`, so a QUIET never-recorded stack emits the
 byte-identical `"drifted": 0` of a watched-clean one. A consumer summing `drifted`
 uses `baseline` to tell an UNWATCHED stack from a watched-clean one (#1095). It is
-omitted on the `error` / `stackDeleted` shapes (never reconciled against a baseline).
+omitted whenever the baseline was **not consulted**: on the `error` / `stackDeleted`
+shapes (never reconciled against a baseline), and on every element of a
+`--pre-deploy` or `--show-all` run (both are baseline-untouched modes, so they
+cannot claim `false` — a committed baseline may well exist; #1335). Absent means
+"not consulted"; `false` means "consulted, never recorded".
 
 Each stack element is `{ "stack": "<name> (<region>)", "drifted": <n>, "baseline": <bool>, "findings": [...] }`
 (`error` added only on a pre-check failure; `stackDeleted: true` only on a deleted
@@ -737,9 +742,10 @@ mode: a `record` / `ignore` that would need the selection prompt refuses without
 `--yes` (`"refused": true`), and `revert` refuses the AWS write without `--yes`
 (`"exit": 2`). Per-verb element:
 
-- `record` → `{ "stack", "recorded": <n>, "wrote": <bool>, "baseline"?: "<path>",
+- `record` → `{ "stack", "recorded": <n>, "wrote": <bool>, "baselinePath"?: "<path>",
 "refused"?: true, "error"?: "<reason>" }` — `recorded` is how many undeclared
-  value(s) were written.
+  value(s) were written; `baselinePath` is the baseline file written (a path string,
+  deliberately NOT named `baseline` — that key is check's boolean flag; #1336).
 - `ignore` → `{ "stack", "added": <n>, "wrote": <bool>, "config"?:
 ".cdkrd/ignore.yaml", "refused"?: true, "error"?: "<reason>" }` — `added` is how
   many new rules were appended.

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -744,7 +744,8 @@ export async function runCheck(args: string[]): Promise<number> {
         );
         const preDeployHeader = `${posPrefix}${stackName} (${region})`;
         // #755: in --json collect the stack's object (printed as one array at the end);
-        // in text mode render inline as before.
+        // in text mode render inline as before. No hasBaseline arg: --pre-deploy never
+        // consults the baseline, so the element OMITS the `baseline` flag (#1335).
         let preDeployCode: number;
         if (a.json) {
           const { json, code } = buildStackJson(preDeployReconciled, preDeployHeader);
@@ -840,12 +841,14 @@ export async function runCheck(args: string[]): Promise<number> {
         // #1095: pass baseline presence so the --json element carries a `baseline` flag —
         // a QUIET no-baseline stack (unwatched) is otherwise byte-identical to a
         // watched-clean one (`drifted: 0`, `findings: []`), so a consumer summing
-        // `drifted` cannot tell them apart. `baseline` is already undefined under
-        // --show-all (loaded that way above), so this correctly reports false there.
+        // `drifted` cannot tell them apart. Under --show-all the baseline is NOT
+        // consulted (loaded as undefined above by design), so pass undefined — the
+        // element then OMITS the flag instead of falsely claiming "never recorded"
+        // when a committed baseline may well exist (#1335).
         const { json, code: jsonCode } = buildStackJson(
           reconciled,
           reportHeader,
-          baseline !== undefined
+          a.showAll ? undefined : baseline !== undefined
         );
         jsonReports.push(json);
         code = jsonCode;

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -100,7 +100,7 @@ export async function runRecord(args: string[]): Promise<number> {
           recorded: result.count ?? 0,
           wrote: result.wrote,
           ...(result.refused && { refused: true }),
-          ...(result.path !== undefined && { baseline: result.path }),
+          ...(result.path !== undefined && { baselinePath: result.path }),
         });
     } catch (e) {
       if (isStackNotDeployed(e)) {

--- a/src/commands/verb-json.ts
+++ b/src/commands/verb-json.ts
@@ -11,7 +11,10 @@ export interface RecordJson {
   recorded: number; // undeclared value(s) written into the baseline
   wrote: boolean; // a baseline file was actually written
   refused?: boolean; // a decision was required but the run was non-interactive without --yes
-  baseline?: string; // the baseline file path (when written)
+  // The baseline file path (when written). Named `baselinePath` — self-describing, and
+  // parallel to ignore's `config` path field — so it never collides with check's BOOLEAN
+  // `baseline` presence flag (#1095): one `--json` key, one type across verbs (#1336).
+  baselinePath?: string;
   error?: string; // set only on a pre-record failure / skip
 }
 

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -359,7 +359,9 @@ export interface StackJsonReport {
   // byte-identical `drifted: 0` of a watched-clean stack. A --json consumer summing
   // `drifted` cannot otherwise tell an UNWATCHED stack from a watched clean one — this
   // field is that distinguisher (false = never recorded / unwatched). Omitted on the
-  // error / deleted-stack shapes below (they were never reconciled against a baseline).
+  // error / deleted-stack shapes below (they were never reconciled against a baseline)
+  // AND on the baseline-not-consulted modes — --pre-deploy / --show-all never load the
+  // baseline, so they must not claim `false` ("never recorded") either (#1335).
   baseline?: boolean;
   // Present ONLY on a stack that ERRORED before it could be checked — so a --json
   // consumer sees WHICH stacks ran and which failed, rather than a silent omission (the
@@ -388,7 +390,9 @@ export function buildStackJson(
   // Whether this stack has a committed `.cdkrd` baseline (#1095). Threaded through so the
   // --json element carries a `baseline` presence flag — a consumer can then tell an
   // UNWATCHED (never-recorded) stack from a watched-clean one, which otherwise emit the
-  // byte-identical `drifted: 0`.
+  // byte-identical `drifted: 0`. `undefined` means the baseline was NOT consulted
+  // (--pre-deploy / --show-all / report()'s single-report json path) — the flag is then
+  // OMITTED, never emitted as a false "never recorded" claim (#1335).
   hasBaseline?: boolean
 ): { json: StackJsonReport; code: number } {
   // Annotate origin hints (diff/hints.ts) so the --json payload carries them exactly as
@@ -406,7 +410,15 @@ export function buildStackJson(
   // findings) is identical either way; every non-secret finding is returned unchanged.
   const redacted = findings.map((f) => redactFinding(f));
   return {
-    json: { stack: header, drifted, findings: redacted, baseline: hasBaseline === true },
+    json: {
+      stack: header,
+      drifted,
+      findings: redacted,
+      // #1335: omit (don't default to false) when the baseline was never consulted —
+      // an omitted arg used to coerce to `baseline: false`, which reads as "never
+      // recorded" even when a committed baseline exists.
+      ...(hasBaseline === undefined ? {} : { baseline: hasBaseline }),
+    },
     code: drifted === 0 ? 0 : 1,
   };
 }

--- a/tests/json-baseline-omitted-1335.test.ts
+++ b/tests/json-baseline-omitted-1335.test.ts
@@ -1,0 +1,146 @@
+// #1335 — sibling of #1095. `--pre-deploy` and `--show-all` never CONSULT the baseline
+// (both are baseline-untouched modes: --pre-deploy compares against the local synth
+// template, --show-all inventories all current undeclared state), yet their --json
+// elements emitted `"baseline": false` — the #1095 contract's "never recorded" claim —
+// even when a committed baseline exists. Mechanism: the --pre-deploy branch called
+// buildStackJson() with no hasBaseline arg and --show-all passed `baseline !== undefined`
+// on a deliberately-unloaded (undefined) baseline; both coerced to present-and-false.
+// The fix OMITS the flag when the baseline was not consulted (absent = "not consulted",
+// false = "consulted, never recorded"), matching the documented omitted-on-error rule.
+// This drives runCheck end to end (synth/read mocked) and asserts the key is ABSENT in
+// both modes — with AND without a baseline on disk — while plain check keeps true/false.
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { baselinePath } from '../src/baseline/baseline-file.js';
+import type { StackJsonReport } from '../src/report/report.js';
+
+const STACK = 'MyStack';
+const ACCOUNT = '111122223333';
+const REGION = 'us-east-1';
+
+// One resolved stack, no synth needed for the stack list. gatherFindings returns a CLEAN
+// gather (no findings) whose desired accountId matches any on-disk baseline's account (so
+// the per-account guard is silent). A quiet stack is exactly where a spurious
+// `baseline: false` would misread as "unwatched" despite a committed baseline.
+vi.mock('../src/commands/resolve-stacks.js', () => ({
+  resolveStacks: () =>
+    Promise.resolve([{ stackName: 'MyStack', region: 'us-east-1', template: {} }]),
+}));
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: () =>
+    Promise.resolve({
+      desired: {
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        accountId: '111122223333',
+        resources: [],
+        rawTemplate: '{}',
+        ctx: {},
+      },
+      findings: [],
+      schemas: new Map(),
+      liveByLogical: new Map(),
+    }),
+}));
+// --pre-deploy synthesizes the local app up front for its declared source: stub the app
+// resolution + synth so the branch runs without a real CDK app.
+vi.mock('../src/synth/resolve-app.js', () => ({ resolveApp: () => 'app' }));
+vi.mock('../src/synth/synth.js', () => ({
+  synthApp: () => Promise.resolve([{ stackName: 'MyStack', region: 'us-east-1', template: {} }]),
+  discoverStacks: () => Promise.resolve([]),
+}));
+
+import { runCheck } from '../src/commands/check.js';
+
+// A v2 (snapshot-tracking) baseline so the schema-v1 warning does not fire.
+async function writeBaseline(): Promise<void> {
+  const p = baselinePath(STACK, ACCOUNT, REGION);
+  await mkdir(dirname(p), { recursive: true });
+  const file = {
+    schemaVersion: 2,
+    stackName: STACK,
+    region: REGION,
+    accountId: ACCOUNT,
+    capturedAt: '',
+    templateHash: '', // empty → warnTemplateHashDrift is a no-op
+    recorded: [],
+    completeResources: [],
+  };
+  await writeFile(p, JSON.stringify(file), 'utf8');
+}
+
+describe('#1335 baseline-not-consulted modes OMIT the --json baseline flag', () => {
+  let cwd: string;
+  let dir: string;
+  let out: string[];
+  beforeEach(async () => {
+    cwd = process.cwd();
+    dir = await mkdtemp(join(tmpdir(), 'cdkrd-json-baseline-1335-'));
+    process.chdir(dir);
+    out = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      out.push(String(m));
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    process.chdir(cwd);
+    await rm(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function parsed(): StackJsonReport[] {
+    expect(out).toHaveLength(1);
+    const value = JSON.parse(out[0]!);
+    expect(Array.isArray(value)).toBe(true);
+    return value as StackJsonReport[];
+  }
+
+  it('--pre-deploy --json, WITH a committed baseline: the baseline key is ABSENT (not false)', async () => {
+    await writeBaseline();
+    const code = await runCheck(['--pre-deploy', '--json', STACK]);
+
+    const el = parsed()[0]!;
+    // The bug: this element carried `baseline: false` — "never recorded" — while the
+    // committed baseline sat right there on disk. Not consulted → omitted.
+    expect('baseline' in el).toBe(false);
+    expect(el.drifted).toBe(0);
+    expect(code).toBe(0);
+  });
+
+  it('--pre-deploy --json, NO baseline: the key is still ABSENT (never a false-asserting flag)', async () => {
+    const code = await runCheck(['--pre-deploy', '--json', STACK]);
+
+    const el = parsed()[0]!;
+    expect('baseline' in el).toBe(false);
+    expect(code).toBe(0);
+  });
+
+  it('--show-all --json, WITH a committed baseline: the baseline key is ABSENT (not false)', async () => {
+    await writeBaseline();
+    const code = await runCheck(['--show-all', '--json', STACK]);
+
+    const el = parsed()[0]!;
+    // --show-all deliberately loads baseline=undefined (inventory mode); the old
+    // `baseline !== undefined` threading turned that into a false "never recorded".
+    expect('baseline' in el).toBe(false);
+    expect(el.drifted).toBe(0);
+    expect(code).toBe(0);
+  });
+
+  it('plain check --json still emits baseline: true / false (#1095 contract unchanged)', async () => {
+    const code = await runCheck(['--json', STACK]);
+    expect(parsed()[0]!.baseline).toBe(false); // consulted, none exists
+
+    out.length = 0;
+    await writeBaseline();
+    const code2 = await runCheck(['--json', STACK]);
+    expect(parsed()[0]!.baseline).toBe(true); // consulted, watched
+
+    expect(code).toBe(0);
+    expect(code2).toBe(0);
+  });
+});

--- a/tests/record-json-baseline-path-1336.test.ts
+++ b/tests/record-json-baseline-path-1336.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// #1336: the per-stack --json element key `baseline` meant two different things across
+// verbs — check's BOOLEAN presence flag (#1095) vs record's baseline-file PATH string
+// (#983). A consumer keying `element.baseline` uniformly across a check-then-record
+// pipeline silently misreads one of them. record's field is renamed `baselinePath`
+// (self-describing, parallel to ignore's `config` path field) BEFORE the --json shape
+// becomes a published API; the `baseline` key now belongs to check alone.
+//
+// Same mocking shape as record-footer-799/949.test.ts, but with --json on so runRecord
+// emits the JSON array instead of the text report.
+
+vi.mock('../src/commands/resolve-stacks.js', () => ({
+  resolveStacks: () => Promise.resolve([{ stackName: 'Dev', region: 'us-east-1', template: {} }]),
+}));
+
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: () => Promise.resolve({ desired: { accountId: '111111111111' }, findings: [] }),
+}));
+
+vi.mock('../src/commands/progress.js', () => ({
+  gatherWithProgress: (_show: boolean, _label: string, fn: () => unknown) => fn(),
+  progressLabel: () => '',
+}));
+
+vi.mock('../src/config/config-file.js', () => ({
+  loadConfig: () => Promise.resolve({}),
+  applyIgnores: (findings: unknown) => findings,
+}));
+
+vi.mock('../src/cli-args.js', () => ({
+  parseCommonArgs: () => ({ profile: undefined, json: true, yes: true, verbose: false }),
+  isInteractive: () => false,
+}));
+
+const recordStack = vi.fn();
+vi.mock('../src/commands/stack-actions.js', () => ({
+  recordStack: (...a: unknown[]) => recordStack(...a),
+  warnStackStatus: () => {},
+}));
+
+import { runRecord } from '../src/commands/record.js';
+
+const PATH = '.cdkrd/baselines/Dev.111111111111.us-east-1.json';
+
+describe('record --json element carries baselinePath, never a `baseline` key (#1336)', () => {
+  let logs: string[];
+  let origLog: typeof console.log;
+  let origErr: typeof console.error;
+
+  beforeEach(() => {
+    recordStack.mockReset();
+    logs = [];
+    origLog = console.log;
+    origErr = console.error;
+    console.log = (s: unknown) => logs.push(String(s));
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.error = origErr;
+  });
+
+  function parsedElement(): Record<string, unknown> {
+    expect(logs).toHaveLength(1); // one top-level JSON array (#868)
+    const arr = JSON.parse(logs[0]!) as Record<string, unknown>[];
+    expect(arr).toHaveLength(1);
+    return arr[0]!;
+  }
+
+  it('a written baseline emits `baselinePath` (the path string) and no `baseline` key', async () => {
+    recordStack.mockResolvedValue({ wrote: true, refused: false, count: 2, path: PATH });
+    const rc = await runRecord([]);
+    expect(rc).toBe(0);
+
+    const el = parsedElement();
+    expect(el.baselinePath).toBe(PATH);
+    // The `baseline` key is check's BOOLEAN flag (#1095) — record must never emit it,
+    // in either the old string form or any other shape.
+    expect('baseline' in el).toBe(false);
+    expect(el).toMatchObject({ recorded: 2, wrote: true });
+  });
+
+  it('no baseline written → both keys absent (baselinePath stays optional)', async () => {
+    recordStack.mockResolvedValue({ wrote: false, refused: false, count: 0 });
+    const rc = await runRecord([]);
+    expect(rc).toBe(0);
+
+    const el = parsedElement();
+    expect('baselinePath' in el).toBe(false);
+    expect('baseline' in el).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two bundled fixes to the per-stack `--json` element's `baseline` key, before the shape becomes a published API.

### #1335 — `--pre-deploy` / `--show-all` --json falsely asserted `baseline: false`
Both are baseline-untouched modes, yet their elements emitted `"baseline": false` — the #1095 contract's "never recorded" claim — even when a committed `.cdkrd` baseline exists. Mechanism: the `--pre-deploy` branch called `buildStackJson` with no `hasBaseline` arg, and `--show-all` threaded a deliberately-unloaded (`undefined`) baseline through `baseline !== undefined`; both coerced to present-and-false. A consumer using the documented semantics (`baseline: false` ⇒ unwatched stack, alert) false-alarms on every watched stack.

Fix: `buildStackJson` OMITS the flag when `hasBaseline` is `undefined` — absent = "not consulted", `false` = "consulted, never recorded" — matching the documented omitted-on-error rule. Plain `check --json` still emits `true`/`false` exactly as before (#1095 contract unchanged).

### #1336 — one `--json` key, two types across verbs
check's `baseline` is a BOOLEAN presence flag (#1095); record's `baseline` was a baseline-file PATH string (#983). A consumer keying `element.baseline` uniformly across a check-then-record pipeline silently misreads. Renamed record's field to `baselinePath` (self-describing, parallel to ignore's `config` path field).

README's JSON-contract section updated for both (omitted-when-not-consulted rule named explicitly; per-verb element list renamed).

## Tests
- `tests/json-baseline-omitted-1335.test.ts` — drives `runCheck` end to end (synth/read mocked): `--pre-deploy`/`--show-all` elements OMIT the key (with AND without a committed baseline on disk); plain check keeps `true`/`false`. 3/4 fail without the fix.
- `tests/record-json-baseline-path-1336.test.ts` — drives `runRecord --json`: a written baseline emits `baselinePath` (path string) and never a `baseline` key; both keys absent when nothing was written. Fails without the fix.
- Full suite: 206 files / 4772 tests green on the rebased tree.

Both issues are offline/deterministic (--json shape only, no AWS interaction) — the end-to-end unit tests ARE the authoritative repro.

Closes #1335
Closes #1336