### PR TITLE
fix(noise): EB Application ResourceLifecycleConfig ServiceRole residual folds so a reverted lifecycle no longer perpetually surfaces (#1437)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -86,7 +86,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // but DISABLED (Enabled:false, MaxCount 200 / MaxAgeInDays 180, DeleteSourceFromS3:false).
   // Equality-gated: enable a lifecycle rule out of band and the object no longer matches,
   // so it re-surfaces as real undeclared drift. Observed live on a fresh elasticbeanstalk-
-  // rich Application (2026-07-07).
+  // rich Application (2026-07-07). This whole-object fold is the CLEAN-deploy fast path (no
+  // ServiceRole present); once a lifecycle rule is set + reverted EB KEEPS a ServiceRole the
+  // object can never shed, so it falls through to the DESCEND_UNDECLARED_OBJECT_PATHS +
+  // KNOWN_DEFAULT_PATHS + GENERATED_NESTED_PATHS split below that folds the residual (#1437).
   'AWS::ElasticBeanstalk::Application': {
     ResourceLifecycleConfig: {
       VersionLifecycleConfig: {
@@ -2061,6 +2064,19 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
       InCluster: true,
     },
   },
+  'AWS::ElasticBeanstalk::Application': {
+    // The substantive half of an undeclared ResourceLifecycleConfig, descended
+    // (DESCEND_UNDECLARED_OBJECT_PATHS above) so it folds independently of the AWS-kept
+    // `ServiceRole` sibling (value-independent via GENERATED_NESTED_PATHS). This pins the
+    // version-lifecycle policy AWS materializes when nothing is declared: both rules PRESENT but
+    // DISABLED (the same constant as the whole-object KNOWN_DEFAULTS entry, minus the ServiceRole).
+    // Equality-gated: enable a rule out of band, or change a MaxCount/MaxAgeInDays, and the object no
+    // longer matches, so the real lifecycle change re-surfaces as undeclared drift (#1437).
+    'ResourceLifecycleConfig.VersionLifecycleConfig': {
+      MaxCountRule: { DeleteSourceFromS3: false, Enabled: false, MaxCount: 200 },
+      MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+    },
+  },
   'AWS::Batch::JobDefinition': {
     // A Fargate job definition reads back the documented runtime-platform defaults
     // (x86_64 / Linux) and the LATEST Fargate platform version when none is declared.
@@ -2592,6 +2608,19 @@ export const DESCEND_UNDECLARED_OBJECT_PATHS: Record<string, ReadonlySet<string>
   // independent via GENERATED_NESTED_PATHS below). A single whole-object KNOWN_DEFAULTS entry
   // can't cover both (the per-account KMS ARN can't be pinned), so descend + split.
   'AWS::MSK::Cluster': new Set(['EncryptionInfo']),
+  // An EB Application that declares no ResourceLifecycleConfig folds the WHOLE object via the
+  // KNOWN_DEFAULTS entry above on a CLEAN deploy (no ServiceRole present). But once a lifecycle
+  // rule is set out of band the API REQUIRES a ServiceRole, and EB KEEPS that ServiceRole even
+  // after `revert` writes the rules back to the disabled default — so the post-revert object is
+  // `{ServiceRole:<arn>, VersionLifecycleConfig:{default}}`, which the whole-object KNOWN_DEFAULTS
+  // no longer matches (the extra ServiceRole key), leaving it perpetually [Potential Drift] (#1437).
+  // Descend it so the two sub-blocks fold independently: `VersionLifecycleConfig` is the stable
+  // constant (folded via KNOWN_DEFAULT_PATHS below) and `ServiceRole` is the AWS-assigned/kept IAM
+  // role ARN (value-independent via GENERATED_NESTED_PATHS below — a user who wants a specific role
+  // DECLARES ResourceLifecycleConfig.ServiceRole, compared in the declared loop). An ENABLED rule
+  // (or a non-default MaxCount) still breaks the VersionLifecycleConfig equality gate and surfaces,
+  // so out-of-band detection is preserved.
+  'AWS::ElasticBeanstalk::Application': new Set(['ResourceLifecycleConfig']),
 };
 
 // Value-DEPENDENT generated-name fold, scoped by type + top-level path. Folds a live value
@@ -2719,6 +2748,17 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
     'EncryptionInfo.EncryptionAtRest',
     'BrokerNodeGroupInfo.SecurityGroups',
   ]),
