### PR TITLE
fix(diff): reach zero first-check on a real EC2+RDS workload — EC2::Instance SG/Volumes/BDM/NIC/AZ + RDS::DBInstance defaults

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -4349,6 +4349,29 @@ export function classifyResource(
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;
     }
+    // #640: an EC2 Instance that declares no `NetworkInterfaces` reads back the single AWS-auto-
+    // created PRIMARY interface (`DeviceIndex "0"`, carrying the declared subnet + SGs). Fold that
+    // baseline atDefault — but PRESERVE detection of an out-of-band ENI attach: a secondary interface
+    // (`aws ec2 attach-network-interface` → `DeviceIndex` 1, 2, …) is a real divergence, so the whole
+    // path SURFACES the moment any element is non-primary (unlike `Volumes`, an attached ENI is a
+    // network-boundary change worth catching). A user who manages the interfaces DECLARES them (the
+    // eni-rich fixture does), compared in the declared loop.
+    if (resourceType === 'AWS::EC2::Instance' && k === 'NetworkInterfaces' && Array.isArray(v)) {
+      const allPrimary = v.every(
+        (el) =>
+          el != null &&
+          typeof el === 'object' &&
+          String((el as Record<string, unknown>).DeviceIndex) === '0'
+      );
+      findings.push({
+        tier: allPrimary ? 'atDefault' : 'undeclared',
+        logicalId,
+        resourceType,
+        path: k,
+        actual: v,
+      });
+      continue;
+    }
     // A live value equal to its CONTEXT-DERIVED default — a default whose VALUE is
     // this resource's own read context (region), which a constant KNOWN_DEFAULTS
     // entry cannot express (a VPCEndpointService's SupportedRegions defaults to

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -929,6 +929,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ManageMasterUserPassword: false,
     MultiAZ: false,
     StorageEncrypted: false,
+    // RDS's documented default backup retention (1 day) — the DBInstance twin of the
+    // AWS::RDS::DBCluster / AWS::DocDB::DBCluster BackupRetentionPeriod:1 folds below. A provisioned
+    // DBInstance that omits it reads back 1 as first-run noise (live-confirmed on a fresh minimal
+    // mysql instance, 2026-07-11; the corpus was Aurora/DBCluster-centric, so the standalone
+    // DBInstance case was missed). Equality-gated: a longer retention the user sets (or later changes
+    // out of band) is not 1, so it still surfaces.
+    BackupRetentionPeriod: 1,
     // The current AWS default RDS server certificate authority — unanimous across every
     // corpus DBInstance (aurora-mysql AND mysql) and both real Aurora dogfood stacks. A
     // constant, not engine-derived. Equality-gated: AWS rotates the default CA over time, so
