### PR TITLE
fix(diff): surface out-of-band ESM disable + lambda-TG health-check toggle via MEANINGFUL_WHEN_OFF + derived pin (#660)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -172,6 +172,23 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // object, which isTrivialEmpty would swallow BEFORE the pin gate — hiding a wholesale
   // security disable. It is unconditionally meaningful when off, so surface it.
   'AWS::GuardDuty::Detector': { DataSources: () => true },
+  // #660: an ESM is created ENABLED for every source type — CreateEventSourceMapping's
+  // Enabled defaults to true, and no clean-deploy configuration reads false undeclared
+  // (live-confirmed on a fresh SQS mapping 2026-07-11; Kafka/MSK/DynamoDB/Kinesis document
+  // the same default). An undeclared Enabled=false is an out-of-band DISABLE that silently
+  // stops the pipeline, so it is unconditionally meaningful.
+  'AWS::Lambda::EventSourceMapping': { Enabled: () => true },
+  // #660: health checks can only be disabled for LAMBDA target groups — ModifyTargetGroup
+  // rejects HealthCheckEnabled=false for every other target type ("Health check enabled
+  // must be true for target groups with target type 'instance'", live-confirmed
+  // 2026-07-11), so a non-lambda TG never reads false on a clean deploy and an undeclared
+  // false there is a real out-of-band state. A lambda TG reads false as its DEFAULT (the
+  // derived knownDef pin below flips to false for it), so its off state is NOT meaningful.
+  // TargetType is create-only and defaults to 'instance' when omitted, so the declared
+  // value (or its absence) is authoritative.
+  'AWS::ElasticLoadBalancingV2::TargetGroup': {
+    HealthCheckEnabled: ({ declared }) => declared['TargetType'] !== 'lambda',
+  },
 };
 
 // #1092: GuardDuty protection Features whose new-detector default Status is DISABLED (not the
@@ -2891,6 +2908,19 @@ export function classifyResource(
     if (creditDefault !== undefined) {
       knownDef = { ...knownDef, CreditSpecification: { CPUCredits: creditDefault } };
     }
+  }
+  // #660: a LAMBDA target group's HealthCheckEnabled default is FALSE (health checks are
+  // opt-in for lambda targets), the inverse of the base KNOWN_DEFAULTS pin `true` (the
+  // default for every other target type, where disabling is API-rejected). Derive the pin
+  // from the declared TargetType (create-only; a lambda TG must declare it — CFn defaults
+  // an omitted TargetType to 'instance') and equality-gate it (fold tier 2): a clean
+  // lambda TG's undeclared false folds atDefault, while an out-of-band health-check
+  // ENABLE (live true ≠ derived false) now surfaces instead of matching the base pin.
+  if (
+    resourceType === 'AWS::ElasticLoadBalancingV2::TargetGroup' &&
+    declared['TargetType'] === 'lambda'
+  ) {
+    knownDef = { ...knownDef, HealthCheckEnabled: false };
   }
   // #640: a gp2 EBS Volume (declared VolumeType "gp2", or omitted — gp2 is the AWS default)
   // reads back an undeclared baseline Iops that AWS computes from the declared Size:

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1420,14 +1420,12 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       }).undeclared
     ).toEqual(['WarmThroughput']);
 
-    // ESM created enabled → folds. (Enabled:false is dropped upstream as trivially-empty,
-    // like the KMS Key Enabled case — neither undeclared nor atDefault.) #632 fixed the
-    // KMS/SQS twins of this via the curated MEANINGFUL_WHEN_OFF allowlist; ESM is left
-    // unchanged here pending a live confirm that an undeclared ESM Enabled=false is
-    // unconditionally a real out-of-band disable.
+    // ESM created enabled → folds. #660 (live-confirmed 2026-07-11): an undeclared
+    // Enabled=false is an out-of-band DISABLE — the MEANINGFUL_WHEN_OFF entry keeps it
+    // from being dropped as trivially-empty, so it SURFACES (the KMS/SQS #632 pattern).
     expect(t('AWS::Lambda::EventSourceMapping', { Enabled: true }).atDefault).toEqual(['Enabled']);
     const disabled = t('AWS::Lambda::EventSourceMapping', { Enabled: false });
