### PR TITLE
fix(desired): note --pre-deploy params whose changed local Default a plain deploy keeps (#1292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,12 @@ before deploying. As a pipeline gate:
 `--pre-deploy` reports **declared** drift only (the undeclared tier is defined
 against the _deployed_ template) and never touches the baseline.
 
+One caveat on template **parameters**: for an existing parameter a plain
+`cdk deploy` keeps the deployed value (`UsePreviousValue`), so drift previewed
+from a **changed local `Default`** is applied only if you pass
+`--parameters <key>=<value>` / `--no-previous-parameters` — `check` prints a
+stderr note naming each such parameter and both values.
+
 ### Ignoring externally-managed properties
 
 Some properties are _legitimately_ rewritten by another system, such as Application

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -191,6 +191,66 @@ export function unpreviewableParamInfo(
   return `warning: ${stackName}: ${unpreviewable.length} local parameter(s) have NO value under --pre-deploy (new/renamed, no Default, absent from the deployed stack) — every declared property that Refs them resolves UNRESOLVED and was NOT compared (cannot preview): ${shown.join(', ')}${more}`;
 }
 
+// #1292: under --pre-deploy a CHANGED local param Default wins over the deployed DescribeStacks
+// value (#1194), so the preview resolves every property fed by the param from the NEW Default —
+// but deployment tools do not apply it that way: for an EXISTING parameter a plain `cdk deploy`
+// (and `aws cloudformation deploy`) always sends `UsePreviousValue: true` (toolkit-lib's
+// ParameterValues), so the gated deploy KEEPS the deployed value unless the user passes
+// `--parameters <key>=<value>` / `--no-previous-parameters`. DescribeStacks offers no
+// explicit-vs-default signal either, so a param explicitly set at deploy time is
+// indistinguishable from a changed Default — either way the previewed declared drift may be
+// one a plain deploy will NOT apply. Resolution is deliberately unchanged (the local Default
+// still wins — reverting #1194 would re-mask the drift); instead surface the divergence LOUDLY:
+// one aggregated stderr note per stack naming each such param, both values, and the
+// UsePreviousValue caveat. NoEcho and SSM `::Parameter::Value<` params are EXCLUDED — their
+// local Default is a placeholder / SSM key that is never seeded (#744/#882), so no preview is
+// derived from it. Only counts params actually REFERENCED by a declared resource property or a
+// Condition (an unused param feeds no previewed value). Returns the note, or null when none.
+// Pure + exported for unit tests; the caller gates on templateOverride.
+export function changedDefaultParamInfo(
+  template: Record<string, any>,
+  stackParams: Record<string, string>,
+  stackName: string
+): string | null {
+  const paramDefs = (template.Parameters ?? {}) as Record<
+    string,
+    { Default?: unknown; Type?: string; NoEcho?: unknown }
+  >;
+  // CloudFormation whitespace-trims CommaDelimitedList values ("a, b" == "a,b"), so compare
+  // list-typed params on the trimmed split — mirroring buildResolverContext's toParam — else
+  // a cosmetic-whitespace Default would false-note. (SSM list variants are excluded above.)
+  const normalize = (k: string, v: string): string => {
+    const t = paramDefs[k]?.Type ?? '';
+    if (t !== 'CommaDelimitedList' && !t.startsWith('List<')) return v;
+    return v
+      .split(',')
+      .map((s) => s.trim())
+      .join(',');
+  };
+  const changed = Object.entries(paramDefs)
+    .filter(([k, def]) => {
+      if (def?.NoEcho === true || def?.NoEcho === 'true') return false; // #744 masked treatment
+      if ((def?.Type ?? '').includes('::Parameter::Value<')) return false; // #882 SSM treatment
+      if (!def || !('Default' in def)) return false; // no local Default → the fill step applies
+      if (!(k in stackParams)) return false; // new param, no deployed value → #1221's warning
+      return normalize(k, String(def.Default)) !== normalize(k, stackParams[k] ?? '');
+    })
+    .map(([k]) => k);
+  if (changed.length === 0) return null;
+  const referenced = collectReferencedNames(template.Resources ?? {});
+  collectReferencedNames(template.Conditions ?? {}, referenced);
+  const diverged = changed.filter((k) => referenced.has(k)).sort();
+  if (diverged.length === 0) return null;
+  const shown = diverged
+    .slice(0, 10)
+    .map(
+      (k) =>
+        `${k} (local Default ${JSON.stringify(String(paramDefs[k]?.Default))}, deployed ${JSON.stringify(stackParams[k])})`
+    );
+  const more = diverged.length > shown.length ? `, …(+${diverged.length - shown.length} more)` : '';
+  return `warning: ${stackName}: ${diverged.length} local parameter(s) changed their Default vs the deployed value — the preview resolves them from the NEW local Default, but a plain \`cdk deploy\` KEEPS the deployed value (UsePreviousValue) unless \`--parameters <key>=<value>\` / \`--no-previous-parameters\` is passed: ${shown.join(', ')}${more}`;
+}
+
 // The AWS::Partition / AWS::URLSuffix pseudo-parameters are a deterministic function of the
 // region, NOT a commercial-partition constant. CDK env-agnostic stacks emit ${AWS::Partition}
 // inside nearly every Sub/Join-built ARN, so hard-coding `aws` / `amazonaws.com` mis-resolves
@@ -583,6 +643,11 @@ export async function loadDesired(
     // above/below. stackParams is the deployed DescribeStacks set built just above.
     const noValueInfo = unpreviewableParamInfo(template, stackParams, stackName);
     if (noValueInfo) console.error(noValueInfo);
+    // #1292: loud caveat for existing params whose local Default DIFFERS from the deployed
+    // value — the preview applies the new Default (#1194) but a plain `cdk deploy` keeps the
+    // deployed value via UsePreviousValue (see changedDefaultParamInfo). Same stderr channel.
+    const changedDefaultInfo = changedDefaultParamInfo(template, stackParams, stackName);
+    if (changedDefaultInfo) console.error(changedDefaultInfo);
   }
 
   // #882: detect logical ids whose Type changed between the deployed stack and the declared

--- a/tests/predeploy-param-note-1292.test.ts
+++ b/tests/predeploy-param-note-1292.test.ts
@@ -1,0 +1,214 @@
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  GetTemplateCommand,
+  ListStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { changedDefaultParamInfo, loadDesired } from '../src/desired/template-adapter.js';
+
+// #1292: under --pre-deploy a CHANGED local param Default wins over the deployed value
+// (#1194) — but a plain `cdk deploy` sends UsePreviousValue: true for every EXISTING
+// parameter, so the previewed drift is one the gated deploy will NOT apply. Resolution stays
+// #1194's (local Default wins); changedDefaultParamInfo surfaces the divergence LOUDLY as one
+// aggregated stderr note per stack, mirroring the #1215/#1221 unpreviewableParamInfo style.
+describe('#1292 — changedDefaultParamInfo (--pre-deploy changed-Default caveat)', () => {
+  // The canonical trigger: an existing param whose local Default changed since deploy.
+  const changedTemplate = {
+    Parameters: { Foo: { Type: 'String', Default: 'NEW' } },
+    Resources: {
+      R: { Type: 'AWS::SNS::Topic', Properties: { TopicName: { Ref: 'Foo' } } },
+    },
+  };
+
+  it('emits the note naming the param, BOTH values, and the UsePreviousValue caveat', () => {
+    const note = changedDefaultParamInfo(changedTemplate, { Foo: 'OLD' }, 'MyStack');
+    expect(note).not.toBeNull();
+    expect(note?.startsWith('warning:')).toBe(true);
+    expect(note).toContain('MyStack');
+    expect(note).toContain('Foo');
+    expect(note).toContain('"NEW"'); // the local Default
+    expect(note).toContain('"OLD"'); // the deployed value a plain deploy keeps
+    expect(note).toContain('UsePreviousValue');
+    expect(note).toContain('--parameters');
+    expect(note).toContain('--no-previous-parameters');
+  });
+
+  it('is null when the local Default EQUALS the deployed value (no divergence)', () => {
+    expect(changedDefaultParamInfo(changedTemplate, { Foo: 'NEW' }, 'S')).toBeNull();
+  });
+
+  it('is null for a param with NO deployed value (a new param — that is #1221 territory)', () => {
+    // A brand-new local param is either seeded from its Default (previewable, nothing to
+    // caveat) or has no value at all (#1215/#1221's unpreviewable warning) — never this note.
+    expect(changedDefaultParamInfo(changedTemplate, {}, 'S')).toBeNull();
+  });
+
+  it('is null for a param with no local Default (the deployed value fills it — no divergence)', () => {
+    const template = {
+      Parameters: { Bar: { Type: 'String' } },
+      Resources: { R: { Type: 'AWS::SNS::Topic', Properties: { TopicName: { Ref: 'Bar' } } } },
+    };
+    expect(changedDefaultParamInfo(template, { Bar: 'deployedVal' }, 'S')).toBeNull();
+  });
+
+  it('is null when the changed-Default param is not referenced anywhere (feeds no preview)', () => {
+    const template = {
+      Parameters: { Unused: { Type: 'String', Default: 'NEW' } },
+      Resources: { R: { Type: 'AWS::SNS::Topic', Properties: { TopicName: 'literal' } } },
+    };
+    expect(changedDefaultParamInfo(template, { Unused: 'OLD' }, 'S')).toBeNull();
+  });
+
+  it('counts a param referenced ONLY through a Condition (it steers resource presence)', () => {
+    const template = {
+      Parameters: { Env: { Type: 'String', Default: 'prod' } },
+      Conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } },
+      Resources: { R: { Type: 'AWS::SNS::Topic', Condition: 'IsProd', Properties: {} } },
+    };
+    const note = changedDefaultParamInfo(template, { Env: 'dev' }, 'S');
+    expect(note).toContain('Env');
+  });
+
+  it('excludes NoEcho and SSM ::Parameter::Value< params (their Defaults are never seeded)', () => {
+    // A NoEcho Default is a placeholder and an SSM-typed Default is the SSM KEY — neither is
+    // seeded (#744/#882), so no preview derives from them and a "differs" note would be false.
+    const template = {
+      Parameters: {
+        Secret: { Type: 'String', NoEcho: true, Default: 'changeme' },
+        Ssm: { Type: 'AWS::SSM::Parameter::Value<String>', Default: '/golden/ami' },
+      },
+      Resources: {
+        R: { Type: 'AWS::SNS::Topic', Properties: { A: { Ref: 'Secret' }, B: { Ref: 'Ssm' } } },
+      },
+    };
+    expect(
+      changedDefaultParamInfo(template, { Secret: 'liveSecret', Ssm: 'ami-0abc' }, 'S')
+    ).toBeNull();
+  });
+
+  it('does not false-note a CommaDelimitedList Default differing only in whitespace', () => {
+    // CloudFormation trims list entries ("a, b" == "a,b") — mirror toParam's normalization.
+    const template = {
+      Parameters: { Csv: { Type: 'CommaDelimitedList', Default: 'a, b' } },
+      Resources: { R: { Type: 'AWS::SNS::Topic', Properties: { TopicName: { Ref: 'Csv' } } } },
+    };
+    expect(changedDefaultParamInfo(template, { Csv: 'a,b' }, 'S')).toBeNull();
+    // A REAL list change still notes.
+    expect(changedDefaultParamInfo(template, { Csv: 'a,c' }, 'S')).not.toBeNull();
+  });
+
+  it('caps the listed params at 10 with an overflow count', () => {
+    const params: Record<string, { Type: string; Default: string }> = {};
+    const deployed: Record<string, string> = {};
+    const props: Record<string, unknown> = {};
+    for (let i = 0; i < 12; i++) {
+      const k = `P${String(i).padStart(2, '0')}`;
+      params[k] = { Type: 'String', Default: 'new' };
+      deployed[k] = 'old';
+      props[k] = { Ref: k };
+    }
+    const template = {
+      Parameters: params,
+      Resources: { R: { Type: 'AWS::SNS::Topic', Properties: props } },
+    };
+    const note = changedDefaultParamInfo(template, deployed, 'S');
+    expect(note).toContain('12 local parameter(s) changed their Default');
+    expect(note).toContain('…(+2 more)');
+  });
+});
+
+// The emission path: loadDesired prints the note to stderr ONLY under --pre-deploy
+// (templateOverride set) — on the deployed path the declared source IS the deployed template,
+// so its Defaults cannot "differ" in the #1292 sense and the note must never fire.
+describe('#1292 — loadDesired emits the changed-Default note ONLY under --pre-deploy', () => {
+  function stack(cfn: ReturnType<typeof mockClient>, deployedFoo: string): void {
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Topic',
+          PhysicalResourceId: 't-phys',
+          ResourceType: 'AWS::SNS::Topic',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [{ ParameterKey: 'Foo', ParameterValue: deployedFoo }],
+        },
+      ],
+    });
+  }
+
+  const synthTemplate = {
+    Parameters: { Foo: { Type: 'String', Default: 'NEW' } },
+    Resources: {
+      Topic: { Type: 'AWS::SNS::Topic', Properties: { TopicName: { Ref: 'Foo' } } },
+    },
+  };
+
+  it('under --pre-deploy, a changed local Default is warned to stderr (resolution unchanged)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).rejects(new Error('GetTemplate must NOT be called in pre-deploy'));
+    stack(cfn, 'OLD');
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let msg = '';
+    let desired;
+    try {
+      desired = await loadDesired(
+        cfn as unknown as CloudFormationClient,
+        'S',
+        'us-east-1',
+        synthTemplate
+      );
+      // read BEFORE mockRestore(): mockRestore() resets .mock.calls.
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    expect(msg).toContain('UsePreviousValue');
+    expect(msg).toContain('Foo (local Default "NEW", deployed "OLD")');
+    // #1194 is KEPT: the local Default still wins in resolution — the note is additive.
+    expect(desired.resources[0]!.declared).toEqual({ TopicName: 'NEW' });
+  });
+
+  it('no note when the deployed value equals the local Default', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).rejects(new Error('GetTemplate must NOT be called in pre-deploy'));
+    stack(cfn, 'NEW');
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let msg = '';
+    try {
+      await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', synthTemplate);
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    expect(msg).not.toContain('UsePreviousValue');
+  });
+
+  it('on the NON-pre-deploy (deployed) path the note never fires', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // Deployed template carries the OLD Default; the deployed value differs — still no note,
+    // because without --pre-deploy the deployed value wins in resolution (nothing previewed).
+    cfn.on(GetTemplateCommand).resolves({ TemplateBody: JSON.stringify(synthTemplate) });
+    stack(cfn, 'OLD');
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let msg = '';
+    try {
+      await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1');
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    expect(msg).not.toContain('UsePreviousValue');
+  });
+});


