### PR TITLE
fix(revert): extend the identity-sorted whole-array revert to NESTED arrays + identity-keyed nested sort (#1306)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -86,6 +86,7 @@ import {
   alignNameValueSubset,
   RATE_EXPRESSION_PATHS,
   resolveGeneratedDefault,
+  NESTED_OBJECT_ARRAY_IDENTITY,
   sortNestedObjectArrays,
   sortUnorderedObjectArray,
   stripAsymmetricIdentityFields,
@@ -1298,27 +1299,6 @@ const isPolicyStatementArray = (arr: unknown[]): boolean =>
 const isInlinePolicyArray = (arr: unknown[]): boolean =>
   arr.length > 0 && arr.every((el) => isNestedObject(el) && 'PolicyDocument' in el);
 
-// A `{Key,Value}` tag list — the shape canonicalizeTagLists (normalize/noise.ts) SORTS on
-// BOTH compare sides by its `Key` identity field, while the live side additionally has its
-// `aws:*` tags stripped. A per-element VALUE change then diffs at a `Tags.<sortedIdx>.Value`
-// path whose index is the SORTED+STRIPPED position — it does NOT map to the RAW live model
-// (raw order, aws:* tags present) Cloud Control patches, so a sub-path patch lands on the
-// WRONG element (silent corruption) or out of range (loud reject) (#750). The safe revert is
-// a WHOLE-ARRAY write of the declared list (revert then re-attaches aws:* managed tags via
-// tagPreservingOps where the array is a tag property), collapsed by the revert plan exactly
-// like an UNORDERED_OBJECT_ARRAY.
-// #1271: this misalignment is NOT unique to `{Key,Value}` tag lists. `canonicalizeTagLists`
-// sorts EVERY object array whose every element carries ANY of the five identity fields
-// (`Key`/`Id`/`AttributeName`/`IndexName`/`Name`) — CloudWatch Alarm `Dimensions` ({Name,Value}),
-// S3 `LifecycleConfiguration.Rules` ({Id,...}), DynamoDB `GlobalSecondaryIndexes` ({IndexName})
-// / `AttributeDefinitions` ({AttributeName}). A per-element sub-value drift inside any of them
-// diffs at the SORTED index, which does not map to the raw model Cloud Control patches — a
-// per-element op would revert the WRONG element (or, for the top-level {Key,Value} case,
-// leave the real drift while corrupting an innocent element). So hoist the whole class, not
-// just Key/Value tags: any identity-sorted object array whose value IS the top-level array.
-const isIdentitySortedObjectArray = (arr: unknown[]): boolean =>
-  arr.length > 0 && identityField(arr) !== undefined;
-
 // True when every key of `sub` is present in `sup` with an equal value (objects
 // recurse so a nested declared block must also be a subset; everything else is
 // deep-equal). Used to align a declared policy statement to the live statement it is
@@ -1654,6 +1634,63 @@ function remapSortedIndexToDeclared(
   if (el === undefined) return path;
   const rawIdx = rawDeclared.findIndex((e) => deepEqual(e, el));
   return rawIdx < 0 ? path : `${arrayKey}.${rawIdx}${m[2]}`;
+}
+
+// #1271/#1306: does a per-element declared-drift path CROSS an object array that classify
+// SORTED before the positional diff — either identity-keyed by canonicalizeTagLists (an
+// array whose every element carries one of the five IDENTITY_FIELDS, at ANY depth) OR a
+// nested insertionOrder:false array sorted by sortNestedObjectArrays? If so, the drift's
+// array index is a SORTED position that does NOT map to the RAW live model Cloud Control
+// patches — a sub-path patch would corrupt the wrong (unchanged) live element while the real
+// drift survives. Returns the OUTERMOST such array's own path + its declared value so the
+// caller can collapse the finding to a whole-ARRAY revert (the #1241 {Key,Value} hoist,
+// generalized to the whole class) — replacing just that array, not the whole top-level
+// property (a nested `DistributionConfig.Origins` reverts Origins, never all of
+// DistributionConfig). The outermost array is the collapse target because any array ABOVE it
+// is unsorted (its index is raw and addressable), while everything at/below the sorted array
+// has a misaligned index. A SINGLE-element array can never be reordered (sorted == raw) so it
+// is skipped — the length check is the only order-independent misalignment signal available
+// here (both compare sides are already canonicalized, so raw order is not visible), and it is
+// what keeps #529's single-entry nested {Key,Value} list (inside the order-significant Logs
+// Transformer pipeline) a precise per-element patch. Walks the declared value `v` (rooted at
+// top-level key `k`); `nestedSubPaths` / `nestedIdentityBySubPath` are keyed RELATIVE to `k`.
+function crossedSortedArrayRevert(
+  v: unknown,
+  k: string,
+  driftPath: string,
+  resourceType: string,
+  nestedSubPaths: readonly string[],
+  nestedIdentityBySubPath: Record<string, string>
+): { path: string; value: unknown } | undefined {
+  if (!driftPath.startsWith(`${k}.`)) return undefined;
+  const orderSigKeys = ORDER_SIGNIFICANT_ARRAY_KEYS[resourceType];
+  const orderSigPaths = ORDER_SIGNIFICANT_PATHS[resourceType];
+  const rel = driftPath.slice(k.length + 1).split('.');
+  let cur: unknown = v;
+  let arrPathRel = ''; // dotted path (object keys only) of `cur`, relative to k
+  let parentKey = k; // the key name the current value sits under (k for the top-level value)
+  for (const seg of rel) {
+    if (Array.isArray(cur)) {
+      const arr: unknown[] = cur;
+      if (!/^\d+$/.test(seg)) return undefined; // a non-index step off an array is malformed
+      const fullPath = arrPathRel ? `${k}.${arrPathRel}` : k;
+      // An ORDER-SIGNIFICANT array (CodePipeline Stages/Actions, Logs Transformer pipeline,
+      // Scheduler PlacementStrategy) is NEVER sorted — its index is RAW and addressable — so
+      // it must stay a surgical per-element revert. Skip it and descend (raw index aligns).
+      const orderSig = (orderSigKeys?.has(parentKey) || orderSigPaths?.has(fullPath)) ?? false;
+      const idField = identityField(arr) ?? nestedIdentityBySubPath[arrPathRel];
+      const sortable = !orderSig && (idField !== undefined || nestedSubPaths.includes(arrPathRel));
+      if (sortable && arr.length >= 2) return { path: fullPath, value: arr };
+      cur = arr[Number(seg)]; // aligned here → descend to check for a deeper reordered array
+    } else if (cur !== null && typeof cur === 'object') {
+      cur = (cur as Record<string, unknown>)[seg];
+      arrPathRel = arrPathRel ? `${arrPathRel}.${seg}` : seg;
+      parentKey = seg;
+    } else {
+      return undefined;
+    }
+  }
+  return undefined;
 }
 
 // Translate a Custom::S3BucketNotifications CR's DECLARED `NotificationConfiguration` (rendered
@@ -3408,6 +3445,13 @@ export function classifyResource(
           .map((p) => p.slice(k.length + 1))
       ),
     ];
