### PR TITLE
fix(diff): gate EB InstanceTypes against the architecture-derived default (cost-bomb detection) (#1278, #1263)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2839,13 +2839,17 @@ export const EB_OPTION_VALUE_INDEPENDENT: ReadonlySet<string> = new Set([
   // instance, a silent p4d.24xlarge cost bomb). ebOptionSettingTier now gates them: SecurityGroups
   // folds only the environment's own awseb-* generated group; InstanceType is derived from the
   // sibling aws:ec2:instances|InstanceTypes option's first element. Any other value surfaces.
+  // #1278/#1263: aws:ec2:instances|InstanceTypes is ALSO no longer value-independent — it is the
+  // option a real OOB resize sets (update-environment …InstanceTypes=p4d.24xlarge), and EB mirrors
+  // the legacy InstanceType scalar to match, so folding it value-independent hid the cost bomb AND
+  // left the #893 InstanceType==InstanceTypes[0] gate anchored on an unvalidated source. It is now
+  // gated (ebInstanceTypesDefaultSet) against the architecture's AWS-assigned default burstable set.
   'aws:cloudformation:template:parameter|AppSource',
   'aws:cloudformation:template:parameter|HooksPkgUrl',
   'aws:cloudformation:template:parameter|InstanceTypeFamily',
   // an aggregate echo of the app EnvironmentVariables (includes per-deploy paths like the
   // Python venv staging dir), so any value is a reflection of the declared env vars, not intent
   'aws:cloudformation:template:parameter|EnvironmentVariables',
-  'aws:ec2:instances|InstanceTypes',
   'aws:ec2:instances|SupportedArchitectures',
   // the platform-injected Python venv path carries a random per-deploy staging id
   'aws:elasticbeanstalk:application:environment|PYTHONPATH',
@@ -2885,6 +2889,29 @@ function isAllEbGeneratedGroups(value: unknown): boolean {
   if (typeof value !== 'string' || value === '') return false;
   return value.split(',').every((el) => isEbGeneratedGroup(el));
 }
+// #1278/#1263: when the user declares no `aws:ec2:instances|InstanceTypes` option, EB assigns
+// the platform's smallest burstable pair for the environment's processor architecture — a
+// DETERMINISTIC function of the sibling `aws:ec2:instances|SupportedArchitectures` option
+// (x86_64 when unset, EB's own default). Pinned from `describe-configuration-options` +
+// the harvested EB corpus (x86_64 → t3.micro/t3.small) and the EB arm64 docs
+// (arm64 → t4g.micro/t4g.small). Folding InstanceTypes against this set keeps a clean deploy
+// at zero drift while surfacing any first element AWS did not assign as a default — an OOB
+// instance-family bump (the silent p4d.24xlarge cost bomb).
+const EB_INSTANCE_TYPES_DEFAULT_BY_ARCH: Record<string, ReadonlySet<string>> = {
+  x86_64: new Set(['t3.micro', 't3.small']),
+  arm64: new Set(['t4g.micro', 't4g.small']),
+};
+function ebInstanceTypesDefaultSet(
+  supportedArchitectures: unknown
+): ReadonlySet<string> | undefined {
+  const arch =
+    typeof supportedArchitectures === 'string' && supportedArchitectures.trim() !== ''
+      ? supportedArchitectures.split(',')[0]?.trim()
+      : 'x86_64';
+  return arch === undefined
+    ? EB_INSTANCE_TYPES_DEFAULT_BY_ARCH.x86_64
+    : EB_INSTANCE_TYPES_DEFAULT_BY_ARCH[arch];
+}
 export function ebOptionSettingTier(
   namespace: unknown,
   optionName: unknown,
@@ -2916,6 +2943,22 @@ export function ebOptionSettingTier(
       typeof instanceTypes === 'string' ? instanceTypes.split(',')[0]?.trim() : undefined;
     if (first !== undefined) return first === value ? 'atDefault' : 'undeclared';
     return 'atDefault';
+  }
+  // #1278/#1263: InstanceTypes — the modern list option a real OOB resize sets. Fold only when
+  // EVERY element is one of the architecture's AWS-assigned default burstable types; a bump to a
+  // bigger/other-family type (p4d.24xlarge cost bomb) surfaces. Unknown/future architecture (the
+  // set can't be pinned) → fail open (fold), so a clean deploy never false-positives.
+  if (key === 'aws:ec2:instances|InstanceTypes') {
+    const defaults = ebInstanceTypesDefaultSet(
+      siblingOption?.('aws:ec2:instances', 'SupportedArchitectures')
+    );
+    if (defaults === undefined) return 'atDefault';
+    const types = String(value)
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t !== '');
+    if (types.length === 0) return 'atDefault';
+    return types.every((t) => defaults.has(t)) ? 'atDefault' : 'undeclared';
   }
   if (EB_OPTION_VALUE_INDEPENDENT.has(key)) return 'atDefault';
   const derived = EB_OPTION_DERIVED[key];

--- a/tests/noise-eb-instancetypes-1278.test.ts
+++ b/tests/noise-eb-instancetypes-1278.test.ts
@@ -1,0 +1,108 @@
+// #1278 / #1263 — the EB `aws:ec2:instances|InstanceTypes` option used to fold
+// VALUE-INDEPENDENT (EB_OPTION_VALUE_INDEPENDENT), so ANY value folded to `atDefault`.
+// But InstanceTypes is the option a real out-of-band resize sets
+// (`aws elasticbeanstalk update-environment --option-settings
+// Namespace=aws:ec2:instances,OptionName=InstanceTypes,Value=p4d.24xlarge`), and EB mirrors
+// the legacy `aws:autoscaling:launchconfiguration|InstanceType` scalar to match — so a silent
+// p4d.24xlarge cost bomb folded through BOTH keys and read CLEAN (#1278). It also left the
+// #893 InstanceType == InstanceTypes[0] derived gate anchored on an unvalidated (value-
+// independent) source (#1263).
+//
+// InstanceTypes now folds ONLY when every element is one of the environment architecture's
+// AWS-assigned default burstable types — a tier-2 DERIVED default keyed on the sibling
+// `aws:ec2:instances|SupportedArchitectures` option (x86_64 → t3.micro/t3.small,
+// arm64 → t4g.micro/t4g.small; x86_64 when the sibling is unset). Any other first element
+// surfaces (`undeclared`).
+import { describe, expect, it } from 'vite-plus/test';
+import { ebOptionSettingTier } from '../src/normalize/noise.js';
+
+const NS = 'aws:ec2:instances';
+const OPT = 'InstanceTypes';
+
+// Classify an InstanceTypes value with a given SupportedArchitectures sibling.
+function tier(value: string, supportedArchitectures?: string): 'atDefault' | 'undeclared' {
+  const siblingOption = (ns: string, opt: string): unknown =>
+    ns === 'aws:ec2:instances' && opt === 'SupportedArchitectures'
+      ? supportedArchitectures
+      : undefined;
+  return ebOptionSettingTier(NS, OPT, value, 'LoadBalanced', siblingOption);
+}
+
+describe('#1278 EB InstanceTypes folds against the architecture-derived default set', () => {
+  it('folds the x86_64 default pair (sibling unset → x86_64)', () => {
+    expect(tier('t3.micro, t3.small')).toBe('atDefault');
+  });
+
+  it('folds the single-element x86_64 default (harvested corpus form)', () => {
+    expect(tier('t3.micro')).toBe('atDefault');
+  });
+
+  it('folds the x86_64 default when SupportedArchitectures is explicitly x86_64', () => {
+    expect(tier('t3.micro, t3.small', 'x86_64')).toBe('atDefault');
+  });
+
+  it('SURFACES an out-of-band p4d.24xlarge resize (the silent cost bomb #1278)', () => {
+    expect(tier('p4d.24xlarge')).toBe('undeclared');
+    expect(tier('p4d.24xlarge', 'x86_64')).toBe('undeclared');
+  });
+
+  it('surfaces a bump even when only one element is non-default', () => {
+    expect(tier('t3.micro, p4d.24xlarge')).toBe('undeclared');
+  });
+
+  it('surfaces a larger burstable bump away from the default (t3.2xlarge)', () => {
+    expect(tier('t3.2xlarge')).toBe('undeclared');
+  });
+
+  it('folds the arm64 default pair when SupportedArchitectures is arm64', () => {
+    expect(tier('t4g.micro, t4g.small', 'arm64')).toBe('atDefault');
+  });
+
+  it('SURFACES an arm64 cost bomb (p4d) resize', () => {
+    expect(tier('p4d.24xlarge', 'arm64')).toBe('undeclared');
+  });
+
+  it('surfaces the x86 default pair when the environment is arm64 (wrong-arch, not the default)', () => {
+    // t3.* are not the arm64 default — an arm64 env showing t3 is a real (non-default) config.
+    expect(tier('t3.micro, t3.small', 'arm64')).toBe('undeclared');
+  });
+
+  it('fails open (folds) for an unknown/future architecture rather than false-positive', () => {
+    expect(tier('anything.large', 'riscv128')).toBe('atDefault');
+  });
+
+  it('folds an unset/empty value', () => {
+    expect(tier('')).toBe('atDefault');
+  });
+});
+
+// #1263 — with InstanceTypes now gated, the #893 legacy-scalar gate
+// (InstanceType == InstanceTypes[0]) anchors on a VALIDATED option: a resize that moves BOTH
+// keys together still surfaces via InstanceTypes, while the mirrored scalar folds (no double
+// report). A legacy-only skew where InstanceType diverges from InstanceTypes[0] surfaces.
+describe('#1263 InstanceType scalar gate anchors on the now-validated InstanceTypes option', () => {
+  function instanceTypeTier(
+    instanceType: string,
+    instanceTypes: string
+  ): 'atDefault' | 'undeclared' {
+    const siblingOption = (ns: string, opt: string): unknown =>
+      ns === 'aws:ec2:instances' && opt === 'InstanceTypes' ? instanceTypes : undefined;
+    return ebOptionSettingTier(
+      'aws:autoscaling:launchconfiguration',
+      'InstanceType',
+      instanceType,
+      'LoadBalanced',
+      siblingOption
+    );
+  }
+
+  it('folds the mirrored scalar when it equals InstanceTypes[0] (bump reported once via InstanceTypes)', () => {
+    // Both bumped to p4d: InstanceTypes surfaces the cost bomb; the scalar mirror folds.
+    expect(instanceTypeTier('p4d.24xlarge', 'p4d.24xlarge')).toBe('atDefault');
+    expect(tier('p4d.24xlarge')).toBe('undeclared');
+  });
+
+  it('surfaces a legacy-only scalar bump that diverges from InstanceTypes[0]', () => {
+    expect(instanceTypeTier('p4d.24xlarge', 't3.micro, t3.small')).toBe('undeclared');
+  });
+});


### PR DESCRIPTION
## What

Gate the EB `aws:ec2:instances|InstanceTypes` option against the environment
architecture's AWS-assigned default burstable set, instead of folding it
value-independent.

Closes #1278, Closes #1263.

## Why

`aws:ec2:instances|InstanceTypes` was in `EB_OPTION_VALUE_INDEPENDENT`, so **any**
value folded to `atDefault`. But `InstanceTypes` is exactly the option a real
out-of-band resize sets:

```
aws elasticbeanstalk update-environment --option-settings \
  Namespace=aws:ec2:instances,OptionName=InstanceTypes,Value=p4d.24xlarge
```

EB then mirrors the legacy `aws:autoscaling:launchconfiguration|InstanceType`
scalar to match, so:

- **#1278** — a silent `p4d.24xlarge` cost bomb folded through **both** keys and
  read CLEAN.
- **#1263** — the #893 `InstanceType == InstanceTypes[0]` derived gate was
  anchored on an unvalidated (value-independent) source, so the gate only ever
  fired in a transient skew state a steady-state env never exhibits.

## How

`InstanceTypes` now folds **only** when every comma-separated element is one of the
architecture's default burstable types — a **tier-2 derived** default keyed on the
sibling `aws:ec2:instances|SupportedArchitectures` option:

- `x86_64` (or unset — EB's own default) → `{ t3.micro, t3.small }`
- `arm64` → `{ t4g.micro, t4g.small }`

Any other first element (a bigger/other-family type) surfaces as `undeclared`.
An unknown/future architecture fails **open** (folds) so a clean deploy never
false-positives. With `InstanceTypes` now gated, the #893 `InstanceType` scalar
gate anchors on a validated option: a resize that moves both keys together
surfaces once via `InstanceTypes` while the mirrored scalar folds (no double
report); a legacy-only skew still surfaces.

Defaults pinned from a live `describe-configuration-options` read + the harvested
EB corpus (`x86_64` → `t3.micro, t3.small`, confirmed clean in corpus-replay) and
the EB arm64 docs.

## Verification

- New unit test `tests/noise-eb-instancetypes-1278.test.ts` (13 cases): folds each
  architecture's default, surfaces the p4d cost bomb (both x86 and arm64), surfaces
  a partial/wrong-arch bump, fails open for unknown arch, and covers the #1263
  scalar mirror-suppression.
- Full suite green (224 files, 4949 tests). No corpus regression — the harvested EB
  fixtures (real live x86_64 data) still fold to zero drift.
- Live evidence: `describe-configuration-options` (read-only) confirmed the x86
  default; no fresh EB deploy needed (fold/classify fix, corpus is authoritative).
