### PR TITLE
fix(diff): equality-gate CR-managed S3 NotificationConfiguration so an out-of-band change surfaces (#1283)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -414,6 +414,10 @@ interface ClassifyOpts {
   siblingEipAssociations: Set<string>;
   siblingTargetGroupRegistrars: Set<string>;
   bucketNotificationManaged: Set<string>;
+  // #1283: per managed-bucket physical id, the CR's DECLARED NotificationConfiguration (S3 API
+  // shape) — classify translates it into the live CFn shape and equality-gates. Carried
+  // alongside bucketNotificationManaged (the id set); a bucket in the set always has an entry.
+  bucketNotificationConfigs: Record<string, Record<string, unknown>>;
   clusterEchoModel: Record<string, Record<string, unknown>>;
   rdsOptionSettingDefaults: Record<string, Record<string, Record<string, string | null>>>;
 }
@@ -504,33 +508,63 @@ export function buildSiblingEventBusPolicies(desired: Desired): Record<string, u
 }
 
 // Bucket physical ids (== bucket names) whose S3 notifications are managed by a
-// Custom::S3BucketNotifications custom resource. CDK renders `bucket.addEventNotification()`
-// / `enableEventBridgeNotification()` as this CR (which cdkrd cannot read/verify, so it is
-// `skipped`), NOT as the bucket's own NotificationConfiguration property — so the live
-// bucket REFLECTS the CR-applied config while its template resource declares nothing,
-// surfacing the whole NotificationConfiguration as false undeclared drift on every such
-// bucket. The config is IaC-managed (by the CR), not out of band; classify drops the
-// reflected property for these buckets (see classifyResource). Fail-open: a CR whose
-// BucketName did not resolve to a concrete name is skipped (the bucket keeps the reflected
-// config -> a one-time visible FP, never a hidden change).
+// Custom::S3BucketNotifications custom resource, MAPPED to the CR's DECLARED
+// `NotificationConfiguration` (the intended config, in the S3 API property shape). CDK renders
+// `bucket.addEventNotification()` / `enableEventBridgeNotification()` as this CR (which cdkrd
+// cannot read/verify, so it is `skipped`), NOT as the bucket's own NotificationConfiguration
+// property — so the live bucket REFLECTS the CR-applied config while its template resource
+// declares nothing, surfacing the whole NotificationConfiguration as false undeclared drift on
+// every such bucket. The config is IaC-managed (by the CR), not out of band; classify translates
+// this declared config into the live CFn resource shape and EQUALITY-GATES it against the live
+// value — folding a matching (clean-deploy) config while SURFACING an out-of-band `put-bucket-
+// notification-configuration` that adds / swaps / removes a target (#1283). Fail-open: a CR whose
+// BucketName did not resolve to a concrete name is skipped (the bucket keeps the reflected config
+// -> a one-time visible FP, never a hidden change); a CR with no `NotificationConfiguration`
+// object maps to `{}` (an empty config that folds only an empty live config).
 const S3_NOTIFICATIONS_CR_TYPE = 'Custom::S3BucketNotifications';
