### PR TITLE
fix(diff): ElastiCache RG cluster-mode derived fold keys on pre-strip declared inputs (#1500)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -2790,6 +2790,23 @@ export function classifyResource(
     isNestedObject(declared['DefinitionSubstitutions'])
       ? declared['DefinitionSubstitutions']
       : undefined;
+  // #1500: the ElastiCache ReplicationGroup cluster-mode-shape inputs (`NumNodeGroups`,
+  // `NodeGroupConfiguration`) are writeOnly, so the strip below removes them from `declared`
+  // before the derived-default helper can key on them. The BAREST cluster-mode shape reads
+  // `NumNodeGroups` back only as a readGap (write-only, unreadable), so the derivation cannot
+  // recover the shape from `live` either. Snapshot the declared cluster-mode inputs HERE, before
+  // the strip, so `elastiCacheReplicationGroupDerivedDefault` can still derive the ClusterMode /
+  // AutomaticFailoverEnabled / NumCacheClusters defaults from the DECLARED shard/replica shape.
+  const elastiCacheRgDeclaredShape =
+    resourceType === 'AWS::ElastiCache::ReplicationGroup'
+      ? {
+          NumNodeGroups: declared['NumNodeGroups'],
+          NodeGroupConfiguration: declared['NodeGroupConfiguration'],
+          ReplicasPerNodeGroup: declared['ReplicasPerNodeGroup'],
+          ClusterMode: declared['ClusterMode'],
+          Engine: declared['Engine'],
+        }
+      : undefined;
   // writeOnly cannot be read back: strip it from the DECLARED side too so it is never
   // compared (the LIVE side was already stripped by normalizeLiveModel above).
   deepStripPaths(declared, schema.writeOnlyPaths);
@@ -4560,7 +4577,12 @@ export function classifyResource(
     // migration / failover flip / shard-replica scale still surfaces). Authoritative like acctDefault
     // above: undefined (non-cluster / non-derivable) falls through to the KNOWN_DEFAULTS constant.
     if (resourceType === 'AWS::ElastiCache::ReplicationGroup') {
-      const rgDerived = elastiCacheReplicationGroupDerivedDefault(k, declared);
+      // Key on the PRE-strip declared shape (writeOnly NumNodeGroups / NodeGroupConfiguration
+      // were removed from `declared` above), falling back to `declared` defensively.
+      const rgDerived = elastiCacheReplicationGroupDerivedDefault(
+        k,
+        elastiCacheRgDeclaredShape ?? declared
+      );
       if (rgDerived !== undefined) {
         findings.push({
           tier: matchesKnownDefault(v, rgDerived.value) ? 'atDefault' : 'undeclared',

--- a/tests/classify-elasticache-cme-1500.test.ts
+++ b/tests/classify-elasticache-cme-1500.test.ts
@@ -132,6 +132,64 @@ describe('#1500 ElastiCache::ReplicationGroup cluster-mode-enabled derived trio'
   });
 });
 
+// #1500 (reopened): the cluster-mode-shape inputs NumNodeGroups / NodeGroupConfiguration are
+// WRITE-ONLY in the real schema, so classify strips them from `declared` before the derived-default
+// helper runs, AND the barest shape reads NumNodeGroups back only as a readGap (write-only, unreadable)
+// — so the derivation cannot recover the shape from either side. The fix snapshots the declared
+// cluster-mode inputs BEFORE the writeOnly strip. This describe mirrors the live HuntCmeRg corpus
+// case (write-only NumNodeGroups, live never echoes it) — it FAILS without the pre-strip snapshot.
+describe('#1500 cluster-mode inputs are write-only (barest-shape corpus repro)', () => {
+  const writeOnlySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(['NumNodeGroups', 'NodeGroupConfiguration']),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: ['NumNodeGroups', 'NodeGroupConfiguration'],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const res: DesiredResource = {
+    logicalId: 'HuntCmeRg',
+    resourceType: 'AWS::ElastiCache::ReplicationGroup',
+    physicalId: 'huntcmerg',
+    declared: {
+      ReplicationGroupDescription: 'hunt cme rg',
+      Engine: 'redis',
+      CacheNodeType: 'cache.t4g.micro',
+      NumNodeGroups: 2,
+      ReplicasPerNodeGroup: 0,
+    },
+  };
+  // Live never echoes NumNodeGroups (write-only → readGap), so the trio can only be derived from
+  // the DECLARED shape snapshotted before the strip.
+  const cleanLive = {
+    ReplicationGroupDescription: 'hunt cme rg',
+    Engine: 'redis',
+    CacheNodeType: 'cache.t4g.micro',
+    ReplicasPerNodeGroup: 0,
+    ClusterMode: 'enabled',
+    AutomaticFailoverEnabled: true,
+    NumCacheClusters: 2,
+  };
+
+  it('folds the derived trio even when NumNodeGroups is write-only-stripped from declared', () => {
+    const f = classifyResource(res, cleanLive, writeOnlySchema);
+    const atDefault = pathsByTier(f, 'atDefault');
+    for (const p of ['ClusterMode', 'AutomaticFailoverEnabled', 'NumCacheClusters']) {
+      expect(atDefault).toContain(p);
+      expect(pathsByTier(f, 'undeclared')).not.toContain(p);
+    }
+  });
+
+  it('still surfaces an out-of-band shard scale when the shape inputs are write-only', () => {
+    const scaled = { ...cleanLive, NumCacheClusters: 4 };
+    const f = classifyResource(res, scaled, writeOnlySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('NumCacheClusters');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('NumCacheClusters');
+  });
+});
+
 describe('#1500 ElastiCache::ReplicationGroup non-cluster + valkey engine axes', () => {
   it('a valkey RG folds AutomaticFailoverEnabled=true even without a cluster-mode shape', () => {
     const res: DesiredResource = {

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntCmeRg.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntCmeRg.json
@@ -250,7 +250,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntCmeRg",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "AutomaticFailoverEnabled",
@@ -259,7 +259,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntCmeRg",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "ClusterMode",
@@ -268,7 +268,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntCmeRg",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "NumCacheClusters",


### PR DESCRIPTION
## What

Reopened #1500: the #1508 derived-default helper (`elastiCacheReplicationGroupDerivedDefault`) keys on the declared cluster-mode shape (`NumNodeGroups` / `NodeGroupConfiguration` / `ReplicasPerNodeGroup`), but `NumNodeGroups` and `NodeGroupConfiguration` are **write-only**. `classifyResource` strips write-only paths from `declared` (line ~2795) **before** the helper runs, and the barest cluster-mode RG reads `NumNodeGroups` back only as a `readGap` (write-only → unreadable) — so the derivation had nothing to key on and the trio first-run-FP'd:

```
undeclared AutomaticFailoverEnabled / ClusterMode / NumCacheClusters
readGap    NumNodeGroups
```

## Fix

Snapshot the declared cluster-mode inputs **before** the write-only strip (same established pattern as the SFN `DefinitionSubstitutions` snapshot immediately above it) and pass that snapshot to the helper. Detection is still preserved — the derivation stays equality-gated against the computed value, so an out-of-band cluster-mode migration / failover flip / shard-replica scale still surfaces.

## Evidence

- The live-harvested corpus case `AWS__ElastiCache__ReplicationGroup.HuntCmeRg.json` (landed in PR #1507, barest `NumNodeGroups: 2 / ReplicasPerNodeGroup: 0` shape, `NumNodeGroups` a `readGap`) now replays the trio as `atDefault` — this is the authoritative offline live-data repro. Its `expected` is updated in the same PR, making the semantic change visible in review.
- New `classify-elasticache-cme-1500.test.ts` describe block uses a schema that marks `NumNodeGroups` / `NodeGroupConfiguration` as write-only and a live model that never echoes `NumNodeGroups` — the production scenario. It **fails without** the pre-strip snapshot and passes with it, plus an out-of-band shard-scale still surfaces.

`vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5301 tests) all green.

Closes #1500
