### PR TITLE
fix(read): treat ApiGateway Deployment.StageName as declaring its stage (#1460)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -549,7 +549,15 @@ export async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<
   // matched against the live responses — suppress gateway-response added-reporting for this api
   // rather than false-flag a live DEFAULT_4XX/5XX as `added` with a DeleteResource offer (#1089).
   let gatewayResponseTypeUnresolved = false;
-  // Declared stages of THIS api. An AWS::ApiGateway::Stage's Ref/physical id IS its StageName.
+  // Fail-safe: a declared AWS::ApiGateway::Deployment whose StageName is UNRESOLVED implicitly
+  // declares a stage whose NAME we cannot know, so we cannot tell whether a live stage is that
+  // declared one — suppress stage added-reporting for the api rather than false-flag the
+  // CFn-managed stage `added` with a destructive DeleteResource offer (#1460, mirroring #1089).
+  let deploymentStageUnresolved = false;
+  // Declared stages of THIS api. An AWS::ApiGateway::Stage's Ref/physical id IS its StageName;
+  // an AWS::ApiGateway::Deployment's StageName ALSO implicitly creates/manages that stage as
+  // part of the Deployment's own CFn contract (deleting the Deployment deletes the stage), so a
+  // Deployment-declared stage is NOT out of band (#1460).
   const declaredStageNames: string[] = [];
   for (const r of desired.resources) {
     if (
@@ -585,6 +593,18 @@ export async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<
     ) {
       const name = typeof r.declared.StageName === 'string' ? r.declared.StageName : r.physicalId;
       if (name) declaredStageNames.push(name);
+    } else if (
+      r.resourceType === 'AWS::ApiGateway::Deployment' &&
+      parentRefMatches(r.declared.RestApiId, apiId)
+    ) {
+      // A Deployment declares its stage via StageName (or StageDescription, which also
+      // materializes the stage but carries no name of its own). A Deployment with NEITHER just
+      // creates a deployment snapshot with no stage, so it contributes nothing.
+      if (r.declared.StageName === UNRESOLVED || hasUnresolved(r.declared.StageName)) {
+        deploymentStageUnresolved = true;
+      } else if (typeof r.declared.StageName === 'string') {
+        declaredStageNames.push(r.declared.StageName);
+      }
     }
   }
 
@@ -688,7 +708,12 @@ export async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<
   const liveStages = stages
     .filter((s): s is ApiGwRestStage & { stageName: string } => typeof s.stageName === 'string')
     .map((s) => ({ name: s.stageName, label: s.stageName }));
-  const stageAdded = diffApiGatewayStages({ apiId, declaredStageNames, liveStages });
+  const stageAdded = diffApiGatewayStages({
+    apiId,
+    declaredStageNames,
+    liveStages,
+    unresolvedDeploymentStage: deploymentStageUnresolved,
+  });
 
   return [
     ...resourceAndMethodAdded,
@@ -708,8 +733,12 @@ export function diffApiGatewayStages(input: {
   apiId: string;
   declaredStageNames: string[];
   liveStages: { name: string; label?: string | undefined }[];
+  // #1460: a declared Deployment.StageName that is UNRESOLVED could name ANY live stage, so
+  // suppress stage added-reporting entirely rather than risk flagging the declared stage.
+  unresolvedDeploymentStage?: boolean | undefined;
 }): AddedChild[] {
   const { apiId, declaredStageNames, liveStages } = input;
+  if (input.unresolvedDeploymentStage) return [];
   const declared = new Set(declaredStageNames);
   const added: AddedChild[] = [];
   for (const s of liveStages) {
@@ -1244,8 +1273,12 @@ export function diffApiGatewayV2Stages(input: {
   // stay diffable (issue #960). Body-defined APIs do NOT materialize stages from the spec, so
   // stage diffing stays fully on for them (this flag is set for quick create only).
   quickCreate?: boolean | undefined;
+  // #1460: a declared Deployment.StageName that is UNRESOLVED could name ANY live stage, so
+  // suppress stage added-reporting entirely rather than risk flagging the declared stage.
+  unresolvedDeploymentStage?: boolean | undefined;
 }): AddedChild[] {
   const { apiId, declaredStageNames, liveStages, quickCreate } = input;
+  if (input.unresolvedDeploymentStage) return [];
   const declared = new Set(declaredStageNames);
   const added: AddedChild[] = [];
   for (const s of liveStages) {
@@ -1305,8 +1338,12 @@ async function enumerateHttpApiChildren(ctx: EnumeratorContext): Promise<AddedCh
   const declaredIntegrationIds: string[] = [];
   // Declared authorizers of THIS api. An Authorizer's physical id (Ref) IS its AuthorizerId.
   const declaredAuthorizerIds: string[] = [];
-  // Declared stages of THIS api. A Stage's physical id (Ref) IS its StageName.
+  // Declared stages of THIS api. A Stage's physical id (Ref) IS its StageName; an
+  // AWS::ApiGatewayV2::Deployment's StageName ALSO implicitly manages that stage as part of its
+  // own CFn contract (rarer for V2, where users usually declare Stage resources, but the same
+  // gap — #1460). An UNRESOLVED Deployment.StageName suppresses stage added-reporting (fail-safe).
   const declaredStageNames: string[] = [];
+  let deploymentStageUnresolved = false;
   for (const r of desired.resources) {
     if (!parentRefMatches(r.declared.ApiId, apiId)) continue;
     if (r.resourceType === 'AWS::ApiGatewayV2::Route' && r.physicalId) {
@@ -1318,6 +1355,12 @@ async function enumerateHttpApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     } else if (r.resourceType === 'AWS::ApiGatewayV2::Stage') {
       const name = r.physicalId ?? (r.declared.StageName as string | undefined);
       if (name) declaredStageNames.push(name);
+    } else if (r.resourceType === 'AWS::ApiGatewayV2::Deployment') {
+      if (r.declared.StageName === UNRESOLVED || hasUnresolved(r.declared.StageName)) {
+        deploymentStageUnresolved = true;
+      } else if (typeof r.declared.StageName === 'string') {
+        declaredStageNames.push(r.declared.StageName);
+      }
     }
   }
 
@@ -1367,6 +1410,7 @@ async function enumerateHttpApiChildren(ctx: EnumeratorContext): Promise<AddedCh
     declaredStageNames,
     liveStages,
     quickCreate,
+    unresolvedDeploymentStage: deploymentStageUnresolved,
   });
   return added.concat(authorizerAdded, stageAdded);
 }

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -588,6 +588,45 @@ describe('Body-defined RestApi suppresses spec-materialized children (#1324)', (
     ]);
     apigw.restore();
   });
+
+  // #1460: a REST stage created the raw-CFn way — AWS::ApiGateway::Deployment with StageName and
+  // NO explicit AWS::ApiGateway::Stage resource — is CFn-managed, not out of band. The enumerator
+  // must treat Deployment.StageName as declaring the stage (else it flags the api's only stage
+  // `added` and offers a destructive DeleteResource).
+  it('a Deployment.StageName-declared stage is NOT flagged added; a genuine 2nd stage is (#1460)', async () => {
+    const apigw = mockClient(APIGatewayClient);
+    apigw
+      .on(GetResourcesCommand)
+      .resolves({ items: [{ id: 'root0', path: '/' }] })
+      .on(GetRestStagesCommand)
+      .resolves({ item: [{ stageName: 'hunt' }, { stageName: 'rogue' }] })
+      .on(GetAuthorizersCommand)
+      .resolves({ items: [] })
+      .on(GetModelsCommand)
+      .resolves({ items: [] })
+      .on(GetRequestValidatorsCommand)
+      .resolves({ items: [] })
+      .on(GetGatewayResponsesCommand)
+      .resolves({ items: [] });
+    const ctx = {
+      parent: { logicalId: 'Api', physicalId: 'hl2qjpw0hj', declared: { Name: 'x' } },
+      desired: {
+        resources: [
+          {
+            resourceType: 'AWS::ApiGateway::Deployment',
+            physicalId: 'f8phbg',
+            declared: { RestApiId: 'hl2qjpw0hj', StageName: 'hunt' },
+          },
+        ],
+        ctx: { liveAttrs: { Api: { RootResourceId: 'root0' } } },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateRestApiChildren(ctx);
+    // 'hunt' (Deployment-declared) is excluded; only the genuinely out-of-band 'rogue' surfaces.
+    expect(added.map((a) => a.identifier)).toEqual(['hl2qjpw0hj|rogue']);
+    apigw.restore();
+  });
 });
 
 describe('diffApiGatewayV2Children (HTTP / WebSocket API)', () => {
@@ -795,6 +834,31 @@ describe('diffApiGatewayStages (REST API stages, #1044)', () => {
     });
     expect(added[0]!.label).toBe('stageX');
   });
+
+  it('a Deployment-declared StageName is not out of band (#1460)', () => {
+    // enumerateRestApiChildren pushes a Deployment.StageName into declaredStageNames, so the
+    // CFn-managed implicit stage is excluded here — no destructive DeleteResource offer.
+    expect(
+      diffApiGatewayStages({
+        apiId: API,
+        declaredStageNames: ['hunt'], // from AWS::ApiGateway::Deployment.StageName
+        liveStages: [{ name: 'hunt' }],
+      })
+    ).toEqual([]);
+  });
+
+  it('an UNRESOLVED Deployment.StageName suppresses ALL stage added-reporting (#1460 fail-safe)', () => {
+    // The Deployment's StageName is a Ref we could not resolve, so any live stage MIGHT be the
+    // declared one — suppress rather than risk flagging a CFn-managed stage `added`.
+    expect(
+      diffApiGatewayStages({
+        apiId: API,
+        declaredStageNames: [],
+        liveStages: [{ name: 'prod' }, { name: 'anything' }],
+        unresolvedDeploymentStage: true,
+      })
+    ).toEqual([]);
+  });
 });
 
 describe('diffApiGatewayV2Stages (HTTP / WebSocket API stages)', () => {
@@ -875,6 +939,17 @@ describe('diffApiGatewayV2Stages (HTTP / WebSocket API stages)', () => {
         live: { StageName: 'roguestage', ApiId: APIV2 },
       },
     ]);
+  });
+
+  it('an UNRESOLVED V2 Deployment.StageName suppresses ALL stage added-reporting (#1460 fail-safe)', () => {
+    expect(
+      diffApiGatewayV2Stages({
+        apiId: APIV2,
+        declaredStageNames: [],
+        liveStages: [{ name: 'prod' }, { name: 'anything' }],
+        unresolvedDeploymentStage: true,
+      })
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #1460.

## Problem (`added`-tier FP with a destructive delete-revert offer)

A REST API whose stage is created the classic raw-CFn way — `AWS::ApiGateway::Deployment` with `StageName` and **no** explicit `AWS::ApiGateway::Stage` resource — had its own CloudFormation-managed stage flagged as `added` ("created out of band") on every `check`. The Stage enumerator (#1044) built `declaredStageNames` **only** from `AWS::ApiGateway::Stage` resources, so the Deployment-implicit stage diffed as `added`. Worse than noise: the `added` tier offers a `DeleteResource` revert — accepting it would tear down the API's only stage and desync the CFn `Deployment` resource. It also gets baked into the baseline by `record`.

## Fix (`src/read/child-enumerators.ts`)

Collect `declaredStageNames` from `AWS::ApiGateway::Deployment.StageName` too — the Deployment implicitly creates/manages that stage as part of its own CFn contract (deleting the Deployment deletes the stage), so it is **not** out of band. An **UNRESOLVED** `Deployment.StageName` (a Ref we could not resolve) suppresses stage added-reporting for that api — fail-safe, mirroring the #1089 GatewayResponse pattern — rather than risk flagging the declared stage. The same one-line gap is fixed on the V2 enumerator (`AWS::ApiGatewayV2::Deployment.StageName`).

A genuinely out-of-band second stage still surfaces (detection preserved).

## Tests (`tests/child-enumerators.test.ts`)

- Pure diff: a Deployment-declared StageName is not out of band; an `unresolvedDeploymentStage` flag suppresses all stage reporting (both REST and V2).
- Enumerator end-to-end (`enumerateRestApiChildren`, mocked `GetStages`): the exact issue repro — `Deployment(StageName='hunt')` + live stage `hunt` → NOT flagged; a genuine second live stage `rogue` still surfaces.

All 5004 unit tests pass; typecheck / lint+format / build green. Live-verified below.
