### PR TITLE
fix(diff): AppRegistry AttributeGroupAssociation name-echoes-id + EC2 Subnet undeclared AZ first-run FPs (#1452, #1453)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -2555,6 +2555,31 @@ export function classifyResource(
       sfnDefinitionSubstitutions
     );
   }
+  // #1452: a ServiceCatalogAppRegistry AttributeGroupAssociation declares `Application` /
+  // `AttributeGroup` by NAME (the schema documents both as "the name or the id"), but Cloud
+  // Control echoes back the resource IDs — so a fresh, un-mutated deploy reports both as a
+  // permanent [CFn-Declared Drift] that `record` cannot accept (declared dimension). Both are
+  // createOnly (name→id can't change out of band without replacement), and the live id is the
+  // trailing segment of the association's OWN composite physical id
+  // (`<applicationArn>|<attributeGroupArn>`). Rewrite the declared name to that id, gated on the
+  // live value equalling the derived id (fold tier 2): a match folds the alias echo, and a
+  // genuine re-point is a replacement (new physical id → new derived id → still equal, still no
+  // false drift), while any mismatch leaves the declared name untouched and surfaces (fail-closed).
+  if (
+    resourceType === 'AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation' &&
+    typeof physicalId === 'string'
+  ) {
+    const [appArn, attrArn] = physicalId.split('|');
+    const derivedIds: Record<string, string | undefined> = {
+      Application: appArn?.split('/').pop(),
+      AttributeGroup: attrArn?.split('/').pop(),
+    };
+    for (const [key, id] of Object.entries(derivedIds)) {
+      if (id && typeof declared[key] === 'string' && declared[key] !== id && live[key] === id) {
+        declared[key] = id;
+      }
+    }
+  }
 
   // Sibling-managed inline Policies (the CDK pattern: grants land in a sibling
   // AWS::IAM::Policy resource, which reflects into the role's live Policies). Drop
@@ -4274,6 +4299,22 @@ export function classifyResource(
       // #705: a Classic ELB's undeclared Policies folds atDefault ONLY when it is exactly the
       // AWS default SSL negotiation policy (by PolicyName); a downgrade / added policy surfaces.
       clbDefaultSslPoliciesAtDefault(resourceType, k, v)
+    ) {
+      findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+      continue;
+    }
+    // #1453: an EC2 Subnet that declares NEITHER `AvailabilityZone` NOR `AvailabilityZoneId`
+    // lets AWS pick the AZ at creation, and CC echoes BOTH forms undeclared (e.g.
+    // AvailabilityZone="us-east-1e", AvailabilityZoneId="use1-az3"). Both are createOnly
+    // AWS-assigned placement values — value-independent (a user who cares DECLARES
+    // AvailabilityZone, then compared in the declared loop). Fold atDefault. When EITHER form IS
+    // declared, this is skipped and the CC_ALT_REPRESENTATION drop below handles the echoed
+    // sibling — so the CDK-typical subnet (declares AvailabilityZone via Fn::Select) is unchanged.
+    if (
+      resourceType === 'AWS::EC2::Subnet' &&
+      (k === 'AvailabilityZone' || k === 'AvailabilityZoneId') &&
+      !('AvailabilityZone' in declared) &&
+      !('AvailabilityZoneId' in declared)
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;

--- a/tests/classify-appregistry-echo-1452.test.ts
+++ b/tests/classify-appregistry-echo-1452.test.ts
@@ -1,0 +1,77 @@
+// #1452 — a ServiceCatalogAppRegistry AttributeGroupAssociation declares `Application` /
+// `AttributeGroup` by NAME (the schema documents both as "the name or the id"), but Cloud Control
+// echoes back the resource IDs — so a fresh, un-mutated deploy reports both as a permanent
+// [CFn-Declared Drift] that `record` cannot accept. classify rewrites the declared name to the id
+// derived from the association's OWN composite physical id (`<applicationArn>|<attributeGroupArn>`),
+// gated on the live value equalling the derived id: a match folds the alias echo, a mismatch surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const TYPE = 'AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation';
+const APP_ID = '0cpp0l6w1qdcdslh6bdgbe94gp';
+const ATTR_ID = '08xz6krei60dtgplip3m80imid';
+const PHYS =
+  `arn:aws:servicecatalog:us-east-1:123456789012:/applications/${APP_ID}` +
+  `|arn:aws:servicecatalog:us-east-1:123456789012:/attribute-groups/${ATTR_ID}`;
+
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'AppRegAttrAssoc',
+  resourceType: TYPE,
+  physicalId: PHYS,
+  declared,
+});
+
+describe('#1452 AppRegistry AttributeGroupAssociation name→id alias echo', () => {
+  it('folds the declared-name vs live-id echo on a clean deploy (no declared drift)', () => {
+    const res = mk({ Application: 'cdkrd-hunt-app', AttributeGroup: 'cdkrd-hunt-attrs' });
+    const f = classifyResource(
+      res,
+      {
+        Application: APP_ID,
+        AttributeGroup: ATTR_ID,
+        ApplicationArn: `arn:aws:servicecatalog:us-east-1:123456789012:/applications/${APP_ID}`,
+        AttributeGroupArn: `arn:aws:servicecatalog:us-east-1:123456789012:/attribute-groups/${ATTR_ID}`,
+      },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).not.toContain('Application');
+    expect(tier(f, 'declared')).not.toContain('AttributeGroup');
+  });
+
+  it('folds even when the template declares the id directly (declared == live)', () => {
+    const res = mk({ Application: APP_ID, AttributeGroup: ATTR_ID });
+    const f = classifyResource(res, { Application: APP_ID, AttributeGroup: ATTR_ID }, emptySchema);
+    expect(tier(f, 'declared')).toEqual([]);
+  });
+
+  it('surfaces when the live id does NOT match the physical-id-derived id (fail-closed)', () => {
+    const res = mk({ Application: 'cdkrd-hunt-app', AttributeGroup: 'cdkrd-hunt-attrs' });
+    // live Application echoes an id that is NOT the trailing segment of the physical-id ARN —
+    // the derivation cannot confirm the echo, so the declared name is left to surface.
+    const f = classifyResource(
+      res,
+      { Application: 'some-other-id', AttributeGroup: ATTR_ID },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toContain('Application');
+    expect(tier(f, 'declared')).not.toContain('AttributeGroup');
+  });
+});

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -9397,19 +9397,23 @@ describe('Cloud Control field mis-echo / alternative-representation folds (VPC n
       classifyResource(r, live, bare).find((f) => f.path === 'AvailabilityZoneId')
     ).toBeUndefined();
   });
