### PR TITLE
fix(release): parse compound fix(x)+fix(y) commit types in the semantic-release headerPattern

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
       {
         "preset": "angular",
         "parserOpts": {
-          "headerPattern": "^(\\w*)(?:\\(([^)]+)\\))?(!)?: (.+)$",
+          "headerPattern": "^(\\w*)(?:\\((.+?)\\))?(!)?: (.+)$",
           "headerCorrespondence": ["type", "scope", "breaking", "subject"],
           "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
         },

--- a/tests/releaserc-header-pattern.test.ts
+++ b/tests/releaserc-header-pattern.test.ts
@@ -1,0 +1,62 @@
+// The semantic-release commit-analyzer `headerPattern` in `.releaserc.json` must parse a
+// COMPOUND conventional-commit type like `fix(read)+fix(revert): …` as a releasing `fix`.
+// The original pattern's scope class `[^)]+` forbade a `)`, so a compound title (which has a
+// `)` mid-header before the colon) failed to match ENTIRELY → the commit parsed as no type →
+// semantic-release logged "no release" and never published. A real merge (#1431, squash title
+// `fix(read)+fix(revert): …`) shipped to main with NO version bump because of exactly this.
+// The fix makes the scope non-greedy (`(.+?)`), which absorbs the extra `)` yet still parses
+// every single-scope / no-scope title identically. This test pins that contract.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+const releaserc = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../.releaserc.json', import.meta.url)), 'utf8')
+) as {
+  plugins: unknown[];
+};
+
+// Pull the commit-analyzer plugin's headerPattern out of the actual config so the test
+// exercises the SHIPPED regex, not a copy.
+const analyzer = releaserc.plugins.find(
+  (p): p is [string, { parserOpts: { headerPattern: string } }] =>
+    Array.isArray(p) && p[0] === '@semantic-release/commit-analyzer'
+);
+const headerPattern = analyzer![1].parserOpts.headerPattern;
+const re = new RegExp(headerPattern);
+
+const parse = (header: string): { type?: string; scope?: string } => {
+  const m = re.exec(header);
+  return m ? { type: m[1], scope: m[2] } : {};
+};
+
+describe('.releaserc.json commit-analyzer headerPattern', () => {
+  it('parses a COMPOUND `fix(x)+fix(y):` title as a releasing `fix` (the #1431 no-release bug)', () => {
+    const p = parse('fix(read)+fix(revert): record-endorse + real delete (#1431) (#1446)');
+    expect(p.type).toBe('fix'); // NOT undefined → semantic-release applies the `fix` → patch rule
+  });
+
+  it('parses a compound `feat(x)+fix(y):` title as `feat`', () => {
+    expect(parse('feat(read)+fix(revert): add a thing (#42)').type).toBe('feat');
+  });
+
+  it('still parses a normal single-scope title identically (type + scope)', () => {
+    expect(parse('fix(diff): classify a thing')).toEqual({ type: 'fix', scope: 'diff' });
+  });
+
+  it('still parses a no-scope title (scope stays undefined, subject may hold parens)', () => {
+    expect(parse('feat: add a thing (#123)').type).toBe('feat');
+    expect(parse('feat: add a thing (#123)').scope).toBeUndefined();
+  });
+
+  it('still parses the release bot chore(release): commit', () => {
+    expect(parse('chore(release): 0.12.73 [skip ci]')).toEqual({
+      type: 'chore',
+      scope: 'release',
+    });
+  });
+
+  it('does not match a non-conventional header (no type/colon)', () => {
+    expect(parse('just some words without a colon type').type).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

The semantic-release commit-analyzer `headerPattern` in `.releaserc.json` used
`[^)]+` for the scope group, which **forbids a `)`**. A compound
conventional-commit title like `fix(read)+fix(revert): …` contains a `)`
mid-header (before the colon), so the pattern **fails to match entirely** → the
commit parses as *no type* → semantic-release logs `Analysis of N commits
complete: no release` and publishes nothing.

This is not hypothetical: **#1431 (PR #1446)** was squash-merged with the title
`fix(read)+fix(revert): record-endorse + real delete …` and shipped to `main`
(`0acddde`) with **no version bump** — its two neighbouring commits were `test:`
(also non-releasing), so nothing triggered a release. The code is on `main` but
unpublished.

## Fix

Make the scope non-greedy — `[^)]+` → `(.+?)`:

```
before: ^(\w*)(?:\(([^)]+)\))?(!)?: (.+)$
after:  ^(\w*)(?:\((.+?)\))?(!)?: (.+)$
```

Non-greedy backtracking absorbs the extra `)` in a compound title while parsing
every single-scope / no-scope / release-bot title **identically** (proven
empirically and pinned by the new test):

| title | type before | type after |
|---|---|---|
| `fix(read)+fix(revert): …` | **NO MATCH** | `fix` |
| `feat(x)+fix(y): …` | **NO MATCH** | `feat` |
| `fix(diff): …` | `fix` (scope `diff`) | `fix` (scope `diff`) |
| `feat: … (#123)` | `feat` | `feat` |
| `chore(release): 0.12.73 [skip ci]` | `chore` | `chore` |

Merging this `fix:`-typed PR also **triggers the release that publishes the
already-merged #1431 code**.

## Tests

`tests/releaserc-header-pattern.test.ts` loads the SHIPPED `headerPattern` from
`.releaserc.json` and asserts compound titles parse as their releasing type while
normal/no-scope/bot titles are unchanged (6 tests). Full suite green (4968).

Tooling-only (no `src/**`) → `verify-pr` live-test exempt; `check` + `docs` cover it.
