### PR TITLE
fix(diff): GuardDuty Detector Features first-run FP returns as AWS ships new protections OFF by default (#1485)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -214,18 +214,40 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
   'AWS::CloudFront::Distribution': { 'DistributionConfig.IPV6Enabled': () => true },
 };
 
-// #1092: GuardDuty protection Features whose new-detector default Status is DISABLED (not the
-// ENABLED norm) — a newer/preview protection AWS ships OFF by default. Its DISABLED state on a
-// clean detector is the default (folds), so only these names are exempt from the "ENABLED is the
-// default" rule below. Extend as AWS ships more OFF-by-default features.
-const GUARDDUTY_DEFAULT_DISABLED_FEATURES: ReadonlySet<string> = new Set(['AI_ANALYST']);
-// True when every GuardDuty Feature (and every nested AdditionalConfiguration entry) is at its
-// per-name default Status — ENABLED for every protection except the known OFF-by-default set.
-// Name-independent for UNKNOWN names (a brand-new protection AWS ships ENABLED still folds), but
-// an out-of-band disable of a protection whose default is ENABLED (RUNTIME_MONITORING,
-// RDS_LOGIN_EVENTS, LAMBDA_NETWORK_LOGS — none have a legacy DataSources mirror) surfaces. Errs
-// toward VISIBILITY: a future OFF-by-default feature not yet in the set surfaces (a recordable FP)
-// rather than hiding a real security downgrade.
+// #1092/#1485: GuardDuty protection Features (and their nested AdditionalConfiguration members)
+// whose new-detector creation-default Status is NOT the ENABLED norm — a newer/preview protection
+// AWS ships OFF by default. Keyed by feature Name → the acceptable creation Status(es); a name
+// absent here defaults to ['ENABLED']. A single-element list preserves detection in BOTH
+// directions (an out-of-band flip away from the default surfaces). A TWO-element list is the
+// era-dependent ONE_OF case (#1486-class): AWS moved the creation default between eras, so either
+// value is a valid clean-deploy default and folds — this LOSES out-of-band detection on that one
+// feature, accepted only because the value is undeclared (a user who cares declares it, and the
+// declared loop then compares it).
+//
+// #1485: a fresh `Enable: true`-only detector today (2026-07, us-east-1) materializes AI_ANALYST,
+// RUNTIME_MONITORING, and EKS_RUNTIME_MONITORING (plus the latter two's AdditionalConfiguration
+// agent-management members) DISABLED at creation — the #1092 all-ENABLED assumption no longer
+// holds and the whole Features array first-run-FP'd. RUNTIME_MONITORING / EKS_RUNTIME_MONITORING
+// are ONE_OF because #1092's own live run observed them ENABLED at creation in its era (the
+// runtime-monitoring family's default moved ENABLED→DISABLED); folding either avoids a first-run
+// FP on a detector created in either era. AI_ANALYST (2026-new, only ever OFF) and the granular
+// agent-management members (a modern-era-only construct materialized OFF) stay single-status
+// DISABLED, so an out-of-band ENABLE — a billable protection turned on later — still surfaces.
+const GUARDDUTY_FEATURE_CREATION_STATUS: Record<string, readonly string[]> = {
+  AI_ANALYST: ['DISABLED'],
+  RUNTIME_MONITORING: ['DISABLED', 'ENABLED'],
+  EKS_RUNTIME_MONITORING: ['DISABLED', 'ENABLED'],
+  EKS_ADDON_MANAGEMENT: ['DISABLED'],
+  ECS_FARGATE_AGENT_MANAGEMENT: ['DISABLED'],
+  EC2_AGENT_MANAGEMENT: ['DISABLED'],
+};
+// True when every GuardDuty Feature (and every nested AdditionalConfiguration entry) is at one of
+// its per-name creation-default Status(es) — ENABLED for every protection except the OFF-by-default
+// / era-moved names in GUARDDUTY_FEATURE_CREATION_STATUS. Name-independent for UNKNOWN names (a
+// brand-new protection AWS ships ENABLED still folds), but an out-of-band disable of a
+// default-ENABLED protection (RDS_LOGIN_EVENTS, LAMBDA_NETWORK_LOGS, …) surfaces. Errs toward
+// VISIBILITY: a future OFF-by-default feature not yet in the map surfaces (a recordable FP) rather
+// than hiding a real security downgrade.
 function guardDutyFeaturesAllAtDefault(features: unknown[]): boolean {
   const atDefault = (node: unknown): boolean => {
     if (Array.isArray(node)) return node.every(atDefault);
@@ -233,10 +255,8 @@ function guardDutyFeaturesAllAtDefault(features: unknown[]): boolean {
       const rec = node as Record<string, unknown>;
       if ('Status' in rec) {
         const name = typeof rec['Name'] === 'string' ? rec['Name'] : '';
-        const defaultStatus = GUARDDUTY_DEFAULT_DISABLED_FEATURES.has(name)
-          ? 'DISABLED'
-          : 'ENABLED';
-        if (rec['Status'] !== defaultStatus) return false;
+        const defaults = GUARDDUTY_FEATURE_CREATION_STATUS[name] ?? ['ENABLED'];
+        if (typeof rec['Status'] !== 'string' || !defaults.includes(rec['Status'])) return false;
       }
       return Object.values(rec).every(atDefault);
     }
@@ -4325,10 +4345,10 @@ export function classifyResource(
       }
       continue;
     }
-    // #1092: GuardDuty Detector Features — fold atDefault ONLY when EVERY protection is
-    // ENABLED (the new-detector default). Replaces the old value-independent fold, which hid
-    // an out-of-band disable of a Features-only protection (a real security downgrade that
-    // never even got recorded). Name-independent, Status-gated (see guardDutyFeaturesAllEnabled).
+    // #1092/#1485: GuardDuty Detector Features — fold atDefault ONLY when EVERY protection is at
+    // its per-name creation-default Status (see guardDutyFeaturesAllAtDefault). Replaces the old
+    // value-independent fold, which hid an out-of-band disable of a Features-only protection (a
+    // real security downgrade that never even got recorded).
     if (resourceType === 'AWS::GuardDuty::Detector' && k === 'Features' && Array.isArray(v)) {
       findings.push({
         tier: guardDutyFeaturesAllAtDefault(v) ? 'atDefault' : 'undeclared',

--- a/tests/noise-guardduty-879.test.ts
+++ b/tests/noise-guardduty-879.test.ts
@@ -124,13 +124,16 @@ describe('#879 GuardDuty::Detector undeclared first-run defaults', () => {
   });
 
   // #1092: the security FNs the old value-independent Features fold + the trivial-empty drop hid.
-  it('#1092: surfaces an out-of-band disable of a Features-only protection (RUNTIME_MONITORING)', () => {
+  // #1485: RUNTIME_MONITORING's creation default moved ENABLED->DISABLED across eras, so it is now
+  // ONE_OF (a DISABLED runtime monitor is a valid clean-deploy default and no longer surfaces).
+  // The #1092 FN-protection intent — an out-of-band disable of a still-default-ENABLED protection
+  // surfaces — is re-expressed on RDS_LOGIN_EVENTS (unchanged ENABLED default).
+  it('#1092/#1485: surfaces an out-of-band disable of a default-ENABLED protection (RDS_LOGIN_EVENTS)', () => {
     const changed = {
       ...cleanLive,
       Features: [
         ...defaultFeatures,
-        { Status: 'ENABLED', Name: 'RDS_LOGIN_EVENTS' },
-        { Status: 'DISABLED', Name: 'RUNTIME_MONITORING' }, // ENABLED-by-default -> disable surfaces
+        { Status: 'DISABLED', Name: 'RDS_LOGIN_EVENTS' }, // ENABLED-by-default -> disable surfaces
       ],
     };
     const f = classifyResource(res, changed, emptySchema);
@@ -138,15 +141,19 @@ describe('#879 GuardDuty::Detector undeclared first-run defaults', () => {
     expect(pathsByTier(f, 'atDefault')).not.toContain('Features');
   });
 
-  it('#1092: surfaces a disable nested in a feature AdditionalConfiguration', () => {
+  // #1485: the granular AdditionalConfiguration agent-management members are DISABLED at creation,
+  // so an out-of-band ENABLE (a billable protection turned on later) is the meaningful drift that
+  // must surface — the nested-detection intent of the original #1092 test, updated for the moved
+  // default.
+  it('#1092/#1485: surfaces an out-of-band enable nested in a feature AdditionalConfiguration', () => {
     const changed = {
       ...cleanLive,
       Features: [
         ...defaultFeatures,
         {
-          Status: 'ENABLED',
+          Status: 'DISABLED',
           Name: 'RUNTIME_MONITORING',
-          AdditionalConfiguration: [{ Status: 'DISABLED', Name: 'EKS_ADDON_MANAGEMENT' }],
+          AdditionalConfiguration: [{ Status: 'ENABLED', Name: 'EKS_ADDON_MANAGEMENT' }],
         },
       ],
     };
@@ -166,5 +173,106 @@ describe('#879 GuardDuty::Detector undeclared first-run defaults', () => {
     const f = classifyResource(res, changed, emptySchema);
     expect(pathsByTier(f, 'undeclared')).toContain('DataSources');
     expect(pathsByTier(f, 'atDefault')).not.toContain('DataSources');
+  });
+});
+
+// #1485: a fresh `Enable: true`-only detector now (2026-07, us-east-1) materializes THREE features
+// DISABLED at creation (AI_ANALYST / RUNTIME_MONITORING / EKS_RUNTIME_MONITORING, plus the latter
+// two's AdditionalConfiguration agent-management members), breaking #1092's all-ENABLED gate and
+// re-surfacing the whole Features array as first-run [Potential Drift]. The per-name creation-Status
+// map must fold the clean model to atDefault while still surfacing an out-of-band ENABLE of an
+// OFF-by-default protection.
+describe('#1485 GuardDuty::Detector Features — new-era OFF-by-default protections', () => {
+  const res: DesiredResource = {
+    logicalId: 'HuntDetector',
+    resourceType: 'AWS::GuardDuty::Detector',
+    physicalId: '2fbe7ac257dc491d9992398365731fc9',
+    declared: { Enable: true },
+  };
+  // The full live Features list of a fresh detector, harvested 2026-07-12 (issue #1485).
+  const cleanFeatures = [
+    { Status: 'DISABLED', Name: 'AI_ANALYST' },
+    { Status: 'ENABLED', Name: 'CLOUD_TRAIL' },
+    { Status: 'ENABLED', Name: 'DNS_LOGS' },
+    { Status: 'ENABLED', Name: 'FLOW_LOGS' },
+    { Status: 'ENABLED', Name: 'S3_DATA_EVENTS' },
+    { Status: 'ENABLED', Name: 'EKS_AUDIT_LOGS' },
+    { Status: 'ENABLED', Name: 'EBS_MALWARE_PROTECTION' },
+    { Status: 'ENABLED', Name: 'RDS_LOGIN_EVENTS' },
+    { Status: 'ENABLED', Name: 'LAMBDA_NETWORK_LOGS' },
+    {
+      Status: 'DISABLED',
+      Name: 'EKS_RUNTIME_MONITORING',
+      AdditionalConfiguration: [{ Status: 'DISABLED', Name: 'EKS_ADDON_MANAGEMENT' }],
+    },
+    {
+      Status: 'DISABLED',
+      Name: 'RUNTIME_MONITORING',
+      AdditionalConfiguration: [
+        { Status: 'DISABLED', Name: 'EKS_ADDON_MANAGEMENT' },
+        { Status: 'DISABLED', Name: 'ECS_FARGATE_AGENT_MANAGEMENT' },
+        { Status: 'DISABLED', Name: 'EC2_AGENT_MANAGEMENT' },
+      ],
+    },
+  ];
+  const cleanLive = {
+    Enable: true,
+    FindingPublishingFrequency: 'SIX_HOURS',
+    Features: cleanFeatures,
+  };
+
+  it('folds the fresh-detector Features (three OFF-by-default protections) to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Features');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Features');
+  });
+
+  it('produces ZERO potential drift on the clean 2026 detector', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band ENABLE of AI_ANALYST (default DISABLED, billable enable)', () => {
+    const changed = {
+      ...cleanLive,
+      Features: cleanFeatures.map((x) =>
+        x.Name === 'AI_ANALYST' ? { ...x, Status: 'ENABLED' } : x
+      ),
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('Features');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('Features');
+  });
+
+  it('surfaces an out-of-band ENABLE of a nested agent-management member (EC2_AGENT_MANAGEMENT)', () => {
+    const changed = {
+      ...cleanLive,
+      Features: cleanFeatures.map((x) =>
+        x.Name === 'RUNTIME_MONITORING'
+          ? {
+              ...x,
+              AdditionalConfiguration: (x.AdditionalConfiguration ?? []).map((m) =>
+                m.Name === 'EC2_AGENT_MANAGEMENT' ? { ...m, Status: 'ENABLED' } : m
+              ),
+            }
+          : x
+      ),
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('Features');
+  });
+
+  it('folds RUNTIME_MONITORING=ENABLED too (era ONE_OF — a detector created when it was ON-by-default)', () => {
+    const olderEra = {
+      ...cleanLive,
+      Features: cleanFeatures.map((x) =>
+        x.Name === 'RUNTIME_MONITORING' || x.Name === 'EKS_RUNTIME_MONITORING'
+          ? { Status: 'ENABLED', Name: x.Name }
+          : x
+      ),
+    };
+    const f = classifyResource(res, olderEra, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Features');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Features');
   });
 });


### PR DESCRIPTION
Closes #1485

## Problem

A fresh `Enable: true`-only GuardDuty detector today (2026-07, us-east-1) materializes THREE Features **DISABLED at creation** — `AI_ANALYST`, `RUNTIME_MONITORING`, `EKS_RUNTIME_MONITORING` (plus the latter two's `AdditionalConfiguration` agent-management members) — breaking #1092's all-ENABLED gate, so the whole `Features` array surfaced as `[Potential Drift]` on every first `check`: the exact FP #1092 set out to prevent.

## Fix

Replace the single OFF-by-default set (`AI_ANALYST` only) with a per-feature creation-`Status` map `GUARDDUTY_FEATURE_CREATION_STATUS`, keyed by `Name` to the acceptable creation `Status`(es). A name absent from the map keeps the ENABLED norm (an out-of-band disable of a default-ENABLED protection still surfaces — #1092's FN protection preserved). Single-status entries preserve detection in both directions; a two-status entry is the era-dependent ONE_OF case:

- `AI_ANALYST` to `[DISABLED]` (2026-new, only ever OFF) — an out-of-band **enable** still surfaces.
- `RUNTIME_MONITORING` / `EKS_RUNTIME_MONITORING` to `[DISABLED, ENABLED]` — the runtime-monitoring family's creation default moved ENABLED to DISABLED across eras (#1092's own live run observed them ENABLED at creation), so folding either avoids a first-run FP on a detector created in **either** era. ONE_OF tradeoff (an out-of-band flip folds silently) accepted only because the value is undeclared.
- granular agent-management members (`EKS_ADDON_MANAGEMENT`, `ECS_FARGATE_AGENT_MANAGEMENT`, `EC2_AGENT_MANAGEMENT`) to `[DISABLED]` — a modern-era-only construct materialized OFF; an out-of-band enable surfaces.

## Tests

The two #1092 tests that asserted the OLD default (RUNTIME_MONITORING / EKS_ADDON_MANAGEMENT surfacing when DISABLED) are re-expressed on genuinely default-ENABLED / OFF-by-default features. A new `#1485` block replays the **full harvested live model** of a fresh 2026 detector (zero first-run drift) plus the out-of-band-ENABLE detections. Full suite: 5132 tests pass, typecheck + lint + build clean.

## Verification

Fold/FP classify fix. The harvested live model in the issue (2026-07-12, us-east-1) is the authoritative live evidence and the unit test replays it exactly. A fresh live A/B deploy is **deliberately deferred**: `AWS::GuardDuty::Detector` is an account-global security service (one detector per account/region) — deploying/deleting one could disrupt the maintainer's real security posture, and the account likely already has a detector enabled.
