### PR TITLE
fix(diff): escalate RedshiftServerless Workgroup + TransitGateway value-independent folds to detection-preserving gates (#1269, #1280)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -6,7 +6,11 @@ import {
   DescribeStackResourcesCommand,
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
-import { DescribeSecurityGroupsCommand, EC2Client } from '@aws-sdk/client-ec2';
+import {
+  DescribeSecurityGroupsCommand,
+  DescribeSubnetsCommand,
+  EC2Client,
+} from '@aws-sdk/client-ec2';
 import { DescribeOptionGroupOptionsCommand, RDSClient } from '@aws-sdk/client-rds';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
@@ -57,6 +61,16 @@ const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // #1266: AmazonMQ Broker's undeclared SecurityGroups default is the VPC default SG — same gate,
   // so the prefetch must fire when a broker is present too.
   'AWS::AmazonMQ::Broker',
+  // #1269: RedshiftServerless Workgroup's undeclared SecurityGroupIds default is the default-VPC SG
+  // — same gate, so the prefetch must fire when a workgroup is present too.
+  'AWS::RedshiftServerless::Workgroup',
+]);
+
+// #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —
+// gated in classify against the prefetched default-VPC subnet ids so an OOB re-placement into a
+// non-default subnet surfaces. Distinct from DEFAULT_SG_LIST_TYPES (that is a single-SG gate).
+const DEFAULT_SUBNET_LIST_TYPES: ReadonlySet<string> = new Set([
+  'AWS::RedshiftServerless::Workgroup',
 ]);
 
 // #889: fetch the account/region VPC-default security-group ids — one `DescribeSecurityGroups`
@@ -90,6 +104,39 @@ async function fetchDefaultSgIds(region: string): Promise<Set<string>> {
     return ids;
   }
   defaultSgIdsCache.set(region, ids);
+  return ids;
+}
+
+// #1269: fetch the account/region DEFAULT-VPC subnet ids — one `DescribeSubnets` filtered by
+// `default-for-az=true` returns exactly the default VPC's subnets (one per AZ; a default VPC's
+// subnets ARE its default-for-az subnets). Mirrors fetchDefaultSgIds: cached per region, FAIL OPEN
+// (empty set on ANY error — missing ec2:DescribeSubnets, throttle, network) so classify keeps
+// folding the undeclared subnet list and a clean deploy never gains a first-run false positive.
+const defaultSubnetIdsCache = new Map<string, Set<string>>();
+async function fetchDefaultVpcSubnetIds(region: string): Promise<Set<string>> {
+  const cached = defaultSubnetIdsCache.get(region);
+  if (cached) return cached;
+  const ids = new Set<string>();
+  try {
+    const c = new EC2Client({ region, ...READ_RETRY });
+    let token: string | undefined;
+    do {
+      const r = await c.send(
+        new DescribeSubnetsCommand({
+          Filters: [{ Name: 'default-for-az', Values: ['true'] }],
+          NextToken: token,
+          MaxResults: 1000,
+        })
+      );
+      for (const s of r.Subnets ?? []) if (s.SubnetId) ids.add(s.SubnetId);
+      token = r.NextToken;
+    } while (token);
+  } catch {
+    // Fail open: leave the set empty so classify keeps folding (no new first-run false positive).
+    // Not cached on error, so the next stack in the region retries (mirrors the transient path).
+    return ids;
+  }
+  defaultSubnetIdsCache.set(region, ids);
   return ids;
 }
 
