### PR TITLE
fix(read): readEc2NetworkAclEntry skips entries omitting optional Egress — default to schema false (#1456)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -1267,10 +1267,13 @@ const readCodeBuildReportGroup: OverrideReader = async ({ physicalId, region }) 
 const readEc2NetworkAclEntry: OverrideReader = async ({ declared, region }) => {
   const naclId = str(declared.NetworkAclId);
   const ruleNumber = declared.RuleNumber;
-  const egress = declared.Egress;
-  // RuleNumber + Egress are required identity; an unresolved NetworkAclId (Symbol) or a
-  // missing identity field -> skipped (fail-open, never a false read).
-  if (!naclId || typeof ruleNumber !== 'number' || typeof egress !== 'boolean') return undefined;
+  // Egress is OPTIONAL in the CFn schema with documented default `false` (every plain
+  // ingress rule omits it), so it is NOT required identity: default it to the schema
+  // default so an omitted-Egress entry still reads and matches the live `Egress=false`
+  // entry. RuleNumber stays genuinely required; an unresolved NetworkAclId (Symbol) or
+  // a missing/non-number RuleNumber -> skipped (fail-open, never a false read).
+  const egress = typeof declared.Egress === 'boolean' ? declared.Egress : false;
+  if (!naclId || typeof ruleNumber !== 'number') return undefined;
 
   const c = new EC2Client({ region, ...READ_RETRY });
   // InvalidNetworkAclID.NotFound surfaces if the NACL itself was deleted out of band —

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -3015,20 +3015,130 @@ describe('EC2 NetworkAclEntry (Cloud Control read-gap: UnsupportedActionExceptio
     );
   });
 
