### PR TITLE
fix(noise): minimal-deploy FP hunt — 14 fold-table additions across DMS/ECS/StackSet/MemoryDB/RDS/Batch/EC2 + 17 fixtures + 45 corpus cases

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -174,6 +174,13 @@ short of a fix the user wanted.
    DBCluster/DBInstance, AppSync ApiKey/GraphQLSchema — all `SDK_OVERRIDES` candidates,
    not hunt targets.)
 
+   The INVERSE is prime hunting ground: an `SDK_OVERRIDES` reader / `SDK_SUPPLEMENTS`
+   entry that EXISTS but has **zero corpus cases and zero fixtures** was added from a
+   live FN report without ever exercising the barest first-run path — deploy its
+   minimal form first (the 2026-07-12 hunt's RedshiftServerless Workgroup trio, #1489,
+   came from exactly this audit; ACM Certificate / ELBv2 TrustStore / DAX /
+   MediaConvert / SageMaker EndpointConfig / ClientVPN remain unexercised).
+
    **A `read` handler being present is NOT enough — also check the
    `primaryIdentifier` ARITY.** A type can have a CC `read` handler yet still be
    silently `skipped` with a `ValidationException` (a DIFFERENT read-gap class than
@@ -317,7 +324,16 @@ clean. Then promote the cases that add coverage into `tests/corpus/`:
   for types **not already present** — `ls tests/corpus/ | grep <Type>` first.
   Genuinely-new resource types are the win; skip near-duplicates of types already
   covered (VPC/subnet/route-table boilerplate a fixture drags along is usually
-  already represented — don't flood the corpus with it).
+  already represented — don't flood the corpus with it). **Also check the exact
+  FILENAME**: generic CDK logical ids (`VpcpublicSubnet1Subnet…`) collide across
+  fixtures, and a same-name `cp` silently OVERWRITES the existing case — rename the
+  new one with a distinct suffix (e.g. `AWS__EC2__Subnet.Ipv6AttachHunt.json`)
+  when the id already exists (2026-07-12 hunt clobbered one this way).
+- A promoted case whose `expected` pins an OPEN issue's wrong behavior WILL churn:
+  parallel agents fix filed issues within hours, so after any rebase re-RUN classify
+  over the promoted cases and regenerate `expected` (a throwaway env-gated test file
+  that rewrites `c.expected` from `classifyResource` output beats hand-editing;
+  delete it before commit). Three peer fixes landed mid-hunt on 2026-07-12 alone.
 - Run `vp run test` and confirm the new `corpus-replay` cases pass. Commit the new
   corpus JSONs in the SAME PR as the fixture (and the fix, if any). An intended
   behavior change updates a case's `expected` in the same diff, making the semantic
@@ -495,6 +511,13 @@ Recorded]` breakdown with `--verbose`.
   `|| fail`), or guard with `set +e`.
 - **Always `npm install` + `cdk synth` before deploy** — a synth-time TS error is
   free to catch; a half-failed deploy is not.
+- **Deploy-time API validation differences across engine/mode variants are
+  FINDINGS, not mere fixture bugs.** A minimal variant deploy that FAILS validation
+  is telling you the variant's defaults differ (valkey RGs default
+  AutomaticFailoverEnabled=true — a 1-node group is rejected — and demand an explicit
+  TransitEncryptionEnabled, both unlike redis; observed 2026-07-12). Record the
+  difference in the fixture comment (it documents the axis) and declare the minimum
+  to proceed — the surviving undeclared surface is still the probe.
 - **`example.com` / `.test` / `.example` are AWS-RESERVED for Route53 hosted zones**
   (`InvalidDomainNameException` on create). A Route53 fixture must use a non-reserved
   placeholder domain (e.g. `cdkrd-fphunt-x9z7q.com.`) — a public hosted zone for a

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -298,6 +298,17 @@ const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // hide an out-of-band SG swap/append (the exact security FN #889 fixed). Gate it through the
   // same derived VPC-default-SG check: fold a single default SG, surface an append or a swap.
   'AWS::Neptune::DBCluster': 'VpcSecurityGroupIds',
+  // 2026-07-12 hunt (aurora-pg-min / rds-postgres-min): the RDS twins of the #976 Neptune
+  // entry above — a barest cluster/instance that declares no security groups reads back the
+  // default VPC's default SG. Both are OOB-mutable (`rds modify-db-cluster` /
+  // `modify-db-instance --vpc-security-group-ids`), so value-independent would hide a rogue
+  // swap/append; the derived VPC-default-SG gate folds the single default and surfaces the
+  // rest. Note the DBInstance path is the API's legacy plural `VPCSecurityGroups`.
+  'AWS::RDS::DBCluster': 'VpcSecurityGroupIds',
+  'AWS::RDS::DBInstance': 'VPCSecurityGroups',
+  // The DocDB twin (corpus-baked FP surfaced by the measure-noise sweep on the same hunt):
+  // same OOB-mutable `docdb modify-db-cluster --vpc-security-group-ids` surface.
+  'AWS::DocDB::DBCluster': 'VpcSecurityGroupIds',
   // #1266: an AmazonMQ Broker that declares no SecurityGroups reads back the VPC default SG — the
   // same single-SG AWS first-run default the ALB/ENI/Neptune cases fold. It is OOB-mutable
   // (`mq update-broker --security-groups`; SecurityGroups is NOT in the schema createOnlyProperties,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -81,6 +81,23 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // undeclared drift. Observed live on a fresh events-apidest-rich ApiDestination
   // (2026-07-08).
   'AWS::Events::ApiDestination': { InvocationRateLimitPerSecond: 300 },
+  // A DMS endpoint that declares no SslMode reads back "none" — the constant service
+  // default for every engine. Equality-gated: an out-of-band hardening (or loosening)
+  // to require / verify-ca / verify-full no longer matches and re-surfaces as real
+  // undeclared drift. Observed live on a fresh minimal mysql source endpoint
+  // (case-idents-min, 2026-07-12; #1490).
+  'AWS::DMS::Endpoint': { SslMode: 'none' },
+  // A SELF_MANAGED StackSet that declares no ExecutionRoleName reads back the documented
+  // conventional default. Equality-gated: an out-of-band switch to a custom execution
+  // role no longer matches and re-surfaces. (The AdministrationRoleARN sibling is
+  // ACCOUNT-derived, so it folds via CONTEXT_ARN_DEFAULTS instead.) Observed live
+  // on a fresh zero-instance SELF_MANAGED StackSet (freemisc-min, 2026-07-12; #1495).
+  'AWS::CloudFormation::StackSet': { ExecutionRoleName: 'AWSCloudFormationStackSetExecutionRole' },
+  // A MANAGED Batch ComputeEnvironment that declares no State reads back "ENABLED" — the
+  // constant service default. Equality-gated: an out-of-band DISABLE (a real operational
+  // change) no longer matches and re-surfaces. Observed live on a fresh minimal EC2 CE
+  // (s3kms-ddb-batch-min, 2026-07-12).
+  'AWS::Batch::ComputeEnvironment': { State: 'ENABLED' },
   // An Elastic Beanstalk Application that declares no ResourceLifecycleConfig reads back
   // the constant service default: a version-lifecycle policy carrying both rules present
   // but DISABLED (Enabled:false, MaxCount 200 / MaxAgeInDays 180, DeleteSourceFromS3:false).
@@ -921,6 +938,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     AutoMinorVersionUpgrade: true,
     BackupTarget: 'region',
     DatabaseInsightsMode: 'standard',
+    // An instance that declares no DBSubnetGroupName is placed into the account's
+    // literal "default" subnet group (the default VPC). Equality-gated: a custom group
+    // is DECLARED (compared in the declared loop), and an out-of-band re-placement no
+    // longer matches "default" and re-surfaces. Observed live on a fresh minimal
+    // postgres instance + aurora-postgresql cluster (rds-postgres-min / aurora-pg-min,
+    // 2026-07-12).
+    DBSubnetGroupName: 'default',
     // EngineLifecycleSupport is NOT a constant default. Its value is set by the resource's
     // ORIGINAL creation era (a pre-RDS-Extended-Support lineage reads `-disabled`, a newer one
     // the `-extended-support` default), but a RESTORE resets the readable `ClusterCreateTime`
@@ -964,6 +988,9 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // era behind the restore-date ClusterCreateTime, so it is not a constant KNOWN_DEFAULTS value.
     NetworkType: 'IPV4',
     EngineMode: 'provisioned', // default; serverless/parallelquery are explicit opt-ins
+    // Same "default" subnet-group placement as the DBInstance twin above (aurora-pg-min,
+    // 2026-07-12).
+    DBSubnetGroupName: 'default',
     // Aurora's documented default backup retention (1 day) — surfaced as undeclared
     // first-run noise whenever a template omits it. The twin AWS::DocDB::DBCluster folds
     // the same BackupRetentionPeriod: 1. Equality-gated: a longer retention the user sets
@@ -1663,6 +1690,18 @@ export const KNOWN_DEFAULT_ONE_OF_PATHS: Record<string, Record<string, readonly 
       'varies_by_storage_class',
     ],
   },
+  // An EC2 MANAGED Batch ComputeEnvironment that declares no Ec2Configuration reads back
+  // the era default image type — ECS_AL2023 for CEs created after Batch's AL2023 default
+  // switch (live-observed on a fresh minimal EC2 CE, s3kms-ddb-batch-min 2026-07-12),
+  // ECS_AL2 for older-era environments (the documented prior default). Both are
+  // AWS-assigned, never user intent when undeclared; a value outside the set (e.g. an
+  // out-of-band switch to ECS_AL2_NVIDIA) still surfaces.
+  'AWS::Batch::ComputeEnvironment': {
+    'ComputeResources.Ec2Configuration': [
+      [{ ImageType: 'ECS_AL2023' }],
+      [{ ImageType: 'ECS_AL2' }],
+    ],
+  },
 };
 
 // R108: nested service defaults — the NESTED-path twin of KNOWN_DEFAULTS. The
@@ -2348,6 +2387,16 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string
     ServiceLinkedRoleARN:
       'arn:{partition}:iam::{accountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling',
   },
+  // A SELF_MANAGED StackSet that declares no AdministrationRoleARN reads back the
+  // conventional default admin role in the STACK SET'S OWN ACCOUNT — f(partition,
+  // accountId), the same own-account-role shape as the SLR folds around it.
+  // Equality-gated with placeholder substitution, so a CUSTOM admin role (or a
+  // cross-account one) still surfaces. Observed live on a fresh zero-instance
+  // SELF_MANAGED StackSet (freemisc-min, 2026-07-12; #1495).
+  'AWS::CloudFormation::StackSet': {
+    AdministrationRoleARN:
+      'arn:{partition}:iam::{accountId}:role/AWSCloudFormationStackSetAdministrationRole',
+  },
   // A Batch ComputeEnvironment that declares no ServiceRole reads back the account's
   // AWS-managed Batch service-linked role ARN — f(partition, accountId) (IAM ARNs carry no
   // region). Verbatim twin of the ASG ServiceLinkedRoleARN SLR fold: a user who passes a
@@ -2432,6 +2481,11 @@ export const ENGINE_DEFAULTS: Record<string, Record<string, (engine: string) => 
     AllocatedStorage: (e) => (e.startsWith('aurora') ? 1 : undefined),
     Port: rdsDefaultPort,
     LicenseModel: rdsDefaultLicense,
+    // SQL Server materializes its default collation when none is declared — live-confirmed
+    // "SQL_Latin1_General_CP1_CI_AS" on a fresh minimal sqlserver-ex (rds-sqlserver-min,
+    // 2026-07-12). CharacterSetName is create-only; a user-chosen collation is DECLARED and
+    // compared in the declared loop. Other engines expose no such echo → undefined.
+    CharacterSetName: (e) => (/sqlserver/.test(e) ? 'SQL_Latin1_General_CP1_CI_AS' : undefined),
   },
   'AWS::RDS::DBCluster': {
     StorageType: (e) => (e.startsWith('aurora') ? 'aurora' : undefined),
@@ -2469,11 +2523,15 @@ function rdsDefaultPort(engine: string): number | undefined {
 }
 
 // RDS engine-family default LicenseModel. MySQL/MariaDB/Aurora-MySQL read back
-// "general-public-license"; Postgres/Aurora-Postgres "postgresql-license". Oracle/SQLServer
-// carry BYOL/license-included with no single default, so they return undefined (no fold).
+// "general-public-license"; Postgres/Aurora-Postgres "postgresql-license". SQL Server on
+// RDS offers License Included ONLY (no BYOL), so every sqlserver-* engine reads back
+// "license-included" — live-confirmed on a fresh minimal sqlserver-ex (rds-sqlserver-min,
+// 2026-07-12). Oracle carries BYOL/license-included with no single default → undefined
+// (no fold).
 function rdsDefaultLicense(engine: string): string | undefined {
   if (/postgres/.test(engine)) return 'postgresql-license';
   if (/mysql|maria/.test(engine)) return 'general-public-license';
+  if (/sqlserver/.test(engine)) return 'license-included';
   return undefined;
 }
 
@@ -2498,6 +2556,11 @@ export const DEFAULT_MANAGED_NAME_PATHS: Record<string, Record<string, RegExp>> 
   // pinnable constant), so it is regex-matched — a CUSTOM group name a user attached does not
   // start with `default.` and still surfaces. Undeclared-only, like the RDS precedent. Found by
   // the offline first-run-noise sweep across the corpus.
+  // #1477's DBInstance entry above missed the CLUSTER twin: a barest aurora-postgresql
+  // DBCluster reads back DBClusterParameterGroupName "default.aurora-postgresql17" — the
+  // same AWS-managed default-group family the DocDB/Neptune cluster entries below fold.
+  // Observed live on a fresh minimal aurora-postgresql cluster (aurora-pg-min, 2026-07-12).
+  'AWS::RDS::DBCluster': { DBClusterParameterGroupName: /^default\./ },
   'AWS::ElastiCache::CacheCluster': { CacheParameterGroupName: /^default\./ },
   'AWS::DocDB::DBCluster': { DBClusterParameterGroupName: /^default\./ },
   'AWS::Neptune::DBCluster': { DBClusterParameterGroupName: /^default\./ },
@@ -3217,6 +3280,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   is compared in the declared loop with VERSION_PREFIX_PATHS partial-track matching (detected).
   //   Live-confirmed on a fresh minimal mysql DBInstance (2026-07-11) — the standalone provisioned
   //   DBInstance was missed while the Aurora/DBCluster corpus drove the existing folds.
+  //   AWS::DMS::Endpoint.KmsKeyId — an endpoint that declares no KMS key reads back the
+  //   AWS-managed `aws/dms` key ARN materialized at creation (create-only for the endpoint's
+  //   storage encryption): the exact twin of the #533 RDS / OpenSearch / EC2-Volume
+  //   AWS-assigned-KmsKeyId class. Never user intent when undeclared; a user who pins a CMK
+  //   DECLARES KmsKeyId and is compared in the declared loop. Observed live on a fresh
+  //   minimal endpoint (case-idents-min, 2026-07-12; #1490).
+  'AWS::DMS::Endpoint': new Set(['KmsKeyId']),
   'AWS::RDS::DBCluster': new Set([
     'KmsKeyId',
     'EngineVersion',
@@ -3406,6 +3476,19 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   prefetched VPC-default SG ids (DEFAULT_SG_LIST_PATHS, the #889/#976 ELBv2/Neptune gate): a
   //   single default SG folds, a 2+-element append or a non-default swap surfaces.
   'AWS::AmazonMQ::Broker': new Set(['MaintenanceWindowStartTime', 'SubnetIds']),
+  //   AWS::EC2::InstanceConnectEndpoint.SecurityGroupIds — an ICE that declares no security
+  //   groups is placed into its VPC's default SG (single-element list). CREATE-ONLY (schema
+  //   createOnlyProperties), so the fold can never hide an out-of-band change — the SGs
+  //   physically cannot move without replacing the endpoint. A user who pins SGs DECLARES
+  //   them (declared loop). Observed live first-run (vpc-attach-min, 2026-07-12).
+  'AWS::EC2::InstanceConnectEndpoint': new Set(['SecurityGroupIds']),
+  //   AWS::EC2::EIPAssociation.PrivateIpAddress / .EIP — an association that declares only
+  //   AllocationId + NetworkInterfaceId reads back the ENI's AWS-allocated primary private IP
+  //   and the EIP's public IP (the legacy public-IP path). Both CREATE-ONLY per-resource
+  //   AWS-assigned addresses (the association identity is already carried by the DECLARED
+  //   AllocationId/NetworkInterfaceId, compared in the declared loop). Observed live
+  //   first-run (vpc-attach-min, 2026-07-12).
+  'AWS::EC2::EIPAssociation': new Set(['PrivateIpAddress', 'EIP']),
   //   Core VPC-networking types whose undeclared, AWS-ASSIGNED, CREATE-ONLY placement identifiers
   //   read back on every first run. Each is a per-resource value AWS picks at creation from the
   //   surrounding VPC/subnet/region — never a constant we can pin, and never user intent when
@@ -4208,7 +4291,13 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // `EndpointType` is effectively immutable (source<->target can't be flipped out
   // of band) and the two valid values differ beyond case, so case-insensitive
   // equality hides no real drift. Observed live on a fresh DMS Endpoint deploy.
-  'AWS::DMS::Endpoint': new Set(['EndpointType']),
+  // `EndpointIdentifier` — DMS stores the identifier LOWERCASED (the same identifier
+  // family as ReplicationInstanceIdentifier / ReplicationSubnetGroupIdentifier above):
+  // a template declaring "CdkrdHunt-Mixed-DMS-EP" reads back "cdkrdhunt-mixed-dms-ep",
+  // a declared-tier FP that survives record on every check of an untouched endpoint.
+  // Two identifiers differing beyond case are a genuine replacement and still surface.
+  // Observed live on a fresh mixed-case endpoint (case-idents-min, 2026-07-12; #1490).
+  'AWS::DMS::Endpoint': new Set(['EndpointType', 'EndpointIdentifier']),
   // A WAFv2 LoggingConfiguration's RedactedFields SingleHeader.Name is stored/echoed
   // LOWERCASED (HTTP header names are case-insensitive per RFC 9110), so a template that
   // declares `Authorization` / `Cookie` false-flags declared drift against the live
@@ -5196,6 +5285,15 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   // EnabledMfas — UsernameAttributes / AutoVerifiedAttributes / AliasAttributes are genuine
   // stored-list create-params that were live-proven ORDER-PRESERVING and are NOT folded.
   'AWS::Cognito::UserPool': new Set(['EnabledMfas']),
+  // Live-observed on a fresh reorder-probes-min deploy (#1491): ECS stores a cluster's
+  // CapacityProviders attachments as a SET and reads them back sorted — declared
+  // ["FARGATE_SPOT","FARGATE"] reads back ["FARGATE","FARGATE_SPOT"], a declared-tier FP
+  // with identical elements that survives record. The values (FARGATE / FARGATE_SPOT /
+  // custom CP names) are not id/ARN-shaped, so the generic id-array sort does not cover
+  // them. Set-semantic (a provider is attached-or-not); a genuine attach/detach still
+  // changes the multiset. DefaultCapacityProviderStrategy order was live-proven PRESERVED
+  // in the same probe and is deliberately NOT folded.
+  'AWS::ECS::Cluster': new Set(['CapacityProviders']),
   'AWS::Cognito::UserPoolClient': new Set([
     'AllowedOAuthFlows',
     'AllowedOAuthScopes',

--- a/tests/classify-sgderive-889.test.ts
+++ b/tests/classify-sgderive-889.test.ts
@@ -52,6 +52,23 @@ const CASES: Array<{ label: string; type: string; key: string }> = [
     type: 'AWS::Neptune::DBCluster',
     key: 'VpcSecurityGroupIds',
   },
+  // 2026-07-12 hunt (aurora-pg-min / rds-postgres-min): the RDS twins of the Neptune entry —
+  // both OOB-mutable via `rds modify-db-cluster` / `modify-db-instance --vpc-security-group-ids`.
+  {
+    label: 'RDS DBCluster VpcSecurityGroupIds',
+    type: 'AWS::RDS::DBCluster',
+    key: 'VpcSecurityGroupIds',
+  },
+  {
+    label: 'RDS DBInstance VPCSecurityGroups (legacy plural path)',
+    type: 'AWS::RDS::DBInstance',
+    key: 'VPCSecurityGroups',
+  },
+  {
+    label: 'DocDB DBCluster VpcSecurityGroupIds',
+    type: 'AWS::DocDB::DBCluster',
+    key: 'VpcSecurityGroupIds',
+  },
 ];
 
 for (const { label, type, key } of CASES) {

--- a/tests/corpus/AWS__ApiGatewayV2__Api.HuntHttpApi.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.HuntHttpApi.json
@@ -1,0 +1,111 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntHttpApi",
+    "resourceType": "AWS::ApiGatewayV2::Api",
+    "physicalId": "lhfs1utag8",
+    "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntHttpApi",
+    "declared": {
+      "CorsConfiguration": {
+        "AllowMethods": ["POST", "GET"],
+        "AllowOrigins": ["https://z.example.org", "https://a.example.org", "https://m.example.org"]
+      },
+      "Name": "cdkrd-hunt-reorder-httpapi",
+      "ProtocolType": "HTTP",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "RouteSelectionExpression": "$request.method $request.path",
+    "CorsConfiguration": {
+      "AllowOrigins": ["https://z.example.org", "https://a.example.org", "https://m.example.org"],
+      "ExposeHeaders": [],
+      "AllowHeaders": [],
+      "AllowMethods": ["POST", "GET"]
+    },
+    "ProtocolType": "HTTP",
+    "ApiEndpoint": "https://lhfs1utag8.execute-api.us-east-1.amazonaws.com",
+    "DisableExecuteApiEndpoint": false,
+    "ApiId": "lhfs1utag8",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegReorderProbesMin",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegReorderProbesMin/e6337560-7d4a-11f1-a1a9-0e48750aef13",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "HuntHttpApi"
+    },
+    "Name": "cdkrd-hunt-reorder-httpapi"
+  },
+  "schema": {
+    "readOnly": ["ApiEndpoint", "ApiId"],
+    "writeOnly": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnly": ["ProtocolType"],
+    "readOnlyPaths": ["ApiEndpoint", "ApiId"],
+    "writeOnlyPaths": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "BodyS3Location.Bucket",
+      "BodyS3Location.Etag",
+      "BodyS3Location.Key",
+      "BodyS3Location.Version",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnlyPaths": ["ProtocolType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
+      "physicalId": "lhfs1utag8",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntHttpApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "lhfs1utag8",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntHttpApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "RouteSelectionExpression",
+      "actual": "$request.method $request.path",
+      "physicalId": "lhfs1utag8",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntHttpApi"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__RestApi.HuntRestApi.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.HuntRestApi.json
@@ -1,0 +1,117 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRestApi",
+    "resourceType": "AWS::ApiGateway::RestApi",
+    "physicalId": "ob75xj2l77",
+    "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntRestApi",
+    "declared": {
+      "BinaryMediaTypes": ["image/webp", "application/octet-stream", "image/avif"],
+      "Name": "cdkrd-hunt-reorder-restapi",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "RootResourceId": "ilaekj8ga1",
+    "SecurityPolicy": "TLS_1_0",
+    "RestApiId": "ob75xj2l77",
+    "ApiKeySourceType": "HEADER",
+    "EndpointConfiguration": {
+      "IpAddressType": "ipv4",
+      "Types": ["EDGE"]
+    },
+    "DisableExecuteApiEndpoint": false,
+    "Tags": [
+      {
+        "Value": "HuntRestApi",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegReorderProbesMin/e6337560-7d4a-11f1-a1a9-0e48750aef13",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegReorderProbesMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "BinaryMediaTypes": ["image/webp", "application/octet-stream", "image/avif"],
+    "Name": "cdkrd-hunt-reorder-restapi"
+  },
+  "schema": {
+    "readOnly": ["RestApiId", "RootResourceId"],
+    "writeOnly": ["Body", "BodyS3Location", "CloneFrom", "FailOnWarnings", "Mode", "Parameters"],
+    "createOnly": [],
+    "readOnlyPaths": ["RestApiId", "RootResourceId"],
+    "writeOnlyPaths": [
+      "Body",
+      "BodyS3Location",
+      "CloneFrom",
+      "FailOnWarnings",
+      "Mode",
+      "Parameters"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRestApi",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "ApiKeySourceType",
+      "actual": "HEADER",
+      "physicalId": "ob75xj2l77",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntRestApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRestApi",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
+      "physicalId": "ob75xj2l77",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntRestApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRestApi",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "EndpointConfiguration",
+      "actual": {
+        "IpAddressType": "ipv4",
+        "Types": ["EDGE"]
+      },
+      "physicalId": "ob75xj2l77",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntRestApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRestApi",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "ob75xj2l77",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntRestApi"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Batch__ComputeEnvironment.HuntEc2Ce.json
+++ b/tests/corpus/AWS__Batch__ComputeEnvironment.HuntEc2Ce.json
@@ -1,0 +1,170 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEc2Ce",
+    "resourceType": "AWS::Batch::ComputeEnvironment",
+    "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-gSceaeX2klnBFu3O",
+    "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntEc2Ce",
+    "declared": {
+      "ComputeResources": {
+        "InstanceRole": "arn:aws:iam::111111111111:instance-profile/cdkrd-hunt-batch-profile",
+        "InstanceTypes": ["m5.large", "c5.large"],
+        "MaxvCpus": 4,
+        "MinvCpus": 0,
+        "SecurityGroupIds": ["sg-08d425c27e4eec7cf"],
+        "Subnets": ["subnet-05ddfe200fef4f0a5"],
+        "Type": "EC2"
+      },
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Type": "MANAGED"
+    }
+  },
+  "liveRaw": {
+    "Type": "MANAGED",
+    "ServiceRole": "arn:aws:iam::111111111111:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch",
+    "ComputeEnvironmentName": "HuntEc2Ce-gSceaeX2klnBFu3O",
+    "ComputeResources": {
+      "Subnets": ["subnet-05ddfe200fef4f0a5"],
+      "Type": "EC2",
+      "MinvCpus": 0,
+      "MaxvCpus": 4,
+      "InstanceRole": "arn:aws:iam::111111111111:instance-profile/cdkrd-hunt-batch-profile",
+      "InstanceTypes": ["m5.large", "c5.large"],
+      "Ec2Configuration": [
+        {
+          "ImageType": "ECS_AL2023"
+        }
+      ],
+      "SecurityGroupIds": ["sg-08d425c27e4eec7cf"],
+      "DesiredvCpus": 0
+    },
+    "State": "ENABLED",
+    "ComputeEnvironmentArn": "arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-gSceaeX2klnBFu3O",
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["ComputeEnvironmentArn"],
+    "writeOnly": ["ReplaceComputeEnvironment", "UpdatePolicy"],
+    "createOnly": ["ComputeEnvironmentName", "EksConfiguration", "Tags", "Type"],
+    "readOnlyPaths": [
+      "ComputeEnvironmentArn",
+      "ComputeResources.Ec2Configuration.*.BatchImageStatus"
+    ],
+    "writeOnlyPaths": [
+      "ComputeResources.UpdateToLatestImageVersion",
+      "ReplaceComputeEnvironment",
+      "UpdatePolicy"
+    ],
+    "createOnlyPaths": [
+      "ComputeEnvironmentName",
+      "ComputeResources.SpotIamFleetRole",
+      "EksConfiguration",
+      "Tags",
+      "Type"
+    ],
+    "defaults": {
+      "ReplaceComputeEnvironment": true
+    },
+    "defaultPaths": {
+      "ComputeResources.UpdateToLatestImageVersion": false,
+      "ReplaceComputeEnvironment": true,
+      "UpdatePolicy.TerminateJobsOnUpdate": false,
+      "UpdatePolicy.JobExecutionTimeoutMinutes": 30,
+      "EksConfiguration.EksClusterArn": false,
+      "EksConfiguration.KubernetesNamespace": false
+    },
+    "unorderedScalarPaths": [
+      "ComputeResources.InstanceTypes",
+      "ComputeResources.SecurityGroupIds",
+      "ComputeResources.Subnets"
+    ],
+    "unorderedObjectArrayPaths": [
+      "ComputeResources.Ec2Configuration",
+      "ComputeResources.LaunchTemplate.Overrides"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Ce",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ComputeResources.Ec2Configuration",
+      "actual": [
+        {
+          "ImageType": "ECS_AL2023"
+        }
+      ],
+      "nested": true,
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-gSceaeX2klnBFu3O",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntEc2Ce"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Ce",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ServiceRole",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-gSceaeX2klnBFu3O",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntEc2Ce"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Ce",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-gSceaeX2klnBFu3O",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntEc2Ce"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntEc2Ce",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ComputeEnvironmentName",
+      "actual": "HuntEc2Ce-gSceaeX2klnBFu3O",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-gSceaeX2klnBFu3O",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntEc2Ce"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntEc2Ce",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ComputeResources.DesiredvCpus",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-gSceaeX2klnBFu3O",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntEc2Ce"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudFormation__StackSet.HuntStackSet.json
+++ b/tests/corpus/AWS__CloudFormation__StackSet.HuntStackSet.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntStackSet",
+    "resourceType": "AWS::CloudFormation::StackSet",
+    "physicalId": "cdkrd-hunt-stackset:71d9e2e2-48b6-4a12-904e-9efe67c6d069",
+    "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntStackSet",
+    "declared": {
+      "PermissionModel": "SELF_MANAGED",
+      "StackSetName": "cdkrd-hunt-stackset",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TemplateBody": "{\"Resources\":{\"HuntWaitHandle\":{\"Type\":\"AWS::CloudFormation::WaitConditionHandle\"}}}"
+    }
+  },
+  "liveRaw": {
+    "StackSetId": "cdkrd-hunt-stackset:71d9e2e2-48b6-4a12-904e-9efe67c6d069",
+    "Capabilities": [],
+    "PermissionModel": "SELF_MANAGED",
+    "AdministrationRoleARN": "arn:aws:iam::111111111111:role/AWSCloudFormationStackSetAdministrationRole",
+    "ExecutionRoleName": "AWSCloudFormationStackSetExecutionRole",
+    "TemplateBody": "{\"Resources\":{\"HuntWaitHandle\":{\"Type\":\"AWS::CloudFormation::WaitConditionHandle\"}}}",
+    "StackSetName": "cdkrd-hunt-stackset",
+    "ManagedExecution": {
+      "Active": false
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["StackSetId"],
+    "writeOnly": ["CallAs", "OperationPreferences", "StackInstancesGroup", "TemplateURL"],
+    "createOnly": ["PermissionModel", "StackSetName"],
+    "readOnlyPaths": ["StackSetId"],
+    "writeOnlyPaths": ["CallAs", "OperationPreferences", "StackInstancesGroup", "TemplateURL"],
+    "createOnlyPaths": ["PermissionModel", "StackSetName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["AutoDeployment.DependsOn", "Capabilities"],
+    "unorderedObjectArrayPaths": ["Parameters", "StackInstancesGroup"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntStackSet",
+      "resourceType": "AWS::CloudFormation::StackSet",
+      "path": "AdministrationRoleARN",
+      "actual": "arn:aws:iam::111111111111:role/AWSCloudFormationStackSetAdministrationRole",
+      "physicalId": "cdkrd-hunt-stackset:71d9e2e2-48b6-4a12-904e-9efe67c6d069",
+      "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntStackSet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntStackSet",
+      "resourceType": "AWS::CloudFormation::StackSet",
+      "path": "ExecutionRoleName",
+      "actual": "AWSCloudFormationStackSetExecutionRole",
+      "physicalId": "cdkrd-hunt-stackset:71d9e2e2-48b6-4a12-904e-9efe67c6d069",
+      "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntStackSet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudFront__Distribution.HuntMinDist.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.HuntMinDist.json
@@ -1,0 +1,342 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntMinDist",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "E3A6RP0TULJC5T",
+    "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist",
+    "declared": {
+      "DistributionConfig": {
+        "DefaultCacheBehavior": {
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+          "TargetOriginId": "origin1",
+          "ViewerProtocolPolicy": "allow-all"
+        },
+        "Enabled": true,
+        "Origins": [
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only"
+            },
+            "DomainName": "example.org",
+            "Id": "origin1"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DistributionConfig": {
+      "Logging": {
+        "IncludeCookies": false,
+        "Bucket": "",
+        "Prefix": ""
+      },
+      "Comment": "",
+      "DefaultRootObject": "",
+      "Origins": [
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "example.org",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "origin1",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["SSLv3", "TLSv1"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        }
+      ],
+      "ViewerCertificate": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "PriceClass": "PriceClass_All",
+      "DefaultCacheBehavior": {
+        "Compress": false,
+        "FunctionAssociations": [],
+        "LambdaFunctionAssociations": [],
+        "TargetOriginId": "origin1",
+        "ViewerProtocolPolicy": "allow-all",
+        "GrpcConfig": {
+          "Enabled": false
+        },
+        "TrustedSigners": [],
+        "FieldLevelEncryptionId": "",
+        "TrustedKeyGroups": [],
+        "AllowedMethods": ["HEAD", "GET"],
+        "CachedMethods": ["HEAD", "GET"],
+        "SmoothStreaming": false,
+        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+      },
+      "Staging": false,
+      "CustomErrorResponses": [],
+      "ContinuousDeploymentPolicyId": "",
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "Enabled": true,
+      "Aliases": [],
+      "IPV6Enabled": true,
+      "WebACLId": "",
+      "HttpVersion": "http1.1",
+      "Restrictions": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "CacheBehaviors": []
+    },
+    "DomainName": "di5r95hjug45f.cloudfront.net",
+    "Id": "E3A6RP0TULJC5T",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["DomainName", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["DomainName", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {
+      "DistributionConfig.CacheBehaviors.*.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.Compress": false,
+      "DistributionConfig.CacheBehaviors.*.DefaultTTL": 86400,
+      "DistributionConfig.CacheBehaviors.*.FieldLevelEncryptionId": "",
+      "DistributionConfig.CacheBehaviors.*.MaxTTL": 31536000,
+      "DistributionConfig.CacheBehaviors.*.MinTTL": 0,
+      "DistributionConfig.CacheBehaviors.*.SmoothStreaming": false,
+      "DistributionConfig.Comment": "",
+      "DistributionConfig.CustomErrorResponses.*.ErrorCachingMinTTL": 300,
+      "DistributionConfig.CustomOrigin.HTTPPort": 80,
+      "DistributionConfig.CustomOrigin.HTTPSPort": 443,
+      "DistributionConfig.DefaultCacheBehavior.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.CachePolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.Compress": false,
+      "DistributionConfig.DefaultCacheBehavior.DefaultTTL": 86400,
+      "DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId": "",
+      "DistributionConfig.DefaultCacheBehavior.MaxTTL": 31536000,
+      "DistributionConfig.DefaultCacheBehavior.MinTTL": 0,
+      "DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.RealtimeLogConfigArn": "",
+      "DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.SmoothStreaming": false,
+      "DistributionConfig.DefaultRootObject": "",
+      "DistributionConfig.HttpVersion": "http1.1",
+      "DistributionConfig.Logging.IncludeCookies": false,
+      "DistributionConfig.Logging.Prefix": "",
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPPort": 80,
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPSPort": 443,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginSSLProtocols": ["TLSv1", "SSLv3"],
+      "DistributionConfig.Origins.*.OriginPath": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginAccessIdentity": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.PriceClass": "PriceClass_All",
+      "DistributionConfig.S3Origin.OriginAccessIdentity": "",
+      "DistributionConfig.WebACLId": ""
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.AllowedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.CachedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.HttpVersion",
+      "actual": "http1.1",
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.IPV6Enabled",
+      "actual": true,
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.OriginGroups",
+      "actual": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginSSLProtocols",
+      "actual": ["SSLv3", "TLSv1"],
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.PriceClass",
+      "actual": "PriceClass_All",
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Restrictions",
+      "actual": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMinDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ViewerCertificate",
+      "actual": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "nested": true,
+      "physicalId": "E3A6RP0TULJC5T",
+      "constructPath": "CdkRealDriftIntegCloudFrontMin/HuntMinDist"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cognito__IdentityPool.HuntIdPool.json
+++ b/tests/corpus/AWS__Cognito__IdentityPool.HuntIdPool.json
@@ -1,0 +1,103 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntIdPool",
+    "resourceType": "AWS::Cognito::IdentityPool",
+    "physicalId": "us-east-1:a3a86be5-a785-487e-8abb-9776db858d76",
+    "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntIdPool",
+    "declared": {
+      "AllowUnauthenticatedIdentities": false,
+      "CognitoIdentityProviders": [
+        {
+          "ClientId": "1n37bfmhf0881dv1ma8a1eceef",
+          "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_jz3pqMAyL"
+        },
+        {
+          "ClientId": "7fa16qtk76omj562c5cpa1fmdc",
+          "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_jz3pqMAyL"
+        }
+      ],
+      "IdentityPoolName": "cdkrd-hunt-reorder-idpool",
+      "IdentityPoolTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "CognitoIdentityProviders": [
+      {
+        "ServerSideTokenCheck": false,
+        "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_jz3pqMAyL",
+        "ClientId": "1n37bfmhf0881dv1ma8a1eceef"
+      },
+      {
+        "ServerSideTokenCheck": false,
+        "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_jz3pqMAyL",
+        "ClientId": "7fa16qtk76omj562c5cpa1fmdc"
+      }
+    ],
+    "Id": "us-east-1:a3a86be5-a785-487e-8abb-9776db858d76",
+    "IdentityPoolName": "cdkrd-hunt-reorder-idpool",
+    "SupportedLoginProviders": {},
+    "AllowUnauthenticatedIdentities": false,
+    "Name": "cdkrd-hunt-reorder-idpool",
+    "SamlProviderARNs": [],
+    "OpenIdConnectProviderARNs": [],
+    "AllowClassicFlow": false,
+    "IdentityPoolTags": [
+      {
+        "Value": "HuntIdPool",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkRealDriftIntegReorderProbesMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegReorderProbesMin/e6337560-7d4a-11f1-a1a9-0e48750aef13",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id", "Name"],
+    "writeOnly": ["CognitoStreams", "PushSync"],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "Name"],
+    "writeOnlyPaths": ["CognitoStreams", "PushSync"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "OpenIdConnectProviderARNs",
+      "PushSync.ApplicationArns",
+      "SamlProviderARNs"
+    ],
+    "unorderedObjectArrayPaths": ["CognitoIdentityProviders"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntIdPool",
+      "resourceType": "AWS::Cognito::IdentityPool",
+      "path": "AllowClassicFlow",
+      "actual": false,
+      "physicalId": "us-east-1:a3a86be5-a785-487e-8abb-9776db858d76",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntIdPool"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DMS__Endpoint.HuntDmsEndpoint.json
+++ b/tests/corpus/AWS__DMS__Endpoint.HuntDmsEndpoint.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDmsEndpoint",
+    "resourceType": "AWS::DMS::Endpoint",
+    "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:7LPR6DUUAVGUFHN4X43CRKAITE",
+    "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntDmsEndpoint",
+    "declared": {
+      "EndpointIdentifier": "CdkrdHunt-Mixed-DMS-EP",
+      "EndpointType": "source",
+      "EngineName": "mysql",
+      "Password": "cdkrd-hunt-password-1",
+      "Port": 3306,
+      "ServerName": "hunt.invalid",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Username": "hunter"
+    }
+  },
+  "liveRaw": {
+    "EndpointIdentifier": "cdkrdhunt-mixed-dms-ep",
+    "EndpointType": "SOURCE",
+    "EngineName": "mysql",
+    "Username": "hunter",
+    "ServerName": "hunt.invalid",
+    "Port": 3306,
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+    "SslMode": "none",
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkRealDriftIntegCaseIdentsMin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntDmsEndpoint"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCaseIdentsMin/09209c20-7d4a-11f1-b021-12e64a14fec7"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ExternalId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["KmsKeyId", "ResourceIdentifier"],
+    "readOnlyPaths": ["ExternalId", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KmsKeyId", "ResourceIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsEndpoint",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:7LPR6DUUAVGUFHN4X43CRKAITE",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntDmsEndpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsEndpoint",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "SslMode",
+      "actual": "none",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:7LPR6DUUAVGUFHN4X43CRKAITE",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntDmsEndpoint"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntDmsEndpoint",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "Password",
+      "note": "declared but not returned by live read",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:7LPR6DUUAVGUFHN4X43CRKAITE",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntDmsEndpoint"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
@@ -64,36 +64,11 @@
   },
   "expected": [
     {
-      "tier": "readGap",
-      "logicalId": "ClusterEB0386A7",
-      "resourceType": "AWS::DocDB::DBCluster",
-      "path": "DBSubnetGroupName",
-      "note": "declared but not returned by live read",
-      "physicalId": "clustereb0386a7-n9uafygdqpfe",
-      "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
-    },
-    {
-      "tier": "unresolved",
-      "logicalId": "ClusterEB0386A7",
-      "resourceType": "AWS::DocDB::DBCluster",
-      "path": "MasterUserPassword",
-      "physicalId": "clustereb0386a7-n9uafygdqpfe",
-      "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
-    },
-    {
-      "tier": "unresolved",
-      "logicalId": "ClusterEB0386A7",
-      "resourceType": "AWS::DocDB::DBCluster",
-      "path": "MasterUsername",
-      "physicalId": "clustereb0386a7-n9uafygdqpfe",
-      "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::DocDB::DBCluster",
-      "path": "Port",
-      "actual": 27017,
+      "path": "DBClusterParameterGroupName",
+      "actual": "default.docdb5.0",
       "physicalId": "clustereb0386a7-n9uafygdqpfe",
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
@@ -103,6 +78,24 @@
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "EngineVersion",
       "actual": "5.0.0",
+      "physicalId": "clustereb0386a7-n9uafygdqpfe",
+      "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::DocDB::DBCluster",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "physicalId": "clustereb0386a7-n9uafygdqpfe",
+      "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::DocDB::DBCluster",
+      "path": "Port",
+      "actual": 27017,
       "physicalId": "clustereb0386a7-n9uafygdqpfe",
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
@@ -125,20 +118,27 @@
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
     {
-      "tier": "atDefault",
+      "tier": "readGap",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::DocDB::DBCluster",
-      "path": "KmsKeyId",
-      "actual": "arn:aws:kms:us-east-1:111111111111:key/9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "path": "DBSubnetGroupName",
+      "note": "declared but not returned by live read",
       "physicalId": "clustereb0386a7-n9uafygdqpfe",
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
     {
-      "tier": "atDefault",
+      "tier": "unresolved",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::DocDB::DBCluster",
-      "path": "DBClusterParameterGroupName",
-      "actual": "default.docdb5.0",
+      "path": "MasterUserPassword",
+      "physicalId": "clustereb0386a7-n9uafygdqpfe",
+      "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::DocDB::DBCluster",
+      "path": "MasterUsername",
       "physicalId": "clustereb0386a7-n9uafygdqpfe",
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     }

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
@@ -61,20 +61,11 @@
   },
   "expected": [
     {
-      "tier": "readGap",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
-      "path": "DBSubnetGroupName",
-      "note": "declared but not returned by live read",
-      "physicalId": "cluster-sgjbomufexjn",
-      "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
-    },
-    {
-      "tier": "readGap",
-      "logicalId": "Cluster",
-      "resourceType": "AWS::DocDB::DBCluster",
-      "path": "MasterUserPassword",
-      "note": "declared but not returned by live read",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
       "physicalId": "cluster-sgjbomufexjn",
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
@@ -82,8 +73,8 @@
       "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
-      "path": "BackupRetentionPeriod",
-      "actual": 1,
+      "path": "DBClusterParameterGroupName",
+      "actual": "default.docdb5.0",
       "physicalId": "cluster-sgjbomufexjn",
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
@@ -118,17 +109,26 @@
       "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
-      "path": "DBClusterParameterGroupName",
-      "actual": "default.docdb5.0",
+      "path": "VpcSecurityGroupIds",
+      "actual": ["sg-00bae803921b5e299"],
       "physicalId": "cluster-sgjbomufexjn",
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "readGap",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
-      "path": "VpcSecurityGroupIds",
-      "actual": ["sg-00bae803921b5e299"],
+      "path": "DBSubnetGroupName",
+      "note": "declared but not returned by live read",
+      "physicalId": "cluster-sgjbomufexjn",
+      "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::DocDB::DBCluster",
+      "path": "MasterUserPassword",
+      "note": "declared but not returned by live read",
       "physicalId": "cluster-sgjbomufexjn",
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     }

--- a/tests/corpus/AWS__DynamoDB__Table.HuntOnDemandTable.json
+++ b/tests/corpus/AWS__DynamoDB__Table.HuntOnDemandTable.json
@@ -1,0 +1,132 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOnDemandTable",
+    "resourceType": "AWS::DynamoDB::Table",
+    "physicalId": "CdkRealDriftIntegS3KmsDdbBatchMin-HuntOnDemandTable-1IHBPPJHPUSEA",
+    "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntOnDemandTable",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        }
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SSESpecification": {
+      "SSEEnabled": false
+    },
+    "TableName": "CdkRealDriftIntegS3KmsDdbBatchMin-HuntOnDemandTable-1IHBPPJHPUSEA",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      }
+    ],
+    "ContributorInsightsSpecification": {
+      "Enabled": false
+    },
+    "BillingMode": "PAY_PER_REQUEST",
+    "PointInTimeRecoverySpecification": {
+      "PointInTimeRecoveryEnabled": false
+    },
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      }
+    ],
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkRealDriftIntegS3KmsDdbBatchMin-HuntOnDemandTable-1IHBPPJHPUSEA",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "TimeToLiveSpecification": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn"],
+    "writeOnly": ["ImportSourceSpecification"],
+    "createOnly": ["ImportSourceSpecification", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn"],
+    "writeOnlyPaths": ["ImportSourceSpecification"],
+    "createOnlyPaths": ["ImportSourceSpecification", "TableName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOnDemandTable",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkRealDriftIntegS3KmsDdbBatchMin-HuntOnDemandTable-1IHBPPJHPUSEA",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntOnDemandTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOnDemandTable",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "CdkRealDriftIntegS3KmsDdbBatchMin-HuntOnDemandTable-1IHBPPJHPUSEA",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntOnDemandTable"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EIP.HuntEip.json
+++ b/tests/corpus/AWS__EC2__EIP.HuntEip.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEip",
+    "resourceType": "AWS::EC2::EIP",
+    "physicalId": "18.215.93.30",
+    "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEip",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Domain": "vpc",
+    "NetworkBorderGroup": "us-east-1",
+    "PublicIp": "18.215.93.30",
+    "PublicIpv4Pool": "amazon",
+    "Tags": [
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      },
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkRealDriftIntegVpcAttachMin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntEip"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcAttachMin/44135ef0-7d4d-11f1-86fa-0ee6188a468b"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AllocationId", "PublicIp"],
+    "writeOnly": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnly": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "readOnlyPaths": ["AllocationId", "PublicIp"],
+    "writeOnlyPaths": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnlyPaths": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEip",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "Domain",
+      "actual": "vpc",
+      "physicalId": "18.215.93.30",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEip"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEip",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "NetworkBorderGroup",
+      "actual": "us-east-1",
+      "physicalId": "18.215.93.30",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEip"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEip",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "PublicIpv4Pool",
+      "actual": "amazon",
+      "physicalId": "18.215.93.30",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEip"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EIPAssociation.HuntEipAssoc.json
+++ b/tests/corpus/AWS__EC2__EIPAssociation.HuntEipAssoc.json
@@ -1,0 +1,73 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEipAssoc",
+    "resourceType": "AWS::EC2::EIPAssociation",
+    "physicalId": "eipassoc-0038c9fea5e46017a",
+    "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEipAssoc",
+    "declared": {
+      "AllocationId": "__cdkrd_corpus_unresolved__",
+      "NetworkInterfaceId": "eni-040a1bc440441bd0d"
+    }
+  },
+  "liveRaw": {
+    "PrivateIpAddress": "10.0.0.141",
+    "AllocationId": "eipalloc-03e831eea5316f289",
+    "Id": "eipassoc-0038c9fea5e46017a",
+    "NetworkInterfaceId": "eni-040a1bc440441bd0d",
+    "EIP": "18.215.93.30"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["AllocationId", "EIP", "InstanceId", "NetworkInterfaceId", "PrivateIpAddress"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AllocationId",
+      "EIP",
+      "InstanceId",
+      "NetworkInterfaceId",
+      "PrivateIpAddress"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEipAssoc",
+      "resourceType": "AWS::EC2::EIPAssociation",
+      "path": "EIP",
+      "actual": "18.215.93.30",
+      "physicalId": "eipassoc-0038c9fea5e46017a",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEipAssoc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEipAssoc",
+      "resourceType": "AWS::EC2::EIPAssociation",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.141",
+      "physicalId": "eipassoc-0038c9fea5e46017a",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEipAssoc"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "HuntEipAssoc",
+      "resourceType": "AWS::EC2::EIPAssociation",
+      "path": "AllocationId",
+      "physicalId": "eipassoc-0038c9fea5e46017a",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntEipAssoc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Instance.HuntM5.json
+++ b/tests/corpus/AWS__EC2__Instance.HuntM5.json
@@ -1,0 +1,410 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntM5",
+    "resourceType": "AWS::EC2::Instance",
+    "physicalId": "i-037127c8331a3dbbc",
+    "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5",
+    "declared": {
+      "ImageId": "ami-0fd6240f599091088",
+      "InstanceType": "m5.large",
+      "SubnetId": "subnet-046c42059a8ba748a",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Tenancy": "default",
+    "SecurityGroups": ["default"],
+    "PrivateDnsName": "ip-10-0-0-207.ec2.internal",
+    "PrivateIpAddress": "10.0.0.207",
+    "BlockDeviceMappings": [
+      {
+        "Ebs": {
+          "SnapshotId": "snap-07059b2224a6e7e8c",
+          "VolumeType": "gp3",
+          "Encrypted": false,
+          "Iops": 3000,
+          "VolumeSize": 8,
+          "DeleteOnTermination": true
+        },
+        "DeviceName": "/dev/xvda"
+      }
+    ],
+    "SubnetId": "subnet-046c42059a8ba748a",
+    "EbsOptimized": false,
+    "Volumes": [
+      {
+        "VolumeId": "vol-0fe6f5a993ffe8e51",
+        "Device": "/dev/xvda"
+      }
+    ],
+    "PrivateIp": "10.0.0.207",
+    "EnclaveOptions": {
+      "Enabled": false
+    },
+    "NetworkInterfaces": [
+      {
+        "AssociateCarrierIpAddress": false,
+        "PrivateIpAddress": "10.0.0.207",
+        "PrivateIpAddresses": [
+          {
+            "PrivateIpAddress": "10.0.0.207",
+            "Primary": true
+          }
+        ],
+        "SecondaryPrivateIpAddressCount": 0,
+        "DeviceIndex": "0",
+        "Ipv6AddressCount": 0,
+        "GroupSet": ["sg-071431ba9ef8424c9"],
+        "Ipv6Addresses": [],
+        "SubnetId": "subnet-046c42059a8ba748a",
+        "AssociatePublicIpAddress": true,
+        "NetworkInterfaceId": "eni-0399a3ca19364a05e",
+        "DeleteOnTermination": true
+      }
+    ],
+    "ImageId": "ami-0fd6240f599091088",
+    "InstanceType": "m5.large",
+    "Monitoring": false,
+    "Tags": [
+      {
+        "Value": "HuntM5",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEc2EbsOptMin/83157a60-7d4e-11f1-909d-0affe5762c3f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEc2EbsOptMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "HibernationOptions": {
+      "Configured": false
+    },
+    "MetadataOptions": {
+      "HttpPutResponseHopLimit": 2,
+      "HttpProtocolIpv6": "disabled",
+      "HttpTokens": "required",
+      "InstanceMetadataTags": "disabled",
+      "HttpEndpoint": "enabled"
+    },
+    "InstanceId": "i-037127c8331a3dbbc",
+    "PublicIp": "3.235.9.9",
+    "InstanceInitiatedShutdownBehavior": "stop",
+    "CpuOptions": {
+      "ThreadsPerCore": 2,
+      "CoreCount": 1
+    },
+    "AvailabilityZone": "us-east-1a",
+    "PrivateDnsNameOptions": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "PublicDnsName": "ec2-3-235-9-9.compute-1.amazonaws.com",
+    "SecurityGroupIds": ["sg-071431ba9ef8424c9"],
+    "DisableApiTermination": false,
+    "SourceDestCheck": true,
+    "PlacementGroupName": "",
+    "VpcId": "vpc-004c9ee4ca5d1764a",
+    "State": {
+      "Code": "16",
+      "Name": "running"
+    },
+    "CreditSpecification": {
+      "CPUCredits": "standard"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "InstanceId",
+      "PrivateDnsName",
+      "PrivateIp",
+      "PublicDnsName",
+      "PublicIp",
+      "State",
+      "VpcId"
+    ],
+    "writeOnly": [
+      "AdditionalInfo",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "LaunchTemplate",
+      "LicenseSpecification",
+      "PropagateTagsToVolumeOnCreation"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "CpuOptions",
+      "ElasticGpuSpecifications",
+      "ElasticInferenceAccelerators",
+      "EnclaveOptions",
+      "HibernationOptions",
+      "HostResourceGroupArn",
+      "ImageId",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "KeyName",
+      "LaunchTemplate",
+      "LicenseSpecifications",
+      "NetworkInterfaces",
+      "PlacementGroupName",
+      "PrivateIpAddress",
+      "SecurityGroups",
+      "SubnetId"
+    ],
+    "readOnlyPaths": [
+      "InstanceId",
+      "PrivateDnsName",
+      "PrivateIp",
+      "PublicDnsName",
+      "PublicIp",
+      "State",
+      "VpcId"
+    ],
+    "writeOnlyPaths": [
+      "AdditionalInfo",
+      "BlockDeviceMappings.*.NoDevice",
+      "BlockDeviceMappings.*.VirtualName",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "LaunchTemplate",
+      "LicenseSpecification",
+      "PropagateTagsToVolumeOnCreation"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "CpuOptions",
+      "ElasticGpuSpecifications",
+      "ElasticInferenceAccelerators",
+      "EnclaveOptions",
+      "HibernationOptions",
+      "HostResourceGroupArn",
+      "ImageId",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "KeyName",
+      "LaunchTemplate",
+      "LicenseSpecifications",
+      "NetworkInterfaces",
+      "PlacementGroupName",
+      "PrivateIpAddress",
+      "SecurityGroups",
+      "SubnetId"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "HibernationOptions.Configured": false,
+      "MetadataOptions.HttpPutResponseHopLimit": 1
+    },
+    "unorderedScalarPaths": ["SecurityGroupIds", "SecurityGroups"],
+    "unorderedObjectArrayPaths": [
+      "BlockDeviceMappings",
+      "ElasticGpuSpecifications",
+      "ElasticInferenceAccelerators",
+      "Ipv6Addresses",
+      "LicenseSpecifications",
+      "NetworkInterfaces",
+      "SsmAssociations",
+      "Volumes"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "BlockDeviceMappings",
+      "actual": [
+        {
+          "Ebs": {
+            "SnapshotId": "snap-07059b2224a6e7e8c",
+            "VolumeType": "gp3",
+            "Encrypted": false,
+            "Iops": 3000,
+            "VolumeSize": 8,
+            "DeleteOnTermination": true
+          },
+          "DeviceName": "/dev/xvda"
+        }
+      ],
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "CpuOptions",
+      "actual": {
+        "ThreadsPerCore": 2,
+        "CoreCount": 1
+      },
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "InstanceInitiatedShutdownBehavior",
+      "actual": "stop",
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "MetadataOptions",
+      "actual": {
+        "HttpPutResponseHopLimit": 2,
+        "HttpProtocolIpv6": "disabled",
+        "HttpTokens": "required",
+        "InstanceMetadataTags": "disabled",
+        "HttpEndpoint": "enabled"
+      },
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "NetworkInterfaces",
+      "actual": [
+        {
+          "AssociateCarrierIpAddress": false,
+          "PrivateIpAddress": "10.0.0.207",
+          "PrivateIpAddresses": [
+            {
+              "PrivateIpAddress": "10.0.0.207",
+              "Primary": true
+            }
+          ],
+          "SecondaryPrivateIpAddressCount": 0,
+          "DeviceIndex": "0",
+          "Ipv6AddressCount": 0,
+          "GroupSet": ["sg-071431ba9ef8424c9"],
+          "Ipv6Addresses": [],
+          "SubnetId": "subnet-046c42059a8ba748a",
+          "AssociatePublicIpAddress": true,
+          "NetworkInterfaceId": "eni-0399a3ca19364a05e",
+          "DeleteOnTermination": true
+        }
+      ],
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateDnsNameOptions",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.207",
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-071431ba9ef8424c9"],
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SecurityGroups",
+      "actual": ["default"],
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Tenancy",
+      "actual": "default",
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Volumes",
+      "actual": [
+        {
+          "VolumeId": "vol-0fe6f5a993ffe8e51",
+          "Device": "/dev/xvda"
+        }
+      ],
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntM5",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "CreditSpecification",
+      "actual": {
+        "CPUCredits": "standard"
+      },
+      "physicalId": "i-037127c8331a3dbbc",
+      "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__InstanceConnectEndpoint.HuntIce.json
+++ b/tests/corpus/AWS__EC2__InstanceConnectEndpoint.HuntIce.json
@@ -1,0 +1,115 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntIce",
+    "resourceType": "AWS::EC2::InstanceConnectEndpoint",
+    "physicalId": "eice-06b5fccf9badd4e5d",
+    "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntIce",
+    "declared": {
+      "SubnetId": "subnet-00c26f3fb4ea65291",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "CreatedAt": "2026-07-11T17:24:14Z",
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "NetworkInterfaceIds": ["eni-00643b8175af84120"],
+    "SubnetId": "subnet-00c26f3fb4ea65291",
+    "SecurityGroupIds": ["sg-08e63f5cc038cca50"],
+    "PreserveClientIp": false,
+    "OwnerId": "111111111111",
+    "VpcId": "vpc-079e8dc0eebeb1ca7",
+    "InstanceConnectEndpointArn": "arn:aws:ec2:us-east-1:111111111111:instance-connect-endpoint/eice-06b5fccf9badd4e5d",
+    "State": "create-complete",
+    "Id": "eice-06b5fccf9badd4e5d",
+    "StateMessage": "",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegVpcAttachMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntIce",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcAttachMin/44135ef0-7d4d-11f1-86fa-0ee6188a468b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "PublicDnsNames": {
+      "Dualstack": {
+        "DnsName": "eice-06b5fccf9badd4e5d.bf5df978.ec2-instance-connect-endpoint.us-east-1.api.aws",
+        "FipsDnsName": "eice-06b5fccf9badd4e5d.bf5df978.fips.ec2-instance-connect-endpoint.us-east-1.api.aws"
+      },
+      "Ipv4": {
+        "DnsName": "eice-06b5fccf9badd4e5d.bf5df978.ec2-instance-connect-endpoint.us-east-1.amazonaws.com",
+        "FipsDnsName": "eice-06b5fccf9badd4e5d.bf5df978.fips.ec2-instance-connect-endpoint.us-east-1.amazonaws.com"
+      }
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CreatedAt",
+      "Id",
+      "InstanceConnectEndpointArn",
+      "NetworkInterfaceIds",
+      "OwnerId",
+      "PublicDnsNames",
+      "State",
+      "StateMessage",
+      "VpcId"
+    ],
+    "writeOnly": ["ClientToken"],
+    "createOnly": ["ClientToken", "PreserveClientIp", "SecurityGroupIds", "SubnetId"],
+    "readOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CreatedAt",
+      "Id",
+      "InstanceConnectEndpointArn",
+      "NetworkInterfaceIds",
+      "OwnerId",
+      "PublicDnsNames",
+      "State",
+      "StateMessage",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["ClientToken"],
+    "createOnlyPaths": ["ClientToken", "PreserveClientIp", "SecurityGroupIds", "SubnetId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SecurityGroupIds"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntIce",
+      "resourceType": "AWS::EC2::InstanceConnectEndpoint",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-08e63f5cc038cca50"],
+      "physicalId": "eice-06b5fccf9badd4e5d",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntIce"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Subnet.Ipv6AttachHunt.json
+++ b/tests/corpus/AWS__EC2__Subnet.Ipv6AttachHunt.json
@@ -1,0 +1,195 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-00c26f3fb4ea65291",
+    "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.0.0/24",
+      "MapPublicIpOnLaunch": true,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "public"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Public"
+        },
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1"
+        }
+      ],
+      "VpcId": "vpc-079e8dc0eebeb1ca7"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": true,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "CidrBlock": "10.0.0.0/24",
+    "SubnetId": "subnet-00c26f3fb4ea65291",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-079e8dc0eebeb1ca7",
+    "NetworkAclAssociationId": "aclassoc-05a3e987e781d09f9",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Ipv6CidrBlocks": ["2600:1f18:2de0:6e00::/64"],
+    "Ipv6CidrBlock": "2600:1f18:2de0:6e00::/64",
+    "Tags": [
+      {
+        "Value": "public",
+        "Key": "aws-cdk:subnet-name"
+      },
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-type"
+      },
+      {
+        "Value": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1",
+        "Key": "Name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
+      "physicalId": "subnet-00c26f3fb4ea65291",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-00c26f3fb4ea65291",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "Ipv6Native",
+      "actual": false,
+      "physicalId": "subnet-00c26f3fb4ea65291",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-00c26f3fb4ea65291",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "Ipv6CidrBlock",
+      "actual": "2600:1f18:2de0:6e00::/64",
+      "physicalId": "subnet-00c26f3fb4ea65291",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-00c26f3fb4ea65291",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SubnetCidrBlock.HuntSubnetIpv6.json
+++ b/tests/corpus/AWS__EC2__SubnetCidrBlock.HuntSubnetIpv6.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntSubnetIpv6",
+    "resourceType": "AWS::EC2::SubnetCidrBlock",
+    "physicalId": "subnet-cidr-assoc-0c55defa345aa38b2",
+    "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntSubnetIpv6",
+    "declared": {
+      "Ipv6CidrBlock": "__cdkrd_corpus_unresolved__",
+      "SubnetId": "subnet-00c26f3fb4ea65291"
+    }
+  },
+  "liveRaw": {
+    "Ipv6AddressAttribute": "public",
+    "IpSource": "amazon",
+    "Id": "subnet-cidr-assoc-0c55defa345aa38b2",
+    "SubnetId": "subnet-00c26f3fb4ea65291",
+    "Ipv6CidrBlock": "2600:1f18:2de0:6e00::/64"
+  },
+  "schema": {
+    "readOnly": ["Id", "IpSource", "Ipv6AddressAttribute"],
+    "writeOnly": ["Ipv6IpamPoolId", "Ipv6NetmaskLength"],
+    "createOnly": ["Ipv6CidrBlock", "Ipv6IpamPoolId", "Ipv6NetmaskLength", "SubnetId"],
+    "readOnlyPaths": ["Id", "IpSource", "Ipv6AddressAttribute"],
+    "writeOnlyPaths": ["Ipv6IpamPoolId", "Ipv6NetmaskLength"],
+    "createOnlyPaths": ["Ipv6CidrBlock", "Ipv6IpamPoolId", "Ipv6NetmaskLength", "SubnetId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "HuntSubnetIpv6",
+      "resourceType": "AWS::EC2::SubnetCidrBlock",
+      "path": "Ipv6CidrBlock",
+      "physicalId": "subnet-cidr-assoc-0c55defa345aa38b2",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntSubnetIpv6"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VPCCidrBlock.HuntIpv6Block.json
+++ b/tests/corpus/AWS__EC2__VPCCidrBlock.HuntIpv6Block.json
@@ -1,0 +1,88 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntIpv6Block",
+    "resourceType": "AWS::EC2::VPCCidrBlock",
+    "physicalId": "vpc-cidr-assoc-04699a70e3c882afc",
+    "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntIpv6Block",
+    "declared": {
+      "AmazonProvidedIpv6CidrBlock": true,
+      "VpcId": "vpc-079e8dc0eebeb1ca7"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-079e8dc0eebeb1ca7",
+    "Ipv6AddressAttribute": "public",
+    "IpSource": "amazon",
+    "Ipv6CidrBlockNetworkBorderGroup": "us-east-1",
+    "Id": "vpc-cidr-assoc-04699a70e3c882afc",
+    "Ipv6CidrBlock": "2600:1f18:2de0:6e00::/56",
+    "AmazonProvidedIpv6CidrBlock": true
+  },
+  "schema": {
+    "readOnly": ["Id", "IpSource", "Ipv6AddressAttribute"],
+    "writeOnly": ["Ipv4IpamPoolId", "Ipv4NetmaskLength", "Ipv6IpamPoolId", "Ipv6NetmaskLength"],
+    "createOnly": [
+      "AmazonProvidedIpv6CidrBlock",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6CidrBlockNetworkBorderGroup",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength",
+      "Ipv6Pool",
+      "VpcId"
+    ],
+    "readOnlyPaths": ["Id", "IpSource", "Ipv6AddressAttribute"],
+    "writeOnlyPaths": [
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AmazonProvidedIpv6CidrBlock",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6CidrBlockNetworkBorderGroup",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength",
+      "Ipv6Pool",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntIpv6Block",
+      "resourceType": "AWS::EC2::VPCCidrBlock",
+      "path": "Ipv6CidrBlock",
+      "actual": "2600:1f18:2de0:6e00::/56",
+      "physicalId": "vpc-cidr-assoc-04699a70e3c882afc",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntIpv6Block"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntIpv6Block",
+      "resourceType": "AWS::EC2::VPCCidrBlock",
+      "path": "Ipv6CidrBlockNetworkBorderGroup",
+      "actual": "us-east-1",
+      "physicalId": "vpc-cidr-assoc-04699a70e3c882afc",
+      "constructPath": "CdkRealDriftIntegVpcAttachMin/HuntIpv6Block"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__Cluster.HuntEcsCluster.json
+++ b/tests/corpus/AWS__ECS__Cluster.HuntEcsCluster.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEcsCluster",
+    "resourceType": "AWS::ECS::Cluster",
+    "physicalId": "cdkrd-hunt-reorder-cluster",
+    "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntEcsCluster",
+    "declared": {
+      "CapacityProviders": ["FARGATE_SPOT", "FARGATE"],
+      "ClusterName": "cdkrd-hunt-reorder-cluster",
+      "DefaultCapacityProviderStrategy": [
+        {
+          "CapacityProvider": "FARGATE_SPOT",
+          "Weight": 2
+        },
+        {
+          "Base": 1,
+          "CapacityProvider": "FARGATE",
+          "Weight": 1
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ClusterSettings": [
+      {
+        "Value": "disabled",
+        "Name": "containerInsights"
+      }
+    ],
+    "DefaultCapacityProviderStrategy": [
+      {
+        "CapacityProvider": "FARGATE_SPOT",
+        "Weight": 2,
+        "Base": 0
+      },
+      {
+        "CapacityProvider": "FARGATE",
+        "Weight": 1,
+        "Base": 1
+      }
+    ],
+    "CapacityProviders": ["FARGATE", "FARGATE_SPOT"],
+    "ClusterName": "cdkrd-hunt-reorder-cluster",
+    "Arn": "arn:aws:ecs:us-east-1:111111111111:cluster/cdkrd-hunt-reorder-cluster",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegReorderProbesMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntEcsCluster",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegReorderProbesMin/e6337560-7d4a-11f1-a1a9-0e48750aef13",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["ServiceConnectDefaults"],
+    "createOnly": ["ClusterName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["ServiceConnectDefaults"],
+    "createOnlyPaths": ["ClusterName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEcsCluster",
+      "resourceType": "AWS::ECS::Cluster",
+      "path": "ClusterSettings",
+      "actual": [
+        {
+          "Value": "disabled",
+          "Name": "containerInsights"
+        }
+      ],
+      "physicalId": "cdkrd-hunt-reorder-cluster",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntEcsCluster"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__Service.HuntEc2Service.json
+++ b/tests/corpus/AWS__ECS__Service.HuntEc2Service.json
@@ -1,0 +1,170 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEc2Service",
+    "resourceType": "AWS::ECS::Service",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+    "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service",
+    "declared": {
+      "Cluster": "cdkrd-hunt-ec2svc-cluster",
+      "DesiredCount": 0,
+      "LaunchType": "EC2",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-hunt-ec2svc-td:1"
+    }
+  },
+  "liveRaw": {
+    "HealthCheckGracePeriodSeconds": 0,
+    "EnableECSManagedTags": false,
+    "EnableExecuteCommand": false,
+    "PlacementConstraints": [],
+    "Cluster": "cdkrd-hunt-ec2svc-cluster",
+    "ServiceArn": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+    "DesiredCount": 0,
+    "PlacementStrategies": [],
+    "DeploymentController": {
+      "Type": "ECS"
+    },
+    "LaunchType": "EC2",
+    "Name": "CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+    "AvailabilityZoneRebalancing": "ENABLED",
+    "SchedulingStrategy": "REPLICA",
+    "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-hunt-ec2svc-td:1",
+    "ServiceName": "CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+    "DeploymentConfiguration": {
+      "BakeTimeInMinutes": 0,
+      "Strategy": "ROLLING",
+      "DeploymentCircuitBreaker": {
+        "ThresholdConfiguration": {
+          "Type": "BOUNDED_PERCENT",
+          "Value": 50
+        },
+        "Enable": false,
+        "ResetOnHealthyTask": true,
+        "Rollback": false
+      },
+      "MaximumPercent": 200,
+      "MinimumHealthyPercent": 100
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Name", "ServiceArn"],
+    "writeOnly": ["ForceNewDeployment", "Monitoring"],
+    "createOnly": ["Cluster", "Role", "SchedulingStrategy", "ServiceName"],
+    "readOnlyPaths": ["Name", "ServiceArn"],
+    "writeOnlyPaths": ["ForceNewDeployment", "Monitoring"],
+    "createOnlyPaths": ["Cluster", "Role", "SchedulingStrategy", "ServiceName"],
+    "defaults": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "defaultPaths": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "unorderedScalarPaths": [
+      "NetworkConfiguration.AwsvpcConfiguration.SecurityGroups",
+      "NetworkConfiguration.AwsvpcConfiguration.Subnets"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["ServiceConnectConfiguration.LogConfiguration.Options"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "AvailabilityZoneRebalancing",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentConfiguration",
+      "actual": {
+        "BakeTimeInMinutes": 0,
+        "Strategy": "ROLLING",
+        "DeploymentCircuitBreaker": {
+          "ThresholdConfiguration": {
+            "Type": "BOUNDED_PERCENT",
+            "Value": 50
+          },
+          "Enable": false,
+          "ResetOnHealthyTask": true,
+          "Rollback": false
+        },
+        "MaximumPercent": 200,
+        "MinimumHealthyPercent": 100
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentController",
+      "actual": {
+        "Type": "ECS"
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "EnableExecuteCommand",
+      "actual": false,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "HealthCheckGracePeriodSeconds",
+      "actual": 0,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEc2Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "SchedulingStrategy",
+      "actual": "REPLICA",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntEc2Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "ServiceName",
+      "actual": "CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-hunt-ec2svc-cluster/CdkRealDriftIntegEcsEc2ServiceMin-HuntEc2Service-I6NPHSZtV91c",
+      "constructPath": "CdkRealDriftIntegEcsEc2ServiceMin/HuntEc2Service"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__TaskDefinition.HuntHostTaskDef.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.HuntHostTaskDef.json
@@ -1,0 +1,155 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntHostTaskDef",
+    "resourceType": "AWS::ECS::TaskDefinition",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-hunt-host-td:1",
+    "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntHostTaskDef",
+    "declared": {
+      "ContainerDefinitions": [
+        {
+          "Image": "public.ecr.aws/docker/library/busybox:stable",
+          "Memory": 128,
+          "Name": "app"
+        }
+      ],
+      "Family": "cdkrd-hunt-host-td",
+      "NetworkMode": "host",
+      "RequiresCompatibilities": ["EC2"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Volumes": [],
+    "InferenceAccelerators": [],
+    "PlacementConstraints": [],
+    "ContainerDefinitions": [
+      {
+        "ExtraHosts": [],
+        "Secrets": [],
+        "Memory": 128,
+        "VolumesFrom": [],
+        "Cpu": 0,
+        "EntryPoint": [],
+        "DnsServers": [],
+        "Image": "public.ecr.aws/docker/library/busybox:stable",
+        "Essential": true,
+        "ResourceRequirements": [],
+        "EnvironmentFiles": [],
+        "Name": "app",
+        "MountPoints": [],
+        "DependsOn": [],
+        "DockerLabels": {},
+        "PortMappings": [],
+        "DockerSecurityOptions": [],
+        "SystemControls": [],
+        "Command": [],
+        "DnsSearchDomains": [],
+        "Environment": [],
+        "Links": [],
+        "CredentialSpecs": [],
+        "Ulimits": []
+      }
+    ],
+    "Family": "cdkrd-hunt-host-td",
+    "RequiresCompatibilities": ["EC2"],
+    "NetworkMode": "host",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "TaskDefinitionArn": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-hunt-host-td:1"
+  },
+  "schema": {
+    "readOnly": ["TaskDefinitionArn"],
+    "writeOnly": [],
+    "createOnly": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "readOnlyPaths": ["TaskDefinitionArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "ContainerDefinitions.*.VersionConsistency": "enabled"
+    },
+    "unorderedScalarPaths": ["RequiresCompatibilities"],
+    "unorderedObjectArrayPaths": ["InferenceAccelerators", "PlacementConstraints"],
+    "freeFormMapPaths": [
+      "ContainerDefinitions.*.DockerLabels",
+      "ContainerDefinitions.*.FirelensConfiguration.Options",
+      "ContainerDefinitions.*.LogConfiguration.Options",
+      "Volumes.*.DockerVolumeConfiguration.DriverOpts",
+      "Volumes.*.DockerVolumeConfiguration.Labels"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHostTaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[app].Cpu",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-hunt-host-td:1",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntHostTaskDef"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHostTaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[app].Essential",
+      "actual": true,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-hunt-host-td:1",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntHostTaskDef"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EFS__FileSystem.HuntEfs.json
+++ b/tests/corpus/AWS__EFS__FileSystem.HuntEfs.json
@@ -1,0 +1,132 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEfs",
+    "resourceType": "AWS::EFS::FileSystem",
+    "physicalId": "fs-06b891adc73d57473",
+    "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntEfs",
+    "declared": {
+      "FileSystemTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "LifecyclePolicies": [
+        {
+          "TransitionToPrimaryStorageClass": "AFTER_1_ACCESS"
+        },
+        {
+          "TransitionToArchive": "AFTER_90_DAYS"
+        },
+        {
+          "TransitionToIA": "AFTER_30_DAYS"
+        }
+      ],
+      "ThroughputMode": "elastic"
+    }
+  },
+  "liveRaw": {
+    "PerformanceMode": "generalPurpose",
+    "Encrypted": false,
+    "FileSystemTags": [
+      {
+        "Value": "HuntEfs",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegReorderProbesMin/e6337560-7d4a-11f1-a1a9-0e48750aef13",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegReorderProbesMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "FileSystemId": "fs-06b891adc73d57473",
+    "FileSystemProtection": {
+      "ReplicationOverwriteProtection": "ENABLED"
+    },
+    "LifecyclePolicies": [
+      {
+        "TransitionToPrimaryStorageClass": "AFTER_1_ACCESS"
+      },
+      {
+        "TransitionToArchive": "AFTER_90_DAYS"
+      },
+      {
+        "TransitionToIA": "AFTER_30_DAYS"
+      }
+    ],
+    "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:file-system/fs-06b891adc73d57473",
+    "ThroughputMode": "elastic",
+    "BackupPolicy": {
+      "Status": "DISABLED"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "FileSystemId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck"],
+    "createOnly": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "readOnlyPaths": [
+      "Arn",
+      "FileSystemId",
+      "ReplicationConfiguration.Destinations.*.Status",
+      "ReplicationConfiguration.Destinations.*.StatusMessage"
+    ],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "ReplicationConfiguration.Destinations.*.AvailabilityZoneName",
+      "ReplicationConfiguration.Destinations.*.KmsKeyId"
+    ],
+    "createOnlyPaths": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEfs",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "fs-06b891adc73d57473",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntEfs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEfs",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "FileSystemProtection",
+      "actual": {
+        "ReplicationOverwriteProtection": "ENABLED"
+      },
+      "physicalId": "fs-06b891adc73d57473",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntEfs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEfs",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "PerformanceMode",
+      "actual": "generalPurpose",
+      "physicalId": "fs-06b891adc73d57473",
+      "constructPath": "CdkRealDriftIntegReorderProbesMin/HuntEfs"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntCmeRg.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntCmeRg.json
@@ -1,0 +1,280 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntCmeRg",
+    "resourceType": "AWS::ElastiCache::ReplicationGroup",
+    "physicalId": "cdh1logc9nwhco4c",
+    "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg",
+    "declared": {
+      "CacheNodeType": "cache.t4g.micro",
+      "Engine": "redis",
+      "NumNodeGroups": 2,
+      "ReplicasPerNodeGroup": 0,
+      "ReplicationGroupDescription": "cdkrd hunt minimal cluster-mode-enabled rg",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ReadEndPoint": {},
+    "ClusterMode": "enabled",
+    "ConfigurationEndPoint": {
+      "Address": "cdh1logc9nwhco4c.jzgy0l.clustercfg.use1.cache.amazonaws.com",
+      "Port": "6379"
+    },
+    "AtRestEncryptionEnabled": false,
+    "ReaderEndPoint": {},
+    "AutoMinorVersionUpgrade": true,
+    "AutomaticFailoverEnabled": true,
+    "ReplicasPerNodeGroup": 0,
+    "ReplicationGroupDescription": "cdkrd hunt minimal cluster-mode-enabled rg",
+    "SnapshotWindow": "08:30-09:30",
+    "CacheNodeType": "cache.t4g.micro",
+    "SnapshotRetentionLimit": 0,
+    "MultiAZEnabled": false,
+    "TransitEncryptionEnabled": false,
+    "NetworkType": "ipv4",
+    "UserGroupIds": [],
+    "IpDiscovery": "ipv4",
+    "ReplicationGroupId": "cdh1logc9nwhco4c",
+    "DataTieringEnabled": false,
+    "LogDeliveryConfigurations": [],
+    "PrimaryEndPoint": {},
+    "Engine": "redis",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "NumCacheClusters": 2,
+    "PreferredMaintenanceWindow": "sat:07:00-sat:08:00",
+    "EngineVersion": "7.1.0"
+  },
+  "schema": {
+    "readOnly": [
+      "ConfigurationEndPoint",
+      "EffectiveDurability",
+      "PrimaryEndPoint",
+      "ReadEndPoint",
+      "ReaderEndPoint"
+    ],
+    "writeOnly": [
+      "AuthToken",
+      "CacheParameterGroupName",
+      "CacheSecurityGroupNames",
+      "CacheSubnetGroupName",
+      "KmsKeyId",
+      "NodeGroupConfiguration",
+      "NumNodeGroups",
+      "PreferredCacheClusterAZs",
+      "PrimaryClusterId",
+      "SecurityGroupIds",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnly": [
+      "AtRestEncryptionEnabled",
+      "CacheSubnetGroupName",
+      "DataTieringEnabled",
+      "GlobalReplicationGroupId",
+      "KmsKeyId",
+      "NetworkType",
+      "Port",
+      "PreferredCacheClusterAZs",
+      "ReplicationGroupId",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "readOnlyPaths": [
+      "ConfigurationEndPoint",
+      "ConfigurationEndPoint.Address",
+      "ConfigurationEndPoint.Port",
+      "EffectiveDurability",
+      "PrimaryEndPoint",
+      "PrimaryEndPoint.Address",
+      "PrimaryEndPoint.Port",
+      "ReadEndPoint",
+      "ReadEndPoint.Addresses",
+      "ReadEndPoint.AddressesList",
+      "ReadEndPoint.Ports",
+      "ReadEndPoint.PortsList",
+      "ReaderEndPoint",
+      "ReaderEndPoint.Address",
+      "ReaderEndPoint.Port"
+    ],
+    "writeOnlyPaths": [
+      "AuthToken",
+      "CacheParameterGroupName",
+      "CacheSecurityGroupNames",
+      "CacheSubnetGroupName",
+      "KmsKeyId",
+      "NodeGroupConfiguration",
+      "NumNodeGroups",
+      "PreferredCacheClusterAZs",
+      "PrimaryClusterId",
+      "SecurityGroupIds",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "AtRestEncryptionEnabled",
+      "CacheSubnetGroupName",
+      "DataTieringEnabled",
+      "GlobalReplicationGroupId",
+      "KmsKeyId",
+      "NetworkType",
+      "Port",
+      "PreferredCacheClusterAZs",
+      "ReplicationGroupId",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "defaults": {
+      "NumNodeGroups": 1,
+      "AutomaticFailoverEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "SnapshotRetentionLimit": 0
+    },
+    "defaultPaths": {
+      "NumNodeGroups": 1,
+      "AutomaticFailoverEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "SnapshotRetentionLimit": 0
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "AtRestEncryptionEnabled",
+      "actual": false,
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "EngineVersion",
+      "actual": "7.1.0",
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "sat:07:00-sat:08:00",
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "SnapshotRetentionLimit",
+      "actual": 0,
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "SnapshotWindow",
+      "actual": "08:30-09:30",
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "TransitEncryptionEnabled",
+      "actual": false,
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "NumNodeGroups",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "AutomaticFailoverEnabled",
+      "actual": true,
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "ClusterMode",
+      "actual": "enabled",
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntCmeRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "NumCacheClusters",
+      "actual": 2,
+      "physicalId": "cdh1logc9nwhco4c",
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntValkeyRg.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntValkeyRg.json
@@ -1,0 +1,272 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntValkeyRg",
+    "resourceType": "AWS::ElastiCache::ReplicationGroup",
+    "physicalId": "cdh15rygbts7ya8",
+    "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg",
+    "declared": {
+      "AutomaticFailoverEnabled": false,
+      "CacheNodeType": "cache.t4g.micro",
+      "Engine": "valkey",
+      "NumCacheClusters": 1,
+      "ReplicationGroupDescription": "cdkrd hunt minimal valkey replication group",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TransitEncryptionEnabled": false
+    }
+  },
+  "liveRaw": {
+    "ReadEndPoint": {
+      "Addresses": "[cdh15rygbts7ya8-001.jzgy0l.0001.use1.cache.amazonaws.com]",
+      "PortsList": ["6379"],
+      "AddressesList": ["cdh15rygbts7ya8-001.jzgy0l.0001.use1.cache.amazonaws.com"],
+      "Ports": "[6379]"
+    },
+    "ClusterMode": "disabled",
+    "Port": 6379,
+    "ReaderEndPoint": {
+      "Address": "cdh15rygbts7ya8-ro.jzgy0l.ng.0001.use1.cache.amazonaws.com",
+      "Port": "6379"
+    },
+    "AutomaticFailoverEnabled": false,
+    "ReplicasPerNodeGroup": 0,
+    "ReplicationGroupDescription": "cdkrd hunt minimal valkey replication group",
+    "MultiAZEnabled": false,
+    "TransitEncryptionEnabled": false,
+    "NetworkType": "ipv4",
+    "ReplicationGroupId": "cdh15rygbts7ya8",
+    "Engine": "valkey",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "NumCacheClusters": 1,
+    "ConfigurationEndPoint": {},
+    "AtRestEncryptionEnabled": true,
+    "AutoMinorVersionUpgrade": true,
+    "SnapshotWindow": "04:00-05:00",
+    "CacheNodeType": "cache.t4g.micro",
+    "SnapshotRetentionLimit": 0,
+    "UserGroupIds": [],
+    "IpDiscovery": "ipv4",
+    "DataTieringEnabled": false,
+    "LogDeliveryConfigurations": [],
+    "PrimaryEndPoint": {
+      "Address": "cdh15rygbts7ya8.jzgy0l.ng.0001.use1.cache.amazonaws.com",
+      "Port": "6379"
+    },
+    "PreferredMaintenanceWindow": "thu:03:00-thu:04:00",
+    "EngineVersion": "9.1.0"
+  },
+  "schema": {
+    "readOnly": [
+      "ConfigurationEndPoint",
+      "EffectiveDurability",
+      "PrimaryEndPoint",
+      "ReadEndPoint",
+      "ReaderEndPoint"
+    ],
+    "writeOnly": [
+      "AuthToken",
+      "CacheParameterGroupName",
+      "CacheSecurityGroupNames",
+      "CacheSubnetGroupName",
+      "KmsKeyId",
+      "NodeGroupConfiguration",
+      "NumNodeGroups",
+      "PreferredCacheClusterAZs",
+      "PrimaryClusterId",
+      "SecurityGroupIds",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnly": [
+      "AtRestEncryptionEnabled",
+      "CacheSubnetGroupName",
+      "DataTieringEnabled",
+      "GlobalReplicationGroupId",
+      "KmsKeyId",
+      "NetworkType",
+      "Port",
+      "PreferredCacheClusterAZs",
+      "ReplicationGroupId",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "readOnlyPaths": [
+      "ConfigurationEndPoint",
+      "ConfigurationEndPoint.Address",
+      "ConfigurationEndPoint.Port",
+      "EffectiveDurability",
+      "PrimaryEndPoint",
+      "PrimaryEndPoint.Address",
+      "PrimaryEndPoint.Port",
+      "ReadEndPoint",
+      "ReadEndPoint.Addresses",
+      "ReadEndPoint.AddressesList",
+      "ReadEndPoint.Ports",
+      "ReadEndPoint.PortsList",
+      "ReaderEndPoint",
+      "ReaderEndPoint.Address",
+      "ReaderEndPoint.Port"
+    ],
+    "writeOnlyPaths": [
+      "AuthToken",
+      "CacheParameterGroupName",
+      "CacheSecurityGroupNames",
+      "CacheSubnetGroupName",
+      "KmsKeyId",
+      "NodeGroupConfiguration",
+      "NumNodeGroups",
+      "PreferredCacheClusterAZs",
+      "PrimaryClusterId",
+      "SecurityGroupIds",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "AtRestEncryptionEnabled",
+      "CacheSubnetGroupName",
+      "DataTieringEnabled",
+      "GlobalReplicationGroupId",
+      "KmsKeyId",
+      "NetworkType",
+      "Port",
+      "PreferredCacheClusterAZs",
+      "ReplicationGroupId",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "defaults": {
+      "NumNodeGroups": 1,
+      "AutomaticFailoverEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "SnapshotRetentionLimit": 0
+    },
+    "defaultPaths": {
+      "NumNodeGroups": 1,
+      "AutomaticFailoverEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "SnapshotRetentionLimit": 0
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "AtRestEncryptionEnabled",
+      "actual": true,
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "ClusterMode",
+      "actual": "disabled",
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "EngineVersion",
+      "actual": "9.1.0",
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "Port",
+      "actual": 6379,
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "thu:03:00-thu:04:00",
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "ReplicasPerNodeGroup",
+      "actual": 0,
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "SnapshotRetentionLimit",
+      "actual": 0,
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyRg",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "SnapshotWindow",
+      "actual": "04:00-05:00",
+      "physicalId": "cdh15rygbts7ya8",
+      "constructPath": "CdkRealDriftIntegElastiCacheValkeyMin/HuntValkeyRg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__Rule.HuntCronRule.json
+++ b/tests/corpus/AWS__Events__Rule.HuntCronRule.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntCronRule",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "CdkRealDriftIntegStreamFifoMin-HuntCronRule-ze460vjwvIT7",
+    "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntCronRule",
+    "declared": {
+      "ScheduleExpression": "cron(0 12 * * ? *)",
+      "State": "DISABLED",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "ScheduleExpression": "cron(0 12 * * ? *)",
+    "State": "DISABLED",
+    "Targets": [],
+    "Id": "CdkRealDriftIntegStreamFifoMin-HuntCronRule-ze460vjwvIT7",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/CdkRealDriftIntegStreamFifoMin-HuntCronRule-ze460vjwvIT7",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegStreamFifoMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntCronRule",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegStreamFifoMin/6b5b0d90-7d49-11f1-89c5-12787c3aadc7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "CdkRealDriftIntegStreamFifoMin-HuntCronRule-ze460vjwvIT7"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "Targets.*.HttpParameters.HeaderParameters",
+      "Targets.*.HttpParameters.QueryStringParameters",
+      "Targets.*.InputTransformer.InputPathsMap"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCronRule",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "CdkRealDriftIntegStreamFifoMin-HuntCronRule-ze460vjwvIT7",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntCronRule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GuardDuty__Detector.HuntDetector.json
+++ b/tests/corpus/AWS__GuardDuty__Detector.HuntDetector.json
@@ -1,0 +1,249 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDetector",
+    "resourceType": "AWS::GuardDuty::Detector",
+    "physicalId": "713e956581494931b2d42a05fe9616d0",
+    "constructPath": "CdkRealDriftIntegGdSecHubMin/HuntDetector",
+    "declared": {
+      "Enable": true,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "FindingPublishingFrequency": "SIX_HOURS",
+    "DataSources": {
+      "MalwareProtection": {
+        "ScanEc2InstanceWithFindings": {
+          "EbsVolumes": true
+        }
+      },
+      "S3Logs": {
+        "Enable": true
+      },
+      "Kubernetes": {
+        "AuditLogs": {
+          "Enable": true
+        }
+      }
+    },
+    "Enable": true,
+    "Features": [
+      {
+        "Status": "ENABLED",
+        "Name": "CLOUD_TRAIL"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "DNS_LOGS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "FLOW_LOGS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "S3_DATA_EVENTS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "EKS_AUDIT_LOGS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "EBS_MALWARE_PROTECTION"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "RDS_LOGIN_EVENTS"
+      },
+      {
+        "Status": "DISABLED",
+        "Name": "AI_ANALYST"
+      },
+      {
+        "Status": "DISABLED",
+        "AdditionalConfiguration": [
+          {
+            "Status": "DISABLED",
+            "Name": "EKS_ADDON_MANAGEMENT"
+          }
+        ],
+        "Name": "EKS_RUNTIME_MONITORING"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "LAMBDA_NETWORK_LOGS"
+      },
+      {
+        "Status": "DISABLED",
+        "AdditionalConfiguration": [
+          {
+            "Status": "DISABLED",
+            "Name": "EKS_ADDON_MANAGEMENT"
+          },
+          {
+            "Status": "DISABLED",
+            "Name": "ECS_FARGATE_AGENT_MANAGEMENT"
+          },
+          {
+            "Status": "DISABLED",
+            "Name": "EC2_AGENT_MANAGEMENT"
+          }
+        ],
+        "Name": "RUNTIME_MONITORING"
+      }
+    ],
+    "Id": "713e956581494931b2d42a05fe9616d0",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegGdSecHubMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntDetector",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegGdSecHubMin/692cbbe0-7d49-11f1-b4f9-0affe6509ac1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDetector",
+      "resourceType": "AWS::GuardDuty::Detector",
+      "path": "DataSources",
+      "actual": {
+        "MalwareProtection": {
+          "ScanEc2InstanceWithFindings": {
+            "EbsVolumes": true
+          }
+        },
+        "S3Logs": {
+          "Enable": true
+        },
+        "Kubernetes": {
+          "AuditLogs": {
+            "Enable": true
+          }
+        }
+      },
+      "physicalId": "713e956581494931b2d42a05fe9616d0",
+      "constructPath": "CdkRealDriftIntegGdSecHubMin/HuntDetector"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDetector",
+      "resourceType": "AWS::GuardDuty::Detector",
+      "path": "Features",
+      "actual": [
+        {
+          "Status": "DISABLED",
+          "Name": "AI_ANALYST"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "CLOUD_TRAIL"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "DNS_LOGS"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "EBS_MALWARE_PROTECTION"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "EKS_AUDIT_LOGS"
+        },
+        {
+          "Status": "DISABLED",
+          "AdditionalConfiguration": [
+            {
+              "Status": "DISABLED",
+              "Name": "EKS_ADDON_MANAGEMENT"
+            }
+          ],
+          "Name": "EKS_RUNTIME_MONITORING"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "FLOW_LOGS"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "LAMBDA_NETWORK_LOGS"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "RDS_LOGIN_EVENTS"
+        },
+        {
+          "Status": "DISABLED",
+          "AdditionalConfiguration": [
+            {
+              "Status": "DISABLED",
+              "Name": "EC2_AGENT_MANAGEMENT"
+            },
+            {
+              "Status": "DISABLED",
+              "Name": "ECS_FARGATE_AGENT_MANAGEMENT"
+            },
+            {
+              "Status": "DISABLED",
+              "Name": "EKS_ADDON_MANAGEMENT"
+            }
+          ],
+          "Name": "RUNTIME_MONITORING"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "S3_DATA_EVENTS"
+        }
+      ],
+      "physicalId": "713e956581494931b2d42a05fe9616d0",
+      "constructPath": "CdkRealDriftIntegGdSecHubMin/HuntDetector"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDetector",
+      "resourceType": "AWS::GuardDuty::Detector",
+      "path": "FindingPublishingFrequency",
+      "actual": "SIX_HOURS",
+      "physicalId": "713e956581494931b2d42a05fe9616d0",
+      "constructPath": "CdkRealDriftIntegGdSecHubMin/HuntDetector"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ImageBuilder__Component.HuntComponent.json
+++ b/tests/corpus/AWS__ImageBuilder__Component.HuntComponent.json
@@ -1,0 +1,95 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntComponent",
+    "resourceType": "AWS::ImageBuilder::Component",
+    "physicalId": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/1.0.0/1",
+    "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntComponent",
+    "declared": {
+      "Data": "name: cdkrd-hunt-noop\ndescription: cdkrd hunt noop component\nschemaVersion: 1.0\nphases:\n  - name: build\n    steps:\n      - name: Noop\n        action: ExecuteBash\n        inputs:\n          commands:\n            - echo noop\n",
+      "Name": "cdkrd-hunt-component",
+      "Platform": "Linux",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Version": "1.0.0"
+    }
+  },
+  "liveRaw": {
+    "Type": "BUILD",
+    "SupportedOsVersions": [],
+    "Platform": "Linux",
+    "Version": "1.0.0",
+    "LatestVersion": {
+      "Major": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/1.x.x",
+      "Minor": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/1.0.x",
+      "Arn": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/x.x.x",
+      "Patch": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/1.0.0"
+    },
+    "Encrypted": true,
+    "Arn": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/1.0.0/1",
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "Name": "cdkrd-hunt-component"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Encrypted", "LatestVersion", "Type"],
+    "writeOnly": ["Data", "Uri"],
+    "createOnly": [
+      "ChangeDescription",
+      "Data",
+      "Description",
+      "KmsKeyId",
+      "Name",
+      "Platform",
+      "SupportedOsVersions",
+      "Uri",
+      "Version"
+    ],
+    "readOnlyPaths": [
+      "Arn",
+      "Encrypted",
+      "LatestVersion",
+      "LatestVersion.Arn",
+      "LatestVersion.Major",
+      "LatestVersion.Minor",
+      "LatestVersion.Patch",
+      "Type"
+    ],
+    "writeOnlyPaths": ["Data", "Uri"],
+    "createOnlyPaths": [
+      "ChangeDescription",
+      "Data",
+      "Description",
+      "KmsKeyId",
+      "Name",
+      "Platform",
+      "SupportedOsVersions",
+      "Uri",
+      "Version"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SupportedOsVersions"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntComponent",
+      "resourceType": "AWS::ImageBuilder::Component",
+      "path": "Data",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/1.0.0/1",
+      "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntComponent"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ImageBuilder__InfrastructureConfiguration.HuntIbInfra.json
+++ b/tests/corpus/AWS__ImageBuilder__InfrastructureConfiguration.HuntIbInfra.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntIbInfra",
+    "resourceType": "AWS::ImageBuilder::InfrastructureConfiguration",
+    "physicalId": "arn:aws:imagebuilder:us-east-1:111111111111:infrastructure-configuration/cdkrd-hunt-ib-infra",
+    "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntIbInfra",
+    "declared": {
+      "InstanceProfileName": "cdkrd-hunt-ib-profile",
+      "Name": "cdkrd-hunt-ib-infra",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "Logging": {
+      "S3Logs": {}
+    },
+    "InstanceProfileName": "cdkrd-hunt-ib-profile",
+    "ResourceTags": {},
+    "TerminateInstanceOnFailure": true,
+    "InstanceTypes": [],
+    "Arn": "arn:aws:imagebuilder:us-east-1:111111111111:infrastructure-configuration/cdkrd-hunt-ib-infra",
+    "SecurityGroupIds": [],
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "Name": "cdkrd-hunt-ib-infra"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SecurityGroupIds"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["ResourceTags"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntIbInfra",
+      "resourceType": "AWS::ImageBuilder::InfrastructureConfiguration",
+      "path": "TerminateInstanceOnFailure",
+      "actual": true,
+      "physicalId": "arn:aws:imagebuilder:us-east-1:111111111111:infrastructure-configuration/cdkrd-hunt-ib-infra",
+      "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntIbInfra"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Kinesis__Stream.HuntOnDemandStream.json
+++ b/tests/corpus/AWS__Kinesis__Stream.HuntOnDemandStream.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOnDemandStream",
+    "resourceType": "AWS::Kinesis::Stream",
+    "physicalId": "CdkRealDriftIntegStreamFifoMin-HuntOnDemandStream-XZtQuI441hsC",
+    "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntOnDemandStream",
+    "declared": {
+      "StreamModeDetails": {
+        "StreamMode": "ON_DEMAND"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "StreamModeDetails": {
+      "StreamMode": "ON_DEMAND"
+    },
+    "WarmThroughputObject": {
+      "CurrentMiBps": 0,
+      "TargetMiBps": 0
+    },
+    "Arn": "arn:aws:kinesis:us-east-1:111111111111:stream/CdkRealDriftIntegStreamFifoMin-HuntOnDemandStream-XZtQuI441hsC",
+    "MaxRecordSizeInKiB": 1024,
+    "RetentionPeriodHours": 24,
+    "DesiredShardLevelMetrics": [],
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "CdkRealDriftIntegStreamFifoMin-HuntOnDemandStream-XZtQuI441hsC",
+    "ShardCount": 4
+  },
+  "schema": {
+    "readOnly": ["Arn", "WarmThroughputObject"],
+    "writeOnly": ["WarmThroughputMiBps"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "WarmThroughputObject"],
+    "writeOnlyPaths": ["WarmThroughputMiBps"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["DesiredShardLevelMetrics"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOnDemandStream",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "MaxRecordSizeInKiB",
+      "actual": 1024,
+      "physicalId": "CdkRealDriftIntegStreamFifoMin-HuntOnDemandStream-XZtQuI441hsC",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntOnDemandStream"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOnDemandStream",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "RetentionPeriodHours",
+      "actual": 24,
+      "physicalId": "CdkRealDriftIntegStreamFifoMin-HuntOnDemandStream-XZtQuI441hsC",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntOnDemandStream"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOnDemandStream",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "ShardCount",
+      "actual": 4,
+      "physicalId": "CdkRealDriftIntegStreamFifoMin-HuntOnDemandStream-XZtQuI441hsC",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntOnDemandStream"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.HuntJavaFn1CE75A4C.json
+++ b/tests/corpus/AWS__Lambda__Function.HuntJavaFn1CE75A4C.json
@@ -1,0 +1,213 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntJavaFn1CE75A4C",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+    "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn",
+    "declared": {
+      "Code": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "ac6e6b9b6b63b7135a3a51cd6fb9a4f29815e6aceb41e48d65ee9391886f7629.zip"
+      },
+      "Handler": "example.Handler::handleRequest",
+      "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaJa-HuntJavaFnServiceRoleAA77-ZmBqw5Q1DnwM",
+      "Runtime": "java21",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "example.Handler::handleRequest",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaJa-HuntJavaFnServiceRoleAA77-ZmBqw5Q1DnwM",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+    "Runtime": "java21",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLambdaJavaMin/6d113720-7d4b-11f1-a4bd-0affffd37699",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "HuntJavaFn1CE75A4C",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegLambdaJavaMin",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Architectures": ["x86_64"],
+    "CodeSha256": "sFSjQhQ7zsKdyAGuo2dyz2U13OWqcy1WIE4wRKtUIg8="
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectStorageMode",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "CodeSha256",
+      "actual": "sFSjQhQ7zsKdyAGuo2dyz2U13OWqcy1WIE4wRKtUIg8=",
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntJavaFn1CE75A4C",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaJavaMin-HuntJavaFn1CE75A4C-VtREvvLX57TV",
+      "constructPath": "CdkRealDriftIntegLambdaJavaMin/HuntJavaFn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__MSK__Configuration.HuntMskConfig.json
+++ b/tests/corpus/AWS__MSK__Configuration.HuntMskConfig.json
@@ -1,0 +1,48 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntMskConfig",
+    "resourceType": "AWS::MSK::Configuration",
+    "physicalId": "arn:aws:kafka:us-east-1:111111111111:configuration/cdkrd-hunt-msk-config/af98036c-0eaf-476f-a6e8-9c6484825ccc-11",
+    "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntMskConfig",
+    "declared": {
+      "Name": "cdkrd-hunt-msk-config",
+      "ServerProperties": "auto.create.topics.enable=false\nlog.retention.hours=168\n"
+    }
+  },
+  "liveRaw": {
+    "LatestRevision": {
+      "Revision": 1,
+      "CreationTime": "2026-07-11T17:18:17.987Z"
+    },
+    "KafkaVersionsList": [],
+    "Arn": "arn:aws:kafka:us-east-1:111111111111:configuration/cdkrd-hunt-msk-config/af98036c-0eaf-476f-a6e8-9c6484825ccc-11",
+    "Name": "cdkrd-hunt-msk-config",
+    "ServerProperties": "auto.create.topics.enable=false\nlog.retention.hours=168\n"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["KafkaVersionsList", "Name"],
+    "readOnlyPaths": [
+      "Arn",
+      "LatestRevision.CreationTime",
+      "LatestRevision.Description",
+      "LatestRevision.Revision"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KafkaVersionsList", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["KafkaVersionsList"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__MemoryDB__Cluster.HuntValkeyCluster.json
+++ b/tests/corpus/AWS__MemoryDB__Cluster.HuntValkeyCluster.json
@@ -1,0 +1,227 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntValkeyCluster",
+    "resourceType": "AWS::MemoryDB::Cluster",
+    "physicalId": "cdkrd-hunt-mdb-valkey",
+    "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster",
+    "declared": {
+      "ACLName": "open-access",
+      "ClusterName": "cdkrd-hunt-mdb-valkey",
+      "Engine": "valkey",
+      "NodeType": "db.t4g.small",
+      "SubnetGroupName": "cdkrd-hunt-mdb-valkey-sng",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Status": "available",
+    "NumReplicasPerShard": 1,
+    "EngineVersion": "7.3",
+    "ParameterGroupName": "default.memorydb-valkey7",
+    "SubnetGroupName": "cdkrd-hunt-mdb-valkey-sng",
+    "Port": 6379,
+    "ACLName": "open-access",
+    "AutoMinorVersionUpgrade": true,
+    "SecurityGroupIds": [],
+    "ClusterEndpoint": {
+      "Address": "clustercfg.cdkrd-hunt-mdb-valkey.jzgy0l.memorydb.us-east-1.amazonaws.com",
+      "Port": 6379
+    },
+    "NumShards": 1,
+    "SnapshotWindow": "05:30-06:30",
+    "SnapshotRetentionLimit": 0,
+    "DataTiering": "false",
+    "TLSEnabled": true,
+    "NetworkType": "ipv4",
+    "NodeType": "db.t4g.small",
+    "IpDiscovery": "ipv4",
+    "ClusterName": "cdkrd-hunt-mdb-valkey",
+    "MaintenanceWindow": "sun:04:30-sun:05:30",
+    "ParameterGroupStatus": "in-sync",
+    "ARN": "arn:aws:memorydb:us-east-1:111111111111:cluster/cdkrd-hunt-mdb-valkey",
+    "Engine": "valkey",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ARN", "ParameterGroupStatus", "Status"],
+    "writeOnly": ["FinalSnapshotName", "MultiRegionClusterName", "SnapshotArns", "SnapshotName"],
+    "createOnly": [
+      "ClusterName",
+      "DataTiering",
+      "KmsKeyId",
+      "MultiRegionClusterName",
+      "NetworkType",
+      "Port",
+      "SnapshotArns",
+      "SnapshotName",
+      "SubnetGroupName",
+      "TLSEnabled"
+    ],
+    "readOnlyPaths": [
+      "ARN",
+      "ClusterEndpoint.Address",
+      "ClusterEndpoint.Port",
+      "ParameterGroupStatus",
+      "Status"
+    ],
+    "writeOnlyPaths": [
+      "FinalSnapshotName",
+      "MultiRegionClusterName",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "ClusterName",
+      "DataTiering",
+      "KmsKeyId",
+      "MultiRegionClusterName",
+      "NetworkType",
+      "Port",
+      "SnapshotArns",
+      "SnapshotName",
+      "SubnetGroupName",
+      "TLSEnabled"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SecurityGroupIds", "SnapshotArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "DataTiering",
+      "actual": "false",
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "EngineVersion",
+      "actual": "7.3",
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "MaintenanceWindow",
+      "actual": "sun:04:30-sun:05:30",
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "NumReplicasPerShard",
+      "actual": 1,
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "NumShards",
+      "actual": 1,
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "ParameterGroupName",
+      "actual": "default.memorydb-valkey7",
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "Port",
+      "actual": 6379,
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "SnapshotRetentionLimit",
+      "actual": 0,
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "SnapshotWindow",
+      "actual": "05:30-06:30",
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntValkeyCluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "TLSEnabled",
+      "actual": true,
+      "physicalId": "cdkrd-hunt-mdb-valkey",
+      "constructPath": "CdkRealDriftIntegMemoryDbValkeyMin/HuntValkeyCluster"
+    }
+  ]
+}

--- a/tests/corpus/AWS__NetworkFirewall__FirewallPolicy.HuntFwPolicy.json
+++ b/tests/corpus/AWS__NetworkFirewall__FirewallPolicy.HuntFwPolicy.json
@@ -1,0 +1,57 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntFwPolicy",
+    "resourceType": "AWS::NetworkFirewall::FirewallPolicy",
+    "physicalId": "arn:aws:network-firewall:us-east-1:111111111111:firewall-policy/cdkrd-hunt-fw-policy",
+    "constructPath": "CdkRealDriftIntegNetFwMin/HuntFwPolicy",
+    "declared": {
+      "FirewallPolicy": {
+        "StatelessDefaultActions": ["aws:forward_to_sfe"],
+        "StatelessFragmentDefaultActions": ["aws:drop"]
+      },
+      "FirewallPolicyName": "cdkrd-hunt-fw-policy",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "FirewallPolicyArn": "arn:aws:network-firewall:us-east-1:111111111111:firewall-policy/cdkrd-hunt-fw-policy",
+    "FirewallPolicyName": "cdkrd-hunt-fw-policy",
+    "FirewallPolicyId": "f5d0cab2-5995-4342-b67f-25ecb4174529",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "FirewallPolicy": {
+      "StatelessDefaultActions": ["aws:forward_to_sfe"],
+      "StatelessFragmentDefaultActions": ["aws:drop"]
+    }
+  },
+  "schema": {
+    "readOnly": ["FirewallPolicyArn", "FirewallPolicyId"],
+    "writeOnly": [],
+    "createOnly": ["FirewallPolicyName"],
+    "readOnlyPaths": ["FirewallPolicyArn", "FirewallPolicyId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FirewallPolicyName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["FirewallPolicy.PolicyVariables.RuleVariables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__NetworkFirewall__RuleGroup.HuntStatefulRg.json
+++ b/tests/corpus/AWS__NetworkFirewall__RuleGroup.HuntStatefulRg.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntStatefulRg",
+    "resourceType": "AWS::NetworkFirewall::RuleGroup",
+    "physicalId": "arn:aws:network-firewall:us-east-1:111111111111:stateful-rulegroup/cdkrd-hunt-stateful-rg",
+    "constructPath": "CdkRealDriftIntegNetFwMin/HuntStatefulRg",
+    "declared": {
+      "Capacity": 10,
+      "RuleGroup": {
+        "RulesSource": {
+          "RulesString": "pass tcp any any -> any 443 (msg:\"cdkrd hunt allow tls\"; sid:1000001; rev:1;)"
+        }
+      },
+      "RuleGroupName": "cdkrd-hunt-stateful-rg",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Type": "STATEFUL"
+    }
+  },
+  "liveRaw": {
+    "Type": "STATEFUL",
+    "RuleGroupId": "649a6980-5fc5-4bbe-a696-dcc01f8a1750",
+    "Capacity": 10,
+    "RuleGroupName": "cdkrd-hunt-stateful-rg",
+    "RuleGroupArn": "arn:aws:network-firewall:us-east-1:111111111111:stateful-rulegroup/cdkrd-hunt-stateful-rg",
+    "RuleGroup": {
+      "RulesSource": {
+        "RulesString": "pass tcp any any -> any 443 (msg:\"cdkrd hunt allow tls\"; sid:1000001; rev:1;)"
+      }
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RuleGroupArn", "RuleGroupId"],
+    "writeOnly": [],
+    "createOnly": ["Capacity", "RuleGroupName", "Type"],
+    "readOnlyPaths": ["RuleGroupArn", "RuleGroupId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Capacity", "RuleGroupName", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "RuleGroup.ReferenceSets.IPSetReferences",
+      "RuleGroup.RuleVariables.IPSets",
+      "RuleGroup.RuleVariables.PortSets"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__NetworkFirewall__RuleGroup.HuntStatelessRg.json
+++ b/tests/corpus/AWS__NetworkFirewall__RuleGroup.HuntStatelessRg.json
@@ -1,0 +1,111 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntStatelessRg",
+    "resourceType": "AWS::NetworkFirewall::RuleGroup",
+    "physicalId": "arn:aws:network-firewall:us-east-1:111111111111:stateless-rulegroup/cdkrd-hunt-stateless-rg",
+    "constructPath": "CdkRealDriftIntegNetFwMin/HuntStatelessRg",
+    "declared": {
+      "Capacity": 10,
+      "RuleGroup": {
+        "RulesSource": {
+          "StatelessRulesAndCustomActions": {
+            "StatelessRules": [
+              {
+                "Priority": 1,
+                "RuleDefinition": {
+                  "Actions": ["aws:pass"],
+                  "MatchAttributes": {
+                    "Destinations": [
+                      {
+                        "AddressDefinition": "0.0.0.0/0"
+                      }
+                    ],
+                    "Protocols": [6],
+                    "Sources": [
+                      {
+                        "AddressDefinition": "0.0.0.0/0"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "RuleGroupName": "cdkrd-hunt-stateless-rg",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Type": "STATELESS"
+    }
+  },
+  "liveRaw": {
+    "Type": "STATELESS",
+    "RuleGroupId": "ce6ce290-b26b-4de6-bf92-88868c4fbc4b",
+    "Capacity": 10,
+    "RuleGroupName": "cdkrd-hunt-stateless-rg",
+    "RuleGroupArn": "arn:aws:network-firewall:us-east-1:111111111111:stateless-rulegroup/cdkrd-hunt-stateless-rg",
+    "RuleGroup": {
+      "RulesSource": {
+        "StatelessRulesAndCustomActions": {
+          "StatelessRules": [
+            {
+              "Priority": 1,
+              "RuleDefinition": {
+                "Actions": ["aws:pass"],
+                "MatchAttributes": {
+                  "Protocols": [6],
+                  "Destinations": [
+                    {
+                      "AddressDefinition": "0.0.0.0/0"
+                    }
+                  ],
+                  "Sources": [
+                    {
+                      "AddressDefinition": "0.0.0.0/0"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RuleGroupArn", "RuleGroupId"],
+    "writeOnly": [],
+    "createOnly": ["Capacity", "RuleGroupName", "Type"],
+    "readOnlyPaths": ["RuleGroupArn", "RuleGroupId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Capacity", "RuleGroupName", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "RuleGroup.ReferenceSets.IPSetReferences",
+      "RuleGroup.RuleVariables.IPSets",
+      "RuleGroup.RuleVariables.PortSets"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__RDS__DBCluster.HuntAuroraPg.json
+++ b/tests/corpus/AWS__RDS__DBCluster.HuntAuroraPg.json
@@ -1,0 +1,337 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntAuroraPg",
+    "resourceType": "AWS::RDS::DBCluster",
+    "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+    "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg",
+    "declared": {
+      "Engine": "aurora-postgresql",
+      "MasterUserPassword": "cdkrdHuntPassw0rd1",
+      "MasterUsername": "huntadmin",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "AssociatedRoles": [],
+    "EnableHttpEndpoint": false,
+    "EngineMode": "provisioned",
+    "Port": 5432,
+    "DBClusterIdentifier": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+    "PreferredBackupWindow": "10:20-10:50",
+    "Endpoint": {
+      "Address": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "5432"
+    },
+    "NetworkType": "IPV4",
+    "VpcSecurityGroupIds": ["sg-0a26e23e2310ee0c9"],
+    "CopyTagsToSnapshot": false,
+    "Engine": "aurora-postgresql",
+    "Tags": [
+      {
+        "Value": "HuntAuroraPg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkRealDriftIntegAuroraPgMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraPgMin/e73e0790-7d4a-11f1-a857-0efea2c7d929",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "EngineVersion": "17.7",
+    "StorageType": "aurora",
+    "AvailabilityZones": ["us-east-1c", "us-east-1a", "us-east-1d"],
+    "StorageEncryptionType": "sse-rds",
+    "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+    "EnableLocalWriteForwarding": false,
+    "PreferredMaintenanceWindow": "wed:09:10-wed:09:40",
+    "DBClusterResourceId": "cluster-LQ6VDMJIPE3Z4RAXNOXPKXJSUE",
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "default",
+    "DeletionProtection": false,
+    "AllocatedStorage": 1,
+    "ManageMasterUserPassword": false,
+    "MasterUserSecret": {},
+    "MasterUsername": "huntadmin",
+    "ReadEndpoint": {
+      "Address": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+    },
+    "EnableIAMDatabaseAuthentication": false,
+    "DBClusterParameterGroupName": "default.aurora-postgresql17",
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "DBClusterArn",
+      "DBClusterResourceId",
+      "Endpoint",
+      "ReadEndpoint",
+      "StorageEncryptionType",
+      "StorageThroughput"
+    ],
+    "writeOnly": [
+      "ClusterScalabilityType",
+      "DBInstanceParameterGroupName",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "AvailabilityZones",
+      "ClusterScalabilityType",
+      "DBClusterIdentifier",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "DatabaseName",
+      "EngineMode",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "StorageEncrypted",
+      "UseLatestRestorableTime"
+    ],
+    "readOnlyPaths": [
+      "DBClusterArn",
+      "DBClusterResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "ReadEndpoint",
+      "ReadEndpoint.Address",
+      "StorageEncryptionType",
+      "StorageThroughput"
+    ],
+    "writeOnlyPaths": [
+      "ClusterScalabilityType",
+      "DBInstanceParameterGroupName",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZones",
+      "ClusterScalabilityType",
+      "DBClusterIdentifier",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "DatabaseName",
+      "EngineMode",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "StorageEncrypted",
+      "UseLatestRestorableTime"
+    ],
+    "defaults": {
+      "BackupRetentionPeriod": 1
+    },
+    "defaultPaths": {
+      "BackupRetentionPeriod": 1
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AllocatedStorage",
+      "actual": 1,
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1c", "us-east-1d"],
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "DBClusterParameterGroupName",
+      "actual": "default.aurora-postgresql17",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "DBSubnetGroupName",
+      "actual": "default",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "EngineMode",
+      "actual": "provisioned",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "EngineVersion",
+      "actual": "17.7",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "Port",
+      "actual": 5432,
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "PreferredBackupWindow",
+      "actual": "10:20-10:50",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "wed:09:10-wed:09:40",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "StorageType",
+      "actual": "aurora",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "VpcSecurityGroupIds",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntAuroraPg",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBClusterParameterGroup.HuntCpg.json
+++ b/tests/corpus/AWS__RDS__DBClusterParameterGroup.HuntCpg.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntCpg",
+    "resourceType": "AWS::RDS::DBClusterParameterGroup",
+    "physicalId": "cdkrdhunt-mixed-cpg",
+    "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCpg",
+    "declared": {
+      "DBClusterParameterGroupName": "CdkrdHunt-Mixed-CPG",
+      "Description": "cdkrd hunt mixed-case cluster parameter group",
+      "Family": "aurora-mysql8.0",
+      "Parameters": {
+        "time_zone": "UTC"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt mixed-case cluster parameter group",
+    "Parameters": {
+      "time_zone": "UTC"
+    },
+    "Family": "aurora-mysql8.0",
+    "DBClusterParameterGroupName": "cdkrdhunt-mixed-cpg",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegCaseIdentsMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntCpg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCaseIdentsMin/09209c20-7d4a-11f1-b021-12e64a14fec7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DBClusterParameterGroupName", "Description", "Family"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DBClusterParameterGroupName", "Description", "Family"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "HuntCpg",
+      "resourceType": "AWS::RDS::DBClusterParameterGroup",
+      "path": "DBClusterParameterGroupName",
+      "desired": "CdkrdHunt-Mixed-CPG",
+      "actual": "cdkrdhunt-mixed-cpg",
+      "physicalId": "cdkrdhunt-mixed-cpg",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCpg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.HuntPostgres.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntPostgres.json
@@ -1,0 +1,489 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPostgres",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+    "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres",
+    "declared": {
+      "AllocatedStorage": "20",
+      "DBInstanceClass": "db.t3.micro",
+      "Engine": "postgres",
+      "MasterUserPassword": "cdkrdHuntPassw0rd1",
+      "MasterUsername": "huntadmin",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-07-11T17:09:20Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "5432",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-VGGGLXOPD3AYOLNBBQMELZE4KQ",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.postgres18",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+    "Endpoint": {
+      "Address": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "5432",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "LatestRestorableTime": "2026-07-11T17:11:48.796Z",
+    "MultiAZ": false,
+    "Engine": "postgres",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegRdsPostgresMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntPostgres",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegRdsPostgresMin/e8447b10-7d4a-11f1-8db0-0e37afc4c625",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "IsStorageConfigUpgradeAvailable": false,
+    "EngineVersion": "18.3",
+    "StorageType": "gp2",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.t3.micro",
+    "AvailabilityZone": "us-east-1c",
+    "OptionGroupName": "default:postgres-18",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "default",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+    "AllocatedStorage": "20",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "huntadmin",
+    "PubliclyAccessible": true,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-07-11T17:10:38.725Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "05:48-06:18",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "LicenseModel": "postgresql-license",
+    "PreferredMaintenanceWindow": "tue:05:13-tue:05:43",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-0a26e23e2310ee0c9"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1c",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.postgres18",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBSubnetGroupName",
+      "actual": "default",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineVersion",
+      "actual": "18.3",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "postgresql-license",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:postgres-18",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "5432",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "05:48-06:18",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "tue:05:13-tue:05:43",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageType",
+      "actual": "gp2",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "VPCSecurityGroups",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntPostgres",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PubliclyAccessible",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.HuntSqlServer.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntSqlServer.json
@@ -1,0 +1,488 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntSqlServer",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+    "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer",
+    "declared": {
+      "AllocatedStorage": "20",
+      "DBInstanceClass": "db.t3.micro",
+      "Engine": "sqlserver-ex",
+      "MasterUserPassword": "cdkrdHuntPassw0rd1",
+      "MasterUsername": "huntadmin",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2029-07-11T17:19:23Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "1433",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-UEZFOSQRUFABEOC6EOLZPPE4HA",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.sqlserver-ex-15.0",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+    "Endpoint": {
+      "Address": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "1433",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "LatestRestorableTime": "2026-07-11T17:23:27.397Z",
+    "MultiAZ": false,
+    "Engine": "sqlserver-ex",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegRdsSqlServerMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntSqlServer",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegRdsSqlServerMin/e9769270-7d4a-11f1-86c0-129f2ad4b51d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "EngineVersion": "15.00.4470.1.v1",
+    "StorageType": "gp2",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.t3.micro",
+    "AvailabilityZone": "us-east-1d",
+    "OptionGroupName": "default:sqlserver-ex-15-00",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "default",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+    "AllocatedStorage": "20",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "huntadmin",
+    "PubliclyAccessible": true,
+    "CharacterSetName": "SQL_Latin1_General_CP1_CI_AS",
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-07-11T17:22:21.533Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "04:57-05:27",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "LicenseModel": "license-included",
+    "PreferredMaintenanceWindow": "fri:04:23-fri:04:53",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-0a26e23e2310ee0c9"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1d",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CharacterSetName",
+      "actual": "SQL_Latin1_General_CP1_CI_AS",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.sqlserver-ex-15.0",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBSubnetGroupName",
+      "actual": "default",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineVersion",
+      "actual": "15.00.4470.1.v1",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "license-included",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:sqlserver-ex-15-00",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "1433",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "04:57-05:27",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "fri:04:23-fri:04:53",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageType",
+      "actual": "gp2",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "VPCSecurityGroups",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntSqlServer",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PubliclyAccessible",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBParameterGroup.HuntPg.json
+++ b/tests/corpus/AWS__RDS__DBParameterGroup.HuntPg.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPg",
+    "resourceType": "AWS::RDS::DBParameterGroup",
+    "physicalId": "cdkrdhunt-mixed-pg",
+    "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntPg",
+    "declared": {
+      "DBParameterGroupName": "CdkrdHunt-Mixed-PG",
+      "Description": "cdkrd hunt mixed-case parameter group",
+      "Family": "mysql8.0",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DBParameterGroupName": "cdkrdhunt-mixed-pg",
+    "Description": "cdkrd hunt mixed-case parameter group",
+    "Parameters": {},
+    "Family": "mysql8.0",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegCaseIdentsMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntPg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCaseIdentsMin/09209c20-7d4a-11f1-b021-12e64a14fec7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DBParameterGroupName", "Description", "Family"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DBParameterGroupName", "Description", "Family"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "HuntPg",
+      "resourceType": "AWS::RDS::DBParameterGroup",
+      "path": "DBParameterGroupName",
+      "desired": "CdkrdHunt-Mixed-PG",
+      "actual": "cdkrdhunt-mixed-pg",
+      "physicalId": "cdkrdhunt-mixed-pg",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntPg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__OptionGroup.HuntOg.json
+++ b/tests/corpus/AWS__RDS__OptionGroup.HuntOg.json
@@ -1,0 +1,114 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOg",
+    "resourceType": "AWS::RDS::OptionGroup",
+    "physicalId": "cdkrdhunt-mixed-og",
+    "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntOg",
+    "declared": {
+      "EngineName": "mysql",
+      "MajorEngineVersion": "8.0",
+      "OptionConfigurations": [],
+      "OptionGroupDescription": "cdkrd hunt mixed-case option group",
+      "OptionGroupName": "CdkrdHunt-Mixed-OG",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "OptionGroupDescription": "cdkrd hunt mixed-case option group",
+    "OptionGroupName": "cdkrdhunt-mixed-og",
+    "OptionConfigurations": [],
+    "MajorEngineVersion": "8.0",
+    "EngineName": "mysql",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegCaseIdentsMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntOg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCaseIdentsMin/09209c20-7d4a-11f1-b021-12e64a14fec7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["EngineName", "MajorEngineVersion", "OptionGroupDescription", "OptionGroupName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "EngineName",
+      "MajorEngineVersion",
+      "OptionGroupDescription",
+      "OptionGroupName"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionConfigurations"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "rdsOptionSettingDefaults": {
+      "cdkrdhunt-mixed-og": {
+        "MARIADB_AUDIT_PLUGIN": {
+          "SERVER_AUDIT_INCL_USERS": null,
+          "SERVER_AUDIT_EXCL_USERS": null,
+          "SERVER_AUDIT_QUERY_LOG_LIMIT": "1024",
+          "SERVER_AUDIT_FILE_ROTATE_SIZE": null,
+          "SERVER_AUDIT_FILE_ROTATIONS": null,
+          "SERVER_AUDIT_LOGGING": "ON",
+          "SERVER_AUDIT_FILE_PATH": "/rdsdbdata/log/audit/",
+          "SERVER_AUDIT": "FORCE_PLUS_PERMANENT",
+          "SERVER_AUDIT_EVENTS": "CONNECT,QUERY"
+        },
+        "MEMCACHED": {
+          "CHUNK_SIZE": "48",
+          "CHUNK_SIZE_GROWTH_FACTOR": "1.25",
+          "ERROR_ON_MEMORY_EXHAUSTED": "0",
+          "DAEMON_MEMCACHED_R_BATCH_SIZE": "1",
+          "DAEMON_MEMCACHED_W_BATCH_SIZE": "1",
+          "INNODB_API_BK_COMMIT_INTERVAL": "5",
+          "INNODB_API_DISABLE_ROWLOCK": "0",
+          "INNODB_API_ENABLE_MDL": "0",
+          "INNODB_API_TRX_LEVEL": "0",
+          "BINDING_PROTOCOL": "auto",
+          "BACKLOG_QUEUE_LIMIT": "1024",
+          "CAS_DISABLED": "0",
+          "MAX_SIMULTANEOUS_CONNECTIONS": "1024",
+          "VERBOSITY": "v"
+        }
+      }
+    }
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "HuntOg",
+      "resourceType": "AWS::RDS::OptionGroup",
+      "path": "OptionGroupName",
+      "desired": "CdkrdHunt-Mixed-OG",
+      "actual": "cdkrdhunt-mixed-og",
+      "physicalId": "cdkrdhunt-mixed-og",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntOg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RedshiftServerless__Namespace.HuntNamespace.json
+++ b/tests/corpus/AWS__RedshiftServerless__Namespace.HuntNamespace.json
@@ -1,0 +1,135 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntNamespace",
+    "resourceType": "AWS::RedshiftServerless::Namespace",
+    "physicalId": "cdkrd-hunt-ns",
+    "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntNamespace",
+    "declared": {
+      "NamespaceName": "cdkrd-hunt-ns",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AdminUsername": "admin",
+    "NamespaceName": "cdkrd-hunt-ns",
+    "IamRoles": [],
+    "SnapshotCopyConfigurations": [],
+    "KmsKeyId": "AWS_OWNED_KMS_KEY",
+    "DbName": "dev",
+    "Namespace": {
+      "Status": "AVAILABLE",
+      "NamespaceName": "cdkrd-hunt-ns",
+      "AdminUsername": "admin",
+      "CreationDate": "2026-07-11T16:56:21.367Z",
+      "IamRoles": [],
+      "NamespaceArn": "arn:aws:redshift-serverless:us-east-1:111111111111:namespace/4c509edc-06c0-40b1-aa7f-e0efbbc4237b",
+      "KmsKeyId": "AWS_OWNED_KMS_KEY",
+      "DbName": "dev",
+      "NamespaceId": "4c509edc-06c0-40b1-aa7f-e0efbbc4237b",
+      "LogExports": []
+    },
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegRedshiftSlMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntNamespace",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegRedshiftSlMin/6a6cb5f0-7d49-11f1-acd0-0e7116711003",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "LogExports": []
+  },
+  "schema": {
+    "readOnly": ["Namespace"],
+    "writeOnly": [
+      "AdminUserPassword",
+      "FinalSnapshotName",
+      "FinalSnapshotRetentionPeriod",
+      "ManageAdminPassword",
+      "RedshiftIdcApplicationArn"
+    ],
+    "createOnly": ["NamespaceName"],
+    "readOnlyPaths": [
+      "Namespace",
+      "Namespace.AdminUsername",
+      "Namespace.CreationDate",
+      "Namespace.DbName",
+      "Namespace.DefaultIamRoleArn",
+      "Namespace.IamRoles",
+      "Namespace.KmsKeyId",
+      "Namespace.LogExports",
+      "Namespace.NamespaceArn",
+      "Namespace.NamespaceId",
+      "Namespace.NamespaceName",
+      "Namespace.Status"
+    ],
+    "writeOnlyPaths": [
+      "AdminUserPassword",
+      "FinalSnapshotName",
+      "FinalSnapshotRetentionPeriod",
+      "ManageAdminPassword",
+      "RedshiftIdcApplicationArn"
+    ],
+    "createOnlyPaths": ["NamespaceName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "IamRoles",
+      "LogExports",
+      "Namespace.IamRoles",
+      "Namespace.LogExports"
+    ],
+    "unorderedObjectArrayPaths": ["SnapshotCopyConfigurations"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntNamespace",
+      "resourceType": "AWS::RedshiftServerless::Namespace",
+      "path": "AdminUsername",
+      "actual": "admin",
+      "physicalId": "cdkrd-hunt-ns",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntNamespace"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntNamespace",
+      "resourceType": "AWS::RedshiftServerless::Namespace",
+      "path": "DbName",
+      "actual": "dev",
+      "physicalId": "cdkrd-hunt-ns",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntNamespace"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntNamespace",
+      "resourceType": "AWS::RedshiftServerless::Namespace",
+      "path": "KmsKeyId",
+      "actual": "AWS_OWNED_KMS_KEY",
+      "physicalId": "cdkrd-hunt-ns",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntNamespace"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RedshiftServerless__Workgroup.HuntWorkgroup.json
+++ b/tests/corpus/AWS__RedshiftServerless__Workgroup.HuntWorkgroup.json
@@ -1,0 +1,442 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntWorkgroup",
+    "resourceType": "AWS::RedshiftServerless::Workgroup",
+    "physicalId": "cdkrd-hunt-wg",
+    "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup",
+    "declared": {
+      "NamespaceName": "cdkrd-hunt-ns",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "WorkgroupName": "cdkrd-hunt-wg"
+    }
+  },
+  "liveRaw": {
+    "NamespaceName": "cdkrd-hunt-ns",
+    "Port": 5439,
+    "WorkgroupName": "cdkrd-hunt-wg",
+    "TrackName": "current",
+    "BaseCapacity": -1,
+    "EnhancedVpcRouting": false,
+    "PubliclyAccessible": false,
+    "PricePerformanceTarget": {
+      "Status": "ENABLED",
+      "Level": 50
+    },
+    "Workgroup": {
+      "Status": "AVAILABLE",
+      "CreationDate": "2026-07-11T16:56:24.005Z",
+      "WorkgroupName": "cdkrd-hunt-wg",
+      "WorkgroupArn": "arn:aws:redshift-serverless:us-east-1:111111111111:workgroup/0a0152ba-c730-4ab3-91ed-5cc3eda8549e",
+      "BaseCapacity": -1,
+      "EnhancedVpcRouting": false,
+      "WorkgroupId": "0a0152ba-c730-4ab3-91ed-5cc3eda8549e",
+      "SecurityGroupIds": ["sg-0a26e23e2310ee0c9"],
+      "SubnetIds": [
+        "subnet-0839f35959eaf9126",
+        "subnet-0db5f5bc4e364ba95",
+        "subnet-0ddbb00e7c1d5b679",
+        "subnet-0f4c1fe007d650275",
+        "subnet-03e44b544889aefe3",
+        "subnet-00c21350a74a112b8"
+      ],
+      "NamespaceName": "cdkrd-hunt-ns",
+      "Endpoint": {
+        "Address": "cdkrd-hunt-wg.111111111111.us-east-1.redshift-serverless.amazonaws.com",
+        "VpcEndpoints": [
+          {
+            "VpcId": "vpc-08cae0035717deb9d",
+            "NetworkInterfaces": [
+              {
+                "PrivateIpAddress": "172.31.14.10",
+                "AvailabilityZone": "us-east-1a",
+                "SubnetId": "subnet-0839f35959eaf9126",
+                "NetworkInterfaceId": "eni-0661522cf8cd89c08"
+              },
+              {
+                "PrivateIpAddress": "172.31.17.122",
+                "AvailabilityZone": "us-east-1c",
+                "SubnetId": "subnet-03e44b544889aefe3",
+                "NetworkInterfaceId": "eni-0d0381c674026c963"
+              },
+              {
+                "PrivateIpAddress": "172.31.95.235",
+                "AvailabilityZone": "us-east-1b",
+                "SubnetId": "subnet-0db5f5bc4e364ba95",
+                "NetworkInterfaceId": "eni-0e14994c613f1d691"
+              }
+            ],
+            "VpcEndpointId": "vpce-0fc44db9132b6dad0"
+          }
+        ],
+        "Port": 5439
+      },
+      "ConfigParameters": [
+        {
+          "ParameterValue": "ISO, MDY",
+          "ParameterKey": "datestyle"
+        },
+        {
+          "ParameterValue": "default",
+          "ParameterKey": "query_group"
+        },
+        {
+          "ParameterValue": "14400",
+          "ParameterKey": "max_query_execution_time"
+        },
+        {
+          "ParameterValue": "false",
+          "ParameterKey": "enable_case_sensitive_identifier"
+        },
+        {
+          "ParameterValue": "true",
+          "ParameterKey": "enable_user_activity_logging"
+        },
+        {
+          "ParameterValue": "$user, public",
+          "ParameterKey": "search_path"
+        },
+        {
+          "ParameterValue": "true",
+          "ParameterKey": "require_ssl"
+        },
+        {
+          "ParameterValue": "false",
+          "ParameterKey": "use_fips_ssl"
+        },
+        {
+          "ParameterValue": "true",
+          "ParameterKey": "auto_mv"
+        }
+      ],
+      "TrackName": "current",
+      "PubliclyAccessible": false,
+      "PricePerformanceTarget": {
+        "Status": "ENABLED",
+        "Level": 50
+      }
+    },
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegRedshiftSlMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntWorkgroup",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegRedshiftSlMin/6a6cb5f0-7d49-11f1-acd0-0e7116711003",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "ConfigParameters": [
+      {
+        "ParameterKey": "auto_mv",
+        "ParameterValue": "true"
+      },
+      {
+        "ParameterKey": "datestyle",
+        "ParameterValue": "ISO, MDY"
+      },
+      {
+        "ParameterKey": "enable_case_sensitive_identifier",
+        "ParameterValue": "false"
+      },
+      {
+        "ParameterKey": "enable_user_activity_logging",
+        "ParameterValue": "true"
+      },
+      {
+        "ParameterKey": "query_group",
+        "ParameterValue": "default"
+      },
+      {
+        "ParameterKey": "require_ssl",
+        "ParameterValue": "true"
+      },
+      {
+        "ParameterKey": "search_path",
+        "ParameterValue": "$user, public"
+      },
+      {
+        "ParameterKey": "use_fips_ssl",
+        "ParameterValue": "false"
+      },
+      {
+        "ParameterKey": "max_query_execution_time",
+        "ParameterValue": "14400"
+      }
+    ],
+    "SecurityGroupIds": ["sg-0a26e23e2310ee0c9"],
+    "SubnetIds": [
+      "subnet-0839f35959eaf9126",
+      "subnet-0db5f5bc4e364ba95",
+      "subnet-0ddbb00e7c1d5b679",
+      "subnet-0f4c1fe007d650275",
+      "subnet-03e44b544889aefe3",
+      "subnet-00c21350a74a112b8"
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["RecoveryPointId", "SnapshotArn", "SnapshotName", "SnapshotOwnerAccount"],
+    "createOnly": ["NamespaceName", "WorkgroupName"],
+    "readOnlyPaths": [
+      "Workgroup.BaseCapacity",
+      "Workgroup.ConfigParameters",
+      "Workgroup.CreationDate",
+      "Workgroup.Endpoint.Address",
+      "Workgroup.Endpoint.Port",
+      "Workgroup.Endpoint.VpcEndpoints.*.NetworkInterfaces.*.AvailabilityZone",
+      "Workgroup.Endpoint.VpcEndpoints.*.NetworkInterfaces.*.NetworkInterfaceId",
+      "Workgroup.Endpoint.VpcEndpoints.*.NetworkInterfaces.*.PrivateIpAddress",
+      "Workgroup.Endpoint.VpcEndpoints.*.NetworkInterfaces.*.SubnetId",
+      "Workgroup.Endpoint.VpcEndpoints.*.VpcEndpointId",
+      "Workgroup.Endpoint.VpcEndpoints.*.VpcId",
+      "Workgroup.EnhancedVpcRouting",
+      "Workgroup.MaxCapacity",
+      "Workgroup.NamespaceName",
+      "Workgroup.PubliclyAccessible",
+      "Workgroup.SecurityGroupIds",
+      "Workgroup.Status",
+      "Workgroup.SubnetIds",
+      "Workgroup.TrackName",
+      "Workgroup.WorkgroupArn",
+      "Workgroup.WorkgroupId",
+      "Workgroup.WorkgroupName"
+    ],
+    "writeOnlyPaths": ["RecoveryPointId", "SnapshotArn", "SnapshotName", "SnapshotOwnerAccount"],
+    "createOnlyPaths": ["NamespaceName", "WorkgroupName"],
+    "defaults": {
+      "EnhancedVpcRouting": false,
+      "PubliclyAccessible": false
+    },
+    "defaultPaths": {
+      "EnhancedVpcRouting": false,
+      "PubliclyAccessible": false
+    },
+    "unorderedScalarPaths": [
+      "SecurityGroupIds",
+      "SubnetIds",
+      "Workgroup.SecurityGroupIds",
+      "Workgroup.SubnetIds"
+    ],
+    "unorderedObjectArrayPaths": [
+      "ConfigParameters",
+      "Workgroup.ConfigParameters",
+      "Workgroup.Endpoint.VpcEndpoints"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "BaseCapacity",
+      "actual": -1,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[auto_mv]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[datestyle]",
+      "actual": "ISO, MDY",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[enable_case_sensitive_identifier]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[enable_user_activity_logging]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[max_query_execution_time]",
+      "actual": "14400",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[query_group]",
+      "actual": "default",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[require_ssl]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[search_path]",
+      "actual": "$user, public",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "ConfigParameters[use_fips_ssl]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "EnhancedVpcRouting",
+      "actual": false,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "Port",
+      "actual": 5439,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "PricePerformanceTarget",
+      "actual": {
+        "Status": "ENABLED",
+        "Level": 50
+      },
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "PubliclyAccessible",
+      "actual": false,
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "SubnetIds",
+      "actual": [
+        "subnet-00c21350a74a112b8",
+        "subnet-03e44b544889aefe3",
+        "subnet-0839f35959eaf9126",
+        "subnet-0db5f5bc4e364ba95",
+        "subnet-0ddbb00e7c1d5b679",
+        "subnet-0f4c1fe007d650275"
+      ],
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "TrackName",
+      "actual": "current",
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntWorkgroup",
+      "resourceType": "AWS::RedshiftServerless::Workgroup",
+      "path": "Workgroup",
+      "actual": {
+        "Endpoint": {
+          "VpcEndpoints": [
+            {
+              "NetworkInterfaces": [{}, {}, {}]
+            }
+          ]
+        },
+        "PricePerformanceTarget": {
+          "Status": "ENABLED",
+          "Level": 50
+        }
+      },
+      "physicalId": "cdkrd-hunt-wg",
+      "constructPath": "CdkRealDriftIntegRedshiftSlMin/HuntWorkgroup"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.HuntCorsBucketFF1953AB.json
+++ b/tests/corpus/AWS__S3__Bucket.HuntCorsBucketFF1953AB.json
@@ -1,0 +1,201 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntCorsBucketFF1953AB",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy",
+    "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCorsBucket",
+    "declared": {
+      "CorsConfiguration": {
+        "CorsRules": [
+          {
+            "AllowedHeaders": ["X-Custom-Header", "Content-Type"],
+            "AllowedMethods": ["GET", "PUT"],
+            "AllowedOrigins": ["https://hunt.example.org"],
+            "ExposedHeaders": ["ETag", "x-amz-request-id"]
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy",
+    "CorsConfiguration": {
+      "CorsRules": [
+        {
+          "ExposedHeaders": ["ETag", "x-amz-request-id"],
+          "AllowedMethods": ["GET", "PUT"],
+          "AllowedOrigins": ["https://hunt.example.org"],
+          "AllowedHeaders": ["X-Custom-Header", "Content-Type"],
+          "MaxAge": 0
+        }
+      ]
+    },
+    "RegionalDomainName": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegCaseIdentsMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntCorsBucketFF1953AB",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCaseIdentsMin/09209c20-7d4a-11f1-b021-12e64a14fec7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCorsBucketFF1953AB",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCorsBucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCorsBucketFF1953AB",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCorsBucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCorsBucketFF1953AB",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCorsBucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCorsBucketFF1953AB",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrealdriftintegcaseidents-huntcorsbucketff1953ab-dyzhrhltr1sy",
+      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCorsBucket"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.HuntKmsBucket.json
+++ b/tests/corpus/AWS__S3__Bucket.HuntKmsBucket.json
@@ -1,0 +1,188 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntKmsBucket",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5",
+    "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntKmsBucket",
+    "declared": {
+      "BucketEncryption": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "aws:kms"
+            }
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5",
+    "RegionalDomainName": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "aws:kms"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegS3KmsDdbBatchMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntKmsBucket",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3KmsDdbBatchMin/d9389b10-7d4f-11f1-8f7d-0affd705329b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKmsBucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntKmsBucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKmsBucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntKmsBucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKmsBucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrealdriftintegs3kmsddbbatchmin-huntkmsbucket-zg6rpkz1cyq5",
+      "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntKmsBucket"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.HuntFifoHighThroughput.json
+++ b/tests/corpus/AWS__SQS__Queue.HuntFifoHighThroughput.json
@@ -1,0 +1,126 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntFifoHighThroughput",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+    "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput",
+    "declared": {
+      "ContentBasedDeduplication": true,
+      "DeduplicationScope": "messageGroup",
+      "FifoQueue": true,
+      "FifoThroughputLimit": "perMessageGroupId",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "FifoThroughputLimit": "perMessageGroupId",
+    "FifoQueue": true,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+    "SqsManagedSseEnabled": true,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "DeduplicationScope": "messageGroup",
+    "ContentBasedDeduplication": true,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+    "QueueName": "CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoHighThroughput",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoHighThroughput",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoHighThroughput",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoHighThroughput",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoHighThroughput",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoHighThroughput",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntFifoHighThroughput",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoHighThroughput-J0s4SH0euAVY.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoHighThroughput"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.HuntFifoMin.json
+++ b/tests/corpus/AWS__SQS__Queue.HuntFifoMin.json
@@ -1,0 +1,141 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntFifoMin",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+    "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin",
+    "declared": {
+      "FifoQueue": true,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "FifoThroughputLimit": "perQueue",
+    "FifoQueue": true,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+    "SqsManagedSseEnabled": true,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "DeduplicationScope": "queue",
+    "ContentBasedDeduplication": false,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+    "QueueName": "CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DeduplicationScope",
+      "actual": "queue",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "FifoThroughputLimit",
+      "actual": "perQueue",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntFifoMin",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegStreamFifoMin-HuntFifoMin-NxQtSnwxbFpx.fifo",
+      "constructPath": "CdkRealDriftIntegStreamFifoMin/HuntFifoMin"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SecurityHub__Hub.HuntHub.json
+++ b/tests/corpus/AWS__SecurityHub__Hub.HuntHub.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntHub",
+    "resourceType": "AWS::SecurityHub::Hub",
+    "physicalId": "arn:aws:securityhub:us-east-1:111111111111:hub/default",
+    "constructPath": "CdkRealDriftIntegGdSecHubMin/HuntHub",
+    "declared": {
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "ControlFindingGenerator": "SECURITY_CONTROL",
+    "SubscribedAt": "2026-07-11T16:56:19.003Z",
+    "AutoEnableControls": false,
+    "ARN": "arn:aws:securityhub:us-east-1:111111111111:hub/default",
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["ARN", "SubscribedAt"],
+    "writeOnly": ["EnableDefaultStandards"],
+    "createOnly": [],
+    "readOnlyPaths": ["ARN", "SubscribedAt"],
+    "writeOnlyPaths": ["EnableDefaultStandards"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHub",
+      "resourceType": "AWS::SecurityHub::Hub",
+      "path": "ControlFindingGenerator",
+      "actual": "SECURITY_CONTROL",
+      "physicalId": "arn:aws:securityhub:us-east-1:111111111111:hub/default",
+      "constructPath": "CdkRealDriftIntegGdSecHubMin/HuntHub"
+    }
+  ]
+}

--- a/tests/hunt-firstrun-folds-1490-1491.test.ts
+++ b/tests/hunt-firstrun-folds-1490-1491.test.ts
@@ -1,0 +1,392 @@
+// #1490 / #1491 — live-hunt first-run folds (2026-07-12 minimal-deploy sweep).
+//   #1490 AWS::DMS::Endpoint (barest mysql source endpoint):
+//     F1 EndpointIdentifier — DMS stores the identifier LOWERCASED, so a mixed-case
+//        declaration false-flagged declared drift that SURVIVED record →
+//        CASE_INSENSITIVE_PATHS entry (a genuinely different identifier still surfaces).
+//     F2 SslMode — every engine's constant creation default is "none" →
+//        KNOWN_DEFAULTS tier-1 pin (an out-of-band verify-full flip surfaces).
+//     F3 KmsKeyId — the AWS-managed `aws/dms` key ARN materialized when no key is
+//        declared → VALUE_INDEPENDENT (the #533 AWS-assigned-KmsKeyId class).
+//   #1491 AWS::ECS::Cluster:
+//     CapacityProviders — ECS reads the attachment list back SORTED (a set), so a
+//     non-sorted declaration false-flagged declared drift that survived record →
+//     UNORDERED_ARRAY_PROPS entry (a genuine attach/detach still surfaces).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const dmsSchema: SchemaInfo = {
+  readOnly: new Set(['ExternalId']),
+  writeOnly: new Set(['Password']),
+  createOnly: new Set(['KmsKeyId']),
+  readOnlyPaths: ['ExternalId'],
+  writeOnlyPaths: ['Password'],
+  createOnlyPaths: ['KmsKeyId'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const mkDms = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'HuntDmsEndpoint',
+  resourceType: 'AWS::DMS::Endpoint',
+  physicalId: 'arn:aws:dms:us-east-1:123456789012:endpoint:ABC123',
+  declared,
+});
+
+const dmsDeclared = {
+  EndpointIdentifier: 'CdkrdHunt-Mixed-DMS-EP',
+  EndpointType: 'source',
+  EngineName: 'mysql',
+  ServerName: 'hunt.invalid',
+  Port: 3306,
+  Username: 'hunter',
+};
+
+// What the live read of the fresh, un-mutated endpoint materializes (case-idents-min).
+const dmsLive = {
+  EndpointIdentifier: 'cdkrdhunt-mixed-dms-ep',
+  EndpointType: 'SOURCE',
+  EngineName: 'mysql',
+  ServerName: 'hunt.invalid',
+  Port: 3306,
+  Username: 'hunter',
+  SslMode: 'none',
+  KmsKeyId: 'arn:aws:kms:us-east-1:123456789012:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6',
+};
+
+describe('#1490 DMS Endpoint first-run folds', () => {
+  it('a fresh minimal endpoint classifies with ZERO declared and ZERO undeclared findings', () => {
+    const findings = classifyResource(mkDms(dmsDeclared), dmsLive, dmsSchema);
+    // Full-tier assertion (not a filtered subset): the first-run invariant is zero
+    // surfaced drift; the AWS-assigned values land in atDefault, nothing else.
+    expect(tier(findings, 'declared')).toEqual([]);
+    expect(tier(findings, 'undeclared')).toEqual([]);
+    expect(tier(findings, 'atDefault')).toEqual(['KmsKeyId', 'SslMode']);
+  });
+
+  it('F1 a genuinely DIFFERENT EndpointIdentifier still surfaces as declared drift', () => {
+    const findings = classifyResource(
+      mkDms(dmsDeclared),
+      { ...dmsLive, EndpointIdentifier: 'someone-renamed-this' },
+      dmsSchema
+    );
+    expect(tier(findings, 'declared')).toEqual(['EndpointIdentifier']);
+  });
+
+  it('F2 an out-of-band SslMode hardening no longer matches the "none" default and surfaces', () => {
+    const findings = classifyResource(
+      mkDms(dmsDeclared),
+      { ...dmsLive, SslMode: 'verify-full' },
+      dmsSchema
+    );
+    expect(tier(findings, 'undeclared')).toEqual(['SslMode']);
+    expect(tier(findings, 'atDefault')).toEqual(['KmsKeyId']);
+  });
+
+  it('F2 a DECLARED SslMode diverging live is compared in the declared loop (detection kept)', () => {
+    const findings = classifyResource(
+      mkDms({ ...dmsDeclared, SslMode: 'require' }),
+      dmsLive, // live still "none"
+      dmsSchema
+    );
+    expect(tier(findings, 'declared')).toEqual(['SslMode']);
+  });
+});
+
+const rdsSchema: SchemaInfo = {
+  readOnly: new Set(['Endpoint']),
+  writeOnly: new Set(['MasterUserPassword']),
+  createOnly: new Set(['Engine']),
+  readOnlyPaths: ['Endpoint'],
+  writeOnlyPaths: ['MasterUserPassword'],
+  createOnlyPaths: ['Engine'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+describe('2026-07-12 hunt: RDS minimal-deploy first-run folds', () => {
+  it('DBInstance undeclared DBSubnetGroupName "default" folds atDefault; a custom group surfaces', () => {
+    const mk = (live: Record<string, unknown>) =>
+      classifyResource(
+        {
+          logicalId: 'HuntPostgres',
+          resourceType: 'AWS::RDS::DBInstance',
+          physicalId: 'huntpostgres',
+          declared: { Engine: 'postgres', DBInstanceClass: 'db.t3.micro' },
+        },
+        { Engine: 'postgres', DBInstanceClass: 'db.t3.micro', ...live },
+        rdsSchema
+      );
+    expect(tier(mk({ DBSubnetGroupName: 'default' }), 'atDefault')).toContain('DBSubnetGroupName');
+    expect(tier(mk({ DBSubnetGroupName: 'default' }), 'undeclared')).toEqual([]);
+    // an out-of-band re-placement into a custom group no longer matches — detection kept
+    expect(tier(mk({ DBSubnetGroupName: 'ops-moved-me' }), 'undeclared')).toEqual([
+      'DBSubnetGroupName',
+    ]);
+  });
+
+  it('DBInstance sqlserver arms: LicenseModel + CharacterSetName fold; a divergence surfaces', () => {
+    const mk = (live: Record<string, unknown>) =>
+      classifyResource(
+        {
+          logicalId: 'HuntSqlServer',
+          resourceType: 'AWS::RDS::DBInstance',
+          physicalId: 'huntsqlserver',
+          declared: { Engine: 'sqlserver-ex', DBInstanceClass: 'db.t3.micro' },
+        },
+        { Engine: 'sqlserver-ex', DBInstanceClass: 'db.t3.micro', ...live },
+        rdsSchema
+      );
+    const clean = mk({
+      LicenseModel: 'license-included',
+      CharacterSetName: 'SQL_Latin1_General_CP1_CI_AS',
+    });
+    expect(tier(clean, 'undeclared')).toEqual([]);
+    expect(tier(clean, 'atDefault')).toEqual(['CharacterSetName', 'LicenseModel']);
+    // a non-default collation (an era/creation divergence) still surfaces
+    expect(tier(mk({ CharacterSetName: 'Latin1_General_100_CS_AS' }), 'undeclared')).toEqual([
+      'CharacterSetName',
+    ]);
+  });
+
+  it('DBCluster undeclared default.<family> parameter group folds; a custom group surfaces', () => {
+    const mk = (live: Record<string, unknown>) =>
+      classifyResource(
+        {
+          logicalId: 'HuntAuroraPg',
+          resourceType: 'AWS::RDS::DBCluster',
+          physicalId: 'huntaurorapg',
+          declared: { Engine: 'aurora-postgresql' },
+        },
+        { Engine: 'aurora-postgresql', ...live },
+        rdsSchema
+      );
+    expect(
+      tier(mk({ DBClusterParameterGroupName: 'default.aurora-postgresql17' }), 'atDefault')
+    ).toContain('DBClusterParameterGroupName');
+    expect(
+      tier(mk({ DBClusterParameterGroupName: 'default.aurora-postgresql17' }), 'undeclared')
+    ).toEqual([]);
+    expect(tier(mk({ DBClusterParameterGroupName: 'my-custom-pg' }), 'undeclared')).toEqual([
+      'DBClusterParameterGroupName',
+    ]);
+  });
+});
+
+describe('#1495 StackSet SELF_MANAGED conventional-role folds', () => {
+  const ssSchema: SchemaInfo = {
+    readOnly: new Set(['StackSetId']),
+    writeOnly: new Set(['TemplateBody']),
+    createOnly: new Set(['StackSetName', 'PermissionModel']),
+    readOnlyPaths: ['StackSetId'],
+    writeOnlyPaths: ['TemplateBody'],
+    createOnlyPaths: ['StackSetName', 'PermissionModel'],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const mk = (live: Record<string, unknown>) =>
+    classifyResource(
+      {
+        logicalId: 'HuntStackSet',
+        resourceType: 'AWS::CloudFormation::StackSet',
+        physicalId: 'cdkrd-hunt-stackset:abc',
+        declared: { StackSetName: 'cdkrd-hunt-stackset', PermissionModel: 'SELF_MANAGED' },
+      },
+      { StackSetName: 'cdkrd-hunt-stackset', PermissionModel: 'SELF_MANAGED', ...live },
+      ssSchema,
+      // CONTEXT_ARN_DEFAULTS substitutes {partition}/{accountId} from the check context
+      { region: 'us-east-1', accountId: '123456789012' }
+    );
+
+  it('folds the conventional admin-role ARN (any account) + execution-role name to atDefault', () => {
+    const findings = mk({
+      AdministrationRoleARN:
+        'arn:aws:iam::123456789012:role/AWSCloudFormationStackSetAdministrationRole',
+      ExecutionRoleName: 'AWSCloudFormationStackSetExecutionRole',
+    });
+    expect(tier(findings, 'undeclared')).toEqual([]);
+    expect(tier(findings, 'atDefault')).toEqual(['AdministrationRoleARN', 'ExecutionRoleName']);
+  });
+
+  it('surfaces a CUSTOM admin role / execution role — detection preserved', () => {
+    const findings = mk({
+      AdministrationRoleARN: 'arn:aws:iam::123456789012:role/OpsCustomStackSetAdmin',
+      ExecutionRoleName: 'OpsCustomExecRole',
+    });
+    expect(tier(findings, 'undeclared')).toEqual(['AdministrationRoleARN', 'ExecutionRoleName']);
+  });
+
+  it('surfaces the conventional role name in a DIFFERENT account (cross-account) — own-account gate', () => {
+    const findings = mk({
+      AdministrationRoleARN:
+        'arn:aws:iam::999999999999:role/AWSCloudFormationStackSetAdministrationRole',
+    });
+    expect(tier(findings, 'undeclared')).toEqual(['AdministrationRoleARN']);
+  });
+});
+
+describe('2026-07-12 hunt: Batch ComputeEnvironment first-run folds', () => {
+  const batchSchema: SchemaInfo = {
+    readOnly: new Set(['ComputeEnvironmentArn']),
+    writeOnly: new Set(),
+    createOnly: new Set(['Type']),
+    readOnlyPaths: ['ComputeEnvironmentArn'],
+    writeOnlyPaths: [],
+    createOnlyPaths: ['Type'],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const declared = {
+    Type: 'MANAGED',
+    ComputeResources: {
+      Type: 'EC2',
+      MaxvCpus: 4,
+      MinvCpus: 0,
+      InstanceTypes: ['m5.large'],
+      Subnets: ['subnet-1'],
+    },
+  };
+  const mk = (live: Record<string, unknown>) =>
+    classifyResource(
+      {
+        logicalId: 'HuntEc2Ce',
+        resourceType: 'AWS::Batch::ComputeEnvironment',
+        physicalId: 'arn:aws:batch:us-east-1:123456789012:compute-environment/x',
+        declared,
+      },
+      { ...declared, ...live },
+      batchSchema
+    );
+
+  it('folds undeclared State=ENABLED and the era Ec2Configuration image types', () => {
+    for (const imageType of ['ECS_AL2023', 'ECS_AL2']) {
+      const findings = mk({
+        State: 'ENABLED',
+        ComputeResources: {
+          ...declared.ComputeResources,
+          Ec2Configuration: [{ ImageType: imageType }],
+        },
+      });
+      expect(tier(findings, 'undeclared')).toEqual([]);
+    }
+  });
+
+  it('surfaces an out-of-band DISABLE and a non-default image type — detection preserved', () => {
+    expect(tier(mk({ State: 'DISABLED' }), 'undeclared')).toEqual(['State']);
+    const findings = mk({
+      State: 'ENABLED',
+      ComputeResources: {
+        ...declared.ComputeResources,
+        Ec2Configuration: [{ ImageType: 'ECS_AL2_NVIDIA' }],
+      },
+    });
+    expect(tier(findings, 'undeclared')).toContain('ComputeResources.Ec2Configuration');
+  });
+});
+
+describe('#1503 MemoryDB minimal valkey first-run folds', () => {
+  const mdbSchema: SchemaInfo = {
+    readOnly: new Set(['ARN', 'Status']),
+    writeOnly: new Set(),
+    createOnly: new Set(['ClusterName']),
+    readOnlyPaths: ['ARN', 'Status'],
+    writeOnlyPaths: [],
+    createOnlyPaths: ['ClusterName'],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const declared = {
+    ClusterName: 'cdkrd-hunt-mdb-valkey',
+    NodeType: 'db.t4g.small',
+    ACLName: 'open-access',
+    Engine: 'valkey',
+    SubnetGroupName: 'cdkrd-hunt-mdb-valkey-sng',
+  };
+  const mk = (live: Record<string, unknown>) =>
+    classifyResource(
+      {
+        logicalId: 'HuntValkeyCluster',
+        resourceType: 'AWS::MemoryDB::Cluster',
+        physicalId: 'cdkrd-hunt-mdb-valkey',
+        declared,
+      },
+      { ...declared, ...live },
+      mdbSchema
+    );
+
+  it('folds the engine-independent creation constants + GA EngineVersion (ZERO first-run drift)', () => {
+    const findings = mk({
+      NumShards: 1,
+      NumReplicasPerShard: 1,
+      SnapshotRetentionLimit: 0,
+      TLSEnabled: true,
+      EngineVersion: '7.3',
+    });
+    expect(tier(findings, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band reshard / snapshot enable — detection preserved', () => {
+    // (TLSEnabled is create-only, so an OFF state cannot arise out of band — a TLS-off
+    // cluster declares it and the declared loop compares it; no OFF-state probe here.)
+    expect(tier(mk({ NumShards: 3 }), 'undeclared')).toEqual(['NumShards']);
+    expect(tier(mk({ SnapshotRetentionLimit: 7 }), 'undeclared')).toEqual([
+      'SnapshotRetentionLimit',
+    ]);
+  });
+});
+
+const ecsSchema: SchemaInfo = {
+  readOnly: new Set(['Arn']),
+  writeOnly: new Set(),
+  createOnly: new Set(['ClusterName']),
+  readOnlyPaths: ['Arn'],
+  writeOnlyPaths: [],
+  createOnlyPaths: ['ClusterName'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const mkEcs = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'HuntEcsCluster',
+  resourceType: 'AWS::ECS::Cluster',
+  physicalId: 'cdkrd-hunt-reorder-cluster',
+  declared,
+});
+
+describe('#1491 ECS Cluster CapacityProviders set-reorder fold', () => {
+  it('an identical provider set echoed sorted is NOT declared drift (ZERO first-run drift)', () => {
+    const findings = classifyResource(
+      mkEcs({
+        ClusterName: 'cdkrd-hunt-reorder-cluster',
+        CapacityProviders: ['FARGATE_SPOT', 'FARGATE'],
+      }),
+      {
+        ClusterName: 'cdkrd-hunt-reorder-cluster',
+        CapacityProviders: ['FARGATE', 'FARGATE_SPOT'],
+      },
+      ecsSchema
+    );
+    expect(tier(findings, 'declared')).toEqual([]);
+  });
+
+  it('a genuine out-of-band provider DETACH still changes the multiset and surfaces', () => {
+    const findings = classifyResource(
+      mkEcs({
+        ClusterName: 'cdkrd-hunt-reorder-cluster',
+        CapacityProviders: ['FARGATE_SPOT', 'FARGATE'],
+      }),
+      {
+        ClusterName: 'cdkrd-hunt-reorder-cluster',
+        CapacityProviders: ['FARGATE'],
+      },
+      ecsSchema
+    );
+    expect(tier(findings, 'declared')).toEqual(['CapacityProviders']);
+  });
+});

--- a/tests/integration/aurora-pg-min/app.ts
+++ b/tests/integration/aurora-pg-min/app.ts
@@ -1,0 +1,20 @@
+// CDK app for the cdk-real-drift aurora-pg-min false-positive integration
+// test. BAREST-possible aurora-postgresql DBCluster (no instances — the
+// cluster alone reaches `available`): only Engine + master credentials
+// declared. The existing RDS fold tables were built from an aurora-mysql +
+// provisioned-mysql corpus (#1477 fixed the provisioned gap); the
+// aurora-postgresql arm (Port 5432 engine default, PG-specific echoes,
+// parameter-group family) has never run live.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDBCluster } from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegAuroraPgMin");
+
+new CfnDBCluster(stack, "HuntAuroraPg", {
+  engine: "aurora-postgresql",
+  masterUsername: "huntadmin",
+  masterUserPassword: "cdkrdHuntPassw0rd1",
+});

--- a/tests/integration/aurora-pg-min/cdk.json
+++ b/tests/integration/aurora-pg-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/aurora-pg-min/package.json
+++ b/tests/integration/aurora-pg-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-aurora-pg-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift aurora-pg-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/aurora-pg-min/verify.sh
+++ b/tests/integration/aurora-pg-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAuroraPgMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/case-idents-min/app.ts
+++ b/tests/integration/case-idents-min/app.ts
@@ -1,0 +1,65 @@
+// CDK app for the cdk-real-drift case-idents-min false-positive integration
+// test. DECLARED-dimension CASE probes: mixed-case declared identifiers on
+// types documented (or suspected) to store them lowercased, plus HTTP-header
+// case in S3 CORS — none exercised by any corpus case (all declare lowercase):
+// - AWS::RDS::DBParameterGroup / DBClusterParameterGroup / OptionGroup names
+//   (CLI docs: "stored as a lowercase string" — same family as the guarded
+//   DBInstanceIdentifier; the DBSubnetGroupName precedent shows docs can be
+//   wrong either way, so live confirmation is required before any fold)
+// - AWS::DMS::Endpoint EndpointIdentifier (DMS identifier family)
+// - AWS::S3::Bucket CorsConfiguration AllowedHeaders/ExposeHeaders case
+// A declared-tier drift on the un-mutated deploy = normalization FP.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnEndpoint } from "aws-cdk-lib/aws-dms";
+import { CfnDBClusterParameterGroup, CfnDBParameterGroup, CfnOptionGroup } from "aws-cdk-lib/aws-rds";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegCaseIdentsMin");
+
+new CfnDBParameterGroup(stack, "HuntPg", {
+  dbParameterGroupName: "CdkrdHunt-Mixed-PG",
+  family: "mysql8.0",
+  description: "cdkrd hunt mixed-case parameter group",
+});
+
+new CfnDBClusterParameterGroup(stack, "HuntCpg", {
+  dbClusterParameterGroupName: "CdkrdHunt-Mixed-CPG",
+  family: "aurora-mysql8.0",
+  description: "cdkrd hunt mixed-case cluster parameter group",
+  parameters: { time_zone: "UTC" },
+});
+
+new CfnOptionGroup(stack, "HuntOg", {
+  optionGroupName: "CdkrdHunt-Mixed-OG",
+  engineName: "mysql",
+  majorEngineVersion: "8.0",
+  optionGroupDescription: "cdkrd hunt mixed-case option group",
+  optionConfigurations: [],
+});
+
+new CfnEndpoint(stack, "HuntDmsEndpoint", {
+  endpointIdentifier: "CdkrdHunt-Mixed-DMS-EP",
+  endpointType: "source",
+  engineName: "mysql",
+  serverName: "hunt.invalid",
+  port: 3306,
+  username: "hunter",
+  password: "cdkrd-hunt-password-1",
+});
+
+const bucket = new Bucket(stack, "HuntCorsBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const cfnBucket = bucket.node.defaultChild as import("aws-cdk-lib/aws-s3").CfnBucket;
+cfnBucket.corsConfiguration = {
+  corsRules: [
+    {
+      allowedMethods: ["GET", "PUT"],
+      allowedOrigins: ["https://hunt.example.org"],
+      allowedHeaders: ["X-Custom-Header", "Content-Type"],
+      exposedHeaders: ["ETag", "x-amz-request-id"],
+    },
+  ],
+};

--- a/tests/integration/case-idents-min/cdk.json
+++ b/tests/integration/case-idents-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/case-idents-min/package.json
+++ b/tests/integration/case-idents-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-case-idents-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift case-idents-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/case-idents-min/verify.sh
+++ b/tests/integration/case-idents-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCaseIdentsMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cloudfront-min/app.ts
+++ b/tests/integration/cloudfront-min/app.ts
@@ -1,0 +1,32 @@
+// CDK app for the cdk-real-drift cloudfront-min false-positive integration
+// test. BAREST-possible CloudFront Distribution — every existing corpus case
+// DECLARES PriceClass and HttpVersion, so their undeclared-default echoes
+// (PriceClass_All / http1.1) have never been exercised and have no fold.
+// Also leaves CustomOriginConfig ports, Comment, Restrictions, Logging,
+// ViewerCertificate, DefaultRootObject, WebACLId undeclared.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDistribution } from "aws-cdk-lib/aws-cloudfront";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegCloudFrontMin");
+
+new CfnDistribution(stack, "HuntMinDist", {
+  distributionConfig: {
+    enabled: true,
+    defaultCacheBehavior: {
+      targetOriginId: "origin1",
+      viewerProtocolPolicy: "allow-all",
+      // CachingOptimized managed cache policy
+      cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+    },
+    origins: [
+      {
+        id: "origin1",
+        domainName: "example.org",
+        customOriginConfig: { originProtocolPolicy: "https-only" },
+      },
+    ],
+  },
+});

--- a/tests/integration/cloudfront-min/cdk.json
+++ b/tests/integration/cloudfront-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront-min/package.json
+++ b/tests/integration/cloudfront-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cloudfront-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudfront-min/verify.sh
+++ b/tests/integration/cloudfront-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCloudFrontMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ec2-ebsopt-min/app.ts
+++ b/tests/integration/ec2-ebsopt-min/app.ts
@@ -1,0 +1,36 @@
+// CDK app for the cdk-real-drift ec2-ebsopt-min false-positive integration
+// test. A BAREST L1 EC2 Instance on an EBS-OPTIMIZED-BY-DEFAULT family
+// (m5.large): the live read returns EbsOptimized=true for an instance that
+// never declared it — corpus only has t3.micro (EbsOptimized=false, which
+// falls out via the trivially-empty husk), and noise.ts has NO EbsOptimized
+// fold — so this probes an expected family-derived first-run FP (the #640
+// class; EbsOptimized is derivable from the declared InstanceType).
+// Minimal 1-AZ public VPC, no NAT; only ImageId/InstanceType/SubnetId
+// declared on the instance.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  AmazonLinuxCpuType,
+  CfnInstance,
+  MachineImage,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegEc2EbsOptMin");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+new CfnInstance(stack, "HuntM5", {
+  imageId: MachineImage.latestAmazonLinux2023({
+    cpuType: AmazonLinuxCpuType.X86_64,
+  }).getImage(stack).imageId,
+  instanceType: "m5.large",
+  subnetId: vpc.selectSubnets({ subnetType: SubnetType.PUBLIC }).subnetIds[0],
+});

--- a/tests/integration/ec2-ebsopt-min/cdk.json
+++ b/tests/integration/ec2-ebsopt-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ec2-ebsopt-min/package.json
+++ b/tests/integration/ec2-ebsopt-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ec2-ebsopt-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ec2-ebsopt-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ec2-ebsopt-min/verify.sh
+++ b/tests/integration/ec2-ebsopt-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEc2EbsOptMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ecs-ec2-service-min/app.ts
+++ b/tests/integration/ecs-ec2-service-min/app.ts
@@ -1,0 +1,37 @@
+// CDK app for the cdk-real-drift ecs-ec2-service-min false-positive
+// integration test. BAREST-possible EC2-launch-type ECS Service
+// (DesiredCount=0, so no container instances are needed and nothing runs):
+// every corpus Service is Fargate/awsvpc, and the GENERATED_TOPLEVEL_PATHS
+// `Role` fold is explicitly commented as awsvpc/Fargate-only — an EC2+bridge
+// service materializes the service-linked Role (and scheduling defaults)
+// differently, never exercised live.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnCluster, CfnService, CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegEcsEc2ServiceMin");
+
+const cluster = new CfnCluster(stack, "HuntCluster", {
+  clusterName: "cdkrd-hunt-ec2svc-cluster",
+});
+
+const taskDef = new CfnTaskDefinition(stack, "HuntBridgeTaskDef", {
+  family: "cdkrd-hunt-ec2svc-td",
+  requiresCompatibilities: ["EC2"],
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "public.ecr.aws/docker/library/busybox:stable",
+      memory: 128,
+    },
+  ],
+});
+
+new CfnService(stack, "HuntEc2Service", {
+  cluster: cluster.ref,
+  taskDefinition: taskDef.ref,
+  launchType: "EC2",
+  desiredCount: 0,
+});

--- a/tests/integration/ecs-ec2-service-min/cdk.json
+++ b/tests/integration/ecs-ec2-service-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecs-ec2-service-min/package.json
+++ b/tests/integration/ecs-ec2-service-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecs-ec2-service-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ecs-ec2-service-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecs-ec2-service-min/verify.sh
+++ b/tests/integration/ecs-ec2-service-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcsEc2ServiceMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/elasticache-cme-min/app.ts
+++ b/tests/integration/elasticache-cme-min/app.ts
@@ -1,0 +1,22 @@
+// CDK app for the cdk-real-drift elasticache-cme-min false-positive
+// integration test. BAREST-possible CLUSTER-MODE-ENABLED redis
+// ReplicationGroup — the KNOWN_DEFAULTS entry pins ClusterMode:'disabled' and
+// every corpus RG is cluster-mode-disabled, so the enabled branch (ClusterMode
+// echo, default.redis7.cluster.on parameter group fill, NodeGroupConfiguration
+// echoes) has never run live. NumNodeGroups=2 + 0 replicas is the smallest
+// cluster-mode shape; CacheNodeType declared only to control cost.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnReplicationGroup } from "aws-cdk-lib/aws-elasticache";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegElastiCacheCmeMin");
+
+new CfnReplicationGroup(stack, "HuntCmeRg", {
+  replicationGroupDescription: "cdkrd hunt minimal cluster-mode-enabled rg",
+  engine: "redis",
+  cacheNodeType: "cache.t4g.micro",
+  numNodeGroups: 2,
+  replicasPerNodeGroup: 0,
+});

--- a/tests/integration/elasticache-cme-min/cdk.json
+++ b/tests/integration/elasticache-cme-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elasticache-cme-min/package.json
+++ b/tests/integration/elasticache-cme-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elasticache-cme-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elasticache-cme-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elasticache-cme-min/verify.sh
+++ b/tests/integration/elasticache-cme-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElastiCacheCmeMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/elasticache-valkey-min/app.ts
+++ b/tests/integration/elasticache-valkey-min/app.ts
@@ -1,0 +1,28 @@
+// CDK app for the cdk-real-drift elasticache-valkey-min false-positive
+// integration test. BAREST-possible VALKEY ReplicationGroup — the
+// ENGINE_DEFAULTS valkey arm (#818: AtRestEncryptionEnabled=true) was added
+// from docs/API knowledge but no valkey RG ever ran live, and valkey-specific
+// echoes (default parameter group name, TransitEncryption* defaults,
+// EngineVersion GA fill) are unverified. Runs in the default VPC (no subnet
+// group declared → probes the `default` CacheSubnetGroupName echo).
+// CacheNodeType is declared only to control cost.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnReplicationGroup } from "aws-cdk-lib/aws-elasticache";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegElastiCacheValkeyMin");
+
+new CfnReplicationGroup(stack, "HuntValkeyRg", {
+  replicationGroupDescription: "cdkrd hunt minimal valkey replication group",
+  engine: "valkey",
+  cacheNodeType: "cache.t4g.micro",
+  numCacheClusters: 1,
+  // valkey RGs default AutomaticFailoverEnabled to TRUE (unlike redis — a live-observed
+  // engine-axis difference), which rejects a single-node group; declare it off to keep
+  // the fixture single-node. TransitEncryptionEnabled has NO default for valkey (the API
+  // demands an explicit value — another engine-axis difference), so it must be declared.
+  automaticFailoverEnabled: false,
+  transitEncryptionEnabled: false,
+});

--- a/tests/integration/elasticache-valkey-min/cdk.json
+++ b/tests/integration/elasticache-valkey-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elasticache-valkey-min/package.json
+++ b/tests/integration/elasticache-valkey-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elasticache-valkey-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elasticache-valkey-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elasticache-valkey-min/verify.sh
+++ b/tests/integration/elasticache-valkey-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElastiCacheValkeyMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/fn-revert-min/app.ts
+++ b/tests/integration/fn-revert-min/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift fn-revert-min DETECTION (false-negative)
+// integration test. Two probes driven by verify.sh:
+// - AWS::SQS::Queue with a declared MUTABLE VisibilityTimeout: the standard
+//   out-of-band-mutate -> detect -> revert -> clean cycle (declared loop).
+// - AWS::DMS::Endpoint minimal: after `record`, an out-of-band SslMode
+//   hardening must RE-SURFACE — live proof that the #1490 KNOWN_DEFAULTS fold
+//   is equality-gated (folds only the "none" default, not any value).
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnEndpoint } from "aws-cdk-lib/aws-dms";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegFnRevertMin");
+
+new CfnQueue(stack, "HuntQueue", {
+  visibilityTimeout: 45,
+});
+
+// postgres, not mysql: the out-of-band mutation flips SslMode to "require",
+// which DMS supports certificate-free for postgres only (mysql rejects it).
+new CfnEndpoint(stack, "HuntDmsEndpoint", {
+  endpointIdentifier: "cdkrd-hunt-fn-dms-ep",
+  endpointType: "source",
+  engineName: "postgres",
+  serverName: "hunt.invalid",
+  port: 5432,
+  databaseName: "huntdb",
+  username: "hunter",
+  password: "cdkrd-hunt-password-1",
+});

--- a/tests/integration/fn-revert-min/cdk.json
+++ b/tests/integration/fn-revert-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/fn-revert-min/package.json
+++ b/tests/integration/fn-revert-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-fn-revert-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift fn-revert-min integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/fn-revert-min/verify.sh
+++ b/tests/integration/fn-revert-min/verify.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Detection (false-negative) integration test (real AWS):
+# deploy -> record -> check CLEAN -> mutate out of band (declared SQS
+# VisibilityTimeout + undeclared DMS SslMode) -> check MUST detect BOTH ->
+# revert the SQS drift -> restore the DMS SslMode manually (no SDK writer) ->
+# check MUST be CLEAN again.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegFnRevertMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] pre-mutation check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN before mutation"
+
+QUEUE_URL=$(aws sqs list-queues --region "$REGION" --query 'QueueUrls' --output text | tr '\t' '\n' | grep -i "$STACK" | head -1)
+[ -n "$QUEUE_URL" ] || fail "queue url not found"
+DMS_ARN=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::DMS::Endpoint'].PhysicalResourceId" --output text)
+[ -n "$DMS_ARN" ] || fail "dms endpoint arn not found"
+
+echo "=== [$STACK] mutate OUT OF BAND (VisibilityTimeout 45->120, SslMode none->require) ==="
+aws sqs set-queue-attributes --region "$REGION" --queue-url "$QUEUE_URL" \
+  --attributes VisibilityTimeout=120 || fail "sqs mutate"
+aws dms modify-endpoint --region "$REGION" --endpoint-arn "$DMS_ARN" --ssl-mode require >/dev/null || fail "dms mutate"
+sleep 10
+
+echo "=== [$STACK] check MUST detect BOTH drifts (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc"
+grep -q "VisibilityTimeout" "/tmp/cdkrd-$STACK.detect.out" || fail "SQS VisibilityTimeout drift NOT detected (FN)"
+grep -q "SslMode" "/tmp/cdkrd-$STACK.detect.out" || fail "DMS SslMode drift NOT re-surfaced (FN — equality gate broken)"
+
+echo "=== [$STACK] revert the SQS declared drift ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+
+echo "=== [$STACK] restore DMS SslMode manually (type has no SDK writer) ==="
+aws dms modify-endpoint --region "$REGION" --endpoint-arn "$DMS_ARN" --ssl-mode none >/dev/null || fail "dms restore"
+sleep 10
+
+echo "=== [$STACK] final check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert/restore"
+
+VT=$(aws sqs get-queue-attributes --region "$REGION" --queue-url "$QUEUE_URL" \
+  --attribute-names VisibilityTimeout --query 'Attributes.VisibilityTimeout' --output text)
+[ "$VT" = "45" ] || fail "live VisibilityTimeout not restored (got $VT)"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/freemisc-min/app.ts
+++ b/tests/integration/freemisc-min/app.ts
@@ -1,0 +1,69 @@
+// CDK app for the cdk-real-drift freemisc-min false-positive integration test.
+// BAREST-possible configs of free/instant zero-coverage types:
+// - AWS::MSK::Configuration: supplement reader exists (#508) but no live
+//   deploy/corpus ever exercised it (ServerProperties round-trip + defaults).
+// - AWS::CloudFormation::StackSet: SELF_MANAGED with zero instances —
+//   OperationPreferences / capabilities echoes unknown.
+// - AWS::ImageBuilder::Component + InfrastructureConfiguration: enterprise AMI
+//   pipeline staples, zero coverage; InfraConfig materializes instance-type /
+//   metadata defaults.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnStackSet } from "aws-cdk-lib/aws-cloudformation";
+import { CfnInstanceProfile, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnComponent, CfnInfrastructureConfiguration } from "aws-cdk-lib/aws-imagebuilder";
+import { CfnConfiguration } from "aws-cdk-lib/aws-msk";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegFreeMiscMin");
+
+new CfnConfiguration(stack, "HuntMskConfig", {
+  name: "cdkrd-hunt-msk-config",
+  serverProperties: "auto.create.topics.enable=false\nlog.retention.hours=168\n",
+});
+
+new CfnStackSet(stack, "HuntStackSet", {
+  stackSetName: "cdkrd-hunt-stackset",
+  permissionModel: "SELF_MANAGED",
+  templateBody: JSON.stringify({
+    Resources: {
+      HuntWaitHandle: { Type: "AWS::CloudFormation::WaitConditionHandle" },
+    },
+  }),
+});
+
+const component = new CfnComponent(stack, "HuntComponent", {
+  name: "cdkrd-hunt-component",
+  platform: "Linux",
+  version: "1.0.0",
+  data: [
+    "name: cdkrd-hunt-noop",
+    "description: cdkrd hunt noop component",
+    "schemaVersion: 1.0",
+    "phases:",
+    "  - name: build",
+    "    steps:",
+    "      - name: Noop",
+    "        action: ExecuteBash",
+    "        inputs:",
+    "          commands:",
+    "            - echo noop",
+    "",
+  ].join("\n"),
+});
+
+const ibRole = new Role(stack, "HuntIbRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+});
+const ibProfile = new CfnInstanceProfile(stack, "HuntIbProfile", {
+  instanceProfileName: "cdkrd-hunt-ib-profile",
+  roles: [ibRole.roleName],
+});
+
+const infra = new CfnInfrastructureConfiguration(stack, "HuntIbInfra", {
+  name: "cdkrd-hunt-ib-infra",
+  instanceProfileName: "cdkrd-hunt-ib-profile",
+});
+infra.addDependency(ibProfile);
+void component;

--- a/tests/integration/freemisc-min/cdk.json
+++ b/tests/integration/freemisc-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/freemisc-min/package.json
+++ b/tests/integration/freemisc-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-freemisc-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift freemisc-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/freemisc-min/verify.sh
+++ b/tests/integration/freemisc-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegFreeMiscMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/guardduty-securityhub-min/app.ts
+++ b/tests/integration/guardduty-securityhub-min/app.ts
@@ -1,0 +1,20 @@
+// CDK app for the cdk-real-drift guardduty-securityhub-min false-positive
+// integration test. BAREST-possible configs of two zero-coverage,
+// account-singleton security staples (deploy only in an account where neither
+// service is enabled — the fixture creates and deletes the singleton):
+// - AWS::GuardDuty::Detector: only `Enable` declared — Features / DataSources /
+//   FindingPublishingFrequency are all AWS-assigned defaults (rich live model).
+// - AWS::SecurityHub::Hub: nothing declared — AutoEnableControls /
+//   ControlFindingGenerator / EnableDefaultStandards defaults.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDetector } from "aws-cdk-lib/aws-guardduty";
+import { CfnHub } from "aws-cdk-lib/aws-securityhub";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegGdSecHubMin");
+
+new CfnDetector(stack, "HuntDetector", { enable: true });
+
+new CfnHub(stack, "HuntHub");

--- a/tests/integration/guardduty-securityhub-min/cdk.json
+++ b/tests/integration/guardduty-securityhub-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/guardduty-securityhub-min/package.json
+++ b/tests/integration/guardduty-securityhub-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-guardduty-securityhub-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift guardduty-securityhub-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/guardduty-securityhub-min/verify.sh
+++ b/tests/integration/guardduty-securityhub-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegGdSecHubMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/lambda-java-min/app.ts
+++ b/tests/integration/lambda-java-min/app.ts
@@ -1,0 +1,21 @@
+// CDK app for the cdk-real-drift lambda-java-min false-positive integration
+// test. A MINIMAL java21 Lambda function: Java is the only runtime family
+// whose live read echoes `SnapStart` ({ApplyOn:"None"} when undeclared) — the
+// corpus is all nodejs/python (no SnapStart key at all) and noise.ts has no
+// SnapStart fold, so this probes an expected first-run FP. The handler asset
+// is a placeholder (never invoked — create-time only validates the zip
+// exists).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import * as path from "node:path";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegLambdaJavaMin");
+
+new LambdaFunction(stack, "HuntJavaFn", {
+  runtime: Runtime.JAVA_21,
+  handler: "example.Handler::handleRequest",
+  code: Code.fromAsset(path.join(import.meta.dirname, "handler")),
+});

--- a/tests/integration/lambda-java-min/cdk.json
+++ b/tests/integration/lambda-java-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-java-min/handler/placeholder.txt
+++ b/tests/integration/lambda-java-min/handler/placeholder.txt
@@ -1,0 +1,1 @@
+cdkrd hunt placeholder (never invoked)

--- a/tests/integration/lambda-java-min/package.json
+++ b/tests/integration/lambda-java-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-java-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-java-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-java-min/verify.sh
+++ b/tests/integration/lambda-java-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaJavaMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/memorydb-valkey-min/app.ts
+++ b/tests/integration/memorydb-valkey-min/app.ts
@@ -1,0 +1,33 @@
+// CDK app for the cdk-real-drift memorydb-valkey-min false-positive
+// integration test. BAREST-possible VALKEY MemoryDB cluster — every MemoryDB
+// fold was live-confirmed on engine=redis only (corpus: redis 7.1); the valkey
+// branch (engine echo, valkey default parameter group name `default.valkey8`,
+// EngineVersion GA fill, ACL/TLS defaults) has never run live. SubnetGroup is
+// required by the API; NodeType/ACLName declared as the minimum viable config.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnSubnetGroup } from "aws-cdk-lib/aws-memorydb";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegMemoryDbValkeyMin");
+
+const vpc = new Vpc(stack, "Vpc", {
+  natGateways: 0,
+  maxAzs: 2,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED }],
+});
+
+const subnetGroup = new CfnSubnetGroup(stack, "HuntSubnetGroup", {
+  subnetGroupName: "cdkrd-hunt-mdb-valkey-sng",
+  subnetIds: vpc.selectSubnets({ subnetType: SubnetType.PRIVATE_ISOLATED }).subnetIds,
+});
+
+new CfnCluster(stack, "HuntValkeyCluster", {
+  clusterName: "cdkrd-hunt-mdb-valkey",
+  nodeType: "db.t4g.small",
+  aclName: "open-access",
+  engine: "valkey",
+  subnetGroupName: subnetGroup.ref,
+});

--- a/tests/integration/memorydb-valkey-min/cdk.json
+++ b/tests/integration/memorydb-valkey-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/memorydb-valkey-min/package.json
+++ b/tests/integration/memorydb-valkey-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-memorydb-valkey-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift memorydb-valkey-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/memorydb-valkey-min/verify.sh
+++ b/tests/integration/memorydb-valkey-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMemoryDbValkeyMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/netfw-min/app.ts
+++ b/tests/integration/netfw-min/app.ts
@@ -1,0 +1,60 @@
+// CDK app for the cdk-real-drift netfw-min false-positive integration test.
+// BAREST-possible Network Firewall building blocks (all free/instant — the
+// firewall ENDPOINT itself is the only billable piece and is NOT deployed):
+// - AWS::NetworkFirewall::RuleGroup STATEFUL: minimal rulesString — probes the
+//   StatefulRuleOptions / RuleVariables echoes.
+// - AWS::NetworkFirewall::RuleGroup STATELESS: one pass-all rule.
+// - AWS::NetworkFirewall::FirewallPolicy: bare default-action-only policy —
+//   probes StatefulEngineOptions / stream-exception defaults.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnFirewallPolicy, CfnRuleGroup } from "aws-cdk-lib/aws-networkfirewall";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegNetFwMin");
+
+new CfnRuleGroup(stack, "HuntStatefulRg", {
+  ruleGroupName: "cdkrd-hunt-stateful-rg",
+  type: "STATEFUL",
+  capacity: 10,
+  ruleGroup: {
+    rulesSource: {
+      rulesString:
+        'pass tcp any any -> any 443 (msg:"cdkrd hunt allow tls"; sid:1000001; rev:1;)',
+    },
+  },
+});
+
+new CfnRuleGroup(stack, "HuntStatelessRg", {
+  ruleGroupName: "cdkrd-hunt-stateless-rg",
+  type: "STATELESS",
+  capacity: 10,
+  ruleGroup: {
+    rulesSource: {
+      statelessRulesAndCustomActions: {
+        statelessRules: [
+          {
+            priority: 1,
+            ruleDefinition: {
+              actions: ["aws:pass"],
+              matchAttributes: {
+                protocols: [6],
+                sources: [{ addressDefinition: "0.0.0.0/0" }],
+                destinations: [{ addressDefinition: "0.0.0.0/0" }],
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+});
+
+new CfnFirewallPolicy(stack, "HuntFwPolicy", {
+  firewallPolicyName: "cdkrd-hunt-fw-policy",
+  firewallPolicy: {
+    statelessDefaultActions: ["aws:forward_to_sfe"],
+    statelessFragmentDefaultActions: ["aws:drop"],
+  },
+});

--- a/tests/integration/netfw-min/cdk.json
+++ b/tests/integration/netfw-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/netfw-min/package.json
+++ b/tests/integration/netfw-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-netfw-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift netfw-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/netfw-min/verify.sh
+++ b/tests/integration/netfw-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNetFwMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/rds-postgres-min/app.ts
+++ b/tests/integration/rds-postgres-min/app.ts
@@ -1,0 +1,20 @@
+// CDK app for the cdk-real-drift rds-postgres-min false-positive integration
+// test. BAREST-possible provisioned postgres DBInstance (the #1477 class, next
+// engine axis branch): only Engine / DBInstanceClass / AllocatedStorage /
+// master credentials declared. ENGINE_DEFAULTS' postgres arm (Port 5432,
+// LicenseModel postgresql-license) has never been exercised by a live deploy.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDBInstance } from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegRdsPostgresMin");
+
+new CfnDBInstance(stack, "HuntPostgres", {
+  engine: "postgres",
+  dbInstanceClass: "db.t3.micro",
+  allocatedStorage: "20",
+  masterUsername: "huntadmin",
+  masterUserPassword: "cdkrdHuntPassw0rd1",
+});

--- a/tests/integration/rds-postgres-min/cdk.json
+++ b/tests/integration/rds-postgres-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rds-postgres-min/package.json
+++ b/tests/integration/rds-postgres-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-rds-postgres-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift rds-postgres-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/rds-postgres-min/verify.sh
+++ b/tests/integration/rds-postgres-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRdsPostgresMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/rds-sqlserver-min/app.ts
+++ b/tests/integration/rds-sqlserver-min/app.ts
@@ -1,0 +1,22 @@
+// CDK app for the cdk-real-drift rds-sqlserver-min false-positive integration
+// test. BAREST-possible sqlserver-ex DBInstance — the highest-risk un-deployed
+// engine branch: ENGINE_DEFAULTS deliberately leaves LicenseModel undefined
+// for sqlserver (so an undeclared LicenseModel is expected to first-run FP
+// today), and the sqlserver-specific echoes (CharacterSetName etc.) are
+// unknown. Only Engine / DBInstanceClass / AllocatedStorage / master
+// credentials declared.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDBInstance } from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegRdsSqlServerMin");
+
+new CfnDBInstance(stack, "HuntSqlServer", {
+  engine: "sqlserver-ex",
+  dbInstanceClass: "db.t3.micro",
+  allocatedStorage: "20",
+  masterUsername: "huntadmin",
+  masterUserPassword: "cdkrdHuntPassw0rd1",
+});

--- a/tests/integration/rds-sqlserver-min/cdk.json
+++ b/tests/integration/rds-sqlserver-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rds-sqlserver-min/package.json
+++ b/tests/integration/rds-sqlserver-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-rds-sqlserver-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift rds-sqlserver-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/rds-sqlserver-min/verify.sh
+++ b/tests/integration/rds-sqlserver-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRdsSqlServerMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/redshift-serverless-min/app.ts
+++ b/tests/integration/redshift-serverless-min/app.ts
@@ -1,0 +1,27 @@
+// CDK app for the cdk-real-drift redshift-serverless-min false-positive
+// integration test. BAREST-possible Redshift Serverless pair — the SDK
+// supplement readers exist (overrides.ts) but have never been exercised by a
+// live deploy or a corpus case:
+// - AWS::RedshiftServerless::Namespace: only NamespaceName declared —
+//   DbName / IamRoles / LogExports / admin defaults are AWS-assigned.
+// - AWS::RedshiftServerless::Workgroup: only WorkgroupName + NamespaceName —
+//   BaseCapacity (128 RPU) / ConfigParameters / EnhancedVpcRouting /
+//   PubliclyAccessible / Port defaults are AWS-assigned.
+// Serverless: no cost while idle. A first `check` must show ZERO
+// [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnNamespace, CfnWorkgroup } from "aws-cdk-lib/aws-redshiftserverless";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegRedshiftSlMin");
+
+const ns = new CfnNamespace(stack, "HuntNamespace", {
+  namespaceName: "cdkrd-hunt-ns",
+});
+
+const wg = new CfnWorkgroup(stack, "HuntWorkgroup", {
+  workgroupName: "cdkrd-hunt-wg",
+  namespaceName: "cdkrd-hunt-ns",
+});
+wg.addDependency(ns);

--- a/tests/integration/redshift-serverless-min/cdk.json
+++ b/tests/integration/redshift-serverless-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/redshift-serverless-min/package.json
+++ b/tests/integration/redshift-serverless-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-redshift-serverless-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift redshift-serverless-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/redshift-serverless-min/verify.sh
+++ b/tests/integration/redshift-serverless-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRedshiftSlMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/reorder-probes-min/app.ts
+++ b/tests/integration/reorder-probes-min/app.ts
@@ -1,0 +1,75 @@
+// CDK app for the cdk-real-drift reorder-probes-min false-positive integration
+// test. DECLARED-dimension set-reorder probes: each declares a multi-element
+// list in a deliberately NON-canonical (non-sorted) order on types whose
+// live read is suspected to canonicalize/sort it, but whose trigger no corpus
+// case exercises (all existing cases have 0-1 elements or sorted order):
+// - AWS::Cognito::IdentityPool CognitoIdentityProviders (2 providers, reversed)
+// - AWS::ECS::Cluster CapacityProviders + DefaultCapacityProviderStrategy
+//   (FARGATE_SPOT before FARGATE)
+// - AWS::ApiGateway::RestApi BinaryMediaTypes (3 entries, non-alphabetical)
+// - AWS::ApiGatewayV2::Api CorsConfiguration.AllowOrigins (3, non-sorted)
+// - AWS::EFS::FileSystem LifecyclePolicies (3 single-key unions, non-canonical)
+// A declared-tier drift on the un-mutated deploy = normalization FP.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnApi } from "aws-cdk-lib/aws-apigatewayv2";
+import { CfnRestApi } from "aws-cdk-lib/aws-apigateway";
+import { CfnIdentityPool, CfnUserPool, CfnUserPoolClient } from "aws-cdk-lib/aws-cognito";
+import { CfnCluster } from "aws-cdk-lib/aws-ecs";
+import { CfnFileSystem } from "aws-cdk-lib/aws-efs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegReorderProbesMin");
+
+const pool = new CfnUserPool(stack, "HuntPool", {
+  userPoolName: "cdkrd-hunt-reorder-pool",
+});
+const clientB = new CfnUserPoolClient(stack, "HuntClientB", {
+  userPoolId: pool.ref,
+  clientName: "cdkrd-hunt-client-b",
+});
+const clientA = new CfnUserPoolClient(stack, "HuntClientA", {
+  userPoolId: pool.ref,
+  clientName: "cdkrd-hunt-client-a",
+});
+
+new CfnIdentityPool(stack, "HuntIdPool", {
+  identityPoolName: "cdkrd-hunt-reorder-idpool",
+  allowUnauthenticatedIdentities: false,
+  cognitoIdentityProviders: [
+    { providerName: `cognito-idp.${stack.region}.amazonaws.com/${pool.ref}`, clientId: clientB.ref },
+    { providerName: `cognito-idp.${stack.region}.amazonaws.com/${pool.ref}`, clientId: clientA.ref },
+  ],
+});
+
+new CfnCluster(stack, "HuntEcsCluster", {
+  clusterName: "cdkrd-hunt-reorder-cluster",
+  capacityProviders: ["FARGATE_SPOT", "FARGATE"],
+  defaultCapacityProviderStrategy: [
+    { capacityProvider: "FARGATE_SPOT", weight: 2 },
+    { capacityProvider: "FARGATE", weight: 1, base: 1 },
+  ],
+});
+
+new CfnRestApi(stack, "HuntRestApi", {
+  name: "cdkrd-hunt-reorder-restapi",
+  binaryMediaTypes: ["image/webp", "application/octet-stream", "image/avif"],
+});
+
+new CfnApi(stack, "HuntHttpApi", {
+  name: "cdkrd-hunt-reorder-httpapi",
+  protocolType: "HTTP",
+  corsConfiguration: {
+    allowOrigins: ["https://z.example.org", "https://a.example.org", "https://m.example.org"],
+    allowMethods: ["POST", "GET"],
+  },
+});
+
+new CfnFileSystem(stack, "HuntEfs", {
+  throughputMode: "elastic",
+  lifecyclePolicies: [
+    { transitionToPrimaryStorageClass: "AFTER_1_ACCESS" },
+    { transitionToArchive: "AFTER_90_DAYS" },
+    { transitionToIa: "AFTER_30_DAYS" },
+  ],
+});

--- a/tests/integration/reorder-probes-min/cdk.json
+++ b/tests/integration/reorder-probes-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/reorder-probes-min/package.json
+++ b/tests/integration/reorder-probes-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-reorder-probes-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift reorder-probes-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/reorder-probes-min/verify.sh
+++ b/tests/integration/reorder-probes-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegReorderProbesMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3kms-ddb-batch-min/app.ts
+++ b/tests/integration/s3kms-ddb-batch-min/app.ts
@@ -1,0 +1,68 @@
+// CDK app for the cdk-real-drift s3kms-ddb-batch-min false-positive
+// integration test. BAREST-possible un-deployed variant branches:
+// - AWS::S3::Bucket with SSE-KMS (aws/s3 managed key): corpus only covers
+//   SSE-S3 / no-encryption — probes the BucketKeyEnabled / KMSMasterKeyID
+//   echoes on the declared encryption block.
+// - AWS::DynamoDB::Table minimal ON-DEMAND: BillingMode PAY_PER_REQUEST with
+//   nothing else — probes on-demand-specific echoes
+//   (BillingModeSummary/Throughput husks, WarmThroughput).
+// - AWS::Batch::ComputeEnvironment MANAGED/EC2 with minvCpus 0 (no instances,
+//   free): corpus only covers FARGATE — probes the EC2-branch default fill
+//   (instance role echo, allocation strategy, launch template) and the
+//   InstanceTypes set order.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnComputeEnvironment } from "aws-cdk-lib/aws-batch";
+import { CfnTable } from "aws-cdk-lib/aws-dynamodb";
+import { CfnInstanceProfile, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegS3KmsDdbBatchMin");
+
+const bucket = new CfnBucket(stack, "HuntKmsBucket", {
+  bucketEncryption: {
+    serverSideEncryptionConfiguration: [
+      { serverSideEncryptionByDefault: { sseAlgorithm: "aws:kms" } },
+    ],
+  },
+});
+bucket.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+new CfnTable(stack, "HuntOnDemandTable", {
+  keySchema: [{ attributeName: "pk", keyType: "HASH" }],
+  attributeDefinitions: [{ attributeName: "pk", attributeType: "S" }],
+  billingMode: "PAY_PER_REQUEST",
+});
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const ecsRole = new Role(stack, "HuntBatchEcsRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+});
+const profile = new CfnInstanceProfile(stack, "HuntBatchProfile", {
+  instanceProfileName: "cdkrd-hunt-batch-profile",
+  roles: [ecsRole.roleName],
+});
+
+const ce = new CfnComputeEnvironment(stack, "HuntEc2Ce", {
+  type: "MANAGED",
+  computeResources: {
+    type: "EC2",
+    maxvCpus: 4,
+    minvCpus: 0,
+    instanceTypes: ["m5.large", "c5.large"],
+    instanceRole: profile.attrArn,
+    subnets: vpc.selectSubnets({ subnetType: SubnetType.PUBLIC }).subnetIds,
+    securityGroupIds: [
+      new SecurityGroup(stack, "HuntBatchSg", { vpc, allowAllOutbound: true }).securityGroupId,
+    ],
+  },
+});
+ce.addDependency(profile);

--- a/tests/integration/s3kms-ddb-batch-min/cdk.json
+++ b/tests/integration/s3kms-ddb-batch-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3kms-ddb-batch-min/package.json
+++ b/tests/integration/s3kms-ddb-batch-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3kms-ddb-batch-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3kms-ddb-batch-min integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3kms-ddb-batch-min/verify.sh
+++ b/tests/integration/s3kms-ddb-batch-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3KmsDdbBatchMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/stream-fifo-min/app.ts
+++ b/tests/integration/stream-fifo-min/app.ts
@@ -1,0 +1,54 @@
+// CDK app for the cdk-real-drift stream-fifo-min false-positive integration
+// test. BAREST-possible configs of un-deployed VARIANT branches of everyday
+// types (a fold built from one variant proves nothing about the others):
+// - AWS::Kinesis::Stream ON_DEMAND: corpus only has PROVISIONED — on-demand
+//   omits ShardCount and may echo on-demand-specific defaults.
+// - AWS::SQS::Queue minimal FIFO: only FifoQueue declared — probes the
+//   DeduplicationScope / FifoThroughputLimit / FifoThroughputScope echoes.
+// - AWS::SQS::Queue full high-throughput FIFO: perMessageGroupId variant.
+// - AWS::ECS::TaskDefinition NetworkMode=host: register-only (no service,
+//   zero cost) — corpus covers only awsvpc and bridge.
+// - AWS::Events::Rule cron(): corpus covers EventPattern and rate() only.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+import { CfnRule } from "aws-cdk-lib/aws-events";
+import { CfnStream } from "aws-cdk-lib/aws-kinesis";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegStreamFifoMin");
+
+new CfnStream(stack, "HuntOnDemandStream", {
+  streamModeDetails: { streamMode: "ON_DEMAND" },
+});
+
+new CfnQueue(stack, "HuntFifoMin", {
+  fifoQueue: true,
+});
+
+new CfnQueue(stack, "HuntFifoHighThroughput", {
+  fifoQueue: true,
+  contentBasedDeduplication: true,
+  deduplicationScope: "messageGroup",
+  fifoThroughputLimit: "perMessageGroupId",
+});
+
+new CfnTaskDefinition(stack, "HuntHostTaskDef", {
+  family: "cdkrd-hunt-host-td",
+  networkMode: "host",
+  requiresCompatibilities: ["EC2"],
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "public.ecr.aws/docker/library/busybox:stable",
+      memory: 128,
+    },
+  ],
+});
+
+new CfnRule(stack, "HuntCronRule", {
+  scheduleExpression: "cron(0 12 * * ? *)",
+  state: "DISABLED",
+});

--- a/tests/integration/stream-fifo-min/cdk.json
+++ b/tests/integration/stream-fifo-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/stream-fifo-min/package.json
+++ b/tests/integration/stream-fifo-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-stream-fifo-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift stream-fifo-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/stream-fifo-min/verify.sh
+++ b/tests/integration/stream-fifo-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegStreamFifoMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/vpc-attach-min/app.ts
+++ b/tests/integration/vpc-attach-min/app.ts
@@ -1,0 +1,56 @@
+// CDK app for the cdk-real-drift vpc-attach-min false-positive integration
+// test. BAREST-possible configs of zero-coverage everyday VPC attachments
+// (all free while attached):
+// - AWS::EC2::InstanceConnectEndpoint: the modern private-subnet SSH path —
+//   only SubnetId declared (PreserveClientIp / SecurityGroupIds defaults echo).
+// - AWS::EC2::EIPAssociation: EIP attached to a bare ENI — AllocationId /
+//   NetworkInterfaceId echoes plus the association's AWS-assigned id.
+// - AWS::EC2::VPCCidrBlock (amazon-provided IPv6) + AWS::EC2::SubnetCidrBlock:
+//   dual-stack assignment branch never exercised (vpc fixtures are IPv4-only).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Fn, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnEIP,
+  CfnEIPAssociation,
+  CfnInstanceConnectEndpoint,
+  CfnNetworkInterface,
+  CfnSubnetCidrBlock,
+  CfnVPCCidrBlock,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegVpcAttachMin");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+const subnetId = vpc.selectSubnets({ subnetType: SubnetType.PUBLIC }).subnetIds[0];
+
+new CfnInstanceConnectEndpoint(stack, "HuntIce", {
+  subnetId,
+});
+
+const eni = new CfnNetworkInterface(stack, "HuntEni", {
+  subnetId,
+});
+const eip = new CfnEIP(stack, "HuntEip", {});
+new CfnEIPAssociation(stack, "HuntEipAssoc", {
+  allocationId: eip.attrAllocationId,
+  networkInterfaceId: eni.ref,
+});
+
+const ipv6Block = new CfnVPCCidrBlock(stack, "HuntIpv6Block", {
+  vpcId: vpc.vpcId,
+  amazonProvidedIpv6CidrBlock: true,
+});
+
+const subnetIpv6 = new CfnSubnetCidrBlock(stack, "HuntSubnetIpv6", {
+  subnetId,
+  ipv6CidrBlock: Fn.select(0, Fn.cidr(Fn.select(0, vpc.vpcIpv6CidrBlocks), 1, "64")),
+});
+subnetIpv6.addDependency(ipv6Block);

--- a/tests/integration/vpc-attach-min/cdk.json
+++ b/tests/integration/vpc-attach-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/vpc-attach-min/package.json
+++ b/tests/integration/vpc-attach-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-vpc-attach-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift vpc-attach-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/vpc-attach-min/verify.sh
+++ b/tests/integration/vpc-attach-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegVpcAttachMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -901,8 +901,12 @@ describe('noise suppressors', () => {
       // The current AWS default RDS server CA (constant; engine-derived RDS values fold via
       // ENGINE_DEFAULTS / DEFAULT_MANAGED_NAME_PATHS instead).
       CACertificateIdentifier: 'rds-ca-rsa2048-g1',
+      // The literal "default" subnet group an undeclared instance is placed into
+      // (rds-postgres-min / aurora-pg-min live, 2026-07-12).
+      DBSubnetGroupName: 'default',
     });
     expect(KNOWN_DEFAULTS['AWS::RDS::DBCluster'].NetworkType).toBe('IPV4');
+    expect(KNOWN_DEFAULTS['AWS::RDS::DBCluster'].DBSubnetGroupName).toBe('default');
     expect(KNOWN_DEFAULTS['AWS::ElastiCache::ReplicationGroup']).toEqual({
       AutoMinorVersionUpgrade: true,
       ClusterMode: 'disabled',


### PR DESCRIPTION
## What

The 2026-07-12 minimal-deploy FP hunt (~20 lenses, us-east-1): deploy each priority type/variant in its BAREST config, `check` before `record`, treat every `[Potential Drift]` as a fold gap. 14 fold-table additions (all equality-/derive-gated — detection preserved), 17 committed regression fixtures, 45 harvested golden-corpus cases, unit tests for every new entry.

Closes #1490, Closes #1491, Closes #1495, Closes #1503.
Partially addresses #1499 / #1501 / #1498 (the derivation-design remainders stay open, each documented on its issue); adds the m5 `CreditSpecification` data point to #640.

## Fixed folds (live-found, live-verified)

| Type | Paths | Mechanism |
|---|---|---|
| DMS Endpoint (#1490) | `EndpointIdentifier` (DECLARED FP, survived record) / `SslMode` / `KmsKeyId` | CASE_INSENSITIVE_PATHS / KNOWN_DEFAULTS / value-independent |
| ECS Cluster (#1491) | `CapacityProviders` set-reorder (DECLARED FP) | UNORDERED_ARRAY_PROPS |
| StackSet (#1495) | `ExecutionRoleName` / account-derived `AdministrationRoleARN` | KNOWN_DEFAULTS / CONTEXT_ARN_DEFAULTS |
| MemoryDB (#1503) | `NumShards` `NumReplicasPerShard` `SnapshotRetentionLimit` `TLSEnabled` / `EngineVersion` | KNOWN_DEFAULTS / value-independent |
| RDS DBCluster+DBInstance (#1499 partial) | default-SG echo (+ DocDB twin) / `DBSubnetGroupName` / `default.<family>` PG / sqlserver `LicenseModel`+`CharacterSetName` | DEFAULT_SG_LIST_PATHS / KNOWN_DEFAULTS / DEFAULT_MANAGED_NAME_PATHS / ENGINE_DEFAULTS |
| Batch CE (#1501 partial) | `State` / era `Ec2Configuration` image type | KNOWN_DEFAULTS / KNOWN_DEFAULT_ONE_OF_PATHS |
| EC2 (#1498 partial) | ICE `SecurityGroupIds`, EIPAssociation `PrivateIpAddress`/`EIP` (all create-only) | value-independent |

## Ruled out live (pinned by the new corpus as permanent offline regressions)

CloudFront minimal (PriceClass/HttpVersion), SQS FIFO variants, ECS host taskdef + EC2-launch-type service, cron() rule, Lambda java21, NetworkFirewall ×3, MSK Configuration, ImageBuilder, S3 SSE-KMS + CORS header case, DDB on-demand, valkey RG (the #818 arm live-verified), RDS PG/OG mixed-case names (docs wrong again — deliberately NOT folded), Cognito IdentityPool / RestApi BinaryMediaTypes / ApiGatewayV2 AllowOrigins / EFS lifecycle reorders (order-preserving).

## Live verification

- `fn-revert-min` full FN cycle with this branch's dist: record → out-of-band mutate (SQS `VisibilityTimeout` declared + DMS `SslMode` undeclared) → **both detected** (the new SslMode fold's equality gate proven live) → `revert` converged (live value restored, verified) → CLEAN.
- The sqlserver fixture's first check ran on the fixed dist and folded the new RDS entries live (only the known-open `PubliclyAccessible` surfaced).
- Peer fixes for #1485/#1486/#1487/#1489 merged mid-hunt were cross-validated against this hunt's harvested corpus cases (expected regenerated to the folded form in this diff).

**Shared CORE suite: deferred** — the diff is fold-table-only, fully covered by unit tests + corpus replay (5284 tests green) and live-proven in the originating hunt; per the /verify-pr deferral rule it runs at the next clean-window release verification.

## Cleanup

All 20 hunt stacks deleted; `sweep-orphans.sh` reports SWEEP CLEAN (after #1505's phantom arms); bughunt gate released for this session.