+    // #1306: per-nested-array identity fields for THIS key, re-keyed from the full dotted
+    // NESTED_OBJECT_ARRAY_IDENTITY path to the `${k}.`-stripped sub-path sortNestedObjectArrays
+    // uses — so the nested set sorts by identity (stable under a non-identity value change)
+    // rather than full canonical JSON (which cascades a single change into several findings).
+    const nestedIdentityBySubPath: Record<string, string> = {};
+    for (const [fullPath, idf] of Object.entries(NESTED_OBJECT_ARRAY_IDENTITY[resourceType] ?? {}))
+      if (fullPath.startsWith(`${k}.`)) nestedIdentityBySubPath[fullPath.slice(k.length + 1)] = idf;
     let declaredVal: unknown = v;
     let liveVal: unknown = live[k];
     // For an UNORDERED_OBJECT_ARRAY, the source whose TOP-LEVEL order still matches the
@@ -3492,20 +3536,24 @@ export function classifyResource(
       // template order, so its elements deep-equal the sorted declaredVal's elements AND
       // its index is the template index — exactly what remapSortedIndexToDeclared needs.
       const declaredNestedSorted =
-        nestedSubPaths.length > 0 ? sortNestedObjectArrays(v, nestedSubPaths) : v;
+        nestedSubPaths.length > 0
+          ? sortNestedObjectArrays(v, nestedSubPaths, nestedIdentityBySubPath)
+          : v;
       // Key the sort on the element's IDENTITY field (when the type has one) so a change to a
       // NON-identity sibling keeps the element aligned on both sides (else a mutable field that
       // sorts before the identity — Cognito ScopeDescription, Secret KmsKeyId — misaligns).
       const idField = UNORDERED_OBJECT_ARRAY_IDENTITY[resourceType]?.[k];
       declaredVal = sortUnorderedObjectArray(declaredNestedSorted, idField);
       liveVal = sortUnorderedObjectArray(
-        nestedSubPaths.length > 0 ? sortNestedObjectArrays(live[k], nestedSubPaths) : live[k],
+        nestedSubPaths.length > 0
+          ? sortNestedObjectArrays(live[k], nestedSubPaths, nestedIdentityBySubPath)
+          : live[k],
         idField
       );
       if (Array.isArray(declaredNestedSorted)) declaredRemapSource = declaredNestedSorted;
     } else if (nestedSubPaths.length > 0) {
-      declaredVal = sortNestedObjectArrays(v, nestedSubPaths);
-      liveVal = sortNestedObjectArrays(live[k], nestedSubPaths);
+      declaredVal = sortNestedObjectArrays(v, nestedSubPaths, nestedIdentityBySubPath);
+      liveVal = sortNestedObjectArrays(live[k], nestedSubPaths, nestedIdentityBySubPath);
     }
     // R95: the live side is compared in FULL — no subset projection. An R75
     // generic `projectLiveToDeclaredSubset` used to drop live elements whose
