### PR TITLE
fix(diff): account-level IMDS defaults overlay MetadataOptions constant — #1070 item 3 (last item)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -12,6 +12,7 @@ import {
   EC2Client,
   GetDefaultCreditSpecificationCommand,
   GetEbsEncryptionByDefaultCommand,
+  GetInstanceMetadataDefaultsCommand,
   type UnlimitedSupportedInstanceFamily,
 } from '@aws-sdk/client-ec2';
 import { ECSClient, ListAccountSettingsCommand } from '@aws-sdk/client-ecs';
@@ -251,6 +252,38 @@ async function fetchRdsDefaultCaIdentifier(region: string): Promise<string | und
     const override = (r.Certificates ?? []).find((cert) => cert.CustomerOverride === true);
     const value = override?.CertificateIdentifier;
     rdsDefaultCaCache.set(region, value);
+    return value;
+  } catch {
+    return undefined;
+  }
+}
+
+// #1070 item 3: ec2:GetInstanceMetadataDefaults — the account-level IMDS defaults the owner set
+// (`ec2:modify-instance-metadata-defaults`). Returns only the SET fields among HttpTokens /
+// HttpPutResponseHopLimit / HttpEndpoint / InstanceMetadataTags (unset ones are absent / null);
+// `ManagedBy` is metadata, not a MetadataOptions field, so it is dropped. classify overlays these
+// onto the AL2023 MetadataOptions constant for an EC2::Instance that declares no MetadataOptions.
+// Undefined when nothing is set at account level → the constant stands. Cached per region, fail-open.
+const instanceMetadataDefaultsCache = new Map<
+  string,
+  Record<string, string | number> | undefined
+>();
+async function fetchInstanceMetadataDefaults(
+  region: string
+): Promise<Record<string, string | number> | undefined> {
+  if (instanceMetadataDefaultsCache.has(region)) return instanceMetadataDefaultsCache.get(region);
+  try {
+    const c = new EC2Client({ region, ...READ_RETRY });
+    const r = await c.send(new GetInstanceMetadataDefaultsCommand({}));
+    const al = r.AccountLevel;
+    const out: Record<string, string | number> = {};
+    if (al?.HttpTokens != null) out.HttpTokens = al.HttpTokens;
+    if (al?.HttpPutResponseHopLimit != null)
+      out.HttpPutResponseHopLimit = al.HttpPutResponseHopLimit;
+    if (al?.HttpEndpoint != null) out.HttpEndpoint = al.HttpEndpoint;
+    if (al?.InstanceMetadataTags != null) out.InstanceMetadataTags = al.InstanceMetadataTags;
+    const value = Object.keys(out).length > 0 ? out : undefined;
+    instanceMetadataDefaultsCache.set(region, value);
     return value;
   } catch {
     return undefined;
@@ -1505,6 +1538,13 @@ export async function gatherFindings(
       if (v !== undefined) map[fam] = v;
     }
     if (Object.keys(map).length > 0) accountDefaults.ec2FamilyCreditDefaults = map;
+  }
+  // #1070 item 3: prefetch the account-level IMDS defaults when the stack declares any EC2::Instance,
+  // so classify can overlay the account-SET fields onto the MetadataOptions constant. Undefined
+  // (nothing set at account level) → the constant stands.
+  if (desired.resources.some((r) => r.resourceType === 'AWS::EC2::Instance')) {
+    const v = await fetchInstanceMetadataDefaults(region);
+    if (v !== undefined) accountDefaults.instanceMetadataDefaults = v;
   }
   // #1070 item 5: prefetch the account's customer-override default CA identifier when the stack
   // declares an RDS or DocDB DBInstance. Undefined (no override) → classify keeps the constant.

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -359,6 +359,13 @@ export interface AccountDefaults {
   // `CustomerOverride=true`), for an RDS/DocDB DBInstance that declares no CACertificateIdentifier.
   // Undefined when no override is set → fall back to the KNOWN_DEFAULTS system-default constant.
   rdsDefaultCaIdentifier?: string;
+  // ec2:GetInstanceMetadataDefaults — the account-level IMDS defaults the owner set
+  // (ec2:modify-instance-metadata-defaults): the SET fields among HttpTokens /
+  // HttpPutResponseHopLimit / HttpEndpoint / InstanceMetadataTags (unset fields are omitted). These
+  // OVERLAY the AL2023 MetadataOptions KNOWN_DEFAULTS constant for an EC2::Instance that declares no
+  // MetadataOptions — a hardened account (hop limit 1, tokens enforced, …) folds its clean deploy.
+  // Undefined when nothing is set at account level → the constant stands.
+  instanceMetadataDefaults?: Record<string, string | number>;
 }
 
 // #1070: for a handful of undeclared properties the value AWS assigns at creation is a function of
@@ -2996,6 +3003,21 @@ export function classifyResource(
     const creditDefault = acctDefault ?? factoryDefault;
     if (creditDefault !== undefined) {
       knownDef = { ...knownDef, CreditSpecification: { CPUCredits: creditDefault } };
+    }
+    // #1070 item 3: the IMDS defaults an instance reads back are also settable ACCOUNT-wide
+    // (`ec2:modify-instance-metadata-defaults` — HttpTokens / HttpPutResponseHopLimit / HttpEndpoint
+    // / InstanceMetadataTags), so a hardened account FPs the AL2023 MetadataOptions constant on every
+    // fresh launch. Overlay the account-SET fields (prefetched by gather.ts) onto the constant. Kept
+    // WHOLE-OBJECT equality-gated below: an overlay that is wrong for this instance — the account did
+    // not set a field, or the AMI's own default differs (#640 AMI variance, account-vs-AMI precedence)
+    // — simply does not match and SURFACES (recordable), never a false fold. Absent prefetch → the
+    // constant stands (today's behavior).
+    const imds = opts.accountDefaults?.instanceMetadataDefaults;
+    if (imds !== undefined && isNestedObject(knownDef.MetadataOptions)) {
+      knownDef = {
+        ...knownDef,
+        MetadataOptions: { ...(knownDef.MetadataOptions as Record<string, unknown>), ...imds },
+      };
     }
   }
   // #660: a LAMBDA target group's HealthCheckEnabled default is FALSE (health checks are

--- a/tests/classify-imds-defaults-1070.test.ts
+++ b/tests/classify-imds-defaults-1070.test.ts
@@ -1,0 +1,81 @@
+// #1070 item 3 — EC2::Instance MetadataOptions IMDS defaults are settable ACCOUNT-wide
+// (ec2:modify-instance-metadata-defaults), so the AL2023 KNOWN_DEFAULTS constant FPs on every fresh
+// launch in a hardened account. classify overlays the account-SET fields (opts.accountDefaults
+// .instanceMetadataDefaults, prefetched by gather.ts) onto the constant, kept WHOLE-OBJECT
+// equality-gated: a hardened clean deploy folds; a value the overlay gets wrong (or #640 AMI
+// variance) simply doesn't match and SURFACES (recordable) — never a false fold.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType: 'AWS::EC2::Instance',
+  physicalId: 'phys',
+  declared,
+});
+// The AL2023 MetadataOptions KNOWN_DEFAULTS constant an instance reads back undeclared.
+const AL2023 = {
+  HttpTokens: 'required',
+  HttpPutResponseHopLimit: 2,
+  HttpProtocolIpv6: 'disabled',
+  InstanceMetadataTags: 'disabled',
+  HttpEndpoint: 'enabled',
+};
+const res = mk({ ImageId: 'ami-1' });
+
+describe('#1070 item 3 EC2::Instance MetadataOptions — account IMDS-default overlay', () => {
+  it('folds a hardened clean deploy: account hop-limit 1 → live {..., hop:1} folds atDefault', () => {
+    const live = { MetadataOptions: { ...AL2023, HttpPutResponseHopLimit: 1 } };
+    const f = classifyResource(res, live, emptySchema, {
+      accountDefaults: { instanceMetadataDefaults: { HttpPutResponseHopLimit: 1 } },
+    });
+    expect(tier(f, 'atDefault')).toContain('MetadataOptions');
+    expect(tier(f, 'undeclared')).not.toContain('MetadataOptions');
+  });
+
+  it('without the overlay the SAME hardened live surfaces (proves the overlay does the work)', () => {
+    const live = { MetadataOptions: { ...AL2023, HttpPutResponseHopLimit: 1 } };
+    const f = classifyResource(res, live, emptySchema, {});
+    expect(tier(f, 'undeclared')).toContain('MetadataOptions');
+    expect(tier(f, 'atDefault')).not.toContain('MetadataOptions');
+  });
+
+  it('folds an account that enabled InstanceMetadataTags', () => {
+    const live = { MetadataOptions: { ...AL2023, InstanceMetadataTags: 'enabled' } };
+    const f = classifyResource(res, live, emptySchema, {
+      accountDefaults: { instanceMetadataDefaults: { InstanceMetadataTags: 'enabled' } },
+    });
+    expect(tier(f, 'atDefault')).toContain('MetadataOptions');
+  });
+
+  it('SURFACES when the live value differs from the account default (detection preserved)', () => {
+    // account default hop:1, but the instance reads hop:2 (AMI default won / not applied) → mismatch.
+    const live = { MetadataOptions: { ...AL2023, HttpPutResponseHopLimit: 2 } };
+    const f = classifyResource(res, live, emptySchema, {
+      accountDefaults: { instanceMetadataDefaults: { HttpPutResponseHopLimit: 1 } },
+    });
+    expect(tier(f, 'undeclared')).toContain('MetadataOptions');
+    expect(tier(f, 'atDefault')).not.toContain('MetadataOptions');
+  });
+
+  it('fail-open: no prefetch → the plain AL2023 constant still folds a clean deploy', () => {
+    const f = classifyResource(res, { MetadataOptions: { ...AL2023 } }, emptySchema, {});
+    expect(tier(f, 'atDefault')).toContain('MetadataOptions');
+  });
+});


