### PR TITLE
fix(diff): surface out-of-band nested off-flip via MEANINGFUL_WHEN_OFF_NESTED — CloudFront IPV6Enabled disable (part of #660)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -671,7 +671,12 @@ curated `MEANINGFUL_WHEN_OFF` allowlist in `classify.ts` names the exact
 pin and surfaces them even on a first run; it is predicate-gated (NOT a blanket
 "any diverging `false` surfaces") because most "default true" booleans are
 CONDITIONAL — an SSE-KMS queue reads `SqsManagedSseEnabled:false` legitimately,
-so the predicate surfaces the OFF state only when the queue uses no KMS key.
+so the predicate surfaces the OFF state only when the queue uses no KMS key. A
+NESTED twin (`MEANINGFUL_WHEN_OFF_NESTED`) applies the same predicate-gated carve-out
+to `KNOWN_DEFAULT_PATHS`-pinned nested booleans that `emitNested` would otherwise
+swallow (e.g. CloudFront `DistributionConfig.IPV6Enabled` disabled out of band, #660);
+it stays a curated allowlist because the blanket nested version broke Route53
+`EnableSNI` (a non-HTTPS HealthCheck legitimately reads `false`).
 
 ## 7. Revert (the only AWS-mutating path)
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -191,6 +191,29 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   },
 };
 
+// #660 item 3: the NESTED twin of MEANINGFUL_WHEN_OFF. The table above gates TOP-LEVEL
+// undeclared booleans; a nested `KNOWN_DEFAULT_PATHS`-pinned `true` flipped `false` out of
+// band is swallowed by `isTrivialEmpty(false)` inside `emitNested` BEFORE the nested pin gate
+// ever runs (the CloudFront `DistributionConfig.IPV6Enabled` disable, #1459 — pinning the
+// default removed the first-run FP but the off-flip stayed invisible). Keyed by resourceType →
+// the pin's SCHEMA-PATH (array indices collapsed to `.*`, the same form `emitNested` computes)
+// → a predicate on { declared, live } that returns true only when the OFF state is a genuine
+// divergence in EVERY clean-deploy configuration of the type. This is a CURATED allowlist, NOT
+// a blanket nested rule: the blanket nested version was reverted in #632 because it broke
+// Route53 `EnableSNI` (a non-HTTPS HealthCheck legitimately reads `false`). Add an entry ONLY
+// after a live confirm that a clean deploy ALWAYS reads the pinned `true` (no restore / import /
+// config path yields an untouched `false`).
+const MEANINGFUL_WHEN_OFF_NESTED: Record<
+  string,
+  Record<string, (ctx: OffStateContext) => boolean>
+> = {
+  // A CloudFront distribution enables IPv6 by default on every clean deploy (the
+  // `DistributionConfig.IPV6Enabled` pin, #1459 live-verified — no restore/import path yields
+  // an untouched `false`), so an undeclared live `false` is unambiguously an out-of-band
+  // disable of dual-stack delivery. Unconditionally meaningful when off.
+  'AWS::CloudFront::Distribution': { 'DistributionConfig.IPV6Enabled': () => true },
+};
+
 // #1092: GuardDuty protection Features whose new-detector default Status is DISABLED (not the
 // ENABLED norm) — a newer/preview protection AWS ships OFF by default. Its DISABLED state on a
 // clean detector is the default (folds), so only these names are exempt from the "ENABLED is the
@@ -3240,7 +3263,20 @@ export function classifyResource(
   const underFreeFormMap = (schemaPath: string): boolean =>
     freeFormMapPaths.some((ff) => schemaPath.startsWith(`${ff}.`));
   const emitNested = (path: string, value: unknown): void => {
-    if (isTrivialEmpty(value)) return;
+    const schemaPath = path.replace(/\[[^\]]*\]/g, '.*');
+    // #660 item 3: the nested twin of the top-level MEANINGFUL_WHEN_OFF gate (classify.ts). A
+    // nested undeclared value pinned `true` by KNOWN_DEFAULT_PATHS that is flipped `false` out
+    // of band DIVERGES from its pin, but `isTrivialEmpty(false)` would swallow it BELOW —
+    // before the atDefault pin gate ever runs (the CloudFront `DistributionConfig.IPV6Enabled`
+    // disable, #1459). When the value diverges from its pin AND the curated nested predicate
+    // says the OFF state is genuinely meaningful in this config, DON'T drop it — let it fall
+    // through to surface as nested `undeclared` (the atDefault gate below returns false because
+    // the value differs from the pin, so it lands as a real out-of-band divergence).
+    const offStateIsMeaningful =
+      schemaPath in knownDefPaths &&
+      !matchesKnownDefault(value, knownDefPaths[schemaPath]) &&
+      (MEANINGFUL_WHEN_OFF_NESTED[resourceType]?.[schemaPath]?.({ declared, live }) ?? false);
+    if (!offStateIsMeaningful && isTrivialEmpty(value)) return;
     // #863: `isAllAwsTags` matches two shapes — an ARRAY of `{Key:'aws:*'}` (an unambiguous
     // tag LIST: AWS-managed system tags, always safe to drop) and an OBJECT whose keys are
     // all `aws:*` (a MAP-shaped tag, e.g. UserPoolTags — BUT ALSO an IAM policy Condition
@@ -3254,7 +3290,6 @@ export function classifyResource(
       const parentKey = (path.split('.').pop() ?? '').replace(/\[.*$/, '');
       if (!isObjectForm || /tags$/i.test(parentKey)) return;
     }
-    const schemaPath = path.replace(/\[[^\]]*\]/g, '.*');
     // Same subset-tolerant default match as the top-level atDefault compare: an
     // OBJECT-valued nested default (CloudFront GeoRestriction, Scheduler RetryPolicy,
     // Cognito SignInPolicy, …) that AWS returns with a sub-key omitted still folds,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1806,9 +1806,9 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   'AWS::CloudFront::Distribution': {
     // CloudFront enables IPv6 on a distribution by default when the template omits it
     // (#1459, live-verified), so an undeclared live `true` folds to atDefault instead of
-    // surfacing as a first-run FP. (An out-of-band flip to `false` is swallowed by
-    // isTrivialEmpty before the pin gate — restoring its detection is the #660-class nested
-    // MEANINGFUL_WHEN_OFF follow-up; pinning here removes the FP without regressing it.)
+    // surfacing as a first-run FP. An out-of-band flip to `false` now surfaces via the nested
+    // MEANINGFUL_WHEN_OFF twin (#660 item 3, classify.ts MEANINGFUL_WHEN_OFF_NESTED) — it was
+    // previously swallowed by isTrivialEmpty before this pin gate.
     'DistributionConfig.IPV6Enabled': true,
     'DistributionConfig.OriginGroups': { Quantity: 0, Items: [] },
     'DistributionConfig.Origins.*.ConnectionAttempts': 3,

--- a/tests/noise-cf-r53r-firstrun-1459-1458-1455.test.ts
+++ b/tests/noise-cf-r53r-firstrun-1459-1458-1455.test.ts
@@ -91,11 +91,15 @@ describe('#1459 CloudFront custom-origin OriginSSLProtocols + IPV6Enabled defaul
     expect(pathsByTier(f, 'atDefault')).toContain('DistributionConfig.IPV6Enabled');
   });
 