-  it('AWS::EC2::Subnet: AvailabilityZoneId still surfaces when AvailabilityZone is NOT declared', () => {
+  it('AWS::EC2::Subnet: undeclared AvailabilityZone + AvailabilityZoneId fold atDefault when NEITHER is declared (#1453)', () => {
     const r: DesiredResource = {
       logicalId: 'Subnet',
       resourceType: 'AWS::EC2::Subnet',
       physicalId: 'subnet-x',
-      declared: { CidrBlock: '10.0.0.0/24' },
+      declared: { CidrBlock: '10.61.0.0/26' },
     };
-    const f = classifyResource(
+    const findings = classifyResource(
       r,
-      { AvailabilityZoneId: 'apne1-az4', CidrBlock: '10.0.0.0/24' },
+      { AvailabilityZone: 'us-east-1e', AvailabilityZoneId: 'use1-az3', CidrBlock: '10.61.0.0/26' },
       bare
-    ).find((x) => x.path === 'AvailabilityZoneId');
-    expect(f?.tier).toBe('undeclared');
+    );
+    // Core invariant: a clean deploy of a raw-CFn subnet that omits the AZ shows ZERO
+    // [Potential Drift] — the AWS-assigned placement values fold, not surface.
+    expect(findings.find((f) => f.path === 'AvailabilityZone')?.tier).toBe('atDefault');
+    expect(findings.find((f) => f.path === 'AvailabilityZoneId')?.tier).toBe('atDefault');
+    expect(findings.some((f) => f.tier === 'undeclared')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Two `src/diff/classify.ts` first-run false-positive folds, both live-verified by the 2026-07-11 bug hunt. Both violate the core invariant (a clean, un-mutated deploy must show ZERO drift on first `check`).

### #1452 — AppRegistry AttributeGroupAssociation declared NAME echoes back as ID
`AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation` declares `Application` / `AttributeGroup` by NAME (the schema documents both as "the name or the id"), but Cloud Control echoes back the resource IDs — so both surface as permanent `[CFn-Declared Drift]` that `record` cannot accept. Both are createOnly, and the live id is the trailing segment of the association's OWN composite physical id (`<applicationArn>|<attributeGroupArn>`). classify rewrites the declared name to that derived id, **gated on the live value equalling it** (fold tier 2): a match folds the alias echo, a mismatch leaves the declared name to surface (fail-closed).

### #1453 — EC2 Subnet undeclared AvailabilityZone / AvailabilityZoneId
An `AWS::EC2::Subnet` that declares NEITHER `AvailabilityZone` NOR `AvailabilityZoneId` lets AWS pick the AZ at creation, and CC echoes BOTH forms undeclared → `[Potential Drift]` on first check. Both are createOnly AWS-assigned placement values — value-independent (tier 3). Folded `atDefault` **only when neither form is declared**; when either IS declared the existing `CC_ALT_REPRESENTATION` drop handles the echoed sibling, so the CDK-typical subnet (declares AvailabilityZone via `Fn::Select(Fn::GetAZs)`) is unchanged — no corpus regression.

Both fixes are entirely in `classify.ts` (self-contained; the #1453 value-independent fold was kept out of `noise.ts` to stay collision-disjoint from the parallel noise lane). Unit tests: new `tests/classify-appregistry-echo-1452.test.ts` (fold + fail-closed cases) and an updated `tests/classify.test.ts` Subnet case (the old test asserted the #1453 bug — now asserts `atDefault`).

Closes #1452
Closes #1453
