### PR TITLE
fix(noise): MemoryDB Cluster barest-valkey first-run FP batch (#1503)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -189,6 +189,12 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   'AWS::ElasticLoadBalancingV2::TargetGroup': {
     HealthCheckEnabled: ({ declared }) => declared['TargetType'] !== 'lambda',
   },
+  // #1503: a MemoryDB cluster is created with in-transit encryption ON — a fresh cluster that
+  // declares no TLSEnabled always reads back true (the KNOWN_DEFAULTS pin). A user who wants
+  // TLS off DECLARES TLSEnabled=false (compared in the declared loop), so an UNDECLARED false
+  // is an out-of-band DISABLE of transit encryption — unconditionally meaningful. Without this
+  // gate the live `false` is dropped by isTrivialEmpty before the pin gate, hiding the disable.
+  'AWS::MemoryDB::Cluster': { TLSEnabled: () => true },
 };
 
 // #660 item 3: the NESTED twin of MEANINGFUL_WHEN_OFF. The table above gates TOP-LEVEL

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -879,12 +879,23 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // defaults. Equality-gated. Per-resource/random values the same read returns
   // (ParameterGroupName is engine-version-derived, Snapshot/MaintenanceWindow are
   // AWS-assigned) are deliberately NOT listed — they are genuine undeclared inventory.
+  // #1503: the memorydb-rich (redis) fixture DECLARED the engine-independent shape/backup/TLS
+  // props, so their undeclared-default path never ran until a BAREST valkey cluster deploy
+  // surfaced them on a first `check`. A single-shard, single-replica, no-backup, TLS-on
+  // cluster is what AWS creates when the template omits them — equality-gated, so a reshard
+  // (NumShards≠1), a replica change, a snapshot enable, or a TLS DISABLE still surfaces (the
+  // TLSEnabled truthy-bool disable via the AWS::MemoryDB::Cluster MEANINGFUL_WHEN_OFF gate in
+  // diff/classify.ts, so a live `false` is not swallowed by isTrivialEmpty).
   'AWS::MemoryDB::Cluster': {
     Port: 6379,
     AutoMinorVersionUpgrade: true,
     DataTiering: 'false',
     NetworkType: 'ipv4',
     IpDiscovery: 'ipv4',
+    NumShards: 1,
+    NumReplicasPerShard: 1,
+    SnapshotRetentionLimit: 0,
+    TLSEnabled: true,
   },
   'AWS::RDS::DBProxy': {
     TargetConnectionNetworkType: 'IPV4',
@@ -3356,7 +3367,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'EngineVersion',
   ]),
   'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime']),