### PR DESCRIPTION
## What

The **last item of #1070** (item 3). An `EC2::Instance` that declares no `MetadataOptions` reads back the IMDS defaults, pinned as the AL2023 constant `{HttpTokens:required, HttpPutResponseHopLimit:2, …}`. But the owner can set **account-level** IMDS defaults (`ec2:modify-instance-metadata-defaults`), so a hardened account (e.g. hop limit 1, tokens enforced) FPs the constant on every fresh launch.

## Design — why this is safe without the full AMI-variance redesign the issue anticipated

The issue deferred item 3 because the *effective* MetadataOptions is a merge of account defaults, AMI defaults (`imds-support`), and service defaults, with account-vs-AMI precedence edge cases — hard to compute exactly.

The key realization: I don't need the exact effective value, because the fold stays **whole-object equality-gated**. I overlay the account-SET fields onto the constant; then:
- overlay **right** → the hardened clean deploy matches → folds `atDefault` ✅
- overlay **wrong** (account didn't set a field, or the AMI's default differs/wins — the #640 AMI-variance dimension) → the whole object **doesn't match** → **SURFACES** (recordable, exactly today's behavior)

So a wrong overlay only ever produces a false *surface* (safe, recordable), **never a false fold** that hides real drift. That is the core-invariant-preserving property. The residual AMI-variance false-surfaces remain #640's domain.

## How

- **`gather.ts`** — prefetch `ec2:GetInstanceMetadataDefaults` (per region, fail-open) when an `EC2::Instance` is present; thread the SET fields (`HttpTokens` / `HttpPutResponseHopLimit` / `HttpEndpoint` / `InstanceMetadataTags`; `ManagedBy` dropped) into `accountDefaults.instanceMetadataDefaults`.
- **`classify.ts`** — overlay those fields onto the `MetadataOptions` constant in the existing EC2::Instance `knownDef` block (alongside the item-4 CreditSpecification overlay).

## Verification

- **Unit tests** (`tests/classify-imds-defaults-1070.test.ts`): a hardened deploy (account hop-limit 1) folds; the same live **surfaces without** the overlay (proves the overlay does the work); a live value differing from the account default surfaces (detection preserved); fail-open folds the plain constant. #640 EC2 first-run tests + corpus replay still green.
- **Read shape live-validated**: `GetInstanceMetadataDefaults.AccountLevel` (this account sets nothing → `ManagedBy` only → overlay empty → strict no-op).
- The gather→classify→overlay plumbing is the same path **live-proven three times** in #1454/#1465 (EBS, credit-spec, RDS-CA).
- Full suite: 232 files / 5035 tests.

## Live-test note

A fresh end-to-end A/B for item 3 would need a **third** account-wide setting toggle (`ec2:modify-instance-metadata-defaults`, IMDS-posture-sensitive) + an EC2 deploy. Deferring that pending maintainer sign-off on the approach (the plumbing is already live-proven; the overlay is unit-covered + read-shape-validated).

Closes #1070