-    expect(disabled.undeclared).toEqual([]);
+    expect(disabled.undeclared).toEqual(['Enabled']);
     expect(disabled.atDefault).toEqual([]);
 
     // AuthType is a derived, non-declarable read-back of the declared Type, so BOTH the
@@ -11791,6 +11789,89 @@ describe('#632 follow-up: unconditional boolean disables surface (undeclared)', 
       expect(tierOf(type, key, true)).toBe('atDefault');
     });
   }
+});
+
+// #660 (config-conditional slice, live-verified 2026-07-11 on Cdkrd660Verify): the two
+// CONDITIONAL members of the #632 blast radius.
+//   - Lambda ESM `Enabled`: created ENABLED for every source type; an undeclared false is an
+//     out-of-band disable that silently stops the pipeline — was swallowed by trivial-empty
+//     (check reported CLEAN on a live disabled mapping).
+//   - ELBv2 TargetGroup `HealthCheckEnabled`: the default is TargetType-DERIVED. A lambda TG
+//     reads false by default (health checks are opt-in there), every other type reads true
+//     and ModifyTargetGroup REJECTS disabling ("Health check enabled must be true for target
+//     groups with target type 'instance'"). So the pin flips to false for a declared-lambda
+//     TG (fold tier 2) and the off state is meaningful only for non-lambda types.
+describe('#660 conditional switches: ESM Enabled + TargetGroup HealthCheckEnabled', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const TG = 'AWS::ElasticLoadBalancingV2::TargetGroup';
+  // Full tier:path list (not a filtered subset) so a double-report or wrong tier fails loudly.
+  const list = (type: string, declared: Record<string, unknown>, live: Record<string, unknown>) =>
+    classifyResource({ logicalId: 'R', resourceType: type, physicalId: 'p', declared }, live, bare)
+      .map((f) => `${f.tier}:${f.path}`)
+      .sort();
+
+  it('ESM undeclared Enabled=false surfaces undeclared (out-of-band disable)', () => {
+    expect(list('AWS::Lambda::EventSourceMapping', {}, { Enabled: false })).toEqual([
+      'undeclared:Enabled',
+    ]);
+  });
+
+  it('ESM undeclared Enabled=true still folds atDefault (clean deploy, no FP)', () => {
+    expect(list('AWS::Lambda::EventSourceMapping', {}, { Enabled: true })).toEqual([
+      'atDefault:Enabled',
+    ]);
+  });
+
+  it('ESM declared Enabled=false vs live true is not masked by the husk fold (#929 twin)', () => {
+    expect(list('AWS::Lambda::EventSourceMapping', { Enabled: false }, { Enabled: true })).toEqual([
+      'declared:Enabled',
+    ]);
+  });
+
+  it('non-lambda TG undeclared HealthCheckEnabled=false surfaces (TargetType omitted)', () => {
+    expect(list(TG, {}, { HealthCheckEnabled: false })).toEqual(['undeclared:HealthCheckEnabled']);
+  });
+
+  it('non-lambda TG undeclared HealthCheckEnabled=false surfaces (TargetType declared ip)', () => {
+    expect(list(TG, { TargetType: 'ip' }, { TargetType: 'ip', HealthCheckEnabled: false })).toEqual(
+      ['undeclared:HealthCheckEnabled']
+    );
+  });
+
+  it('non-lambda TG undeclared HealthCheckEnabled=true still folds atDefault (clean deploy)', () => {
+    expect(list(TG, {}, { HealthCheckEnabled: true })).toEqual(['atDefault:HealthCheckEnabled']);
+  });
+
+  it('lambda TG undeclared HealthCheckEnabled=false folds atDefault (its real default — no FP)', () => {
+    expect(
+      list(TG, { TargetType: 'lambda' }, { TargetType: 'lambda', HealthCheckEnabled: false })
+    ).toEqual(['atDefault:HealthCheckEnabled']);
+  });
+
+  it('lambda TG undeclared HealthCheckEnabled=true surfaces (out-of-band ENABLE, was folded by the base pin)', () => {
+    expect(
+      list(TG, { TargetType: 'lambda' }, { TargetType: 'lambda', HealthCheckEnabled: true })
+    ).toEqual(['undeclared:HealthCheckEnabled']);
+  });
+
+  it('lambda TG declared HealthCheckEnabled=false vs live true surfaces as declared drift', () => {
+    expect(
+      list(
+        TG,
+        { TargetType: 'lambda', HealthCheckEnabled: false },
+        { TargetType: 'lambda', HealthCheckEnabled: true }
+      )
+    ).toEqual(['declared:HealthCheckEnabled']);
+  });
 });
 
 // #929: the DECLARED-side twin of #632. The declared trivially-empty husk fold

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.LamTgA990B741.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.LamTgA990B741.json
@@ -104,6 +104,15 @@
       "tier": "atDefault",
       "logicalId": "LamTgA990B741",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": false,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "IpAddressType",
       "actual": "ipv4",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",


