### PR TITLE
ci: reject compound PR titles so releases and the changelog stay clean

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -33,3 +33,12 @@ jobs:
             chore
             revert
           requireScope: false
+      # The action above only checks the LEADING type; it accepts a COMPOUND title like
+      # `fix(read)+fix(revert): …`, which renders an ugly CHANGELOG scope and historically
+      # failed to release at all (semantic-release headerPattern; fixed in #1448). Enforce a
+      # SINGLE type + optional single scope here so the release + changelog stay clean.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+      - name: Reject compound / malformed PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/check-pr-title.mjs "$PR_TITLE"

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Enforce that a PR title carries a SINGLE conventional-commit type with an OPTIONAL SINGLE
+// scope — e.g. `fix(revert): …`, `feat: …`, `chore(release): …`.
+//
+// The `amannn/action-semantic-pull-request` gate only checks that the LEADING type is allowed;
+// it accepts a COMPOUND title like `fix(read)+fix(revert): …`. But a compound title:
+//   1. failed to RELEASE entirely — semantic-release's `.releaserc.json` headerPattern scope
+//      class `[^)]+` cannot span the `)` that sits mid-header, so the commit parsed as no type
+//      and semantic-release logged "no release" (PR #1431/#1446 shipped to main unpublished);
+//      #1448 made the parser tolerant, but…
+//   2. still renders an UGLY CHANGELOG scope (`read)+fix(revert`).
+// So reject compound / malformed titles at the PR gate: pick ONE type and put the rest in the
+// scope / subject. Keep the type list in sync with `.github/workflows/pr-title-check.yml`.
+export const PR_TITLE_TYPES = [
+  'feat',
+  'fix',
+  'docs',
+  'style',
+  'refactor',
+  'perf',
+  'test',
+  'build',
+  'ci',
+  'chore',
+  'revert',
+];
+
+// A single type, an optional single scope with NO nested `)`, an optional breaking `!`, then
+// `: ` and a non-empty subject. A compound `fix(read)+fix(revert): …` fails because `: ` does
+// not immediately follow the first `(scope)`.
+const PR_TITLE_RE = new RegExp(`^(?:${PR_TITLE_TYPES.join('|')})(?:\\([^)]+\\))?!?: .+`);
+
+export function isValidPrTitle(title) {
+  return PR_TITLE_RE.test(title);
+}
+
+// CLI: `node scripts/check-pr-title.mjs "<title>"` → exit 0 if valid, 1 (with a GitHub
+// ::error:: annotation) otherwise. Guarded so importing the module for tests never runs it.
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const title = process.argv[2] ?? '';
+  if (!isValidPrTitle(title)) {
+    console.error(
+      `::error::PR title must be a SINGLE conventional-commit type with an optional single scope, ` +
+        `e.g. 'fix(revert): …'. Compound titles like 'fix(read)+fix(revert): …' are not allowed — ` +
+        `pick one type and put the detail in the scope/subject. Got: ${title}`
+    );
+    process.exit(1);
+  }
+}