@@ -3875,13 +3923,26 @@ export function classifyResource(
       // per-element pointer against a sorted index that does not exist in the raw model.
       // Only fires for a per-element (`${k}.` sub-path) drift; a whole-array drift already
       // carries the right path. The unorderedObjArray branch above handles the type-/schema-
-      // opted-in unordered object arrays; this covers the identity-sorted arrays it misses
-      // (CloudWatch Alarm Dimensions, S3 lifecycle Rules, DynamoDB GSI/AttributeDefinitions, …).
-      const identitySortedWhole =
-        !unorderedObjArray &&
-        Array.isArray(v) &&
-        isIdentitySortedObjectArray(v) &&
-        d.path.startsWith(`${k}.`);
+      // opted-in unordered object arrays; this covers the identity-sorted arrays it misses.
+      // #1271 (top-level identity arrays) landed via #1440; #1306 extends the hoist to a per-
+      // element drift whose path crosses a sorted object array at ANY depth — a nested
+      // insertionOrder:false array (Bedrock Guardrail FiltersConfig) OR a nested identity-keyed
+      // array (S3 LifecycleConfiguration.Rules, CloudFront DistributionConfig.Origins). Collapse
+      // to a whole-ARRAY revert of that SPECIFIC array (its own path + declared value), so a
+      // nested Origins reverts Origins — never all of DistributionConfig; the plan reads
+      // Finding.wholeArrayRevert (tagPreservingOps still re-attaches aws:* tags where the array
+      // is a tag property). Superset of #1440's top-level-only gate (which used {path:k,value:v};
+      // for a top-level array where v IS the array this returns the identical {path:k,value:arr}).
+      const crossedSorted = unorderedObjArray
+        ? undefined
+        : crossedSortedArrayRevert(
+            v,
+            k,
+            d.path,
+            resourceType,
+            nestedSubPaths,
+            nestedIdentityBySubPath
+          );
       const unorderedExtra =
         unorderedObjArray && Array.isArray(declaredVal) && declaredRemapSource
           ? {
@@ -3892,8 +3953,8 @@ export function classifyResource(
               path: remapSortedIndexToDeclared(d.path, k, declaredVal, declaredRemapSource),
               wholeArrayRevert: { path: k, value: v },
             }
-          : identitySortedWhole
-            ? { wholeArrayRevert: { path: k, value: v } }
+          : crossedSorted
+            ? { wholeArrayRevert: crossedSorted }
             : {};
       pushDeclaredFinding(findings, {
         logicalId,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -5571,18 +5571,60 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
   ]),
 };
 
+// #1306: per-type NESTED object-array IDENTITY fields — the nested twin of
+// UNORDERED_OBJECT_ARRAY_IDENTITY (which reaches TOP-LEVEL arrays only). Keyed by
+// resourceType -> { full DOTTED path (from the resource root, matching
+// UNORDERED_NESTED_OBJECT_ARRAY_PATHS) -> the element's identity field }. Passed to
+// sortNestedObjectArrays so the nested set is sorted by identity FIRST (then canonical
+// JSON), keeping an element in the SAME aligned slot on both compare sides when a
+// NON-identity value drifts — otherwise a plain canonical-JSON sort moves the changed
+// element to a new slot and the positional diff CASCADES into several bogus findings
+// (a single out-of-band Guardrail FiltersConfig OutputStrength change reported 3 drifts).
+// Only OBJECT arrays whose elements carry a stable identity + a mutable sibling need this;
+// scalar sets (Headers/Aliases/KafkaBootstrapServers/NonKeyAttributes) do not. The
+// identity need not be one of canonicalizeTagLists's five IDENTITY_FIELDS — these are
+// per-type (Type/Text/ContainerPort/SourceContainer/ConditionKey).
+export const NESTED_OBJECT_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
+  'AWS::Bedrock::Guardrail': {
+    'ContentPolicyConfig.FiltersConfig': 'Type',
+    'TopicPolicyConfig.TopicsConfig': 'Name',
+    'SensitiveInformationPolicyConfig.PiiEntitiesConfig': 'Type',
+    'SensitiveInformationPolicyConfig.RegexesConfig': 'Name',
+    'WordPolicyConfig.WordsConfig': 'Text',
+  },
+  'AWS::ECS::TaskDefinition': {
+    'ContainerDefinitions.PortMappings': 'ContainerPort',
+    'ContainerDefinitions.VolumesFrom': 'SourceContainer',
+  },
+  'AWS::Backup::BackupSelection': {
+    'BackupSelection.ListOfTags': 'ConditionKey',
+  },
+};
+
 // Return a deep clone of `value` (a declared/live property subtree rooted at one
 // top-level key) with the object array at each of `subPaths` (dotted, RELATIVE to that
 // root) sorted into canonical order. Applied to BOTH the declared and live side before
 // the positional nested diff so a reordered-but-equal set aligns; a non-array or absent
 // path is left untouched, and a genuine element change still differs after the sort.