-  it('undefined (skipped) when NetworkAclId is unresolved or identity is missing', async () => {
+  it('undefined (skipped) when NetworkAclId is unresolved or RuleNumber is missing', async () => {
+    // unresolved NetworkAclId (str() -> undefined for a non-string / Symbol)
     expect(
       await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](ctx({ RuleNumber: 100, Egress: false }))
     ).toBeUndefined();
+    // missing RuleNumber (still genuinely required identity)
     expect(
       await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
         ctx({ NetworkAclId: 'acl-123', Egress: false })
       )
     ).toBeUndefined();
-    expect(
-      await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
-        ctx({ NetworkAclId: 'acl-123', RuleNumber: 100 })
-      )
-    ).toBeUndefined();
+  });
+
+  it('reads an ingress rule that OMITS the optional Egress (#1456): defaults Egress to false and matches the live Egress=false entry', async () => {
+    ec2.on(DescribeNetworkAclsCommand).resolves({
+      NetworkAcls: [
+        {
+          NetworkAclId: 'acl-123',
+          Entries: [
+            // a decoy EGRESS entry with the same RuleNumber must NOT match the
+            // default-ingress lookup (Egress defaults to false)
+            { RuleNumber: 100, Egress: true, Protocol: '-1', RuleAction: 'deny' },
+            {
+              RuleNumber: 100,
+              Egress: false,
+              Protocol: '-1',
+              RuleAction: 'allow',
+              CidrBlock: '0.0.0.0/0',
+            },
+          ],
+        },
+      ],
+    });
+    // NO Egress declared — the natural way to write a plain ingress rule
+    const out = await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
+      ctx({
+        NetworkAclId: 'acl-123',
+        RuleNumber: 100,
+        Protocol: -1,
+        RuleAction: 'allow',
+        CidrBlock: '0.0.0.0/0',
+      })
+    );
+    expect(out).toBeDefined();
+    expect(out).toEqual({
+      NetworkAclId: 'acl-123',
+      RuleNumber: 100,
+      Egress: false,
+      Protocol: -1,
+      RuleAction: 'allow',
+      CidrBlock: '0.0.0.0/0',
+    });
+  });
+
+  it('detects an out-of-band change on an omitted-Egress ingress rule (allow -> deny reflected in the read model)', async () => {
+    ec2.on(DescribeNetworkAclsCommand).resolves({
+      NetworkAcls: [
+        {
+          NetworkAclId: 'acl-123',
+          Entries: [
+            {
+              RuleNumber: 100,
+              Egress: false,
+              Protocol: '-1',
+              RuleAction: 'deny', // flipped out of band from the declared 'allow'
+              CidrBlock: '0.0.0.0/0',
+            },
+          ],
+        },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
+      ctx({
+        NetworkAclId: 'acl-123',
+        RuleNumber: 100,
+        Protocol: -1,
+        RuleAction: 'allow',
+        CidrBlock: '0.0.0.0/0',
+      })
+    );
+    // the read reflects the LIVE value so the allow -> deny drift is detectable
+    expect(out?.RuleAction).toBe('deny');
+  });
+
+  it('regression: an entry declaring Egress: true still reads and matches the egress entry', async () => {
+    ec2.on(DescribeNetworkAclsCommand).resolves({
+      NetworkAcls: [
+        {
+          NetworkAclId: 'acl-eg',
+          Entries: [
+            // decoy ingress with same RuleNumber must not match Egress: true lookup
+            { RuleNumber: 300, Egress: false, Protocol: '-1', RuleAction: 'allow' },
+            {
+              RuleNumber: 300,
+              Egress: true,
+              Protocol: '6',
+              RuleAction: 'allow',
+              CidrBlock: '0.0.0.0/0',
+              PortRange: { From: 443, To: 443 },
+            },
+          ],
+        },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
+      ctx({
+        NetworkAclId: 'acl-eg',
+        RuleNumber: 300,
+        Egress: true,
+        Protocol: 6,
+        RuleAction: 'allow',
+        CidrBlock: '0.0.0.0/0',
+        PortRange: { From: 443, To: 443 },
+      })
+    );
+    expect(out).toEqual({
+      NetworkAclId: 'acl-eg',
+      RuleNumber: 300,
+      Egress: true,
+      Protocol: 6,
+      RuleAction: 'allow',
+      CidrBlock: '0.0.0.0/0',
+      PortRange: { From: 443, To: 443 },
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

An `AWS::EC2::NetworkAclEntry` that OMITS the optional `Egress` property (CFn default `false` — i.e. every plain ingress rule written the natural way) was silently `skipped` on every check. Its declared props (`RuleAction`, `Protocol`, `CidrBlock`, `PortRange`) went unwatched — a false negative where an out-of-band allow→deny flip was invisible.

Root cause in `src/read/overrides.ts` `readEc2NetworkAclEntry`: `Egress` was treated as required identity, so an omitted `Egress` (`declared.Egress === undefined`) made the reader bail and the router mapped the resource to `skipped`.

## Fix

`Egress` is OPTIONAL in the CFn schema with documented default `false`, so default the identity to the schema default when undeclared and remove `egress` from the bail guard:

```ts
const egress = typeof declared.Egress === 'boolean' ? declared.Egress : false;
if (!naclId || typeof ruleNumber !== 'number') return undefined;
```

`RuleNumber` stays genuinely required; an unresolved `NetworkAclId` (Symbol) or a missing/non-number `RuleNumber` still skips. An omitted-Egress declared entry now matches the live `Egress=false` entry via the existing `e.Egress === egress` lookup and folds through the normal schema-default path. A template declaring `Egress: true` keeps working unchanged.

## Tests (`tests/overrides.test.ts`)

- Declared NaclEntry WITHOUT `Egress` reads (not skipped) with `Egress: false`, matching the live ingress entry (a decoy egress entry with the same RuleNumber does not match).
- Detection still works: live `RuleAction` flipped allow→deny is reflected in the read model.
- Regression: an entry declaring `Egress: true` still reads and matches the egress entry.
- Unresolved `NetworkAclId` / missing `RuleNumber` still returns undefined (skip preserved).

All 5015 unit tests pass.

Closes #1456
