### PR TITLE
fix(diff): per-element gate for RedshiftServerless Workgroup ConfigParameters (#1272)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -268,6 +268,22 @@ export function shouldFoldDefaultSubnetList(
 const DEFAULT_SUBNET_LIST_PATHS: Record<string, string> = {
   'AWS::RedshiftServerless::Workgroup': 'SubnetIds',
 };
+// #1272: the AWS default effective ConfigParameters a RedshiftServerless Workgroup reads back when
+// it declares none (harvested live from a fresh us-east-1 workgroup, 2026-07-11). Keyed by
+// ParameterKey → default ParameterValue (all serialized as strings by the service). A known key at
+// its default folds atDefault; a known key CHANGED (e.g. require_ssl "false", audit-logging off)
+// surfaces; an UNKNOWN new key still folds (AWS extends the set over time — #653).
+const RS_WORKGROUP_CONFIG_PARAM_DEFAULTS: Record<string, string> = {
+  auto_mv: 'true',
+  datestyle: 'ISO, MDY',
+  enable_case_sensitive_identifier: 'false',
+  enable_user_activity_logging: 'true',
+  query_group: 'default',
+  require_ssl: 'true',
+  search_path: '$user, public',
+  use_fips_ssl: 'false',
+  max_query_execution_time: '14400',
+};
 /** #889 fold decision for an UNDECLARED default-SG list (ALB SecurityGroups / ENI GroupSet).
  *  Returns whether the value-independent fold should still apply for this live value:
  *   - `true`  → FOLD (atDefault): the live list is a single VPC-default SG id, OR the prefetch is
@@ -3992,6 +4008,42 @@ export function classifyResource(
         path: k,
         actual: v,
       });
+      continue;
+    }
+    // #1272: a RedshiftServerless Workgroup that declares no ConfigParameters reads back AWS's full
+    // default effective-parameter set. Replaces the old value-independent fold, which hid an OOB
+    // `update-workgroup --config-parameters` change to a security-load-bearing key (require_ssl=false
+    // plaintext, enable_user_activity_logging=false audit-off). Per-element equality gate keyed by
+    // ParameterKey against the live-harvested defaults: a known key at its default folds; a known key
+    // CHANGED away from its default surfaces; an UNKNOWN new key still folds (AWS extends the set over
+    // time — the #653 recursive-subset lesson).
+    if (
+      resourceType === 'AWS::RedshiftServerless::Workgroup' &&
+      k === 'ConfigParameters' &&
+      Array.isArray(v)
+    ) {
+      for (const el of v) {
+        if (!el || typeof el !== 'object') continue;
+        const e = el as Record<string, unknown>;
+        const pk = e.ParameterKey ?? e.parameterKey;
+        const pv = e.ParameterValue ?? e.parameterValue;
+        if (typeof pk !== 'string') continue;
+        const def = RS_WORKGROUP_CONFIG_PARAM_DEFAULTS[pk];
+        // Unknown key (AWS extended the set) → fold; known key equal to its default → fold; a known
+        // key CHANGED away from its default surfaces (the out-of-band edit #1272 targets). The live
+        // values are strings ("true"/"14400"), so a plain string compare handles them; the
+        // isStringlyEqualScalar arm additionally tolerates a boolean/number live value vs the string
+        // default (isStringlyEqualScalar returns false for string-vs-string).
+        const isDefault = def === undefined || pv === def || isStringlyEqualScalar(pv, def);
+        findings.push({
+          tier: isDefault ? 'atDefault' : 'undeclared',
+          logicalId,
+          resourceType,
+          path: `${k}[${pk}]`,
+          actual: pv,
+          nested: true,
+        });
+      }
       continue;
     }
     // NOTE: no `schema.writeOnly.has(k)` guard — a top-level write-only key was

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3407,18 +3407,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   now DERIVE-gated in classify: SecurityGroupIds via the #889/#976 default-SG gate (single default
   //   SG folds); SubnetIds via a default-VPC-subnet gate (fold only when EVERY live subnet is a
   //   default-VPC subnet, surface any subnet outside it). Both fail open when the prefetch is absent.
-  //   AWS::RedshiftServerless::Workgroup.ConfigParameters — a workgroup that declares no
-  //   ConfigParameters reads back AWS's full default effective-parameter set
-  //   ([{ParameterKey:"auto_mv",ParameterValue:"true"},{ParameterKey:"datestyle",…}, …]). The
-  //   documented default set is not fully enumerated in the evidence and AWS extends it over
-  //   time (a pinned whole-array constant would rot into a false positive the moment AWS adds a
-  //   parameter — the #653 recursive-subset lesson). A per-element equality gate (keyed by
-  //   ParameterKey) would preserve out-of-band-parameter detection but needs an
-  //   IDENTITY_KEYED_SUBSET_ARRAYS registration in classify.ts; until that follow-up lands, fold
-  //   value-independent: undeclared, so the whole AWS default parameter set is its choice, not
-  //   user intent (a user who pins a parameter DECLARES ConfigParameters, compared in the
-  //   declared loop). Live-confirmed on a fresh minimal workgroup (2026-07-09, us-east-1; #958).
-  'AWS::RedshiftServerless::Workgroup': new Set(['ConfigParameters']),
+  //   NOTE: AWS::RedshiftServerless::Workgroup.ConfigParameters was ALSO here (#958) — a workgroup
+  //   that declares none reads back AWS's full default effective-parameter set. But it is MUTABLE out
+  //   of band (`update-workgroup --config-parameters`) and carries security-load-bearing keys
+  //   (require_ssl, enable_user_activity_logging), so a value-independent fold hid an OOB
+  //   require_ssl=false / audit-off change (#1272). It is now PER-ELEMENT gated in classify against
+  //   the live-harvested defaults (RS_WORKGROUP_CONFIG_PARAM_DEFAULTS): a known key at its default
+  //   folds, a changed known key surfaces, an unknown new key still folds (AWS extends the set, #653).
   //   AWS::CloudFormation::Stack (the parent-side resource of every CDK `NestedStack`) is
   //   CC-read and returns the child stack's FULL live model, but the template's Stack resource
   //   declares only `TemplateURL` (an S3 asset URL) + `Parameters` + `Tags` — so three live

--- a/tests/noise-958-977-folds.test.ts
+++ b/tests/noise-958-977-folds.test.ts
@@ -58,7 +58,7 @@ describe('#958 RedshiftServerless Workgroup placement + config parameters', () =
     expect(tier(f, 'undeclared')).not.toContain('SecurityGroupIds');
     expect(tier(f, 'undeclared')).not.toContain('SubnetIds');
   });
-  it('folds the undeclared default ConfigParameters set value-independent (tier 3)', () => {
+  it('folds each undeclared default ConfigParameter PER-ELEMENT (tier 2, #1272 superseded the tier-3 fold)', () => {
     const f = classifyResource(
       wg,
       {
@@ -70,8 +70,17 @@ describe('#958 RedshiftServerless Workgroup placement + config parameters', () =
       },
       emptySchema
     );
-    expect(tier(f, 'atDefault')).toContain('ConfigParameters');
-    expect(tier(f, 'undeclared')).not.toContain('ConfigParameters');
+    // #1272: ConfigParameters is no longer folded whole (value-independent); each element folds
+    // atDefault by ParameterKey against the harvested defaults, so an OOB change to a known key
+    // (require_ssl=false) surfaces while the defaults stay folded.
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining([
+        'ConfigParameters[auto_mv]',
+        'ConfigParameters[datestyle]',
+        'ConfigParameters[enable_case_sensitive_identifier]',
+      ])
+    );
+    expect(tier(f, 'undeclared')).toHaveLength(0);
   });
 });
 

--- a/tests/rs-configparams-gate-1272.test.ts
+++ b/tests/rs-configparams-gate-1272.test.ts
@@ -1,0 +1,92 @@
+// #1272 — AWS::RedshiftServerless::Workgroup.ConfigParameters was folded value-independent (#958),
+// which HID an out-of-band `update-workgroup --config-parameters` change to a security-load-bearing
+// key (require_ssl=false plaintext, enable_user_activity_logging=false audit-off). It is now a
+// PER-ELEMENT equality gate keyed by ParameterKey against the live-harvested defaults: a known key
+// at its default folds atDefault, a changed known key surfaces, an unknown NEW key still folds
+// (AWS extends the set over time). Live-verified 2026-07-11 on a fresh us-east-1 workgroup: a clean
+// deploy is CLEAN (all 9 params fold) and an OOB require_ssl=false surfaces exactly that one param.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tierOf = (fs: Finding[], path: string): string | undefined =>
+  fs.find((f) => f.path === path)?.tier;
+const res: DesiredResource = {
+  logicalId: 'Wg',
+  resourceType: 'AWS::RedshiftServerless::Workgroup',
+  physicalId: 'cdkrd-wg',
+  declared: { WorkgroupName: 'w', NamespaceName: 'n' }, // declares NO ConfigParameters
+};
+// The full default effective-parameter set a fresh workgroup reads back (live-harvested).
+const DEFAULTS = [
+  { ParameterKey: 'auto_mv', ParameterValue: 'true' },
+  { ParameterKey: 'datestyle', ParameterValue: 'ISO, MDY' },
+  { ParameterKey: 'enable_case_sensitive_identifier', ParameterValue: 'false' },
+  { ParameterKey: 'enable_user_activity_logging', ParameterValue: 'true' },
+  { ParameterKey: 'query_group', ParameterValue: 'default' },
+  { ParameterKey: 'require_ssl', ParameterValue: 'true' },
+  { ParameterKey: 'search_path', ParameterValue: '$user, public' },
+  { ParameterKey: 'use_fips_ssl', ParameterValue: 'false' },
+  { ParameterKey: 'max_query_execution_time', ParameterValue: '14400' },
+];
+
+describe('#1272 RedshiftServerless::Workgroup.ConfigParameters per-element gate', () => {
+  it('(a) folds EVERY default parameter to atDefault (clean deploy — zero potential drift)', () => {
+    const f = classifyResource(res, { ConfigParameters: DEFAULTS }, emptySchema, {});
+    for (const p of DEFAULTS) {
+      expect(tierOf(f, `ConfigParameters[${p.ParameterKey}]`)).toBe('atDefault');
+    }
+    expect(f.some((x) => x.tier === 'undeclared')).toBe(false);
+  });
+
+  it('(b) SURFACES an out-of-band require_ssl=false (plaintext) while the rest still fold', () => {
+    const mutated = DEFAULTS.map((p) =>
+      p.ParameterKey === 'require_ssl' ? { ...p, ParameterValue: 'false' } : p
+    );
+    const f = classifyResource(res, { ConfigParameters: mutated }, emptySchema, {});
+    expect(tierOf(f, 'ConfigParameters[require_ssl]')).toBe('undeclared');
+    // exactly one surfaced; every other key still folds
+    expect(f.filter((x) => x.tier === 'undeclared').map((x) => x.path)).toEqual([
+      'ConfigParameters[require_ssl]',
+    ]);
+    expect(tierOf(f, 'ConfigParameters[enable_user_activity_logging]')).toBe('atDefault');
+  });
+
+  it('(c) SURFACES an out-of-band audit-logging-off (enable_user_activity_logging=false)', () => {
+    const mutated = DEFAULTS.map((p) =>
+      p.ParameterKey === 'enable_user_activity_logging' ? { ...p, ParameterValue: 'false' } : p
+    );
+    const f = classifyResource(res, { ConfigParameters: mutated }, emptySchema, {});
+    expect(tierOf(f, 'ConfigParameters[enable_user_activity_logging]')).toBe('undeclared');
+  });
+
+  it('(d) FOLDS an unknown NEW key (AWS extends the set over time — #653)', () => {
+    const withNew = [
+      ...DEFAULTS,
+      { ParameterKey: 'some_future_param', ParameterValue: 'whatever' },
+    ];
+    const f = classifyResource(res, { ConfigParameters: withNew }, emptySchema, {});
+    expect(tierOf(f, 'ConfigParameters[some_future_param]')).toBe('atDefault');
+  });
+
+  it('(e) tolerates a boolean/number live value vs the string default (no false surface)', () => {
+    // If the read path ever yields a boolean/number instead of a string, the value still matches.
+    const coerced = [
+      { ParameterKey: 'require_ssl', ParameterValue: true },
+      { ParameterKey: 'max_query_execution_time', ParameterValue: 14400 },
+    ];
+    const f = classifyResource(res, { ConfigParameters: coerced }, emptySchema, {});
+    expect(tierOf(f, 'ConfigParameters[require_ssl]')).toBe('atDefault');
+    expect(tierOf(f, 'ConfigParameters[max_query_execution_time]')).toBe('atDefault');
+  });
+});


### PR DESCRIPTION
## What

`AWS::RedshiftServerless::Workgroup.ConfigParameters` was folded **value-independent** (#958), which LOSES change detection: an out-of-band `update-workgroup --config-parameters` change to a security-load-bearing key — `require_ssl=false` (plaintext connections) or `enable_user_activity_logging=false` (audit logging off) — classified `atDefault` and was never recorded/watched.

It is now a **per-element equality gate** keyed by `ParameterKey` against the **live-harvested** default effective-parameter set (`RS_WORKGROUP_CONFIG_PARAM_DEFAULTS`):
- a known key at its default → folds `atDefault`;
- a known key **changed** away from its default → surfaces (`undeclared`);
- an **unknown new key** → still folds (AWS extends the set over time — the #653 recursive-subset lesson).

`ConfigParameters` is dropped from the RS Workgroup value-independent set — all three of its previously-VI props are now derive-gated (`SecurityGroupIds`/`SubnetIds` via #1269).

## Harvested defaults (fresh us-east-1 workgroup, 2026-07-11)
`auto_mv=true`, `datestyle="ISO, MDY"`, `enable_case_sensitive_identifier=false`, `enable_user_activity_logging=true`, `query_group=default`, `require_ssl=true`, `search_path="$user, public"`, `use_fips_ssl=false`, `max_query_execution_time=14400`.

## Files
- `src/diff/classify.ts` — `RS_WORKGROUP_CONFIG_PARAM_DEFAULTS` table + per-element ConfigParameters gate in the undeclared loop.
- `src/normalize/noise.ts` — drop `ConfigParameters` from the RS Workgroup value-independent set (the entry is now empty and removed).
- `tests/rs-configparams-gate-1272.test.ts` — new: fold-all-defaults / surface-require_ssl / surface-audit-off / fold-unknown-key / boolean-number-tolerance.
- `tests/noise-958-977-folds.test.ts` — update the #958 whole-key VI assertion to the new per-element contract.

## Verification (LIVE)
Deployed a fresh RedshiftServerless Namespace+Workgroup (`Cdkrd1272Verify`, `cdkrd:ephemeral=1`), declaring no ConfigParameters/SG/Subnets:
1. **Clean deploy → `cdkrd check` CLEAN** (`atDefault=19`; all 9 ConfigParameters fold, plus the #1269 SG/Subnet gates fold the default SG + 6 default-VPC subnets — this PR also live-verifies #1269).
2. **OOB `update-workgroup --config-parameters require_ssl=false` → `cdkrd check` surfaces exactly `Wg.ConfigParameters[require_ssl]`** (1 potential drift), every other param still folded.
3. Stack force-deleted with `delstack`; `sweep-orphans.sh` → `SWEEP CLEAN`.

Full suite green (222 files, 4929 tests). No new IAM perm / dependency / CLI surface.

Closes #1272