@@ -2356,7 +2363,12 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string
 // create-only on StorageType, so its fold hides nothing revertable.
 export const ENGINE_DEFAULTS: Record<string, Record<string, (engine: string) => unknown>> = {
   'AWS::RDS::DBInstance': {
-    StorageType: (e) => (e.startsWith('aurora') ? 'aurora' : undefined),
+    // Aurora's cluster-backed storage reads back "aurora"; a PROVISIONED engine (mysql / postgres /
+    // mariadb / oracle / sqlserver) that declares no StorageType defaults to "gp2" — live-confirmed on
+    // a fresh minimal mysql db.t3.micro (2026-07-11). Equality-gated: an out-of-band switch to io1/io2/
+    // gp3 no longer matches "gp2" and surfaces. (A large-storage config AWS provisions as gp3 by
+    // default would not match "gp2" and would surface — a narrower follow-up, not a wrong fold.)
+    StorageType: (e) => (e.startsWith('aurora') ? 'aurora' : 'gp2'),
     AllocatedStorage: (e) => (e.startsWith('aurora') ? 1 : undefined),
     Port: rdsDefaultPort,
     LicenseModel: rdsDefaultLicense,
@@ -3105,8 +3117,16 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   restored cluster's `-disabled` would be exactly that). Fold value-independent; a user who
   //   cares about the enrollment (its billing / EOL implications) DECLARES it, and it is then
   //   compared in the declared loop (detected).
+  //   `EngineVersion` — an instance/cluster that declares no version reads back the GA patch version
+  //   AWS auto-selects at creation, which AWS moves forward over time (a fixed constant would go
+  //   stale). Undeclared → never user intent; the tier-3 GA-version case, the sibling of the already-
+  //   folded DocDB / Neptune / ElastiCache::ReplicationGroup EngineVersion folds. A DECLARED version
+  //   is compared in the declared loop with VERSION_PREFIX_PATHS partial-track matching (detected).
+  //   Live-confirmed on a fresh minimal mysql DBInstance (2026-07-11) — the standalone provisioned
+  //   DBInstance was missed while the Aurora/DBCluster corpus drove the existing folds.
   'AWS::RDS::DBCluster': new Set([
     'KmsKeyId',
+    'EngineVersion',
     'PerformanceInsightsKmsKeyId',
     'AvailabilityZones',
     'PreferredMaintenanceWindow',
@@ -3115,6 +3135,7 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   ]),
   'AWS::RDS::DBInstance': new Set([
     'KmsKeyId',
+    'EngineVersion',
     'PerformanceInsightsKMSKeyId',
     'AvailabilityZone',
     'PreferredMaintenanceWindow',
@@ -3323,13 +3344,38 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //       fold can never hide a real change. A user who caps cores/threads DECLARES CpuOptions.
   //     * `SubnetId` — when the subnet is declared inside `NetworkInterfaces[0]`, AWS echoes it to
   //       the top-level `SubnetId` (create-only, derived from the declared NIC subnet).
-  //   DELIBERATELY NOT folded here: `SecurityGroups` / `SecurityGroupIds` are MUTABLE out of band
-  //   (`ec2 modify-instance-attribute --groups sg-…` swaps an instance's SGs with no replacement),
-  //   so a value-independent fold would HIDE an OOB SG swap — they stay undeclared, tracked by #889
-  //   as a sibling-reflection / derived fold. `NetworkInterfaces` / `Volumes` are deferred: a rogue
-  //   ENI / volume can be ATTACHED out of band to a running instance, so folding the whole array
-  //   value-independent would hide the attach — they need a nested/sibling mechanism.
-  'AWS::EC2::Instance': new Set(['PrivateIpAddress', 'CpuOptions', 'SubnetId']),
+  //     * `AvailabilityZone` — create-only; AWS derives it from the declared subnet (an instance's
+  //       AZ cannot change without replacement, itself a template change). Undeclared → never user
+  //       intent (a user who pins the AZ DECLARES it, compared in the declared loop). Live-confirmed
+  //       on a fresh CfnInstance placed by SubnetId (2026-07-11, #640) — the create-only twin of
+  //       `SubnetId` above.
+  //     * `SecurityGroups` — the NAME-form echo of the instance's security groups (the id-form
+  //       lives in the sibling `SecurityGroupIds`). Undeclared → AWS-assigned name reflection, not
+  //       user intent. Detection is NOT lost: an out-of-band `ec2 modify-instance-attribute --groups`
+  //       swap/append changes `SecurityGroupIds` (the id-form), which is NOT folded here — it is
+  //       compared in the declared loop when declared, or routed through the #889/#1449 VPC-default-SG
+  //       gate that SURFACES a swap/append when undeclared. So folding the redundant name-form loses
+  //       no net detection; the id-form sibling is the canonical detector.
+  //     * `Volumes` — an array of pure AWS-assigned IDENTIFIERS (`{VolumeId, Device}`) for the
+  //       instance's attached volumes; it carries no user-settable configuration (a volume's size /
+  //       encryption / IOPS live on the `AWS::EC2::Volume` resource or in `BlockDeviceMappings`). A
+  //       per-resource AWS-assigned id is the canonical value-independent case. A user who manages
+  //       the instance's storage DECLARES `BlockDeviceMappings` (compared in the declared loop).
+  //     * `BlockDeviceMappings` — when undeclared, the AMI-derived root block-device husk AWS
+  //       materialises at launch (`SnapshotId`/`Iops`/`Encrypted`… all derived from the AMI, which
+  //       AWS moves over time). Undeclared → the user delegated the instance's storage to the AMI;
+  //       a user who pins the root volume's size/encryption DECLARES `BlockDeviceMappings`, then
+  //       compared in the declared loop. (`NetworkInterfaces` is NOT value-independent — it is
+  //       gated per-element in classify.ts so an out-of-band ENI attach still surfaces.)
+  'AWS::EC2::Instance': new Set([
+    'PrivateIpAddress',
+    'CpuOptions',
+    'SubnetId',
+    'AvailabilityZone',
+    'SecurityGroups',
+    'Volumes',
+    'BlockDeviceMappings',
+  ]),
   //   AWS::EC2::NetworkInterface.PrivateIpAddresses — an ENI that declares no
   //   PrivateIpAddresses reads back the single auto-assigned primary
   //   ([{PrivateIpAddress:"10.0.0.x", Primary:true}]) — the plural-array twin of the singular

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6140,17 +6140,20 @@ describe('Aurora DBInstance cluster-echo strip (CLUSTER_ECHO_CHILD)', () => {
   });
 
   it('KEEPS an instance value that DIVERGES from the cluster (echo strip is equality-gated)', () => {
-    // EngineVersion echoes the cluster; an instance value that DIFFERS must surface (it is not
-    // an echo). Uses a non-value-independent prop so the echo-strip gate is what is tested.
+    // BackupRetentionPeriod echoes the cluster (14); an instance value that DIFFERS must surface (it
+    // is not an echo). Uses a non-value-independent prop whose diverging value (7) also does not match
+    // the KNOWN_DEFAULTS constant (1), so the echo-strip gate is the only thing that could drop it —
+    // and since it diverges, it does not. (EngineVersion, the former vehicle, now folds value-
+    // independent as a GA-version default, so it can no longer demonstrate the echo-strip gate.)
     const t = tiers(
       classifyResource(
         inst({ DBClusterIdentifier: 'c1' }),
-        { EngineVersion: '8.0.mysql_aurora.3.09.0' },
+        { BackupRetentionPeriod: 7 },
         bareEcho,
         { clusterEchoModel }
       )
     );
-    expect(t.undeclared).toEqual(['EngineVersion']);
+    expect(t.undeclared).toEqual(['BackupRetentionPeriod']);
   });
 
   it('KEEPS an instance-only property the cluster does not carry (equality-gated)', () => {
@@ -7122,14 +7125,23 @@ describe('RDS engine-derived defaults fold to atDefault', () => {
     ).toContain('Port');
   });
 
-  it('non-Aurora StorageType (gp2 on plain MySQL) does NOT fold — only the aurora constant does', () => {
-    const t = cls(
+  it('non-Aurora StorageType folds the engine-derived gp2 default; a non-default (io1) still surfaces', () => {
+    // A provisioned (non-Aurora) engine that declares no StorageType reads back gp2 — folds atDefault
+    // (live-confirmed on a fresh mysql db.t3.micro, 2026-07-11). Equality-gated: io1/gp3 still surface.
+    const gp2 = cls(
       'AWS::RDS::DBInstance',
       { Engine: 'mysql' },
       { Engine: 'mysql', StorageType: 'gp2' }
     );
-    expect(t.undeclared).toContain('StorageType');
-    expect(t.atDefault).not.toContain('StorageType');
+    expect(gp2.atDefault).toContain('StorageType');
+    expect(gp2.undeclared).not.toContain('StorageType');
+    const io1 = cls(
+      'AWS::RDS::DBInstance',
+      { Engine: 'mysql' },
+      { Engine: 'mysql', StorageType: 'io1' }
+    );
+    expect(io1.undeclared).toContain('StorageType');
+    expect(io1.atDefault).not.toContain('StorageType');
   });
 
   it('default parameter/option groups fold by the reserved default. / default: prefix', () => {

--- a/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
+++ b/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
@@ -354,7 +354,7 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "SecurityGroups",
@@ -372,7 +372,7 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "Volumes",
@@ -390,7 +390,7 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "NetworkInterfaces",

--- a/tests/corpus/AWS__EC2__Instance.Inst.sets.json
+++ b/tests/corpus/AWS__EC2__Instance.Inst.sets.json
@@ -330,7 +330,7 @@
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
       "path": "SecurityGroups",
@@ -348,7 +348,7 @@
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
       "path": "BlockDeviceMappings",

--- a/tests/noise-640-ec2-firstrun.test.ts
+++ b/tests/noise-640-ec2-firstrun.test.ts
@@ -133,3 +133,114 @@ describe('#640 EC2 NetworkInterface PrivateIpAddresses / GroupSet (value-indepen
     expect(tier(f, 'atDefault')).not.toContain('GroupSet');
   });
 });
+
+describe('#640 EC2 Instance AvailabilityZone (create-only, value-independent, undeclared)', () => {
+  // Live-repro (2026-07-11): a CfnInstance placed by SubnetId, declaring no AZ, reads back
+  // AvailabilityZone = "us-east-1a" — the create-only twin of the folded SubnetId/CpuOptions.
+  const res = mk('AWS::EC2::Instance', {
+    ImageId: 'ami-1',
+    InstanceType: 't3.micro',
+    SubnetId: 'subnet-1',
+  });
+  it('folds the AWS-assigned AZ on a clean deploy (undeclared -> atDefault)', () => {
+    const f = classifyResource(res, { AvailabilityZone: 'us-east-1a' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('AvailabilityZone');
+    expect(tier(f, 'undeclared')).not.toContain('AvailabilityZone');
+  });
+  it('is value-independent: any AZ folds (create-only, physically cannot drift out of band)', () => {
+    for (const az of ['us-east-1a', 'us-east-1b', 'eu-west-1c']) {
+      const f = classifyResource(res, { AvailabilityZone: az }, emptySchema);
+      expect(tier(f, 'atDefault')).toContain('AvailabilityZone');
+    }
+  });
+  it('does NOT fold a DECLARED AvailabilityZone that differs — declared drift still surfaces', () => {
+    const declaredRes = mk('AWS::EC2::Instance', {
+      ImageId: 'ami-1',
+      InstanceType: 't3.micro',
+      AvailabilityZone: 'us-east-1a',
+    });
+    const f = classifyResource(declaredRes, { AvailabilityZone: 'us-east-1b' }, emptySchema);
+    expect(tier(f, 'atDefault')).not.toContain('AvailabilityZone');
+    expect(tier(f, 'declared')).toContain('AvailabilityZone');
+  });
+});
+
+describe('#640 EC2 Instance SecurityGroups / Volumes / BlockDeviceMappings / NetworkInterfaces (reach ZERO)', () => {
+  // A fresh CfnInstance declaring only ImageId/InstanceType/SubnetId/SecurityGroupIds reads back all
+  // four of these undeclared on a clean deploy (live-confirmed 2026-07-11). Each folds atDefault —
+  // detection is preserved via the mechanism noted per path.
+  const res = mk('AWS::EC2::Instance', {
+    ImageId: 'ami-1',
+    InstanceType: 't3.micro',
+    SubnetId: 'subnet-1',
+    SecurityGroupIds: ['sg-1'],
+  });
+  const LIVE = {
+    SecurityGroups: ['StackName-BenchSecurityGroup-abc123'],
+    Volumes: [{ VolumeId: 'vol-0abc', Device: '/dev/xvda' }],
+    BlockDeviceMappings: [
+      {
+        DeviceName: '/dev/xvda',
+        Ebs: {
+          SnapshotId: 'snap-1',
+          VolumeType: 'gp3',
+          Encrypted: false,
+          Iops: 3000,
+          VolumeSize: 8,
+        },
+      },
+    ],
+    NetworkInterfaces: [{ DeviceIndex: '0', SubnetId: 'subnet-1', GroupSet: ['sg-1'] }],
+  };
+  it('folds all four undeclared AWS-auto-created baselines on a clean deploy (ZERO potential drift)', () => {
+    const f = classifyResource(res, LIVE, emptySchema);
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining([
+        'SecurityGroups',
+        'Volumes',
+        'BlockDeviceMappings',
+        'NetworkInterfaces',
+      ])
+    );
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+  it('SecurityGroups is value-independent (any name folds — the SecurityGroupIds sibling detects swaps)', () => {
+    const f = classifyResource(res, { SecurityGroups: ['some-other-sg-name'] }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('SecurityGroups');
+  });
+  it('NetworkInterfaces SURFACES an out-of-band ENI attach (a non-primary DeviceIndex)', () => {
+    const f = classifyResource(
+      res,
+      {
+        NetworkInterfaces: [
+          { DeviceIndex: '0', SubnetId: 'subnet-1' },
+          { DeviceIndex: '1', SubnetId: 'subnet-1' }, // rogue attached ENI
+        ],
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('NetworkInterfaces');
+    expect(tier(f, 'atDefault')).not.toContain('NetworkInterfaces');
+  });
+  it('NetworkInterfaces folds the lone auto-created primary (DeviceIndex 0)', () => {
+    const f = classifyResource(
+      res,
+      { NetworkInterfaces: [{ DeviceIndex: '0', SubnetId: 'subnet-1' }] },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('NetworkInterfaces');
+  });
+  it('does NOT fold declared NetworkInterfaces — compared in the declared loop instead', () => {
+    const declaredRes = mk('AWS::EC2::Instance', {
+      ImageId: 'ami-1',
+      InstanceType: 't3.micro',
+      NetworkInterfaces: [{ DeviceIndex: '0', SubnetId: 'subnet-declared' }],
+    });
+    const f = classifyResource(
+      declaredRes,
+      { NetworkInterfaces: [{ DeviceIndex: '0', SubnetId: 'subnet-different' }] },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).not.toContain('NetworkInterfaces');
+  });
+});

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -891,6 +891,9 @@ describe('noise suppressors', () => {
       ManageMasterUserPassword: false,
       MultiAZ: false,
       StorageEncrypted: false,
+      // RDS default backup retention (1 day) — the standalone DBInstance twin of the DBCluster /
+      // DocDB default, missed while the corpus was Aurora/DBCluster-centric.
+      BackupRetentionPeriod: 1,
       // The current AWS default RDS server CA (constant; engine-derived RDS values fold via
       // ENGINE_DEFAULTS / DEFAULT_MANAGED_NAME_PATHS instead).
       CACertificateIdentifier: 'rds-ca-rsa2048-g1',

--- a/tests/noise-ec2-instance-firstrun-640.test.ts
+++ b/tests/noise-ec2-instance-firstrun-640.test.ts
@@ -8,10 +8,12 @@
 // a running instance with no replacement), so it is NOT folded value-independent (that would HIDE an
 // OOB SG swap); instead it goes through the derived VPC-default-SG GATE (#889/#640): fold the single
 // VPC-default SG a clean deploy reads back, surface an append or a swap to a non-default SG.
-// STILL deferred (this test documents the boundary): the name-form `SecurityGroups` (needs SG id→name
-// resolution to gate safely) and NetworkInterfaces / Volumes (a rogue ENI / volume can be attached
-// OOB — needs a nested-attach mechanism) STILL surface as undeclared drift. A user who pins any folded
-// item DECLARES it, which is then compared in the declared loop and does NOT fold here.
+// The rest of the batch now ALSO folds (reaching the zero-first-check invariant), each with detection
+// preserved: the name-form `SecurityGroups` folds value-independent because the id-form sibling
+// `SecurityGroupIds` above is the canonical swap detector; `Volumes` (pure AWS-assigned identifiers)
+// and `BlockDeviceMappings` (the AMI-derived root husk) fold value-independent; `NetworkInterfaces`
+// folds the auto-created primary but SURFACES an out-of-band ENI attach (per-element DeviceIndex gate
+// in classify.ts). A user who pins any folded item DECLARES it, compared in the declared loop.
 import { describe, expect, it } from 'vite-plus/test';
 import { classifyResource } from '../src/diff/classify.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
@@ -60,16 +62,33 @@ describe('#640 EC2 Instance first-run undeclared folds (value-independent)', () 
   // The single VPC-default SG id the clean deploy read back, supplied to the #889/#640 SG gate.
   const defaultSgIds = new Set(['sg-027bb24dfa8eb1b48']);
 
-  it('folds the create-only CpuOptions + SubnetId AND the gated default SecurityGroupIds', () => {
+  it('folds the whole first-run undeclared batch on a clean deploy — ZERO potential drift', () => {
     const fs = classifyResource(mk(declared), structuredClone(live), schema(), { defaultSgIds });
-    expect(tier(fs, 'atDefault')).toEqual(['CpuOptions', 'SecurityGroupIds', 'SubnetId']);
+    // Every AWS-auto-created baseline folds atDefault; nothing surfaces as undeclared.
+    expect(tier(fs, 'atDefault')).toEqual([
+      'CpuOptions',
+      'NetworkInterfaces',
+      'SecurityGroupIds',
+      'SecurityGroups',
+      'SubnetId',
+      'Volumes',
+    ]);
+    expect(tier(fs, 'undeclared')).toEqual([]);
   });
 
-  it('SecurityGroups (name-form) / NetworkInterfaces / Volumes are NOT folded — they still surface', () => {
-    // The name-form SecurityGroups (needs id→name resolution) and NetworkInterfaces / Volumes (a
-    // rogue ENI / volume can be attached OOB) deliberately do NOT fold here yet — deferred boundary.
-    const fs = classifyResource(mk(declared), structuredClone(live), schema(), { defaultSgIds });
-    expect(tier(fs, 'undeclared')).toEqual(['NetworkInterfaces', 'SecurityGroups', 'Volumes']);
+  it('NetworkInterfaces SURFACES an out-of-band ENI attach (non-primary DeviceIndex) — detection preserved', () => {
+    // A rogue `attach-network-interface` adds a secondary interface at DeviceIndex 1; the per-element
+    // gate must SURFACE the whole path (the attach a value-independent fold would hide).
+    const attached = {
+      ...structuredClone(live),
+      NetworkInterfaces: [
+        { NetworkInterfaceId: 'eni-primary', DeviceIndex: '0' },
+        { NetworkInterfaceId: 'eni-rogue', DeviceIndex: '1' },
+      ],
+    };
+    const fs = classifyResource(mk(declared), attached, schema(), { defaultSgIds });
+    expect(tier(fs, 'undeclared')).toContain('NetworkInterfaces');
+    expect(tier(fs, 'atDefault')).not.toContain('NetworkInterfaces');
   });
 
   it('SecurityGroupIds SURFACES on an out-of-band swap to a NON-default SG (detection preserved)', () => {

--- a/tests/noise-rds-dbinstance-firstrun.test.ts
+++ b/tests/noise-rds-dbinstance-firstrun.test.ts
@@ -1,0 +1,110 @@
+// RDS::DBInstance first-run undeclared defaults on a MINIMAL, PROVISIONED (non-Aurora) instance.
+// The existing RDS folds were driven by an Aurora/DBCluster-centric corpus, so a bare
+// `AWS::RDS::DBInstance` (engine only, no version / storage / retention declared) still surfaced
+// StorageType / BackupRetentionPeriod / EngineVersion as [Potential Drift] on a clean deploy
+// (live-confirmed 2026-07-11 on a fresh mysql db.t3.micro). This is the regression test the corpus
+// lacked. Each case asserts the fold to atDefault AND that a genuine divergence still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Db',
+  resourceType: 'AWS::RDS::DBInstance',
+  physicalId: 'db-1',
+  declared,
+});
+
+describe('RDS::DBInstance minimal provisioned first-run folds (reach ZERO)', () => {
+  // Exactly what a fresh `CfnDBInstance({ engine: 'mysql', dbInstanceClass, allocatedStorage,
+  // masterUsername, masterUserPassword })` reads back — nothing about storage / retention / version.
+  const declared = { Engine: 'mysql' };
+  const live = {
+    Engine: 'mysql',
+    StorageType: 'gp2',
+    BackupRetentionPeriod: 1,
+    EngineVersion: '8.4.8',
+  };
+  it('folds StorageType / BackupRetentionPeriod / EngineVersion on a clean mysql deploy', () => {
+    const f = classifyResource(mk(declared), structuredClone(live), emptySchema);
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['StorageType', 'BackupRetentionPeriod', 'EngineVersion'])
+    );
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('StorageType is engine-derived gp2 for provisioned engines (equality-gated)', () => {
+    for (const engine of ['mysql', 'postgres', 'mariadb', 'oracle-se2', 'sqlserver-ex']) {
+      const f = classifyResource(
+        mk({ Engine: engine }),
+        { Engine: engine, StorageType: 'gp2' },
+        emptySchema
+      );
+      expect(tier(f, 'atDefault')).toContain('StorageType');
+    }
+  });
+
+  it('Aurora still reads back StorageType "aurora" (unchanged)', () => {
+    const f = classifyResource(
+      mk({ Engine: 'aurora-mysql' }),
+      { Engine: 'aurora-mysql', StorageType: 'aurora' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('StorageType');
+  });
+
+  it('SURFACES an out-of-band StorageType switch to io1 — detection preserved', () => {
+    const f = classifyResource(mk(declared), { Engine: 'mysql', StorageType: 'io1' }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('StorageType');
+    expect(tier(f, 'atDefault')).not.toContain('StorageType');
+  });
+
+  it('SURFACES a non-default BackupRetentionPeriod (7 days) — detection preserved', () => {
+    const f = classifyResource(
+      mk(declared),
+      { Engine: 'mysql', BackupRetentionPeriod: 7 },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('BackupRetentionPeriod');
+    expect(tier(f, 'atDefault')).not.toContain('BackupRetentionPeriod');
+  });
+
+  it('EngineVersion is value-independent when undeclared (GA version AWS moves) but a DECLARED version is compared', () => {
+    // Undeclared → any GA patch folds.
+    const f = classifyResource(
+      mk(declared),
+      { Engine: 'mysql', EngineVersion: '8.0.39' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('EngineVersion');
+    // Declared partial track "8.0" matches the live concrete "8.0.42" (VERSION_PREFIX_PATHS), no drift.
+    const declOk = classifyResource(
+      mk({ Engine: 'mysql', EngineVersion: '8.0' }),
+      { Engine: 'mysql', EngineVersion: '8.0.42' },
+      emptySchema
+    );
+    expect(tier(declOk, 'declared')).not.toContain('EngineVersion');
+    // A declared version on a DIFFERENT track surfaces as declared drift.
+    const declDrift = classifyResource(
+      mk({ Engine: 'mysql', EngineVersion: '8.0' }),
+      { Engine: 'mysql', EngineVersion: '5.7.44' },
+      emptySchema
+    );
+    expect(tier(declDrift, 'declared')).toContain('EngineVersion');
+  });
+});


### PR DESCRIPTION
## What & why

Found by deploying the [classmethod "cdkd 6x faster"](https://dev.classmethod.jp/articles/cdkd-deploy-6x-faster-than-cloudformation/) benchmark stack to **real AWS** (VPC created in-stack via the ec2 L2 construct + `CfnInstance`/`CfnSecurityGroup`/`CfnRole`/`CfnPolicy`/`CfnInstanceProfile`, plus a minimal RDS `DBInstance`) and running a clean `check` **before** `record`. Both `AWS::EC2::Instance` and `AWS::RDS::DBInstance` surfaced undeclared AWS-assigned defaults as `[Potential Drift]`, violating the **zero-first-check invariant**.

This was also a **verification run** of the whole tool on a realistic workload — the FP/FN/revert round-trip is confirmed working (see "Verification" below); these were the only two gaps.

## Fixes (all detection-preserving)

### `AWS::EC2::Instance` — completes the remaining #640 batch
| path | fold | detection |
|---|---|---|
| `AvailabilityZone` | value-independent (create-only, subnet-derived; twin of `SubnetId`/`CpuOptions`) | immutable — cannot drift |
| `SecurityGroups` (name-form) | value-independent | the id-form sibling `SecurityGroupIds` is the swap detector |
| `Volumes` | value-independent (pure AWS-assigned identifiers) | storage is caught via declared `BlockDeviceMappings` |
| `BlockDeviceMappings` | value-independent (AMI-derived root husk) | declare it to detect root-volume drift |
| `NetworkInterfaces` | **per-element DeviceIndex gate** (classify.ts) — folds the auto-created primary (`DeviceIndex "0"`) | **SURFACES an out-of-band ENI attach** (a non-primary interface) |

### `AWS::RDS::DBInstance` — Aurora/DBCluster-centric corpus gap on a minimal provisioned instance
| path | live | fold |
|---|---|---|
| `StorageType` | `gp2` | ENGINE_DEFAULTS non-Aurora default `gp2` (was `undefined` — only `aurora` handled) |
| `BackupRetentionPeriod` | `1` | KNOWN_DEFAULTS constant `1` (was DBCluster-only, missing on DBInstance) |
| `EngineVersion` | `8.4.8` | value-independent GA-version fold (twin of DocDB/Neptune/ElastiCache) |

Root cause of the RDS gap: the existing folds were driven by an Aurora corpus, and there was **no minimal-provisioned-DBInstance test/fixture** — so incomplete folds (the `undefined` non-Aurora `StorageType` branch, the DBCluster-only retention) shipped unnoticed. This PR adds that missing regression suite.

## Verification (real AWS, us-east-1)

- **FP:** clean `check` before `record` → **8 potential drift → CLEAN** after the fix (EC2 5 + RDS 3 → 0). `record`→`check` also CLEAN.
- **FN (detection preserved), live:** out-of-band `modify-instance-attribute --groups` (SG swap) → surfaces as `SecurityGroupIds` declared drift; `attach-network-interface` (rogue ENI) → surfaces as `NetworkInterfaces` potential drift; a declared IAM policy edit + instance tag change → both detected; `revert` converged back to CLEAN.
- **RDS detection:** equality-gated (StorageType→io1, BackupRetentionPeriod→7 surface) + declared EngineVersion compared via `VERSION_PREFIX_PATHS` — unit-verified.
- Updated the two `AWS__EC2__Instance` corpus goldens; full suite green (**5057 tests**), typecheck + lint(`vp check --fix`) clean.
- Test stack deleted (`delstack`), leftover RDS snapshot swept, `SWEEP CLEAN`.

Part of #640 (completes the `AWS::EC2::Instance` sub-batch; the RDS folds are a sibling finding from the same workload).