-  'AWS::MemoryDB::Cluster': new Set(['MaintenanceWindow', 'SnapshotWindow']),
+  //   AWS::MemoryDB::Cluster.EngineVersion — #1503: a cluster that declares no EngineVersion
+  //   reads back the current GA patch AWS auto-selected for the engine track (valkey "7.3"
+  //   today), which AWS moves over time as it ships new GA versions — not a constant we can
+  //   pin. Undeclared → whatever GA AWS assigned is its default, never user intent; a user
+  //   who pins a version DECLARES it and is then compared in the declared loop. The RDS /
+  //   DocDB / Neptune / ElastiCache::ReplicationGroup undeclared-EngineVersion twin.
+  'AWS::MemoryDB::Cluster': new Set(['MaintenanceWindow', 'SnapshotWindow', 'EngineVersion']),
   //   AWS::Redshift::Cluster.AvailabilityZone — AWS places an undeclared cluster in an AZ it picks
   //   (create-only, never user intent when undeclared), exactly like RDS AvailabilityZone above.
   //   OffPeakWindowOptions on an OpenSearch domain is the AWS-ASSIGNED off-peak maintenance window

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -544,6 +544,10 @@ describe('noise suppressors', () => {
       DataTiering: 'false',
       NetworkType: 'ipv4',
       IpDiscovery: 'ipv4',
+      NumShards: 1,
+      NumReplicasPerShard: 1,
+      SnapshotRetentionLimit: 0,
+      TLSEnabled: true,
     });
     expect(KNOWN_DEFAULTS['AWS::Config::ConfigRule']).toEqual({
       EvaluationModes: [{ Mode: 'DETECTIVE' }],

--- a/tests/noise-memorydb-1503.test.ts
+++ b/tests/noise-memorydb-1503.test.ts
@@ -1,0 +1,122 @@
+// #1503: MemoryDB::Cluster first-run fold gaps mined from a clean, un-mutated LIVE deploy of a
+// BAREST valkey cluster (stack Cdkrd1503..., us-east-1, 2026-07-12). The memorydb-rich (redis)
+// fixture DECLARED the engine-independent shape/backup/TLS props, so their undeclared-default
+// path never ran until this minimal valkey deploy surfaced five undeclared properties as
+// [Potential Drift] on a first `check`:
+//   NumShards / NumReplicasPerShard / SnapshotRetentionLimit -> tier-1 KNOWN_DEFAULTS constants
+//     (a reshard / replica change / snapshot enable still surfaces).
+//   TLSEnabled -> tier-1 KNOWN_DEFAULTS truthy-bool constant, paired with a MEANINGFUL_WHEN_OFF
+//     gate so an out-of-band TLS DISABLE (undeclared false) still surfaces.
+//   EngineVersion -> tier-3 VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS (AWS moves the auto-selected
+//     GA patch over time, so a pinned constant rots; undeclared, so any value AWS returns is its
+//     default, not user intent — the RDS/DocDB/Neptune/ElastiCache twin).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1503 MemoryDB::Cluster undeclared first-run defaults (barest valkey)', () => {
+  const res: DesiredResource = {
+    logicalId: 'HuntValkeyCluster',
+    resourceType: 'AWS::MemoryDB::Cluster',
+    physicalId: 'huntvalkeycluster',
+    // The barest valkey CfnCluster: only these five props are declared.
+    declared: {
+      ClusterName: 'huntvalkeycluster',
+      NodeType: 'db.t4g.small',
+      ACLName: 'open-access',
+      Engine: 'valkey',
+      SubnetGroupName: 'huntsubnetgroup',
+    },
+  };
+  // The clean live model of a fresh valkey cluster: the declared echoes plus every undeclared
+  // default AWS materialized. Port/AutoMinorVersionUpgrade/DataTiering/NetworkType/IpDiscovery
+  // were already pinned; the five #1503 additions are NumShards/NumReplicasPerShard/
+  // SnapshotRetentionLimit/TLSEnabled/EngineVersion. MaintenanceWindow/SnapshotWindow are the
+  // AWS-assigned random windows already folded value-independent.
+  const cleanLive = {
+    ClusterName: 'huntvalkeycluster',
+    NodeType: 'db.t4g.small',
+    ACLName: 'open-access',
+    Engine: 'valkey',
+    SubnetGroupName: 'huntsubnetgroup',
+    Port: 6379,
+    AutoMinorVersionUpgrade: true,
+    DataTiering: 'false',
+    NetworkType: 'ipv4',
+    IpDiscovery: 'ipv4',
+    NumShards: 1,
+    NumReplicasPerShard: 1,
+    SnapshotRetentionLimit: 0,
+    TLSEnabled: true,
+    EngineVersion: '7.3',
+    MaintenanceWindow: 'sun:07:00-sun:08:00',
+    SnapshotWindow: '05:00-06:00',
+  };
+
+  it('produces ZERO potential drift on a clean, un-mutated valkey cluster', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('folds the five undeclared defaults to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    const atDefault = pathsByTier(f, 'atDefault');
+    for (const p of [
+      'NumShards',
+      'NumReplicasPerShard',
+      'SnapshotRetentionLimit',
+      'TLSEnabled',
+      'EngineVersion',
+    ]) {
+      expect(atDefault).toContain(p);
+      expect(pathsByTier(f, 'undeclared')).not.toContain(p);
+    }
+  });
+
+  it('folds EngineVersion value-independently (a different GA patch still folds)', () => {
+    const moved = { ...cleanLive, EngineVersion: '7.9' };
+    const f = classifyResource(res, moved, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('EngineVersion');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('EngineVersion');
+  });
+
+  it('surfaces an out-of-band reshard (NumShards away from the default)', () => {
+    const changed = { ...cleanLive, NumShards: 3 };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('NumShards');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('NumShards');
+  });
+
+  it('surfaces an out-of-band snapshot-retention enable', () => {
+    const changed = { ...cleanLive, SnapshotRetentionLimit: 7 };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('SnapshotRetentionLimit');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('SnapshotRetentionLimit');
+  });
+
+  it('surfaces an out-of-band TLS DISABLE (undeclared false, via MEANINGFUL_WHEN_OFF)', () => {
+    // Without the AWS::MemoryDB::Cluster MEANINGFUL_WHEN_OFF gate the live `false` is dropped
+    // by isTrivialEmpty before the pin gate, hiding the transit-encryption disable.
+    const changed = { ...cleanLive, TLSEnabled: false };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('TLSEnabled');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('TLSEnabled');
+  });
+});


### PR DESCRIPTION
## What

A BAREST valkey `CfnCluster` (only `clusterName`/`nodeType`/`aclName`/`engine`/`subnetGroupName` declared) surfaced **five** undeclared properties as `[Potential Drift]` on a first `check` — latent under the declared-rich redis fixture (#615 class), which DECLARED these engine-independent props so their undeclared-default path never ran until a minimal valkey deploy.

Live repro (us-east-1, 2026-07-12), first `check`:

```
[Potential Drift: 5]
  HuntValkeyCluster.NumReplicasPerShard       actual =1
  HuntValkeyCluster.EngineVersion             actual ="7.3"
  HuntValkeyCluster.NumShards                 actual =1
  HuntValkeyCluster.SnapshotRetentionLimit    actual =0
  HuntValkeyCluster.TLSEnabled                actual =true
```

## Fix

- `KNOWN_DEFAULTS['AWS::MemoryDB::Cluster']` += `NumShards:1`, `NumReplicasPerShard:1`, `SnapshotRetentionLimit:0`, `TLSEnabled:true` — engine-independent creation constants (tier-1, equality-gated: a reshard, replica change, snapshot enable, or TLS disable still surfaces).
- `MEANINGFUL_WHEN_OFF['AWS::MemoryDB::Cluster']` += `TLSEnabled` (classify.ts) — so an out-of-band transit-encryption DISABLE (an undeclared `false`) is not swallowed by `isTrivialEmpty` before the pin gate.
- `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::MemoryDB::Cluster']` += `EngineVersion` — GA-moving auto-selected track (tier-3; the RDS/DocDB/Neptune/ElastiCache::ReplicationGroup twin). A declared version goes through the declared loop.

## Tests

- New `tests/noise-memorydb-1503.test.ts` (harvested clean valkey model pinned inline): ZERO potential drift on the clean cluster; the five props fold to `atDefault`; and out-of-band cases still surface — a reshard (`NumShards` != 1), a snapshot enable, and a **TLS disable** (`TLSEnabled=false`). EngineVersion folds value-independently across GA patches.
- Updated the exact-shape `KNOWN_DEFAULTS['AWS::MemoryDB::Cluster']` assertion in `noise-and-strip.test.ts`.
- Full suite: 245 files / 5194 tests pass.

## Verification

Fold/FP fix — live-proven in its originating hunt (#1503 carries the exact us-east-1 live repro); the harvested clean model is pinned inline in the new unit test (the hunt's corpus JSON lives in the unmerged hunt worktree). Shared CORE integration suite DEFERRED (offline + inline-test + hunt-verified; no fresh deploy).

Closes #1503
