### PR TITLE
fix(read): type-key sibling-probe cache + positional siblingLookupId for Logs filters (#1310)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -278,6 +278,13 @@ export function hasForeignScopeSignal(c: AddedChild, accountId: string, region: 
 // stack own a resource of THIS child's type (`c.resourceType`) with this exact physical id?
 // Returns the tri-state and memoizes any DEFINITIVE answer per physical id (a transient
 // throttle / unverifiable foreign-scope id is left un-cached so a retry can resolve it).
+// The memo MUST be keyed by `${resourceType}|${physicalId}`, not the physical id alone: the
+// `owns` predicate gates on `ResourceType === c.resourceType`, so the SAME physical id can be
+// 'managed' for one child type yet 'notManaged' for another (#1310). Two child types can share
+// a segment name — e.g. a shared log group's MetricFilter and SubscriptionFilter fan-out both
+// probe a `errors` segment — and a type-blind cache would replay a MetricFilter's 'managed'
+// answer for a SubscriptionFilter of the same name, folding a rogue OOB subscription filter to
+// managed. Keying by type keeps each type's answer independent.
 async function probeSiblingPhysicalId(
   cfn: CloudFormationClient,
   c: AddedChild,
@@ -286,7 +293,8 @@ async function probeSiblingPhysicalId(
   accountId: string,
   region: string
 ): Promise<SiblingCheck> {
-  const cached = cache.get(physicalId);
+  const cacheKey = `${c.resourceType}|${physicalId}`;
+  const cached = cache.get(cacheKey);
   if (cached !== undefined) return cached;
   let managed = false;
   try {
@@ -348,13 +356,13 @@ async function probeSiblingPhysicalId(
       isDefinitiveNotManaged(physicalId, accountId, region) &&
       !hasForeignScopeSignal(c, accountId, region)
     ) {
-      cache.set(physicalId, 'notManaged');
+      cache.set(cacheKey, 'notManaged');
       return 'notManaged';
     }
     return 'unverified';
   }
   const result: SiblingCheck = managed ? 'managed' : 'notManaged';
-  cache.set(physicalId, result);
+  cache.set(cacheKey, result);
   return result;
 }
 

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -2718,6 +2718,17 @@ function diffLogGroupFilters(
       identifier: identifierOf(f.name),
       label: f.label ?? f.name,
       live: { FilterName: f.name, LogGroupName: logGroupName },
+      // The CFn PHYSICAL id of both AWS::Logs::MetricFilter and ::SubscriptionFilter is the
+      // FilterName (its `Ref`) — which we KNOW here positionally. Carry it on siblingLookupId
+      // so the sibling-membership probe uses the EXACT id and skips the `|`-segment fan-out of
+      // the CC composite `identifier` (#1310). The FilterName charset is `[^:*]*`, so a `|` is
+      // legal INSIDE a name (`error|filter`); splitting the composite `LogGroupName|error|filter`
+      // on `|` never probes the true physical id `error|filter`, false-flagging a sibling-managed
+      // filter `added` with a destructive DeleteResource (edge 1). The fan-out also cross-probes
+      // the LogGroupName segment as if it were the child's physical id, false-MATCHING an
+      // unrelated sibling filter that happens to share the log group's name (edge 2). Probing the
+      // exact FilterName avoids both.
+      siblingLookupId: f.name,
     });
   }
   return added;

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1644,8 +1644,22 @@ describe('diffLogGroupChildren (CloudWatch Logs metric filters)', () => {
         identifier: `${LG}|cdkrd-integ-oob`,
         label: 'cdkrd-integ-oob',
         live: { FilterName: 'cdkrd-integ-oob', LogGroupName: LG },
+        // #1310: the CFn physical id is the FilterName, carried positionally so the sibling
+        // check probes the exact id (and skips the `|` fan-out that mishandles a `|` in a name).
+        siblingLookupId: 'cdkrd-integ-oob',
       },
     ]);
+  });
+
+  it('#1310: siblingLookupId is the bare FilterName even when it contains a `|`', () => {
+    const added = diffLogGroupChildren({
+      logGroupName: LG,
+      declaredFilterNames: [],
+      liveFilters: [{ name: 'error|filter' }],
+    });
+    // the CC composite splits into 3 on `|`, but the true physical id is the whole FilterName
+    expect(added[0]!.identifier).toBe(`${LG}|error|filter`);
+    expect(added[0]!.siblingLookupId).toBe('error|filter');
   });
 
   it('identifier is the CC composite LogGroupName|FilterName', () => {
@@ -1684,6 +1698,8 @@ describe('diffLogGroupSubscriptionFilters (CloudWatch Logs subscription filters)
         identifier: `cdkrd-oob-sub|${LG}`,
         label: 'cdkrd-oob-sub',
         live: { FilterName: 'cdkrd-oob-sub', LogGroupName: LG },
+        // #1310: the CFn physical id is the FilterName, carried positionally.
+        siblingLookupId: 'cdkrd-oob-sub',
       },
     ]);
   });

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -1535,6 +1535,165 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
   });
 
