### PR TITLE
fix(diff): fold Application Auto Scaling-governed declared props within their band (#688)

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,10 +512,17 @@ no such gap and compares transformed stacks fully; prefer it for SAM/macro apps.
 
 ### Ignoring externally-managed properties
 
-Some properties are _legitimately_ rewritten by another system, such as Application
-Auto Scaling moving an ECS Service `DesiredCount`, or autoscaled DynamoDB capacity.
-A recorded snapshot would re-flag every move. Run **`cdkrd ignore`** to pick the
-drift to suppress, or hand-edit the git-committed `.cdkrd/ignore.yaml`. It is a
+Some properties are _legitimately_ rewritten by another system. cdkrd already folds
+the most common case automatically: a property a sibling
+`AWS::ApplicationAutoScaling::ScalableTarget` governs — an ECS Service `DesiredCount`,
+autoscaled DynamoDB capacity, a Lambda alias's provisioned concurrency, … — is **not**
+flagged while its live value stays within the declared `MinCapacity`/`MaxCapacity`
+band (the autoscaler enforcing the template's own delegation is intent, not drift,
+#688). A value pushed _beyond_ the band still surfaces as real drift, but `revert`
+deliberately refuses it (writing the initial value back would just be re-scaled). For
+anything cdkrd does not fold — an externally-managed Lambda **reserved** concurrency,
+a value another controller rewrites — run **`cdkrd ignore`** to pick the drift to
+suppress, or hand-edit the git-committed `.cdkrd/ignore.yaml`. It is a
 hand-edited policy file (the `.gitignore` / `.dockerignore` / `.trivyignore`
 family), so it is YAML rather than JSON: the single most valuable hand-edit is a
 `#` comment recording **why** a property is ignored, and YAML can carry it where
@@ -525,10 +532,10 @@ machine-generated, wholesale-rewritten data, not human policy.)
 ```yaml
 # cdkrd ignore rules — properties cdkrd should stop reporting as drift.
 ignore:
-  # DesiredCount is managed by Application Auto Scaling
-  - path: '*.DesiredCount'
+  # reserved concurrency is managed by an external controller (not AAS, so not auto-folded)
+  - path: '*.ReservedConcurrentExecutions'
   # the common case: scope a rule to one stack
-  - path: '*.DesiredCount'
+  - path: '*.ReservedConcurrentExecutions'
     stack: Prod*
   # narrow further to a single account and/or region when the same stack
   # name is deployed to several (a property may legitimately drift in only one)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1057,11 +1057,17 @@ DynamoDB `SSESpecification`) — derived from a full golden-corpus audit. This c
 the whole removed-collection FN class for every type at once; a new genuine readGap
 surfaces as a VISIBLE, denylist-able false positive, never a silent FN.
 
-`ignored` (R32) is for properties an external system legitimately keeps rewriting —
-Application Auto Scaling moving an ECS Service `DesiredCount`, DynamoDB autoscaled
-capacity, externally-managed Lambda reserved concurrency. Because `record` is a value
-snapshot, recording such a property would re-detect and force a re-record every time
-the value moves. Path-level ignore rules (the `.driftignore` / Terraform
+`ignored` (R32) is for properties an external system legitimately keeps rewriting.
+The most common case — a property a sibling `AWS::ApplicationAutoScaling::ScalableTarget`
+governs (ECS Service `DesiredCount`, DynamoDB autoscaled capacity, a Lambda alias's
+provisioned concurrency) — is now folded automatically while the live value stays
+within the declared `MinCapacity`/`MaxCapacity` band, so it needs no rule (#688,
+`AAS_SCALABLE_DIMENSIONS` in `diff/classify.ts`, band map built by
+`gather.buildScalableTargetBands`; a value beyond the band surfaces and is marked
+non-revertable). `ignored` remains for what that does not cover — externally-managed
+Lambda **reserved** concurrency, or any property another controller rewrites. Because
+`record` is a value snapshot, recording such a property would re-detect and force a
+re-record every time the value moves. Path-level ignore rules (the `.driftignore` / Terraform
 `ignore_changes` equivalent) live in a git-committed **`.cdkrd/ignore.yaml`** —
 deliberately separate from the baseline, which `record` rewrites wholesale (a
 hand-written rule there would be erased), and because a rule is hand-edited policy,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -53,7 +53,12 @@ case that matters is still caught: a recorded value that later flips to
 
 **A property keeps drifting because an autoscaler manages it — do I re-record
 forever?**
-No — list it in `.cdkrd/ignore.yaml` (see
+No. For a property an `AWS::ApplicationAutoScaling::ScalableTarget` governs (ECS
+Service `DesiredCount`, autoscaled DynamoDB capacity, a Lambda alias's provisioned
+concurrency, …), cdkrd folds it automatically while the live value stays within the
+declared `MinCapacity`/`MaxCapacity` band — no rule needed (#688). For a property a
+_different_ controller rewrites (e.g. Lambda reserved concurrency), or an autoscaler
+value pushed beyond its band, list it in `.cdkrd/ignore.yaml` (see
 [Ignoring externally-managed properties](../README.md#ignoring-externally-managed-properties)).
 
 **Is it safe to run in CI / on production accounts?**

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -25,6 +25,7 @@ import { GetServiceSettingCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
 import {
+  AAS_SCALABLE_DIMENSIONS,
   type AccountDefaults,
   CLUSTER_ECHO_CHILD,
   classifyResource,
@@ -1138,6 +1139,113 @@ export function buildClusterEchoModels(desired: Desired): Record<string, Record<
   return map;
 }
 
+const SCALABLE_TARGET_TYPE = 'AWS::ApplicationAutoScaling::ScalableTarget';
+
+// Every logicalId referenced by a value's intrinsics — a `{Ref: X}`, an `{Fn::GetAtt: [X, ...]}`
+// (or the string `X.attr` form), the `${X}` / `${X.attr}` substitutions inside an `{Fn::Sub}`, and
+// recursively through `{Fn::Join}` parts / arrays / objects. Used to link a ScalableTarget to the
+// resource its `ResourceId` names (a CDK ScalableTarget builds ResourceId by interpolating a Ref /
+// GetAtt to the governed service/table). Pure.
+function collectRefLogicalIds(v: unknown, out: Set<string> = new Set()): Set<string> {
+  if (v == null) return out;
+  if (Array.isArray(v)) {
+    for (const el of v) collectRefLogicalIds(el, out);
+    return out;
+  }
+  if (typeof v !== 'object') return out;
+  const o = v as Record<string, unknown>;
+  if ('Ref' in o && typeof o.Ref === 'string') out.add(o.Ref);
+  if ('Fn::GetAtt' in o) {
+    const g = o['Fn::GetAtt'];
+    if (Array.isArray(g) && typeof g[0] === 'string') out.add(g[0]);
+    else if (typeof g === 'string') out.add(g.split('.')[0] ?? g);
+  }
+  if ('Fn::Sub' in o) {
+    const s = o['Fn::Sub'];
+    const body = Array.isArray(s) ? s[0] : s;
+    if (typeof body === 'string') {
+      for (const m of body.matchAll(/\$\{([A-Za-z0-9]+)(?:\.[^}]+)?\}/g)) {
+        if (m[1]) out.add(m[1]);
+      }
+    }
+    if (Array.isArray(s) && s[1] && typeof s[1] === 'object') collectRefLogicalIds(s[1], out);
+  }
+  for (const [k, val] of Object.entries(o)) {
+    if (k === 'Ref' || k === 'Fn::GetAtt' || k === 'Fn::Sub') continue;
+    collectRefLogicalIds(val, out);
+  }
+  return out;
+}
+
+// #688: per GOVERNED resource logicalId, the Application Auto Scaling bands a sibling
+// AWS::ApplicationAutoScaling::ScalableTarget declares over its properties — `{ path, min, max }[]`.
+// classify (applyAutoscalerBandFold) folds a declared finding whose live value is within its band
+// (the autoscaler enforcing the template's own delegation — not drift) and marks an OUT-OF-BAND
+// value non-revertable. Each ScalableTarget's ScalableDimension is looked up in
+// AAS_SCALABLE_DIMENSIONS for the governed type + property path(s); the governed resource is linked
+// by the Ref/GetAtt in the (raw) ResourceId, falling back to matching the resolved ResourceId string
+// against a candidate's physical id. Fail-open at every step (an unresolved link / non-numeric band
+// simply yields no fold, so the finding stays visible — never a hidden change).
+export function buildScalableTargetBands(
+  desired: Desired
+): Record<string, { path: string; min: number; max: number }[]> {
+  const byLogicalId = new Map<string, DesiredResource>();
+  const byType = new Map<string, DesiredResource[]>();
+  for (const r of desired.resources) {
+    byLogicalId.set(r.logicalId, r);
+    const arr = byType.get(r.resourceType);
+    if (arr) arr.push(r);
+    else byType.set(r.resourceType, [r]);
+  }
+  const map: Record<string, { path: string; min: number; max: number }[]> = {};
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+
+  for (const r of desired.resources) {
+    if (r.resourceType !== SCALABLE_TARGET_TYPE) continue;
+    const decl = (r.declared ?? {}) as Record<string, unknown>;
+    const dim = decl.ScalableDimension;
+    if (typeof dim !== 'string') continue;
+    const spec = AAS_SCALABLE_DIMENSIONS[dim];
+    if (!spec) continue;
+
+    // Band: the declared MinCapacity/MaxCapacity (intent), falling back to the live model.
+    const live = desired.ctx.liveAttrs[r.logicalId] ?? {};
+    const min = num(decl.MinCapacity) ?? num(live.MinCapacity);
+    const max = num(decl.MaxCapacity) ?? num(live.MaxCapacity);
+    if (min === undefined || max === undefined) continue;
+
+    // Link to the governed resource: prefer a Ref/GetAtt in the raw ResourceId, of the right type.
+    const rawResourceId = (r.declaredRaw as Record<string, unknown> | undefined)?.ResourceId;
+    let governed: DesiredResource | undefined;
+    for (const id of collectRefLogicalIds(rawResourceId)) {
+      const cand = byLogicalId.get(id);
+      if (cand && cand.resourceType === spec.resourceType) {
+        governed = cand;
+        break;
+      }
+    }
+    // Fallback: match the resolved ResourceId string against a candidate's physical id.
+    if (!governed) {
+      const rid = decl.ResourceId;
+      if (typeof rid === 'string') {
+        const segs = new Set(rid.split('/'));
+        governed = byType
+          .get(spec.resourceType)
+          ?.find(
+            (c) =>
+              c.physicalId !== undefined && (segs.has(c.physicalId) || rid.endsWith(c.physicalId))
+          );
+      }
+    }
+    if (!governed) continue;
+
+    const entries = (map[governed.logicalId] ??= []);
+    for (const path of spec.paths) entries.push({ path, min, max });
+  }
+  return map;
+}
+
 // #978: resolve each AWS::RDS::OptionGroup's option-default catalog from
 // `describe-option-group-options` (per engine+version, cached and paginated), keyed
 // `physicalId -> optionName -> settingName -> DefaultValue|null`. classify folds a live-only
@@ -1585,6 +1693,7 @@ export async function gatherFindings(
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     bucketNotificationConfigs: buildBucketNotificationConfigs(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
+    scalableTargetBands: buildScalableTargetBands(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 
@@ -1696,6 +1805,7 @@ export async function regatherTouched(
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     bucketNotificationConfigs: buildBucketNotificationConfigs(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
+    scalableTargetBands: buildScalableTargetBands(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -2222,6 +2222,95 @@ function pushDeclaredFinding(findings: Finding[], finding: Omit<Finding, 'tier'>
   findings.push({ tier: 'declared', ...finding });
 }
 
+// #688: an AWS::ApplicationAutoScaling::ScalableTarget's `ScalableDimension` names the exact
+// declared property the autoscaler governs on the target resource. This maps each supported
+// dimension to the governed CFn resource type and the declared property path(s) the autoscaler
+// moves — a DATA table so a new dimension is one entry, not a special case. gather.ts
+// (buildScalableTargetBands) reads it to build the per-resource band map threaded as
+// `scalableTargetBands`. Scope: dimensions whose governed path is a STATIC dotted path (the
+// live-proven ECS DesiredCount + DynamoDB table Read/Write capacity, plus the same-shaped Lambda
+// alias provisioned-concurrency and ElastiCache node/replica counts). Per-index dynamodb GSI
+// (`dynamodb:index:*`, path needs the index name), native AWS::AutoScaling ASG DesiredCapacity (no
+// ScalableTarget sibling — a different signal), and readGap-only SageMaker variants are follow-ups.
+export const AAS_SCALABLE_DIMENSIONS: Record<string, { resourceType: string; paths: string[] }> = {
+  'ecs:service:DesiredCount': { resourceType: 'AWS::ECS::Service', paths: ['DesiredCount'] },
+  'dynamodb:table:ReadCapacityUnits': {
+    resourceType: 'AWS::DynamoDB::Table',
+    paths: ['ProvisionedThroughput.ReadCapacityUnits'],
+  },
+  'dynamodb:table:WriteCapacityUnits': {
+    resourceType: 'AWS::DynamoDB::Table',
+    paths: ['ProvisionedThroughput.WriteCapacityUnits'],
+  },
+  'lambda:function:ProvisionedConcurrency': {
+    resourceType: 'AWS::Lambda::Alias',
+    paths: ['ProvisionedConcurrencyConfig.ProvisionedConcurrentExecutions'],
+  },
+  'elasticache:replication-group:NodeGroups': {
+    resourceType: 'AWS::ElastiCache::ReplicationGroup',
+    paths: ['NumNodeGroups'],
+  },
+  'elasticache:replication-group:Replicas': {
+    resourceType: 'AWS::ElastiCache::ReplicationGroup',
+    paths: ['ReplicasPerNodeGroup'],
+  },
+};
+
+const AUTOSCALER_HINT_PREFIX =
+  'governed by a sibling AWS::ApplicationAutoScaling::ScalableTarget (Application Auto Scaling)';
+
+/**
+ * #688: fold declared findings whose property the stack DELEGATES to Application Auto Scaling.
+ * A sibling ScalableTarget over `(resource, dimension)` means the live value moving within the
+ * declared `[MinCapacity, MaxCapacity]` band is the autoscaler enforcing the template's own
+ * intent (min-enforcement fires within minutes of a clean deploy, zero traffic) — NOT drift, so
+ * the declared finding is DROPPED. A value OUTSIDE the band is a real over-set: it stays, but is
+ * marked `autoscalerGoverned` (+ a hint) so the revert plan refuses a write the scaler would
+ * immediately undo. Range-gated → detection preserved. Pure; only touches `declared`-tier
+ * findings whose path is a governed path (all else passes through untouched).
+ */
+export function applyAutoscalerBandFold(
+  findings: Finding[],
+  bands: { path: string; min: number; max: number }[]
+): Finding[] {
+  const out: Finding[] = [];
+  for (const f of findings) {
+    if (f.tier !== 'declared') {
+      out.push(f);
+      continue;
+    }
+    const band = bands.find((b) => b.path === f.path);
+    if (band === undefined) {
+      out.push(f);
+      continue;
+    }
+    const actual = f.actual;
+    if (
+      typeof actual === 'number' &&
+      Number.isFinite(actual) &&
+      actual >= band.min &&
+      actual <= band.max
+    ) {
+      // within the declared scaling band — the autoscaler did exactly what the template asked.
+      continue;
+    }
+    // outside the band (or non-numeric) — a genuine over-set. Keep it visible, but block revert.
+    out.push({
+      ...f,
+      autoscalerGoverned: true,
+      ...(f.hint === undefined
+        ? {
+            hint:
+              `${AUTOSCALER_HINT_PREFIX}, band ${band.min}..${band.max}; the live value is outside ` +
+              `it, so this is a real change — but revert cannot converge (the scaler re-adjusts it). ` +
+              `Change the ScalableTarget band / scaling policy, or record/ignore to accept it`,
+          }
+        : {}),
+    });
+  }
+  return out;
+}
+
 export function classifyResource(
   resource: DesiredResource,
   liveRaw: Record<string, unknown>,
@@ -2326,6 +2415,16 @@ export function classifyResource(
     // sentinel default to the listener's port), so classify derives + equality-gates the undeclared
     // HealthCheckPort from it. Built from the desired set in gather.ts (buildSiblingListenerPorts).
     siblingListenerPorts?: Record<string, number>;
+    // #688: per GOVERNED resource logicalId, the Application Auto Scaling bands a sibling
+    // AWS::ApplicationAutoScaling::ScalableTarget declares over that resource's properties —
+    // `{ path, min, max }[]` (built from the ScalableDimension → AAS_SCALABLE_DIMENSIONS map in
+    // gather.ts, buildScalableTargetBands). The template DELEGATES the property to the autoscaler,
+    // which moves the live value WITHIN [min,max] within minutes of a clean deploy (min-enforcement)
+    // — declared intent, not drift, so classify FOLDS a declared finding whose live value is in the
+    // band (the delegation is visible in the template itself). A value OUTSIDE the band is a real
+    // over-set and SURFACES, marked autoscalerGoverned so revert refuses (a write-back the scaler
+    // re-adjusts would never converge). Absent → no fold (fail-open, the finding stays visible).
+    scalableTargetBands?: Record<string, { path: string; min: number; max: number }[]>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -4794,7 +4893,11 @@ export function classifyResource(
   // live IAM is worse than an un-reverted FP). Applies to Role / User / Group alike.
   const unresolvedSibling =
     IAM_PRINCIPAL_POLICY_TYPES.has(resourceType) && resource.siblingPolicyNames === 'unresolved';
-  return findings.map((f) => ({
+  // #688: fold declared drift the template delegates to a sibling AAS ScalableTarget (within its
+  // declared band); an out-of-band value beyond the band stays but is marked non-revertable.
+  const bands = opts.scalableTargetBands?.[resource.logicalId];
+  const folded = bands ? applyAutoscalerBandFold(findings, bands) : findings;
+  return folded.map((f) => ({
     ...f,
     ...(pid !== undefined && { physicalId: pid }),
     ...(cp !== undefined && { constructPath: cp }),

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -802,6 +802,20 @@ export function buildRevertPlan(
       wholeArrayEmitted.add(waKey);
       f = { ...f, path: f.wholeArrayRevert.path, desired: f.wholeArrayRevert.value };
     }
+    // #688: a property the stack delegates to Application Auto Scaling (a sibling ScalableTarget
+    // governs it). classify folded the in-band case; this residual finding is an out-of-band value
+    // BEYOND the declared band. Writing the declared initial value back would be re-adjusted by the
+    // scaler on its next evaluation — a non-convergent revert (the #667 flavor), so refuse it.
+    if (f.autoscalerGoverned) {
+      notRevertable.push({
+        displayId,
+        resourceType: f.resourceType,
+        path: f.path,
+        reason:
+          'managed by Application Auto Scaling — revert would fight the scaler; change the ScalableTarget band / scaling policy, or record/ignore to accept',
+      });
+      continue;
+    }
     if (f.tier === 'deleted') {
       // a resource deleted out of band cannot be patched back — it must be
       // recreated by re-deploying the stack.

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,14 @@ export interface Finding {
   // policy (real IAM grants). Mirrors DesiredResource.siblingPolicyNames; only the
   // 'unresolved' sentinel is propagated (the resolved case is already filtered out).
   siblingPolicyNames?: 'unresolved' | undefined;
+  // declared tier only (#688): this property is DELEGATED to Application Auto Scaling — the stack
+  // declares a sibling AWS::ApplicationAutoScaling::ScalableTarget over it. classify already FOLDED
+  // the common case (live value within the declared [MinCapacity,MaxCapacity] band = the scaler
+  // enforcing intent); this flag rides only on the residual OUT-OF-BAND finding (a real over-set).
+  // The revert plan reads it and refuses to act — writing the declared initial value back would be
+  // immediately re-adjusted by the autoscaler, so the revert never converges (non-revertable, the
+  // user must change the ScalableTarget band / scaling policy, or record/ignore to accept).
+  autoscalerGoverned?: boolean | undefined;
   // declared tier only: this per-element finding lives inside an UNORDERED_OBJECT_ARRAY
   // (a SET the service returns REORDERED — SecurityGroup rules, PrefixList Entries, …).
   // classify sorts BOTH sides by canonical JSON before the positional subset diff, so the

--- a/tests/autoscale-scalable-target-688.test.ts
+++ b/tests/autoscale-scalable-target-688.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildScalableTargetBands } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import { applyAutoscalerBandFold, classifyResource } from '../src/diff/classify.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// #688: a declared property the stack DELEGATES to Application Auto Scaling (a sibling
+// AWS::ApplicationAutoScaling::ScalableTarget whose ScalableDimension names it) surfaces as
+// [CFn-Declared Drift] within minutes of a clean deploy — the autoscaler enforces MinCapacity,
+// moving the live value above the declared initial. That is intent, not drift: gather builds the
+// per-resource band map (buildScalableTargetBands), classify FOLDS a value within the declared
+// [MinCapacity, MaxCapacity] band and SURFACES one outside it (marked non-revertable so a
+// scaler-fighting write is refused).
+
+// --- desired-model helpers -------------------------------------------------------------------
+
+const desiredOf = (
+  resources: DesiredResource[],
+  liveAttrs: Record<string, Record<string, unknown>> = {}
+): Desired => ({ resources, ctx: { liveAttrs } }) as unknown as Desired;
+
+// ECS Service ScalableTarget: ResourceId built by CDK as `service/<cluster>/<serviceName>` via a
+// GetAtt on the service — the raw form carries the Ref/GetAtt we link by.
+const ecsScalableTarget = (over: Record<string, unknown> = {}): DesiredResource => ({
+  logicalId: 'Target',
+  resourceType: 'AWS::ApplicationAutoScaling::ScalableTarget',
+  declared: {
+    ScalableDimension: 'ecs:service:DesiredCount',
+    ServiceNamespace: 'ecs',
+    MinCapacity: 2,
+    MaxCapacity: 4,
+    ResourceId: 'service/my-cluster/my-service',
+    ...over,
+  },
+  declaredRaw: {
+    ScalableDimension: 'ecs:service:DesiredCount',
+    ServiceNamespace: 'ecs',
+    MinCapacity: 2,
+    MaxCapacity: 4,
+    ResourceId: {
+      'Fn::Join': ['', ['service/', { Ref: 'Cluster' }, '/', { 'Fn::GetAtt': ['Svc', 'Name'] }]],
+    },
+    ...over,
+  },
+});
+
+const ecsService = (): DesiredResource => ({
+  logicalId: 'Svc',
+  resourceType: 'AWS::ECS::Service',
+  physicalId: 'my-service',
+  declared: { DesiredCount: 1 },
+});
+
+const ecsCluster = (): DesiredResource => ({
+  logicalId: 'Cluster',
+  resourceType: 'AWS::ECS::Cluster',
+  physicalId: 'my-cluster',
+  declared: {},
+});
+
+describe('#688 buildScalableTargetBands', () => {
+  it('links an ECS ScalableTarget to its Service by the Ref/GetAtt in the raw ResourceId', () => {
+    const map = buildScalableTargetBands(
+      desiredOf([ecsCluster(), ecsService(), ecsScalableTarget()])
+    );
+    expect(map.Svc).toEqual([{ path: 'DesiredCount', min: 2, max: 4 }]);
+  });
+
+  it('collects both read and write capacity bands for a DynamoDB table', () => {
+    const table: DesiredResource = {
+      logicalId: 'Table',
+      resourceType: 'AWS::DynamoDB::Table',
+      physicalId: 'my-table',
+      declared: { ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 } },
+    };
+    const st = (dim: string, id: string): DesiredResource => ({
+      logicalId: id,
+      resourceType: 'AWS::ApplicationAutoScaling::ScalableTarget',
+      declared: {
+        ScalableDimension: dim,
+        MinCapacity: 5,
+        MaxCapacity: 50,
+        ResourceId: 'table/my-table',
+      },
+      declaredRaw: {
+        ScalableDimension: dim,
+        MinCapacity: 5,
+        MaxCapacity: 50,
+        ResourceId: { 'Fn::Join': ['', ['table/', { Ref: 'Table' }]] },
+      },
+    });
+    const map = buildScalableTargetBands(
+      desiredOf([
+        table,
+        st('dynamodb:table:ReadCapacityUnits', 'R'),
+        st('dynamodb:table:WriteCapacityUnits', 'W'),
+      ])
+    );
+    expect(map.Table).toEqual([
+      { path: 'ProvisionedThroughput.ReadCapacityUnits', min: 5, max: 50 },
+      { path: 'ProvisionedThroughput.WriteCapacityUnits', min: 5, max: 50 },
+    ]);
+  });
+
+  it('falls back to matching the resolved ResourceId string against a physical id (no raw refs)', () => {
+    const st = ecsScalableTarget();
+    delete (st as { declaredRaw?: unknown }).declaredRaw; // force the physicalId-string fallback
+    const map = buildScalableTargetBands(desiredOf([ecsService(), st]));
+    expect(map.Svc).toEqual([{ path: 'DesiredCount', min: 2, max: 4 }]);
+  });
+
+  it('takes the band from the live model when MinCapacity/MaxCapacity are not literal in the template', () => {
+    const st = ecsScalableTarget({
+      MinCapacity: { Ref: 'MinParam' },
+      MaxCapacity: { Ref: 'MaxParam' },
+    });
+    const map = buildScalableTargetBands(
+      desiredOf([ecsService(), st], { Target: { MinCapacity: 3, MaxCapacity: 9 } })
+    );
+    expect(map.Svc).toEqual([{ path: 'DesiredCount', min: 3, max: 9 }]);
+  });
+
+  it('skips an unrecognized ScalableDimension (fail-open, no fold)', () => {
+    const st = ecsScalableTarget({ ScalableDimension: 'custom-resource:ResourceType:Property' });
+    expect(buildScalableTargetBands(desiredOf([ecsService(), st]))).toEqual({});
+  });
+
+  it('skips when neither the template nor the live model gives a numeric band', () => {
+    const st = ecsScalableTarget({ MinCapacity: { Ref: 'P' }, MaxCapacity: { Ref: 'Q' } });
+    expect(buildScalableTargetBands(desiredOf([ecsService(), st]))).toEqual({});
+  });
+});
+
+// --- pure fold -------------------------------------------------------------------------------
+
+const declaredFinding = (over: Partial<Finding>): Finding => ({
+  tier: 'declared',
+  logicalId: 'Svc',
+  resourceType: 'AWS::ECS::Service',
+  path: 'DesiredCount',
+  desired: 1,
+  actual: 2,
+  ...over,
+});
+
+describe('#688 applyAutoscalerBandFold', () => {
+  const bands = [{ path: 'DesiredCount', min: 2, max: 4 }];
+
+  it('DROPS a declared finding whose live value is within the declared band', () => {
+    expect(applyAutoscalerBandFold([declaredFinding({ actual: 2 })], bands)).toEqual([]);
+    expect(applyAutoscalerBandFold([declaredFinding({ actual: 4 })], bands)).toEqual([]);
+  });
+
+  it('KEEPS a value above the band, marked autoscalerGoverned with a hint', () => {
+    const [f] = applyAutoscalerBandFold([declaredFinding({ actual: 7 })], bands);
+    expect(f?.autoscalerGoverned).toBe(true);
+    expect(f?.hint).toContain('Application Auto Scaling');
+    expect(f?.tier).toBe('declared');
+  });
+
+  it('KEEPS a value below the band (an odd under-set) marked non-revertable', () => {
+    const [f] = applyAutoscalerBandFold([declaredFinding({ actual: 0 })], bands);
+    expect(f?.autoscalerGoverned).toBe(true);
+  });
+
+  it('leaves a finding at a non-governed path untouched', () => {
+    const other = declaredFinding({ path: 'LaunchType', desired: 'EC2', actual: 'FARGATE' });
+    expect(applyAutoscalerBandFold([other], bands)).toEqual([other]);
+  });
+
+  it('never touches a non-declared tier finding', () => {
+    const undeclared = declaredFinding({ tier: 'undeclared', actual: 99 });
+    expect(applyAutoscalerBandFold([undeclared], bands)).toEqual([undeclared]);
+  });
+});
+
+// --- classify integration --------------------------------------------------------------------
+
+const ecsSchema: SchemaInfo = {
+  readOnly: new Set([]),
+  writeOnly: new Set([]),
+  createOnly: new Set([]),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+describe('#688 classifyResource with scalableTargetBands', () => {
+  const bands = { Svc: [{ path: 'DesiredCount', min: 2, max: 4 }] };
+
+  it('folds the in-band DesiredCount drift (clean-deploy false positive)', () => {
+    const findings = classifyResource(ecsService(), { DesiredCount: 2 }, ecsSchema, {
+      scalableTargetBands: bands,
+    });
+    expect(findings.filter((f) => f.path === 'DesiredCount')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band DesiredCount beyond the band, marked autoscalerGoverned', () => {
+    const findings = classifyResource(ecsService(), { DesiredCount: 9 }, ecsSchema, {
+      scalableTargetBands: bands,
+    });
+    const dc = findings.find((f) => f.path === 'DesiredCount');
+    expect(dc?.tier).toBe('declared');
+    expect(dc?.autoscalerGoverned).toBe(true);
+  });
+
+  it('without bands, the clean-deploy drift still surfaces (the bug being fixed)', () => {
+    const findings = classifyResource(ecsService(), { DesiredCount: 2 }, ecsSchema, {});
+    expect(findings.find((f) => f.path === 'DesiredCount')?.tier).toBe('declared');
+  });
+});
+
+// --- revert guard ----------------------------------------------------------------------------
+
+describe('#688 revert guard', () => {
+  it('refuses to revert an autoscaler-governed finding (would fight the scaler)', () => {
+    const f = declaredFinding({
+      physicalId: 'my-service',
+      actual: 9,
+      autoscalerGoverned: true,
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toEqual([]);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]?.reason).toContain('Application Auto Scaling');
+  });
+});


### PR DESCRIPTION
Closes #688.

## Problem

A declared property the stack **delegates to Application Auto Scaling** — a sibling
`AWS::ApplicationAutoScaling::ScalableTarget` whose `ScalableDimension` names it —
surfaced as `[CFn-Declared Drift]` within minutes of a clean, un-mutated deploy. AAS
enforces `MinCapacity`, so the live value rises above the declared initial with zero
traffic and zero user action. The drift survived `record` (declared tier) so
`check --fail` was permanently red for every autoscaled service/table, and `revert`
offered to write the initial value back — which AAS immediately re-raises (a
non-convergent revert, the #667 flavor). This hits the most common production patterns
there are (ECS target-tracking, provisioned DynamoDB autoscaling).

## Fix

A **data table**, not an ECS/DDB special case:

- **`diff/classify.ts`** — `AAS_SCALABLE_DIMENSIONS` maps each `ScalableDimension` to
  the governed CFn type + declared property path(s). `applyAutoscalerBandFold` DROPS a
  declared finding whose live value is within the declared `[MinCapacity, MaxCapacity]`
  band (the autoscaler enforcing the template's own delegation — intent, not drift);
  a value OUTSIDE the band still surfaces (**range-gated → detection preserved**),
  marked `autoscalerGoverned` with an explanatory hint.
- **`commands/gather.ts`** — `buildScalableTargetBands` builds the per-governed-resource
  band map, linking each `ScalableTarget` to the resource its `ResourceId` names (the
  Ref/GetAtt in the raw `ResourceId`, with a resolved-string physical-id fallback).
  Fail-open at every step (an unresolved link / non-numeric band → no fold, the finding
  stays visible — never a hidden change).
- **`revert/plan.ts`** — an `autoscalerGoverned` finding is `notRevertable`: writing the
  initial value back would be re-scaled, so revert refuses and tells the user to adjust
  the ScalableTarget band / scaling policy, or record/ignore.
- **docs** — cdkrd now auto-folds the in-band autoscaler case, so it no longer needs an
  `ignore` rule; README / faq / ARCHITECTURE updated (the `ignore` example switched to
  Lambda **reserved** concurrency, which is genuinely not auto-folded).

Covered dimensions: `ecs:service:DesiredCount`, `dynamodb:table:{Read,Write}CapacityUnits`,
`lambda:function:ProvisionedConcurrency`, `elasticache:replication-group:{NodeGroups,Replicas}`.
**Follow-ups** (same table): per-index DynamoDB GSI (`dynamodb:index:*`, path needs the
index name), native `AWS::AutoScaling` ASG `DesiredCapacity` (no ScalableTarget sibling —
a different signal), SageMaker variant instance count (readGap territory).

## Tests

`tests/autoscale-scalable-target-688.test.ts` (15 cases): the gather band builder
(Ref/GetAtt link, physical-id fallback, live-model band fallback, unknown-dimension /
non-numeric skips), the pure fold (in-band drop, out-of-band keep+mark, non-governed /
non-declared pass-through), classify integration (the FP folds, an out-of-band value
surfaces, no-bands reproduces the bug), and the revert guard. Full suite green
(238 files / 5093 tests).

Live-verification (ECS `DesiredCount` + DynamoDB provisioned capacity on real AWS) to
follow via `/verify-pr`.
