### PR TITLE
fix(revert): route EB Application ResourceLifecycleConfig through UpdateApplicationResourceLifecycle (#1295)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,8 +1046,10 @@ place, since Cloud Control has no handler for the type),
 `ecs:UpdateService` (reverts an `AWS::ECS::Service` `ServiceConnectConfiguration` /
 `VolumeConfigurations` drift — the whole writeOnly prop is re-supplied, since Cloud
 Control cannot sub-path patch it),
-`elasticbeanstalk:UpdateApplication` / `elasticbeanstalk:UpdateEnvironment`
-(revert an `AWS::ElasticBeanstalk::Application` / `Environment`),
+`elasticbeanstalk:UpdateApplication` / `elasticbeanstalk:UpdateEnvironment` /
+`elasticbeanstalk:UpdateApplicationResourceLifecycle` (revert an
+`AWS::ElasticBeanstalk::Application` — including its `ResourceLifecycleConfig` — or
+`Environment`),
 `codebuild:UpdateReportGroup` (reverts an `AWS::CodeBuild::ReportGroup`),
 `dax:UpdateCluster` / `dax:UpdateParameterGroup` (revert an `AWS::DAX::Cluster` /
 `ParameterGroup`),

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -73,6 +73,7 @@ import {
 import {
   ElasticBeanstalkClient,
   UpdateApplicationCommand,
+  UpdateApplicationResourceLifecycleCommand,
   UpdateEnvironmentCommand,
 } from '@aws-sdk/client-elastic-beanstalk';
 import {
@@ -2370,31 +2371,70 @@ const writeLexBotLocales: SdkWriter = async (ctx, ops) => {
 // The revertable declared surface is thin: ApplicationName / EnvironmentName are create-only
 // identities, the Environment's Tier is create-only, and its OptionSettings is write-only
 // (read gap) — so a DECLARED drift only ever lands on Description. ResourceLifecycleConfig
-// (Application) needs a separate UpdateApplicationResourceLifecycle call and is left to CC
-// (it folds atDefault when undeclared, so a declared drift on it is rare); a future writer
-// can extend the allowlist.
+// (Application) needs a separate UpdateApplicationResourceLifecycle call (below).
 const EB_APPLICATION_MODIFY_PARAMS = new Set(['Description']);
+// #1295 — AWS::ElasticBeanstalk::Application.ResourceLifecycleConfig is mutable out of band
+// (`aws elasticbeanstalk update-application-resource-lifecycle` — e.g. enabling a MaxCountRule
+// that auto-deletes application versions) and folds atDefault when undeclared. An OOB change
+// therefore surfaces as drift whose revert op lands on this writer, but UpdateApplication cannot
+// set ResourceLifecycleConfig, so before this fix the op hit the #804 assertOpsConsumed
+// honest-fail ("update it manually") and the drift could never converge in-tool. Route it
+// through its OWN UpdateApplicationResourceLifecycle call. The revert-to-default value (for a
+// `remove` on an undeclared, at-default finding) mirrors the KNOWN_DEFAULTS service default in
+// src/normalize/noise.ts — kept as a local constant here so this writer stays self-contained:
+// a version-lifecycle policy carrying both rules present but DISABLED (so no ServiceRole is
+// required). A declared drift writes the declared intent instead.
+const EB_APPLICATION_DEFAULT_RESOURCE_LIFECYCLE: Record<string, unknown> = {
+  VersionLifecycleConfig: {
+    MaxCountRule: { DeleteSourceFromS3: false, Enabled: false, MaxCount: 200 },
+    MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+  },
+};
+const asObject = (v: unknown): Record<string, unknown> | undefined =>
+  v !== null && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
 const writeElasticBeanstalkApplication: SdkWriter = async (ctx, ops) => {
   const name = str(ctx.physicalId) ?? str(ctx.declared['ApplicationName']);
   if (!name) throw new Error('cannot resolve Elastic Beanstalk ApplicationName for revert');
+  const client = new ElasticBeanstalkClient({ region: ctx.region, ...CLIENT_TIMEOUTS });
   const input: { ApplicationName: string; Description?: string } = { ApplicationName: name };
   let any = false;
+  let lifecycle: Record<string, unknown> | undefined;
   for (const op of ops) {
     const top = op.path.replace(/^\//, '').split('/')[0];
     if (top && EB_APPLICATION_MODIFY_PARAMS.has(top)) {
       // add -> declared value; remove -> clear (empty string, which EB reads as unset)
       input[top as 'Description'] = op.op === 'remove' ? '' : (str(ctx.declared[top]) ?? '');
       any = true;
+    } else if (top === 'ResourceLifecycleConfig') {
+      // remove -> the at-default service default (undeclared finding reverting to default);
+      // add/replace -> the declared intent (whole object), falling back to the op's carried
+      // value then the default. The declared object is preferred over op.value so a NESTED
+      // op path still writes the complete, coherent config rather than a leaf fragment.
+      lifecycle =
+        op.op === 'remove'
+          ? EB_APPLICATION_DEFAULT_RESOURCE_LIFECYCLE
+          : (asObject(ctx.declared['ResourceLifecycleConfig']) ??
+            asObject(op.value) ??
+            EB_APPLICATION_DEFAULT_RESOURCE_LIFECYCLE);
     }
   }
-  if (any)
-    await new ElasticBeanstalkClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
-      new UpdateApplicationCommand(input)
+  if (any) await client.send(new UpdateApplicationCommand(input));
+  if (lifecycle !== undefined)
+    await client.send(
+      new UpdateApplicationResourceLifecycleCommand({
+        ApplicationName: name,
+        ResourceLifecycleConfig: lifecycle,
+      })
     );
-  // #804 — ResourceLifecycleConfig (needs a separate UpdateApplicationResourceLifecycle call)
-  // and any other prop outside EB_APPLICATION_MODIFY_PARAMS are NOT applied here; report them
-  // not-reverted instead of silently succeeding.
-  assertOpsConsumed('ElasticBeanstalk Application', ops, EB_APPLICATION_MODIFY_PARAMS);
+  // Any other prop outside the handled set (Description + ResourceLifecycleConfig) is NOT
+  // applied here; report it not-reverted (#804) instead of silently succeeding.
+  assertOpsConsumed(
+    'ElasticBeanstalk Application',
+    ops,
+    new Set([...EB_APPLICATION_MODIFY_PARAMS, 'ResourceLifecycleConfig'])
+  );
 };
 
 const EB_ENVIRONMENT_MODIFY_PARAMS = new Set(['Description']);

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -72,6 +72,7 @@ import {
 import {
   ElasticBeanstalkClient,
   UpdateApplicationCommand,
+  UpdateApplicationResourceLifecycleCommand,
   UpdateEnvironmentCommand,
 } from '@aws-sdk/client-elastic-beanstalk';
 import {
@@ -1712,6 +1713,119 @@ describe('ElasticBeanstalk Application/Environment writers (CC UpdateResource Se
       SDK_WRITERS['AWS::ElasticBeanstalk::Application'](ctx({ physicalId: '', declared: {} }), [
         descOp('x'),
       ])
+    ).rejects.toThrow(/ApplicationName/);
+  });
+
+  // #1295 — ResourceLifecycleConfig is mutable out of band and folds atDefault when undeclared.
+  // Its revert op used to hit the #804 assertOpsConsumed honest-fail (UpdateApplication cannot
+  // set it); it now routes through UpdateApplicationResourceLifecycle and converges.
+  const DEFAULT_RLC = {
+    VersionLifecycleConfig: {
+      MaxCountRule: { DeleteSourceFromS3: false, Enabled: false, MaxCount: 200 },
+      MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+    },
+  };
+  const enabledRLC = {
+    VersionLifecycleConfig: {
+      MaxCountRule: { DeleteSourceFromS3: true, Enabled: true, MaxCount: 5 },
+    },
+  };
+
+  it('reverts an undeclared, at-default ResourceLifecycleConfig (remove op) to the service default via UpdateApplicationResourceLifecycle', async () => {
+    eb.on(UpdateApplicationResourceLifecycleCommand).resolves({});
+    // The undeclared prop folded atDefault, drifted out of band, and the revert plan emits a
+    // `remove` (desired = absent/default). The writer must NOT honest-fail; it writes the default.
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+      ctx({ physicalId: 'my-app', declared: { ApplicationName: 'my-app' } }),
+      [
+        {
+          op: 'remove',
+          path: '/ResourceLifecycleConfig',
+          human: 'ResourceLifecycleConfig -> default',
+        },
+      ]
+    );
+    const calls = eb.commandCalls(UpdateApplicationResourceLifecycleCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({
+      ApplicationName: 'my-app',
+      ResourceLifecycleConfig: DEFAULT_RLC,
+    });
+    // no UpdateApplication (Description) call was sent for a pure lifecycle revert
+    expect(eb.commandCalls(UpdateApplicationCommand)).toHaveLength(0);
+  });
+
+  it('reverts a DECLARED ResourceLifecycleConfig drift (add op) to the declared intent', async () => {
+    eb.on(UpdateApplicationResourceLifecycleCommand).resolves({});
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+      ctx({
+        physicalId: 'my-app',
+        declared: { ApplicationName: 'my-app', ResourceLifecycleConfig: enabledRLC },
+      }),
+      [{ op: 'add', path: '/ResourceLifecycleConfig', value: enabledRLC, human: 'x' }]
+    );
+    expect(eb.commandCalls(UpdateApplicationResourceLifecycleCommand)[0]!.args[0].input).toEqual({
+      ApplicationName: 'my-app',
+      ResourceLifecycleConfig: enabledRLC,
+    });
+  });
+
+  it('a nested-path add op still writes the WHOLE declared ResourceLifecycleConfig (not a leaf fragment)', async () => {
+    eb.on(UpdateApplicationResourceLifecycleCommand).resolves({});
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+      ctx({
+        physicalId: 'my-app',
+        declared: { ApplicationName: 'my-app', ResourceLifecycleConfig: enabledRLC },
+      }),
+      [
+        {
+          op: 'add',
+          path: '/ResourceLifecycleConfig/VersionLifecycleConfig/MaxCountRule/Enabled',
+          value: true,
+          human: 'x',
+        },
+      ]
+    );
+    expect(eb.commandCalls(UpdateApplicationResourceLifecycleCommand)[0]!.args[0].input).toEqual({
+      ApplicationName: 'my-app',
+      ResourceLifecycleConfig: enabledRLC,
+    });
+  });
+
+  it('applies Description AND ResourceLifecycleConfig in one op set (two distinct commands)', async () => {
+    eb.on(UpdateApplicationCommand).resolves({});
+    eb.on(UpdateApplicationResourceLifecycleCommand).resolves({});
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+      ctx({
+        physicalId: 'my-app',
+        declared: { ApplicationName: 'my-app', Description: 'declared' },
+      }),
+      [
+        descOp('declared'),
+        {
+          op: 'remove',
+          path: '/ResourceLifecycleConfig',
+          human: 'ResourceLifecycleConfig -> default',
+        },
+      ]
+    );
+    expect(eb.commandCalls(UpdateApplicationCommand)[0]!.args[0].input).toEqual({
+      ApplicationName: 'my-app',
+      Description: 'declared',
+    });
+    expect(eb.commandCalls(UpdateApplicationResourceLifecycleCommand)[0]!.args[0].input).toEqual({
+      ApplicationName: 'my-app',
+      ResourceLifecycleConfig: DEFAULT_RLC,
+    });
+  });
+
+  it('still reports a truly off-allowlist prop (not Description/ResourceLifecycleConfig) not-reverted (#804)', async () => {
+    eb.on(UpdateApplicationResourceLifecycleCommand).resolves({});
+    await expect(
+      SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+        ctx({ physicalId: 'my-app', declared: { ApplicationName: 'my-app' } }),
+        [{ op: 'add', path: '/ApplicationName', value: 'renamed', human: 'x' }]
+      )
     ).rejects.toThrow(/ApplicationName/);
   });
 });


