### PR TITLE
fix(sweep): fold subnet/ECS-INACTIVE/KMS-PendingDeletion phantom orphans (new resource_gone arms)

### DIFF
--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -223,6 +223,72 @@ resource_gone() {
           printf '%s' "$err" | grep -q 'InvalidVolume.NotFound' && return 0
           return 1
           ;;
+        *:subnet/subnet-*)
+          # arn:aws:ec2:<region>:<acct>:subnet/subnet-<id> — the fifth RGT-lag subtype
+          # (2026-07-12 hunt): a subnet deleted with its stack lingered in the tag index
+          # while DescribeSubnets answered InvalidSubnetID.NotFound. Only NotFound counts
+          # as gone (fail-safe, mirrors the volume arm).
+          id="${arn##*/}"
+          err="$(aws ec2 describe-subnets --subnet-ids "$id" --region "$REGION" 2>&1 >/dev/null)" && return 1
+          printf '%s' "$err" | grep -q 'InvalidSubnetID.NotFound' && return 0
+          return 1
+          ;;
+        *) return 1 ;;
+      esac
+      ;;
+    ecs)
+      # ECS keeps deregistered/deleted resources visible as INACTIVE (by design), and the
+      # RGT index returns them under the tag filter long after the stack is gone
+      # (observed 2026-07-12: task-definition revisions CFn deregistered, a deleted
+      # service, both INACTIVE). Nothing deletable remains in the INACTIVE state, so it
+      # counts as gone; a MissingException/NotFound answer counts too. Any ACTIVE/
+      # DRAINING answer (or an ambiguous error) keeps the ORPHAN RED (fail-safe).
+      case "$arn" in
+        *:task-definition/*)
+          local st
+          st="$(aws ecs describe-task-definition --task-definition "${arn##*task-definition/}" \
+            --region "$REGION" --query 'taskDefinition.status' --output text 2>/dev/null)" || return 0
+          [ "$st" = "INACTIVE" ] && return 0
+          return 1
+          ;;
+        *:service/*)
+          # arn:aws:ecs:<region>:<acct>:service/<cluster>/<service>
+          local rest cluster service out
+          rest="${arn##*:service/}"; cluster="${rest%%/*}"; service="${rest#*/}"
+          [ -n "$cluster" ] && [ -n "$service" ] || return 1
+          out="$(aws ecs describe-services --cluster "$cluster" --services "$service" \
+            --region "$REGION" --query 'services[0].status' --output text 2>/dev/null)" || return 0
+          { [ "$out" = "INACTIVE" ] || [ "$out" = "None" ]; } && return 0
+          return 1
+          ;;
+        *:cluster/*)
+          local cst
+          cst="$(aws ecs describe-clusters --clusters "${arn##*/}" --region "$REGION" \
+            --query 'clusters[0].status' --output text 2>/dev/null)" || return 0
+          { [ "$cst" = "INACTIVE" ] || [ "$cst" = "None" ]; } && return 0
+          return 1
+          ;;
+        *) return 1 ;;
+      esac
+      ;;
+    kms)
+      # arn:aws:kms:<region>:<acct>:key/<id> — a key already SCHEDULED FOR DELETION
+      # (PendingDeletion / PendingReplicaDeletion) is self-resolving debris: nothing
+      # deletable remains (deletion is scheduled; cancelling would be a restore, not a
+      # sweep), yet it stays in the tag index for the whole 7-30-day window, which
+      # deadlocked the bughunt-clean gate (2026-07-12 hunt: two rollback-orphaned CMKs).
+      # An Enabled/Disabled key stays RED — a real orphan that needs schedule-key-deletion.
+      case "$arn" in
+        *:key/*)
+          local kst
+          kst="$(aws kms describe-key --key-id "${arn##*/}" --region "$REGION" \
+            --query 'KeyMetadata.KeyState' --output text 2>/dev/null)" || {
+              # NotFoundException = fully gone
+              return 0
+            }
+          { [ "$kst" = "PendingDeletion" ] || [ "$kst" = "PendingReplicaDeletion" ]; } && return 0
+          return 1
+          ;;
         *) return 1 ;;
       esac
       ;;

--- a/tests/integration/sweep-orphans.test.sh
+++ b/tests/integration/sweep-orphans.test.sh
@@ -126,6 +126,60 @@ live_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
 assert "#1463 fail-safe: an EXISTING volume stays a hard ORPHAN (never folded)" "$live_out" "ORPHAN.*volume/vol-0liveaaaa00000000"
 refute "#1463 fail-safe: an existing volume is NOT folded to the RGT-lag SKIP" "$live_out" "already-deleted resource.*volume/vol-0liveaaaa00000000"
 