+  // An EB Application's undeclared ResourceLifecycleConfig is descended
+  // (DESCEND_UNDECLARED_OBJECT_PATHS), so once a lifecycle rule is set out of band EB stamps in a
+  // `ServiceRole` (an IAM role ARN the UpdateApplicationResourceLifecycle API requires) and KEEPS
+  // it even after `revert` writes the disabled default — leaving `ResourceLifecycleConfig.ServiceRole`
+  // as a live-only leaf here. It is an AWS-assigned/kept role ARN, never user intent when undeclared
+  // (the RDS/OpenSearch/MSK KmsKeyId / SecurityGroups value-independent class): fold it regardless of
+  // value so a lifecycle-config that is otherwise at-default no longer perpetually surfaces (#1437). A
+  // user who wants a specific role DECLARES ResourceLifecycleConfig.ServiceRole, compared in the
+  // declared loop. The substantive VersionLifecycleConfig still folds equality-gated via
+  // KNOWN_DEFAULT_PATHS, so an enabled rule / non-default MaxCount is still detected.
+  'AWS::ElasticBeanstalk::Application': new Set(['ResourceLifecycleConfig.ServiceRole']),
 };
 
 // Elastic Beanstalk ConfigurationTemplate `OptionSettings` first-run default fold. A template

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -2412,11 +2412,18 @@ const writeElasticBeanstalkApplication: SdkWriter = async (ctx, ops) => {
       // add/replace -> the declared intent (whole object), falling back to the op's carried
       // value then the default. The declared object is preferred over op.value so a NESTED
       // op path still writes the complete, coherent config rather than a leaf fragment.
+      // op.value is only the WHOLE ResourceLifecycleConfig when the op targets the object
+      // itself (`/ResourceLifecycleConfig`); a nested set-default op (#1437 —
+      // `/ResourceLifecycleConfig/VersionLifecycleConfig`, emitted since the object is now
+      // DESCENDED) carries only that sub-block, so writing op.value there would send a
+      // wrapper-less fragment as the whole config. Trust op.value ONLY for the whole-object op;
+      // otherwise fall to the declared object then the default (the coherent whole either way).
+      const targetsWholeObject = op.path.replace(/^\//, '') === 'ResourceLifecycleConfig';
       lifecycle =
         op.op === 'remove'
           ? EB_APPLICATION_DEFAULT_RESOURCE_LIFECYCLE
           : (asObject(ctx.declared['ResourceLifecycleConfig']) ??
-            asObject(op.value) ??
+            (targetsWholeObject ? asObject(op.value) : undefined) ??
             EB_APPLICATION_DEFAULT_RESOURCE_LIFECYCLE);
     }
   }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3315,8 +3315,11 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
           emptySchema
         )
       );
+      // #1437: once ResourceLifecycleConfig diverges from the whole-object default it is DESCENDED,
+      // so the enabled rule surfaces at the precise nested VersionLifecycleConfig sub-block (still
+      // undeclared drift, never atDefault — detection preserved).
       expect(t.atDefault).toEqual([]);
-      expect(t.undeclared).toEqual(['ResourceLifecycleConfig']);
+      expect(t.undeclared).toEqual(['ResourceLifecycleConfig.VersionLifecycleConfig']);
     });
 
     it('an Environment folds the default WebServer/Standard/1.0 Tier and the derived PlatformArn', () => {
@@ -12420,5 +12423,97 @@ describe('#890 EKS AccessEntry.Username derived fold (deterministic transform of
     );
     expect(t.undeclared).toEqual(['Username']);
     expect(t.atDefault).toEqual([]);
+  });
+});
+
+// #1437: EB Application ResourceLifecycleConfig — the AWS-kept ServiceRole residual.
+// A lifecycle change out of band forces EB to stamp a ServiceRole (the
+// UpdateApplicationResourceLifecycle API requires one) and EB KEEPS it even after `revert`
+// writes the disabled default. The whole-object KNOWN_DEFAULTS fold (no ServiceRole) then no
+// longer matches, so the reverted config perpetually surfaced as [Potential Drift]. Descend the
+// object: VersionLifecycleConfig folds equality-gated (KNOWN_DEFAULT_PATHS) and ServiceRole folds
+// value-independent (GENERATED_NESTED_PATHS), while an enabled rule still surfaces.
+describe('EB Application ResourceLifecycleConfig ServiceRole residual (#1437)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const app: DesiredResource = {
+    logicalId: 'App',
+    resourceType: 'AWS::ElasticBeanstalk::Application',
+    physicalId: 'my-eb-app',
+    declared: { ApplicationName: 'my-eb-app' },
+  };
+  const DEFAULT_LIFECYCLE = {
+    VersionLifecycleConfig: {
+      MaxCountRule: { DeleteSourceFromS3: false, Enabled: false, MaxCount: 200 },
+      MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+    },
+  };
+  const SERVICE_ROLE = 'arn:aws:iam::111111111111:role/aws-elasticbeanstalk-service-role';
+
+  it('clean deploy: whole default object (no ServiceRole) folds atDefault — no drift', () => {
+    const t = tiers(
+      classifyResource(app, { ResourceLifecycleConfig: DEFAULT_LIFECYCLE }, emptySchema)
+    );
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault).toEqual(['ResourceLifecycleConfig']);
+  });
+
+  it('post-revert residual: default lifecycle + AWS-kept ServiceRole folds — no [Potential Drift]', () => {
+    const findings = classifyResource(
+      app,
+      { ResourceLifecycleConfig: { ServiceRole: SERVICE_ROLE, ...DEFAULT_LIFECYCLE } },
+      emptySchema
+    );
+    const t = tiers(findings);
+    // The residual is folded, NOT surfaced: VersionLifecycleConfig atDefault, ServiceRole generated.
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault).toEqual(['ResourceLifecycleConfig.VersionLifecycleConfig']);
+    expect(t.generated).toEqual(['ResourceLifecycleConfig.ServiceRole']);
+  });
+
+  it('any ServiceRole value folds (value-independent) — a custom role ARN is still not drift', () => {
+    const t = tiers(
+      classifyResource(
+        app,
+        {
+          ResourceLifecycleConfig: {
+            ServiceRole: 'arn:aws:iam::111111111111:role/some-other-role',
+            ...DEFAULT_LIFECYCLE,
+          },
+        },
+        emptySchema
+      )
+    );
+    expect(t.undeclared).toEqual([]);
+    expect(t.generated).toEqual(['ResourceLifecycleConfig.ServiceRole']);
+  });
+
+  it('detection preserved: an ENABLED MaxCountRule (with a ServiceRole) still surfaces', () => {
+    const t = tiers(
+      classifyResource(
+        app,
+        {
+          ResourceLifecycleConfig: {
+            ServiceRole: SERVICE_ROLE,
+            VersionLifecycleConfig: {
+              MaxCountRule: { DeleteSourceFromS3: false, Enabled: true, MaxCount: 5 },
+              MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+            },
+          },
+        },
+        emptySchema
+      )
+    );
+    // The substantive lifecycle change surfaces; the ServiceRole still folds.
+    expect(t.undeclared).toEqual(['ResourceLifecycleConfig.VersionLifecycleConfig']);
+    expect(t.generated).toEqual(['ResourceLifecycleConfig.ServiceRole']);
   });
 });

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1660,6 +1660,37 @@ describe('buildRevertPlan', () => {
     }
   });
 
