### PR TITLE
fix(noise): fold SecurityHub Hub era-dependent ControlFindingGenerator default (#1486)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1603,6 +1603,19 @@ export const KNOWN_DEFAULT_ONE_OF: Record<string, Record<string, readonly unknow
   'AWS::ApiGatewayV2::Integration': {
     TimeoutInMillis: [29000, 30000],
   },
+  // #1486: a SecurityHub Hub materializes ControlFindingGenerator at creation, and the value is
+  // ERA-dependent (the S3 TransitionDefaultMinimumObjectSize class, #1249): a hub enabled after
+  // consolidated control findings GA (2023-02) reads "SECURITY_CONTROL", one enabled before that
+  // never opted in reads "STANDARD_CONTROL". Both are stable constants, but the discriminator —
+  // the account's enablement era — is off the resource's own model, so a single KNOWN_DEFAULTS
+  // constant would first-run-FP on the other era (the same-template asymmetry ONE_OF exists for).
+  // Folding {SECURITY_CONTROL, STANDARD_CONTROL} keeps a clean hub of either era at zero first-run
+  // drift while equality-gating preserves detection: a user who DECLARES it is compared in the
+  // declared dimension (never folded), and any THIRD value still surfaces. ONE_OF tradeoff — an
+  // out-of-band flip between the two folds silently, accepted only because the value is undeclared.
+  'AWS::SecurityHub::Hub': {
+    ControlFindingGenerator: ['SECURITY_CONTROL', 'STANDARD_CONTROL'],
+  },
 };
 
 // The NESTED-path twin of KNOWN_DEFAULT_ONE_OF (#979): a nested undeclared value whose AWS

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -12614,3 +12614,64 @@ describe('EB Application ResourceLifecycleConfig ServiceRole residual (#1437)', 
     expect(t.generated).toEqual(['ResourceLifecycleConfig.ServiceRole']);
   });
 });
+
+// #1486: SecurityHub Hub ControlFindingGenerator is an era-dependent creation default folded via
+// the top-level KNOWN_DEFAULT_ONE_OF {SECURITY_CONTROL, STANDARD_CONTROL}. A fresh hub (harvested
+// live 2026-07-12) reads SECURITY_CONTROL; a pre-2023 hub reads STANDARD_CONTROL. Either folds to
+// atDefault (zero first-run drift); a third value or a declared value still surfaces.
+describe('#1486 SecurityHub::Hub ControlFindingGenerator era-dependent ONE_OF default', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const hub = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'HuntHub',
+    resourceType: 'AWS::SecurityHub::Hub',
+    physicalId: 'arn:aws:securityhub:us-east-1:123456789012:hub/default',
+    declared,
+  });
+  // The full live model of a fresh hub, harvested 2026-07-12 (issue #1486). SubscribedAt / ARN
+  // are already stripped/folded elsewhere; AutoEnableControls did not surface.
+  const cleanLive = { ControlFindingGenerator: 'SECURITY_CONTROL', AutoEnableControls: false };
+
+  it('folds the fresh-hub ControlFindingGenerator=SECURITY_CONTROL to atDefault (zero drift)', () => {
+    const t = tiers(classifyResource(hub({}), cleanLive, emptySchema));
+    expect(t.atDefault).toContain('ControlFindingGenerator');
+    expect(t.undeclared).not.toContain('ControlFindingGenerator');
+  });
+
+  it('folds the pre-2023 era default ControlFindingGenerator=STANDARD_CONTROL too', () => {
+    const t = tiers(
+      classifyResource(hub({}), { ControlFindingGenerator: 'STANDARD_CONTROL' }, emptySchema)
+    );
+    expect(t.atDefault).toContain('ControlFindingGenerator');
+    expect(t.undeclared).not.toContain('ControlFindingGenerator');
+  });
+
+  it('surfaces a THIRD, non-default ControlFindingGenerator value (detection preserved)', () => {
+    const t = tiers(
+      classifyResource(hub({}), { ControlFindingGenerator: 'SOMETHING_ELSE' }, emptySchema)
+    );
+    expect(t.undeclared).toContain('ControlFindingGenerator');
+    expect(t.atDefault).not.toContain('ControlFindingGenerator');
+  });
+
+  it('does not fold the same value on an UNLISTED resource type', () => {
+    const other: DesiredResource = {
+      logicalId: 'X',
+      resourceType: 'AWS::Other::Thing',
+      physicalId: 'x',
+      declared: {},
+    };
+    const t = tiers(
+      classifyResource(other, { ControlFindingGenerator: 'SECURITY_CONTROL' }, emptySchema)
+    );
+    expect(t.undeclared).toContain('ControlFindingGenerator');
+  });
+});


### PR DESCRIPTION
Closes #1486

## Problem

A barest SecurityHub hub (`CfnHub()`, nothing declared) surfaced `ControlFindingGenerator = "SECURITY_CONTROL"` as `[Potential Drift]` on a first `check` — an AWS creation default that was never folded.

## Fix

The value is **era-dependent** (the S3 `TransitionDefaultMinimumObjectSize` class, #1249): a hub enabled after consolidated control findings GA (2023-02) reads `SECURITY_CONTROL`, one enabled before that never opted in reads `STANDARD_CONTROL`. Both are stable constants, but the discriminator — the account's enablement era — is off the resource's own model, so a single `KNOWN_DEFAULTS` constant would first-run-FP on the other era.

Add `AWS::SecurityHub::Hub` to `{ ControlFindingGenerator: [SECURITY_CONTROL, STANDARD_CONTROL] }` in the top-level `KNOWN_DEFAULT_ONE_OF` table. Folding the set keeps a clean hub of either era at zero first-run drift while equality-gating preserves detection: a declared value is compared in the declared dimension (never folded), and any **third** value still surfaces. ONE_OF tradeoff — an out-of-band flip between the two folds silently, accepted only because the value is undeclared.

## Tests

A `#1486` block replays the harvested live model: fresh hub folds, pre-2023 era value folds, a third value surfaces, an unlisted type is not folded. Full suite: 5131 tests pass, typecheck + lint + build clean.

## Verification

Fold/FP noise fix. The harvested live model in the issue (2026-07-12, us-east-1) is the authoritative live evidence and the unit test replays it exactly. A fresh live A/B deploy is **deliberately deferred**: `AWS::SecurityHub::Hub` is an account-global security service (one hub per account/region) — enabling/disabling it could disrupt the maintainer's real security posture, and the account likely already has SecurityHub enabled.