+  // #1310 edge 3: the memo is TYPE-BLIND if keyed by physical id alone. `owns` gates on
+  // `ResourceType === c.resourceType`, so a 'managed' answer recorded for a MetricFilter named
+  // `errors` must NOT be replayed for a SubscriptionFilter of the same name — else a rogue OOB
+  // subscription filter on a shared log group folds to managed and stays invisible.
+  it('#1310: a per-type cache does NOT replay a MetricFilter answer for a same-named SubscriptionFilter', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // A SIBLING stack owns a MetricFilter physically named `errors`; NO stack owns a
+    // SubscriptionFilter by that name (a ValidationError for anything else).
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      if (input.PhysicalResourceId === 'errors') {
+        return {
+          StackResources: [
+            {
+              StackName: 'MetricsStack',
+              LogicalResourceId: 'ErrorsMF',
+              PhysicalResourceId: 'errors',
+              ResourceType: 'AWS::Logs::MetricFilter',
+              Timestamp: new Date(0),
+              ResourceStatus: 'CREATE_COMPLETE',
+            },
+          ],
+        };
+      }
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    // The SubscriptionFilter probe of `errors` gets the MetricFilter-typed resource back (wrong
+    // type -> `owns` misses), triggering the #726 pagination fallback on `MetricsStack`; it holds
+    // no SubscriptionFilter by that id -> notManaged.
+    cfn.on(ListStackResourcesCommand).resolves({ StackResourceSummaries: [] });
+    // Same shared cache across both children (as gather uses one cache per run).
+    const cache = new Map<string, SiblingCheck>();
+    // The sibling-managed MetricFilter `errors` on a shared log group -> managed.
+    const mf = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      { resourceType: 'AWS::Logs::MetricFilter', identifier: 'errors', label: 'errors', live: {} },
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(mf).toBe('managed');
+    // A rogue OOB SubscriptionFilter ALSO named `errors` must NOT inherit the MetricFilter's
+    // 'managed' from the cache — it re-probes as its OWN type and, finding no owning stack, is
+    // correctly notManaged (surfaced as `added`). With a type-blind cache this returned 'managed'.
+    const sf = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      {
+        resourceType: 'AWS::Logs::SubscriptionFilter',
+        identifier: 'errors',
+        label: 'errors',
+        live: {},
+      },
+      cache,
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(sf).toBe('notManaged');
+    // The two entries are kept apart by the `${resourceType}|${physicalId}` key.
+    expect(cache.get('AWS::Logs::MetricFilter|errors')).toBe('managed');
+    expect(cache.get('AWS::Logs::SubscriptionFilter|errors')).toBe('notManaged');
+  });
+
+  // #1310 edge 1: a FilterName may legally contain `|` (charset `[^:*]*`). The enumerator carries
+  // the true FilterName on `siblingLookupId`, so the sibling check probes the EXACT physical id and
+  // skips the CC-composite `|` fan-out. Without it, `shared-lg|error|filter` splits into
+  // `shared-lg`/`error`/`filter`, never probing the real physical id `error|filter` -> false added.
+  it('#1310: a MetricFilter whose name contains `|` resolves via siblingLookupId, not the split', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    const filterName = 'error|filter'; // legal FilterName with a `|`
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      if (input.PhysicalResourceId === filterName) {
+        return {
+          StackResources: [
+            {
+              StackName: 'SiblingStack',
+              LogicalResourceId: 'ErrFilter',
+              PhysicalResourceId: filterName,
+              ResourceType: 'AWS::Logs::MetricFilter',
+              Timestamp: new Date(0),
+              ResourceStatus: 'CREATE_COMPLETE',
+            },
+          ],
+        };
+      }
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      {
+        resourceType: 'AWS::Logs::MetricFilter',
+        identifier: `shared-lg|${filterName}`, // CC composite LogGroupName|FilterName
+        label: filterName,
+        live: {},
+        siblingLookupId: filterName, // enumerator carries the true physical id positionally
+      },
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    expect(managed).toBe('managed');
+    // exactly ONE probe, of the whole FilterName — the `|` was NOT split into segments
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)[0]!.args[0].input).toMatchObject({
+      PhysicalResourceId: filterName,
+    });
+  });
+
+  // #1310 edge 2: without the positional id, the composite `app-logs|rogue-exfil-filter` fan-out
+  // cross-probes the LOG-GROUP segment `app-logs` as if it were the child's physical id — which
+  // false-MATCHES an unrelated sibling filter literally named `app-logs`, folding a rogue OOB
+  // filter on OUR `app-logs` log group to managed (invisible). With siblingLookupId set to the true
+  // FilterName, only `rogue-exfil-filter` is probed, so the rogue filter correctly surfaces.
+  it('#1310: a rogue filter on a log group named like a sibling filter surfaces via siblingLookupId', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // A sibling stack owns a MetricFilter literally named `app-logs` (coincides with our log group
+    // name); nothing owns `rogue-exfil-filter`.
+    cfn.on(DescribeStackResourcesCommand).callsFake((input) => {
+      if (input.PhysicalResourceId === 'app-logs') {
+        return {
+          StackResources: [
+            {
+              StackName: 'SiblingStack',
+              LogicalResourceId: 'AppLogsMF',
+              PhysicalResourceId: 'app-logs',
+              ResourceType: 'AWS::Logs::MetricFilter',
+              Timestamp: new Date(0),
+              ResourceStatus: 'CREATE_COMPLETE',
+            },
+          ],
+        };
+      }
+      const notFound = new Error(`Stack for ${input.PhysicalResourceId} does not exist`);
+      notFound.name = 'ValidationError';
+      throw notFound;
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      {
+        resourceType: 'AWS::Logs::MetricFilter',
+        identifier: 'app-logs|rogue-exfil-filter', // CC composite LogGroupName|FilterName
+        label: 'rogue-exfil-filter',
+        live: {},
+        siblingLookupId: 'rogue-exfil-filter', // enumerator carries the true physical id
+      },
+      new Map(),
+      LOCAL_ACCOUNT,
+      LOCAL_REGION
+    );
+    // the exact FilterName is probed, NOT the coincidental log-group segment -> genuinely added
+    expect(managed).toBe('notManaged');
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)[0]!.args[0].input).toMatchObject({
+      PhysicalResourceId: 'rogue-exfil-filter',
+    });
+  });
+
   it('memoizes the resolution per physical id (one API call for a repeated child)', async () => {
     const cfn = mockClient(CloudFormationClient);
     cfn.on(DescribeStackResourcesCommand).resolves({
@@ -1565,7 +1724,8 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
       LOCAL_REGION
     );
     expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
-    expect(cache.get(subArn)).toBe('managed');
+    // #1310: the memo is keyed by `${resourceType}|${physicalId}`, not the physical id alone.
+    expect(cache.get(`AWS::SNS::Subscription|${subArn}`)).toBe('managed');
   });
 
   it('#754: a THROTTLE/denied error returns unverified and is NOT memoized', async () => {
@@ -1584,7 +1744,7 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     // a failed check is 'unverified' (the caller reports coverage-incomplete, never a false added)
     expect(first).toBe('unverified');
     // NOT cached -> a later candidate re-attempts (a transient throttle must not poison the run)
-    expect(cache.has(subArn)).toBe(false);
+    expect(cache.has(`AWS::SNS::Subscription|${subArn}`)).toBe(false);
     const second = await isManagedBySiblingStack(
       cfn as unknown as CloudFormationClient,
       child(subArn),
@@ -1712,7 +1872,7 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     // fail safe: unverifiable, so NOT a destructive-deletable `added`
     expect(managed).toBe('unverified');
     // and NOT memoized as notManaged (uniform with the other unverifiable cases)
-    expect(cache.has(foreignAccountArn)).toBe(false);
+    expect(cache.has(`AWS::SNS::Subscription|${foreignAccountArn}`)).toBe(false);
   });
 
   it('#959: a CROSS-REGION-managed subscription (ValidationError, foreign region ARN) is UNVERIFIED, not added', async () => {
@@ -1748,7 +1908,7 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     );
     // a real local out-of-band addition is verifiable and MUST still surface (and be cached)
     expect(managed).toBe('notManaged');
-    expect(cache.get(subArn)).toBe('notManaged');
+    expect(cache.get(`AWS::SNS::Subscription|${subArn}`)).toBe('notManaged');
   });
 
   describe('isDefinitiveNotManaged (#959 foreign-scope classifier)', () => {


### PR DESCRIPTION
Closes #1310

## Problem
#1231's sibling-stack segment probing (fix for #800) was position/type-blind, opening three edges — all reproduced offline against `isManagedBySiblingStack` with a mocked CloudFormation client:

1. **FP** — a `|` inside a segment value. The Logs `FilterName` charset is `[^:*]*`, so `|` is legal (`error|filter`). Splitting the composite `shared-lg|error|filter` never probes the true id → false `added` + destructive DeleteResource.
2. **FN** — cross-segment id coincidence: probing the parent `LogGroupName` segment false-matches an unrelated sibling of the child's type → a rogue OOB filter folds to `managed`.
3. **FN** — type-blind memo cache: `probeSiblingPhysicalId` cached per physical id only, but `owns()` is type-gated, so a MetricFilter's `managed` answer replayed for a same-named SubscriptionFilter.

## Fix
- Key the probe cache by `${resourceType}|${physicalId}` (edge 3).
- The Logs `FilterName` IS the CFn physical id and is known positionally in the enumerator — carry it on `siblingLookupId` so the probe uses the exact id and skips the `|`-segment fan-out (edges 1 & 2). Segment fan-out stays only as the fallback for composites with no positional id.

## Tests
New unit tests against `isManagedBySiblingStack` (mocked CFn) for each edge, each failing without the fix and passing with it; existing cache-key and enumerator assertions updated.

Offline/deterministic.