### PR TITLE
fix(tooling): sweep-orphans ec2:volume resource_gone arm — deleted-volume RGT-lag phantom no longer deadlocks the gate (#1463)

### DIFF
--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -183,8 +183,8 @@ resource_gone() {
       # arn:aws:ec2:<region>:<acct>:vpc-endpoint/vpce-<id> — the second type observed
       # lingering in the RGT index after deletion (2026-07-10): DescribeVpcEndpoints
       # returned InvalidVpcEndpointId.NotFound while the tag filter still listed it,
-      # keeping an unrelated agent's gate RED. Probed subtypes: vpc-endpoint and
-      # instance; every other ec2 resource stays fail-safe (return 1 → ORPHAN stays RED).
+      # keeping an unrelated agent's gate RED. Probed subtypes: vpc-endpoint, instance,
+      # and volume; every other ec2 resource stays fail-safe (return 1 → ORPHAN stays RED).
       case "$arn" in
         *:vpc-endpoint/vpce-*)
           id="${arn##*/}"
@@ -209,6 +209,18 @@ resource_gone() {
           fi
           state="$(printf '%s' "$out" | tr -d '[:space:]')"
           { [ -z "$state" ] || [ "$state" = "terminated" ]; } && return 0
+          return 1
+          ;;
+        *:volume/vol-*)
+          # arn:aws:ec2:<region>:<acct>:volume/vol-<id> — the fourth RGT-lag subtype
+          # (2026-07-11, #1463): a just-deleted EBS volume lingers in the tag index for
+          # minutes after DeleteVolume. DescribeVolumes answers InvalidVolume.NotFound once
+          # it is gone. Only NotFound counts as gone — a volume that still exists in ANY
+          # state (available / in-use / deleting) keeps the ORPHAN RED (fail-safe), mirroring
+          # the vpc-endpoint arm.
+          id="${arn##*/}"
+          err="$(aws ec2 describe-volumes --volume-ids "$id" --region "$REGION" 2>&1 >/dev/null)" && return 1
+          printf '%s' "$err" | grep -q 'InvalidVolume.NotFound' && return 0
           return 1
           ;;
         *) return 1 ;;

--- a/tests/integration/sweep-orphans.test.sh
+++ b/tests/integration/sweep-orphans.test.sh
@@ -92,6 +92,40 @@ mem_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 CDKRD_SWEEP_MIN_AGE_HOURS=0 ba
 assert "layer 1 membership PROTECTS a truncated-name member even when OLD + name-unbacked" "$mem_out" "SKIP \(active-stack member.*IAM-role CdkRealDriftIntegImageBuilderRi-BuilderRole-abc"
 refute "the member role is NOT reported as an orphan" "$mem_out" "ORPHAN.*IAM-role CdkRealDriftIntegImageBuilderRi-BuilderRole-abc"
 
+# #1463: a just-deleted EBS volume lingering in the RGT tag index (InvalidVolume.NotFound on a
+# direct probe) must fold to the RGT-lag SKIP, never a hard ORPHAN that deadlocks the gate —
+# mirroring the vpc-endpoint / instance resource_gone arms.
+cat > "$tmp/aws" <<'MOCK'
+#!/usr/bin/env bash
+case "$1/${2:-}" in
+  cloudformation/list-stacks)              echo "SomeUnrelatedStack" ;;
+  resourcegroupstaggingapi/get-resources)  printf '%s\tNone\n' "arn:aws:ec2:us-east-1:123456789012:volume/vol-0deadbeef00000000" ;;
+  ec2/describe-volumes)                     echo "An error occurred (InvalidVolume.NotFound) when calling the DescribeVolumes operation: The volume 'vol-0deadbeef00000000' does not exist." >&2; exit 255 ;;
+  *) : ;;
+esac
+MOCK
+chmod +x "$tmp/aws"
+gone_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
+assert "#1463 a NotFound EBS volume folds to the RGT-lag SKIP (not ORPHAN)" "$gone_out" "SKIP \(tagged mapping for an already-deleted resource.*volume/vol-0deadbeef00000000"
+refute "#1463 the deleted volume is NOT reported as an orphan" "$gone_out" "ORPHAN.*volume/vol-0deadbeef00000000"
+assert "#1463 sweep is CLEAN once the phantom volume is folded" "$gone_out" "SWEEP CLEAN"
+
+# #1463 fail-safe: a volume that STILL EXISTS (DescribeVolumes succeeds) is a REAL orphan and must
+# stay RED — resource_gone folds ONLY a definitive InvalidVolume.NotFound, never a live volume.
+cat > "$tmp/aws" <<'MOCK'
+#!/usr/bin/env bash
+case "$1/${2:-}" in
+  cloudformation/list-stacks)              echo "SomeUnrelatedStack" ;;
+  resourcegroupstaggingapi/get-resources)  printf '%s\tNone\n' "arn:aws:ec2:us-east-1:123456789012:volume/vol-0liveaaaa00000000" ;;
+  ec2/describe-volumes)                     echo "available" ;;
+  *) : ;;
+esac
+MOCK
+chmod +x "$tmp/aws"
+live_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
+assert "#1463 fail-safe: an EXISTING volume stays a hard ORPHAN (never folded)" "$live_out" "ORPHAN.*volume/vol-0liveaaaa00000000"
+refute "#1463 fail-safe: an existing volume is NOT folded to the RGT-lag SKIP" "$live_out" "already-deleted resource.*volume/vol-0liveaaaa00000000"
+
 rm -rf "$tmp"
 echo "----"
 echo "sweep-orphans: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## What

Recurrence of the #1422 RGT tag-index lag class on a new subtype (anticipated by #1422's follow-up note). A just-deleted, `cdkrd:ephemeral`-tagged **EBS volume** lingers in the Resource Groups Tagging API index for minutes after `DeleteVolume`. `sweep-orphans.sh`'s generic tag net reported it as a hard `ORPHAN`, keeping `bughunt-track.sh verify` **RED** (gate deadlock) even though a direct `DescribeVolumes` proves it gone (`InvalidVolume.NotFound`).

I hit this exact phantom (`vol-067216935d9f5bccb`) twice during my #1070 live-tests and had to `CDKRD_BUGHUNT_FORCE_CLEAR=1` — this closes that hole.

EC2 **instances** got their `resource_gone` arm in #1422; **volumes** had none, so a just-deleted volume was a hard orphan.

## How

- **`tests/integration/sweep-orphans.sh`** — add a `*:volume/vol-*` arm to `resource_gone`, mirroring the `vpc-endpoint` arm: a definitive `InvalidVolume.NotFound` folds to the RGT-lag `SKIP`; a volume that still exists in ANY state (available / in-use / deleting) keeps the `ORPHAN` RED (**fail-safe** — never hides a real orphan). Subtype comment updated (vpc-endpoint, instance, **volume**).
- **`tests/integration/sweep-orphans.test.sh`** — two shell-level tests against the mock `aws` CLI: (1) a `NotFound` volume folds to the RGT-lag SKIP and the sweep is CLEAN; (2) fail-safe — an existing volume stays a hard ORPHAN.

## Verification

`bash tests/integration/sweep-orphans.test.sh` → **14 passed, 0 failed** (9 existing + 5 new). Tooling-only change (no `src/**`) → verify-pr-gate exempt; `vp` typecheck / lint / build / 5030 unit tests all green.

Closes #1463