### PR DESCRIPTION
## Summary

#1194 made the LOCAL template's param `Default` win over the deployed DescribeStacks value under `--pre-deploy`, so a changed Default is no longer masked. But deployment tools do not apply it that way: for an EXISTING parameter a plain `cdk deploy` (and `aws cloudformation deploy`) always sends `UsePreviousValue: true` (verified in the vendored toolkit-lib `ParameterValues`), so the previewed drift is applied only via `--parameters <k>=<v>` / `--no-previous-parameters`. Two bad cells (#1292):

1. Changed Default on an existing param: `check --pre-deploy --fail` blocks a deploy that would in fact KEEP the old value.
2. Param explicitly set at deploy time: every property fed by it is a permanent, unexplained declared FP.

## Fix

Keep #1194's resolution (reality-vs-intent, not a revert) and add the missing loudness, mirroring #1221: `changedDefaultParamInfo` emits ONE aggregated stderr note per stack naming each REFERENCED param whose local `Default` differs from the deployed value, both values, and the UsePreviousValue caveat.

- NoEcho / SSM `::Parameter::Value<` params excluded (#744/#882 — their Default is never seeded).
- Only params referenced by Resources/Conditions count (unused params feed no preview).
- CommaDelimitedList / `List<` values compare whitespace-trimmed (no cosmetic false notes).
- More than 10 params truncate with `…(+N more)` (existing style).
- README `--pre-deploy` section documents the caveat (single hunk).

## Tests

`tests/predeploy-param-note-1292.test.ts` — 12 new tests (10 fail without the fix): note fires with param + both values + hint; equal values / no local Default / new param (#1221's territory) / unreferenced → no note; Condition-referenced counts; NoEcho + SSM excluded; list whitespace normalization; truncation; `loadDesired` emits only under `--pre-deploy` and resolution stays #1194 (declared = new Default asserted).

Gates: typecheck / lint+format / `vp pack` / `vp test run` (207 files, 4784 tests) all green on top of 0.12.49.

Closes #1292
