### PR TITLE
fix(noise): first-run FP folds — ELBv2 TargetGroup TargetType/stickiness + lowercase-identifier case-fold family (#1451, #1457)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -448,6 +448,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ProtocolVersion: 'HTTP1',
     IpAddressType: 'ipv4',
     Matcher: { HttpCode: '200' },
+    // TargetType is create-only; a TG that omits it defaults to `instance` and echoes it
+    // undeclared. Equality-gated so a declared lambda/ip/alb value is compared in the
+    // declared loop. Live-verified 2026-07-11.
+    TargetType: 'instance',
   },
   'AWS::ElasticLoadBalancingV2::LoadBalancer': {
     IpAddressType: 'ipv4',
@@ -3833,6 +3837,10 @@ export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
     'load_balancing.algorithm.type': 'round_robin',
     'load_balancing.cross_zone.enabled': 'use_load_balancer_configuration',
     'slow_start.duration_seconds': '0',
+    // instance/ip TGs return this attribute-bag default even while stickiness is off; bag
+    // values are strings so the trivial-empty drop misses "false". Equality-gated: an
+    // out-of-band stickiness ENABLE ("true") still surfaces.
+    'stickiness.enabled': 'false',
     // latent stickiness defaults AWS returns even while stickiness.enabled is false
     'stickiness.app_cookie.duration_seconds': '86400',
     'stickiness.lb_cookie.duration_seconds': '86400',
@@ -4026,6 +4034,28 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // Observed live on fresh (non-imported) Aurora stacks in ap-northeast-1.
   'AWS::RDS::DBInstance': new Set(['DBInstanceIdentifier']),
   'AWS::RDS::DBCluster': new Set(['DBClusterIdentifier']),
+  // The "stored as a lowercase string" identifier family — ElastiCache, DocumentDB,
+  // Neptune, and DMS all lowercase their resource identifier on creation (AWS CLI help:
+  // "This parameter is stored as a lowercase string"), so a template that declares a
+  // mixed-case identifier (e.g. CDK derives it from a construct id) reads back all-lowercase
+  // and a case-sensitive compare false-flags DECLARED drift on every check — a permanent FP
+  // that survives `record` and never converges (a revert just re-writes the mixed case, which
+  // the service lowercases again). Every identifier here is create-only, so case-insensitive
+  // equality hides no revertable drift (a genuine rename is a replacement). ElastiCache
+  // SubnetGroup live-verified; the rest docs-verified from the AWS CLI help. NOTE:
+  // AWS::RDS::DBSubnetGroup.DBSubnetGroupName and AWS::Route53::HostedZone.Name were
+  // live-ruled-out (RDS/Route53 PRESERVE case on read) so they are deliberately NOT added.
+  'AWS::ElastiCache::SubnetGroup': new Set(['CacheSubnetGroupName']),
+  'AWS::ElastiCache::ReplicationGroup': new Set(['ReplicationGroupId']),
+  'AWS::ElastiCache::CacheCluster': new Set(['ClusterName']),
+  'AWS::DocDB::DBCluster': new Set(['DBClusterIdentifier']),
+  'AWS::DocDB::DBInstance': new Set(['DBInstanceIdentifier']),
+  'AWS::DocDB::DBSubnetGroup': new Set(['DBSubnetGroupName']),
+  'AWS::Neptune::DBCluster': new Set(['DBClusterIdentifier']),
+  'AWS::Neptune::DBInstance': new Set(['DBInstanceIdentifier']),
+  'AWS::Neptune::DBSubnetGroup': new Set(['DBSubnetGroupName']),
+  'AWS::DMS::ReplicationInstance': new Set(['ReplicationInstanceIdentifier']),
+  'AWS::DMS::ReplicationSubnetGroup': new Set(['ReplicationSubnetGroupIdentifier']),
   // DMS Endpoint `EndpointType` — the CFn/CDK value is lowercase (`source` /
   // `target`) but the DMS API echoes it UPPERCASE (`SOURCE` / `TARGET`) on the
   // DescribeEndpoints read (the SDK_OVERRIDES reader), so a case-sensitive compare

--- a/tests/noise-firstrun-1451-1453-1457.test.ts
+++ b/tests/noise-firstrun-1451-1453-1457.test.ts
@@ -1,0 +1,142 @@
+// First-run false-positive folds bundled from three fix(noise) issues, all landing in
+// src/normalize/noise.ts. Each is an equality-gated / value-independent / case-fold entry,
+// so every test asserts BOTH the fold (atDefault / no declared drift on a clean deploy) AND
+// that a genuine divergence still surfaces.
+//   #1451 — ELBv2 TargetGroup: TargetType constant + stickiness.enabled attribute-bag default.
+//   #1457 — case-insensitive lowercase-identifier family (ElastiCache SubnetGroup live-anchor).
+// #1453 (EC2 Subnet AvailabilityZone) is DEFERRED — it needs a forbidden classify.ts change
+// (see the NOTE below and the PR description).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const declaredPaths = (findings: Finding[]) => pathsByTier(findings, 'declared');
+
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({ logicalId: 'R', resourceType, physicalId, declared });
+
+// #1451 (a) — TargetType constant
+describe('#1451 ELBv2 TargetGroup TargetType default', () => {
+  const T = 'AWS::ElasticLoadBalancingV2::TargetGroup';
+  it('folds an undeclared TargetType "instance" to atDefault', () => {
+    const f = classifyResource(
+      mk(T, { Port: 80, Protocol: 'HTTP', VpcId: 'vpc-1' }),
+      {
+        Port: 80,
+        Protocol: 'HTTP',
+        VpcId: 'vpc-1',
+        TargetType: 'instance',
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('TargetType');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('TargetType');
+  });
+
+  it('a declared lambda TargetType still compares (drift on a mismatch)', () => {
+    const f = classifyResource(
+      mk(T, { TargetType: 'lambda' }),
+      { TargetType: 'instance' },
+      emptySchema
+    );
+    expect(declaredPaths(f)).toContain('TargetType');
+  });
+});
+
+// #1451 (b) — stickiness.enabled attribute-bag default
+describe('#1451 ELBv2 TargetGroup stickiness.enabled attribute-bag default', () => {
+  const T = 'AWS::ElasticLoadBalancingV2::TargetGroup';
+  const withBag = (entries: { Key: string; Value: string }[]) => ({
+    Port: 80,
+    Protocol: 'HTTP',
+    VpcId: 'vpc-1',
+    TargetType: 'instance',
+    TargetGroupAttributes: entries,
+  });
+
+  it('folds an undeclared stickiness.enabled "false" to atDefault', () => {
+    const f = classifyResource(
+      mk(T, { Port: 80, Protocol: 'HTTP', VpcId: 'vpc-1' }),
+      withBag([{ Key: 'stickiness.enabled', Value: 'false' }]),
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('TargetGroupAttributes[stickiness.enabled]');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('TargetGroupAttributes[stickiness.enabled]');
+  });
+
+  it('an out-of-band stickiness ENABLE ("true") still surfaces as undeclared', () => {
+    const f = classifyResource(
+      mk(T, { Port: 80, Protocol: 'HTTP', VpcId: 'vpc-1' }),
+      withBag([{ Key: 'stickiness.enabled', Value: 'true' }]),
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('TargetGroupAttributes[stickiness.enabled]');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('TargetGroupAttributes[stickiness.enabled]');
+  });
+});
+
+// NOTE: #1453 (EC2 Subnet undeclared AvailabilityZone / AvailabilityZoneId) is intentionally
+// NOT fixed in this PR — see the PR description. The tier-3 value-independent fold planned for
+// it collides with the pre-existing AvailabilityZone/AvailabilityZoneId handling in
+// classify.ts (CC_ALT_REPRESENTATION + its deliberate test), which is a forbidden file for this
+// lane, so #1453 is deferred rather than shipped half-done.
+
+// #1457 — case-insensitive lowercase-identifier family
+describe('#1457 lowercase-identifier case-fold family', () => {
+  it('ElastiCache SubnetGroup mixed-case name vs lowercase live is NOT declared drift', () => {
+    const T = 'AWS::ElastiCache::SubnetGroup';
+    const f = classifyResource(
+      mk(T, { CacheSubnetGroupName: 'CdkrdHunt-EcSubnets', SubnetIds: ['subnet-1'] }),
+      { CacheSubnetGroupName: 'cdkrdhunt-ecsubnets', SubnetIds: ['subnet-1'] },
+      emptySchema
+    );
+    expect(declaredPaths(f)).not.toContain('CacheSubnetGroupName');
+  });
+
+  it('a genuinely different SubnetGroup name still surfaces as declared drift', () => {
+    const T = 'AWS::ElastiCache::SubnetGroup';
+    const f = classifyResource(
+      mk(T, { CacheSubnetGroupName: 'group-aaa', SubnetIds: ['subnet-1'] }),
+      { CacheSubnetGroupName: 'group-bbb', SubnetIds: ['subnet-1'] },
+      emptySchema
+    );
+    expect(declaredPaths(f)).toContain('CacheSubnetGroupName');
+  });
+
+  it('the family covers DocDB / Neptune / DMS identifiers too', () => {
+    const cases: [string, string, string, string][] = [
+      ['AWS::DocDB::DBCluster', 'DBClusterIdentifier', 'MyDocDb-Cluster', 'mydocdb-cluster'],
+      ['AWS::Neptune::DBInstance', 'DBInstanceIdentifier', 'MyGraph-DB', 'mygraph-db'],
+      [
+        'AWS::DMS::ReplicationInstance',
+        'ReplicationInstanceIdentifier',
+        'MyDms-Repl',
+        'mydms-repl',
+      ],
+    ];
+    for (const [T, prop, declared, live] of cases) {
+      const f = classifyResource(mk(T, { [prop]: declared }), { [prop]: live }, emptySchema);
+      expect(declaredPaths(f)).not.toContain(prop);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a `regionStackNames` prop to `MultiRegionStack` to override the CloudFormation stack names of the twins/groups, instead of the default (every twin reusing the main stack's name).

```ts
new MultiRegionStack(app, 'MyApp', {
  env: { region: 'ap-northeast-1' },
  stackName: 'App-Tokyo',
  regionStackNames: {
    'us-east-1': {
      stackName: 'App-Virginia',
      groupStackNames: { Alarms: 'App-Virginia-Alarms' },
    },
  },
});
```

Keyed by region: the region's default twin via `stackName`, its groups via `groupStackNames`. Names are declared on the stack (not passed at each `regionScope()` call), so `regionScope()` stays a pure, order-independent accessor.

## Why

The default gives every region the same stack name. A workload already deployed as separate hand-split stacks with different names per region (e.g. `App-Tokyo` in the main region, `App-Virginia` in us-east-1) could not adopt `MultiRegionStack` without creating brand-new stacks and orphaning the deployed ones. Matching the existing names lets CloudFormation update them in place — a stack is identified by `(name, region, account)`.

The shared name was only a convention. Cross-region references resolve against the twin's actual name under every reference strength, `weak` included: the main stack embeds `Fn::GetStackOutput` with the overridden name (verified in `refs.js` → `Fn.getStackOutput(exportingStack.stackName, ...)`).

## Validation

- **At construction (fail-fast):** each name's format (`^[A-Za-z][A-Za-z0-9-]*$`) and 128-char length; group key format; a `stackName` for the stack's own region is rejected (use the top-level `stackName` prop), though own-region groups may be named.
- **At twin creation:** two stacks with the same `(name, region)` are rejected (collision with the main stack name or another override).
- **At synth (warning):** a `regionStackNames` entry whose twin is never created (a typo in the region/group, or a region intentionally skipped in this environment) emits an acknowledgeable warning — not a hard error, to keep the conditional-skip pattern working — deduped across repeated synths.

Works with `strong` / `weak` / `both`.

## Tests

- **52 unit cases**: verbatim naming (twin + group), fallback to the derived name, order-independent accessor, weak `Fn::GetStackOutput` embedding the overridden name, strong reader/writer wiring, own-region `stackName` rejected / groups allowed, format/length/group-key validation, per-region collision (both the main-name and twin-name branches), and the unused-entry warning (twin, group, mixed, once-per-double-synth).
- **Integ `integ.multi-region-stack-rename`** — a renamed twin AND a renamed group referencing back into the main stack, exercising `groupStackNames` and both cross-region reference directions (main → twin, group → main) with overridden names. **Live-deployed and destroyed (~292s).**

## Docs

- New README section "Migrating existing differently-named stacks".
- Replaced the misleading "shared name" wording with "the main stack's name" throughout.
- New `RegionStackNames` struct; regenerated `API.md` and JSDoc.
