### PR TITLE
fix(diff): escalate RoleARN + AmazonMQ Broker SecurityGroups value-independent folds to detection-preserving gates (#1284, #1266)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -54,6 +54,9 @@ const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // #976: Neptune DBCluster's undeclared VpcSecurityGroupIds default is the VPC default SG —
   // gated in classify against the prefetched default-SG ids so an OOB swap/append surfaces.
   'AWS::Neptune::DBCluster',
+  // #1266: AmazonMQ Broker's undeclared SecurityGroups default is the VPC default SG — same gate,
+  // so the prefetch must fire when a broker is present too.
+  'AWS::AmazonMQ::Broker',
 ]);
 
 // #889: fetch the account/region VPC-default security-group ids — one `DescribeSecurityGroups`

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -231,6 +231,12 @@ const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // hide an out-of-band SG swap/append (the exact security FN #889 fixed). Gate it through the
   // same derived VPC-default-SG check: fold a single default SG, surface an append or a swap.
   'AWS::Neptune::DBCluster': 'VpcSecurityGroupIds',
+  // #1266: an AmazonMQ Broker that declares no SecurityGroups reads back the VPC default SG — the
+  // same single-SG AWS first-run default the ALB/ENI/Neptune cases fold. It is OOB-mutable
+  // (`mq update-broker --security-groups`; SecurityGroups is NOT in the schema createOnlyProperties,
+  // unlike SubnetIds), so a value-independent fold would hide a rogue SG swap/append. Gate it
+  // through the same derived VPC-default-SG check: fold a single default SG, surface an append/swap.
+  'AWS::AmazonMQ::Broker': 'SecurityGroups',
 };
 /** #889 fold decision for an UNDECLARED default-SG list (ALB SecurityGroups / ENI GroupSet).
  *  Returns whether the value-independent fold should still apply for this live value:

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2428,6 +2428,17 @@ export const DEFAULT_MANAGED_NAME_PATHS: Record<string, Record<string, RegExp>> 
   'AWS::Neptune::DBInstance': { DBParameterGroupName: /^default\./ },
   'AWS::Redshift::Cluster': { ClusterParameterGroupName: /^default\./ },
   'AWS::MemoryDB::Cluster': { ParameterGroupName: /^default\./ },
+  // #1284: a nested-stack Stack resource that declares no RoleARN reads back the CFn service role
+  // AWS/CDK attached — the CDK bootstrap cfn-exec-role, whose ARN is a DETERMINISTIC shape of the
+  // stack's own account/region: `arn:<partition>:iam::<acct>:role/cdk-<qualifier>-cfn-exec-role-
+  // <acct>-<region>`. Fold that (undeclared, AWS-assigned, not user intent). But RoleARN is MUTABLE
+  // out of band (`cloudformation update-stack --role-arn`, which CFn REMEMBERS for all future ops)
+  // and is a privilege boundary, so a value-independent fold would hide a rogue exec-role swap
+  // forever — an OOB RoleARN that does NOT match this shape (e.g. `role/attacker-admin-role`) does
+  // not match the pattern and surfaces as undeclared (recordable, then watched).
+  'AWS::CloudFormation::Stack': {
+    RoleARN: /^arn:aws[\w-]*:iam::\d{12}:role\/cdk-[a-z0-9]+-cfn-exec-role-\d{12}-[a-z0-9-]+$/,
+  },
 };
 
 // Top-level UNDECLARED keys that are ALWAYS a service-minted, AWS-managed generated
@@ -3216,13 +3227,18 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   back an AWS-assigned one as an OBJECT ({DayOfWeek, TimeOfDay, TimeZone}); value-independent
   //   folds the whole top-level property whatever its shape, so the assigned window is not first-
   //   run noise (a DECLARED window is compared in the declared loop).
-  //   AWS::AmazonMQ::Broker.SecurityGroups / .SubnetIds — a broker that declares neither reads back
-  //   a single-element default-VPC placement (an AWS-assigned sg-… / subnet-… id, not in the
-  //   broker's declared inputs and not derivable without a VPC lookup). Verbatim twin of the ELBv2
-  //   LoadBalancer.SecurityGroups fold above: undeclared, so whatever placement AWS chose is its
-  //   default, never user intent — a user who wants specific SGs/subnets DECLARES them, compared in
-  //   the declared loop. Corpus baked FP (#844).
-  'AWS::AmazonMQ::Broker': new Set(['MaintenanceWindowStartTime', 'SecurityGroups', 'SubnetIds']),
+  //   AWS::AmazonMQ::Broker.SubnetIds — a broker that declares no SubnetIds reads back a
+  //   single-element default-VPC placement (an AWS-assigned subnet-… id, not in the broker's
+  //   declared inputs and not derivable without a VPC lookup). SubnetIds is CREATE-ONLY (schema
+  //   createOnlyProperties), so a value-independent fold cannot hide an out-of-band swap — the
+  //   subnet cannot change without replacing the broker. Undeclared, so whatever placement AWS
+  //   chose is its default, never user intent. Corpus baked FP (#844).
+  //   NOTE: `.SecurityGroups` was ALSO here, but it is MUTABLE out of band
+  //   (`mq update-broker --security-groups`, NOT createOnly), so folding it value-independent hid
+  //   a rogue SG swap/append forever (#1266). It is now derive-gated in classify against the
+  //   prefetched VPC-default SG ids (DEFAULT_SG_LIST_PATHS, the #889/#976 ELBv2/Neptune gate): a
+  //   single default SG folds, a 2+-element append or a non-default swap surfaces.
+  'AWS::AmazonMQ::Broker': new Set(['MaintenanceWindowStartTime', 'SubnetIds']),
   //   Core VPC-networking types whose undeclared, AWS-ASSIGNED, CREATE-ONLY placement identifiers
   //   read back on every first run. Each is a per-resource value AWS picks at creation from the
   //   surrounding VPC/subnet/region — never a constant we can pin, and never user intent when
@@ -3422,16 +3438,19 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //       (cdkrd triggering a child-stack update to a stale template — a real hazard). Undeclared,
   //       unpinnable, moves per deploy → value-independent (a user who wants to compare the child
   //       compares the child stack itself; the parent never declares its body).
-  //     * `RoleARN` — the CloudFormation service role (the `cdk-hnb659fds-cfn-exec-role-…` CDK
-  //       bootstrap role) AWS/CDK attaches; undeclared on the Stack resource, per-account/region
-  //       AWS-assigned, not user intent when undeclared.
   //     * `Capabilities` — the capability set AWS records for the child (e.g.
   //       `["CAPABILITY_IAM","CAPABILITY_AUTO_EXPAND"]`); undeclared, AWS-assigned, and a plain
   //       reflection of what the child needs, not intent on the parent Stack resource.
-  //   All three are undeclared → whatever AWS assigned is its default, never user intent; a real
+  //   Both are undeclared → whatever AWS assigned is its default, never user intent; a real
   //   drift in the child's own resources surfaces when that child stack is checked directly.
   //   First-run FP on every nested-stack deploy (#723, live-repro'd on tests/integration/nested).
-  'AWS::CloudFormation::Stack': new Set(['TemplateBody', 'RoleARN', 'Capabilities']),
+  //   NOTE: `.RoleARN` was ALSO here, but it is MUTABLE out of band
+  //   (`cloudformation update-stack --role-arn`, which CFn then REMEMBERS for all future ops — a
+  //   privilege boundary), so folding it value-independent hid a rogue exec-role swap forever
+  //   (#1284). It is now pattern-gated in DEFAULT_MANAGED_NAME_PATHS against the deterministic CDK
+  //   cfn-exec-role ARN shape: the `cdk-<qualifier>-cfn-exec-role-<acct>-<region>` role folds, any
+  //   other RoleARN surfaces as undeclared (recordable, then watched).
+  'AWS::CloudFormation::Stack': new Set(['TemplateBody', 'Capabilities']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/vi-escalation-rolearn-mqsg-1284-1266.test.ts
+++ b/tests/vi-escalation-rolearn-mqsg-1284-1266.test.ts
@@ -1,0 +1,132 @@
+// Two value-independent folds ESCALATED to detection-preserving gates:
+//   #1284 — AWS::CloudFormation::Stack.RoleARN (the nested-stack CFn service role) was folded
+//     value-independent (#723). But RoleARN is MUTABLE out of band (`update-stack --role-arn`,
+//     which CFn REMEMBERS) and is a privilege boundary, so the fold hid a rogue exec-role swap
+//     forever. It is now pattern-gated in DEFAULT_MANAGED_NAME_PATHS against the deterministic CDK
+//     cfn-exec-role ARN shape: the `cdk-<qualifier>-cfn-exec-role-<acct>-<region>` role folds
+//     atDefault; any other RoleARN surfaces as undeclared (recordable, then watched).
+//   #1266 — AWS::AmazonMQ::Broker.SecurityGroups was folded value-independent (#844). But it is
+//     OOB-mutable (`mq update-broker --security-groups`, NOT createOnly), so the fold hid a rogue
+//     SG swap/append. It is now derive-gated through the same #889/#976 VPC-default-SG check.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource, shouldFoldDefaultSgList } from '../src/diff/classify.js';
+import { DEFAULT_MANAGED_NAME_PATHS } from '../src/normalize/noise.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+// ---- #1284: nested-stack RoleARN pattern gate ----------------------------------------------
+describe('#1284 AWS::CloudFormation::Stack.RoleARN pattern gate', () => {
+  // A nested-stack parent resource that declares no RoleARN (the common case — CDK/AWS attaches it).
+  const res = mk('AWS::CloudFormation::Stack', { TemplateURL: 'https://s3/child.json' });
+  const CDK_EXEC_ROLE =
+    'arn:aws:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role-123456789012-us-east-1';
+
+  it('(a) folds the deterministic CDK cfn-exec-role ARN to atDefault (clean deploy, no drift)', () => {
+    const f = classifyResource(res, { RoleARN: CDK_EXEC_ROLE }, emptySchema, {});
+    expect(tier(f, 'atDefault')).toContain('RoleARN');
+    expect(tier(f, 'undeclared')).not.toContain('RoleARN');
+  });
+
+  it('(b) SURFACES an out-of-band non-CDK RoleARN swap (update-stack --role-arn attacker)', () => {
+    const f = classifyResource(
+      res,
+      { RoleARN: 'arn:aws:iam::123456789012:role/attacker-admin-role' },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'undeclared')).toContain('RoleARN');
+    expect(tier(f, 'atDefault')).not.toContain('RoleARN');
+  });
+
+  it('(c) folds a custom-qualifier cfn-exec-role and non-aws partitions; surfaces shape look-alikes', () => {
+    const rx = DEFAULT_MANAGED_NAME_PATHS['AWS::CloudFormation::Stack']?.RoleARN;
+    expect(rx).toBeInstanceOf(RegExp);
+    if (!rx) throw new Error('unreachable');
+    // custom bootstrap qualifier
+    expect(
+      rx.test('arn:aws:iam::123456789012:role/cdk-myqualif01-cfn-exec-role-123456789012-eu-west-2')
+    ).toBe(true);
+    // GovCloud / China partitions
+    expect(
+      rx.test(
+        'arn:aws-us-gov:iam::123456789012:role/cdk-hnb659fds-cfn-exec-role-123456789012-us-gov-west-1'
+      )
+    ).toBe(true);
+    // NOT the cfn-exec-role: a different CDK role (file-publishing) must still surface
+    expect(
+      rx.test(
+        'arn:aws:iam::123456789012:role/cdk-hnb659fds-file-publishing-role-123456789012-us-east-1'
+      )
+    ).toBe(false);
+    // a role merely NAMED to look like one but with a bogus (non-12-digit) account is not folded
+    expect(rx.test('arn:aws:iam::123:role/cdk-x-cfn-exec-role-123-us-east-1')).toBe(false);
+  });
+});
+
+// ---- #1266: AmazonMQ Broker SecurityGroups derived gate -------------------------------------
+const DEFAULT_SG = 'sg-0defau1t00000000';
+const ROGUE_SG = 'sg-0rogue00000000000';
+const defaultSgIds = new Set([DEFAULT_SG]);
+
+describe('#1266 AWS::AmazonMQ::Broker.SecurityGroups derived VPC-default-SG gate', () => {
+  // A broker declaring no SecurityGroups (so the live list is UNDECLARED and reaches the fold).
+  const res = mk('AWS::AmazonMQ::Broker', { EngineType: 'ACTIVEMQ', BrokerName: 'b' });
+  const key = 'SecurityGroups';
+
+  it('(a) folds a single VPC-default SG to atDefault (clean deploy, no drift)', () => {
+    const f = classifyResource(res, { [key]: [DEFAULT_SG] }, emptySchema, { defaultSgIds });
+    expect(tier(f, 'atDefault')).toContain(key);
+    expect(tier(f, 'undeclared')).not.toContain(key);
+  });
+
+  it('(b) SURFACES a 2-element list (out-of-band SG append via update-broker)', () => {
+    const f = classifyResource(res, { [key]: [DEFAULT_SG, ROGUE_SG] }, emptySchema, {
+      defaultSgIds,
+    });
+    expect(tier(f, 'undeclared')).toContain(key);
+    expect(tier(f, 'atDefault')).not.toContain(key);
+  });
+
+  it('(c) SURFACES a single NON-default SG (out-of-band SG swap)', () => {
+    const f = classifyResource(res, { [key]: [ROGUE_SG] }, emptySchema, { defaultSgIds });
+    expect(tier(f, 'undeclared')).toContain(key);
+    expect(tier(f, 'atDefault')).not.toContain(key);
+  });
+
+  it('(d) FOLDS on lookup failure (defaultSgIds absent → fail open, no first-run FP)', () => {
+    const f = classifyResource(res, { [key]: [ROGUE_SG, DEFAULT_SG] }, emptySchema, {});
+    expect(tier(f, 'atDefault')).toContain(key);
+    expect(tier(f, 'undeclared')).not.toContain(key);
+  });
+
+  it('pure decision: shouldFoldDefaultSgList gates Broker SecurityGroups', () => {
+    const b = 'AWS::AmazonMQ::Broker';
+    expect(shouldFoldDefaultSgList(b, key, [DEFAULT_SG], defaultSgIds)).toBe(true);
+    expect(shouldFoldDefaultSgList(b, key, [DEFAULT_SG, ROGUE_SG], defaultSgIds)).toBe(false);
+    expect(shouldFoldDefaultSgList(b, key, [ROGUE_SG], defaultSgIds)).toBe(false);
+    expect(shouldFoldDefaultSgList(b, key, [ROGUE_SG], undefined)).toBe(true);
+    // SubnetIds stays value-independent (createOnly) — not this gate's business.
+    expect(shouldFoldDefaultSgList(b, 'SubnetIds', ['subnet-x'], defaultSgIds)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Two `value-independent` (tier-3) folds LOSE change detection — an out-of-band swap reads CLEAN forever, and because neither property is create-only, `record` never watches it (`atDefault` is not recorded). Both are escalated to detection-preserving gates.

### #1284 — `AWS::CloudFormation::Stack.RoleARN`
The nested-stack CFn service role (#723). MUTABLE out of band via `cloudformation update-stack --role-arn` (which CFn then REMEMBERS for all future ops) and a **privilege boundary** — the credentials CFn uses to mutate every child resource. Now **pattern-gated** in `DEFAULT_MANAGED_NAME_PATHS` against the deterministic CDK cfn-exec-role ARN shape `^arn:aws[\w-]*:iam::\d{12}:role/cdk-[a-z0-9]+-cfn-exec-role-\d{12}-[a-z0-9-]+$`.

The `cdk-<qualifier>-cfn-exec-role-<acct>-<region>` role folds `atDefault`; any other RoleARN (e.g. `role/attacker-admin-role`) surfaces as `undeclared` (recordable, then watched). `TemplateBody` / `Capabilities` keep their #723 rationale.

### #1266 — `AWS::AmazonMQ::Broker.SecurityGroups`
Added value-independent for the single default-VPC-SG first-run echo (#844). But it is MUTABLE out of band via `mq update-broker --security-groups` (`SecurityGroups` is NOT in the schema `createOnlyProperties`, unlike `SubnetIds`). Now **derive-gated** through the existing #889/#976 VPC-default-SG check (added to `DEFAULT_SG_LIST_PATHS` + the `gather.ts` `DEFAULT_SG_LIST_TYPES` prefetch trigger): a single VPC-default SG folds, a 2+-element append or a non-default swap surfaces. **Fails open** when the prefetch is unavailable (no new first-run FP). `SubnetIds` (createOnly) and `MaintenanceWindowStartTime` (cosmetic) stay value-independent.

## Files
- `src/normalize/noise.ts` — drop `RoleARN` from the `Stack` value-independent set + add the cfn-exec-role pattern to `DEFAULT_MANAGED_NAME_PATHS`; drop `SecurityGroups` from the `AmazonMQ::Broker` value-independent set.
- `src/diff/classify.ts` — add `AWS::AmazonMQ::Broker` → `SecurityGroups` to `DEFAULT_SG_LIST_PATHS`.
- `src/commands/gather.ts` — add `AWS::AmazonMQ::Broker` to `DEFAULT_SG_LIST_TYPES` (so the default-SG prefetch fires for broker stacks).
- `tests/vi-escalation-rolearn-mqsg-1284-1266.test.ts` — new: fold-clean-deploy / surface-OOB-swap-append / fail-open cases for both.

## Verification
Offline/deterministic — the issues' repros are offline `classify` cases (the authoritative evidence for a fold/classify fix). New test file: 8 tests. Full suite green (220 files, 4895 tests). No new IAM perm (reuses the existing `ec2:DescribeSecurityGroups` #889 prefetch), no new dependency, no CLI surface change.

Closes #1284
Closes #1266