### PR DESCRIPTION
Closes #1295

## Problem

`AWS::ElasticBeanstalk::Application.ResourceLifecycleConfig` is mutable out of band (`aws elasticbeanstalk update-application-resource-lifecycle` — e.g. enabling a `MaxCountRule` that auto-deletes application versions) and folds `atDefault` when undeclared (`KNOWN_DEFAULTS`). An out-of-band change therefore surfaces as drift whose revert op reaches `writeElasticBeanstalkApplication` — but that writer only modelled `Description` (`EB_APPLICATION_MODIFY_PARAMS`), and `UpdateApplication` cannot set `ResourceLifecycleConfig`. So the op hit the #804 `assertOpsConsumed` honest-fail ("update it manually") and the drift could **never converge in-tool**.

## Fix

Consume the `ResourceLifecycleConfig` op via a **separate `UpdateApplicationResourceLifecycle` call**:
- `remove` (an undeclared, at-default finding reverting to default) → writes the service default (both lifecycle rules present but disabled, so no `ServiceRole` is required).
- `add`/`replace` (a declared drift) → writes the declared intent as the **whole object**, so even a nested-path op writes a coherent config rather than a leaf fragment.

The revert-to-default value is a **local constant** mirroring the `KNOWN_DEFAULTS` service default in `src/normalize/noise.ts`, keeping the writer self-contained — this lane does **not** touch the peer-contended `src/revert/plan.ts` or `src/normalize/noise.ts`. `assertOpsConsumed` now treats `ResourceLifecycleConfig` as handled, while any other off-allowlist prop still reports not-reverted (#804 preserved).

## Scope
- `src/revert/writers.ts` — the writer branch + local default.
- `tests/writers.test.ts` — 5 new tests (remove→default, declared add→intent, nested-path→whole object, Description+lifecycle together, off-allowlist still #804).
- `README.md` — new `elasticbeanstalk:UpdateApplicationResourceLifecycle` revert IAM perm.

## Tests
`vp run typecheck` ✓ · `vp check` 0 errors ✓ · `vp pack` ✓ · `vp test run` 219 files / 4892 tests ✓
