### PR TITLE
fix(synth): resolve staged-stack positionals by hierarchicalId + abort on a selected stack's addError (#1316)

### DIFF
--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -17,6 +17,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { CommonArgs } from '../cli-args.js';
 import { resolveApp } from '../synth/resolve-app.js';
+import type { DiscoveredStack } from '../synth/synth.js';
 import { discoverStacks } from '../synth/synth.js';
 import { isGlob, matchesGlob } from './glob-match.js';
 
@@ -130,6 +131,59 @@ export interface ResolvedStack {
   template: Record<string, unknown>;
 }
 
+/**
+ * #1316: does a CLI positional select this discovered stack? A positional matches against BOTH
+ * the deployed CloudFormation `stackName` AND the toolkit `hierarchicalId` (`Stage/Stack` for a
+ * stack nested in a CDK `Stage`), so BOTH `check Dev-Net` (the stage-qualified stackName cdkrd
+ * historically accepted) AND the cdk-native `check Dev/Net` (what `cdk ls`/`cdk synth` show, and
+ * what the #905 selector actually matches on) resolve to the staged stack. A positional with a
+ * glob metachar (`*`/`?`) is matched as a glob against each identifier; a plain positional matches
+ * either identifier EXACTLY (equivalent to a metachar-free glob, but kept as `===` for clarity and
+ * to preserve the exact-name semantics). For a top-level stack the two identifiers are identical,
+ * so behavior there is unchanged. Pure + exported for unit tests.
+ */
+export function positionalMatchesStack(
+  positional: string,
+  stack: { stackName: string; hierarchicalId?: string | undefined }
+): boolean {
+  // `hierarchicalId` falls back to `stackName` for a top-level stack (they are identical there),
+  // so an absent id degrades to a stackName-only match — never a crash.
+  const hierarchicalId = stack.hierarchicalId ?? stack.stackName;
+  if (isGlob(positional)) {
+    return matchesGlob(positional, stack.stackName) || matchesGlob(positional, hierarchicalId);
+  }
+  return positional === stack.stackName || positional === hierarchicalId;
+}
+
+/**
+ * #1316: the residual-hole guard. toolkit.synth's metadata validation aborts on a stack's
+ * error-level annotations (`Annotations.addError(...)` — cdk-nag, a security aspect, a
+ * "do not deploy" guard), but ONLY for the SELECTOR-matched collection, and the #905 selector
+ * matches on hierarchicalId. A stackName-form positional (`Dev-Net`) matches zero hierarchicalIds,
+ * so that validation is silently skipped — cdkrd would then read (and `revert --yes` write back)
+ * a template from an app in an error state. After selecting the target stacks, re-check THEIR
+ * error annotations and throw so the caller aborts (check maps a resolveStacks throw to exit 2),
+ * restoring the no-args abort behavior for the named case. The no-args / --all path already had
+ * toolkit.synth validate every stack (no selector), so this is a belt for the named case.
+ * Aggregates messages across every selected stack. Pure + exported for unit tests.
+ */
+export function assertNoStackErrors(
+  selected: readonly { stackName: string; errorMessages?: readonly string[] | undefined }[]
+): void {
+  const lines: string[] = [];
+  for (const s of selected) {
+    // An absent `errorMessages` (an older/looser caller) degrades to "no errors" — never a crash.
+    for (const msg of s.errorMessages ?? []) lines.push(`  ${s.stackName}: ${msg}`);
+  }
+  if (lines.length > 0) {
+    throw new Error(
+      `the CDK app synthesized with ${lines.length} error(s) (an Annotations.addError — cdk-nag / ` +
+        'security aspect / do-not-deploy guard) on the selected stack(s); refusing to read or ' +
+        `revert an app in an error state:\n${lines.join('\n')}`
+    );
+  }
+}
+
 export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
   const app = resolveApp(a.app);
   if (!app) {
@@ -179,6 +233,10 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
   // --all, or no names → every stack the app defines. --all is the explicit form of the
   // no-argument default; it also overrides any positional names (target everything).
   if (a.all || a.stackNames.length === 0) {
+    // #1316: every stack is selected here, so surface any error-level annotation and abort —
+    // mirroring the named case below. (toolkit.synth already validated all stacks with no
+    // selector on this path, so it normally threw first; this keeps the guard uniform.)
+    assertNoStackErrors(discovered);
     return discovered.map((s) => ({
       stackName: s.stackName,
       region: s.region ?? fallbackRegion,
@@ -187,9 +245,14 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
     }));
   }
 
-  // names (exact and/or glob) matched against the app's stacks
+  // names (exact and/or glob) matched against the app's stacks — matched against BOTH the
+  // deployed stackName AND the toolkit hierarchicalId (#1316, positionalMatchesStack).
   const seen = new Set<string>();
   const out: ResolvedStack[] = [];
+  // #1316: the DISCOVERED stacks a positional selected — so we can re-check their error-level
+  // annotations after selection and abort (the residual hole a stackName-form positional opened:
+  // the #905 hierarchicalId-scoped selector skipped their validation). Keyed like `add`'s dedup.
+  const selectedByKey = new Map<string, DiscoveredStack>();
   const add = (
     stackName: string,
     region: string | undefined,
@@ -209,40 +272,52 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
     seen.add(key);
     out.push({ stackName, region, account, template });
   };
-  const known = (): string => discovered.map((s) => s.stackName).join(', ') || 'none';
+  // The known-stacks hint lists BOTH identifier forms when they differ (`Stage/Stack (Stage-Stack)`,
+  // mirroring `cdk ls`), so a user who mistyped one form sees the other they could have used (#1316).
+  const known = (): string =>
+    discovered
+      .map((s) =>
+        s.hierarchicalId === s.stackName ? s.stackName : `${s.hierarchicalId} (${s.stackName})`
+      )
+      .join(', ') || 'none';
+  // Record a positional-selected discovered stack for the post-selection error check (#1316).
+  const select = (s: DiscoveredStack): void => {
+    add(s.stackName, s.region ?? fallbackRegion, s.account, s.template);
+    selectedByKey.set(`${s.stackName}\0${s.region ?? ''}\0${s.account ?? ''}`, s);
+  };
   for (const name of a.stackNames) {
+    // Match a positional against BOTH the stackName AND the hierarchicalId (#1316) — a plain
+    // positional matches either EXACTLY, a `*`/`?` positional globs either. This is what makes
+    // the cdk-native `Dev/Net` form resolve (and scope the #905 selector correctly), while the
+    // stage-qualified `Dev-Net` stackName form keeps working.
+    const hits = discovered.filter((s) => positionalMatchesStack(name, s));
     if (isGlob(name)) {
-      // Count MATCHES (matchesGlob true), NOT net add() calls: `add` dedups via
+      // Count MATCHES (positionalMatchesStack true), NOT net add() calls: `add` dedups via
       // `seen`, so a glob hitting an already-added stack is still a match and must
       // NOT error. A glob that matches ZERO discovered stacks is a hard error,
       // mirroring the exact-name-typo throw — otherwise `check 'Pord-*' Dev --fail`
       // (a typo'd prod glob) silently checks nothing for the glob and exits 0, so
       // CI believes prod was covered.
-      let matched = 0;
-      for (const s of discovered) {
-        if (matchesGlob(name, s.stackName)) {
-          matched++;
-          add(s.stackName, s.region ?? fallbackRegion, s.account, s.template);
-        }
-      }
-      if (matched === 0)
+      if (hits.length === 0)
         throw new Error(
           `glob "${name}" matched no stacks defined by the CDK app (found: ${known()})`
         );
+      for (const hit of hits) select(hit);
     } else {
-      // Collect ALL discovered stacks with this exact name, NOT just the first
-      // (#884). A multi-REGION app can define the same stackName in two envs
+      // Collect ALL discovered stacks matching this exact name/hierarchicalId, NOT just the
+      // first (#884). A multi-REGION app can define the same stackName in two envs
       // (e.g. `Dup` in us-east-1 AND us-west-2); `add` dedups on name+region so
       // the two distinct-region instances are both kept while a same-name
       // same-region duplicate still collapses. `find` silently dropped every
       // instance but the first, so `check Dup --fail` greenlit the other region.
-      const hits = discovered.filter((s) => s.stackName === name);
       if (hits.length === 0)
         throw new Error(`stack "${name}" is not defined by the CDK app (found: ${known()})`);
-      for (const hit of hits)
-        add(hit.stackName, hit.region ?? fallbackRegion, hit.account, hit.template);
+      for (const hit of hits) select(hit);
     }
   }
+  // #1316: abort on any error-level annotation of the SELECTED stacks — the validation
+  // toolkit.synth's hierarchicalId-scoped #905 selector skipped for a stackName-form positional.
+  assertNoStackErrors([...selectedByKey.values()]);
   if (out.length === 0) {
     throw new Error(`no stacks match ${a.stackNames.join(', ')} (found: ${known()})`);
   }

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -62,12 +62,25 @@ export function buildStackSelector(patterns: string[] | undefined): StackSelecto
 
 export interface SynthStack {
   stackName: string;
+  // #1316: the toolkit-lib HIERARCHICAL id (`Stage/Stack` for a stack nested in a CDK `Stage`,
+  // else identical to stackName). CDK-native tooling (`cdk ls`/`cdk synth`) identifies a staged
+  // stack by this, while the deployed CloudFormation `stackName` is the stage-qualified
+  // `Stage-Stack`. resolveStacks matches a CLI positional against BOTH forms so the cdk-native
+  // `Dev/Net` works AND scopes the #905 selector (which matches on hierarchicalId) correctly.
+  hierarchicalId: string;
   region: string | undefined; // the stack's own env.region (concrete) — for per-stack drift reads
   // #740: the stack's own env.account (concrete 12-digit id), or undefined for an
   // env-agnostic stack — used by check to skip a stack pinned to an account the active
   // credentials are NOT for (instead of misreporting it "not deployed yet") and to guard
   // against a same-named stack in the reachable account being wrong-account compared.
   account: string | undefined;
+  // #1316: the stack's OWN error-level synthesis messages (an `Annotations.addError(...)` —
+  // cdk-nag, a security aspect, a "do not deploy" guard). toolkit.synth's metadata validation
+  // only aborts on the SELECTOR-matched collection, and the #905 selector matches on
+  // hierarchicalId; a stackName-form positional (`Dev-Net`) matches ZERO hierarchicalIds, so
+  // that validation is silently skipped and a broken app is read/reverted. resolveStacks
+  // re-checks these for the SELECTED stacks and aborts, restoring the no-args abort behavior.
+  errorMessages: string[];
   template: Record<string, unknown>;
 }
 
@@ -82,6 +95,40 @@ export const CONCRETE_REGION = /^[a-z]{2}(-[a-z]+)+-\d+$/;
 // neither of which matches — so an unpinned account maps to undefined (see concreteAccount),
 // mirroring how CONCRETE_REGION distinguishes a real region pin from a token/placeholder.
 export const CONCRETE_ACCOUNT = /^\d{12}$/;
+
+// The `level` string a toolkit-lib `SynthesisMessage` carries for an error-level annotation
+// (`Annotations.addError(...)`). `SynthesisMessageLevel.ERROR`'s runtime value — compared as a
+// string literal because toolkit-lib does NOT re-export the `SynthesisMessageLevel` enum (#1316).
+const SYNTHESIS_ERROR_LEVEL = 'error';
+
+/** The minimal shape of a toolkit-lib `SynthesisMessage` we read: only its `level` + a
+ *  human-readable `entry.data`. */
+interface SynthMessageLike {
+  readonly level: string;
+  readonly entry?: { readonly data?: unknown } | undefined;
+}
+
+/**
+ * Extract the ERROR-level synthesis messages of a single stack artifact (#1316).
+ *
+ * A stack's `Annotations.addError(...)` (cdk-nag, a security aspect, a "do not deploy" guard)
+ * surfaces as a `messages` entry with `level === 'error'`. toolkit.synth's own
+ * `validateStacksMetadata` aborts on these — but ONLY for the SELECTOR-matched stacks, and the
+ * #905 selector matches on hierarchicalId, so a stackName-form positional (`Dev-Net`) that
+ * matches zero hierarchicalIds skips that validation entirely. We re-collect them here so
+ * resolveStacks can abort on the SELECTED stacks, restoring the no-args abort behavior for the
+ * named case. Pure + exported for unit tests. Returns the human-readable error strings (empty
+ * when the stack has no error annotation).
+ */
+export function stackErrorMessages(messages: readonly SynthMessageLike[] | undefined): string[] {
+  if (!messages) return [];
+  return messages
+    .filter((m) => m.level === SYNTHESIS_ERROR_LEVEL)
+    .map((m) => {
+      const data = m.entry?.data;
+      return typeof data === 'string' && data.length > 0 ? data : 'error';
+    });
+}
 
 // Map a raw `s.environment.account` to a concrete 12-digit account id, or undefined when it
 // is not pinned (toolkit-lib's `"unknown-account"` / a `${Token...}` for an env-agnostic
@@ -297,10 +344,16 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
     // correct live-read target.
     return cached.cloudAssembly.stacksRecursively.map((s) => ({
       stackName: s.stackName,
+      // #1316: the toolkit HIERARCHICAL id (`Stage/Stack` for a staged stack) so resolveStacks
+      // can match a cdk-native positional against it AND scope the #905 selector correctly.
+      hierarchicalId: s.hierarchicalId,
       region: CONCRETE_REGION.test(s.environment.region) ? s.environment.region : undefined,
       // #740: carry the stack's own env.account (concrete 12-digit id, else undefined) so
       // check can tell a stack pinned to ANOTHER account from a genuinely-undeployed one.
       account: concreteAccount(s.environment.account),
+      // #1316: the stack's error-level annotations, so resolveStacks can abort on a SELECTED
+      // stack whose validation toolkit.synth's hierarchicalId-scoped selector skipped.
+      errorMessages: stackErrorMessages(s.messages),
       template: s.template as Record<string, unknown>,
     }));
   } finally {
@@ -310,9 +363,15 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
 
 export interface DiscoveredStack {
   stackName: string;
+  // #1316: the toolkit HIERARCHICAL id (`Stage/Stack` for a staged stack, else == stackName) —
+  // resolveStacks matches a positional against this too (see SynthStack.hierarchicalId).
+  hierarchicalId: string;
   region: string | undefined; // the stack's own env.region, when concrete
   // #740: the stack's own env.account, when concrete (12-digit) — see SynthStack.account.
   account: string | undefined;
+  // #1316: the stack's error-level synthesis annotations (see SynthStack.errorMessages) —
+  // resolveStacks aborts on a SELECTED stack that carries any.
+  errorMessages: string[];
   // the synthesized template — carried through so the check path can recover GetTemplate's
   // `?`-masked non-ASCII literals from it without re-synthesizing (synthApp already built it).
   template: Record<string, unknown>;
@@ -329,8 +388,10 @@ export async function discoverStacks(
 ): Promise<DiscoveredStack[]> {
   return (await synthApp(app, opts)).map((s) => ({
     stackName: s.stackName,
+    hierarchicalId: s.hierarchicalId,
     region: s.region,
     account: s.account,
+    errorMessages: s.errorMessages,
     template: s.template,
   }));
 }

--- a/tests/staged-selector-1316.test.ts
+++ b/tests/staged-selector-1316.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { assertNoStackErrors, positionalMatchesStack } from '../src/commands/resolve-stacks.js';
+import { stackErrorMessages } from '../src/synth/synth.js';
+
+// #1316: for a stack nested in a CDK `Stage`, cdkrd and toolkit-lib disagreed on the identifying
+// name — resolveStacks matched a CLI positional against the deployed `stackName` (`Dev-Net`), while
+// the #905 synth selector forwarded the SAME positional to `toolkit.synth`, which matches on the
+// `hierarchicalId` (`Dev/Net`, picomatch — `*` does not cross `/`). Two bugs:
+//   1. UX inversion — `cdk synth Dev/Net` works but cdkrd only accepted `Dev-Net`, and vice versa.
+//   2. Validation silently disabled — `toolkit.synth` runs metadata validation only on the
+//      selector-matched collection; a `Dev-Net` positional matches ZERO hierarchicalIds, so an
+//      `Annotations.addError(...)` that would abort a no-args check is silently ignored.
+// The fix threads `hierarchicalId` + the stack's error-level messages through discovery, matches a
+// positional against BOTH identifiers, and re-checks the selected stacks' error annotations.
+
+describe('stackErrorMessages (#1316) — extract a stack artifact ERROR-level annotations', () => {
+  it('returns [] for no messages / undefined', () => {
+    expect(stackErrorMessages(undefined)).toEqual([]);
+    expect(stackErrorMessages([])).toEqual([]);
+  });
+
+  it('keeps only level "error" (an addError), dropping info/warning', () => {
+    const msgs = [
+      { level: 'info', entry: { data: 'just fyi' } },
+      { level: 'warning', entry: { data: 'be careful' } },
+      { level: 'error', entry: { data: 'THIS STACK IS BROKEN' } },
+    ];
+    expect(stackErrorMessages(msgs)).toEqual(['THIS STACK IS BROKEN']);
+  });
+
+  it('surfaces the human-readable entry.data, falling back to "error" when absent', () => {
+    expect(
+      stackErrorMessages([
+        { level: 'error', entry: { data: 'cdk-nag AwsSolutions-IAM5' } },
+        { level: 'error', entry: {} },
+        { level: 'error' },
+      ])
+    ).toEqual(['cdk-nag AwsSolutions-IAM5', 'error', 'error']);
+  });
+});
+
+describe('positionalMatchesStack (#1316) — a positional matches stackName OR hierarchicalId', () => {
+  const staged = { stackName: 'Dev-Net', hierarchicalId: 'Dev/Net' };
+
+  it('matches the cdk-native hierarchicalId form (Dev/Net)', () => {
+    expect(positionalMatchesStack('Dev/Net', staged)).toBe(true);
+  });
+
+  it('matches the deployed stackName form (Dev-Net)', () => {
+    expect(positionalMatchesStack('Dev-Net', staged)).toBe(true);
+  });
+
+  it('does NOT match an unrelated name', () => {
+    expect(positionalMatchesStack('Prod/Net', staged)).toBe(false);
+    expect(positionalMatchesStack('Dev-Web', staged)).toBe(false);
+  });
+
+  it('a glob matches the hierarchicalId (Dev/* → Dev/Net)', () => {
+    expect(positionalMatchesStack('Dev/*', staged)).toBe(true);
+  });
+
+  it('a glob matches the stackName form too (Dev-* → Dev-Net)', () => {
+    expect(positionalMatchesStack('Dev-*', staged)).toBe(true);
+  });
+
+  it('a top-level stack (identifiers identical) is unchanged', () => {
+    const top = { stackName: 'Top', hierarchicalId: 'Top' };
+    expect(positionalMatchesStack('Top', top)).toBe(true);
+    expect(positionalMatchesStack('To*', top)).toBe(true);
+    expect(positionalMatchesStack('Nope', top)).toBe(false);
+  });
+
+  it('an absent hierarchicalId degrades to a stackName-only match (no crash)', () => {
+    expect(positionalMatchesStack('Solo', { stackName: 'Solo' })).toBe(true);
+    expect(positionalMatchesStack('So*', { stackName: 'Solo' })).toBe(true);
+  });
+});
+
+describe('assertNoStackErrors (#1316) — abort on a SELECTED stack error annotation', () => {
+  it('is a no-op when no selected stack carries an error', () => {
+    expect(() =>
+      assertNoStackErrors([
+        { stackName: 'A', errorMessages: [] },
+        { stackName: 'B', errorMessages: [] },
+      ])
+    ).not.toThrow();
+  });
+
+  it('throws (naming the stack + message) when a selected stack has an addError', () => {
+    expect(() =>
+      assertNoStackErrors([{ stackName: 'Dev-Net', errorMessages: ['THIS STACK IS BROKEN'] }])
+    ).toThrow(/Dev-Net: THIS STACK IS BROKEN/);
+  });
+
+  it('aggregates errors across multiple selected stacks', () => {
+    let caught: Error | undefined;
+    try {
+      assertNoStackErrors([
+        { stackName: 'Dev-Net', errorMessages: ['broken A'] },
+        { stackName: 'Dev-Web', errorMessages: ['broken B1', 'broken B2'] },
+      ]);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.message).toContain('3 error(s)');
+    expect(caught?.message).toContain('Dev-Net: broken A');
+    expect(caught?.message).toContain('Dev-Web: broken B1');
+    expect(caught?.message).toContain('Dev-Web: broken B2');
+  });
+
+  it('degrades to no-op for a caller without errorMessages (no crash)', () => {
+    expect(() => assertNoStackErrors([{ stackName: 'A' }])).not.toThrow();
+  });
+});
+
+// End-to-end through resolveStacks with discoverStacks mocked: assert BOTH identifier forms
+// resolve the staged stack, a Dev/* glob matches it, and a stackName-form positional aborts on the
+// staged stack's error annotation (the validation the hierarchicalId selector would have skipped).
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+
+interface Disc {
+  stackName: string;
+  hierarchicalId: string;
+  region: string | undefined;
+  account: string | undefined;
+  errorMessages: string[];
+  template: Record<string, unknown>;
+}
+
+// A CDK app: a top-level `Top` stack + a `Net` stack nested in a `Dev` Stage (deployed stackName
+// `Dev-Net`, hierarchicalId `Dev/Net`). `stagedErrors` is injected per-test to simulate an
+// Annotations.addError on the staged stack.
+let stagedErrors: string[] = [];
+const discovered = (): Disc[] => [
+  {
+    stackName: 'Top',
+    hierarchicalId: 'Top',
+    region: 'us-east-1',
+    account: undefined,
+    errorMessages: [],
+    template: { top: true },
+  },
+  {
+    stackName: 'Dev-Net',
+    hierarchicalId: 'Dev/Net',
+    region: 'us-east-1',
+    account: undefined,
+    errorMessages: stagedErrors,
+    template: { net: true },
+  },
+];
+vi.mock('../src/synth/synth.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/synth/synth.js')>();
+  return { ...actual, discoverStacks: () => Promise.resolve(discovered()) };
+});
+
+import type { CommonArgs } from '../src/cli-args.js';
+import { resolveStacks } from '../src/commands/resolve-stacks.js';
+
+function args(overrides: Partial<CommonArgs>): CommonArgs {
+  return {
+    stackNames: [],
+    all: false,
+    region: 'us-east-1',
+    profile: undefined,
+    app: undefined,
+    context: {},
+    json: false,
+    showAll: false,
+    yes: false,
+    preDeploy: false,
+    undeclaredOnly: false,
+    declaredOnly: false,
+    fail: false,
+    strict: false,
+    removeUnrecorded: false,
+    force: false,
+    verbose: false,
+    waitMs: undefined,
+    ...overrides,
+  };
+}
+
+describe('resolveStacks — staged-stack selector accepts both identifier forms (#1316)', () => {
+  beforeEach(() => {
+    stagedErrors = [];
+  });
+
+  it('check Dev/Net (cdk-native hierarchicalId form) resolves the staged stack', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Dev/Net'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Dev-Net']);
+  });
+
+  it('check Dev-Net (deployed stackName form) resolves the staged stack', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Dev-Net'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Dev-Net']);
+  });
+
+  it('Dev/* glob matches the staged stack', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Dev/*'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Dev-Net']);
+  });
+
+  it('Dev-* glob (stackName form) still matches the staged stack', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Dev-*'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Dev-Net']);
+  });
+
+  it('a bogus positional lists both identifier forms in the error', async () => {
+    await expect(resolveStacks(args({ stackNames: ['Nope'] }))).rejects.toThrow(
+      /Dev\/Net \(Dev-Net\)/
+    );
+  });
+});
+
+describe('resolveStacks — a stackName-form positional still surfaces the addError (#1316)', () => {
+  beforeEach(() => {
+    stagedErrors = [];
+  });
+
+  it('check Dev-Net aborts on the staged stack error annotation (validation not silently skipped)', async () => {
+    stagedErrors = ['THIS STACK IS BROKEN'];
+    // The bug: `Dev-Net` matches zero hierarchicalIds, so toolkit.synth's metadata validation is
+    // skipped and the broken app is read/reverted. The fix re-checks the selected stack's errors.
+    await expect(resolveStacks(args({ stackNames: ['Dev-Net'] }))).rejects.toThrow(
+      /Dev-Net: THIS STACK IS BROKEN/
+    );
+  });
+
+  it('check Dev/Net (hierarchicalId form) also aborts on the error annotation', async () => {
+    stagedErrors = ['THIS STACK IS BROKEN'];
+    await expect(resolveStacks(args({ stackNames: ['Dev/Net'] }))).rejects.toThrow(
+      /THIS STACK IS BROKEN/
+    );
+  });
+
+  it('no-args (all stacks selected) aborts on a staged stack error too', async () => {
+    stagedErrors = ['THIS STACK IS BROKEN'];
+    await expect(resolveStacks(args({ stackNames: [] }))).rejects.toThrow(/THIS STACK IS BROKEN/);
+  });
+
+  it('a clean staged stack resolves normally (no false abort)', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Dev-Net'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Dev-Net']);
+  });
+});

--- a/tests/synth-selector-905.test.ts
+++ b/tests/synth-selector-905.test.ts
@@ -50,8 +50,22 @@ vi.mock('../src/synth/resolve-app.js', () => ({
 }));
 
 const discovered = [
-  { stackName: 'GoodStack', region: 'us-east-1', template: {} },
-  { stackName: 'BadLookupStack', region: 'us-east-1', template: {} },
+  {
+    stackName: 'GoodStack',
+    hierarchicalId: 'GoodStack',
+    region: 'us-east-1',
+    account: undefined,
+    errorMessages: [],
+    template: {},
+  },
+  {
+    stackName: 'BadLookupStack',
+    hierarchicalId: 'BadLookupStack',
+    region: 'us-east-1',
+    account: undefined,
+    errorMessages: [],
+    template: {},
+  },
 ];
 type DiscoverFn = (
   app: string,


### PR DESCRIPTION
Closes #1316.

## Problem
For a stack nested in a CDK `Stage`, cdkrd matched CLI positionals against the deployed **stackName** (`Dev-Net`) while the #905 synth selector forwards them to `toolkit.synth`, which matches on **hierarchicalId** (`Dev/Net`). Two consequences:
1. **Validation silently disabled (the real bug).** `toolkit.synth` runs `validateStacksMetadata` only on the selector-matched collection; `Dev-Net` matches ZERO hierarchicalIds, so a stack's `Annotations.addError(...)` (cdk-nag, a security aspect, a do-not-deploy guard) is silently ignored — `check` then compares, and `revert --yes` writes back, a template from an app in an error state.
2. **UX inversion.** `cdk ls`/`cdk synth Dev/Net` work but cdkrd rejected `Dev/Net` and only accepted `Dev-Net`.

## Fix
- Thread the toolkit `hierarchicalId` + the stack's error-level `messages` through `synthApp` → `SynthStack`/`DiscoveredStack`.
- `positionalMatchesStack`: a positional matches BOTH `stackName` and `hierarchicalId` (exact for a plain name, glob for a `*`/`?` pattern) — so `Dev/Net`, `Dev-Net`, `Dev/*`, `Dev-*` all resolve the staged stack, and accepting the cdk-native form scopes the #905 selector correctly.
- `assertNoStackErrors`: after selecting the target stacks, re-check THEIR error-level annotations and throw (check.ts maps a resolveStacks throw to exit 2) — restoring the no-args abort for the stackName-form named case. The known-stacks hint now lists `Dev/Net (Dev-Net)`.

## Live-test (offline, the issue's exact repro — no AWS deploy)
A `Stage('Dev')/Stack('Net')` with `Annotations.addError` + a top-level `Top`:
- **PRE-FIX (0.12.48):** `check Dev-Net` → exit 0, "not deployed yet — skipped" (silently proceeded past validation).
- **FIX:** `check Dev-Net` → **exit 2**, surfaces "THIS STACK IS BROKEN"; `check Dev/Net` → exit 2 too.

## Tests
New `tests/staged-selector-1316.test.ts`: `positionalMatchesStack` (both forms + globs resolve; top-level unchanged; absent id degrades), `assertNoStackErrors` (throws on a selected stack's error, aggregates), `stackErrorMessages` (level filter), and end-to-end `resolveStacks` (all four name forms resolve `Dev-Net`; `check Dev-Net` aborts on the staged addError). Offline-deterministic; verify-pr live-test done above.

Disjoint from concurrent lanes #1322 (gather/child-enum), #1412 (classify), #1413 (noise), #1348 (plan).