### PR TITLE
fix(revert): bar Route53::RecordSet added delete as notRevertable — CC has no DeleteResource handler (#1312)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -746,7 +746,14 @@ function isUnderCreateOnly(findingPath: string, createOnlyPaths: readonly string
 //   - AWS::EC2::NetworkAclEntry: live-proven (#1315/#1405). CC GetResource reads it via the
 //     SDK override (`readEc2NetworkAclEntry`), but DeleteResource returns the unsupported-action
 //     error above (its CFn delete flows through the parent NetworkAcl's EC2 API, not CC).
-const CC_DELETE_UNSUPPORTED_ADDED_TYPES = new Set<string>(['AWS::EC2::NetworkAclEntry']);
+//   - AWS::Route53::RecordSet: NON_PROVISIONABLE per describe-type — a CC DeleteResource
+//     returns UnsupportedActionException (#1312). Surfaced by the HostedZone child enumerator;
+//     its real delete would go through the Route53 `ChangeResourceRecordSets` API (a DELETE
+//     change action), not CC. A type-specific SDK writer could make it actually revertable later.
+const CC_DELETE_UNSUPPORTED_ADDED_TYPES = new Set<string>([
+  'AWS::EC2::NetworkAclEntry',
+  'AWS::Route53::RecordSet',
+]);
 
 export function buildRevertPlan(
   findings: Finding[],

--- a/tests/revert-plan-recordset-1312.test.ts
+++ b/tests/revert-plan-recordset-1312.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+// #1312: an out-of-band `added` AWS::Route53::RecordSet (surfaced by the HostedZone child
+// enumerator) must be reported as notRevertable UP FRONT — the type is NON_PROVISIONABLE per
+// describe-type, so Cloud Control has NO DeleteResource handler and a `delete`-kind item would
+// fail only at apply with UnsupportedActionException. Its real delete would flow through the
+// Route53 `ChangeResourceRecordSets` API (a DELETE change action), not CC.
+const addedFinding = (over: Partial<Finding>): Finding => ({
+  tier: 'added',
+  logicalId: 'RogueRecord',
+  physicalId: 'Z1234567890ABC|example.mytld.|A',
+  resourceType: 'AWS::Route53::RecordSet',
+  path: '',
+  unrecorded: true,
+  ...over,
+});
+
+describe('buildRevertPlan — #1312 CC-delete-unsupported added Route53::RecordSet', () => {
+  it('an added RecordSet is notRevertable up front under --remove-unrecorded (no delete op)', () => {
+    const f = addedFinding({});
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('Cloud Control cannot delete');
+    expect(plan.notRevertable[0]!.resourceType).toBe('AWS::Route53::RecordSet');
+  });
+
+  it('without --remove-unrecorded it is the ordinary unrecorded gate (never a silent delete)', () => {
+    const f = addedFinding({});
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('unrecorded');
+  });
+});


### PR DESCRIPTION
Addresses the **revert-delete honest-bar half** of #1312 (the #1042 limitation, now wired). Adds `AWS::Route53::RecordSet` to `CC_DELETE_UNSUPPORTED_ADDED_TYPES` (the #1405 set): CC has no DeleteResource handler for this NON_PROVISIONABLE type, so an added-tier RecordSet delete failed only at apply time with UnsupportedActionException. It is now reported `notRevertable` up front (its real delete would go through the Route53 ChangeResourceRecordSets API). Unit test asserts the notRevertable path. Offline/deterministic; unit test is authoritative.

Does NOT auto-close #1312 — the other two halves (record-endorse via the child-enumerator snippet, and a real ChangeResourceRecordSets DELETE writer to make it actually revertable) are tracked in #1431.