### PR TITLE
fix(noise): fold ELBv2 TargetGroup generated Name value-independently — first-run FP (#1473)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2490,6 +2490,15 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // or a lambda TargetType). classify folds `Targets` via the sibling-derived registrar gate
   // (opts.siblingTargetGroupRegistrars) and SURFACES a non-empty membership no registrar explains;
   // an EMPTY live `Targets: []` is dropped by the shared trivial-empty rule either way.
+  // A TargetGroup whose `Name` the template omits reads back CloudFormation's generated
+  // `<stackName>-<logicalId>-<random>` name, TRUNCATED to the 32-char TG-name cap (e.g.
+  // "Cdkrd1-Insta-MCQ3G4BOIKE6"). When the deployed template carries no `aws:cdk:path` metadata
+  // (raw-CFn / stripped), isCfnGeneratedName has no stack name to validate the truncation against
+  // and misses it, so it floods the first run. `Name` is createOnly — an undeclared value is
+  // always the AWS-minted identity, never user intent (a user who pins a Name DECLARES it and it
+  // is compared in the declared loop), so fold it value-independently (same class as the
+  // SecretsManager Secret.Name entry above). Live, #1473 (found while verifying #1451).
+  'AWS::ElasticLoadBalancingV2::TargetGroup': new Set(['Name']),
   // An Application Auto Scaling policy attached to a target via ScalingTargetId (the CDK
   // pattern) reads back the target's ResourceId / ServiceNamespace / ScalableDimension,
   // which AWS derives from the target and the template never declares. They echo the

--- a/tests/noise-tg-generated-name-1473.test.ts
+++ b/tests/noise-tg-generated-name-1473.test.ts
@@ -1,0 +1,92 @@
+// #1473 — an ELBv2 TargetGroup that declares no `Name` reads back CloudFormation's generated
+// `<stackName>-<logicalId>-<random>` name, TRUNCATED to the 32-char TG-name cap (e.g.
+// "Cdkrd1-Insta-MCQ3G4BOIKE6"). When the deployed template has no `aws:cdk:path` metadata the
+// resource's constructPath is undefined, so isCfnGeneratedName can't validate the truncation and
+// the name floods the first `check` as [Potential Drift]. GENERATED_TOPLEVEL_PATHS folds it
+// value-independently (Name is createOnly — an undeclared value is always the AWS-minted identity).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const TYPE = 'AWS::ElasticLoadBalancingV2::TargetGroup';
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+// No constructPath / physicalId ARN — the raw-CFn / stripped-metadata case that defeats
+// isCfnGeneratedName's stack-prefix + truncated branches.
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'InstanceTg',
+  resourceType: TYPE,
+  physicalId:
+    'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/Cdkrd1-Insta-MCQ3G4BOIKE6/f5d5aeadf380a557',
+  declared,
+});
+
+describe('#1473 ELBv2 TargetGroup generated Name folds value-independently', () => {
+  it('an undeclared generated Name (truncated, no constructPath) folds as generated, not drift', () => {
+    const t = tiers(
+      classifyResource(
+        mk({ Port: 80, Protocol: 'HTTP' }),
+        { Name: 'Cdkrd1-Insta-MCQ3G4BOIKE6' },
+        emptySchema
+      )
+    );
+    expect(t.generated).toEqual(['Name']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('a DIFFERENT generated Name still folds (value-independent — createOnly, always AWS-minted)', () => {
+    const t = tiers(
+      classifyResource(
+        mk({ Port: 80, Protocol: 'HTTP' }),
+        { Name: 'Some-Other-ZZ9Qw3RtVak2' },
+        emptySchema
+      )
+    );
+    expect(t.generated).toEqual(['Name']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('a DECLARED Name is compared in the declared loop (a real change still surfaces)', () => {
+    const t = tiers(
+      classifyResource(mk({ Name: 'my-tg', Port: 80 }), { Name: 'renamed-tg' }, emptySchema)
+    );
+    expect(t.declared).toContain('Name');
+    expect(t.generated).toEqual([]);
+  });
+
+  it('the fold is scoped per-type (a Name on another type stays undeclared)', () => {
+    const other: DesiredResource = {
+      logicalId: 'X',
+      resourceType: 'AWS::S3::Bucket',
+      physicalId: 'x',
+      declared: {},
+    };
+    expect(
+      tiers(classifyResource(other, { Name: 'Cdkrd1-Insta-MCQ3G4BOIKE6' }, emptySchema)).undeclared
+    ).toEqual(['Name']);
+  });
+});
+
+function tiers(findings: Finding[]) {
+  return {
+    declared: tier(findings, 'declared'),
+    undeclared: tier(findings, 'undeclared'),
+    atDefault: tier(findings, 'atDefault'),
+    generated: tier(findings, 'generated'),
+  };
+}


### PR DESCRIPTION
Follow-up to the #1451 live-test, which surfaced a third first-run FP on the same clean TargetGroup: the AWS-generated `Name`.

## Root cause

A TargetGroup that omits `Name` reads back CloudFormation's generated `<stackName>-<logicalId>-<random>` name, **truncated** to the 32-char TG-name cap (e.g. `Cdkrd1-Insta-MCQ3G4BOIKE6`). `isCfnGeneratedName` has a truncated-short-name branch for exactly this, but it needs the stack name from `constructPath` — and when the deployed template carries no `aws:cdk:path` metadata (raw-CFn / stripped), `constructPath` is undefined, so the branch never runs and the name floods the first `check` as `[Potential Drift]`.

## Fix

`Name` is createOnly, so an undeclared value is always the AWS-minted identity (a user who pins a Name DECLARES it → compared in the declared loop). Fold it value-independently via `GENERATED_TOPLEVEL_PATHS` — the same class as, and adjacent to, the existing `SecretsManager::Secret.Name` entry. Works regardless of whether `constructPath` survived.

## Verification

- Unit tests: new `tests/noise-tg-generated-name-1473.test.ts` (undeclared generated Name → `generated`; a different generated value still folds; a DECLARED Name still surfaces on change; per-type scoping). Full suite 5047 pass.
- Live: deployed `Cdkrd1473VerifyS332f` (us-east-1); the fixed binary checks CLEAN (`Name` → `generated=1`) where every non-fixed binary this session surfaced it as `[Potential Drift]`. Stack delstack'd, SWEEP CLEAN.

Closes #1473
