### PR TITLE
fix(diff): ElastiCache RG cluster-mode-enabled derived-default trio (#1500)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -466,6 +466,71 @@ function accountDerivedDefault(
   return undefined;
 }
 
+// #1500: for a CLUSTER-MODE-ENABLED ElastiCache ReplicationGroup, three undeclared properties AWS
+// materializes at creation are DETERMINISTIC FUNCTIONS of the declared shard/replica shape, not
+// fixed constants — the KNOWN_DEFAULTS `ClusterMode:'disabled'` pin only covers the non-cluster
+// case, so a cluster-mode RG (NumNodeGroups>1) first-run-FPs on all three. Derive (tier-2) and
+// equality-gate against the COMPUTED value so an out-of-band migration / failover flip / shard-
+// replica scale still surfaces:
+//   ClusterMode              -> 'enabled' when the declared shape is cluster-mode (NumNodeGroups>1,
+//                               a NodeGroupConfiguration, or an explicit ClusterMode='enabled').
+//   AutomaticFailoverEnabled -> true for a cluster-mode RG (cluster mode REQUIRES failover) and for
+//                               ANY valkey RG (the valkey API defaults it true even single-node —
+//                               it rejects a 1-node valkey RG unless failover is explicitly off).
+//   NumCacheClusters         -> NumNodeGroups x (1 + ReplicasPerNodeGroup) (total nodes across the
+//                               shards; the repro's 2x(1+0)=2), or the sum over a NodeGroupConfig.
+// Returns undefined for a property it cannot derive from the declared inputs (e.g. a non-cluster
+// redis AutomaticFailoverEnabled=false -> today's trivial-empty drop; a non-cluster ClusterMode ->
+// the KNOWN_DEFAULTS 'disabled' constant), leaving today's behavior for those.
+function elastiCacheReplicationGroupDerivedDefault(
+  key: string,
+  declared: Record<string, unknown>
+): { value: unknown } | undefined {
+  const numNodeGroups =
+    typeof declared['NumNodeGroups'] === 'number'
+      ? (declared['NumNodeGroups'] as number)
+      : undefined;
+  const nodeGroupConfig = Array.isArray(declared['NodeGroupConfiguration'])
+    ? (declared['NodeGroupConfiguration'] as Array<Record<string, unknown>>)
+    : undefined;
+  const replicasPerNodeGroup =
+    typeof declared['ReplicasPerNodeGroup'] === 'number'
+      ? (declared['ReplicasPerNodeGroup'] as number)
+      : undefined;
+  const engine =
+    typeof declared['Engine'] === 'string'
+      ? (declared['Engine'] as string).toLowerCase()
+      : undefined;
+  const clusterModeEnabled =
+    (numNodeGroups !== undefined && numNodeGroups > 1) ||
+    (nodeGroupConfig !== undefined && nodeGroupConfig.length > 0) ||
+    declared['ClusterMode'] === 'enabled';
+
+  if (key === 'ClusterMode') {
+    return clusterModeEnabled ? { value: 'enabled' } : undefined;
+  }
+  if (key === 'AutomaticFailoverEnabled') {
+    return clusterModeEnabled || engine === 'valkey' ? { value: true } : undefined;
+  }
+  if (key === 'NumCacheClusters') {
+    if (numNodeGroups !== undefined) {
+      return { value: numNodeGroups * (1 + (replicasPerNodeGroup ?? 0)) };
+    }
+    if (nodeGroupConfig !== undefined && nodeGroupConfig.length > 0) {
+      const total = nodeGroupConfig.reduce((sum, g) => {
+        const rc =
+          typeof g['ReplicaCount'] === 'number'
+            ? (g['ReplicaCount'] as number)
+            : (replicasPerNodeGroup ?? 0);
+        return sum + 1 + rc;
+      }, 0);
+      return { value: total };
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements
 // AWS always returns — keyed by the property -> the element's identity field. Cognito
 // UserPool `Schema` is the case: AWS returns all ~21 standard attributes (sub, email,
@@ -4477,6 +4542,24 @@ export function classifyResource(
         actual: v,
       });
       continue;
+    }
+    // #1500: a cluster-mode ElastiCache RG's undeclared ClusterMode / AutomaticFailoverEnabled /
+    // NumCacheClusters are DERIVED from the declared shard/replica shape (see the helper). Fold
+    // atDefault when the live value equals the computed default (equality-gated — an out-of-band
+    // migration / failover flip / shard-replica scale still surfaces). Authoritative like acctDefault
+    // above: undefined (non-cluster / non-derivable) falls through to the KNOWN_DEFAULTS constant.
+    if (resourceType === 'AWS::ElastiCache::ReplicationGroup') {
+      const rgDerived = elastiCacheReplicationGroupDerivedDefault(k, declared);
+      if (rgDerived !== undefined) {
+        findings.push({
+          tier: matchesKnownDefault(v, rgDerived.value) ? 'atDefault' : 'undeclared',
+          logicalId,
+          resourceType,
+          path: k,
+          actual: v,
+        });
+        continue;
+      }
     }
     // NOTE: no `schema.writeOnly.has(k)` guard — a top-level write-only key was
     // already stripped from `live` by writeOnlyPaths above, so it cannot reach here

--- a/tests/classify-elasticache-cme-1500.test.ts
+++ b/tests/classify-elasticache-cme-1500.test.ts
@@ -1,0 +1,179 @@
+// #1500: ElastiCache ReplicationGroup CLUSTER-MODE-ENABLED first-run FP trio (the #1477 variant-axis
+// class — every corpus RG is cluster-mode-disabled, and KNOWN_DEFAULTS pins ClusterMode:'disabled').
+// A barest cluster-mode RG (numNodeGroups:2, replicasPerNodeGroup:0), first `check` (live us-east-1,
+// 2026-07-12):
+//   HuntCmeRg.ClusterMode                actual ="enabled"
+//   HuntCmeRg.AutomaticFailoverEnabled   actual =true
+//   HuntCmeRg.NumCacheClusters           actual =2
+// All three are tier-2 DERIVED from the declared shard/replica shape (see
+// elastiCacheReplicationGroupDerivedDefault): equality-gated against the computed value, so an
+// out-of-band migration / failover flip / shard-replica scale still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1500 ElastiCache::ReplicationGroup cluster-mode-enabled derived trio', () => {
+  const res: DesiredResource = {
+    logicalId: 'HuntCmeRg',
+    resourceType: 'AWS::ElastiCache::ReplicationGroup',
+    physicalId: 'huntcmerg',
+    declared: {
+      ReplicationGroupDescription: 'hunt cme rg',
+      Engine: 'redis',
+      CacheNodeType: 'cache.t4g.micro',
+      NumNodeGroups: 2,
+      ReplicasPerNodeGroup: 0,
+    },
+  };
+  // Clean live model of the fresh cluster-mode RG: the declared echoes plus the three derived
+  // trio props and the already-pinned AutoMinorVersionUpgrade / IpDiscovery / NetworkType defaults.
+  const cleanLive = {
+    ReplicationGroupDescription: 'hunt cme rg',
+    Engine: 'redis',
+    CacheNodeType: 'cache.t4g.micro',
+    NumNodeGroups: 2,
+    ReplicasPerNodeGroup: 0,
+    ClusterMode: 'enabled',
+    AutomaticFailoverEnabled: true,
+    NumCacheClusters: 2,
+    AutoMinorVersionUpgrade: true,
+    IpDiscovery: 'ipv4',
+    NetworkType: 'ipv4',
+  };
+
+  it('produces ZERO potential drift on a clean, un-mutated cluster-mode RG', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('folds the derived trio (ClusterMode / AutomaticFailoverEnabled / NumCacheClusters) to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    const atDefault = pathsByTier(f, 'atDefault');
+    for (const p of ['ClusterMode', 'AutomaticFailoverEnabled', 'NumCacheClusters']) {
+      expect(atDefault).toContain(p);
+      expect(pathsByTier(f, 'undeclared')).not.toContain(p);
+    }
+  });
+
+  it('surfaces an out-of-band shard/replica scale (NumCacheClusters away from NumNodeGroups*(1+replicas))', () => {
+    const scaled = { ...cleanLive, NumCacheClusters: 4 };
+    const f = classifyResource(res, scaled, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('NumCacheClusters');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('NumCacheClusters');
+  });
+
+  it('surfaces an out-of-band failover DISABLE on a cluster-mode RG', () => {
+    const noFailover = { ...cleanLive, AutomaticFailoverEnabled: false };
+    const f = classifyResource(res, noFailover, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('AutomaticFailoverEnabled');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('AutomaticFailoverEnabled');
+  });
+
+  it('surfaces an out-of-band ClusterMode divergence (live disabled vs declared cluster-mode shape)', () => {
+    const migrated = { ...cleanLive, ClusterMode: 'disabled' };
+    const f = classifyResource(res, migrated, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('ClusterMode');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('ClusterMode');
+  });
+
+  it('derives NumCacheClusters with a bigger replica count (2 shards x (1+1) = 4)', () => {
+    const biggerRes: DesiredResource = {
+      ...res,
+      declared: { ...res.declared, ReplicasPerNodeGroup: 1 },
+    };
+    const live = { ...cleanLive, ReplicasPerNodeGroup: 1, NumCacheClusters: 4 };
+    const f = classifyResource(biggerRes, live, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('NumCacheClusters');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('NumCacheClusters');
+  });
+
+  it('derives NumCacheClusters from a NodeGroupConfiguration (2 groups x (1+1) = 4)', () => {
+    const ngcRes: DesiredResource = {
+      logicalId: 'HuntNgcRg',
+      resourceType: 'AWS::ElastiCache::ReplicationGroup',
+      physicalId: 'huntngcrg',
+      declared: {
+        ReplicationGroupDescription: 'ngc rg',
+        Engine: 'redis',
+        CacheNodeType: 'cache.t4g.micro',
+        NodeGroupConfiguration: [{ ReplicaCount: 1 }, { ReplicaCount: 1 }],
+      },
+    };
+    const live = {
+      ReplicationGroupDescription: 'ngc rg',
+      Engine: 'redis',
+      CacheNodeType: 'cache.t4g.micro',
+      NodeGroupConfiguration: [{ ReplicaCount: 1 }, { ReplicaCount: 1 }],
+      ClusterMode: 'enabled',
+      AutomaticFailoverEnabled: true,
+      NumCacheClusters: 4,
+    };
+    const f = classifyResource(ngcRes, live, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('NumCacheClusters');
+    expect(pathsByTier(f, 'atDefault')).toContain('ClusterMode');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('NumCacheClusters');
+  });
+});
+
+describe('#1500 ElastiCache::ReplicationGroup non-cluster + valkey engine axes', () => {
+  it('a valkey RG folds AutomaticFailoverEnabled=true even without a cluster-mode shape', () => {
+    const res: DesiredResource = {
+      logicalId: 'HuntValkeyRg',
+      resourceType: 'AWS::ElastiCache::ReplicationGroup',
+      physicalId: 'huntvalkeyrg',
+      declared: {
+        ReplicationGroupDescription: 'valkey rg',
+        Engine: 'valkey',
+        CacheNodeType: 'cache.t4g.micro',
+      },
+    };
+    const live = {
+      ReplicationGroupDescription: 'valkey rg',
+      Engine: 'valkey',
+      CacheNodeType: 'cache.t4g.micro',
+      AutomaticFailoverEnabled: true,
+    };
+    const f = classifyResource(res, live, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('AutomaticFailoverEnabled');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('AutomaticFailoverEnabled');
+  });
+
+  it('a non-cluster redis RG keeps ClusterMode=disabled folding via the KNOWN_DEFAULTS constant', () => {
+    const res: DesiredResource = {
+      logicalId: 'HuntPlainRg',
+      resourceType: 'AWS::ElastiCache::ReplicationGroup',
+      physicalId: 'huntplainrg',
+      declared: {
+        ReplicationGroupDescription: 'plain rg',
+        Engine: 'redis',
+        CacheNodeType: 'cache.t4g.micro',
+      },
+    };
+    const live = {
+      ReplicationGroupDescription: 'plain rg',
+      Engine: 'redis',
+      CacheNodeType: 'cache.t4g.micro',
+      ClusterMode: 'disabled',
+    };
+    const f = classifyResource(res, live, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('ClusterMode');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('ClusterMode');
+  });
+});


### PR DESCRIPTION
## What

A BAREST **cluster-mode-enabled** ElastiCache `ReplicationGroup` (`numNodeGroups: 2`, `replicasPerNodeGroup: 0`) surfaced **three** undeclared properties as `[Potential Drift]` on a first `check` — the #1477 variant-axis class: every corpus RG is cluster-mode DISABLED and `KNOWN_DEFAULTS` pins `ClusterMode:'disabled'`, so the cluster-mode axis never had a fold.

Live repro (us-east-1, 2026-07-12), first `check`:

```
[Potential Drift: 3]
  HuntCmeRg.ClusterMode                actual ="enabled"
  HuntCmeRg.AutomaticFailoverEnabled   actual =true
  HuntCmeRg.NumCacheClusters           actual =2
```

## Fix (tier-2 derived — deterministic functions of the declared shape)

All three are DETERMINISTIC FUNCTIONS of the declared shard/replica shape, so derive and equality-gate against the computed value (an out-of-band migration / failover flip / shard-replica scale still surfaces):

- **ClusterMode** → `'enabled'` when the declared shape is cluster-mode (`NumNodeGroups > 1`, a `NodeGroupConfiguration`, or an explicit `ClusterMode='enabled'`); else `undefined` → the `KNOWN_DEFAULTS 'disabled'` constant stands (non-cluster case unchanged).
- **AutomaticFailoverEnabled** → `true` for a cluster-mode RG (cluster mode REQUIRES failover) and for ANY **valkey** RG (the valkey API defaults it true even single-node); else `undefined` → today's trivial-empty drop.
- **NumCacheClusters** → `NumNodeGroups × (1 + ReplicasPerNodeGroup)` (total nodes across shards; the repro's `2×(1+0)=2`), or the sum over a `NodeGroupConfiguration`.

`classify.ts` only: a new `elastiCacheReplicationGroupDerivedDefault` helper + one authoritative branch in the undeclared loop (mirroring `accountDerivedDefault`). The `noise.ts` `ClusterMode:'disabled'` pin is untouched.

## Tests

New `tests/classify-elasticache-cme-1500.test.ts` (harvested CME model pinned inline): ZERO potential drift on the clean cluster-mode RG; the trio folds to `atDefault`; out-of-band cases still surface (shard/replica scale, failover disable, ClusterMode divergence); `NumCacheClusters` derives from both `ReplicasPerNodeGroup` and `NodeGroupConfiguration`; a valkey RG folds `AutomaticFailoverEnabled=true` without a cluster shape; a non-cluster redis keeps folding `ClusterMode=disabled` via the constant. Full suite: 246 files / 5203 tests pass (the existing cluster-mode-disabled corpus is unaffected).

## Verification

Fold/classify FP fix — live-proven in its originating hunt (#1500 carries the exact us-east-1 live repro); the harvested clean model is pinned inline in the new unit test (the hunt's corpus JSON lives in the unmerged hunt worktree). Shared CORE integration suite DEFERRED (offline + inline-test + hunt-verified; no fresh deploy).

Closes #1500