@@ -1270,12 +1317,20 @@ export async function gatherFindings(
   if (desired.resources.some((r) => DEFAULT_SG_LIST_TYPES.has(r.resourceType))) {
     defaultSgIds = await fetchDefaultSgIds(region);
   }
+  // #1269: prefetch the default-VPC subnet ids when the stack declares a RedshiftServerless
+  // Workgroup, so classify can DERIVE-gate the undeclared SubnetIds fold (fold when every live
+  // subnet is a default-VPC subnet, surface an OOB re-placement). Fail open, same as the SG prefetch.
+  let defaultSubnetIds: ReadonlySet<string> = new Set();
+  if (desired.resources.some((r) => DEFAULT_SUBNET_LIST_TYPES.has(r.resourceType))) {
+    defaultSubnetIds = await fetchDefaultVpcSubnetIds(region);
+  }
   const classifyOpts = {
     accountId: desired.accountId,
     region,
     kmsAliasTargets,
     stackTags: desired.stackTags ?? {},
     defaultSgIds,
+    defaultSubnetIds,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),
@@ -1375,12 +1430,18 @@ export async function regatherTouched(
   if (targets.some((r) => DEFAULT_SG_LIST_TYPES.has(r.resourceType))) {
     defaultSgIds = await fetchDefaultSgIds(region);
   }
+  // #1269: mirror the default-VPC subnet prefetch on the regather (revert re-check) path too.
+  let defaultSubnetIds: ReadonlySet<string> = new Set();
+  if (targets.some((r) => DEFAULT_SUBNET_LIST_TYPES.has(r.resourceType))) {
+    defaultSubnetIds = await fetchDefaultVpcSubnetIds(region);
+  }
   const classifyOpts = {
     accountId: desired.accountId,
     region,
     kmsAliasTargets,
     stackTags: desired.stackTags ?? {},
     defaultSgIds,
+    defaultSubnetIds,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -237,6 +237,36 @@ const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // unlike SubnetIds), so a value-independent fold would hide a rogue SG swap/append. Gate it
   // through the same derived VPC-default-SG check: fold a single default SG, surface an append/swap.
   'AWS::AmazonMQ::Broker': 'SecurityGroups',
+  // #1269: a RedshiftServerless Workgroup that declares no SecurityGroupIds is placed into the
+  // account's default VPC and reads back that VPC's default SG (a single SG, #958-live). It is
+  // OOB-mutable (`redshift-serverless update-workgroup --security-group-ids`; createOnlyProperties
+  // is NamespaceName/WorkgroupName only), so a value-independent fold hid a rogue SG swap/append.
+  // Same derived VPC-default-SG check: fold a single default SG, surface an append/swap.
+  'AWS::RedshiftServerless::Workgroup': 'SecurityGroupIds',
+};
+/** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
+ *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into
+ *  the default VPC reads back ALL of that VPC's subnets, so the clean-deploy list has MANY
+ *  elements — fold when EVERY element is a known default-VPC subnet; surface if ANY subnet is
+ *  outside the default VPC (an out-of-band re-placement, e.g. into a public subnet).
+ *   - `true`  → FOLD (atDefault): every live subnet is a default-VPC subnet, OR the prefetch is
+ *               unavailable (fail OPEN — no ec2:DescribeSubnets / lookup failed / empty).
+ *   - `false` → SURFACE (undeclared): at least one live subnet is NOT a default-VPC subnet.
+ *  Pure; `defaultSubnetIds` is the resolved set of default-VPC subnet ids (undefined/empty when
+ *  unresolved). */
+export function shouldFoldDefaultSubnetList(
+  resourceType: string,
+  key: string,
+  liveValue: unknown,
+  defaultSubnetIds?: ReadonlySet<string>
+): boolean {
+  if (DEFAULT_SUBNET_LIST_PATHS[resourceType] !== key) return false; // not a gated subnet-list path
+  if (!defaultSubnetIds || defaultSubnetIds.size === 0) return true; // fail OPEN (unchanged behavior)
+  if (!Array.isArray(liveValue)) return true;
+  return liveValue.every((s) => typeof s === 'string' && defaultSubnetIds.has(s));
+}
+const DEFAULT_SUBNET_LIST_PATHS: Record<string, string> = {
+  'AWS::RedshiftServerless::Workgroup': 'SubnetIds',
 };
 /** #889 fold decision for an UNDECLARED default-SG list (ALB SecurityGroups / ENI GroupSet).
  *  Returns whether the value-independent fold should still apply for this live value:
@@ -2042,6 +2072,12 @@ export function classifyResource(
     // DERIVED equality gate rather than a value-independent one: a single default SG folds, a
     // 2+-element APPEND or a single non-default SG SWAP surfaces. Undefined/empty → fail open (fold).
     defaultSgIds?: ReadonlySet<string>;
+    // #1269: the account/region DEFAULT-VPC subnet ids, prefetched by gather.ts so the UNDECLARED
+    // default-subnet-list fold (RedshiftServerless Workgroup SubnetIds) is a DERIVED gate: a
+    // workgroup that declares no SubnetIds is placed into the default VPC and reads back all its
+    // subnets, so fold when EVERY live subnet is a default-VPC subnet and surface an OOB
+    // re-placement into a subnet outside it. Undefined/empty → fail open (fold).
+    defaultSubnetIds?: ReadonlySet<string>;
     oaiCanonicalIds?: Record<string, string>; // OAI id -> S3CanonicalUserId, for CloudFront OAI principal match
     // Rules declared by SIBLING standalone AWS::EC2::SecurityGroupIngress/::SecurityGroupEgress
     // resources, keyed by the target SG's resolved GroupId (== the SG's physical id). Subtracted
@@ -3910,6 +3946,47 @@ export function classifyResource(
         tier: shouldFoldDefaultSgList(resourceType, k, v, opts.defaultSgIds)
           ? 'atDefault'
           : 'undeclared',
+        logicalId,
+        resourceType,
+        path: k,
+        actual: v,
+      });
+      continue;
+    }
+    // #1269: an UNDECLARED default-subnet list (RedshiftServerless Workgroup SubnetIds) — replaces
+    // the old value-independent fold, which hid an out-of-band subnet re-placement. Fold atDefault
+    // ONLY when every live subnet is a default-VPC subnet (the clean-deploy placement, or the
+    // prefetch is unavailable → fail open); any subnet outside the default VPC surfaces.
+    if (DEFAULT_SUBNET_LIST_PATHS[resourceType] === k && !isTrivialEmpty(v)) {
+      findings.push({
+        tier: shouldFoldDefaultSubnetList(resourceType, k, v, opts.defaultSubnetIds)
+          ? 'atDefault'
+          : 'undeclared',
+        logicalId,
+        resourceType,
+        path: k,
+        actual: v,
+      });
+      continue;
+    }
+    // #1280: AWS::EC2::TransitGateway Association/PropagationDefaultRouteTableId — at creation both
+    // point at the SAME AWS-minted default route table (equal). Replaces the old value-independent
+    // fold, which hid an out-of-band `modify-transit-gateway --options …DefaultRouteTableId=…` swap.
+    // Fold atDefault UNLESS both ids are present AND differ (a single-field swap re-segments future
+    // attachments and surfaces). A lone id (one of association/propagation disabled) folds fail-safe
+    // — it has no sibling to cross-check. RESIDUAL: a both-fields swap to the same NEW table stays
+    // equal and is not caught offline (needs a live DescribeTransitGatewayRouteTables).
+    if (
+      resourceType === 'AWS::EC2::TransitGateway' &&
+      (k === 'AssociationDefaultRouteTableId' || k === 'PropagationDefaultRouteTableId') &&
+      typeof v === 'string'
+    ) {
+      const assoc = live.AssociationDefaultRouteTableId;
+      const prop = live.PropagationDefaultRouteTableId;
+      const bothPresentAndDiffer =
+        typeof assoc === 'string' && typeof prop === 'string' && assoc !== prop;
+      findings.push({
+        tier: bothPresentAndDiffer ? 'undeclared' : 'atDefault',
         logicalId,
         resourceType,
         path: k,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3337,21 +3337,15 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //       never user intent. First-run FP on every clean dual-stack VPC (#684, live 2026-07-08);
   //       mirrors EIP `NetworkBorderGroup` / `PrivateIpAddress`.
   'AWS::EC2::VPCCidrBlock': new Set(['Ipv6CidrBlock', 'Ipv6CidrBlockNetworkBorderGroup']),
-  //   AWS::EC2::TransitGateway.AssociationDefaultRouteTableId / .PropagationDefaultRouteTableId — a
-  //   TGW that declares `DefaultRouteTableAssociation` / `DefaultRouteTablePropagation: "enable"` (the
-  //   switches, not the ids) reads back the id of the default route table AWS MINTS at creation
-  //   ("tgw-rtb-…", the same id in both fields). It is a per-resource AWS-assigned identifier — never a
-  //   constant we can pin, and effectively read-only (the default route table is created with the TGW
-  //   and cannot be swapped out of band without replacing the TGW), so a value-independent fold can
-  //   never hide a real change. The registry schema's readOnly list omits these two ids (only
-  //   EncryptionSupportState / Id / TransitGatewayArn are marked), so schema-strip never drops them.
-  //   Undeclared → whatever id AWS minted is not user intent; a real change to the association/
-  //   propagation POLICY surfaces on the declared `DefaultRouteTableAssociation` / `…Propagation`
-  //   switches in the declared loop. Corpus baked FP (#976).
-  'AWS::EC2::TransitGateway': new Set([
-    'AssociationDefaultRouteTableId',
-    'PropagationDefaultRouteTableId',
-  ]),
+  //   NOTE: AWS::EC2::TransitGateway.AssociationDefaultRouteTableId / .PropagationDefaultRouteTableId
+  //   were ALSO here (#976), justified as "effectively read-only, cannot be swapped out of band". That
+  //   premise is FALSE (#1280): `modify-transit-gateway --options AssociationDefaultRouteTableId=…,
+  //   PropagationDefaultRouteTableId=…` swaps them at will, silently re-segmenting which route table
+  //   every NEW attachment associates/propagates with. A value-independent fold hid that. They are now
+  //   CROSS-FIELD gated in classify: at creation both ids point at the SAME AWS-minted default route
+  //   table, so fold while they are equal and surface a single-field OOB swap (they then differ). The
+  //   registry schema's readOnly list omits these two ids (only EncryptionSupportState / Id /
+  //   TransitGatewayArn are marked), so schema-strip never drops them. Corpus baked FP (#976).
   //   AWS::Grafana::Workspace.GrafanaVersion — a workspace that pins no explicit version reads
   //   back the concrete Grafana version AWS provisioned ("10.4" today). AWS assigns the current
   //   GA default at creation, and that default moves over time (a fresh deploy next year reads a
@@ -3405,13 +3399,14 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   folded as an equality-gated tier-1 KNOWN_DEFAULTS entry instead — a real out-of-band EndTime
   //   timestamp then surfaces rather than folding to any value (#946). Live, hunt 2026-07-09 (#847).
   'AWS::AutoScaling::ScheduledAction': new Set(['StartTime']),
-  //   AWS::RedshiftServerless::Workgroup.SecurityGroupIds / .SubnetIds — a workgroup that
-  //   declares neither is placed by the service into the account's DEFAULT VPC: it reads back
-  //   the default VPC's default security group (["sg-…"]) and ALL of that VPC's subnets
-  //   (["subnet-…", …]). These are per-account AWS-assigned ids, not constants and not
-  //   derivable from the workgroup's own declared inputs. Undeclared → whatever placement AWS
-  //   chose is its default, never user intent; a user who cares about network placement
-  //   DECLARES SecurityGroupIds/SubnetIds, which is then compared in the declared loop.
+  //   NOTE: AWS::RedshiftServerless::Workgroup.SecurityGroupIds / .SubnetIds were ALSO here (#958),
+  //   for the default-VPC placement echo (default SG ["sg-…"] + ALL default-VPC subnets). But both
+  //   are MUTABLE out of band (`redshift-serverless update-workgroup --security-group-ids /
+  //   --subnet-ids`; createOnlyProperties is NamespaceName/WorkgroupName only), so a value-independent
+  //   fold hid an OOB SG swap/append or a subnet re-placement into a public subnet (#1269). They are
+  //   now DERIVE-gated in classify: SecurityGroupIds via the #889/#976 default-SG gate (single default
+  //   SG folds); SubnetIds via a default-VPC-subnet gate (fold only when EVERY live subnet is a
+  //   default-VPC subnet, surface any subnet outside it). Both fail open when the prefetch is absent.
   //   AWS::RedshiftServerless::Workgroup.ConfigParameters — a workgroup that declares no
   //   ConfigParameters reads back AWS's full default effective-parameter set
   //   ([{ParameterKey:"auto_mv",ParameterValue:"true"},{ParameterKey:"datestyle",…}, …]). The
@@ -3423,11 +3418,7 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   value-independent: undeclared, so the whole AWS default parameter set is its choice, not
   //   user intent (a user who pins a parameter DECLARES ConfigParameters, compared in the
   //   declared loop). Live-confirmed on a fresh minimal workgroup (2026-07-09, us-east-1; #958).
-  'AWS::RedshiftServerless::Workgroup': new Set([
-    'ConfigParameters',
-    'SecurityGroupIds',
-    'SubnetIds',
-  ]),
+  'AWS::RedshiftServerless::Workgroup': new Set(['ConfigParameters']),
   //   AWS::CloudFormation::Stack (the parent-side resource of every CDK `NestedStack`) is
   //   CC-read and returns the child stack's FULL live model, but the template's Stack resource
   //   declares only `TemplateURL` (an S3 asset URL) + `Parameters` + `Tags` — so three live

--- a/tests/visg-rs-tgw-1269-1280.test.ts
+++ b/tests/visg-rs-tgw-1269-1280.test.ts
@@ -1,0 +1,167 @@
+// Three more value-independent folds ESCALATED to detection-preserving gates:
+//   #1269 — RedshiftServerless Workgroup SecurityGroupIds / SubnetIds (default-VPC placement echo,
+//     #958) were value-independent but BOTH are OOB-mutable (`update-workgroup`). SecurityGroupIds
+//     now goes through the #889/#976 single-default-SG gate; SubnetIds through a new default-VPC
+//     subnet gate (fold only when EVERY live subnet is a default-VPC subnet). ConfigParameters stays
+//     value-independent (#1272, needs a live per-element default).
+//   #1280 — TransitGateway Association/PropagationDefaultRouteTableId were value-independent on a
+//     FALSE create-only premise (`modify-transit-gateway --options` swaps them). Now cross-field
+//     gated: at creation both point at the same AWS-minted default RT, so fold while equal and
+//     surface a single-field OOB swap.
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  classifyResource,
+  shouldFoldDefaultSgList,
+  shouldFoldDefaultSubnetList,
+} from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+// ---- #1269 RedshiftServerless Workgroup SecurityGroupIds (SG gate) --------------------------
+const DEFAULT_SG = 'sg-0defau1t00000000';
+const ROGUE_SG = 'sg-0rogue00000000000';
+const defaultSgIds = new Set([DEFAULT_SG]);
+
+describe('#1269 RedshiftServerless::Workgroup.SecurityGroupIds derived VPC-default-SG gate', () => {
+  const res = mk('AWS::RedshiftServerless::Workgroup', { WorkgroupName: 'w', NamespaceName: 'n' });
+  const key = 'SecurityGroupIds';
+
+  it('folds a single VPC-default SG (clean deploy); surfaces append + swap; fails open', () => {
+    expect(
+      tier(
+        classifyResource(res, { [key]: [DEFAULT_SG] }, emptySchema, { defaultSgIds }),
+        'atDefault'
+      )
+    ).toContain(key);
+    expect(
+      tier(
+        classifyResource(res, { [key]: [DEFAULT_SG, ROGUE_SG] }, emptySchema, { defaultSgIds }),
+        'undeclared'
+      )
+    ).toContain(key);
+    expect(
+      tier(
+        classifyResource(res, { [key]: [ROGUE_SG] }, emptySchema, { defaultSgIds }),
+        'undeclared'
+      )
+    ).toContain(key);
+    // fail open: no prefetch → fold (no first-run FP)
+    expect(
+      tier(classifyResource(res, { [key]: [ROGUE_SG] }, emptySchema, {}), 'atDefault')
+    ).toContain(key);
+  });
+
+  it('pure decision covers the workgroup SG path', () => {
+    const t = 'AWS::RedshiftServerless::Workgroup';
+    expect(shouldFoldDefaultSgList(t, key, [DEFAULT_SG], defaultSgIds)).toBe(true);
+    expect(shouldFoldDefaultSgList(t, key, [ROGUE_SG], defaultSgIds)).toBe(false);
+    expect(shouldFoldDefaultSgList(t, key, [ROGUE_SG], undefined)).toBe(true);
+  });
+});
+
+// ---- #1269 RedshiftServerless Workgroup SubnetIds (default-VPC subnet gate) -----------------
+const SUB_A = 'subnet-0defaulta0000';
+const SUB_B = 'subnet-0defaultb0000';
+const SUB_PUBLIC = 'subnet-0attackerpub0'; // an OOB re-placement, outside the default VPC
+const defaultSubnetIds = new Set([SUB_A, SUB_B]);
+
+describe('#1269 RedshiftServerless::Workgroup.SubnetIds default-VPC-subnet gate', () => {
+  const res = mk('AWS::RedshiftServerless::Workgroup', { WorkgroupName: 'w', NamespaceName: 'n' });
+  const key = 'SubnetIds';
+
+  it('(a) folds ALL default-VPC subnets (clean deploy — every subnet is default-VPC)', () => {
+    const f = classifyResource(res, { [key]: [SUB_A, SUB_B] }, emptySchema, { defaultSubnetIds });
+    expect(tier(f, 'atDefault')).toContain(key);
+    expect(tier(f, 'undeclared')).not.toContain(key);
+  });
+
+  it('(b) SURFACES an OOB re-placement into a non-default subnet (public subnet)', () => {
+    const f = classifyResource(res, { [key]: [SUB_A, SUB_PUBLIC] }, emptySchema, {
+      defaultSubnetIds,
+    });
+    expect(tier(f, 'undeclared')).toContain(key);
+    expect(tier(f, 'atDefault')).not.toContain(key);
+  });
+
+  it('(c) FOLDS on lookup failure (defaultSubnetIds absent → fail open, no first-run FP)', () => {
+    const f = classifyResource(res, { [key]: [SUB_PUBLIC] }, emptySchema, {});
+    expect(tier(f, 'atDefault')).toContain(key);
+    expect(tier(f, 'undeclared')).not.toContain(key);
+  });
+
+  it('pure decision: shouldFoldDefaultSubnetList folds all-default, surfaces a stray, fails open', () => {
+    const t = 'AWS::RedshiftServerless::Workgroup';
+    expect(shouldFoldDefaultSubnetList(t, key, [SUB_A, SUB_B], defaultSubnetIds)).toBe(true);
+    expect(shouldFoldDefaultSubnetList(t, key, [SUB_A, SUB_PUBLIC], defaultSubnetIds)).toBe(false);
+    expect(shouldFoldDefaultSubnetList(t, key, [SUB_PUBLIC], undefined)).toBe(true);
+    expect(shouldFoldDefaultSubnetList(t, key, [SUB_PUBLIC], new Set())).toBe(true);
+    // a non-gated key is not this gate's business
+    expect(shouldFoldDefaultSubnetList(t, 'SecurityGroupIds', [SUB_A], defaultSubnetIds)).toBe(
+      false
+    );
+  });
+});
+
+// ---- #1280 TransitGateway Association/PropagationDefaultRouteTableId cross-field gate --------
+describe('#1280 TransitGateway default-route-table-id cross-field equality gate', () => {
+  const res = mk('AWS::EC2::TransitGateway', { DefaultRouteTableAssociation: 'enable' });
+  const RT_DEFAULT = 'tgw-rtb-0default00000';
+  const RT_ROGUE = 'tgw-rtb-0rogue0000000';
+
+  it('(a) folds both ids when EQUAL (clean creation — both point at the minted default RT)', () => {
+    const f = classifyResource(
+      res,
+      { AssociationDefaultRouteTableId: RT_DEFAULT, PropagationDefaultRouteTableId: RT_DEFAULT },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['AssociationDefaultRouteTableId', 'PropagationDefaultRouteTableId'])
+    );
+    expect(tier(f, 'undeclared')).not.toContain('AssociationDefaultRouteTableId');
+  });
+
+  it('(b) SURFACES both ids when they DIFFER (single-field OOB swap re-segments attachments)', () => {
+    const f = classifyResource(
+      res,
+      { AssociationDefaultRouteTableId: RT_ROGUE, PropagationDefaultRouteTableId: RT_DEFAULT },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'undeclared')).toEqual(
+      expect.arrayContaining(['AssociationDefaultRouteTableId', 'PropagationDefaultRouteTableId'])
+    );
+  });
+
+  it('(c) folds a LONE id fail-safe (one of association/propagation disabled → no sibling to cross-check)', () => {
+    const f = classifyResource(
+      res,
+      { AssociationDefaultRouteTableId: RT_DEFAULT },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'atDefault')).toContain('AssociationDefaultRouteTableId');
+    expect(tier(f, 'undeclared')).not.toContain('AssociationDefaultRouteTableId');
+  });
+});


### PR DESCRIPTION
## What

Three more `value-independent` (tier-3) folds LOSE change detection on **OOB-mutable, security-relevant network properties**. Each is escalated to a derived gate that still folds the clean-deploy default but surfaces an out-of-band change. All gates **fail open** (fold) when the prefetch is unavailable, so a clean deploy never gains a first-run false positive.

### #1269 — `AWS::RedshiftServerless::Workgroup.SecurityGroupIds`
A workgroup that declares no SGs is placed into the default VPC and reads back its default SG (`createOnlyProperties` is `NamespaceName`/`WorkgroupName` only → mutable via `update-workgroup --security-group-ids`). Routed through the existing #889/#976 VPC-default-SG gate: a single default SG folds, an append/swap surfaces. Added to `DEFAULT_SG_LIST_PATHS` + the `gather.ts` prefetch trigger.

### #1269 — `AWS::RedshiftServerless::Workgroup.SubnetIds`
A workgroup that declares no subnets is placed into the default VPC and reads back **ALL** of its subnets (#958 live-confirmed). New default-VPC-subnet gate (`shouldFoldDefaultSubnetList` + `fetchDefaultVpcSubnetIds`, one `DescribeSubnets` filtered `default-for-az=true`): fold only when **every** live subnet is a default-VPC subnet; surface an OOB re-placement into a non-default (e.g. public) subnet. `ConfigParameters` stays value-independent (#1272 — needs a live per-element default set).

### #1280 — `AWS::EC2::TransitGateway.Association/PropagationDefaultRouteTableId`
Folded value-independent on a FALSE create-only premise; `modify-transit-gateway --options …DefaultRouteTableId=…` swaps them, silently re-segmenting which route table every NEW attachment associates/propagates with. At creation both ids point at the **same** AWS-minted default RT, so they are now **cross-field gated**: fold while equal, surface a single-field OOB swap (they then differ). A lone id (association or propagation disabled) folds fail-safe. **RESIDUAL**: a both-fields swap to the same NEW table stays equal and is not caught offline (needs a live `DescribeTransitGatewayRouteTables`; documented).

## Files
- `src/diff/classify.ts` — RS Workgroup `SecurityGroupIds` → `DEFAULT_SG_LIST_PATHS`; new `DEFAULT_SUBNET_LIST_PATHS` + `shouldFoldDefaultSubnetList` + subnet gate call site; TGW cross-field gate call site; `defaultSubnetIds` opt.
- `src/commands/gather.ts` — RS Workgroup in `DEFAULT_SG_LIST_TYPES`; new `DEFAULT_SUBNET_LIST_TYPES` + `fetchDefaultVpcSubnetIds` prefetch; wire `defaultSubnetIds` into both classifyOpts sites.
- `src/normalize/noise.ts` — drop `SecurityGroupIds`/`SubnetIds` from the RS Workgroup value-independent set (keep `ConfigParameters`); drop the two RouteTableIds from the TransitGateway set.
- `tests/visg-rs-tgw-1269-1280.test.ts` — new: fold-clean-deploy / surface-OOB / fail-open cases for all three gates.

## Verification
Offline/deterministic. New test file: 9 tests. Full suite green (221 files, 4909 tests). The **real corpus** `AWS__EC2__TransitGateway.Tgw.json` has both RouteTableIds equal (`tgw-rtb-0507484a86237d0ae`) → the cross-field gate folds `atDefault` (validated on live-harvested data). RS Workgroup gates rest on the #958 live-harvest premise + the proven #889/#1266 SG mechanism + fail-open. No new IAM perm (`ec2:DescribeSecurityGroups` from #889, `ec2:DescribeSubnets` already documented), no new dependency, no CLI surface change.

Closes #1269
Closes #1280