--- a/tests/check-pr-title.test.ts
+++ b/tests/check-pr-title.test.ts
@@ -1,0 +1,78 @@
+// The `pr-title-check` workflow enforces that a PR title carries a SINGLE conventional-commit
+// type with an optional single scope. A COMPOUND title like `fix(read)+fix(revert): …` passes
+// the lenient `amannn/action-semantic-pull-request` gate but (1) historically failed to release
+// at all — semantic-release's headerPattern scope class `[^)]+` cannot span the mid-header `)`
+// (#1431/#1446 shipped unpublished; fixed in #1448) — and (2) renders an ugly CHANGELOG scope
+// (`read)+fix(revert`). This drives the SHIPPED validator exactly as the workflow does — the CLI
+// `node scripts/check-pr-title.mjs "<title>"` (exit 0 = accepted, 1 = rejected) — so the test
+// pins the real gate behavior without importing the untyped `.mjs` into the type-checker.
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+const SCRIPT = fileURLToPath(new URL('../scripts/check-pr-title.mjs', import.meta.url));
+
+// Run the validator CLI; return true if it accepted the title (exit 0), false if it rejected it.
+function accepts(title: string): boolean {
+  try {
+    execFileSync('node', [SCRIPT, title], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('check-pr-title CLI — single conventional type + optional single scope', () => {
+  it('rejects the COMPOUND title that shipped #1431 unpublished', () => {
+    expect(accepts('fix(read)+fix(revert): record-endorse + real delete (#1431)')).toBe(false);
+  });
+
+  it('rejects other compound forms', () => {
+    expect(accepts('feat(a)+fix(b): thing')).toBe(false);
+    expect(accepts('fix(read)+revert: thing')).toBe(false);
+  });
+
+  it('accepts a single scoped type', () => {
+    expect(accepts('fix(revert): converge a thing')).toBe(true);
+    expect(accepts('feat(read): add an override')).toBe(true);
+  });
+
+  it('accepts a no-scope type (subject may contain parens)', () => {
+    expect(accepts('fix: handle the (#123) edge case')).toBe(true);
+    expect(accepts('docs: update README')).toBe(true);
+  });
+
+  it('accepts a breaking-change marker', () => {
+    expect(accepts('feat(api)!: drop the legacy flag')).toBe(true);
+    expect(accepts('feat!: drop the legacy flag')).toBe(true);
+  });
+
+  it('accepts the release bot chore(release): commit form', () => {
+    expect(accepts('chore(release): 0.12.74 [skip ci]')).toBe(true);
+  });
+
+  it('rejects an unknown type, a missing colon, and an empty subject', () => {
+    expect(accepts('wip(read): thing')).toBe(false);
+    expect(accepts('fix add a thing')).toBe(false);
+    expect(accepts('fix(read): ')).toBe(false);
+    expect(accepts('')).toBe(false);
+  });
+
+  it('accepts every conventional type the release pipeline knows', () => {
+    for (const t of [
+      'feat',
+      'fix',
+      'docs',
+      'style',
+      'refactor',
+      'perf',
+      'test',
+      'build',
+      'ci',
+      'chore',
+      'revert',
+    ]) {
+      expect(accepts(`${t}: a subject`)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #1448. The `pr-title-check` workflow's `amannn/action-semantic-pull-request`
step only validates the **leading** type, so a **compound** title like
`fix(read)+fix(revert): …` passed it. Such a title:

1. **historically failed to release at all** — semantic-release's `.releaserc.json`
   `headerPattern` scope class `[^)]+` can't span the `)` that sits mid-header, so
   the commit parsed as *no type* → `no release`. **#1431 (PR #1446) shipped to
   `main` unpublished** for exactly this reason; #1448 relaxed the *parser*, but
2. a compound title still renders an **ugly CHANGELOG scope** (`read)+fix(revert`).

So reject compound / malformed titles at the PR gate — pick one type, put the rest
in the scope/subject.

## What

- `scripts/check-pr-title.mjs` — dependency-free validator (`isValidPrTitle`) that
  enforces a SINGLE conventional-commit type + optional single scope. Exported for
  tests; runnable as a CLI (`node scripts/check-pr-title.mjs "<title>"`, exits 1 with
  a `::error::` annotation on failure).
- `.github/workflows/pr-title-check.yml` — adds a checkout + a step that runs the
  validator on `github.event.pull_request.title` (after the existing lenient step).
- `tests/check-pr-title.test.ts` — 8 tests pinning the rule (compound rejected;
  single-scope / no-scope / `!` breaking / `chore(release):` accepted; unknown type /
  missing colon / empty subject rejected), so the regex can't silently weaken.

| title | accepted? |
|---|---|
| `fix(read)+fix(revert): …` | ❌ (compound) |
| `feat(a)+fix(b): …` | ❌ |
| `fix(revert): …` | ✅ |
| `feat: … (#123)` | ✅ |
| `feat(api)!: …` | ✅ |
| `chore(release): 0.12.74 [skip ci]` | ✅ |

## Notes

- Tooling-only (no `src/**`) → `verify-pr` live-test exempt; `check` + `docs` cover it.
- Non-releasing by design (`ci:` type) — this PR fixes the *gate*, it doesn't ship product code.
- The one local `vp check` finding is a pre-existing `no-base-to-string` in
  `src/diff/classify.ts` (from #640/#1449), not in this diff — CI treats it as a
  warning and `main` CI is green on that code.