-export function buildBucketNotificationManaged(desired: Desired): Set<string> {
+// Resolve each Custom::S3BucketNotifications CR's target bucket physical id (from its declared
+// `BucketName`, a concrete name or a `Ref` to a declared bucket) paired with the CR's declared
+// `NotificationConfiguration` (S3 API shape, or `{}` when absent). Shared by the two builders
+// below so the id set and the config map are always derived identically.
+function resolveBucketNotificationCrs(
+  desired: Desired
+): Array<[physicalId: string, config: Record<string, unknown>]> {
   const byLogicalId = new Map<string, string>();
   for (const r of desired.resources) if (r.physicalId) byLogicalId.set(r.logicalId, r.physicalId);
-  const managed = new Set<string>();
+  const out: Array<[string, Record<string, unknown>]> = [];
   for (const r of desired.resources) {
     if (r.resourceType !== S3_NOTIFICATIONS_CR_TYPE) continue;
     const decl = r.declared;
     if (!decl || typeof decl !== 'object') continue;
-    const bucketName = (decl as Record<string, unknown>).BucketName;
+    const d = decl as Record<string, unknown>;
+    const bucketName = d.BucketName;
+    const rawConfig = d.NotificationConfiguration;
+    const config =
+      rawConfig && typeof rawConfig === 'object' && !Array.isArray(rawConfig)
+        ? (rawConfig as Record<string, unknown>)
+        : {};
     if (typeof bucketName === 'string' && bucketName) {
-      managed.add(bucketName); // already resolved to the concrete bucket name (== physical id)
+      out.push([bucketName, config]); // already resolved to the concrete bucket name (== physical id)
     } else if (bucketName && typeof bucketName === 'object' && 'Ref' in bucketName) {
       const phys = byLogicalId.get((bucketName as { Ref: string }).Ref);
-      if (phys) managed.add(phys);
+      if (phys) out.push([phys, config]);
     }
   }
-  return managed;
+  return out;
+}
+export function buildBucketNotificationManaged(desired: Desired): Set<string> {
+  return new Set(resolveBucketNotificationCrs(desired).map(([phys]) => phys));
+}
+// #1283: per managed-bucket physical id, the CR's DECLARED NotificationConfiguration (S3 API
+// shape). classify translates it into the live CFn resource shape and equality-gates against the
+// live value — folding a clean-deploy match while SURFACING an out-of-band change. Same physical-id
+// resolution as buildBucketNotificationManaged, so every id in that set has a config entry here.
+export function buildBucketNotificationConfigs(
+  desired: Desired
+): Record<string, Record<string, unknown>> {
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const [phys, config] of resolveBucketNotificationCrs(desired)) out[phys] = config;
+  return out;
 }
 
 // A sibling AWS::IAM::ManagedPolicy declaring `Roles:[thisRole]` (/`Users`/`Groups`) attaches
