### PR TITLE
fix(diff): fold ON_DEMAND Kinesis stream undeclared ShardCount (#1487)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -4621,6 +4621,22 @@ export function classifyResource(
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;
     }
+    // #1487: an ON_DEMAND Kinesis stream cannot declare `ShardCount` (CloudFormation rejects
+    // ShardCount together with `StreamMode: ON_DEMAND`), so the undeclared live value can never be
+    // user intent; AWS materializes an initial shard count (4 today) and AUTO-SCALES it with
+    // traffic, so no constant pins it — a tier-2 sibling-gated, value-independent fold. Gate on the
+    // effective `StreamModeDetails.StreamMode` (declared preferred, else the live echo) being
+    // ON_DEMAND. A PROVISIONED stream declares `ShardCount` and is compared in the declared loop
+    // (unchanged), so this never hides a provisioned-count drift.
+    if (resourceType === 'AWS::Kinesis::Stream' && k === 'ShardCount') {
+      const streamMode =
+        (declared.StreamModeDetails as Record<string, unknown> | undefined)?.StreamMode ??
+        (live.StreamModeDetails as Record<string, unknown> | undefined)?.StreamMode;
+      if (streamMode === 'ON_DEMAND') {
+        findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+        continue;
+      }
+    }
     // A live value that is an AWS-MANAGED default resource NAME, recognized by its reserved
     // `default.` / `default:` prefix (an RDS instance's default parameter/option group) rather
     // than a constant — a CUSTOM group name never carries the prefix, so it still surfaces.

--- a/tests/classify-kinesis-ondemand-1487.test.ts
+++ b/tests/classify-kinesis-ondemand-1487.test.ts
@@ -1,0 +1,84 @@
+// #1487 — an ON_DEMAND Kinesis stream first-run FP: `ShardCount` cannot be declared together with
+// `StreamMode: ON_DEMAND` (CloudFormation rejects the pair), so the undeclared live `ShardCount`
+// (4 today, auto-scaled with traffic) can never be user intent. Fold it value-independently,
+// gated on the effective `StreamModeDetails.StreamMode` being ON_DEMAND. A PROVISIONED stream
+// declares `ShardCount` and is compared in the declared loop (unchanged).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  declared: Record<string, unknown>,
+  physicalId = 'HuntOnDemandStream'
+): DesiredResource => ({
+  logicalId: 'HuntOnDemandStream',
+  resourceType: 'AWS::Kinesis::Stream',
+  physicalId,
+  declared,
+});
+
+describe('#1487 Kinesis ON_DEMAND stream undeclared ShardCount', () => {
+  it('folds the undeclared ShardCount to atDefault for an ON_DEMAND stream (declared sibling)', () => {
+    // The harvested live model of a barest `CfnStream({ streamModeDetails: { streamMode: "ON_DEMAND" } })`.
+    const f = classifyResource(
+      mk({ StreamModeDetails: { StreamMode: 'ON_DEMAND' } }),
+      { StreamModeDetails: { StreamMode: 'ON_DEMAND' }, ShardCount: 4 },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('ShardCount');
+    expect(tier(f, 'undeclared')).not.toContain('ShardCount');
+  });
+
+  it('folds regardless of the specific shard count (value-independent — AWS auto-scales it)', () => {
+    const f = classifyResource(
+      mk({ StreamModeDetails: { StreamMode: 'ON_DEMAND' } }),
+      { StreamModeDetails: { StreamMode: 'ON_DEMAND' }, ShardCount: 17 },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('ShardCount');
+    expect(tier(f, 'undeclared')).not.toContain('ShardCount');
+  });
+
+  it('derives ON_DEMAND from the LIVE StreamModeDetails when the stream declares none', () => {
+    const f = classifyResource(
+      mk({}),
+      { StreamModeDetails: { StreamMode: 'ON_DEMAND' }, ShardCount: 4 },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('ShardCount');
+    expect(tier(f, 'undeclared')).not.toContain('ShardCount');
+  });
+
+  it('does NOT fold an undeclared ShardCount when the stream is PROVISIONED — detection preserved', () => {
+    // A PROVISIONED stream that omits ShardCount cannot exist, but assert the gate is mode-scoped:
+    // an undeclared ShardCount reaching classify under PROVISIONED must still surface.
+    const f = classifyResource(
+      mk({ StreamModeDetails: { StreamMode: 'PROVISIONED' } }),
+      { StreamModeDetails: { StreamMode: 'PROVISIONED' }, ShardCount: 4 },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('ShardCount');
+    expect(tier(f, 'atDefault')).not.toContain('ShardCount');
+  });
+
+  it('compares a DECLARED ShardCount in the declared dimension (provisioned path unchanged)', () => {
+    const f = classifyResource(mk({ ShardCount: 2 }), { ShardCount: 5 }, emptySchema);
+    expect(tier(f, 'declared')).toContain('ShardCount');
+    expect(tier(f, 'atDefault')).not.toContain('ShardCount');
+  });
+});


### PR DESCRIPTION
## What

Fixes a first-run false positive on a barest ON_DEMAND Kinesis stream: `ShardCount=4` surfaced as undeclared drift on a clean deploy.

## Why

An ON_DEMAND stream **cannot declare `ShardCount`** — CloudFormation rejects `ShardCount` together with `StreamMode: ON_DEMAND` — so the live value can never be user intent. AWS materializes an initial count (4 today) and **auto-scales it with traffic**, so no constant pins it (decision-order tier 2 — sibling-gated, value-independent). Same shape as the existing EB `MaxSize`-from-`EnvironmentType` / ECS `Role`-from-mode folds.

## How

Adds a focused block in the `classify` undeclared loop (`src/diff/classify.ts`): fold `ShardCount` to `atDefault` when the effective `StreamModeDetails.StreamMode` (declared preferred, else the live echo) is `ON_DEMAND`. A PROVISIONED stream declares `ShardCount` and is compared in the declared loop (unchanged), so this never hides a provisioned-count drift.

## Tests

`tests/classify-kinesis-ondemand-1487.test.ts` replays the issue's harvested live model inline (no `tests/corpus/` file, so no collision with the hunt session's corpus PR):
- ON_DEMAND undeclared `ShardCount` folds `atDefault` (declared sibling, and any value — auto-scaled)
- derives ON_DEMAND from the LIVE `StreamModeDetails` when the stream declares none
- a PROVISIONED undeclared `ShardCount` still surfaces (detection preserved)
- a DECLARED `ShardCount` is compared in the declared dimension (provisioned path unchanged)

Full suite green (243 files / 5161 tests).

Closes #1487
