### PR TITLE
fix(diff): account-level default overrides break constant fold pins — ECS containerInsights / SSM tier / EBS encrypt-by-default (#1070)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -10,11 +10,19 @@ import {
   DescribeSecurityGroupsCommand,
   DescribeSubnetsCommand,
   EC2Client,
+  GetEbsEncryptionByDefaultCommand,
 } from '@aws-sdk/client-ec2';
+import { ECSClient, ListAccountSettingsCommand } from '@aws-sdk/client-ecs';
 import { DescribeOptionGroupOptionsCommand, RDSClient } from '@aws-sdk/client-rds';
+import { GetServiceSettingCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
-import { CLUSTER_ECHO_CHILD, classifyResource, normalizeLiveModel } from '../diff/classify.js';
+import {
+  type AccountDefaults,
+  CLUSTER_ECHO_CHILD,
+  classifyResource,
+  normalizeLiveModel,
+} from '../diff/classify.js';
 import { resolveProperties } from '../normalize/intrinsic-resolver.js';
 import { READ_RETRY } from '../read/client-config.js';
 import {
@@ -138,6 +146,63 @@ async function fetchDefaultVpcSubnetIds(region: string): Promise<Set<string>> {
   }
   defaultSubnetIdsCache.set(region, ids);
   return ids;
+}
+
+// #1070: the effective account/region default settings a few undeclared defaults derive from — each
+// is an account-level control the owner can change (a documented hardening best practice), so a
+// fixed KNOWN_DEFAULTS pin FPs on every fresh deploy in an account that adopted it. Each lookup is
+// ONE read-only call, cached per region, and FAILS OPEN (returns undefined on any error — denied
+// permission, throttle, network — WITHOUT caching, so the next stack retries) so classify falls back
+// to the factory-default constant and a clean deploy never gains a first-run false positive. The
+// derived out-of-band change detection is therefore best-effort and requires the read permission.
+
+// ecs:ListAccountSettings effective `containerInsights` — AWS::ECS::Cluster.ClusterSettings default.
+const ecsContainerInsightsCache = new Map<string, string | undefined>();
+async function fetchEcsContainerInsightsDefault(region: string): Promise<string | undefined> {
+  if (ecsContainerInsightsCache.has(region)) return ecsContainerInsightsCache.get(region);
+  try {
+    const c = new ECSClient({ region, ...READ_RETRY });
+    const r = await c.send(
+      new ListAccountSettingsCommand({ name: 'containerInsights', effectiveSettings: true })
+    );
+    const value = r.settings?.find((s) => s.name === 'containerInsights')?.value;
+    ecsContainerInsightsCache.set(region, value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+// ssm:GetServiceSetting `/ssm/parameter-store/default-parameter-tier` — AWS::SSM::Parameter.Tier default.
+const ssmParameterTierCache = new Map<string, string | undefined>();
+async function fetchSsmDefaultParameterTier(region: string): Promise<string | undefined> {
+  if (ssmParameterTierCache.has(region)) return ssmParameterTierCache.get(region);
+  try {
+    const c = new SSMClient({ region, ...READ_RETRY });
+    const r = await c.send(
+      new GetServiceSettingCommand({ SettingId: '/ssm/parameter-store/default-parameter-tier' })
+    );
+    const value = r.ServiceSetting?.SettingValue;
+    ssmParameterTierCache.set(region, value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+// ec2:GetEbsEncryptionByDefault — AWS::EC2::Volume.Encrypted reads back `true` undeclared when on.
+const ebsEncryptionByDefaultCache = new Map<string, boolean | undefined>();
+async function fetchEbsEncryptionByDefault(region: string): Promise<boolean | undefined> {
+  if (ebsEncryptionByDefaultCache.has(region)) return ebsEncryptionByDefaultCache.get(region);
+  try {
+    const c = new EC2Client({ region, ...READ_RETRY });
+    const r = await c.send(new GetEbsEncryptionByDefaultCommand({}));
+    const value = r.EbsEncryptionByDefault;
+    ebsEncryptionByDefaultCache.set(region, value);
+    return value;
+  } catch {
+    return undefined;
+  }
 }
 
 // Regions already warned about a denied kms:ListAliases — the warning is one-per-region
@@ -1352,6 +1417,24 @@ export async function gatherFindings(
   if (desired.resources.some((r) => DEFAULT_SUBNET_LIST_TYPES.has(r.resourceType))) {
     defaultSubnetIds = await fetchDefaultVpcSubnetIds(region);
   }
+  // #1070: prefetch the effective account/region default settings a few undeclared defaults derive
+  // from — only for the affected type present in the stack, each fail-open. Threaded into classify
+  // so the ECS containerInsights / SSM default-tier / EBS encryption-by-default fold is a DERIVED
+  // equality gate against the account's real setting rather than a fixed constant that FPs once the
+  // owner adopts the hardening control (each NEW resource re-noising until recorded).
+  const accountDefaults: AccountDefaults = {};
+  if (desired.resources.some((r) => r.resourceType === 'AWS::ECS::Cluster')) {
+    const v = await fetchEcsContainerInsightsDefault(region);
+    if (v !== undefined) accountDefaults.ecsContainerInsights = v;
+  }
+  if (desired.resources.some((r) => r.resourceType === 'AWS::SSM::Parameter')) {
+    const v = await fetchSsmDefaultParameterTier(region);
+    if (v !== undefined) accountDefaults.ssmParameterTier = v;
+  }
+  if (desired.resources.some((r) => r.resourceType === 'AWS::EC2::Volume')) {
+    const v = await fetchEbsEncryptionByDefault(region);
+    if (v !== undefined) accountDefaults.ebsEncryptionByDefault = v;
+  }
   const classifyOpts = {
     accountId: desired.accountId,
     region,
@@ -1359,6 +1442,7 @@ export async function gatherFindings(
     stackTags: desired.stackTags ?? {},
     defaultSgIds,
     defaultSubnetIds,
+    accountDefaults,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     siblingEventBusPolicies: buildSiblingEventBusPolicies(desired),

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -310,6 +310,59 @@ export function shouldFoldDefaultSgList(
   );
 }
 
+// #1070: the effective ACCOUNT/REGION-level default settings that turn a few "constant" undeclared
+// defaults into a function of account state. The owner can change each via a documented account/
+// region API (often a hardening best practice), so a fixed KNOWN_DEFAULTS pin FPs on every fresh
+// deploy in an account that adopted the setting. gather.ts resolves each via one read-only lookup;
+// a field is undefined when the lookup was denied/unavailable → the fold FAILS OPEN to today's
+// factory-default constant.
+export interface AccountDefaults {
+  // ecs:ListAccountSettings effective `containerInsights` — 'disabled' | 'enabled' | 'enhanced'.
+  ecsContainerInsights?: string;
+  // ssm:GetServiceSetting `/ssm/parameter-store/default-parameter-tier` — 'Standard' | 'Advanced'
+  // | 'Intelligent-Tiering'.
+  ssmParameterTier?: string;
+  // ec2:GetEbsEncryptionByDefault — whether a new volume that declares no `Encrypted` reads true.
+  ebsEncryptionByDefault?: boolean;
+}
+
+// #1070: for a handful of undeclared properties the value AWS assigns at creation is a function of
+// an account/region-level setting the owner can change, not a fixed constant. When gather.ts
+// resolved the effective setting, return the DERIVED expected value so the caller equality-gates it
+// (folding a clean deploy but SURFACING an out-of-band change away from the account default — e.g. a
+// cluster with Insights disabled in an Insights-enabled account). Returns undefined when the lookup
+// was unavailable OR this (type, key) is not account-derived → the caller falls back to the factory
+// KNOWN_DEFAULTS constant (ECS/SSM) or to plain `undeclared` (EBS has no constant) — today's behavior.
+function accountDerivedDefault(
+  resourceType: string,
+  key: string,
+  ad: AccountDefaults | undefined
+): { value: unknown } | undefined {
+  if (!ad) return undefined;
+  if (
+    resourceType === 'AWS::ECS::Cluster' &&
+    key === 'ClusterSettings' &&
+    ad.ecsContainerInsights !== undefined
+  ) {
+    return { value: [{ Name: 'containerInsights', Value: ad.ecsContainerInsights }] };
+  }
+  if (
+    resourceType === 'AWS::SSM::Parameter' &&
+    key === 'Tier' &&
+    ad.ssmParameterTier !== undefined
+  ) {
+    return { value: ad.ssmParameterTier };
+  }
+  if (
+    resourceType === 'AWS::EC2::Volume' &&
+    key === 'Encrypted' &&
+    ad.ebsEncryptionByDefault !== undefined
+  ) {
+    return { value: ad.ebsEncryptionByDefault };
+  }
+  return undefined;
+}
+
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements
 // AWS always returns — keyed by the property -> the element's identity field. Cognito
 // UserPool `Schema` is the case: AWS returns all ~21 standard attributes (sub, email,
@@ -2137,6 +2190,12 @@ export function classifyResource(
     // subnets, so fold when EVERY live subnet is a default-VPC subnet and surface an OOB
     // re-placement into a subnet outside it. Undefined/empty → fail open (fold).
     defaultSubnetIds?: ReadonlySet<string>;
+    // #1070: effective ACCOUNT/REGION-level default settings resolved by gather.ts (ECS
+    // containerInsights, SSM default parameter tier, EBS encryption-by-default). A few undeclared
+    // defaults are a function of these, not a fixed constant — the pin FPs on every fresh deploy in
+    // an account that adopted the setting. Each field undefined → the fold falls back to the factory
+    // constant (fail-open). See accountDerivedDefault.
+    accountDefaults?: AccountDefaults;
     oaiCanonicalIds?: Record<string, string>; // OAI id -> S3CanonicalUserId, for CloudFront OAI principal match
     // Rules declared by SIBLING standalone AWS::EC2::SecurityGroupIngress/::SecurityGroupEgress
     // resources, keyed by the target SG's resolved GroupId (== the SG's physical id). Subtracted
@@ -4113,6 +4172,26 @@ export function classifyResource(
           nested: true,
         });
       }
+      continue;
+    }
+    // #1070: a value equal to its ACCOUNT/REGION-DERIVED default — ECS containerInsights, SSM
+    // default parameter tier, EBS encryption-by-default. Each default's VALUE is an account-level
+    // setting the owner can change (a documented hardening control), so a fixed KNOWN_DEFAULTS
+    // constant FPs on every fresh deploy in an account that adopted it. gather.ts prefetched the
+    // effective value; fold atDefault when the live value equals it (equality-gated — an out-of-band
+    // change AWAY from the account default still surfaces as `undeclared`). This branch is
+    // AUTHORITATIVE when the lookup resolved (so the stale factory constant below never wrongly
+    // folds a real change); when the lookup was denied/unavailable it returns undefined and the fold
+    // falls through to the factory constant (ECS/SSM) or to plain `undeclared` (EBS) — today's behavior.
+    const acctDefault = accountDerivedDefault(resourceType, k, opts.accountDefaults);
+    if (acctDefault !== undefined) {
+      findings.push({
+        tier: matchesKnownDefault(v, acctDefault.value) ? 'atDefault' : 'undeclared',
+        logicalId,
+        resourceType,
+        path: k,
+        actual: v,
+      });
       continue;
     }
     // NOTE: no `schema.writeOnly.has(k)` guard — a top-level write-only key was

--- a/tests/classify-account-defaults-1070.test.ts
+++ b/tests/classify-account-defaults-1070.test.ts
@@ -1,0 +1,128 @@
+// #1070 — a few "constant" undeclared defaults are actually a function of an ACCOUNT/REGION-level
+// setting the owner can change (a documented hardening control): ECS containerInsights, SSM default
+// parameter tier, EBS encryption-by-default. A fixed KNOWN_DEFAULTS pin therefore FPs on every fresh
+// deploy in an account that adopted the setting. gather.ts prefetches the effective setting into
+// opts.accountDefaults; classify now DERIVE-gates the fold against it:
+//   - live value EQUAL to the account default folds atDefault (clean deploy, no drift);
+//   - a value CHANGED away from the account default surfaces as `undeclared` (an out-of-band edit);
+//   - NO prefetch (denied/unavailable) FAILS OPEN to today's behavior — the factory KNOWN_DEFAULTS
+//     constant (ECS/SSM) or plain `undeclared` (EBS, which has no constant).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+// Declare NOTHING for the gated property, so the live value reaches the UNDECLARED fold path.
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+describe('#1070 ECS::Cluster containerInsights — account-derived default', () => {
+  const res = mk('AWS::ECS::Cluster', { ClusterName: 'c' });
+  const live = (v: string) => ({ ClusterSettings: [{ Name: 'containerInsights', Value: v }] });
+
+  it('folds atDefault when the live value equals the account default (Insights ENABLED account)', () => {
+    const f = classifyResource(res, live('enabled'), emptySchema, {
+      accountDefaults: { ecsContainerInsights: 'enabled' },
+    });
+    expect(tier(f, 'atDefault')).toContain('ClusterSettings');
+    expect(tier(f, 'undeclared')).not.toContain('ClusterSettings');
+  });
+
+  it('folds the newer `enhanced` account default too', () => {
+    const f = classifyResource(res, live('enhanced'), emptySchema, {
+      accountDefaults: { ecsContainerInsights: 'enhanced' },
+    });
+    expect(tier(f, 'atDefault')).toContain('ClusterSettings');
+  });
+
+  it('SURFACES an out-of-band disable in an Insights-enabled account (real downgrade)', () => {
+    const f = classifyResource(res, live('disabled'), emptySchema, {
+      accountDefaults: { ecsContainerInsights: 'enabled' },
+    });
+    expect(tier(f, 'undeclared')).toContain('ClusterSettings');
+    expect(tier(f, 'atDefault')).not.toContain('ClusterSettings');
+  });
+
+  it('fail-open: no prefetch → factory KNOWN_DEFAULTS constant (disabled folds, enabled surfaces)', () => {
+    // Insights disabled is the factory default → folds via the constant even without the prefetch.
+    const disabled = classifyResource(res, live('disabled'), emptySchema, {});
+    expect(tier(disabled, 'atDefault')).toContain('ClusterSettings');
+    // Insights enabled with NO prefetch surfaces (today's behavior — the constant is 'disabled').
+    const enabled = classifyResource(res, live('enabled'), emptySchema, {});
+    expect(tier(enabled, 'undeclared')).toContain('ClusterSettings');
+  });
+});
+
+describe('#1070 SSM::Parameter Tier — account-derived default', () => {
+  const res = mk('AWS::SSM::Parameter', { Name: '/p', Type: 'String', Value: 'x' });
+
+  it('folds atDefault when live Tier equals the account default (default-tier = Advanced)', () => {
+    const f = classifyResource(res, { Tier: 'Advanced' }, emptySchema, {
+      accountDefaults: { ssmParameterTier: 'Advanced' },
+    });
+    expect(tier(f, 'atDefault')).toContain('Tier');
+    expect(tier(f, 'undeclared')).not.toContain('Tier');
+  });
+
+  it('SURFACES a Tier that differs from the account default', () => {
+    const f = classifyResource(res, { Tier: 'Standard' }, emptySchema, {
+      accountDefaults: { ssmParameterTier: 'Advanced' },
+    });
+    expect(tier(f, 'undeclared')).toContain('Tier');
+    expect(tier(f, 'atDefault')).not.toContain('Tier');
+  });
+
+  it('fail-open: no prefetch → factory constant (Standard folds, Advanced surfaces)', () => {
+    const std = classifyResource(res, { Tier: 'Standard' }, emptySchema, {});
+    expect(tier(std, 'atDefault')).toContain('Tier');
+    const adv = classifyResource(res, { Tier: 'Advanced' }, emptySchema, {});
+    expect(tier(adv, 'undeclared')).toContain('Tier');
+  });
+});
+
+describe('#1070 EC2::Volume Encrypted — account-derived default (EBS encryption-by-default)', () => {
+  // A volume that declares no `Encrypted`; live reads back true when the account enabled EBS
+  // encryption-by-default. No KNOWN_DEFAULTS constant exists for it — the fold ONLY exists via the
+  // prefetch, so fail-open keeps today's behavior (surfaces).
+  const res = mk('AWS::EC2::Volume', { Size: 10, VolumeType: 'gp3' });
+
+  it('folds atDefault when encryption-by-default is ON and the volume reads Encrypted:true', () => {
+    const f = classifyResource(res, { Encrypted: true }, emptySchema, {
+      accountDefaults: { ebsEncryptionByDefault: true },
+    });
+    expect(tier(f, 'atDefault')).toContain('Encrypted');
+    expect(tier(f, 'undeclared')).not.toContain('Encrypted');
+  });
+
+  it('SURFACES Encrypted:true when the account default is OFF (not account-derived)', () => {
+    const f = classifyResource(res, { Encrypted: true }, emptySchema, {
+      accountDefaults: { ebsEncryptionByDefault: false },
+    });
+    expect(tier(f, 'undeclared')).toContain('Encrypted');
+    expect(tier(f, 'atDefault')).not.toContain('Encrypted');
+  });
+
+  it('fail-open: no prefetch → no fold (Encrypted:true surfaces, today`s behavior)', () => {
+    const f = classifyResource(res, { Encrypted: true }, emptySchema, {});
+    expect(tier(f, 'undeclared')).toContain('Encrypted');
+    expect(tier(f, 'atDefault')).not.toContain('Encrypted');
+  });
+});


### PR DESCRIPTION
## What

Fixes the `#1070` account-level-default-override false-positive class for the three cleanest, self-contained items. Several folds pin "what AWS assigns at creation" as a fixed constant, but AWS lets the account owner change that creation default via a documented account/region setting (usually a security-hardening best practice). In such an account, **every fresh clean deploy** of the affected type surfaces a `[Potential Drift]` on first `check`, permanently (each new resource re-noises until recorded) — breaking the zero-first-run invariant.

The fix is **tier-2 derived**: prefetch the effective account/region setting via one read-only lookup, equality-gate the fold against it (so an out-of-band change **away** from the account default still surfaces), and **fail open** to today's factory constant when the lookup is denied/unavailable.

| Type / path | Account setting (read-only) | Fold |
|---|---|---|
| `AWS::ECS::Cluster.ClusterSettings` | `ecs:ListAccountSettings` effective `containerInsights` (`disabled`/`enabled`/`enhanced`) | derived, was constant `disabled` |
| `AWS::SSM::Parameter.Tier` | `ssm:GetServiceSetting /ssm/parameter-store/default-parameter-tier` (`Standard`/`Advanced`) | derived, was constant `Standard` |
| `AWS::EC2::Volume.Encrypted` | `ec2:GetEbsEncryptionByDefault` | new fold (the boolean `true` had none) |

## How

- **`src/commands/gather.ts`** — three per-region cached, fail-open prefetch functions (mirroring the existing `fetchDefaultSgIds` pattern), fired only when the affected type is present in the stack, threaded into `classifyOpts.accountDefaults`.
- **`src/diff/classify.ts`** — new `AccountDefaults` type + `accountDerivedDefault()` helper + an authoritative branch before the `KNOWN_DEFAULTS` fold. When the lookup resolved, this branch decides the tier (so the stale factory constant never wrongly folds a real change); when it did not resolve, it falls through to the factory constant (ECS/SSM) or to plain `undeclared` (EBS) — **today's behavior**.

## Verification

- **Unit tests** (`tests/classify-account-defaults-1070.test.ts`) — for each item: folds atDefault when live == account default; surfaces when it differs (out-of-band change); fail-open behavior with no prefetch.
- **Corpus replay** — 694 golden cases green; all three types' existing corpus cases have the property **declared** or absent, so the undeclared-path change is a strict no-op there (and `accountDefaults` is absent in replay → no-op).
- **Live-validated SDK shapes** — the three read-only lookups were run against a real account: `EbsEncryptionByDefault: false`, SSM `SettingValue: "Standard"`, ECS `settings[].value: "disabled"` — confirming the exact response fields the code reads. (Account is at factory defaults, so at rest the fold matches the old constant — the "zero behavior change in a factory-default account" safety property.)
- Full suite: 226 files / 4972 tests pass.

## Deferred (same mechanism, follow-up)

IMDS metadata-defaults (interacts with AMI variance #640), per-family credit-spec, RDS/DocDB default-CA.

Closes #1070