-export function sortNestedObjectArrays(value: unknown, subPaths: readonly string[]): unknown {
+export function sortNestedObjectArrays(
+  value: unknown,
+  subPaths: readonly string[],
+  // #1306: per-sub-path identity field (keyed by the SAME relative sub-path as `subPaths`).
+  // Without it a nested unordered array is sorted by full canonical JSON, so a per-element
+  // VALUE change moves the element to a new sorted slot and the positional diff cascades to
+  // several bogus findings (a 1-change Bedrock Guardrail FiltersConfig edit reported 3×).
+  // Keying the sort on the element identity FIRST (FiltersConfig→Type, WordsConfig→Text, …)
+  // keeps the changed element in the SAME aligned slot on both sides, so only it differs —
+  // the nested twin of UNORDERED_OBJECT_ARRAY_IDENTITY for the top-level branch.
+  identityBySubPath?: Record<string, string>
+): unknown {
   if (subPaths.length === 0 || value === null || typeof value !== 'object') return value;
   // A sub-path may cross an ARRAY (ECS `ContainerDefinitions.PortMappings`: the parent
   // ContainerDefinitions is itself an array, so PortMappings lives one level down inside
   // EACH element). Recurse element-wise, applying the same remaining sub-paths inside
   // every element, so the nested set is sorted within each container.
-  if (Array.isArray(value)) return value.map((el) => sortNestedObjectArrays(el, subPaths));
+  if (Array.isArray(value))
+    return value.map((el) => sortNestedObjectArrays(el, subPaths, identityBySubPath));
   const clone = structuredClone(value) as Record<string, unknown>;
   for (const sub of subPaths) {
     const segs = sub.split('.');
@@ -5593,7 +5635,8 @@ export function sortNestedObjectArrays(value: unknown, subPaths: readonly string
         next !== null && typeof next === 'object' ? (next as Record<string, unknown>) : undefined;
     }
     const last = segs[segs.length - 1] as string;
-    if (cur && Array.isArray(cur[last])) cur[last] = sortUnorderedObjectArray(cur[last]);
+    if (cur && Array.isArray(cur[last]))
+      cur[last] = sortUnorderedObjectArray(cur[last], identityBySubPath?.[sub]);
   }
   return clone;
 }

--- a/tests/corpus/AWS__CloudFront__Distribution.MultiOriginCdn.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.MultiOriginCdn.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "Identity-keyed array sets: a multi-origin distribution returns Origins in a different ORDER (sorted by Id on both sides — not drift), while a REAL change inside one origin (OriginPath) still surfaces as declared drift with the post-sort index path.",
+  "description": "Identity-keyed array sets: a multi-origin distribution returns Origins in a different ORDER (sorted by Id on both sides — not drift), while a REAL change inside one origin (OriginPath) still surfaces as declared drift. The finding carries the post-sort index path AND (#1271) a wholeArrayRevert hoisting to the whole DistributionConfig.Origins array, so the revert replaces the array by declared value rather than patching a post-sort index that does not map to the raw live model.",
   "resource": {
     "logicalId": "MultiOriginCdn",
     "resourceType": "AWS::CloudFront::Distribution",
@@ -63,7 +63,22 @@
       "path": "DistributionConfig.Origins.1.OriginPath",
       "desired": "/v1",
       "actual": "/v2",
-      "physicalId": "E7F8G9H0J1K2L3"
+      "physicalId": "E7F8G9H0J1K2L3",
+      "wholeArrayRevert": {
+        "path": "DistributionConfig.Origins",
+        "value": [
+          {
+            "DomainName": "api.corpus.example.com",
+            "Id": "api-origin",
+            "OriginPath": ""
+          },
+          {
+            "DomainName": "corpus-assets.s3.us-east-1.amazonaws.com",
+            "Id": "static-assets",
+            "OriginPath": "/v1"
+          }
+        ]
+      }
     }
   ]
 }