### PR DESCRIPTION
## Summary

The CONFIG-CONDITIONAL slice of #660 (item 2), live-verified end to end on `Cdkrd660Verify` (us-east-1, 2026-07-11). Extends `MEANINGFUL_WHEN_OFF` (classify.ts only — the noise.ts / revert tables owned by parallel lanes are untouched):

- **`AWS::Lambda::EventSourceMapping` `Enabled`** — an ESM is created ENABLED for every source type, so an undeclared `Enabled=false` is an out-of-band disable that silently stops the pipeline. It was swallowed by the trivial-empty drop: pre-fix `check` reported **CLEAN on a live disabled mapping** (FN proven). Entry: `() => true`. Post-fix `check` detects it and `revert` CONVERGES (the CC `remove` re-enables the mapping — live `State: Enabled` confirmed).
- **`AWS::ElasticLoadBalancingV2::TargetGroup` `HealthCheckEnabled`** — the default is **TargetType-derived**:
  - `ModifyTargetGroup --no-health-check-enabled` is **API-rejected for non-lambda types** (live: `Health check enabled must be true for target groups with target type 'instance'`), so a non-lambda TG never reads `false` on a clean deploy → `MEANINGFUL_WHEN_OFF` predicate `declared['TargetType'] !== 'lambda'` is FP-safe and errs to visibility.
  - A clean **lambda** TG reads `false` (its real default), so the `KNOWN_DEFAULTS` pin flips to `false` for a declared-lambda TG (fold tier 2, derived from the create-only declared `TargetType`). This also fixes an inverse FN the issue didn't list: an out-of-band health-check **ENABLE** on a lambda TG used to fold `atDefault` against the base `true` pin — proven live pre-fix, detected live post-fix.

Both also lift the #929 declared-side husk mask for these paths (declared `false` vs live `true` now surfaces — unit-tested).

## Live evidence (A/B, one deploy)

| Step | pre-fix (main dist) | post-fix (this branch) |
| --- | --- | --- |
| first `check` on clean deploy | CLEAN for these paths | CLEAN (lambda-TG `false` folds `atDefault`) |
| `update-event-source-mapping --no-enabled` + lambda-TG HC enable | **CLEAN (FN)** | **2 drifts detected** (`Esm.Enabled`, `LambdaTg.HealthCheckEnabled`) |
| `revert --yes` | n/a | ESM converges (live re-enabled); TG remove is a provider no-op, honestly reported `1 drift(s) remain` |
| restore + final `check` | n/a | CLEAN |

## Follow-ups (out of this lane's claimed files)

- **Revert set-default for lambda-TG `HealthCheckEnabled`** (`REVERT_SET_DEFAULT_PATHS` sources values from `KNOWN_DEFAULTS`, but the correct write value is the TargetType-DERIVED `false`) — deferred, `src/revert/plan.ts` is claimed by parallel lanes; noted on #660.
- #1451 filed for two unrelated TG first-run FPs the probe surfaced (omitted `TargetType` echo + `stickiness.enabled` attribute default).
- #660 items 1 (restore-path booleans) and 3 (nested mechanism) remain open.

## Tests

- `tests/classify.test.ts`: new `#660` describe (full `tier:path`-list assertions): ESM disable surfaces / clean folds / declared-mask lifted; non-lambda TG `false` surfaces (omitted + declared `ip`); lambda TG `false` folds, `true` surfaces, declared-mask lifted. Updated the old pin that froze the pre-fix ESM behavior "pending a live confirm" (the live confirm is done).
- Corpus golden `AWS__ElasticLoadBalancingV2__TargetGroup.LamTgA990B741.json`: the harvested lambda TG's undeclared `false` now folds `atDefault` (was dropped) — still zero potential drift.

Closes nothing (partial slice of #660 — the issue stays open for items 1/3).
