### PR TITLE
fix(commands): apply the #740 cross-account mismatch gate to record/ignore/revert (#1309)

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,10 +778,11 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `DescribeType`; `DescribeStackResources` (the sibling-ownership check for the
   `added` tier — see the `added`-tier entry below); `ListExports` (only for
   templates using `Fn::ImportValue`)
-- `sts:GetCallerIdentity` (resolves the current account so `check` can tell a stack
-  never deployed in THIS account from one deleted out of band, under the
-  multi-account baseline pattern — allowed for any valid credentials, so no policy
-  statement is normally required)
+- `sts:GetCallerIdentity` (resolves the current account so every verb can tell a
+  stack never deployed in THIS account from one deleted out of band, under the
+  multi-account baseline pattern — `check`/`record`/`ignore` skip a stack pinned
+  to a different account and `revert` refuses to write to it; allowed for any
+  valid credentials, so no policy statement is normally required)
 - `cloudcontrol:GetResource`: Cloud Control invokes each type's own read handler,
   so it needs that type's read permissions (this is why `ReadOnlyAccess` is the
   simple answer). `revert` additionally uses `cloudcontrol:UpdateResource` /

--- a/src/commands/account-gate.ts
+++ b/src/commands/account-gate.ts
@@ -1,0 +1,162 @@
+// #1309: the #740 cross-account mismatch gate, shared by all four verbs.
+//
+// #1195 (#740) taught `check` to gate on a stack env-pinned (via `env.account`) to a
+// DIFFERENT account than the active credentials: a pre-read `sts:GetCallerIdentity`
+// vs `env.account` comparison, plus a post-read `desired.accountId` vs `env.account`
+// belt-and-suspenders for when STS could not resolve the caller. But the gate lived
+// inline in check.ts, so `record`, `ignore`, and `revert` ran UNGATED (#1309): with
+// account-B credentials and a same-named stack deployed in B,
+//   - `revert` (the one AWS-mutating verb) planned A-intent vs B-live and WROTE the
+//     confirmed ops onto account B's resources — a wrong-account AWS write that
+//     `checkBaselineAccount` cannot catch (no baseline exists for B),
+//   - `record` snapshotted B's live values into a fresh
+//     `<stack>.<B-account>.<region>.json` baseline as reviewed intent,
+//   - `ignore` scoped rules to the wrong accountId,
+// and without the same-named-stack coincidence all three misreported the pinned stack
+// as "not deployed" instead of check's accurate cross-account skip.
+//
+// This module is the gate's shared home. check.ts re-exports the primitives it always
+// used (`resolveCallerAccount`, `classifyAccountMismatch`) so its behavior — and the
+// import surface existing tests pin — is unchanged; record/ignore/revert gate through
+// `createAccountGate`. A proven mismatch is a SKIP for check/record/ignore (a
+// multi-account app is operated one account at a time, so the other account's stack
+// is simply out of reach for this run) and a per-stack ERROR (exit 2) for `revert` —
+// the user explicitly asked to MUTATE that stack, so silently not doing so would read
+// as "nothing to revert".
+import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import { CLIENT_TIMEOUTS } from '../read/client-config.js';
+
+export interface AccountMismatch {
+  skip: boolean;
+  message: string;
+}
+
+// The verb whose loop is gating — it only shapes the message tail: how the user is
+// told to redo the operation ("… credentials to record it"), and, for `revert`, the
+// refusal framing (an error, not a skip).
+export type AccountGateVerb = 'check' | 'record' | 'ignore' | 'revert';
+
+// The shared "what to do about it" tail. check/record/ignore skip; revert REFUSES —
+// same fact, but the caller surfaced it as an error (#1309).
+function mismatchTail(declaredAccount: string, verb: AccountGateVerb): string {
+  return verb === 'revert'
+    ? `refusing to revert (run with account-${declaredAccount} credentials to revert it)`
+    : `skipped (run with account-${declaredAccount} credentials to ${verb} it)`;
+}
+
+/**
+ * #1046: resolve the CURRENT account (region-free `sts:GetCallerIdentity`, a zero-permission
+ * call) so `hasBaselineForStack` can pin the baseline filename's account segment. Returns
+ * `undefined` on ANY failure (expired creds, blocked STS, network) so the caller falls back
+ * to today's account-wildcard rather than erroring — a `check` that reached the not-deployed
+ * catch already has working creds, so the STS call almost always succeeds. `--profile` is
+ * already in `process.env.AWS_PROFILE` (set by the verb entry points), so the default
+ * credential chain resolves it. Exported for unit tests (moved here from check.ts, #1309).
+ */
+export async function resolveCallerAccount(region: string): Promise<string | undefined> {
+  try {
+    const sts = new STSClient({ region, ...CLIENT_TIMEOUTS });
+    const id = await sts.send(new GetCallerIdentityCommand({}));
+    return id.Account;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * #740: decide whether a stack must be SKIPPED because it is pinned (via `env.account`) to a
+ * different AWS account than the active credentials are for.
+ *
+ * A CDK app with dev+prod stacks in DIFFERENT accounts (the CDK Pipelines / multi-env staple)
+ * is checked one account at a time — the caller runs `check --all` per account with that
+ * account's credentials. A stack whose `env.account` names an OTHER account cannot be read
+ * with the current creds: `DescribeStacks` throws "does not exist" (the stack IS deployed, just
+ * in its own account), which `isStackNotDeployed` mistakes for "never deployed yet — skipped"
+ * — a misleading green pass that hides an UNCHECKED stack. Worse, if a SAME-NAMED stack happens
+ * to exist in the reachable account, cdkrd would silently compare intent against the WRONG
+ * account's live resources. Detecting the mismatch UP FRONT lets each verb act accurately
+ * without reading the wrong account.
+ *
+ * Rule: skip ONLY when BOTH accounts are known (concrete) AND they differ — a proven mismatch.
+ * When either is undefined (an env-agnostic stack with no account pin, or STS could not resolve
+ * the caller) we CANNOT prove a mismatch, so we do NOT skip — behavior is identical to today
+ * (the stack is read; a real "not deployed" still surfaces as before). `verb` only shapes the
+ * message tail (#1309); the default keeps check's message byte-identical. Pure (no AWS) +
+ * exported for unit tests (moved here from check.ts, #1309).
+ */
+export function classifyAccountMismatch(
+  declaredAccount: string | undefined,
+  callerAccount: string | undefined,
+  verb: AccountGateVerb = 'check'
+): AccountMismatch {
+  if (declaredAccount && callerAccount && declaredAccount !== callerAccount) {
+    return {
+      skip: true,
+      message: `stack is pinned to account ${declaredAccount} but the active credentials are for account ${callerAccount} — ${mismatchTail(declaredAccount, verb)}`,
+    };
+  }
+  return { skip: false, message: '' };
+}
+
+/**
+ * #740 (belt-and-suspenders for case 2): the pre-read gate above skips a proven
+ * cross-account mismatch, but if the caller account could not be resolved (STS blocked)
+ * it lets the read proceed — and a SAME-NAMED stack in the reachable account would then
+ * be compared against the WRONG account. After the read the deployed stack's account IS
+ * known (`desired.accountId`); if this stack is pinned to a concrete account that differs,
+ * the live state just read is the wrong account's — the verb must not trust it (report /
+ * record / ignore / write against it). Defense-in-depth; the pre-read gate covers the
+ * common case where the caller account IS known. Extracted from check.ts's inline guard
+ * (#1309) so record/ignore/revert apply the identical rule; the default `verb` keeps
+ * check's message byte-identical. Pure (no AWS) + exported for unit tests.
+ */
+export function classifyReadAccountMismatch(
+  declaredAccount: string | undefined,
+  readAccountId: string,
+  verb: AccountGateVerb = 'check'
+): AccountMismatch {
+  if (declaredAccount && readAccountId !== declaredAccount) {
+    return {
+      skip: true,
+      message: `compared against account ${readAccountId} but the stack is pinned to ${declaredAccount} — ${mismatchTail(declaredAccount, verb)}`,
+    };
+  }
+  return { skip: false, message: '' };
+}
+
+export interface AccountGate {
+  // The pre-read gate: resolve the caller account (at most once per run, lazily — the
+  // STS call is made only when this stack IS account-pinned, so an env-agnostic app
+  // never pays it) and classify against the stack's env.account. Call BEFORE the gather
+  // so the wrong account is never even read.
+  preRead: (declaredAccount: string | undefined, region: string) => Promise<AccountMismatch>;
+  // The post-read guard: classify the gather's resolved accountId against the stack's
+  // env.account. Call AFTER the gather, BEFORE anything consumes the live state.
+  postRead: (declaredAccount: string | undefined, readAccountId: string) => AccountMismatch;
+}
+
+/**
+ * #1309: one per-run gate instance for a verb's stack loop. Mirrors check.ts's one-shot
+ * caller-account resolution (`sts:GetCallerIdentity` is region-free — the account is the
+ * same across regions — so the first answer is cached for every subsequent stack), but
+ * LAZILY: the STS call only happens for a stack that actually carries an `env.account`
+ * pin. An `undefined` cached answer (STS failed) is remembered too — the post-read guard
+ * is the backstop for that case, exactly as in check.
+ */
+export function createAccountGate(verb: AccountGateVerb): AccountGate {
+  let callerAccount: string | undefined;
+  let callerAccountResolved = false;
+  return {
+    preRead: async (declaredAccount, region) => {
+      // No env.account pin → no mismatch can be proven; skip the STS call entirely.
+      if (!declaredAccount) return { skip: false, message: '' };
+      if (!callerAccountResolved) {
+        callerAccount = await resolveCallerAccount(region);
+        callerAccountResolved = true;
+      }
+      return classifyAccountMismatch(declaredAccount, callerAccount, verb);
+    },
+    postRead: (declaredAccount, readAccountId) =>
+      classifyReadAccountMismatch(declaredAccount, readAccountId, verb),
+  };
+}

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -8,7 +8,6 @@
 // stacks.
 import { readdirSync } from 'node:fs';
 import { dirname } from 'node:path';
-import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
@@ -36,10 +35,14 @@ import {
 } from '../report/report.js';
 import { style } from '../report/style.js';
 import { UNRESOLVED } from '../normalize/intrinsic-resolver.js';
-import { CLIENT_TIMEOUTS } from '../read/client-config.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
 import type { DesiredResource, Finding } from '../types.js';
+import {
+  classifyAccountMismatch,
+  classifyReadAccountMismatch,
+  resolveCallerAccount,
+} from './account-gate.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import {
@@ -367,57 +370,11 @@ export function hasBaselineForStack(
   });
 }
 
-/**
- * #1046: resolve the CURRENT account (region-free `sts:GetCallerIdentity`, a zero-permission
- * call) so `hasBaselineForStack` can pin the baseline filename's account segment. Returns
- * `undefined` on ANY failure (expired creds, blocked STS, network) so the caller falls back
- * to today's account-wildcard rather than erroring — a `check` that reached the not-deployed
- * catch already has working creds, so the STS call almost always succeeds. `--profile` is
- * already in `process.env.AWS_PROFILE` (set by the verb entry points), so the default
- * credential chain resolves it. Exported for unit tests.
- */
-export async function resolveCallerAccount(region: string): Promise<string | undefined> {
-  try {
-    const sts = new STSClient({ region, ...CLIENT_TIMEOUTS });
-    const id = await sts.send(new GetCallerIdentityCommand({}));
-    return id.Account;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * #740: decide whether a stack must be SKIPPED because it is pinned (via `env.account`) to a
- * different AWS account than the active credentials are for.
- *
- * A CDK app with dev+prod stacks in DIFFERENT accounts (the CDK Pipelines / multi-env staple)
- * is checked one account at a time — the caller runs `check --all` per account with that
- * account's credentials. A stack whose `env.account` names an OTHER account cannot be read
- * with the current creds: `DescribeStacks` throws "does not exist" (the stack IS deployed, just
- * in its own account), which `isStackNotDeployed` mistakes for "never deployed yet — skipped"
- * — a misleading green pass that hides an UNCHECKED stack. Worse, if a SAME-NAMED stack happens
- * to exist in the reachable account, cdkrd would silently compare intent against the WRONG
- * account's live resources. Detecting the mismatch UP FRONT lets check skip accurately without
- * reading the wrong account.
- *
- * Rule: skip ONLY when BOTH accounts are known (concrete) AND they differ — a proven mismatch.
- * When either is undefined (an env-agnostic stack with no account pin, or STS could not resolve
- * the caller) we CANNOT prove a mismatch, so we do NOT skip — behavior is identical to today
- * (the stack is read; a real "not deployed" still surfaces as before). Pure (no AWS) + exported
- * for unit tests.
- */
-export function classifyAccountMismatch(
-  declaredAccount: string | undefined,
-  callerAccount: string | undefined
-): { skip: boolean; message: string } {
-  if (declaredAccount && callerAccount && declaredAccount !== callerAccount) {
-    return {
-      skip: true,
-      message: `stack is pinned to account ${declaredAccount} but the active credentials are for account ${callerAccount} — skipped (run with account-${declaredAccount} credentials to check it)`,
-    };
-  }
-  return { skip: false, message: '' };
-}
+// #1309: the #740 cross-account mismatch gate now lives in account-gate.ts, shared with
+// record / ignore / revert (which previously ran ungated — revert could WRITE to the wrong
+// account's same-named stack). Re-exported so check's public surface (pinned by the #740 /
+// #1046 unit tests and this file's historical import path) is unchanged.
+export { classifyAccountMismatch, resolveCallerAccount };
 
 // #1060 — the top-level `--json` emit runs AFTER the per-stack loop, OUTSIDE any
 // try/catch, so a non-serializable finding value (a BigInt, a circular reference)
@@ -664,11 +621,11 @@ export async function runCheck(args: string[]): Promise<number> {
       // After the read we KNOW the deployed stack's account (desired.accountId); if this stack
       // is pinned to a concrete account that differs, the live state we just read is the wrong
       // account's — skip rather than trust it. Defense-in-depth; the pre-read gate covers the
-      // common case where the caller account IS known.
-      if (account && desired.accountId !== account) {
-        const msg = `compared against account ${desired.accountId} but the stack is pinned to ${account} — skipped (run with account-${account} credentials to check it)`;
-        console.error(`note: ${stackName}: ${msg}`);
-        jsonError(stackName, region, msg);
+      // common case where the caller account IS known. Shared with record/ignore/revert (#1309).
+      const readMismatch = classifyReadAccountMismatch(account, desired.accountId);
+      if (readMismatch.skip) {
+        console.error(`note: ${stackName}: ${readMismatch.message}`);
+        jsonError(stackName, region, readMismatch.message);
         worst = Math.max(worst, a.strict ? 1 : 0);
         continue;
       }

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -17,6 +17,7 @@ import {
 import type { Desired } from '../desired/template-adapter.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
+import { createAccountGate } from './account-gate.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
@@ -72,7 +73,13 @@ export async function runIgnore(args: string[]): Promise<number> {
   let wroteAny = false;
   // gather-phase spinner (see gatherWithProgress) — text mode + TTY only.
   const showProgress = !a.json && isInteractive();
-  for (const [idx, { stackName, region, template }] of stacks.entries()) {
+  // #1309: the #740 cross-account mismatch gate (previously check-only). Without it, a
+  // stack env-pinned to another account either misreported "not deployed yet" or — with
+  // a same-named stack in the reachable account — appended ignore rules scoped to the
+  // WRONG accountId (and offered the wrong account's drift to pick from). Skip (not
+  // error), mirroring check: a multi-account app is operated one account at a time.
+  const accountGate = createAccountGate('ignore');
+  for (const [idx, { stackName, region, account, template }] of stacks.entries()) {
     if (!region) {
       const msg =
         'no region — set env on the stack, pass --region, or set a region for the AWS profile';
@@ -82,11 +89,41 @@ export async function runIgnore(args: string[]): Promise<number> {
       continue;
     }
     try {
+      // #1309 pre-read gate: a proven mismatch skips BEFORE any live read, so the wrong
+      // account is never even queried (same placement as check's gate).
+      const mismatch = await accountGate.preRead(account, region);
+      if (mismatch.skip) {
+        console.error(`note: ${stackName}: ${mismatch.message}`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            added: 0,
+            wrote: false,
+            error: mismatch.message,
+          });
+        continue;
+      }
       const { desired, findings } = await gatherWithProgress(
         showProgress,
         progressLabel(idx, stacks.length, stackName, region),
         () => gatherFindings(stackName, region, undefined, template)
       );
+      // #1309 post-read guard (belt-and-suspenders, mirrors check's #740 case 2): if STS
+      // could not resolve the caller, the pre-read gate let the read proceed — a
+      // SAME-NAMED stack in the reachable account means the state just read is the wrong
+      // account's. Never derive ignore rules from it.
+      const readMismatch = accountGate.postRead(account, desired.accountId);
+      if (readMismatch.skip) {
+        console.error(`note: ${stackName}: ${readMismatch.message}`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            added: 0,
+            wrote: false,
+            error: readMismatch.message,
+          });
+        continue;
+      }
       // #786: surface the mid-operation / failed-state warning the same way check does —
       // an in-flux stack's drift may be transient, so ignoring it could bake in a rule for
       // a value that settles on its own once the deploy completes.

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -5,6 +5,7 @@
 import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
+import { createAccountGate } from './account-gate.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
@@ -50,7 +51,14 @@ export async function runRecord(args: string[]): Promise<number> {
   let wroteAny = false;
   // gather-phase spinner (see gatherWithProgress) — text mode + TTY only.
   const showProgress = !a.json && isInteractive();
-  for (const [idx, { stackName, region, template }] of stacks.entries()) {
+  // #1309: the #740 cross-account mismatch gate (previously check-only). Without it, a
+  // stack env-pinned to another account either misreported "not deployed yet" or — with
+  // a same-named stack in the reachable account — snapshotted the WRONG account's live
+  // values into a fresh `<stack>.<wrong-account>.<region>.json` baseline as reviewed
+  // intent. Skip (not error), mirroring check: a multi-account app is recorded one
+  // account at a time.
+  const accountGate = createAccountGate('record');
+  for (const [idx, { stackName, region, account, template }] of stacks.entries()) {
     if (!region) {
       const msg =
         'no region — set env on the stack, pass --region, or set a region for the AWS profile';
@@ -60,6 +68,20 @@ export async function runRecord(args: string[]): Promise<number> {
       continue;
     }
     try {
+      // #1309 pre-read gate: a proven mismatch skips BEFORE any live read, so the wrong
+      // account is never even queried (same placement as check's gate).
+      const mismatch = await accountGate.preRead(account, region);
+      if (mismatch.skip) {
+        console.error(`note: ${stackName}: ${mismatch.message}`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            recorded: 0,
+            wrote: false,
+            error: mismatch.message,
+          });
+        continue;
+      }
       // gather FIRST: the baseline filename embeds the accountId, which only the
       // gather (DescribeStackResources) resolves. (R21 — was load-then-gather.)
       // `template` (synth) recovers GetTemplate's `?`-masked non-ASCII literals.
@@ -68,6 +90,22 @@ export async function runRecord(args: string[]): Promise<number> {
         progressLabel(idx, stacks.length, stackName, region),
         () => gatherFindings(stackName, region, undefined, template)
       );
+      // #1309 post-read guard (belt-and-suspenders, mirrors check's #740 case 2): if STS
+      // could not resolve the caller, the pre-read gate let the read proceed — a
+      // SAME-NAMED stack in the reachable account means the state just read is the wrong
+      // account's. Never write it into a baseline.
+      const readMismatch = accountGate.postRead(account, desired.accountId);
+      if (readMismatch.skip) {
+        console.error(`note: ${stackName}: ${readMismatch.message}`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            recorded: 0,
+            wrote: false,
+            error: readMismatch.message,
+          });
+        continue;
+      }
       // #786: warn loudly when the stack is mid-operation / failed — recording now would
       // snapshot TRANSIENT live values into the git-committed baseline. Same wording/stderr
       // routing check uses; a --yes run still records (just warned), matching check's behavior.

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -13,6 +13,7 @@ import {
 } from '../baseline/baseline-file.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { loadConfig } from '../config/config-file.js';
+import { createAccountGate } from './account-gate.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
 import { resolveStacks } from './resolve-stacks.js';
@@ -52,7 +53,15 @@ export async function runRevert(args: string[]): Promise<number> {
   // gather-phase spinner (see gatherWithProgress) — text mode + TTY only. The revert
   // confirm prompt fires AFTER the gather, so the spinner never overlaps it.
   const showProgress = !a.json && isInteractive();
-  for (const [idx, { stackName, region, template }] of stacks.entries()) {
+  // #1309: the #740 cross-account mismatch gate (previously check-only), and revert is
+  // where it matters MOST — this is the one AWS-mutating verb. With account-B credentials
+  // and a same-named stack deployed in B, an ungated revert planned A-intent vs B-live and
+  // WROTE the confirmed ops onto account B's resources (checkBaselineAccount cannot catch
+  // it: no baseline exists for B). Unlike check/record/ignore, a proven mismatch here is a
+  // per-stack ERROR (exit 2), not a skip — the user explicitly asked to MUTATE this stack,
+  // so silently doing nothing would read as "nothing to revert".
+  const accountGate = createAccountGate('revert');
+  for (const [idx, { stackName, region, account, template }] of stacks.entries()) {
     if (!region) {
       const msg =
         'no region — set env on the stack, pass --region, or set a region for the AWS profile';
@@ -70,6 +79,23 @@ export async function runRevert(args: string[]): Promise<number> {
       continue;
     }
     try {
+      // #1309 pre-read gate: a proven mismatch refuses BEFORE any live read, so the wrong
+      // account is never even queried — let alone written to.
+      const mismatch = await accountGate.preRead(account, region);
+      if (mismatch.skip) {
+        console.error(`error: ${stackName}: ${mismatch.message}`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            reverted: 0,
+            failed: 0,
+            aborted: false,
+            exit: 2,
+            error: mismatch.message,
+          });
+        worst = Math.max(worst, 2);
+        continue;
+      }
       // gather FIRST: the baseline filename embeds the accountId, which only the
       // gather (DescribeStackResources) resolves. (R21 — was load-then-gather.)
       // `template` (synth) recovers GetTemplate's `?`-masked non-ASCII literals so a
@@ -79,6 +105,25 @@ export async function runRevert(args: string[]): Promise<number> {
         progressLabel(idx, stacks.length, stackName, region),
         () => gatherFindings(stackName, region, undefined, template)
       );
+      // #1309 post-read guard (belt-and-suspenders, mirrors check's #740 case 2): if STS
+      // could not resolve the caller, the pre-read gate let the read proceed — a SAME-NAMED
+      // stack in the reachable account means the state just read (and any plan built on it)
+      // is the wrong account's. Refuse before the plan / confirm / write path runs.
+      const readMismatch = accountGate.postRead(account, gathered.desired.accountId);
+      if (readMismatch.skip) {
+        console.error(`error: ${stackName}: ${readMismatch.message}`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            reverted: 0,
+            failed: 0,
+            aborted: false,
+            exit: 2,
+            error: readMismatch.message,
+          });
+        worst = Math.max(worst, 2);
+        continue;
+      }
       const baseline: BaselineFile | undefined = await loadBaseline(
         stackName,
         gathered.desired.accountId,

--- a/tests/account-gate-1309.test.ts
+++ b/tests/account-gate-1309.test.ts
@@ -1,0 +1,332 @@
+// #1309: the #740 cross-account mismatch gate was CHECK-ONLY. `record`, `ignore`, and
+// `revert` destructured `{ stackName, region, template }` and ignored the resolved
+// `account`, so a stack env-pinned to account A, run with account-B credentials:
+//   - revert: with a same-named stack in B, the gather read B's live state and the
+//     confirmed ops were WRITTEN to account B's resources — a wrong-account AWS write,
+//   - record: wrote a fresh `<stack>.<B-account>.<region>.json` baseline snapshotting
+//     the wrong account's live values as reviewed intent,
+//   - ignore: appended rules scoped to the wrong accountId,
+// and without the same-named-stack coincidence all three misreported the pinned stack
+// as "not deployed" instead of check's accurate cross-account skip message.
+//
+// The fix extracts check's gate into src/commands/account-gate.ts and applies it in the
+// three verb loops: a proven mismatch is a per-stack ERROR (exit 2) for revert (the user
+// explicitly asked to mutate that stack) and a skip (mirroring check's message style)
+// for record/ignore. These tests drive the three run* loops with the same module-mock
+// shape as record-footer-949.test.ts, plus aws-sdk-client-mock for the gate's real
+// sts:GetCallerIdentity, and pin the pure classifiers (including that check's messages
+// stayed byte-identical).
+
+import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import {
+  classifyAccountMismatch,
+  classifyReadAccountMismatch,
+  createAccountGate,
+} from '../src/commands/account-gate.js';
+
+const PINNED = '111111111111'; // the stack's env.account
+const CALLER = '222222222222'; // the active credentials' account
+
+// One stack list per test, swapped via this hoisted holder (the vi.mock factory is
+// hoisted above module consts, so it must close over something hoisted too).
+const h = vi.hoisted(() => ({
+  stacks: [] as {
+    stackName: string;
+    region: string | undefined;
+    account: string | undefined;
+    template: Record<string, unknown>;
+  }[],
+  json: false,
+}));
+
+vi.mock('../src/commands/resolve-stacks.js', () => ({
+  resolveStacks: () => Promise.resolve(h.stacks),
+}));
+
+const gatherFindings = vi.fn();
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: (...a: unknown[]) => gatherFindings(...a),
+}));
+
+vi.mock('../src/commands/progress.js', () => ({
+  gatherWithProgress: (_show: boolean, _label: string, fn: () => unknown) => fn(),
+  progressLabel: () => '',
+}));
+
+vi.mock('../src/config/config-file.js', () => ({
+  loadConfig: () => Promise.resolve({}),
+  applyIgnores: (findings: unknown) => findings,
+}));
+
+vi.mock('../src/cli-args.js', () => ({
+  parseCommonArgs: () => ({
+    profile: undefined,
+    json: h.json,
+    yes: true,
+    verbose: false,
+    stackNames: [],
+    all: false,
+  }),
+  isInteractive: () => false,
+}));
+
+const recordStack = vi.fn();
+const ignoreStack = vi.fn();
+const revertStack = vi.fn();
+vi.mock('../src/commands/stack-actions.js', () => ({
+  recordStack: (...a: unknown[]) => recordStack(...a),
+  ignoreStack: (...a: unknown[]) => ignoreStack(...a),
+  revertStack: (...a: unknown[]) => revertStack(...a),
+  warnStackStatus: () => {},
+}));
+
+// ignore.ts / revert.ts reconcile against the baseline before their stack action; none
+// of that is under test here, so stub the file I/O away (loadBaseline → no baseline).
+vi.mock('../src/baseline/baseline-file.js', () => ({
+  loadBaseline: () => Promise.resolve(undefined),
+  checkBaselineAccount: () => {},
+  applyBaseline: (findings: unknown) => findings,
+  declaredKeysByLogical: () => new Map(),
+  constructPathsByLogical: () => new Map(),
+  physicalIdsByLogical: () => new Map(),
+}));
+
+import { runIgnore } from '../src/commands/ignore.js';
+import { runRecord } from '../src/commands/record.js';
+import { runRevert } from '../src/commands/revert.js';
+
+const sts = mockClient(STSClient);
+
+// A gather result whose resolved accountId is the CALLER's (the reachable account) —
+// the same-named-stack-in-the-wrong-account shape when the loop's stack is PINNED.
+function gatherResult(accountId: string): unknown {
+  return {
+    desired: { accountId, resources: [], stackStatusWarning: undefined },
+    findings: [],
+    schemas: new Map(),
+    liveByLogical: new Map(),
+  };
+}
+
+function pinnedStack(): void {
+  h.stacks = [{ stackName: 'Pinned', region: 'us-east-1', account: PINNED, template: {} }];
+}
+
+describe('#1309 cross-account gate in record / ignore / revert', () => {
+  let errs: string[];
+  let logs: string[];
+  let origErr: typeof console.error;
+  let origLog: typeof console.log;
+
+  beforeEach(() => {
+    sts.reset();
+    sts.on(GetCallerIdentityCommand).resolves({ Account: CALLER });
+    gatherFindings.mockReset();
+    gatherFindings.mockResolvedValue(gatherResult(CALLER));
+    recordStack.mockReset();
+    recordStack.mockResolvedValue({ wrote: true, refused: false, count: 1 });
+    ignoreStack.mockReset();
+    ignoreStack.mockResolvedValue({ wrote: true, refused: false, added: 1 });
+    revertStack.mockReset();
+    revertStack.mockResolvedValue({ exit: 0, reverted: 1, failed: 0, aborted: false });
+    h.json = false;
+    errs = [];
+    logs = [];
+    origErr = console.error;
+    origLog = console.log;
+    console.error = (s: unknown) => errs.push(String(s));
+    console.log = (s: unknown) => logs.push(String(s));
+  });
+
+  afterEach(() => {
+    console.error = origErr;
+    console.log = origLog;
+  });
+
+  describe('revert — a proven mismatch is a per-stack ERROR (exit 2), never a write', () => {
+    it('REFUSES pre-read: exit 2, no gather (wrong account never read), no revertStack', async () => {
+      pinnedStack();
+      const rc = await runRevert([]);
+      expect(rc).toBe(2);
+      expect(gatherFindings).not.toHaveBeenCalled();
+      expect(revertStack).not.toHaveBeenCalled();
+      const err = errs.join('\n');
+      expect(err).toContain(`error: Pinned:`);
+      expect(err).toContain(`pinned to account ${PINNED}`);
+      expect(err).toContain(CALLER);
+      expect(err).toContain('refusing to revert');
+      expect(err).toContain(`account-${PINNED} credentials`);
+    });
+
+    it('REFUSES post-read when STS is blocked (caller unresolved) but the read proves the wrong account', async () => {
+      pinnedStack();
+      sts.on(GetCallerIdentityCommand).rejects(new Error('ExpiredToken'));
+      const rc = await runRevert([]);
+      expect(rc).toBe(2);
+      expect(gatherFindings).toHaveBeenCalledTimes(1); // pre-read gate could not prove, so it read…
+      expect(revertStack).not.toHaveBeenCalled(); // …but the post-read guard refused the write
+      const err = errs.join('\n');
+      expect(err).toContain(`compared against account ${CALLER}`);
+      expect(err).toContain('refusing to revert');
+    });
+
+    it('carries the refusal into the --json element (exit 2 + error)', async () => {
+      pinnedStack();
+      h.json = true;
+      const rc = await runRevert([]);
+      expect(rc).toBe(2);
+      const reports = JSON.parse(logs.join('\n')) as { exit: number; error?: string }[];
+      expect(reports).toHaveLength(1);
+      expect(reports[0]!.exit).toBe(2);
+      expect(reports[0]!.error).toContain('refusing to revert');
+    });
+
+    it('proceeds normally when the pinned account matches the caller', async () => {
+      pinnedStack();
+      sts.on(GetCallerIdentityCommand).resolves({ Account: PINNED });
+      gatherFindings.mockResolvedValue(gatherResult(PINNED));
+      const rc = await runRevert([]);
+      expect(rc).toBe(0);
+      expect(revertStack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('record — a mismatch never writes a wrong-account baseline', () => {
+    it('SKIPS pre-read (exit 0, note): no gather, no recordStack → no baseline written', async () => {
+      pinnedStack();
+      const rc = await runRecord([]);
+      expect(rc).toBe(0); // a skip, mirroring check — not an error
+      expect(gatherFindings).not.toHaveBeenCalled();
+      expect(recordStack).not.toHaveBeenCalled();
+      const err = errs.join('\n');
+      expect(err).toContain(`note: Pinned:`);
+      expect(err).toContain(`pinned to account ${PINNED}`);
+      expect(err).toContain(`skipped (run with account-${PINNED} credentials to record it)`);
+    });
+
+    it('SKIPS post-read when STS is blocked but the read resolved the wrong account', async () => {
+      pinnedStack();
+      sts.on(GetCallerIdentityCommand).rejects(new Error('ExpiredToken'));
+      const rc = await runRecord([]);
+      expect(rc).toBe(0);
+      expect(gatherFindings).toHaveBeenCalledTimes(1);
+      expect(recordStack).not.toHaveBeenCalled();
+      expect(errs.join('\n')).toContain(`compared against account ${CALLER}`);
+    });
+
+    it('reports the accurate cross-account skip, NOT "not deployed", when no same-named stack exists', async () => {
+      // Without the fix the ungated gather throws DescribeStacks "does not exist" and the
+      // catch prints the misleading "not deployed yet — nothing to record".
+      pinnedStack();
+      gatherFindings.mockRejectedValue(
+        Object.assign(new Error('Stack with id Pinned does not exist'), {
+          name: 'ValidationError',
+        })
+      );
+      const rc = await runRecord([]);
+      expect(rc).toBe(0);
+      const err = errs.join('\n');
+      expect(err).toContain(`pinned to account ${PINNED}`);
+      expect(err).not.toContain('not deployed');
+    });
+
+    it('proceeds normally when the pinned account matches the caller', async () => {
+      pinnedStack();
+      sts.on(GetCallerIdentityCommand).resolves({ Account: PINNED });
+      gatherFindings.mockResolvedValue(gatherResult(PINNED));
+      const rc = await runRecord([]);
+      expect(rc).toBe(0);
+      expect(recordStack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ignore — a mismatch never writes wrong-account rules', () => {
+    it('SKIPS pre-read (exit 0, note): no gather, no ignoreStack → no rules written', async () => {
+      pinnedStack();
+      const rc = await runIgnore([]);
+      expect(rc).toBe(0);
+      expect(gatherFindings).not.toHaveBeenCalled();
+      expect(ignoreStack).not.toHaveBeenCalled();
+      const err = errs.join('\n');
+      expect(err).toContain(`note: Pinned:`);
+      expect(err).toContain(`skipped (run with account-${PINNED} credentials to ignore it)`);
+    });
+
+    it('SKIPS post-read when STS is blocked but the read resolved the wrong account', async () => {
+      pinnedStack();
+      sts.on(GetCallerIdentityCommand).rejects(new Error('ExpiredToken'));
+      const rc = await runIgnore([]);
+      expect(rc).toBe(0);
+      expect(ignoreStack).not.toHaveBeenCalled();
+      expect(errs.join('\n')).toContain(`compared against account ${CALLER}`);
+    });
+  });
+
+  describe('the gate is lazy — an env-agnostic app never pays the STS call', () => {
+    it('makes NO GetCallerIdentity call when no stack carries an env.account pin', async () => {
+      // The pre-#1309 verb loops made no STS call at all; the gate must not add one for
+      // the (common) unpinned case — it can prove nothing without a declared account.
+      h.stacks = [{ stackName: 'Agnostic', region: 'us-east-1', account: undefined, template: {} }];
+      const rc = await runRecord([]);
+      expect(rc).toBe(0);
+      expect(sts.calls()).toHaveLength(0);
+      expect(recordStack).toHaveBeenCalledTimes(1); // proceeds as before
+    });
+
+    it('resolves the caller AT MOST ONCE across a multi-stack run', async () => {
+      h.stacks = [
+        { stackName: 'A', region: 'us-east-1', account: PINNED, template: {} },
+        { stackName: 'B', region: 'us-west-2', account: PINNED, template: {} },
+      ];
+      await runRecord([]);
+      expect(sts.calls()).toHaveLength(1);
+    });
+  });
+});
+
+describe('#1309 pure classifiers (shared home of the #740 gate)', () => {
+  it("classifyAccountMismatch default keeps check's message byte-identical", () => {
+    const r = classifyAccountMismatch(PINNED, CALLER);
+    expect(r.skip).toBe(true);
+    expect(r.message).toBe(
+      `stack is pinned to account ${PINNED} but the active credentials are for account ${CALLER} — skipped (run with account-${PINNED} credentials to check it)`
+    );
+  });
+
+  it('classifyAccountMismatch tails name the invoking verb (record / ignore)', () => {
+    expect(classifyAccountMismatch(PINNED, CALLER, 'record').message).toContain(
+      `skipped (run with account-${PINNED} credentials to record it)`
+    );
+    expect(classifyAccountMismatch(PINNED, CALLER, 'ignore').message).toContain(
+      `skipped (run with account-${PINNED} credentials to ignore it)`
+    );
+  });
+
+  it('classifyAccountMismatch revert tail is a refusal, not a skip', () => {
+    const r = classifyAccountMismatch(PINNED, CALLER, 'revert');
+    expect(r.skip).toBe(true);
+    expect(r.message).toContain('refusing to revert');
+    expect(r.message).not.toContain('skipped');
+  });
+
+  it("classifyReadAccountMismatch default keeps check's post-read message byte-identical", () => {
+    const r = classifyReadAccountMismatch(PINNED, CALLER);
+    expect(r.skip).toBe(true);
+    expect(r.message).toBe(
+      `compared against account ${CALLER} but the stack is pinned to ${PINNED} — skipped (run with account-${PINNED} credentials to check it)`
+    );
+  });
+
+  it('classifyReadAccountMismatch does not fire when unpinned or matching', () => {
+    expect(classifyReadAccountMismatch(undefined, CALLER).skip).toBe(false);
+    expect(classifyReadAccountMismatch(PINNED, PINNED).skip).toBe(false);
+  });
+
+  it('createAccountGate.preRead cannot prove a mismatch without a declared account', async () => {
+    const gate = createAccountGate('record');
+    // account undefined → no STS call is even attempted (nothing to compare against).
+    expect((await gate.preRead(undefined, 'us-east-1')).skip).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

#1195 (#740) gated `check` against comparing a stack env-pinned to account A with a same-named stack in the reachable account B (one-shot `sts:GetCallerIdentity` + `classifyAccountMismatch` + a post-gather `desired.accountId` guard) — but only `check` consumed it (#1309). Under the same multi-account scenario:

- **revert** (the one AWS-mutating verb) WROTE the A-intent plan to account B's resources — the wrong-account compare escalated to a wrong-account WRITE (`checkBaselineAccount` has no baseline for B, so it never fired).
- **record** snapshotted B's live values into a fresh `<stack>.<B-account>.<region>.json` baseline as reviewed intent.
- **ignore** wrote rules scoped to the wrong accountId.
- Without the same-named-stack coincidence, all three mis-reported the pinned stack as "not deployed" instead of check's accurate cross-account skip.

## Fix

- **`src/commands/account-gate.ts`** (new) — shared home of the gate: `resolveCallerAccount` + `classifyAccountMismatch` moved from check.ts (an optional `verb` param keeps check's messages byte-identical), `classifyReadAccountMismatch` (the extracted post-gather guard), and `createAccountGate(verb)` — a per-run factory with a **lazy, cached** `preRead` (STS called only when a stack carries an `env.account` pin; at most once per run, `undefined`/STS-failure cached with the postRead guard as backstop, exactly as in check) and `postRead`.
- **`src/commands/check.ts`** — delegates to and re-exports the primitives (existing #740/#1046 tests import from `check.js` unchanged; both messages pinned byte-identical by test).
- **`src/commands/record.ts` / `ignore.ts`** — pre-read + post-read gates: skip with check's cross-account message (exit 0), never write a wrong-account baseline / rules.
- **`src/commands/revert.ts`** — same gates, but a proven mismatch is a per-stack **ERROR (exit 2)** with a "refusing to revert (run with account-A credentials to revert it)" message — the user explicitly asked to mutate that stack, so refusing loudly beats skipping silently.
- README: the `sts:GetCallerIdentity` permission entry now describes all four verbs.

## Tests

`tests/account-gate-1309.test.ts` — 18 new tests (9 fail with the verb loops reverted to HEAD, verified empirically): revert pre-read refusal (exit 2, no gather, no `revertStack`) / post-read refusal under blocked STS / `--json` element carries the error / matching account proceeds; record pre-read + post-read skips (no baseline written) + cross-account message instead of "not deployed" + matching account proceeds; ignore both skips (no rules written); laziness (zero STS calls for env-agnostic stacks, at most one across a multi-stack run); pure classifiers (check messages byte-identical, verb tails, unpinned/matching no-ops).

Gates: typecheck / lint+format / `vp pack` / `vp test run` (208 files, 4813 tests) all green on top of current main.

Closes #1309