+  it('EB Application nested ResourceLifecycleConfig.VersionLifecycleConfig undeclared -> sdk item, op top routes to the EB writer (#1437)', () => {
+    // Post-#1437 an out-of-band lifecycle change surfaces at the DESCENDED nested path (the
+    // ServiceRole residual folds separately), so the revert op path is nested. It must still
+    // route through the EB SDK writer (top segment ResourceLifecycleConfig), which rewrites the
+    // whole lifecycle to the disabled default.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ElasticBeanstalk::Application',
+      path: 'ResourceLifecycleConfig.VersionLifecycleConfig',
+      actual: {
+        MaxCountRule: { DeleteSourceFromS3: false, Enabled: true, MaxCount: 5 },
+        MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+      },
+      physicalId: 'my-eb-app',
+      logicalId: 'App',
+      unrecorded: true,
+    });
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items[0]).toMatchObject({
+      kind: 'sdk',
+      resourceType: 'AWS::ElasticBeanstalk::Application',
+    });
+    const op = plan.items[0]!.ops[0]!;
+    // The nested path is in KNOWN_DEFAULT_PATHS, so it reverts as an explicit set-default `add`
+    // of the default VersionLifecycleConfig (not a bare `remove`). Its op path top segment still
+    // routes to the EB SDK writer, which reconstructs the WHOLE default ResourceLifecycleConfig.
+    expect(op.op).toBe('add');
+    expect(op.path.replace(/^\//, '').split('/')[0]).toBe('ResourceLifecycleConfig');
+  });
+
   it('Cognito IdentityPool: CognitoEvents -> prop-scoped sdk item, a base prop -> cc item', () => {
     // The IdentityPool SDK override only ENRICHES the CC read with the writeOnly
     // CognitoEvents, so it is CC_REVERTABLE_DESPITE_READ_OVERRIDE: base-property reverts

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -1792,6 +1792,32 @@ describe('ElasticBeanstalk Application/Environment writers (CC UpdateResource Se
     });
   });
 
