### PR TITLE
fix(desired): make --pre-deploy honest for Transform-bearing apps + pin Processed template stage (#904)

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,15 @@ from a **changed local `Default`** is applied only if you pass
 `--parameters <key>=<value>` / `--no-previous-parameters` — `check` prints a
 stderr note naming each such parameter and both values.
 
+A second caveat on **server-side transforms** (SAM `AWS::Serverless-2016-10-31`,
+`AWS::LanguageExtensions`, macros): CloudFormation expands these in the cloud at
+deploy time, but `--pre-deploy` compares against your **local, unprocessed** synth
+template. So under `--pre-deploy` every `AWS::Serverless::*` resource is `skipped`
+(its declared props are not compared) and transform-generated resources are
+invisible — `check` prints a per-stack stderr note when it sees a transformed
+template. Normal `check` (against the deployed, already-**processed** template) has
+no such gap and compares transformed stacks fully; prefer it for SAM/macro apps.
+
 ### Ignoring externally-managed properties
 
 Some properties are _legitimately_ rewritten by another system, such as Application

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -251,6 +251,52 @@ export function changedDefaultParamInfo(
   return `warning: ${stackName}: ${diverged.length} local parameter(s) changed their Default vs the deployed value — the preview resolves them from the NEW local Default, but a plain \`cdk deploy\` KEEPS the deployed value (UsePreviousValue) unless \`--parameters <key>=<value>\` / \`--no-previous-parameters\` is passed: ${shown.join(', ')}${more}`;
 }
 
+// #904: a local synth template that carries a server-side Transform (SAM
+// `AWS::Serverless-2016-10-31`, `AWS::LanguageExtensions`, or a custom macro) is
+// systemically un-previewable under `--pre-deploy`. The normal deployed path fetches
+// the PROCESSED template (transforms already expanded server-side), so a SAM
+// `AWS::Serverless::Function` is an ordinary `AWS::Lambda::Function` and the
+// transform-GENERATED Role/RestApi are declared resources that compare cleanly. But
+// `--pre-deploy` swaps in the LOCAL, UNPROCESSED template: CDK never runs the
+// server-side transform, so every `AWS::Serverless::*` resource has no readable live
+// type (CC `TypeNotFoundException` → permanently `skipped`, its Handler/Runtime/Policies
+// never compared) and each transform-generated live resource is invisible (the `added`
+// tier only enumerates children of DECLARED parents). Rather than emit confusing
+// per-type DescribeType spam + silent skips, surface ONE honest per-stack warning naming
+// the Transform and the affected Serverless resources. Pure + exported for unit tests;
+// the caller gates on templateOverride (--pre-deploy). Returns the note, or null when the
+// template carries no server-side transform.
+export function transformStackWarning(
+  template: Record<string, any>,
+  stackName: string
+): string | null {
+  // A `Transform` directive names one or more macros (string or array). SAM and
+  // LanguageExtensions are the common named ones; any value is a server-side transform.
+  const rawTransform = template.Transform as unknown;
+  const transforms = (Array.isArray(rawTransform) ? rawTransform : [rawTransform])
+    .filter((t): t is string => typeof t === 'string' && t.length > 0)
+    .sort();
+  const resources = (template.Resources ?? {}) as Record<string, { Type?: unknown }>;
+  const serverless = Object.entries(resources)
+    .filter(([, def]) => typeof def?.Type === 'string' && def.Type.startsWith('AWS::Serverless::'))
+    .map(([logicalId]) => logicalId)
+    .sort();
+  // Fire only when the local template actually carries a transform (a named Transform
+  // directive OR a SAM `AWS::Serverless::*` resource — SAM stacks always declare the
+  // Transform, but guard on the resource set too so a macro that mutates ordinary types
+  // is still caught). A transform-free stack previews normally.
+  if (transforms.length === 0 && serverless.length === 0) return null;
+  const parts: string[] = [];
+  if (transforms.length > 0) parts.push(`Transform ${transforms.join(', ')}`);
+  if (serverless.length > 0) {
+    const shown = serverless.slice(0, 10);
+    const more =
+      serverless.length > shown.length ? `, …(+${serverless.length - shown.length} more)` : '';
+    parts.push(`${serverless.length} AWS::Serverless::* resource(s): ${shown.join(', ')}${more}`);
+  }
+  return `warning: ${stackName}: --pre-deploy CANNOT process server-side transforms — CDK's local synth output is UNPROCESSED, so transform-expanded resources are NOT previewed (${parts.join('; ')}). Each AWS::Serverless::* resource is \`skipped\` (its declared props are not compared) and any transform-generated resource is invisible. Run \`check\` WITHOUT --pre-deploy (the deployed, already-processed template) for a full comparison of a transformed stack.`;
+}
+
 // The AWS::Partition / AWS::URLSuffix pseudo-parameters are a deterministic function of the
 // region, NOT a commercial-partition constant. CDK env-agnostic stacks emit ${AWS::Partition}
 // inside nearly every Sub/Join-built ARN, so hard-coding `aws` / `amazonaws.com` mis-resolves
@@ -570,7 +616,15 @@ export async function loadDesired(
   const [tmplRes, stkRes, { physIds, typeOf: deployedTypeOf }] = await Promise.all([
     templateOverride
       ? Promise.resolve({ TemplateBody: undefined })
-      : client.send(new GetTemplateCommand({ StackName: stackName })),
+      : // #904: pin TemplateStage explicitly. The deployed-path desired model MUST be the
+        // PROCESSED template — server-side Transforms (SAM `AWS::Serverless-2016-10-31`,
+        // `AWS::LanguageExtensions`, macros) already expanded — so its logical ids and types
+        // match the live resources CFn actually created (a SAM `AWS::Serverless::Function`
+        // becomes an ordinary `AWS::Lambda::Function` + generated Role/RestApi). `Processed`
+        // IS the GetTemplate API default, but nothing pinned it; make it explicit so a future
+        // default change can never silently swap in the unprocessed `Original` (which would
+        // regress every transformed stack to the broken `--pre-deploy` shape — see #904).
+        client.send(new GetTemplateCommand({ StackName: stackName, TemplateStage: 'Processed' })),
     client.send(new DescribeStacksCommand({ StackName: stackName })),
     listStackResources(client, stackName),
   ]);
@@ -648,6 +702,12 @@ export async function loadDesired(
     // deployed value via UsePreviousValue (see changedDefaultParamInfo). Same stderr channel.
     const changedDefaultInfo = changedDefaultParamInfo(template, stackParams, stackName);
     if (changedDefaultInfo) console.error(changedDefaultInfo);
+    // #904: a Transform-bearing (SAM / LanguageExtensions / macro) local template cannot be
+    // server-side-processed by CDK's local synth, so its AWS::Serverless::* resources are
+    // `skipped` and its transform-generated resources are invisible under --pre-deploy. One
+    // honest per-stack note (vs confusing DescribeType spam) pointing to the deployed path.
+    const transformInfo = transformStackWarning(template, stackName);
+    if (transformInfo) console.error(transformInfo);
   }
 
   // #882: detect logical ids whose Type changed between the deployed stack and the declared

--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -299,6 +299,19 @@ export function resolve(node: unknown, ctx: ResolverContext, inCondition = false
         break;
     }
   }
+  // #904: `Fn::Transform` is a SERVER-SIDE macro directive (AWS::Include, a custom
+  // macro): CloudFormation MERGES the macro's expansion INTO the enclosing object at
+  // deploy time, so it legally sits ALONGSIDE sibling keys — the canonical API GW
+  // `Body: { swagger: "2.0", "Fn::Transform": { … } }` (AWS::Include) pattern. The
+  // single-key `{ "Fn::Transform": … }` form already degrades to UNRESOLVED via the
+  // `Fn::`-prefix default above, but a SIBLING-keyed occurrence fell through to the
+  // generic object-walk below and leaked the LITERAL `Fn::Transform` key into the
+  // declared value — a guaranteed `--pre-deploy` declared-tier false positive (the
+  // local synth template is unprocessed, so the macro is unexpanded), and a revert
+  // would then write the raw macro object back into the live resource. cdkrd cannot
+  // compute the expansion locally, so fail closed to UNRESOLVED whenever an object
+  // CONTAINS an `Fn::Transform` key, at ANY arity — the same treatment as Fn::GetAtt.
+  if ('Fn::Transform' in obj) return UNRESOLVED;
   const out: Record<string, unknown> = {};
   for (const [kk, vv] of Object.entries(obj)) out[kk] = resolve(vv, ctx, inCondition);
   return out;

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -784,4 +784,33 @@ describe('intrinsic resolver', () => {
     // a plain literal with no token is unchanged.
     expect(resolve('just-a-plain-value', ctx())).toBe('just-a-plain-value');
   });
+
+  // #904 part 2: `Fn::Transform` is a server-side macro directive that CFn merges INTO the
+  // enclosing object at deploy time, so it legally sits ALONGSIDE sibling keys. cdkrd cannot
+  // expand it locally → any object CONTAINING an `Fn::Transform` key (any arity) → UNRESOLVED.
+  it('#904 single-key `{Fn::Transform}` resolves UNRESOLVED (via the Fn:: default)', () => {
+    expect(resolve({ 'Fn::Transform': { Name: 'AWS::Include', Parameters: {} } }, ctx())).toBe(
+      UNRESOLVED
+    );
+  });
+
+  it('#904 SIBLING-keyed `Fn::Transform` (the API GW Body + AWS::Include pattern) → UNRESOLVED, not a leaked literal', () => {
+    // The canonical failure: an OpenAPI Body with an inline AWS::Include macro. Before the fix
+    // this fell through to the object-walk and kept the literal `Fn::Transform` key (a guaranteed
+    // --pre-deploy declared-tier FP that a revert would then write back into the live resource).
+    const body = {
+      swagger: '2.0',
+      'Fn::Transform': { Name: 'AWS::Include', Parameters: { Location: 's3://b/paths.yaml' } },
+    };
+    expect(resolve(body, ctx())).toBe(UNRESOLVED);
+    // and nested one level down inside a declared property object.
+    expect(resolve({ Body: body }, ctx())).toEqual({ Body: UNRESOLVED });
+  });
+
+  it('#904 NEGATIVE: an ordinary sibling-keyed object with NO Fn::Transform is walked normally', () => {
+    expect(resolve({ swagger: '2.0', info: { title: 't' } }, ctx())).toEqual({
+      swagger: '2.0',
+      info: { title: 't' },
+    });
+  });
 });

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -15,6 +15,7 @@ import {
   deletedResourceInfo,
   loadDesired,
   parseTemplateBody,
+  transformStackWarning,
   typeChangedResources,
   typeChangeReplaceInfo,
 } from '../src/desired/template-adapter.js';
