### PR TITLE
fix(revert): SDK-writer indexed ops verify op.prior against the fresh model before applying (#805)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -1671,7 +1671,7 @@ export function rejectedEmptyStripOps(
 // the user confirms the revert (a prepend/reorder in a same-length object array during the
 // confirm-prompt window), an op at `/Prop/0/Sub` silently lands on a DIFFERENT element and
 // corrupts a sibling (#762).
-function hasArrayIndexSegment(pointer: string): boolean {
+export function hasArrayIndexSegment(pointer: string): boolean {
   return pointer.split('/').some((seg) => /^\d+$/.test(seg));
 }
 
@@ -1681,8 +1681,8 @@ function hasArrayIndexSegment(pointer: string): boolean {
 // descends OBJECT keys), this walks LITERAL numeric array-index segments too, as an
 // index-bearing revert pointer (`/Rules/0/GroupSet`) requires. Each pointer segment is
 // RFC6901-unescaped (`~1` -> `/`, `~0` -> `~`).
-const POINTER_ABSENT = Symbol('pointer-absent');
-function rawValueAtPointer(model: Record<string, unknown>, pointer: string): unknown {
+export const POINTER_ABSENT = Symbol('pointer-absent');
+export function rawValueAtPointer(model: Record<string, unknown>, pointer: string): unknown {
   let node: unknown = model;
   for (const rawSeg of pointer.split('/').slice(1)) {
     const seg = rawSeg.replace(/~1/g, '/').replace(/~0/g, '~');

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -208,6 +208,7 @@ import { SetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { SetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { partitionForRegion } from '../desired/template-adapter.js';
 import { NESTED_ARRAY_IDENTITY } from '../diff/classify.js';
+import { deepEqual } from '../diff/drift-calculator.js';
 import { identityField } from '../normalize/noise.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
 import { pageResourceRecordSets, route53RecordSetIdentifier } from '../read/child-enumerators.js';
@@ -218,7 +219,7 @@ import {
   SDK_OVERRIDES,
 } from '../read/overrides.js';
 import { applyOps } from './apply-ops.js';
-import type { PatchOp } from './plan.js';
+import { hasArrayIndexSegment, type PatchOp, POINTER_ABSENT, rawValueAtPointer } from './plan.js';
 import { classifyTransient, errorText } from './transient.js';
 
 export type SdkWriter = (ctx: OverrideCtx, ops: PatchOp[]) => Promise<void>;
@@ -261,6 +262,42 @@ const assertOpsConsumed = (
     );
 };
 
+// #805: a whole-document SDK writer that re-reads and re-canonicalizes the live model at apply
+// time (desiredModel below, writeWafv2WebAcl) fixes raw-vs-canonical ORDER, not index FRESHNESS.
+// A revert op's numeric index (e.g. `/PolicyDocument/Statement/1/Resource`, `/Rules/1/Action`)
+// was computed against the CHECK-time model. If a statement/rule was added, removed, or reordered
+// while the user sat on the confirm prompt (the #760 mutation point), the canonically-sorted FRESH
+// array puts a DIFFERENT element at that index -> the whole-document PUT (PutBucketPolicy /
+// PutRolePolicy via SetTopicAttributes/SetQueueAttributes / UpdateWebACL) would corrupt an
+// innocent (security-relevant) element AND write it, while leaving the real drift unreverted.
+// Every op carries `prior` (the check-time live value = the finding's `f.actual`), and both the
+// prior and the freshly-read model are canonicalized the SAME way (this is the very model the
+// following applyOps mutates), so before applying an index-bearing op assert the fresh node at its
+// pointer still deep-equals `prior`. On mismatch — or if the index shifted away entirely
+// (POINTER_ABSENT) — abort the whole item (the writer throws, stack-actions.ts records `ok:false`,
+// an honest FAILED) so the user re-runs check. Fail-closed: a false abort merely declines to write;
+// it never corrupts. This is the SDK-path twin of #762/#853's Cloud Control `test` precondition
+// (which the CC path already carries in toPatchDocument; #762's text wrongly assumed the SDK
+// re-read guarded freshness — it only aligns order). Non-indexed scalar pointers carry no aliasing
+// risk (a named property is stable regardless of array order), so they are not checked.
+export function assertIndexedPriorsFresh(
+  resourceType: string,
+  freshModel: Record<string, unknown>,
+  ops: readonly PatchOp[]
+): void {
+  for (const { path, prior } of ops) {
+    // A `prior` of undefined is nothing to assert against (RFC6902 has no "undefined"): an
+    // append at a new index, or an op the plan built without a check-time value.
+    if (!hasArrayIndexSegment(path) || prior === undefined) continue;
+    const fresh = rawValueAtPointer(freshModel, path);
+    if (fresh === POINTER_ABSENT || !deepEqual(fresh, prior))
+      throw new Error(
+        `${resourceType} revert aborted: the live value at ${path} changed since check ` +
+          `(an element was added, removed, or reordered) — re-run check and revert again`
+      );
+  }
+}
+
 // reconstruct the desired full model = current (read back) with revert ops applied
 async function desiredModel(
   type: string,
@@ -281,6 +318,8 @@ async function desiredModel(
     current.PolicyDocument === undefined
       ? current
       : { ...current, PolicyDocument: canonicalizeForCompare(current.PolicyDocument) };
+  // #805: fail-closed if an index-bearing op's target element changed since check.
+  assertIndexedPriorsFresh(type, aligned, ops);
   return applyOps(aligned, ops);
 }
 const policyJson = (m: Record<string, unknown>): string | undefined =>
@@ -773,13 +812,13 @@ const writeWafv2WebAcl: SdkWriter = async (ctx, ops) => {
   // misalignment class, here on the SDK-writer path). Canonicalize the current model the
   // same way so an indexed op hits the SAME rule; Rule order is not significant to WAFv2
   // (Priority governs evaluation), so re-sending the sorted array changes no behavior.
-  const m = applyOps(
-    canonicalizeForCompare(cur.WebACL as unknown as Record<string, unknown>) as Record<
-      string,
-      unknown
-    >,
-    ops
-  );
+  const canonWebAcl = canonicalizeForCompare(
+    cur.WebACL as unknown as Record<string, unknown>
+  ) as Record<string, unknown>;
+  // #805: fail-closed if a Rule was added/removed/reordered since check, so an indexed op
+  // (`/Rules/1/Action`) can no longer corrupt whatever rule now sits at that sorted index.
+  assertIndexedPriorsFresh('AWS::WAFv2::WebACL', canonWebAcl, ops);
+  const m = applyOps(canonWebAcl, ops);
   const desc = m.Description;
   await c.send(
     new UpdateWebACLCommand({

--- a/tests/writers-stale-index-805.test.ts
+++ b/tests/writers-stale-index-805.test.ts
@@ -1,0 +1,144 @@
+// #805 — SDK writers that re-read the live model at apply time and re-canonicalize it
+// (desiredModel for the policy writers, writeWafv2WebAcl) fix raw-vs-canonical ORDER, not index
+// FRESHNESS. A revert op's numeric index (`…/Statement/1/Resource`, `/Rules/1/Action`) was
+// computed against the CHECK-time model; if a statement/rule is added, removed, or reordered while
+// the user sits on the confirm prompt (#760), the canonically-sorted FRESH array puts a DIFFERENT
+// element at that index — so the whole-document PUT would corrupt an innocent (security-relevant)
+// element AND write it. `assertIndexedPriorsFresh` fails CLOSED: before applying an index-bearing
+// op it asserts the fresh node at the pointer still equals the op's `prior` (the check-time value),
+// throwing (an honest FAILED the caller records as not-reverted) on any mismatch, so nothing is
+// written. This is the SDK-path twin of #762/#853's Cloud Control `test` precondition.
+import { GetWebACLCommand, UpdateWebACLCommand, WAFV2Client } from '@aws-sdk/client-wafv2';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { OverrideCtx } from '../src/read/overrides.js';
+import type { PatchOp } from '../src/revert/plan.js';
+import { SDK_WRITERS, assertIndexedPriorsFresh } from '../src/revert/writers.js';
+
+const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
+  physicalId: 'pid',
+  declared: {},
+  region: 'us-east-1',
+  accountId: '123456789012',
+  ...over,
+});
+
+describe('#805 assertIndexedPriorsFresh — precondition on index-bearing revert ops', () => {
+  const op = (path: string, prior: unknown): PatchOp => ({
+    op: 'add',
+    path,
+    value: 'anything',
+    prior,
+    human: 'x',
+  });
+
+  it('passes when the fresh node at the index still equals the check-time prior', () => {
+    const fresh = { Statement: [{ Resource: 'arn:a' }, { Resource: 'arn:b' }] };
+    expect(() =>
+      assertIndexedPriorsFresh('AWS::S3::BucketPolicy', fresh, [
+        op('/Statement/1/Resource', 'arn:b'),
+      ])
+    ).not.toThrow();
+  });
+
+  it('throws when the element at the index changed since check (reordered / replaced)', () => {
+    // Someone added a statement out of band while the user sat on the confirm prompt, so the
+    // canonically-sorted fresh array now has a DIFFERENT statement at index 1 than classify saw.
+    const fresh = { Statement: [{ Resource: 'arn:a' }, { Resource: 'arn:NEW' }] };
+    expect(() =>
+      assertIndexedPriorsFresh('AWS::S3::BucketPolicy', fresh, [
+        op('/Statement/1/Resource', 'arn:b'),
+      ])
+    ).toThrow(/changed since check/);
+  });
+
+  it('throws when the indexed element was removed (index now beyond array length)', () => {
+    const fresh = { Statement: [{ Resource: 'arn:a' }] };
+    expect(() =>
+      assertIndexedPriorsFresh('AWS::S3::BucketPolicy', fresh, [
+        op('/Statement/1/Resource', 'arn:b'),
+      ])
+    ).toThrow(/changed since check/);
+  });
+
+  it('does not check a non-indexed scalar pointer (a named property is stable under reorder)', () => {
+    // Even a differing value: a named top-level prop cannot be aliased by an array reorder, so it
+    // is not this guard's concern — the whole-document write still carries the desired value.
+    const fresh = { Description: 'now-different' };
+    expect(() =>
+      assertIndexedPriorsFresh('AWS::WAFv2::WebACL', fresh, [op('/Description', 'was-this')])
+    ).not.toThrow();
+  });
+
+  it('skips an index-bearing op with an undefined prior (an append at a new index)', () => {
+    const fresh = { Statement: [{ Resource: 'arn:a' }] };
+    expect(() =>
+      assertIndexedPriorsFresh('AWS::S3::BucketPolicy', fresh, [
+        op('/Statement/1/Resource', undefined),
+      ])
+    ).not.toThrow();
+  });
+});
+
+describe('#805 WAFv2 WebACL writer aborts a stale-index revert before UpdateWebACL', () => {
+  const wafv2 = mockClient(WAFV2Client);
+  const PID = 'cdkrd-acl|abc-123|REGIONAL';
+  beforeEach(() => wafv2.reset());
+
+  // GetWebACL returns two rules; canonicalizeForCompare sorts them by Name to [alpha, zeta], so a
+  // finding op on `/Rules/1/Action` targets ZETA. `prior` carries the Action classify saw on zeta.
+  const stubGet = (zetaAction: unknown): void => {
+    wafv2.on(GetWebACLCommand).resolves({
+      LockToken: 'LOCK1',
+      WebACL: {
+        Name: 'cdkrd-acl',
+        Id: 'abc-123',
+        DefaultAction: { Allow: {} },
+        Rules: [
+          { Name: 'zeta', Priority: 0, Action: zetaAction },
+          { Name: 'alpha', Priority: 1, Action: { Block: {} } },
+        ],
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'm',
+        },
+      },
+    } as never);
+    wafv2.on(UpdateWebACLCommand).resolves({});
+  };
+  const ruleActionOp = (prior: unknown): PatchOp => ({
+    op: 'add',
+    path: '/Rules/1/Action',
+    value: { Block: {} },
+    prior,
+    human: 'Rules.1.Action -> deployed-template value',
+  });
+
+  it('aborts (no UpdateWebACL) when zeta.Action changed out of band since check', async () => {
+    // check saw zeta.Action = Allow; the live rule is now Block (out-of-band change while the user
+    // confirmed). The whole-ACL PUT would otherwise re-write zeta with the wrong basis.
+    stubGet({ Block: {} });
+    await expect(
+      SDK_WRITERS['AWS::WAFv2::WebACL'](ctx({ physicalId: PID }), [ruleActionOp({ Allow: {} })])
+    ).rejects.toThrow(/changed since check/);
+    expect(wafv2.commandCalls(UpdateWebACLCommand)).toHaveLength(0);
+  });
+
+  it('proceeds to UpdateWebACL when the fresh zeta.Action still matches prior', async () => {
+    stubGet({ Allow: {} });
+    await SDK_WRITERS['AWS::WAFv2::WebACL'](ctx({ physicalId: PID }), [
+      ruleActionOp({ Allow: {} }),
+    ]);
+    const calls = wafv2.commandCalls(UpdateWebACLCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input as unknown as {
+      Rules: { Name: string; Action: unknown }[];
+    };
+    // the op landed on ZETA (index aligned to the sorted model), leaving ALPHA untouched
+    const zeta = input.Rules.find((r) => r.Name === 'zeta')!;
+    const alpha = input.Rules.find((r) => r.Name === 'alpha')!;
+    expect(zeta.Action).toEqual({ Block: {} });
+    expect(alpha.Action).toEqual({ Block: {} });
+  });
+});


### PR DESCRIPTION
Closes #805.

## Problem

The SDK writers that re-read the live model at apply time and re-canonicalize it
— `desiredModel` (the S3/SNS/SQS resource-policy writers) and `writeWafv2WebAcl`
— fix raw-vs-canonical **ORDER**, not index **FRESHNESS**. A revert op's numeric
index (`/PolicyDocument/Statement/1/Resource`, `/Rules/1/Action`) was computed
against the **check-time** model. If a statement/rule is added, removed, or
reordered while the user sits on the revert confirm prompt (the #760 mutation
point), the canonically-sorted **fresh** array puts a *different* element at that
index. The whole-document PUT (`PutBucketPolicy` / `SetTopicAttributes` /
`SetQueueAttributes` / `UpdateWebACL`) then corrupts an innocent, security-relevant
element **and writes it**, while leaving the real drift unreverted.

#762 added an RFC6902 `test` precondition on the **Cloud Control** path
(`toPatchDocument`) but its text explicitly (and incorrectly) treated the SDK path
as guarded — the SDK re-read only re-canonicalizes ORDER; no writer verified
`op.prior` against the fresh node.

## Fix

`assertIndexedPriorsFresh(resourceType, freshModel, ops)`: before the `applyOps`
in both re-read writers, for every index-bearing op with a defined `prior`, assert
the freshly-read (identically canonicalized — the very model `applyOps` mutates)
node at the op's pointer still deep-equals `op.prior` (the check-time `f.actual`).
On mismatch — or if the index shifted away entirely (`POINTER_ABSENT`) — throw an
honest failure so `stack-actions.ts` records `ok:false` ("re-run check"). **Fail-
closed**: a false abort merely declines to write; it never corrupts. Non-indexed
scalar pointers carry no aliasing risk (a named property is stable under reorder)
and are not checked, keeping the patch minimal. This is the SDK-path twin of
#762/#853's CC `test` op.

Reuses `hasArrayIndexSegment` / `rawValueAtPointer` / `POINTER_ABSENT` from
`plan.ts` (now exported) so pointer resolution is identical to the CC path. No
`SDK_WRITERS` keys change, so README's revertable/non-revertable claims are
unaffected.

## Adjacent notes from the issue

- The `apply-ops.ts` array-hole concern (`removeAt` leaving a `null`, `setAt`
  fabricating `{}`) under a diverged fresh read is **subsumed** by this
  precondition — a diverged index now aborts before `applyOps` runs.
- `writeEventBusPolicy`'s missing concurrency token remains a documented apply-time
  (ms-window) limitation, out of scope here.

## Tests

`tests/writers-stale-index-805.test.ts` — direct unit tests on the helper (fresh
match passes; changed/removed element aborts; non-indexed and undefined-prior ops
skipped) plus an end-to-end WAFv2 case proving the writer aborts before
`UpdateWebACL` when the sorted-index rule changed out of band, and still proceeds
when `prior` matches. Full suite: 230 files / 5019 tests green.
