### PR TITLE
fix(diff): anchor EB generated-SecurityGroup fold to the real awseb-e-…AWSEBSecurityGroup shape (#1264)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2847,14 +2847,32 @@ export const EB_OPTION_VALUE_INDEPENDENT: ReadonlySet<string> = new Set([
 // default (value-independent, derived-from-EnvironmentType, or equality-gated constant), else
 // 'undeclared' so a change away from the default still surfaces. `envType` is the sibling
 // `EnvironmentType` option's value (defaults to LoadBalanced, AWS's default when unset).
-// #893: an undeclared EB SecurityGroups option folds ONLY when every element is the
-// environment's own AWS-generated `awseb-*` security group (the value AWS assigns when the
-// user never set the option) — a resolved `awseb-e-…-AWSEBSecurityGroup-…` name or the
-// unresolved `{"Ref":"AWSEB…SecurityGroup"}` a ConfigurationTemplate still carries. A rogue
-// SG (`eb update-environment …SecurityGroups=sg-…`) matches neither and surfaces.
+// #893/#1264: an undeclared EB SecurityGroups option folds ONLY when every element is the
+// environment's own AWS-generated security group (the value AWS assigns when the user never
+// set the option). The generated shapes are ANCHORED — a bare `/awseb/i` substring match
+// (the #1264 bug) also folded any user/attacker-controllable SG name that merely CONTAINS
+// "awseb" (`my-awseb-backdoor`, a lone `awseb-backdoor`), hiding a rogue SG. The legitimate
+// generated forms are:
+//   - a resolved name `awseb-e-<envid>-stack-AWSEBSecurityGroup-<suffix>` — starts with the
+//     `awseb-e-` environment-resource prefix (case-insensitive);
+//   - a name carrying the exact CFn logical fragment `AWSEBSecurityGroup` /
+//     `AWSEBLoadBalancerSecurityGroup`;
+//   - the unresolved intrinsic logical id an `{"Ref":"AWSEB…SecurityGroup"}` a
+//     ConfigurationTemplate still carries collapses to — an element that IS exactly the
+//     `AWSEB…SecurityGroup` logical-id shape.
+// A rogue SG (`eb update-environment …SecurityGroups=sg-…`, `my-awseb-backdoor`) matches
+// none of these anchored shapes and surfaces.
+function isEbGeneratedGroup(el: string): boolean {
+  const name = el.trim();
+  if (name === '') return false;
+  // resolved environment-resource name: awseb-e-<envid>-…
+  if (/^awseb-e-/i.test(name)) return true;
+  // resolved name carrying the CFn logical fragment, or the bare logical id (Ref echo)
+  return /AWSEB(LoadBalancer)?SecurityGroup/.test(name);
+}
 function isAllEbGeneratedGroups(value: unknown): boolean {
   if (typeof value !== 'string' || value === '') return false;
-  return value.split(',').every((el) => /awseb/i.test(el.trim()));
+  return value.split(',').every((el) => isEbGeneratedGroup(el));
 }
 export function ebOptionSettingTier(
   namespace: unknown,

--- a/tests/noise-eb-sg-anchor-1264.test.ts
+++ b/tests/noise-eb-sg-anchor-1264.test.ts
@@ -1,0 +1,55 @@
+// #1264 — the EB SecurityGroups fold (#893) folded to `atDefault` when every
+// comma-separated element merely CONTAINED "awseb" (an UNANCHORED `/awseb/i` substring).
+// A user/attacker-controllable SG name that happens to contain "awseb"
+// (`my-awseb-backdoor`, a lone `awseb-backdoor`) then folded, hiding a rogue security
+// group. The fold must fire ONLY for EB's own anchored generated-group shapes:
+//   - `awseb-e-<envid>-stack-AWSEBSecurityGroup-<suffix>` (the `awseb-e-` env prefix);
+//   - a name carrying the exact `AWSEBSecurityGroup` / `AWSEBLoadBalancerSecurityGroup`
+//     CFn logical fragment, or the bare `AWSEB…SecurityGroup` logical id (Ref echo).
+// Anything else → `undeclared` (surfaces).
+import { describe, expect, it } from 'vite-plus/test';
+import { ebOptionSettingTier } from '../src/normalize/noise.js';
+
+const KEY_NS = 'aws:autoscaling:launchconfiguration';
+const KEY_OPT = 'SecurityGroups';
+const ELB_NS = 'aws:elb:loadbalancer';
+
+function tier(value: string, ns = KEY_NS, opt = KEY_OPT): 'atDefault' | 'undeclared' {
+  return ebOptionSettingTier(ns, opt, value, 'LoadBalanced');
+}
+
+describe('#1264 EB SecurityGroups fold anchors on the generated-group shape', () => {
+  it('folds the resolved awseb-e-…-AWSEBSecurityGroup-… generated name', () => {
+    expect(tier('awseb-e-abc123-stack-AWSEBSecurityGroup-XYZ')).toBe('atDefault');
+  });
+
+  it('folds the bare AWSEBSecurityGroup logical-id (Ref echo)', () => {
+    expect(tier('AWSEBSecurityGroup')).toBe('atDefault');
+  });
+
+  it('folds the load-balancer generated group on the ELB namespace', () => {
+    expect(tier('awseb-e-abc123-stack-AWSEBLoadBalancerSecurityGroup-Q', ELB_NS)).toBe('atDefault');
+  });
+
+  it('folds when every element is a generated group', () => {
+    expect(tier('awseb-e-abc123-stack-AWSEBSecurityGroup-XYZ,AWSEBLoadBalancerSecurityGroup')).toBe(
+      'atDefault'
+    );
+  });
+
+  it('surfaces a rogue backdoor mixed in with a generated group (#1264)', () => {
+    expect(tier('awseb-e-abc123-stack-AWSEBSecurityGroup-Y,my-awseb-backdoor')).toBe('undeclared');
+  });
+
+  it('surfaces a lone awseb-backdoor (contains "awseb" but is not a generated shape)', () => {
+    expect(tier('awseb-backdoor')).toBe('undeclared');
+  });
+
+  it('surfaces a rogue SG whose name merely contains awseb as a substring', () => {
+    expect(tier('my-awseb-backdoor')).toBe('undeclared');
+  });
+
+  it('surfaces an explicit user-supplied sg-… id', () => {
+    expect(tier('sg-0123456789abcdef0')).toBe('undeclared');
+  });
+});


### PR DESCRIPTION
Closes #1264

The #893 EB SecurityGroups fold matched `awseb` as an unanchored substring, so any user/attacker-named SG containing `awseb` (e.g. `my-awseb-backdoor`) folded and bypassed the gate. Anchors the match to EB's real generated-group shapes (`awseb-e-…AWSEBSecurityGroup[…]` / the LB variant / the unresolved `{Ref:AWSEB…SecurityGroup}` form); a rogue SG now surfaces while the legitimate generated group still folds.