### PR TITLE
fix(diff): account-level default overrides — EC2 credit-spec + RDS/DocDB default CA (#1070 items 4-5)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -10,10 +10,16 @@ import {
   DescribeSecurityGroupsCommand,
   DescribeSubnetsCommand,
   EC2Client,
+  GetDefaultCreditSpecificationCommand,
   GetEbsEncryptionByDefaultCommand,
+  type UnlimitedSupportedInstanceFamily,
 } from '@aws-sdk/client-ec2';
 import { ECSClient, ListAccountSettingsCommand } from '@aws-sdk/client-ecs';
-import { DescribeOptionGroupOptionsCommand, RDSClient } from '@aws-sdk/client-rds';
+import {
+  DescribeCertificatesCommand,
+  DescribeOptionGroupOptionsCommand,
+  RDSClient,
+} from '@aws-sdk/client-rds';
 import { GetServiceSettingCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
@@ -199,6 +205,52 @@ async function fetchEbsEncryptionByDefault(region: string): Promise<boolean | un
     const r = await c.send(new GetEbsEncryptionByDefaultCommand({}));
     const value = r.EbsEncryptionByDefault;
     ebsEncryptionByDefaultCache.set(region, value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+// #1070 item 4: ec2:GetDefaultCreditSpecification per burstable family — the account-effective
+// default CpuCredits ('standard'|'unlimited') an EC2::Instance of that family reads back when it
+// declares no CreditSpecification. Cached per (region, family), fail-open (undefined, not cached).
+const ec2CreditDefaultCache = new Map<string, string | undefined>();
+async function fetchEc2FamilyCreditDefault(
+  region: string,
+  family: string
+): Promise<string | undefined> {
+  const cacheKey = `${region}|${family}`;
+  if (ec2CreditDefaultCache.has(cacheKey)) return ec2CreditDefaultCache.get(cacheKey);
+  try {
+    const c = new EC2Client({ region, ...READ_RETRY });
+    // `family` is regex-gated to a `t<digit>` burstable prefix; an unsupported value simply throws
+    // at the API and is caught below (fail-open). The SDK types InstanceFamily as a closed union.
+    const r = await c.send(
+      new GetDefaultCreditSpecificationCommand({
+        InstanceFamily: family as UnlimitedSupportedInstanceFamily,
+      })
+    );
+    const value = r.InstanceFamilyCreditSpecification?.CpuCredits;
+    ec2CreditDefaultCache.set(cacheKey, value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+// #1070 item 5: rds:DescribeCertificates — the account's CUSTOMER-OVERRIDE default CA identifier
+// (the cert with `CustomerOverride=true`), which every new RDS/DocDB DBInstance that declares no
+// CACertificateIdentifier reads back. Undefined when no override is set (the account uses AWS's
+// system default) → classify falls back to the KNOWN_DEFAULTS constant. Cached per region, fail-open.
+const rdsDefaultCaCache = new Map<string, string | undefined>();
+async function fetchRdsDefaultCaIdentifier(region: string): Promise<string | undefined> {
+  if (rdsDefaultCaCache.has(region)) return rdsDefaultCaCache.get(region);
+  try {
+    const c = new RDSClient({ region, ...READ_RETRY });
+    const r = await c.send(new DescribeCertificatesCommand({}));
+    const override = (r.Certificates ?? []).find((cert) => cert.CustomerOverride === true);
+    const value = override?.CertificateIdentifier;
+    rdsDefaultCaCache.set(region, value);
     return value;
   } catch {
     return undefined;
@@ -1434,6 +1486,36 @@ export async function gatherFindings(
   if (desired.resources.some((r) => r.resourceType === 'AWS::EC2::Volume')) {
     const v = await fetchEbsEncryptionByDefault(region);
     if (v !== undefined) accountDefaults.ebsEncryptionByDefault = v;
+  }
+  // #1070 item 4: prefetch the account-effective default credit spec for each BURSTABLE family
+  // declared by an EC2::Instance (t2/t3/t3a/t4g). Only burstable families have a credit spec, so
+  // gate on the `t<digit>` prefix; a per-family lookup that fails (unsupported family / denied)
+  // is simply omitted → classify falls back to the AWS factory default for that family.
+  const burstableFamilies = new Set<string>();
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::EC2::Instance') continue;
+    const it = r.declared?.InstanceType;
+    const fam = typeof it === 'string' ? it.split('.')[0] : undefined;
+    if (fam !== undefined && /^t\d/.test(fam)) burstableFamilies.add(fam);
+  }
+  if (burstableFamilies.size > 0) {
+    const map: Record<string, string> = {};
+    for (const fam of burstableFamilies) {
+      const v = await fetchEc2FamilyCreditDefault(region, fam);
+      if (v !== undefined) map[fam] = v;
+    }
+    if (Object.keys(map).length > 0) accountDefaults.ec2FamilyCreditDefaults = map;
+  }
+  // #1070 item 5: prefetch the account's customer-override default CA identifier when the stack
+  // declares an RDS or DocDB DBInstance. Undefined (no override) → classify keeps the constant.
+  if (
+    desired.resources.some(
+      (r) =>
+        r.resourceType === 'AWS::RDS::DBInstance' || r.resourceType === 'AWS::DocDB::DBInstance'
+    )
+  ) {
+    const v = await fetchRdsDefaultCaIdentifier(region);
+    if (v !== undefined) accountDefaults.rdsDefaultCaIdentifier = v;
   }
   const classifyOpts = {
     accountId: desired.accountId,

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -350,6 +350,15 @@ export interface AccountDefaults {
   ssmParameterTier?: string;
   // ec2:GetEbsEncryptionByDefault — whether a new volume that declares no `Encrypted` reads true.
   ebsEncryptionByDefault?: boolean;
+  // ec2:GetDefaultCreditSpecification per burstable family (t2/t3/t3a/t4g) — the account-effective
+  // default `CpuCredits` ('standard' | 'unlimited') for an EC2::Instance that declares no
+  // CreditSpecification. Keyed by instance-family. A family absent here falls back to the AWS
+  // factory default (t2 standard, t3/t3a/t4g unlimited).
+  ec2FamilyCreditDefaults?: Record<string, string>;
+  // rds:DescribeCertificates — the account's customer-override default CA identifier (the cert with
+  // `CustomerOverride=true`), for an RDS/DocDB DBInstance that declares no CACertificateIdentifier.
+  // Undefined when no override is set → fall back to the KNOWN_DEFAULTS system-default constant.
+  rdsDefaultCaIdentifier?: string;
 }
 
 // #1070: for a handful of undeclared properties the value AWS assigns at creation is a function of
@@ -385,6 +394,18 @@ function accountDerivedDefault(
     ad.ebsEncryptionByDefault !== undefined
   ) {
     return { value: ad.ebsEncryptionByDefault };
+  }
+  // #1070 item 5: an RDS/DocDB DBInstance that declares no CACertificateIdentifier reads back the
+  // ACCOUNT default CA. `rds:modify-certificates` lets the owner override that default for all new
+  // instances; when a customer-override cert is set, gather.ts resolves its identifier here and this
+  // branch is authoritative (folding the overridden CA, surfacing any other). No override → undefined
+  // → falls through to the KNOWN_DEFAULTS system-default constant (rds-ca-rsa2048-g1) — today's behavior.
+  if (
+    (resourceType === 'AWS::RDS::DBInstance' || resourceType === 'AWS::DocDB::DBInstance') &&
+    key === 'CACertificateIdentifier' &&
+    ad.rdsDefaultCaIdentifier !== undefined
+  ) {
+    return { value: ad.rdsDefaultCaIdentifier };
   }
   return undefined;
 }
@@ -2958,12 +2979,21 @@ export function classifyResource(
   if (resourceType === 'AWS::EC2::Instance') {
     const instanceType = declared['InstanceType'];
     const family = typeof instanceType === 'string' ? instanceType.split('.')[0] : undefined;
-    const creditDefault =
+    // #1070 item 4: the per-family default CpuCredits is an ACCOUNT/REGION setting the owner can
+    // flip (`ec2:modify-default-credit-specification --instance-family t3 --cpu-credits standard`),
+    // so the hardcoded factory default FPs on every fresh T-family launch in an account that changed
+    // it. Prefer gather.ts's prefetched account-effective default for the declared family; fall back
+    // to the AWS factory default (t2 standard, t3/t3a/t4g unlimited) when the lookup was
+    // denied/unavailable. Equality-gated below → an out-of-band credit-mode change still surfaces.
+    const factoryDefault =
       family === 't2'
         ? 'standard'
         : family === 't3' || family === 't3a' || family === 't4g'
           ? 'unlimited'
           : undefined;
+    const acctDefault =
+      family !== undefined ? opts.accountDefaults?.ec2FamilyCreditDefaults?.[family] : undefined;
+    const creditDefault = acctDefault ?? factoryDefault;
     if (creditDefault !== undefined) {
       knownDef = { ...knownDef, CreditSpecification: { CPUCredits: creditDefault } };
     }

--- a/tests/classify-account-defaults-345-1070.test.ts
+++ b/tests/classify-account-defaults-345-1070.test.ts
@@ -1,0 +1,115 @@
+// #1070 items 4 + 5 — two more "constant/derived" undeclared defaults are actually a function of an
+// ACCOUNT/REGION-level setting the owner can change:
+//   item 4: EC2::Instance CreditSpecification.CPUCredits per-family default
+//           (ec2:modify-default-credit-specification) — was a fixed t2→standard / t3·t3a·t4g→unlimited
+//           derivation; now the account-effective default (opts.accountDefaults.ec2FamilyCreditDefaults)
+//           overrides it, falling back to the factory default when the lookup is unavailable.
+//   item 5: RDS/DocDB DBInstance CACertificateIdentifier account default CA (rds:modify-certificates) —
+//           was a fixed rds-ca-rsa2048-g1 constant; now the account customer-override CA
+//           (opts.accountDefaults.rdsDefaultCaIdentifier) overrides it, falling back to the constant.
+// Each: folds atDefault when live == the account default; surfaces when it differs; fail-open with no
+// prefetch reproduces today's factory-default behavior.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+describe('#1070 item 4 EC2::Instance CreditSpecification — account-derived per-family default', () => {
+  // A t3 instance; the account flipped the t3 family default to `standard`
+  // (ec2:modify-default-credit-specification --instance-family t3 --cpu-credits standard).
+  const t3 = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 't3.micro' });
+  const live = (c: string) => ({ CreditSpecification: { CPUCredits: c } });
+
+  it('folds the ACCOUNT default (t3 flipped to standard) over the factory unlimited', () => {
+    const f = classifyResource(t3, live('standard'), emptySchema, {
+      accountDefaults: { ec2FamilyCreditDefaults: { t3: 'standard' } },
+    });
+    expect(tier(f, 'atDefault')).toContain('CreditSpecification');
+    expect(tier(f, 'undeclared')).not.toContain('CreditSpecification');
+  });
+
+  it('SURFACES a value differing from the account default (account standard, live unlimited)', () => {
+    const f = classifyResource(t3, live('unlimited'), emptySchema, {
+      accountDefaults: { ec2FamilyCreditDefaults: { t3: 'standard' } },
+    });
+    expect(tier(f, 'undeclared')).toContain('CreditSpecification');
+    expect(tier(f, 'atDefault')).not.toContain('CreditSpecification');
+  });
+
+  it('folds a t2 account default flipped to unlimited (over the factory standard)', () => {
+    const t2 = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 't2.small' });
+    const f = classifyResource(t2, live('unlimited'), emptySchema, {
+      accountDefaults: { ec2FamilyCreditDefaults: { t2: 'unlimited' } },
+    });
+    expect(tier(f, 'atDefault')).toContain('CreditSpecification');
+  });
+
+  it('fail-open: no prefetch → factory default (t3 unlimited folds, t3 standard surfaces)', () => {
+    const unlimited = classifyResource(t3, live('unlimited'), emptySchema, {});
+    expect(tier(unlimited, 'atDefault')).toContain('CreditSpecification');
+    const standard = classifyResource(t3, live('standard'), emptySchema, {});
+    expect(tier(standard, 'undeclared')).toContain('CreditSpecification');
+  });
+
+  it('fail-open: a family absent from the prefetch falls back to the factory default', () => {
+    // Prefetch resolved t2 but not t3; the t3 instance must still use the factory t3 default.
+    const f = classifyResource(t3, live('unlimited'), emptySchema, {
+      accountDefaults: { ec2FamilyCreditDefaults: { t2: 'unlimited' } },
+    });
+    expect(tier(f, 'atDefault')).toContain('CreditSpecification');
+  });
+});
+
+describe('#1070 item 5 RDS/DocDB CACertificateIdentifier — account-derived default CA', () => {
+  for (const type of ['AWS::RDS::DBInstance', 'AWS::DocDB::DBInstance']) {
+    describe(type, () => {
+      const res = mk(type, { Engine: 'x' });
+      const OVERRIDE = 'rds-ca-ecc384-g1'; // the account customer-override CA
+      const SYSTEM = 'rds-ca-rsa2048-g1'; // the KNOWN_DEFAULTS system-default constant
+
+      it('folds the account customer-override CA', () => {
+        const f = classifyResource(res, { CACertificateIdentifier: OVERRIDE }, emptySchema, {
+          accountDefaults: { rdsDefaultCaIdentifier: OVERRIDE },
+        });
+        expect(tier(f, 'atDefault')).toContain('CACertificateIdentifier');
+        expect(tier(f, 'undeclared')).not.toContain('CACertificateIdentifier');
+      });
+
+      it('SURFACES a CA differing from the account override', () => {
+        const f = classifyResource(res, { CACertificateIdentifier: SYSTEM }, emptySchema, {
+          accountDefaults: { rdsDefaultCaIdentifier: OVERRIDE },
+        });
+        expect(tier(f, 'undeclared')).toContain('CACertificateIdentifier');
+        expect(tier(f, 'atDefault')).not.toContain('CACertificateIdentifier');
+      });
+
+      it('fail-open: no override → KNOWN_DEFAULTS constant (system CA folds, override CA surfaces)', () => {
+        const sys = classifyResource(res, { CACertificateIdentifier: SYSTEM }, emptySchema, {});
+        expect(tier(sys, 'atDefault')).toContain('CACertificateIdentifier');
+        const other = classifyResource(res, { CACertificateIdentifier: OVERRIDE }, emptySchema, {});
+        expect(tier(other, 'undeclared')).toContain('CACertificateIdentifier');
+      });
+    });
+  }
+});


### PR DESCRIPTION
## What

Follow-up to #1454 (v0.12.78), extending the same account-settings-prefetch mechanism to **items 4 and 5** of #1070 — two more folds that pin "what AWS assigns at creation" as a constant/derivation the account owner can actually change via a documented account/region API, so they FP on every fresh deploy in such an account.

| Item / path | Account setting (read-only) | Was | Now |
|---|---|---|---|
| **4** `EC2::Instance.CreditSpecification.CPUCredits` | `ec2:GetDefaultCreditSpecification` (per burstable family) | derived t2→standard / t3·t3a·t4g→unlimited | account-effective per-family default overrides the derivation |
| **5** `RDS::DBInstance` / `DocDB::DBInstance.CACertificateIdentifier` | `rds:DescribeCertificates` (`CustomerOverride==true`) | constant `rds-ca-rsa2048-g1` | account customer-override CA overrides the constant |

Both **equality-gated** (an out-of-band change away from the account default still surfaces) and **fail-open** to today's factory default. The factory constants/derivations are **untouched** — they remain the fail-open fallback, so there is **no regression in a factory-default account**.

## How

- **`src/commands/gather.ts`** — two fail-open, cached prefetch functions (`ec2:GetDefaultCreditSpecification` per burstable family declared; `rds:DescribeCertificates` once when an RDS/DocDB instance is present), threaded into `classifyOpts.accountDefaults`.
- **`src/diff/classify.ts`** — two new `AccountDefaults` fields; item 5 handled in `accountDerivedDefault()` (top-level path), item 4 in the existing `CreditSpecification` `knownDef`-injection block (nested path) which now prefers the account-effective per-family value.

## Verification

- **Unit tests** (`tests/classify-account-defaults-345-1070.test.ts`): each item folds atDefault when live == account default, surfaces when it differs, and fail-open reproduces the factory-default behavior. #640 credit-spec derivation tests still green.
- **Corpus replay** green — the factory constants are untouched and `accountDefaults` is absent in replay, so it is a strict no-op there.
- **Live-validated SDK shapes** (read-only, real account): `GetDefaultCreditSpecification.InstanceFamilyCreditSpecification.CpuCredits` (t3 → `unlimited`), `DescribeCertificates[].CustomerOverride` (no override set → falls back to the constant).
- The end-to-end gather→classify→fold plumbing was live-proven in #1454 (EBS A/B); items 4/5 reuse it. Item 4 threads a **new** per-family field.
- Full suite: 229 files / 5011 tests pass.

## Deferred

item 3 (`EC2::Instance.MetadataOptions` account IMDS defaults) — a whole-object PARTIAL override entangled with AMI variance (#640); cannot be equality-gated as one constant without a redesign. Left tracked on #1070.

Part of #1070 (items 4-5).
