### PR TITLE
fix(diff): gate EC2 Instance SecurityGroupIds against the VPC-default SG (#640)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -244,6 +244,15 @@ const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // is NamespaceName/WorkgroupName only), so a value-independent fold hid a rogue SG swap/append.
   // Same derived VPC-default-SG check: fold a single default SG, surface an append/swap.
   'AWS::RedshiftServerless::Workgroup': 'SecurityGroupIds',
+  // #640: an EC2 Instance that declares no security group is placed into its VPC's default SG and
+  // reads back that single SG id in `SecurityGroupIds` — the same AWS first-run default the
+  // ALB/ENI/Neptune/MQ/Workgroup cases fold. It is OOB-mutable (`ec2 modify-instance-attribute
+  // --groups sg-…` swaps an instance's SGs with NO replacement), so the value-independent fold the
+  // noise.ts note deliberately withheld would hide a rogue SG swap/append. Gate it through the same
+  // derived VPC-default-SG check: fold a single default SG, surface an append/swap. (The name-form
+  // sibling `SecurityGroups` — an echo of the declared SGs or "default" — needs SG id→name
+  // resolution to gate safely and stays undeclared for a follow-up; #640.)
+  'AWS::EC2::Instance': 'SecurityGroupIds',
 };
 /** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
  *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into

--- a/tests/classify-ec2-instance-sg-640.test.ts
+++ b/tests/classify-ec2-instance-sg-640.test.ts
@@ -1,0 +1,82 @@
+// #640: an EC2 Instance that declares no security group reads back its VPC's single default SG id
+// in `SecurityGroupIds`. It was surfacing as first-run undeclared drift on every clean instance.
+// It is OOB-mutable (`ec2 modify-instance-attribute --groups`), so — like the ALB/ENI/Neptune/MQ/
+// Workgroup cases (#889/#976/#1266/#1269) — it must fold through the derived VPC-default-SG GATE,
+// not value-independent: fold a single default SG (clean deploy), surface an append or a swap to a
+// non-default SG (a rogue out-of-band change), fail open when the prefetch is unavailable.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource, shouldFoldDefaultSgList } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Inst',
+  resourceType: 'AWS::EC2::Instance',
+  physicalId: 'i-000000000000',
+  declared,
+});
+
+const DEFAULT_SG = 'sg-0defau1t00000000';
+const ROGUE_SG = 'sg-0rogue00000000000';
+const defaultSgIds = new Set([DEFAULT_SG]);
+const key = 'SecurityGroupIds';
+
+describe('#640 EC2::Instance.SecurityGroupIds derived VPC-default-SG gate', () => {
+  // A CDK instance declares InstanceType/ImageId/SubnetId but no SG; AWS assigns the VPC default SG.
+  const res = mk({ ImageId: 'ami-0', InstanceType: 't3.micro', SubnetId: 'subnet-0' });
+
+  it('folds a single VPC-default SG (clean deploy)', () => {
+    expect(
+      tier(
+        classifyResource(res, { [key]: [DEFAULT_SG] }, emptySchema, { defaultSgIds }),
+        'atDefault'
+      )
+    ).toContain(key);
+  });
+
+  it('surfaces an out-of-band SG append (2+ elements)', () => {
+    expect(
+      tier(
+        classifyResource(res, { [key]: [DEFAULT_SG, ROGUE_SG] }, emptySchema, { defaultSgIds }),
+        'undeclared'
+      )
+    ).toContain(key);
+  });
+
+  it('surfaces an out-of-band SG swap (single non-default SG)', () => {
+    expect(
+      tier(
+        classifyResource(res, { [key]: [ROGUE_SG] }, emptySchema, { defaultSgIds }),
+        'undeclared'
+      )
+    ).toContain(key);
+  });
+
+  it('fails open when the default-SG prefetch is unavailable (no first-run FP)', () => {
+    expect(
+      tier(classifyResource(res, { [key]: [ROGUE_SG] }, emptySchema, {}), 'atDefault')
+    ).toContain(key);
+  });
+
+  it('pure decision covers the EC2::Instance SG path', () => {
+    const t = 'AWS::EC2::Instance';
+    expect(shouldFoldDefaultSgList(t, key, [DEFAULT_SG], defaultSgIds)).toBe(true);
+    expect(shouldFoldDefaultSgList(t, key, [ROGUE_SG], defaultSgIds)).toBe(false);
+    expect(shouldFoldDefaultSgList(t, key, [DEFAULT_SG, ROGUE_SG], defaultSgIds)).toBe(false);
+    expect(shouldFoldDefaultSgList(t, key, [ROGUE_SG], undefined)).toBe(true); // fail open
+  });
+});

--- a/tests/corpus/AWS__EC2__Instance.Inst.sets.json
+++ b/tests/corpus/AWS__EC2__Instance.Inst.sets.json
@@ -449,7 +449,7 @@
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
       "path": "SecurityGroupIds",

--- a/tests/noise-ec2-instance-firstrun-640.test.ts
+++ b/tests/noise-ec2-instance-firstrun-640.test.ts
@@ -4,12 +4,14 @@
 // NetworkInterfaces block — a create-only value cannot drift out of band, so folding it can never
 // hide a real change, and it is never user intent when undeclared.
 //
-// DELIBERATELY NOT folded (a #889 handoff / deferred boundary this test documents): SecurityGroups
-// / SecurityGroupIds are MUTABLE out of band (`ec2 modify-instance-attribute --groups sg-…` swaps
-// them on a running instance with no replacement), so value-independent would HIDE an OOB SG swap —
-// they STILL surface as undeclared drift. NetworkInterfaces / Volumes are likewise deferred (a rogue
-// ENI / volume can be attached OOB). A user who pins any folded item DECLARES it, which is then
-// compared in the declared loop and does NOT fold here.
+// SecurityGroupIds is MUTABLE out of band (`ec2 modify-instance-attribute --groups sg-…` swaps it on
+// a running instance with no replacement), so it is NOT folded value-independent (that would HIDE an
+// OOB SG swap); instead it goes through the derived VPC-default-SG GATE (#889/#640): fold the single
+// VPC-default SG a clean deploy reads back, surface an append or a swap to a non-default SG.
+// STILL deferred (this test documents the boundary): the name-form `SecurityGroups` (needs SG id→name
+// resolution to gate safely) and NetworkInterfaces / Volumes (a rogue ENI / volume can be attached
+// OOB — needs a nested-attach mechanism) STILL surface as undeclared drift. A user who pins any folded
+// item DECLARES it, which is then compared in the declared loop and does NOT fold here.
 import { describe, expect, it } from 'vite-plus/test';
 import { classifyResource } from '../src/diff/classify.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
@@ -55,22 +57,27 @@ describe('#640 EC2 Instance first-run undeclared folds (value-independent)', () 
     Volumes: [{ VolumeId: 'vol-094cd4ee2e33c8e54', Device: '/dev/xvda' }],
   };
 
-  it('folds only the create-only CpuOptions + SubnetId to atDefault', () => {
-    const fs = classifyResource(mk(declared), structuredClone(live), schema(), {});
-    expect(tier(fs, 'atDefault')).toEqual(['CpuOptions', 'SubnetId']);
+  // The single VPC-default SG id the clean deploy read back, supplied to the #889/#640 SG gate.
+  const defaultSgIds = new Set(['sg-027bb24dfa8eb1b48']);
+
+  it('folds the create-only CpuOptions + SubnetId AND the gated default SecurityGroupIds', () => {
+    const fs = classifyResource(mk(declared), structuredClone(live), schema(), { defaultSgIds });
+    expect(tier(fs, 'atDefault')).toEqual(['CpuOptions', 'SecurityGroupIds', 'SubnetId']);
   });
 
-  it('SecurityGroupIds / SecurityGroups / NetworkInterfaces / Volumes are NOT folded — they still surface as undeclared drift', () => {
-    // These four are MUTABLE out of band (an SG swap or a rogue ENI / volume attach on a running
-    // instance), so a value-independent fold would HIDE that change. They deliberately do NOT fold
-    // here — SecurityGroups/SecurityGroupIds are a #889 handoff, NetworkInterfaces/Volumes deferred.
-    const fs = classifyResource(mk(declared), structuredClone(live), schema(), {});
-    expect(tier(fs, 'undeclared')).toEqual([
-      'NetworkInterfaces',
-      'SecurityGroupIds',
-      'SecurityGroups',
-      'Volumes',
-    ]);
+  it('SecurityGroups (name-form) / NetworkInterfaces / Volumes are NOT folded — they still surface', () => {
+    // The name-form SecurityGroups (needs id→name resolution) and NetworkInterfaces / Volumes (a
+    // rogue ENI / volume can be attached OOB) deliberately do NOT fold here yet — deferred boundary.
+    const fs = classifyResource(mk(declared), structuredClone(live), schema(), { defaultSgIds });
+    expect(tier(fs, 'undeclared')).toEqual(['NetworkInterfaces', 'SecurityGroups', 'Volumes']);
+  });
+
+  it('SecurityGroupIds SURFACES on an out-of-band swap to a NON-default SG (detection preserved)', () => {
+    // A rogue `modify-instance-attribute --groups` swaps the instance onto a non-default SG. The
+    // gate must SURFACE it (undeclared) — this is the OOB SG swap a value-independent fold would hide.
+    const swapped = { ...structuredClone(live), SecurityGroupIds: ['sg-0deadbeef00000000'] };
+    const fs = classifyResource(mk(declared), swapped, schema(), { defaultSgIds });
+    expect(tier(fs, 'undeclared')).toContain('SecurityGroupIds');
   });
 
   it('WITHOUT the folds every value would surface (guards the regression this fixes)', () => {


### PR DESCRIPTION
## Problem (#640, EC2::Instance sub-piece)

An `AWS::EC2::Instance` that declares no security group is placed into its VPC's
**default** security group and reads that single SG id back in `SecurityGroupIds`.
On a fresh, un-mutated deploy this surfaced as first-run **undeclared** drift on
every instance — a fold gap (violates the zero-potential-drift invariant).

## Why a gate, not value-independent

An instance's SGs are **mutable out of band** (`ec2 modify-instance-attribute
--groups sg-…` swaps them on a running instance with no replacement). A
value-independent fold would therefore **hide a rogue SG swap/append** — the exact
FN class #889 was created to fix. The existing note in `noise.ts` deliberately
withheld the value-independent fold for this reason.

## Fix

Route `AWS::EC2::Instance` → `SecurityGroupIds` through the existing derived
VPC-default-SG gate (`DEFAULT_SG_LIST_PATHS` / `shouldFoldDefaultSgList`, the
#889/#976/#1266/#1269 mechanism):

- **fold** `atDefault` when the live list is the single VPC-default SG a clean
  deploy reads back (or the `defaultSgIds` prefetch is unavailable → fail open, no
  first-run FP);
- **surface** an out-of-band **append** (2+ elements) or a **swap** to a
  non-default SG — detection preserved.

One-entry table extension; no new plumbing (`opts.defaultSgIds` already prefetched
by gather.ts).

## Deliberately deferred (still surface — flagged on #640)

- `SecurityGroups` **name-form** — echoes the declared SGs or `"default"`; needs SG
  id→name resolution to gate safely.
- `NetworkInterfaces` / `Volumes` — a rogue ENI / volume can be attached OOB; needs
  a nested-attach mechanism.
- `BlockDeviceMappings` husk-fill.

## Tests / verification

- New `tests/classify-ec2-instance-sg-640.test.ts` — fold-default / surface-append
  / surface-swap / fail-open + the pure decision.
- Updated the existing `#640` boundary test to the new gate behavior (adds a
  swap-surfaces case proving detection is preserved).
- Corpus `AWS__EC2__Instance.Inst.sets.json`: `SecurityGroupIds` `undeclared` →
  `atDefault` (the clean-deploy live payload harvested 2026-07-08; corpus-replay
  pins it). Live evidence is the harvested corpus case per the verify-pr fold rule.
- Full suite: 225 files, 4955 tests green.

Closes #640 partially (the `SecurityGroupIds` sub-piece); the deferred items remain
tracked on #640.