@@ -1050,5 +1051,107 @@ describe('#882 — buildResolverContext does NOT seed an SSM-typed param Default
     };
     const ctx = buildResolverContext(template, {}, {}, 'us-east-1', '999', 'S', 'arn');
     expect('Sgs' in ctx.params).toBe(false);
+  });
+});
+
+// #904 part 1: honest per-stack warning when a Transform-bearing / SAM local template
+// is compared under --pre-deploy (CDK's local synth is UNPROCESSED, so Serverless
+// resources are `skipped` and transform-generated resources are invisible).
+describe('#904 transformStackWarning', () => {
+  it('warns for a Transform directive (string) + names the AWS::Serverless::* resources', () => {
+    const w = transformStackWarning(
+      {
+        Transform: 'AWS::Serverless-2016-10-31',
+        Resources: {
+          Fn: { Type: 'AWS::Serverless::Function' },
+          Api: { Type: 'AWS::Serverless::Api' },
+          Tbl: { Type: 'AWS::DynamoDB::Table' },
+        },
+      },
+      'S'
+    );
+    expect(w).toContain('--pre-deploy CANNOT process server-side transforms');
+    expect(w).toContain('Transform AWS::Serverless-2016-10-31');
+    expect(w).toContain('2 AWS::Serverless::* resource(s): Api, Fn');
+    expect(w).not.toContain('Tbl'); // ordinary declared resources are not listed
+  });
+
+  it('warns for an array Transform (e.g. LanguageExtensions) even with no Serverless resources', () => {
+    const w = transformStackWarning(
+      { Transform: ['AWS::LanguageExtensions'], Resources: { B: { Type: 'AWS::S3::Bucket' } } },
+      'S'
+    );
+    expect(w).toContain('Transform AWS::LanguageExtensions');
+  });
+
+  it('warns for a SAM stack that only carries Serverless resources (macro caught via the type set)', () => {
+    const w = transformStackWarning(
+      { Resources: { Fn: { Type: 'AWS::Serverless::Function' } } },
+      'S'
+    );
+    expect(w).toContain('1 AWS::Serverless::* resource(s): Fn');
+  });
+
+  it('returns null for a transform-free stack (previews normally)', () => {
+    expect(
+      transformStackWarning({ Resources: { B: { Type: 'AWS::S3::Bucket' } } }, 'S')
+    ).toBeNull();
+    expect(transformStackWarning({}, 'S')).toBeNull();
+  });
+});
+
+// #904 part 1 (wiring) + part 3 (explicit TemplateStage).
+describe('#904 loadDesired — transform warning under --pre-deploy + Processed TemplateStage', () => {
+  function liveStack(cfn: ReturnType<typeof mockClient>): void {
+    cfn.on(ListStackResourcesCommand).resolves({ StackResourceSummaries: [] });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+  }
+
+  it('emits the transform warning to stderr under --pre-deploy for a SAM template', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).rejects(new Error('GetTemplate must NOT be called in pre-deploy'));
+    liveStack(cfn);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let msg = '';
+    try {
+      await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1', {
+        Transform: 'AWS::Serverless-2016-10-31',
+        Resources: { Fn: { Type: 'AWS::Serverless::Function' } },
+      });
+      msg = err.mock.calls.map((c) => String(c[0])).join('\n');
+    } finally {
+      err.mockRestore();
+    }
+    expect(msg).toContain('--pre-deploy CANNOT process server-side transforms');
+  });
+
+  it('fetches the deployed template with TemplateStage: Processed (part 3) and does not warn', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Resources: { B: { Type: 'AWS::S3::Bucket', Properties: {} } },
+      }),
+    });
+    liveStack(cfn);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // deployed path (no templateOverride) — the transform warning never fires.
+      await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1');
+    } finally {
+      err.mockRestore();
+    }
+    const calls = cfn.commandCalls(GetTemplateCommand);
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.args[0].input).toMatchObject({ StackName: 'S', TemplateStage: 'Processed' });
   });
 });


