### PR TITLE
fix(revert): skip conditional-create-only write-only props in writeOnlyReincludeOps (#1330)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -1414,6 +1414,22 @@ export function writeOnlyReincludeOps(
     // and create-only, so re-including it made every revert fail "createOnlyProperties
     // [/properties/CacheSubnetGroupName] cannot be updated".
     if (isUnderCreateOnly(path, schema.createOnlyPaths)) continue;
+    // A write-only prop that is ALSO conditional-create-only (RDS DBInstance
+    // DBSnapshotIdentifier / SourceDBInstanceIdentifier — create-only ONLY when restoring
+    // from a snapshot / creating a read replica) must ALSO be skipped. parseSchema keeps
+    // conditionalCreateOnlyProperties OUT of createOnlyPaths (so the revert BAR does not
+    // block reverting everyday mutable props — #413/#421), so the isUnderCreateOnly check
+    // above does NOT catch these. But re-including such a prop into a CC read-modify-write
+    // patch is fatal: a read handler never returns a write-only prop, so the update handler
+    // sees the re-included value as NEWLY ADDED, and for a prop that is create-only in its
+    // condition the "added" transition IS the create-only condition → the WHOLE revert fails
+    // (#1330, the #252 failure class — e.g. reverting BackupRetentionPeriod on a
+    // snapshot-restored DBInstance failed because `add /DBSnapshotIdentifier` was re-included).
+    // Omitting it is safe by the SAME argument as the createOnly skip: the prop is fixed at
+    // creation in its create-only condition, and the provider preserves an absent write-only
+    // prop it cannot diff. The revert BAR (#413's honest-failure contract) is UNTOUCHED — only
+    // this re-inclusion path changes.
+    if (isUnderCreateOnly(path, schema.conditionalCreateOnlyPaths ?? [])) continue;
     const value = valueAtDottedPath(declared, path);
     if (value === undefined || value === UNRESOLVED || hasUnresolved(value)) continue;
     const pointer = toPointer(path);

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -18,6 +18,7 @@ const EMPTY: SchemaInfo = {
   readOnlyPaths: [],
   writeOnlyPaths: [],
   createOnlyPaths: [],
+  conditionalCreateOnlyPaths: [],
   defaults: {},
   defaultPaths: {},
   unorderedScalarPaths: [],
@@ -568,6 +569,12 @@ export function parseSchema(schemaJson: string): SchemaInfo {
   // rejects it cleanly (it never silently replaces) — an honest failure beats a silent
   // bar. (Live-confirmed on AWS::RDS::DBInstance BackupRetentionPeriod.)
   const createOnlyPaths = dotted(schema.createOnlyProperties);
+  // The conditional-create-only props, kept SEPARATE from createOnlyPaths (the revert BAR
+  // deliberately excludes them — they are mutable in the common case). writeOnlyReincludeOps
+  // consults this to avoid re-including a conditional-create-only write-only prop into a CC
+  // read-modify-write patch, which the provider's update handler would reject as a create-only
+  // "add" (#1330). Same pointer-normalization (pointerToDotted) as createOnlyPaths.
+  const conditionalCreateOnlyPaths = dotted(schema.conditionalCreateOnlyProperties);
   // Build the TOP-LEVEL defaults map. A top-level property may carry its `default`
   // DIRECTLY, or be written as `{ "$ref": "#/definitions/X" }` where definition X holds
   // the `default` (IoTFleetWise Status=DRAFT, HealthLake SseConfiguration, Deadline Queue
@@ -609,6 +616,7 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     readOnlyPaths,
     writeOnlyPaths,
     createOnlyPaths,
+    conditionalCreateOnlyPaths,
     defaults,
     defaultPaths,
     unorderedScalarPaths: unorderedArrayPaths.scalar,

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,20 @@ export interface SchemaInfo {
   readOnlyPaths: string[]; // full dotted paths incl '*' wildcard (strip from live, any depth)
   writeOnlyPaths: string[]; // full dotted paths incl '*' wildcard (skip from compare, any depth)
   createOnlyPaths: string[]; // full dotted paths incl '*' wildcard (revert is impossible — replacement)
+  // Full dotted paths (incl '*' wildcard) of the schema's `conditionalCreateOnlyProperties`
+  // — props that are create-only ONLY in a specific case (an RDS read replica, a
+  // snapshot-restored DBInstance) and MUTABLE in the common case. These are deliberately
+  // NOT merged into `createOnlyPaths` (that would bar revert of everyday mutable props like
+  // RDS BackupRetentionPeriod — #413/#421), so the revert BAR ignores them. But
+  // `writeOnlyReincludeOps` MUST still SKIP them: re-including a conditional-create-only
+  // write-only prop into a CC read-modify-write patch makes the provider's update handler
+  // see it as newly ADDED (a read handler never returns a write-only prop), and for a prop
+  // that is create-only in its condition the "added" transition is the create-only case →
+  // the whole revert fails (#1330, the #252 failure class). Omitting it is safe: it is fixed
+  // at creation in that condition and the provider preserves an absent write-only prop it
+  // cannot diff. Optional: production (parseSchema / reviveSchema / EMPTY) sets it; older
+  // corpus fixtures may omit it (read with `?.`).
+  conditionalCreateOnlyPaths?: string[];
   defaults: Record<string, unknown>; // top-level schema `default` values
   defaultPaths: Record<string, unknown>; // schema `default` values at ANY depth, dotted-path keyed ('*' for array items)
   // Dotted paths of arrays the schema marks `insertionOrder: false` (AWS declares the

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -2617,6 +2617,48 @@ describe('writeOnlyReincludeOps (Cloud Control read-modify-write contract, cdkd 
     ]);
   });
 
+  it('does NOT re-include a write-only prop that is CONDITIONAL-create-only (RDS DBInstance DBSnapshotIdentifier) — reverting an unrelated prop must not fail #1330', () => {
+    // AWS::RDS::DBInstance DBSnapshotIdentifier is write-only AND in
+    // conditionalCreateOnlyProperties (create-only ONLY when restoring from a snapshot).
+    // parseSchema deliberately keeps it OUT of createOnlyPaths (so the revert BAR does not
+    // block reverting everyday mutable props — #413/#421), so the isUnderCreateOnly
+    // createOnlyPaths check does NOT catch it. Before the fix, reverting an unrelated
+    // BackupRetentionPeriod re-included `add /DBSnapshotIdentifier`, and because a CC read
+    // handler never returns a write-only prop the update handler saw it as newly ADDED — the
+    // create-only condition — so the WHOLE revert failed (#1330, the #252 failure class). It
+    // must be skipped via conditionalCreateOnlyPaths.
+    const rdsSchema: SchemaInfo = {
+      readOnly: new Set<string>(),
+      writeOnly: new Set(['DBSnapshotIdentifier', 'MasterUserPassword']),
+      createOnly: new Set<string>(),
+      readOnlyPaths: [],
+      writeOnlyPaths: ['DBSnapshotIdentifier', 'MasterUserPassword'],
+      createOnlyPaths: [], // conditional props are NOT here (the #413/#421 split)
+      conditionalCreateOnlyPaths: ['DBSnapshotIdentifier'],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const rdsDeclared = {
+      DBSnapshotIdentifier: 'rds:prod-snap',
+      MasterUserPassword: 'hunter2',
+      BackupRetentionPeriod: 7,
+    };
+    const ops = writeOnlyReincludeOps(rdsDeclared, rdsSchema, [
+      { op: 'add', path: '/BackupRetentionPeriod', value: 7, human: 'x' },
+    ]);
+    // DBSnapshotIdentifier (conditional-create-only) is NOT re-included; the plain
+    // write-only MasterUserPassword still IS (it would silently vanish otherwise).
+    expect(ops).toEqual([
+      {
+        op: 'add',
+        path: '/MasterUserPassword',
+        value: 'hunter2',
+        human:
+          'MasterUserPassword -> re-include write-only (Cloud Control read-modify-write contract)',
+      },
+    ]);
+  });
+
   it('re-includes a NESTED write-only prop (IAM User LoginProfile.Password) — no credential reset (WAVE24)', () => {
     // AWS::IAM::User has only the NESTED write-only path LoginProfile.Password; the
     // top-level write-only set is EMPTY, so the old top-level-only loop re-included
@@ -2957,6 +2999,39 @@ describe('conditional/hard create-only split invariant over real CFn schemas (is
     expect(hardAsserted).toBeGreaterThan(50);
     expect(condAsserted).toBeGreaterThan(20);
     expect(typesWithConditional).toBeGreaterThan(3);
+  });
+
+  it('parseSchema: every CONDITIONAL create-only prop IS carried on conditionalCreateOnlyPaths (for the #1330 write-only re-include skip)', () => {
+    // The conditional props are excluded from createOnlyPaths (asserted above), but they
+    // must still be REACHABLE for writeOnlyReincludeOps to skip a conditional-create-only
+    // write-only prop (#1330). parseSchema exposes them on the separate
+    // conditionalCreateOnlyPaths field.
+    let condAsserted = 0;
+    for (const fx of fixtures) {
+      const info = parseSchema(
+        JSON.stringify({
+          createOnlyProperties: fx.createOnlyProperties,
+          conditionalCreateOnlyProperties: fx.conditionalCreateOnlyProperties,
+        })
+      );
+      const conditional = new Set(info.conditionalCreateOnlyPaths ?? []);
+      const hard = new Set(info.createOnlyPaths);
+      // Every conditional prop is carried on conditionalCreateOnlyPaths (1:1 count — the
+      // field is populated by parseSchema for exactly these props) and NONE of them leak
+      // into the hard createOnlyPaths bar.
+      expect(conditional.size).toBe(fx.conditionalCreateOnlyProperties.length);
+      for (const dotted of conditional) expect(hard.has(dotted)).toBe(false);
+      // The simple TOP-LEVEL conditional props (`/properties/<Name>`, no further segments)
+      // match the test's local pointerToDotted directly, proving the stored values are the
+      // real dotted paths — not just the right count.
+      for (const p of fx.conditionalCreateOnlyProperties) {
+        if (/^\/properties\/[^/]+$/.test(p)) {
+          expect(conditional.has(pointerToDotted(p))).toBe(true);
+        }
+      }
+      condAsserted += fx.conditionalCreateOnlyProperties.length;
+    }
+    expect(condAsserted).toBeGreaterThan(20);
   });
 
   it('consumer (buildRevertPlan/isUnderCreateOnly): a HARD create-only top-level prop bars revert, a CONDITIONAL one does not', () => {


### PR DESCRIPTION
Closes #1330

## Problem
A write-only prop that is ALSO conditional-create-only (RDS DBInstance `DBSnapshotIdentifier`/`RestoreTime`/`SourceDBInstanceIdentifier`, ElastiCache ReplicationGroup `AuthToken`, SSM Document `Attachments`, …) was re-included into EVERY unrelated Cloud Control revert patch. Reverting e.g. `BackupRetentionPeriod` on a snapshot-restored DBInstance appended `add /DBSnapshotIdentifier`.

Because CC applies patches read-modify-write and a read handler never returns a write-only prop, the update handler sees the re-included value as newly ADDED; for a prop create-only in its condition, that transition is the create-only case → the WHOLE revert fails (the #252 failure class).

## Root cause
`parseSchema` deliberately keeps `conditionalCreateOnlyProperties` OUT of `createOnlyPaths` (correct for the revert BAR — #413/#421 keep everyday mutable props revertable). `writeOnlyReincludeOps` inherited that exclusion and re-included them.

## Fix
- Carry `conditionalCreateOnlyPaths` on `SchemaInfo`, populated by `parseSchema` with the same pointer-normalization as `createOnlyPaths`.
- Skip those paths in `writeOnlyReincludeOps` ONLY. The revert BAR / #413 honest-failure contract is UNTOUCHED.

## Tests
- Issue's exact offline repro against the real RDS DBInstance registry schema: reverting `BackupRetentionPeriod` returns only the plain write-only prop, NOT `DBSnapshotIdentifier`. Fails without the fix, passes with it; a plain write-only prop is still re-included.
- Data-driven parseSchema invariant: every conditional-create-only prop is on `conditionalCreateOnlyPaths` and none leak into `createOnlyPaths`.

Offline/deterministic (one live probe recommended per the issue but the corpus repro is authoritative).