+  it('#1437: an UNDECLARED nested set-default add (no declared config) writes the WHOLE default lifecycle, not the leaf fragment', async () => {
+    eb.on(UpdateApplicationResourceLifecycleCommand).resolves({});
+    // Post-#1437 an out-of-band lifecycle change surfaces at the DESCENDED nested path, so the
+    // undeclared revert plan emits a set-default `add` at `/ResourceLifecycleConfig/
+    // VersionLifecycleConfig` whose value is the VersionLifecycleConfig CONTENTS (no wrapper) and
+    // there is NO declared config. The writer must reconstruct the whole default object — writing
+    // op.value directly would send a wrapper-less fragment as the whole ResourceLifecycleConfig.
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+      ctx({ physicalId: 'my-app', declared: { ApplicationName: 'my-app' } }),
+      [
+        {
+          op: 'add',
+          path: '/ResourceLifecycleConfig/VersionLifecycleConfig',
+          value: DEFAULT_RLC.VersionLifecycleConfig,
+          human: 'ResourceLifecycleConfig.VersionLifecycleConfig -> AWS default',
+        },
+      ]
+    );
+    const calls = eb.commandCalls(UpdateApplicationResourceLifecycleCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({
+      ApplicationName: 'my-app',
+      ResourceLifecycleConfig: DEFAULT_RLC,
+    });
+  });
+
   it('applies Description AND ResourceLifecycleConfig in one op set (two distinct commands)', async () => {
     eb.on(UpdateApplicationCommand).resolves({});
     eb.on(UpdateApplicationResourceLifecycleCommand).resolves({});


### PR DESCRIPTION
## Summary

Fixes both nuances in #1437 around reverting `AWS::ElasticBeanstalk::Application.ResourceLifecycleConfig`.

An out-of-band lifecycle change forces EB to stamp a `ServiceRole` (the `UpdateApplicationResourceLifecycle` API requires one), and EB **keeps** that `ServiceRole` even after `revert` writes the disabled-rules default back. The whole-object `KNOWN_DEFAULTS` fold (which carries no `ServiceRole`) then no longer matched, so:

- **Nuance 1** — the reverted config perpetually surfaced as `[Potential Drift]` (the residual `ServiceRole` broke the whole-object equality gate).
- **Nuance 2** — the revert convergence re-read reported `CLEAN after revert` while a fresh `check` showed the residual, because the residual was borderline-foldable and the two reads raced EB's eventual consistency.

## Fix

Descend an undeclared `ResourceLifecycleConfig` (`DESCEND_UNDECLARED_OBJECT_PATHS`) so its two halves fold independently — the exact `AWS::MSK::Cluster` `EncryptionInfo` precedent:

- **`VersionLifecycleConfig`** → equality-gated `KNOWN_DEFAULT_PATHS` (tier 1). An enabled rule / non-default `MaxCount` still breaks the gate and surfaces → **detection preserved**.
- **`ServiceRole`** → value-independent `GENERATED_NESTED_PATHS` (tier 3). It is an AWS-assigned/kept IAM role ARN, never user intent when undeclared (the RDS/OpenSearch/MSK `KmsKeyId` class); a user who wants a specific role **declares** it, compared in the declared loop.

The whole-object `KNOWN_DEFAULTS` entry stays as the clean-deploy fast path.

Because the residual now folds **regardless of read timing**, the convergence re-read and a fresh `check` agree — **nuance 2 is resolved as a consequence of nuance 1** (no speculative change to the shared convergence path).

The descent makes an undeclared lifecycle drift revert as a set-default `add` at the nested path, so the EB SDK writer now reconstructs the **whole** default `ResourceLifecycleConfig` for any nested op (`op.value` is trusted only for a whole-object op) instead of sending a wrapper-less leaf fragment.

## Tests

- `classify.test.ts` — clean deploy folds whole-object; post-revert residual (`ServiceRole` + default lifecycle) folds (no `[Potential Drift]`); any `ServiceRole` value folds; an enabled `MaxCountRule` still surfaces at `VersionLifecycleConfig`. Updated the existing `#1295`-era "enabled rule" test to the now-precise nested path.
- `revert-plan.test.ts` — the nested undeclared finding plans a set-default `add` whose op top routes to the EB SDK writer.
- `writers.test.ts` — an undeclared nested set-default `add` (no declared config) writes the **whole** default lifecycle, not the leaf fragment.
- Full suite: 4955 pass; typecheck + lint clean.

## Live verification (us-east-1, torn down)

1. Deploy an EB Application with no `ResourceLifecycleConfig` → first `check` **CLEAN**.
2. `aws elasticbeanstalk update-application-resource-lifecycle` with a `ServiceRole` + enabled `MaxCountRule` (MaxCount=5).
3. `check` → `[Potential Drift: 1]` on `ResourceLifecycleConfig.VersionLifecycleConfig`; `ServiceRole` folds `[AWS Generated]`.
4. `revert --remove-unrecorded --yes` → `CLEAN after revert`; live `MaxCount` back to 200, `ServiceRole` still present (the AWS constraint).
5. Fresh `check` → **CLEAN** (`VersionLifecycleConfig` `[At AWS Default]`, `ServiceRole` `[AWS Generated]`) — nuance 1 fixed, convergence + check agree (nuance 2).
6. A/B vs installed `0.12.57`: old surfaces the whole `ResourceLifecycleConfig` as `[Potential Drift]`; new folds it.

Closes #1437
