### PR TITLE
fix(revert): whole-array revert for ALL identity-sorted object arrays, not just {Key,Value} tags (#1271)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1288,14 +1288,20 @@ const isInlinePolicyArray = (arr: unknown[]): boolean =>
 // path whose index is the SORTED+STRIPPED position — it does NOT map to the RAW live model
 // (raw order, aws:* tags present) Cloud Control patches, so a sub-path patch lands on the
 // WRONG element (silent corruption) or out of range (loud reject) (#750). The safe revert is
-// a WHOLE-ARRAY `/Tags` write of the declared list (revert then re-attaches aws:* managed
-// tags via tagPreservingOps), collapsed by the revert plan exactly like an UNORDERED_OBJECT_
-// ARRAY. Recognized by the Key identity field + a Value on every element (a plain identity-
-// keyed object array — CloudFront Origins, etc. — has no Value and is unaffected).
-const isKeyValueTagList = (arr: unknown[]): boolean =>
-  arr.length > 0 &&
-  identityField(arr) === 'Key' &&
-  arr.every((el) => isNestedObject(el) && 'Value' in el);
+// a WHOLE-ARRAY write of the declared list (revert then re-attaches aws:* managed tags via
+// tagPreservingOps where the array is a tag property), collapsed by the revert plan exactly
+// like an UNORDERED_OBJECT_ARRAY.
+// #1271: this misalignment is NOT unique to `{Key,Value}` tag lists. `canonicalizeTagLists`
+// sorts EVERY object array whose every element carries ANY of the five identity fields
+// (`Key`/`Id`/`AttributeName`/`IndexName`/`Name`) — CloudWatch Alarm `Dimensions` ({Name,Value}),
+// S3 `LifecycleConfiguration.Rules` ({Id,...}), DynamoDB `GlobalSecondaryIndexes` ({IndexName})
+// / `AttributeDefinitions` ({AttributeName}). A per-element sub-value drift inside any of them
+// diffs at the SORTED index, which does not map to the raw model Cloud Control patches — a
+// per-element op would revert the WRONG element (or, for the top-level {Key,Value} case,
+// leave the real drift while corrupting an innocent element). So hoist the whole class, not
+// just Key/Value tags: any identity-sorted object array whose value IS the top-level array.
+const isIdentitySortedObjectArray = (arr: unknown[]): boolean =>
+  arr.length > 0 && identityField(arr) !== undefined;
 
 // True when every key of `sub` is present in `sup` with an equal value (objects
 // recurse so a nested declared block must also be a subset; everything else is
@@ -3842,21 +3848,23 @@ export function classifyResource(
         matchesAncestorPropertyTransform(schema.propertyTransforms, d.path, declared, live)
       )
         continue;
-      // A per-element drift INSIDE a `{Key,Value}` tag list (#750): canonicalizeTagLists
-      // sorted the list by `Key` on both compare sides (and stripped the live side's aws:*
-      // tags), so `d.path`'s index is the SORTED+STRIPPED position that does NOT map to the
-      // RAW live model Cloud Control patches — a sub-path `add /Tags/<i>/Value` patch would
-      // corrupt the wrong live element or go out of range. Carry the WHOLE declared tag list
-      // on wholeArrayRevert so the revert plan collapses these into ONE whole-array `/Tags`
-      // replacement (tagPreservingOps then re-attaches the live aws:* managed tags), never a
+      // A per-element drift INSIDE an identity-sorted object array (#750 for {Key,Value} tags,
+      // #1271 for the wider class): canonicalizeTagLists sorted the array by its identity field
+      // on both compare sides (and stripped the live side's aws:* tags where it is a tag list),
+      // so `d.path`'s index is the SORTED+STRIPPED position that does NOT map to the RAW live
+      // model Cloud Control patches — a sub-path `add /<key>/<i>/<sub>` patch would corrupt the
+      // wrong live element or go out of range. Carry the WHOLE declared array on wholeArrayRevert
+      // so the revert plan collapses these into ONE whole-array replacement (tagPreservingOps then
+      // re-attaches the live aws:* managed tags where the array is a tag property), never a
       // per-element pointer against a sorted index that does not exist in the raw model.
       // Only fires for a per-element (`${k}.` sub-path) drift; a whole-array drift already
       // carries the right path. The unorderedObjArray branch above handles the type-/schema-
-      // opted-in unordered object arrays; this covers the identity-sorted tag lists it misses.
-      const tagListWhole =
+      // opted-in unordered object arrays; this covers the identity-sorted arrays it misses
+      // (CloudWatch Alarm Dimensions, S3 lifecycle Rules, DynamoDB GSI/AttributeDefinitions, …).
+      const identitySortedWhole =
         !unorderedObjArray &&
         Array.isArray(v) &&
-        isKeyValueTagList(v) &&
+        isIdentitySortedObjectArray(v) &&
         d.path.startsWith(`${k}.`);
       const unorderedExtra =
         unorderedObjArray && Array.isArray(declaredVal) && declaredRemapSource
@@ -3868,7 +3876,7 @@ export function classifyResource(
               path: remapSortedIndexToDeclared(d.path, k, declaredVal, declaredRemapSource),
               wholeArrayRevert: { path: k, value: v },
             }
-          : tagListWhole
+          : identitySortedWhole
             ? { wholeArrayRevert: { path: k, value: v } }
             : {};
       pushDeclaredFinding(findings, {

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -299,6 +299,81 @@ describe('buildRevertPlan', () => {
     expect(finalTags).toHaveLength(3);
   });
 
+  it('#1271: a value change inside a canonicalize-SORTED {Name,Value} array (NOT a {Key,Value} tag list) reverts as a WHOLE-ARRAY write, not a per-element patch against the wrong sorted index', () => {
+    // The #750 hoist only fired for {Key,Value} tag lists (identityField === "Key"). But
+    // canonicalizeTagLists sorts EVERY object array whose every element carries ANY of the five
+    // identity fields (Key/Id/AttributeName/IndexName/Name). A CloudWatch Alarm `Dimensions`
+    // array is {Name,Value} — sorted by `Name` on both sides — so a per-element VALUE drift
+    // diffs at a SORTED index that does NOT map to the RAW live model. A `/Dimensions/<i>/Value`
+    // patch would revert the WRONG (innocent) element while the real drift survives.
+
+    // Declared in NON-sorted Name order (QueueName before Env); QueueName's value drifted OOB.
+    const declaredDims = [
+      { Name: 'QueueName', Value: 'prod-queue' }, // desired value (drifted live)
+      { Name: 'Env', Value: 'prod' },
+    ];
+    // RAW live model: same (raw, unsorted) order, only QueueName.Value changed out of band.
+    const liveRaw: Record<string, unknown> = {
+      Dimensions: [
+        { Name: 'QueueName', Value: 'HACKED-queue' },
+        { Name: 'Env', Value: 'prod' },
+      ],
+    };
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const findings = classifyResource(
+      {
+        logicalId: 'Alarm',
+        resourceType: 'AWS::CloudWatch::Alarm',
+        physicalId: 'my-alarm',
+        declared: { Dimensions: declaredDims },
+      },
+      liveRaw,
+      emptySchema
+    );
+    const drift = findings.find((f) => f.tier === 'declared');
+    expect(drift).toBeDefined();
+    // canonicalizeTagLists sorted by Name → [Env(0), QueueName(1)], so the finding's own path is
+    // the SORTED index `Dimensions.1.Value` — which in the RAW model is Env, NOT QueueName. A
+    // per-element patch here is exactly the corruption #1271 describes. The hoist saves it:
+    expect(drift!.path).toBe('Dimensions.1.Value');
+    expect(drift!.wholeArrayRevert).toBeDefined();
+    expect(drift!.wholeArrayRevert!.path).toBe('Dimensions');
+    expect(drift!.wholeArrayRevert!.value).toEqual(
+      expect.arrayContaining([
+        { Name: 'QueueName', Value: 'prod-queue' },
+        { Name: 'Env', Value: 'prod' },
+      ])
+    );
+
+    // The revert plan collapses to ONE whole-array `/Dimensions` op — never a per-element
+    // `/Dimensions/<sortedIdx>/Value` patch against an index that misaligns with the raw model.
+    const plan = buildRevertPlan(findings, undefined, {
+      liveByLogical: new Map([['Alarm', liveRaw]]),
+    });
+    expect(plan.items).toHaveLength(1);
+    const ops = plan.items[0]!.ops;
+    expect(ops).toHaveLength(1);
+    expect(ops[0]!.path).toBe('/Dimensions');
+    expect(ops[0]!.op).toBe('add');
+    expect(ops.some((o) => /^\/Dimensions\/\d+\//.test(o.path))).toBe(false);
+    // The whole-array value applied reverts QueueName AND leaves Env untouched (not corrupted).
+    expect(ops[0]!.value).toEqual(
+      expect.arrayContaining([
+        { Name: 'QueueName', Value: 'prod-queue' },
+        { Name: 'Env', Value: 'prod' },
+      ])
+    );
+  });
+
   it('ManagedPolicy attachment detach -> SDK item, op carries the member on attributeKey', () => {
     // a declared-but-detached Role finding (path Roles, attributeKey = role name) must
     // route to the SDK writer (ManagedPolicy is a whole-type writer) and carry the


### PR DESCRIPTION
## Summary

Fixes #1271 — a silent corruption in `revert` (the one AWS-mutating verb).

`canonicalizeTagLists` (`normalize/noise.ts`) sorts **every** object array whose every element carries any of the five identity fields (`Key`/`Id`/`AttributeName`/`IndexName`/`Name`) on both compare sides. A per-element sub-value drift inside such an array therefore diffs at a **sorted** index that does **not** map to the raw live model Cloud Control patches — a sub-path `add /<key>/<i>/<sub>` op reverts the **wrong (innocent) element** while the real (possibly attacker-made) drift survives.

The #750/#1241 hoist to a whole-array `wholeArrayRevert` only fired for **top-level `{Key,Value}` tag lists** (`identityField === 'Key'` + a `Value` on every element). Every sibling shape still emitted a per-element op against a misaligned index:

- `{Name,Value}` — CloudWatch Alarm `Dimensions`
- `{Id,...}` — S3 `LifecycleConfiguration.Rules`
- `{IndexName}` / `{AttributeName}` — DynamoDB `GlobalSecondaryIndexes` / `AttributeDefinitions`

## Fix

Generalize the hoist gate from `isKeyValueTagList` (Key-only) to `isIdentitySortedObjectArray` (`identityField(v) !== undefined`) — the **same predicate `canonicalizeTagLists` sorts on**, so the two are always in agreement (an array is hoisted iff it was sorted). A whole-array replace of the declared array is always correct regardless of index alignment; `tagPreservingOps` still re-attaches `aws:*` managed tags where the array is a tag property, and non-tag arrays get a plain whole-array write.

Scope: **top-level identity-sorted arrays** (the array IS the declared value at the key). The deeper **nested `{Key,Value}` sub-list** case (drift path crosses an object before reaching the array) remains for a follow-up — noted on the issue.

## Test

`tests/revert-plan.test.ts` adds an end-to-end regression on the issue's exact CloudWatch Alarm `Dimensions` repro (classify → `buildRevertPlan`): the finding's own path is the sorted index `Dimensions.1.Value` (= `Env` in the raw model, **not** the drifted `QueueName`), yet the plan collapses to ONE whole-array `/Dimensions` op that reverts `QueueName` and leaves `Env` untouched — no `/Dimensions/<i>/` per-element pointer.

## Checks

- `vp run typecheck` — pass
- `vp check --fix` — pass (0 errors)
- `vp pack` — pass
- `vp test run` — 221 files, 4925 tests pass

Addresses #1271 (top-level identity-sorted arrays; the nested `{Key,Value}` sub-list case stays tracked on the issue for a follow-up — leaving it OPEN, same as the incremental #640 batch).