-  // NOTE: an out-of-band IPV6Enabled=false disable is NOT surfaced here — a nested `false`
-  // is swallowed by isTrivialEmpty before the pin gate, and the nested MEANINGFUL_WHEN_OFF
-  // wiring that would preserve it is the #660-class deferred follow-up (see classify.ts
-  // MEANINGFUL_WHEN_OFF header). Pinning the default still correctly removes the first-run FP
-  // (the reported symptom) without regressing detection (false was already swallowed before).
+  // #660 item 3: an out-of-band IPV6Enabled=false disable — a nested `false` that used to be
+  // swallowed by isTrivialEmpty before the pin gate — now surfaces as `undeclared` via the
+  // nested MEANINGFUL_WHEN_OFF twin, while the clean `true` still folds atDefault (above).
+  it('surfaces an out-of-band undeclared IPV6Enabled=false disable as undeclared (#660)', () => {
+    const f = classifyResource(res, live({ ipv6: false }), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('DistributionConfig.IPV6Enabled');
+    // The sibling undeclared creation defaults still fold — only the disabled flag surfaces.
+    expect(pathsByTier(f, 'atDefault')).toContain(SSL_PATH);
+  });
 });
 
 describe('#1455 Route53Resolver FirewallRuleGroupAssociation MutationProtection default', () => {


### PR DESCRIPTION
## Part of #660 (item 3: nested `MEANINGFUL_WHEN_OFF`)

The top-level `MEANINGFUL_WHEN_OFF` gate in `classify.ts` had **no nested twin**, so a nested `KNOWN_DEFAULT_PATHS`-pinned `true` flipped `false` out of band was swallowed by `isTrivialEmpty(false)` inside `emitNested` **before** the pin gate ever ran. The CloudFront `DistributionConfig.IPV6Enabled` disable is the exact case: #1459 pinned the default to kill the first-run FP, but explicitly deferred the off-flip detection to this #660-class follow-up — so an out-of-band IPv6 disable read **CLEAN** (a false negative: undetectable, unrecordable, unrevertable).

### Fix
- New `MEANINGFUL_WHEN_OFF_NESTED` table (`resourceType → schema-path → { declared, live }` predicate) — the nested twin of `MEANINGFUL_WHEN_OFF`.
- `emitNested` now hoists `schemaPath` and consults it: when a nested value **diverges from its `KNOWN_DEFAULT_PATHS` pin** AND the curated predicate says the OFF state is meaningful, it is **not** dropped — it falls through to surface as nested `undeclared`.
- Seeded with `AWS::CloudFront::Distribution` → `DistributionConfig.IPV6Enabled` (unconditionally meaningful when off — a clean deploy always reads `true`, no restore/import path yields an untouched `false`).
- Kept a **curated allowlist**, not blanket: the blanket nested version was reverted in #632 because it broke Route53 `EnableSNI` (a non-HTTPS HealthCheck legitimately reads `false`).

### Live A/B — `Cdkrd660VerifyIpv6` (us-east-1), swept clean
| | clean deploy | after out-of-band IPv6 disable |
|---|---|---|
| **base** | 1 drift (unrelated Cookies FP), `IPV6Enabled` folds atDefault | 1 drift — **`IPV6Enabled` invisible (FN)** |
| **fix** | 1 drift (same), `IPV6Enabled` folds atDefault | **2 drift — surfaces `DistributionConfig.IPV6Enabled` `actual=false`** |

Detection restored; zero new first-run FP. Corpus-replay on 3 real harvested CloudFront Distribution models still green.

### Scope
Partial fix. Item 1 (restore/import-path booleans) and the other nested paths (Athena / EKS / Cognito-password / Route53 `EnableSNI`) stay open — each needs its own live verification. **No auto-close.**
