### PR TITLE
fix(noise): CloudFront IPV6Enabled/OriginSSLProtocols + CustomErrorResponses reorder + Route53Resolver MutationProtection first-run folds

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1424,6 +1424,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Rbin::Rule': {
     Status: 'available',
   },
+  // A FirewallRuleGroupAssociation that declares no MutationProtection reads back the
+  // documented service default "DISABLED" (associate-firewall-rule-group: "the default
+  // setting is Disabled") on the very first check (#1455, live-verified). Equality-gated
+  // — the property is MUTABLE (UpdateFirewallRuleGroupAssociation --mutation-protection),
+  // so a real out-of-band flip to "ENABLED" still surfaces.
+  'AWS::Route53Resolver::FirewallRuleGroupAssociation': {
+    MutationProtection: 'DISABLED',
+  },
   // RolesAnywhere service-filled constant SETS on create (observed live on hunt
   // 2026-07-03, #492): a trust anchor reads back the two-entry certificate-expiry
   // notification set, and a profile reads back the default x509 attribute-mapping rules,
@@ -1793,12 +1801,23 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'Quota.Offset': 0,
   },
   'AWS::CloudFront::Distribution': {
+    // CloudFront enables IPv6 on a distribution by default when the template omits it
+    // (#1459, live-verified), so an undeclared live `true` folds to atDefault instead of
+    // surfacing as a first-run FP. (An out-of-band flip to `false` is swallowed by
+    // isTrivialEmpty before the pin gate — restoring its detection is the #660-class nested
+    // MEANINGFUL_WHEN_OFF follow-up; pinning here removes the FP without regressing it.)
+    'DistributionConfig.IPV6Enabled': true,
     'DistributionConfig.OriginGroups': { Quantity: 0, Items: [] },
     'DistributionConfig.Origins.*.ConnectionAttempts': 3,
     'DistributionConfig.Origins.*.ConnectionTimeout': 10,
     'DistributionConfig.Origins.*.CustomOriginConfig.HTTPPort': 80,
     'DistributionConfig.Origins.*.CustomOriginConfig.HTTPSPort': 443,
     'DistributionConfig.Origins.*.CustomOriginConfig.OriginKeepaliveTimeout': 5,
+    // A custom origin that pins no OriginSSLProtocols reads back the documented legacy
+    // default [SSLv3, TLSv1] (#1459, live-verified). Equality-gated, so tightening it
+    // out of band (e.g. to [TLSv1.2]) still surfaces. The L2 construct always emits this
+    // list, which is why existing corpus/fixture distributions kept it latent.
+    'DistributionConfig.Origins.*.CustomOriginConfig.OriginSSLProtocols': ['SSLv3', 'TLSv1'],
     'DistributionConfig.Origins.*.S3OriginConfig.OriginReadTimeout': 30,
     'DistributionConfig.Restrictions': {
       GeoRestriction: { Locations: [], RestrictionType: 'none' },
@@ -5540,7 +5559,16 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
   // CloudFront returns it reordered relative to the template (declared [apex, wildcard]
   // reads back [wildcard, apex]), so a positional compare false-flags the identical
   // alias set as declared drift. Same nested-scalar-set treatment as CachePolicy Headers.
-  'AWS::CloudFront::Distribution': new Set(['DistributionConfig.Aliases']),
+  // `DistributionConfig.CustomErrorResponses` is a SET keyed by ErrorCode (CloudFront
+  // allows one entry per error code and echoes them SORTED by ErrorCode, not template
+  // order), so a distribution declaring them non-ascending (the natural SPA 500/403/404
+  // pattern) cascades into several bogus DECLARED drifts on every check (#1458). Sorting
+  // both sides by the ErrorCode identity (NESTED_OBJECT_ARRAY_IDENTITY below) aligns equal
+  // entries; a real out-of-band ResponsePagePath change stays a single aligned finding.
+  'AWS::CloudFront::Distribution': new Set([
+    'DistributionConfig.Aliases',
+    'DistributionConfig.CustomErrorResponses',
+  ]),
   // An IoT ThingType's `ThingTypeProperties.SearchableAttributes` is a nested SCALAR set
   // (attribute names) that IoT stores as a set and returns in its OWN sorted order —
   // declared ["serial","model"] reads back ["model","serial"], so a positional compare
@@ -5713,6 +5741,9 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
 // identity need not be one of canonicalizeTagLists's five IDENTITY_FIELDS — these are
 // per-type (Type/Text/ContainerPort/SourceContainer/ConditionKey).
 export const NESTED_OBJECT_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
+  'AWS::CloudFront::Distribution': {
+    'DistributionConfig.CustomErrorResponses': 'ErrorCode',
+  },
   'AWS::Bedrock::Guardrail': {
     'ContentPolicyConfig.FiltersConfig': 'Type',
     'TopicPolicyConfig.TopicsConfig': 'Name',

--- a/tests/noise-cf-r53r-firstrun-1459-1458-1455.test.ts
+++ b/tests/noise-cf-r53r-firstrun-1459-1458-1455.test.ts
@@ -1,0 +1,176 @@
+// First-run fold gaps + a declared reorder cascade mined from the 2026-07-11 bug hunt:
+//   #1459 — CloudFront custom-origin OriginSSLProtocols + IPV6Enabled undeclared creation
+//           defaults surfacing as first-run [Potential Drift].
+//   #1455 — Route53Resolver FirewallRuleGroupAssociation undeclared MutationProtection
+//           default "DISABLED" surfacing as first-run [Potential Drift].
+//   #1458 — CloudFront CustomErrorResponses echoed ErrorCode-sorted, cascading a
+//           non-ascending declaration into several bogus DECLARED drifts.
+// Each fold is equality-gated (or identity-aligned), so a genuine divergence still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import {
+  NESTED_OBJECT_ARRAY_IDENTITY,
+  UNORDERED_NESTED_OBJECT_ARRAY_PATHS,
+} from '../src/normalize/noise.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1459 CloudFront custom-origin OriginSSLProtocols + IPV6Enabled defaults', () => {
+  // A minimal custom-origin distribution declaring neither OriginSSLProtocols nor IPV6Enabled.
+  const res: DesiredResource = {
+    logicalId: 'Dist',
+    resourceType: 'AWS::CloudFront::Distribution',
+    physicalId: 'E123ABC',
+    declared: {
+      DistributionConfig: {
+        Enabled: true,
+        DefaultCacheBehavior: { TargetOriginId: 'origin1', ViewerProtocolPolicy: 'allow-all' },
+        Origins: [
+          {
+            Id: 'origin1',
+            DomainName: 'example.com',
+            CustomOriginConfig: { OriginProtocolPolicy: 'https-only' },
+          },
+        ],
+      },
+    },
+  };
+  const live = (over: { ssl?: unknown; ipv6?: unknown }) => ({
+    DistributionConfig: {
+      Enabled: true,
+      IPV6Enabled: over.ipv6 ?? true,
+      DefaultCacheBehavior: { TargetOriginId: 'origin1', ViewerProtocolPolicy: 'allow-all' },
+      Origins: [
+        {
+          Id: 'origin1',
+          DomainName: 'example.com',
+          CustomOriginConfig: {
+            OriginProtocolPolicy: 'https-only',
+            HTTPPort: 80,
+            HTTPSPort: 443,
+            OriginKeepaliveTimeout: 5,
+            OriginSSLProtocols: over.ssl ?? ['SSLv3', 'TLSv1'],
+          },
+        },
+      ],
+    },
+  });
+
+  // Live findings key an identity-bearing array element by its Id (`Origins[origin1]`),
+  // not a positional index.
+  const SSL_PATH = 'DistributionConfig.Origins[origin1].CustomOriginConfig.OriginSSLProtocols';
+
+  it('folds the undeclared creation defaults to atDefault (zero first-run drift)', () => {
+    const f = classifyResource(res, live({}), emptySchema);
+    const atDefault = pathsByTier(f, 'atDefault');
+    expect(atDefault).toContain('DistributionConfig.IPV6Enabled');
+    expect(atDefault).toContain(SSL_PATH);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band tightened OriginSSLProtocols as undeclared (equality gate)', () => {
+    const f = classifyResource(res, live({ ssl: ['TLSv1.2'] }), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain(SSL_PATH);
+    // The other undeclared creation defaults still fold — only the changed one surfaces.
+    expect(pathsByTier(f, 'atDefault')).toContain('DistributionConfig.IPV6Enabled');
+  });
+
+  // NOTE: an out-of-band IPV6Enabled=false disable is NOT surfaced here — a nested `false`
+  // is swallowed by isTrivialEmpty before the pin gate, and the nested MEANINGFUL_WHEN_OFF
+  // wiring that would preserve it is the #660-class deferred follow-up (see classify.ts
+  // MEANINGFUL_WHEN_OFF header). Pinning the default still correctly removes the first-run FP
+  // (the reported symptom) without regressing detection (false was already swallowed before).
+});
+
+describe('#1455 Route53Resolver FirewallRuleGroupAssociation MutationProtection default', () => {
+  const res: DesiredResource = {
+    logicalId: 'DnsFwAssoc',
+    resourceType: 'AWS::Route53Resolver::FirewallRuleGroupAssociation',
+    physicalId: 'rslvr-frgassoc-abc',
+    declared: {
+      FirewallRuleGroupId: 'rslvr-frg-1',
+      VpcId: 'vpc-1',
+      Priority: 101,
+      Name: 'x',
+    },
+  };
+  it('folds the undeclared "DISABLED" default to atDefault', () => {
+    const f = classifyResource(res, { MutationProtection: 'DISABLED' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('MutationProtection');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('MutationProtection');
+  });
+  it('surfaces an out-of-band ENABLED as undeclared', () => {
+    const f = classifyResource(res, { MutationProtection: 'ENABLED' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('MutationProtection');
+  });
+});
+
+describe('#1458 CloudFront CustomErrorResponses is an ErrorCode-keyed set (no reorder cascade)', () => {
+  // The template lists them 500/403/404 (natural SPA order); CloudFront echoes them sorted
+  // ascending by ErrorCode (403/404/500).
+  const mk = (declaredOrder: number[]): DesiredResource => ({
+    logicalId: 'Dist',
+    resourceType: 'AWS::CloudFront::Distribution',
+    physicalId: 'E123ABC',
+    declared: {
+      DistributionConfig: {
+        Enabled: true,
+        CustomErrorResponses: declaredOrder.map((c) => ({
+          ErrorCode: c,
+          ResponseCode: 200,
+          ResponsePagePath: `/e${c}.html`,
+        })),
+      },
+    },
+  });
+  const liveSorted = (paths: Record<number, string>) => ({
+    DistributionConfig: {
+      Enabled: true,
+      CustomErrorResponses: [403, 404, 500].map((c) => ({
+        ErrorCode: c,
+        ResponseCode: 200,
+        ResponsePagePath: paths[c] ?? `/e${c}.html`,
+      })),
+    },
+  });
+
+  it('registers CustomErrorResponses as an ErrorCode-keyed unordered nested set', () => {
+    expect(UNORDERED_NESTED_OBJECT_ARRAY_PATHS['AWS::CloudFront::Distribution']).toContain(
+      'DistributionConfig.CustomErrorResponses'
+    );
+    expect(NESTED_OBJECT_ARRAY_IDENTITY['AWS::CloudFront::Distribution']).toMatchObject({
+      'DistributionConfig.CustomErrorResponses': 'ErrorCode',
+    });
+  });
+
+  it('produces zero declared drift when the only difference is declaration order', () => {
+    const f = classifyResource(mk([500, 403, 404]), liveSorted({}), emptySchema);
+    expect(pathsByTier(f, 'declared')).toEqual([]);
+  });
+
+  it('surfaces a real out-of-band ResponsePagePath change as a single aligned finding', () => {
+    // 404's page was changed out of band; the identity-keyed sort keeps 404 in the same
+    // slot on both sides, so exactly one aligned finding surfaces (no positional cascade).
+    const f = classifyResource(mk([500, 403, 404]), liveSorted({ 404: '/oops.html' }), emptySchema);
+    const declared = pathsByTier(f, 'declared');
+    expect(declared.length).toBe(1);
+    expect(declared[0]).toContain('CustomErrorResponses');
+    expect(declared[0]).toContain('ResponsePagePath');
+  });
+});


### PR DESCRIPTION
Three surgical first-run fold gaps mined from the 2026-07-11 bug hunt, all landing in `src/normalize/noise.ts` (`classify.ts` imports the array tables unchanged). File-disjoint from the active `#835` lane (`gather.ts`/`child-enumerators.ts`/`writers.ts`).

### #1459 — CloudFront custom-origin `OriginSSLProtocols` + `IPV6Enabled`
A custom-origin distribution declaring neither surfaced both undeclared creation defaults on first `check`. Pinned as equality-gated `KNOWN_DEFAULT_PATHS` constants (`OriginSSLProtocols=[SSLv3,TLSv1]`, `IPV6Enabled=true`). An out-of-band `OriginSSLProtocols` tightening still surfaces.
- The `IPV6Enabled=false` off-flip is **not** surfaced (a nested `false` is swallowed by `isTrivialEmpty` before the pin gate) — that is the #660-class nested `MEANINGFUL_WHEN_OFF` follow-up. Pinning removes the first-run FP (the reported symptom) without regressing detection (it was already swallowed before).

### #1458 — CloudFront `CustomErrorResponses` ErrorCode-sorted reorder cascade
CloudFront echoes `CustomErrorResponses` sorted by `ErrorCode`, so a non-ascending declaration (the natural SPA 500/403/404 order) cascaded into several bogus **declared** drifts. Registered as an `ErrorCode`-keyed `UNORDERED_NESTED_OBJECT_ARRAY_PATHS` + `NESTED_OBJECT_ARRAY_IDENTITY` entry (the #1306 mechanism) so equal sets align and a real `ResponsePagePath` change stays a single aligned finding.

### #1455 — Route53Resolver `FirewallRuleGroupAssociation.MutationProtection`
An association declaring no `MutationProtection` read back the documented service default `"DISABLED"` as a first-run `[Potential Drift]`. Pinned as an equality-gated `KNOWN_DEFAULTS` constant; a real out-of-band `ENABLED` flip still surfaces. (The revert `REVERT_SET_DEFAULT_PATHS` question in the issue is left for a follow-up — this PR changes no revert code.)

### Tests
`tests/noise-cf-r53r-firstrun-1459-1458-1455.test.ts` — each fold to `atDefault` (zero first-run drift) plus the preserved change-detection. Full suite: 5085 passing.

Closes #1459
Closes #1458
Closes #1455
