### PR TITLE
fix(noise): gp3 EC2::Volume undeclared Iops/Throughput baseline fold — first-run FP (#1471)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -3069,6 +3069,14 @@ export function classifyResource(
     if (volumeType === 'gp2' && typeof size === 'number') {
       knownDef = { ...knownDef, Iops: Math.min(16000, Math.max(100, 3 * size)) };
     }
+    // #1471: a gp3 EBS Volume that declares no Iops/Throughput reads back AWS's gp3 BASELINE —
+    // a fixed 3000 IOPS + 125 MiB/s, SIZE-INDEPENDENT (unlike gp2's size-derived Iops). Pin both,
+    // equality-gated (fold tier 2): a user who provisions above the baseline (declared) is compared
+    // in the declared loop, and an out-of-band bump away from the baseline still surfaces. #640
+    // covered only gp2 Iops; a gp3 volume left both undeclared as first-run [Potential Drift].
+    if (volumeType === 'gp3') {
+      knownDef = { ...knownDef, Iops: 3000, Throughput: 125 };
+    }
   }
   // #640: an EC2 NetworkInterface that declares a PrivateIpAddresses list reads back an
   // undeclared SecondaryPrivateIpAddressCount = all-but-the-primary of that list, i.e.

--- a/tests/classify-gp3-1471.test.ts
+++ b/tests/classify-gp3-1471.test.ts
@@ -1,0 +1,66 @@
+// #1471 — a gp3 EC2::Volume that declares no Iops/Throughput reads back AWS's gp3 baseline (3000
+// IOPS + 125 MiB/s, size-independent) undeclared → first-run [Potential Drift]. #640 covered only
+// gp2 (size-derived Iops); gp3 needs its own fixed-baseline derived fold. classify folds both
+// atDefault when they equal the baseline, and surfaces a value provisioned away from it.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType: 'AWS::EC2::Volume',
+  physicalId: 'phys',
+  declared,
+});
+
+describe('#1471 gp3 EC2::Volume undeclared Iops/Throughput baseline fold', () => {
+  const gp3 = mk({ VolumeType: 'gp3', Size: 10 });
+
+  it('folds the gp3 baseline Iops 3000 + Throughput 125 on a clean deploy', () => {
+    const f = classifyResource(gp3, { Iops: 3000, Throughput: 125 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('Iops');
+    expect(tier(f, 'atDefault')).toContain('Throughput');
+    expect(tier(f, 'undeclared')).not.toContain('Iops');
+    expect(tier(f, 'undeclared')).not.toContain('Throughput');
+  });
+
+  it('is size-INDEPENDENT — a large gp3 still folds the fixed baseline (not gp2-style 3*Size)', () => {
+    const big = mk({ VolumeType: 'gp3', Size: 4000 });
+    const f = classifyResource(big, { Iops: 3000, Throughput: 125 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('Iops');
+    expect(tier(f, 'atDefault')).toContain('Throughput');
+  });
+
+  it('SURFACES an Iops provisioned above the baseline (detection preserved)', () => {
+    const f = classifyResource(gp3, { Iops: 6000, Throughput: 125 }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('Iops');
+    expect(tier(f, 'atDefault')).not.toContain('Iops');
+  });
+
+  it('SURFACES a Throughput provisioned above the baseline (detection preserved)', () => {
+    const f = classifyResource(gp3, { Iops: 3000, Throughput: 250 }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('Throughput');
+    expect(tier(f, 'atDefault')).not.toContain('Throughput');
+  });
+
+  it('does NOT fold Throughput for a gp2 volume (gp2 has no Throughput knob)', () => {
+    const gp2 = mk({ VolumeType: 'gp2', Size: 10 });
+    const f = classifyResource(gp2, { Throughput: 125 }, emptySchema);
+    expect(tier(f, 'atDefault')).not.toContain('Throughput');
+  });
+});


### PR DESCRIPTION
## What

A gp3 `EC2::Volume` that declares no `Iops`/`Throughput` reads back AWS's gp3 **baseline** — a fixed **3000 IOPS + 125 MiB/s**, size-independent (unlike gp2's `3*Size` Iops) — surfacing both as `[Potential Drift]` on a clean first `check`. #640 shipped the gp2 Iops derivation but not gp3, so a gp3 volume left both undeclared.

## How

Extend the `AWS::EC2::Volume` derived-default block in `src/diff/classify.ts`: when `VolumeType === 'gp3'`, pin `Iops=3000` + `Throughput=125` in `knownDef`, equality-gated (fold tier 2) — a value provisioned above the baseline (declared, or an out-of-band bump) still surfaces.

## Verification

- **Unit tests** (`tests/classify-gp3-1471.test.ts`): baseline folds; size-independence (a 4000 GiB gp3 still folds the fixed baseline, not `3*Size`); an Iops/Throughput above baseline surfaces; gp2 Throughput is not folded. #640 gp2 tests + corpus replay still green (the gp3 corpus case declares Iops/Throughput, so it is a strict no-op).
- **Live A/B** (us-east-1): a gp3 volume declaring only `Size`/`VolumeType` read back `Iops:3000, Throughput:125`; no-fix `0.12.85` surfaced both as `[Potential Drift]`, the fix folds both `atDefault` → **zero first-run drift** (the core invariant). Stack deleted, SWEEP CLEAN.
- Full suite: 236 files / 5057 tests.

Closes #1471