+# 2026-07-12 hunt phantom set: subnet NotFound (RGT lag), ECS task-definition / service
+# INACTIVE (kept visible by design), KMS key PendingDeletion (self-resolving debris that
+# otherwise deadlocks the gate for the whole deletion window) — all fold to SKIP.
+cat > "$tmp/aws" <<'MOCK'
+#!/usr/bin/env bash
+case "$1/${2:-}" in
+  cloudformation/list-stacks)              echo "SomeUnrelatedStack" ;;
+  resourcegroupstaggingapi/get-resources)
+    printf '%s\tNone\n' "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-0deadbeef0000000a"
+    printf '%s\tNone\n' "arn:aws:ecs:us-east-1:123456789012:task-definition/cdkrd-hunt-td:1"
+    printf '%s\tNone\n' "arn:aws:ecs:us-east-1:123456789012:service/cdkrd-hunt-cluster/cdkrd-hunt-svc"
+    printf '%s\tNone\n' "arn:aws:kms:us-east-1:123456789012:key/00000000-dead-beef-0000-000000000000"
+    ;;
+  ec2/describe-subnets)                     echo "An error occurred (InvalidSubnetID.NotFound) when calling the DescribeSubnets operation: The subnet ID 'subnet-0deadbeef0000000a' does not exist" >&2; exit 255 ;;
+  ecs/describe-task-definition)             echo "INACTIVE" ;;
+  ecs/describe-services)                    echo "INACTIVE" ;;
+  kms/describe-key)                         echo "PendingDeletion" ;;
+  *) : ;;
+esac
+MOCK
+chmod +x "$tmp/aws"
+gone2_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
+assert "a NotFound subnet folds to the RGT-lag SKIP" "$gone2_out" "SKIP \(tagged mapping for an already-deleted resource.*subnet/subnet-0deadbeef0000000a"
+assert "an INACTIVE task definition folds to SKIP" "$gone2_out" "SKIP \(tagged mapping for an already-deleted resource.*task-definition/cdkrd-hunt-td:1"
+assert "an INACTIVE service folds to SKIP" "$gone2_out" "SKIP \(tagged mapping for an already-deleted resource.*service/cdkrd-hunt-cluster/cdkrd-hunt-svc"
+assert "a PendingDeletion KMS key folds to SKIP" "$gone2_out" "SKIP \(tagged mapping for an already-deleted resource.*key/00000000-dead-beef-0000-000000000000"
+assert "sweep is CLEAN once the phantom set is folded" "$gone2_out" "SWEEP CLEAN"
+
+# fail-safe twins: a live subnet / ACTIVE task definition / ACTIVE service / Enabled key
+# all stay hard ORPHANs.
+cat > "$tmp/aws" <<'MOCK'
+#!/usr/bin/env bash
+case "$1/${2:-}" in
+  cloudformation/list-stacks)              echo "SomeUnrelatedStack" ;;
+  resourcegroupstaggingapi/get-resources)
+    printf '%s\tNone\n' "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-0liveaaaa0000000a"
+    printf '%s\tNone\n' "arn:aws:ecs:us-east-1:123456789012:task-definition/cdkrd-live-td:1"
+    printf '%s\tNone\n' "arn:aws:ecs:us-east-1:123456789012:service/cdkrd-live-cluster/cdkrd-live-svc"
+    printf '%s\tNone\n' "arn:aws:kms:us-east-1:123456789012:key/11111111-aaaa-bbbb-0000-000000000000"
+    ;;
+  ec2/describe-subnets)                     echo "subnet-0liveaaaa0000000a" ;;
+  ecs/describe-task-definition)             echo "ACTIVE" ;;
+  ecs/describe-services)                    echo "ACTIVE" ;;
+  kms/describe-key)                         echo "Enabled" ;;
+  *) : ;;
+esac
+MOCK
+chmod +x "$tmp/aws"
+live2_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
+assert "fail-safe: a live subnet stays a hard ORPHAN" "$live2_out" "ORPHAN.*subnet/subnet-0liveaaaa0000000a"
+assert "fail-safe: an ACTIVE task definition stays a hard ORPHAN" "$live2_out" "ORPHAN.*task-definition/cdkrd-live-td:1"
+assert "fail-safe: an ACTIVE service stays a hard ORPHAN" "$live2_out" "ORPHAN.*service/cdkrd-live-cluster/cdkrd-live-svc"
+assert "fail-safe: an Enabled KMS key stays a hard ORPHAN" "$live2_out" "ORPHAN.*key/11111111-aaaa-bbbb-0000-000000000000"
+
 rm -rf "$tmp"
 echo "----"
 echo "sweep-orphans: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## What

Adds four `resource_gone` arms to `tests/integration/sweep-orphans.sh` (+ mocked smoke tests) for phantom "orphans" the 2026-07-12 bug-hunt teardown surfaced — all confirmed by direct describes to be already gone or self-resolving:

- **EC2 subnet** — deleted with its stack, lingering in the RGT tag index (`InvalidSubnetID.NotFound`); the fifth RGT-lag subtype (after cognito user pool, vpc-endpoint, instance, volume).
- **ECS task definition / service** — ECS keeps deregistered/deleted resources visible as `INACTIVE` by design; the tag index returns them long after the stack is gone. Nothing deletable remains.
- **KMS key `PendingDeletion` / `PendingReplicaDeletion`** — self-resolving debris (two rollback-orphaned CMKs already scheduled for deletion) that would otherwise keep the bughunt-clean gate deadlocked for the whole 7–30-day deletion window.

## Why now

The active hunt session's gate release (`bughunt-track.sh verify`) is RED on exactly these phantoms; per the established flow this lands as a standalone tooling PR first, then the hunt session re-verifies with main's updated script.

## Safety

Fail-safe posture preserved: only a definitive `NotFound` / `INACTIVE` / `PendingDeletion` answer folds to SKIP; a live subnet, ACTIVE task definition/service, or Enabled key stays a hard ORPHAN. Smoke test extends to 23 assertions with green + fail-safe twins for every new arm.

Tooling-only diff (`tests/integration/**`) — no `src/**`, verify-pr-exempt.