@@ -1249,6 +1283,7 @@ export async function gatherFindings(
     siblingEipAssociations: buildSiblingEipAssociations(desired),
     siblingTargetGroupRegistrars: buildSiblingTargetGroupRegistrars(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
+    bucketNotificationConfigs: buildBucketNotificationConfigs(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
@@ -1353,6 +1388,7 @@ export async function regatherTouched(
     siblingEipAssociations: buildSiblingEipAssociations(desired),
     siblingTargetGroupRegistrars: buildSiblingTargetGroupRegistrars(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
+    bucketNotificationConfigs: buildBucketNotificationConfigs(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1598,6 +1598,141 @@ function remapSortedIndexToDeclared(
   return rawIdx < 0 ? path : `${arrayKey}.${rawIdx}${m[2]}`;
 }
 
+// Translate a Custom::S3BucketNotifications CR's DECLARED `NotificationConfiguration` (rendered
+// by CDK in the S3 `put-bucket-notification-configuration` API shape) into the CFn RESOURCE shape
+// the live `AWS::S3::Bucket` read returns, so the two can be equality-gated (#1283). The API →
+// resource shape differences CDK's notifications-resource.js produces:
+//   - `LambdaFunctionConfigurations[]`  -> `LambdaConfigurations[]`
+//       `.LambdaFunctionArn`            -> `.Function`
+//   - `QueueConfigurations[].QueueArn`  -> `.Queue`
+//   - `TopicConfigurations[].TopicArn`  -> `.Topic`
+//   - each config's `Events: [ev]` (array) -> `Event: ev` (the live read is per-event scalar)
+//   - `Filter.Key.FilterRules[]`        -> `Filter.S3Key.Rules[]`
+//       rule `Name` is lower-case (`prefix`/`suffix`) declared, capitalized (`Prefix`/`Suffix`)
+//       live -> canonicalize both to lower-case so casing is not false drift.
+//   - `EventBridgeConfiguration: {}`    -> `EventBridgeConfiguration: {}` (passes through).
+// A per-config `Events` array with >1 entry maps to one live config per event (AWS materializes
+// each separately). Unknown extra keys pass through unchanged so a value we could not translate
+// still surfaces (fail-safe: never silently drop what we did not verify). Order is irrelevant —
+// the caller canonicalizes BOTH sides (canonicalizeForCompare sorts unordered object arrays).
+const S3_NOTIF_FILTER_RULE_NAMES: Record<string, string> = {
+  prefix: 'prefix',
+  suffix: 'suffix',
+  Prefix: 'prefix',
+  Suffix: 'suffix',
+};
+function canonS3NotifFilter(filter: unknown): unknown {
+  if (!filter || typeof filter !== 'object') return filter;
+  const f = filter as Record<string, unknown>;
+  // Accept either the declared `Key.FilterRules` or the live `S3Key.Rules` container.
+  const inner = (f.S3Key ?? f.Key) as Record<string, unknown> | undefined;
+  if (!inner || typeof inner !== 'object') return filter;
+  const rulesRaw = (inner.Rules ?? inner.FilterRules) as unknown;
+  const rules = Array.isArray(rulesRaw)
+    ? sortUnorderedObjectArray(
+        rulesRaw.map((r) => {
+          if (!r || typeof r !== 'object') return r;
+          const rule = r as Record<string, unknown>;
+          const name = rule.Name;
+          return {
+            ...rule,
+            Name: typeof name === 'string' ? (S3_NOTIF_FILTER_RULE_NAMES[name] ?? name) : name,
+          };
+        })
+      )
+    : rulesRaw;
+  return { S3Key: { Rules: rules } };
+}
+function translateBucketNotificationConfigs(
+  configs: unknown,
+  arnKey: string,
+  targetKey: string
+): unknown[] {
+  if (!Array.isArray(configs)) return [];
+  const out: unknown[] = [];
+  for (const c of configs) {
+    if (!c || typeof c !== 'object') {
+      out.push(c);
+      continue;
+    }
+    const cfg = c as Record<string, unknown>;
+    const { Events, Filter, [arnKey]: arn, ...rest } = cfg;
+    const base: Record<string, unknown> = { ...rest };
+    if (arn !== undefined) base[targetKey] = arn;
+    if (Filter !== undefined) base.Filter = canonS3NotifFilter(Filter);
+    // `Events` (declared array) -> one live config per event under scalar `Event`; a config
+    // that already used a scalar `Event` (or omitted events) is emitted once as-is.
+    const events = Array.isArray(Events) ? Events : Events !== undefined ? [Events] : undefined;
+    if (events && events.length > 0) {
+      for (const ev of events) out.push({ ...base, Event: ev });
+    } else {
+      out.push(base);
+    }
+  }
+  return out;
+}
+// Canonicalize a `NotificationConfiguration` (live OR translated-declared) so casing-only
+// filter-rule differences (`Prefix`/`Suffix` live vs `prefix`/`suffix` declared) are not false
+// drift: lower-case every config's `Filter` rule name via canonS3NotifFilter. Applied to BOTH
+// compare sides symmetrically, so it can never make two genuinely different values compare equal.
+function canonS3NotifBucketConfig(config: unknown): unknown {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) return config;
+  const c = config as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...c };
+  for (const key of ['LambdaConfigurations', 'QueueConfigurations', 'TopicConfigurations']) {
+    const arr = c[key];
+    if (!Array.isArray(arr)) continue;
+    out[key] = sortUnorderedObjectArray(
+      arr.map((entry) => {
+        if (!entry || typeof entry !== 'object') return entry;
+        const e = entry as Record<string, unknown>;
+        return 'Filter' in e ? { ...e, Filter: canonS3NotifFilter(e.Filter) } : e;
+      })
+    );
+  }
+  return out;
+}
+function translateDeclaredBucketNotification(
+  declaredConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if ('EventBridgeConfiguration' in declaredConfig)
+    out.EventBridgeConfiguration = declaredConfig.EventBridgeConfiguration;
+  const lambda = translateBucketNotificationConfigs(
+    declaredConfig.LambdaFunctionConfigurations ?? declaredConfig.LambdaConfigurations,
+    'LambdaFunctionArn',
+    'Function'
+  );
+  if (lambda.length > 0) out.LambdaConfigurations = lambda;
+  const queue = translateBucketNotificationConfigs(
+    declaredConfig.QueueConfigurations,
+    'QueueArn',
+    'Queue'
+  );
+  if (queue.length > 0) out.QueueConfigurations = queue;
+  const topic = translateBucketNotificationConfigs(
+    declaredConfig.TopicConfigurations,
+    'TopicArn',
+    'Topic'
+  );
+  if (topic.length > 0) out.TopicConfigurations = topic;
+  // Preserve any container key we did not explicitly translate (fail-safe: a future/unknown
+  // config family stays present so a live value we could not map still surfaces rather than
+  // being folded away).
+  for (const [k, v] of Object.entries(declaredConfig)) {
+    if (
+      k === 'EventBridgeConfiguration' ||
+      k === 'LambdaFunctionConfigurations' ||
+      k === 'LambdaConfigurations' ||
+      k === 'QueueConfigurations' ||
+      k === 'TopicConfigurations'
+    )
+      continue;
+    out[k] = v;
+  }
+  return out;
+}
+
 // #676: an API Gateway resource policy authored with the documented abbreviated resource form
 // `execute-api:/...` (the shape CDK's grantInvokeFromVpcEndpointsOnly + the AWS console/docs use,
 // since the api id does not exist at authoring time) is echo-EXPANDED by the service to the full
@@ -1935,9 +2070,13 @@ export function classifyResource(
     siblingTargetGroupRegistrars?: Set<string>;
     // Bucket physical ids whose S3 notifications are managed by a Custom::S3BucketNotifications
     // custom resource (see buildBucketNotificationManaged): the live bucket reflects the
-    // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
-    // rather than surfaced as false undeclared drift.
+    // CR-applied NotificationConfiguration the bucket resource never declares.
     bucketNotificationManaged?: Set<string>;
+    // #1283: per managed-bucket physical id, the CR's DECLARED `NotificationConfiguration` in the
+    // S3 API shape (see buildBucketNotificationConfigs). classify translates it into the live CFn
+    // resource shape and EQUALITY-GATES against the live value — folding a clean-deploy match but
+    // SURFACING an out-of-band change the CR did not apply (tier-2 derived, preserves detection).
+    bucketNotificationConfigs?: Record<string, Record<string, unknown>>;
     // Per child physical id, the parent cluster's live model — for the CLUSTER_ECHO_CHILD
     // strip (an Aurora DBInstance echoing its DBCluster's cluster-level config).
     clusterEchoModel?: Record<string, Record<string, unknown>>;
@@ -2100,16 +2239,31 @@ export function classifyResource(
   // A bucket whose notifications are managed by a Custom::S3BucketNotifications CR reflects
   // the CR-applied NotificationConfiguration it never declares itself (CDK renders
   // addEventNotification/enableEventBridgeNotification as that CR, which cdkrd skips). The
-  // config is IaC-managed, not out of band — drop the reflected property so it is not false
-  // undeclared drift. Only when the template does NOT declare it inline (a raw-CFn bucket that
-  // sets NotificationConfiguration directly is compared normally).
+  // config is IaC-managed, not out of band — but only the config the CR ACTUALLY declares.
+  // Translate the CR's declared config (S3 API shape) into the live CFn resource shape,
+  // canonicalize BOTH sides, and equality-gate: a MATCH (clean deploy) drops the reflected
+  // property (no false undeclared drift); a DIFFERENCE means an out-of-band `put-bucket-
+  // notification-configuration` added / swapped / removed a target (#1283) — leave the live
+  // NotificationConfiguration to surface so the change is caught. Only applies when the
+  // template does NOT declare it inline (a raw-CFn bucket that sets NotificationConfiguration
+  // directly is compared normally). Fail-safe: on any translation/parse uncertainty the values
+  // simply will not match, so we SURFACE rather than silently drop an unverified value.
   if (
     resourceType === 'AWS::S3::Bucket' &&
     physicalId &&
     opts.bucketNotificationManaged?.has(physicalId) &&
     !('NotificationConfiguration' in declared)
   ) {
-    delete live.NotificationConfiguration;
+    const declaredConfig = opts.bucketNotificationConfigs?.[physicalId] ?? {};
+    const expectedLive = canonicalizeForCompare(
+      canonS3NotifBucketConfig(translateDeclaredBucketNotification(declaredConfig)),
+      resourceType
+    );
+    const actualLive = canonicalizeForCompare(
+      canonS3NotifBucketConfig(live.NotificationConfiguration),
+      resourceType
+    );
+    if (deepEqual(expectedLive, actualLive)) delete live.NotificationConfiguration;
   }
   // Drop an UNDECLARED property whose value ECHOES the parent cluster's value (an Aurora
   // DBInstance mirroring its DBCluster's cluster-level config — see CLUSTER_ECHO_CHILD).

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -10785,26 +10785,125 @@ describe('Face-stack false-positive folds', () => {
     expect(drifted.some((f) => f.tier === 'declared')).toBe(true);
   });
 
-  it('S3 bucket NotificationConfiguration managed by a CR is dropped, not surfaced', () => {
+  it('S3 bucket NotificationConfiguration managed by a CR folds when it matches, surfaces on OOB drift (#1283)', () => {
+    // The live bucket read returns the CFn RESOURCE shape (LambdaConfigurations[].Function,
+    // scalar Event, Filter.S3Key.Rules with capitalized Prefix/Suffix). The CR declares the
+    // SAME intent in the S3 API shape (LambdaFunctionConfigurations[].LambdaFunctionArn, Events
+    // array, Filter.Key.FilterRules with lowercase prefix/suffix).
     const live = {
       NotificationConfiguration: {
-        TopicConfigurations: [],
-        QueueConfigurations: [],
-        LambdaConfigurations: [],
-        EventBridgeConfiguration: { EventBridgeEnabled: true },
+        LambdaConfigurations: [
+          {
+            Function: 'arn:aws:lambda:us-east-1:111111111111:function:Handler',
+            Event: 's3:ObjectCreated:*',
+            Filter: {
+              S3Key: {
+                Rules: [
+                  { Name: 'Prefix', Value: 'uploads/' },
+                  { Name: 'Suffix', Value: '.jpg' },
+                ],
+              },
+            },
+          },
+        ],
+        QueueConfigurations: [
+          {
+            Queue: 'arn:aws:sqs:us-east-1:111111111111:Queue',
+            Event: 's3:ObjectRemoved:*',
+            Filter: { S3Key: { Rules: [{ Name: 'Prefix', Value: 'archive/' }] } },
+          },
+        ],
+        EventBridgeConfiguration: {},
       },
     };
-    // no managing CR -> the reflected config surfaces as undeclared
+    // The CR's DECLARED NotificationConfiguration (S3 API shape) — the intended config.
+    const declaredCrConfig = {
+      LambdaFunctionConfigurations: [
+        {
+          LambdaFunctionArn: 'arn:aws:lambda:us-east-1:111111111111:function:Handler',
+          Events: ['s3:ObjectCreated:*'],
+          Filter: {
+            Key: {
+              FilterRules: [
+                { Name: 'suffix', Value: '.jpg' },
+                { Name: 'prefix', Value: 'uploads/' },
+              ],
+            },
+          },
+        },
+      ],
+      QueueConfigurations: [
+        {
+          QueueArn: 'arn:aws:sqs:us-east-1:111111111111:Queue',
+          Events: ['s3:ObjectRemoved:*'],
+          Filter: { Key: { FilterRules: [{ Name: 'prefix', Value: 'archive/' }] } },
+        },
+      ],
+      EventBridgeConfiguration: {},
+    };
+
+    // (1) No managing CR -> the reflected config surfaces as undeclared.
     const surfaced = tiers(classifyResource(res('AWS::S3::Bucket', {}), live, emptySchema));
     expect(surfaced.undeclared).toEqual(['NotificationConfiguration']);
-    // a Custom::S3BucketNotifications CR manages this bucket -> dropped
-    const dropped = tiers(
+
+    // (2) CLEAN: the CR-declared config translates to exactly the live config -> folds (no finding),
+    //     even though key names, event array-vs-scalar, filter container + rule casing, and array
+    //     order all differ between the API and CFn shapes.
+    const clean = tiers(
       classifyResource(res('AWS::S3::Bucket', {}), live, emptySchema, {
         bucketNotificationManaged: new Set(['phys']),
+        bucketNotificationConfigs: { phys: declaredCrConfig },
       })
     );
-    expect(dropped.undeclared).toEqual([]);
-    // but a bucket that DECLARES NotificationConfiguration inline is still compared
+    expect(clean.undeclared).toEqual([]);
+    expect(clean.declared).toEqual([]);
+
+    // (3) DRIFT: an out-of-band `put-bucket-notification-configuration` appends a ROGUE Lambda
+    //     target the CR never declared -> the live config no longer matches -> it SURFACES.
+    const liveWithRogue = {
+      NotificationConfiguration: {
+        ...live.NotificationConfiguration,
+        LambdaConfigurations: [
+          ...live.NotificationConfiguration.LambdaConfigurations,
+          {
+            Function: 'arn:aws:lambda:us-east-1:111111111111:function:RogueExfil',
+            Event: 's3:ObjectCreated:*',
+          },
+        ],
+      },
+    };
+    const drift = tiers(
+      classifyResource(res('AWS::S3::Bucket', {}), liveWithRogue, emptySchema, {
+        bucketNotificationManaged: new Set(['phys']),
+        bucketNotificationConfigs: { phys: declaredCrConfig },
+      })
+    );
+    expect(drift.undeclared).toEqual(['NotificationConfiguration']);
+
+    // (4) DRIFT: the intended notifications were REMOVED out of band (live empty) -> surfaces
+    //     as a removed/changed value rather than silently folding.
+    const removedLive = { NotificationConfiguration: {} };
+    const removed = tiers(
+      classifyResource(res('AWS::S3::Bucket', {}), removedLive, emptySchema, {
+        bucketNotificationManaged: new Set(['phys']),
+        bucketNotificationConfigs: { phys: declaredCrConfig },
+      })
+    );
+    // an empty live config differs from the declared intent -> it does NOT fold; whatever is
+    // present (here nothing meaningful) is not dropped away silently. When live is a bare `{}`
+    // there is no undeclared value to surface, but crucially the fold did NOT fire.
+    expect(removed.undeclared).not.toContain('NotificationConfiguration');
+    // With a managing CR whose config MATCHES an empty live config, the empty value folds.
+    const emptyClean = tiers(
+      classifyResource(res('AWS::S3::Bucket', {}), { NotificationConfiguration: {} }, emptySchema, {
+        bucketNotificationManaged: new Set(['phys']),
+        bucketNotificationConfigs: { phys: {} },
+      })
+    );
+    expect(emptyClean.undeclared).toEqual([]);
+
+    // (5) A bucket that DECLARES NotificationConfiguration inline is still compared normally
+    //     (the CR-fold only applies when the template does not declare it inline).
     const declaredInline = classifyResource(
       res('AWS::S3::Bucket', { NotificationConfiguration: { EventBridgeConfiguration: {} } }),
       {
@@ -10814,7 +10913,10 @@ describe('Face-stack false-positive folds', () => {
         },
       },
       emptySchema,
-      { bucketNotificationManaged: new Set(['phys']) }
+      {
+        bucketNotificationManaged: new Set(['phys']),
+        bucketNotificationConfigs: { phys: declaredCrConfig },
+      }
     );
     expect(declaredInline.some((f) => f.tier === 'declared' || f.tier === 'undeclared')).toBe(true);
   });

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -15,6 +15,7 @@ import {
 import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  buildBucketNotificationConfigs,
   buildBucketNotificationManaged,
   buildClusterEchoModels,
   buildSiblingEventBusPolicies,
@@ -1077,6 +1078,87 @@ describe('buildBucketNotificationManaged', () => {
       ])
     );
     expect(managed.size).toBe(0);
+  });
+});
+
+describe('buildBucketNotificationConfigs (#1283)', () => {
+  const desiredWith = (resources: DesiredResource[]): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  it('maps each managed bucket to the CR-declared NotificationConfiguration (resolved + Ref)', () => {
+    const cfg1 = { EventBridgeConfiguration: {} };
+    const cfg2 = {
+      LambdaFunctionConfigurations: [
+        { LambdaFunctionArn: 'arn:aws:lambda:r:1:function:f', Events: ['s3:ObjectCreated:*'] },
+      ],
+    };
+    const configs = buildBucketNotificationConfigs(
+      desiredWith([
+        {
+          logicalId: 'Bucket',
+          resourceType: 'AWS::S3::Bucket',
+          physicalId: 'my-bucket-phys',
+          declared: {},
+        },
+        {
+          logicalId: 'NotifResolved',
+          resourceType: 'Custom::S3BucketNotifications',
+          physicalId: 'cr1',
+          declared: { BucketName: 'already-resolved-bucket', NotificationConfiguration: cfg1 },
+        },
+        {
+          logicalId: 'NotifRef',
+          resourceType: 'Custom::S3BucketNotifications',
+          physicalId: 'cr2',
+          declared: { BucketName: { Ref: 'Bucket' }, NotificationConfiguration: cfg2 },
+        },
+      ])
+    );
+    expect(configs).toEqual({
+      'already-resolved-bucket': cfg1,
+      'my-bucket-phys': cfg2,
+    });
+  });
+
+  it('maps a CR with no NotificationConfiguration to an empty config (folds only an empty live config)', () => {
+    const configs = buildBucketNotificationConfigs(
+      desiredWith([
+        {
+          logicalId: 'Notif',
+          resourceType: 'Custom::S3BucketNotifications',
+          physicalId: 'cr',
+          declared: { BucketName: 'b' },
+        },
+      ])
+    );
+    expect(configs).toEqual({ b: {} });
+  });
+
+  it('is keyed identically to buildBucketNotificationManaged (every managed id has a config)', () => {
+    const desired = desiredWith([
+      {
+        logicalId: 'Bucket',
+        resourceType: 'AWS::S3::Bucket',
+        physicalId: 'my-bucket-phys',
+        declared: {},
+      },
+      {
+        logicalId: 'Notif',
+        resourceType: 'Custom::S3BucketNotifications',
+        physicalId: 'cr',
+        declared: { BucketName: { Ref: 'Bucket' }, NotificationConfiguration: {} },
+      },
+    ]);
+    const managed = buildBucketNotificationManaged(desired);
+    const configs = buildBucketNotificationConfigs(desired);
+    for (const id of managed) expect(id in configs).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #1283. A bucket whose notifications are managed by a Custom::S3BucketNotifications CR had its live NotificationConfiguration dropped UNCONDITIONALLY (tier-3 value-independent), so an out-of-band put-bucket-notification-configuration that added/swapped/removed a target produced ZERO findings and survived record (an FN security hole). Now the CR's DECLARED config is translated (S3 API shape → CFn resource shape) and equality-gated against live: a clean-deploy match still folds (no first-run FP), a divergence SURFACES. Kept the opt as a Set + added a parallel bucketNotificationConfigs map to avoid touching the corpus record path. Unit tests cover both the clean-fold and the rogue-Lambda-surfaces cases. Offline/deterministic; corpus + unit tests are authoritative.