--- a/tests/noise-nested-identity-sort-1306.test.ts
+++ b/tests/noise-nested-identity-sort-1306.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { NESTED_OBJECT_ARRAY_IDENTITY, sortNestedObjectArrays } from '../src/normalize/noise.js';
+
+// #1306: sortNestedObjectArrays keys the nested sort on the element IDENTITY (when the type
+// declares one via NESTED_OBJECT_ARRAY_IDENTITY) so a NON-identity value change keeps its
+// element in the SAME aligned slot on both compare sides — otherwise a plain canonical-JSON
+// sort moves the changed element to a new slot and the positional diff cascades into several
+// bogus findings.
+describe('#1306 sortNestedObjectArrays identity keying', () => {
+  const idBy = { FiltersConfig: 'Type' };
+
+  it('sorts a nested object array by its identity field (Type), not full canonical JSON', () => {
+    const value = {
+      FiltersConfig: [
+        { Type: 'SEXUAL', OutputStrength: 'NONE' },
+        { Type: 'HATE', OutputStrength: 'HIGH' },
+      ],
+    };
+    const sorted = sortNestedObjectArrays(value, ['FiltersConfig'], idBy) as {
+      FiltersConfig: { Type: string }[];
+    };
+    // ordered by Type: HATE < SEXUAL, independent of the mutable OutputStrength value.
+    expect(sorted.FiltersConfig.map((f) => f.Type)).toEqual(['HATE', 'SEXUAL']);
+  });
+
+  it('keeps a changed element in the SAME slot as its unchanged twin (no cascade)', () => {
+    // Declared vs live differ ONLY in SEXUAL.OutputStrength. An identity-keyed sort puts SEXUAL
+    // at the same index on both sides, so a positional diff sees ONE difference — not two.
+    const declared = {
+      FiltersConfig: [
+        { Type: 'HATE', OutputStrength: 'HIGH' },
+        { Type: 'SEXUAL', OutputStrength: 'HIGH' },
+      ],
+    };
+    const live = {
+      FiltersConfig: [
+        { Type: 'SEXUAL', OutputStrength: 'NONE' },
+        { Type: 'HATE', OutputStrength: 'HIGH' },
+      ],
+    };
+    const ds = sortNestedObjectArrays(declared, ['FiltersConfig'], idBy) as typeof declared;
+    const ls = sortNestedObjectArrays(live, ['FiltersConfig'], idBy) as typeof live;
+    // index 0 (HATE) is identical on both sides; only index 1 (SEXUAL) differs.
+    expect(ds.FiltersConfig[0]).toEqual(ls.FiltersConfig[0]);
+    expect(ds.FiltersConfig[1]!.Type).toBe(ls.FiltersConfig[1]!.Type);
+    expect(ds.FiltersConfig[1]!.OutputStrength).not.toBe(ls.FiltersConfig[1]!.OutputStrength);
+  });
+
+  it('without an identity field a value change cascades (both slots differ — the bug the table fixes)', () => {
+    const declared = {
+      FiltersConfig: [
+        { Type: 'HATE', OutputStrength: 'LOW' },
+        { Type: 'SEXUAL', OutputStrength: 'LOW' },
+      ],
+    };
+    const live = {
+      FiltersConfig: [
+        { Type: 'SEXUAL', OutputStrength: 'HIGH' },
+        { Type: 'HATE', OutputStrength: 'LOW' },
+      ],
+    };
+    // No identity map → canonical-JSON sort. Strengthening SEXUAL to HIGH ("HIGH" < "LOW")
+    // moves it BEFORE HATE, so the sorted sides no longer align element-for-element: declared
+    // = [HATE(LOW), SEXUAL(LOW)] but live = [SEXUAL(HIGH), HATE(LOW)] — BOTH slots now differ.
+    const ds = sortNestedObjectArrays(declared, ['FiltersConfig']) as typeof declared;
+    const ls = sortNestedObjectArrays(live, ['FiltersConfig']) as typeof live;
+    const misaligned =
+      JSON.stringify(ds.FiltersConfig[0]) !== JSON.stringify(ls.FiltersConfig[0]) &&
+      JSON.stringify(ds.FiltersConfig[1]) !== JSON.stringify(ls.FiltersConfig[1]);
+    expect(misaligned).toBe(true);
+  });
+
+  it('the Guardrail identity table names the documented per-array identity fields', () => {
+    expect(NESTED_OBJECT_ARRAY_IDENTITY['AWS::Bedrock::Guardrail']).toMatchObject({
+      'ContentPolicyConfig.FiltersConfig': 'Type',
+      'TopicPolicyConfig.TopicsConfig': 'Name',
+      'WordPolicyConfig.WordsConfig': 'Text',
+    });
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -319,16 +319,6 @@ describe('buildRevertPlan', () => {
         { Name: 'Env', Value: 'prod' },
       ],
     };
-    const emptySchema: SchemaInfo = {
-      readOnly: new Set(),
-      writeOnly: new Set(),
-      createOnly: new Set(),
-      readOnlyPaths: [],
-      writeOnlyPaths: [],
-      createOnlyPaths: [],
-      defaults: {},
-      defaultPaths: {},
-    };
     const findings = classifyResource(
       {
         logicalId: 'Alarm',
@@ -337,11 +327,11 @@ describe('buildRevertPlan', () => {
         declared: { Dimensions: declaredDims },
       },
       liveRaw,
-      emptySchema
+      emptySchema()
     );
     const drift = findings.find((f) => f.tier === 'declared');
     expect(drift).toBeDefined();
-    // canonicalizeTagLists sorted by Name → [Env(0), QueueName(1)], so the finding's own path is
+    // canonicalizeTagLists sorted by Name -> [Env(0), QueueName(1)], so the finding's own path is
     // the SORTED index `Dimensions.1.Value` — which in the RAW model is Env, NOT QueueName. A
     // per-element patch here is exactly the corruption #1271 describes. The hoist saves it:
     expect(drift!.path).toBe('Dimensions.1.Value');
@@ -372,6 +362,81 @@ describe('buildRevertPlan', () => {
         { Name: 'Env', Value: 'prod' },
       ])
     );
+  });
+
+  const emptySchema = (): SchemaInfo => ({
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  });
+
+  it('#1306: a nested Guardrail FiltersConfig value drift reports ONE finding (identity-keyed sort) and hoists to a whole-NESTED-array revert', () => {
+    // FiltersConfig is a nested insertionOrder:false array keyed by Type. AWS reorders it and
+    // one filter's OutputStrength drifted out of band. The identity-keyed nested sort keeps the
+    // changed element aligned (ONE finding, not the canonical-JSON cascade), and the whole-array
+    // revert targets the NESTED array path — never the whole ContentPolicyConfig.
+    const declared = {
+      ContentPolicyConfig: {
+        FiltersConfig: [
+          { Type: 'HATE', InputStrength: 'HIGH', OutputStrength: 'HIGH' },
+          { Type: 'SEXUAL', InputStrength: 'HIGH', OutputStrength: 'HIGH' },
+        ],
+      },
+    };
+    const liveRaw = {
+      ContentPolicyConfig: {
+        FiltersConfig: [
+          // reordered by AWS, and SEXUAL.OutputStrength weakened out of band HIGH -> NONE.
+          { Type: 'SEXUAL', InputStrength: 'HIGH', OutputStrength: 'NONE' },
+          { Type: 'HATE', InputStrength: 'HIGH', OutputStrength: 'HIGH' },
+        ],
+      },
+    };
+    const findings = classifyResource(
+      { logicalId: 'Gr', resourceType: 'AWS::Bedrock::Guardrail', physicalId: 'gr', declared },
+      liveRaw,
+      emptySchema()
+    );
+    const declaredDrifts = findings.filter((f) => f.tier === 'declared');
+    // ONE finding — the identity-keyed nested sort prevents the canonical-JSON cascade.
+    expect(declaredDrifts).toHaveLength(1);
+    expect(declaredDrifts[0]!.wholeArrayRevert).toBeDefined();
+    expect(declaredDrifts[0]!.wholeArrayRevert!.path).toBe('ContentPolicyConfig.FiltersConfig');
+    const plan = buildRevertPlan(findings, undefined, {
+      liveByLogical: new Map([['Gr', liveRaw]]),
+    });
+    const ops = plan.items[0]!.ops;
+    expect(ops).toHaveLength(1);
+    expect(ops[0]!.path).toBe('/ContentPolicyConfig/FiltersConfig');
+    // The whole declared FiltersConfig is written — the SEXUAL filter reverts to HIGH and the
+    // untouched HATE filter is preserved (never corrupted by a misaligned per-element patch).
+    expect(ops[0]!.value).toEqual(
+      expect.arrayContaining([
+        { Type: 'SEXUAL', InputStrength: 'HIGH', OutputStrength: 'HIGH' },
+        { Type: 'HATE', InputStrength: 'HIGH', OutputStrength: 'HIGH' },
+      ])
+    );
+  });
+
+  it('#1306/#529 NEGATIVE: a SINGLE-element identity array cannot misalign, so it stays a surgical per-element revert', () => {
+    // One dimension -> sorting is a no-op -> the index is raw and addressable -> no whole-array
+    // hoist (the #529 single-entry principle: only a 2+-element sortable array can misalign).
+    const declared = { Dimensions: [{ Name: 'QueueName', Value: 'prod-queue' }] };
+    const liveRaw = { Dimensions: [{ Name: 'QueueName', Value: 'HACKED-queue' }] };
+    const findings = classifyResource(
+      { logicalId: 'Al', resourceType: 'AWS::CloudWatch::Alarm', physicalId: 'al', declared },
+      liveRaw,
+      emptySchema()
+    );
+    const drift = findings.find((f) => f.tier === 'declared');
+    expect(drift).toBeDefined();
+    expect(drift!.wholeArrayRevert).toBeUndefined();
+    expect(drift!.path).toBe('Dimensions.0.Value');
   });
 
   it('ManagedPolicy attachment detach -> SDK item, op carries the member on attributeKey', () => {


### PR DESCRIPTION
Closes #1306. (Builds on #1440, which landed the #1271 top-level identity-sorted whole-array revert.)

`#1440` hoisted a per-element drift inside a **top-level** identity-sorted object array to a whole-array revert — but only when the drifted array **is** the top-level property value. Two gaps remained, both **#1306**:

- **Nested** sorted arrays (Bedrock Guardrail `ContentPolicyConfig.FiltersConfig`, S3 `LifecycleConfiguration.Rules`, CloudFront `DistributionConfig.Origins`) still emitted a per-element op against a **sorted** index that does not map to the raw live model — the CC patch corrupts the **wrong (unchanged)** element while the real drift survives.
- A nested unordered array sorted by full canonical JSON **cascades** a single value change into several bogus findings.

### Fix (`classify.ts` + `noise.ts`; `plan.ts` unchanged — its collapse is already generic on `Finding.wholeArrayRevert`)

1. **`crossedSortedArrayRevert`** walks the declared value along the drift path and, at the **outermost** sorted 2+-element array it crosses (identity-keyed at **any depth**, or a nested `insertionOrder:false` array), returns *that array's own path + declared value* → the finding collapses to a whole-array revert of just that array (a nested `Origins` reverts Origins, never all of `DistributionConfig`). It is a **superset** of #1440's top-level gate — for a top-level array where `v` **is** the array it returns the identical `{path:k, value}`. Order-significant arrays are excluded (raw index), and a **single-element** array is skipped (can't misalign — keeps **#529**'s single-entry nested `{Key,Value}` list a per-element patch).
2. **`NESTED_OBJECT_ARRAY_IDENTITY`** + a threaded identity arg to `sortNestedObjectArrays` sort a nested set by its element identity (`FiltersConfig`→`Type`, `WordsConfig`→`Text`, `PortMappings`→`ContainerPort`, …) instead of canonical JSON, so a non-identity value change keeps its element aligned and reports **one** finding, not a cascade.

### Live-verified (revert hot-path)
Deployed a real Bedrock Guardrail (4 content filters). AWS **reordered** them (declared `[HATE,INSULTS,SEXUAL,VIOLENCE]` → live `[VIOLENCE,HATE,SEXUAL,INSULTS]`). Weakened VIOLENCE `outputStrength` HIGH→LOW out of band (live raw index **0**):
- `check` detected exactly **one** drift at `FiltersConfig.3.OutputStrength` (the **sorted** index).
- `revert` collapsed to a whole-array `/ContentPolicyConfig/FiltersConfig` replace and converged (`CLEAN after revert`).
- All four filters HIGH afterwards — VIOLENCE restored, and **INSULTS (raw index 3, where a naive per-element `/FiltersConfig/3/…` patch would have landed) NOT corrupted**.

Stack torn down with `delstack`; `SWEEP CLEAN`.

### Tests
Guardrail `FiltersConfig` end-to-end nested collapse, the single-element negative, the identity-keyed nested sort (`noise-nested-identity-sort-1306.test.ts`), and the `MultiOriginCdn` corpus golden updated to carry the correct `wholeArrayRevert` on the nested `Origins` finding. Full suite: 4936 pass.