### PR DESCRIPTION
Closes #904.

`--pre-deploy` compares live state against the **local, unprocessed** synth template, so server-side transforms (SAM `AWS::Serverless-2016-10-31`, `AWS::LanguageExtensions`, macros) are never expanded. Addresses all three of the issue's fix directions, in two FREE files (`desired/template-adapter.ts`, `normalize/intrinsic-resolver.ts`).

### Part 1 — honest per-stack warning (MEDIUM)
A Transform-bearing / `AWS::Serverless::*` local template degrades every Serverless resource to `skipped` (CC `TypeNotFoundException`) and makes transform-generated resources invisible under `--pre-deploy`. New pure `transformStackWarning` emits ONE clear stderr note (naming the Transform + the Serverless resources, pointing to the deployed path) instead of confusing per-type DescribeType spam — wired into the existing `templateOverride` warning block next to `deletedResourceInfo` / `unpreviewableParamInfo` / `changedDefaultParamInfo`.

### Part 2 — sibling-keyed `Fn::Transform` → UNRESOLVED (LOW-MEDIUM, a real FP)
The intrinsic resolver only detected a single-key `{Fn::Transform}`. The canonical API GW `Body: { swagger: "2.0", "Fn::Transform": {…} }` (AWS::Include) pattern sits ALONGSIDE sibling keys and fell through to the object-walk, leaking the literal `Fn::Transform` key into the declared model — a guaranteed `--pre-deploy` declared-tier false positive that a revert would then write back into the live resource. Any object CONTAINING an `Fn::Transform` key (any arity) now folds to `UNRESOLVED` (fail-safe, like `Fn::GetAtt`).

### Part 3 — pin `TemplateStage: Processed` (LOW hardening)
The deployed path's `GetTemplate` had no explicit `TemplateStage`. `Processed` is the API default (exactly what the deployed path needs so transformed resources compare cleanly), but nothing pinned it. Now explicit so a future default change can never silently regress every transformed stack to the unprocessed shape.

### Docs
README `--pre-deploy` caveat on server-side transforms (normal `check` works; `--pre-deploy` does not).

### Scope note
Not touching `schema-strip.ts` (owned by another in-flight lane) — the DescribeType-spam symptom is contextualized by the new warning rather than suppressed.

### Tests
- `intrinsic-resolver.test.ts`: single-key + sibling-keyed `Fn::Transform` → UNRESOLVED, nested one level down, and a NEGATIVE (ordinary sibling-keyed object walked normally).
- `template-adapter.test.ts`: `transformStackWarning` (string Transform + named Serverless resources, array Transform, SAM-only via the type set, transform-free → null); `loadDesired` emits the warning under `--pre-deploy` and sends `GetTemplate` with `TemplateStage: Processed` on the deployed path.
- Full suite: 4909 tests pass.

Offline/deterministic (the issue's finding-1 was live-confirmed by the maintainer on 2026-07-09).
