### PR TITLE
fix(diff): add nested value-independent fold; Batch CE DesiredvCpus (#1501)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -95,6 +95,7 @@ import {
   UNORDERED_NESTED_OBJECT_ARRAY_PATHS,
   UNORDERED_OBJECT_ARRAY_IDENTITY,
   UNORDERED_OBJECT_ARRAY_PROPS,
+  VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS,
   VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS,
   VERSION_PREFIX_PATHS,
 } from '../normalize/noise.js';
@@ -3425,6 +3426,14 @@ export function classifyResource(
         matchesKnownDefault(value, d)
       ) ??
         false) ||
+      // The nested twin of the top-level VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS fold (fold tier
+      // 3, "nested kin"): a nested scalar path whose AWS value is service-managed and moves after
+      // creation (Batch ComputeResources.DesiredvCpus) — folded atDefault regardless of value.
+      // Suppressed when the path also has a knownDefPaths equality gate this run (the gate already
+      // folds the default and must surface a real change), matching the top-level `!(k in knownDef)`
+      // guard. A trivially-empty value has already returned at the top of emitNested.
+      (VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS[resourceType]?.has(schemaPath) &&
+        !(schemaPath in knownDefPaths)) ||
       // #627: a GSI's undeclared WarmThroughput echoing that GSI's effective capacity
       // (on-demand constant or its own ProvisionedThroughput) — a per-GSI derived default.
       dynamoGsiWarmThroughputAtDefault(resourceType, path, value, live) ||

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3714,6 +3714,28 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   'AWS::CloudFormation::Stack': new Set(['TemplateBody', 'Capabilities']),
 };
 
+// The NESTED twin of VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS (fold-strategy tier 3, "nested
+// kin"): undeclared NESTED scalar paths whose AWS-chosen value is SERVICE-MANAGED and genuinely
+// cannot be pinned OR derived from the declared inputs — AWS moves it continuously after creation.
+// Keyed by resource type -> a set of SCHEMA-PATHS (array indices collapsed to `.*`, the form
+// emitNested computes). Folded to `atDefault` REGARDLESS of value: the property is not declared,
+// so whatever AWS materializes is its own choice, never user intent (a user who cares DECLARES it
+// and is then compared in the declared loop, never reaching emitNested). Like the top-level table
+// this LOSES change-detection at the path, so it is the LAST resort — reserved for a value AWS owns
+// and moves, not one a user can meaningfully set. Suppressed for any path that also has a
+// knownDefPaths equality gate this run (that gate already folds the default and must surface a
+// real change), same as the top-level `!(k in knownDef)` guard.
+//   AWS::Batch::ComputeEnvironment.ComputeResources.DesiredvCpus — for a MANAGED CE, Batch OWNS the
+//   desired vCPU count and scales it continuously with the job load (0 when idle, up to MaxvCpus as
+//   jobs run). No constant / ONE_OF / derivation can pin a moving target, and an equality-gate on
+//   the creation value (0) would false-positive on every busy environment's later checks after
+//   record. Undeclared + service-managed → value-independent. A user who pins a starting count
+//   DECLARES DesiredvCpus, compared in the declared loop. First-run FP on a barest MANAGED/EC2 CE
+//   (#1501, live-repro'd 2026-07-12 on tests/integration/s3kms-ddb-batch-min).
+export const VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::Batch::ComputeEnvironment': new Set(['ComputeResources.DesiredvCpus']),
+};
+
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.
 // Folds a GENERATED_PATHS value only when it ECHOES an id AWS minted (an ApiGateway
 // Method's CacheNamespace = the parent Resource id, the middle segment of

--- a/tests/classify-batch-desiredvcpus-1501.test.ts
+++ b/tests/classify-batch-desiredvcpus-1501.test.ts
@@ -1,0 +1,103 @@
+// #1501: a MANAGED Batch ComputeEnvironment's undeclared ComputeResources.DesiredvCpus is
+// SERVICE-MANAGED — Batch scales it continuously with the job load (0 when idle, up to MaxvCpus as
+// jobs run), so no constant / ONE_OF / derivation can pin it and an equality-gate on the creation
+// value (0) would FP on every busy environment after record. Folded via the new NESTED value-
+// independent table (VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS) — the tier-3 "nested kin" of the
+// top-level table — to atDefault regardless of value. Live-repro'd 2026-07-12 (us-east-1) on a
+// barest MANAGED/EC2 CE; the AWS__Batch__ComputeEnvironment.HuntEc2Ce corpus case pins the fold.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const findByPath = (findings: Finding[], path: string) => findings.find((f) => f.path === path);
+
+// A MANAGED/EC2 CE that declares its ComputeResources but not DesiredvCpus (the CDK-typical shape).
+const res: DesiredResource = {
+  logicalId: 'HuntEc2Ce',
+  resourceType: 'AWS::Batch::ComputeEnvironment',
+  physicalId: 'arn:aws:batch:us-east-1:111111111111:compute-environment/HuntEc2Ce-abc',
+  declared: {
+    Type: 'MANAGED',
+    ComputeResources: {
+      Type: 'EC2',
+      MaxvCpus: 4,
+      MinvCpus: 0,
+      InstanceTypes: ['m5.large'],
+      Subnets: ['subnet-0'],
+      SecurityGroupIds: ['sg-0'],
+      InstanceRole: 'arn:aws:iam::111111111111:instance-profile/p',
+    },
+  },
+};
+
+describe('#1501 Batch ComputeEnvironment DesiredvCpus nested value-independent fold', () => {
+  it('folds an idle DesiredvCpus=0 to atDefault (value-independent), not undeclared', () => {
+    const live = {
+      Type: 'MANAGED',
+      ComputeResources: {
+        Type: 'EC2',
+        MaxvCpus: 4,
+        MinvCpus: 0,
+        InstanceTypes: ['m5.large'],
+        Subnets: ['subnet-0'],
+        SecurityGroupIds: ['sg-0'],
+        InstanceRole: 'arn:aws:iam::111111111111:instance-profile/p',
+        DesiredvCpus: 0,
+      },
+    };
+    const f = classifyResource(res, live, emptySchema);
+    const finding = findByPath(f, 'ComputeResources.DesiredvCpus');
+    expect(finding?.tier).toBe('atDefault');
+  });
+
+  it('folds a SCALED DesiredvCpus (value-independent: any value AWS moves it to is atDefault)', () => {
+    const live = {
+      Type: 'MANAGED',
+      ComputeResources: {
+        Type: 'EC2',
+        MaxvCpus: 4,
+        MinvCpus: 0,
+        InstanceTypes: ['m5.large'],
+        Subnets: ['subnet-0'],
+        SecurityGroupIds: ['sg-0'],
+        InstanceRole: 'arn:aws:iam::111111111111:instance-profile/p',
+        DesiredvCpus: 3,
+      },
+    };
+    const f = classifyResource(res, live, emptySchema);
+    const finding = findByPath(f, 'ComputeResources.DesiredvCpus');
+    expect(finding?.tier).toBe('atDefault');
+  });
+
+  it('does NOT fold an unrelated nested path on the same resource (table is path-scoped)', () => {
+    const live = {
+      Type: 'MANAGED',
+      ComputeResources: {
+        Type: 'EC2',
+        MaxvCpus: 4,
+        MinvCpus: 0,
+        InstanceTypes: ['m5.large'],
+        Subnets: ['subnet-0'],
+        SecurityGroupIds: ['sg-0'],
+        InstanceRole: 'arn:aws:iam::111111111111:instance-profile/p',
+        DesiredvCpus: 0,
+        // An out-of-band nested scalar NOT in the value-independent table must still surface.
+        BidPercentage: 50,
+      },
+    };
+    const f = classifyResource(res, live, emptySchema);
+    expect(findByPath(f, 'ComputeResources.DesiredvCpus')?.tier).toBe('atDefault');
+    expect(findByPath(f, 'ComputeResources.BidPercentage')?.tier).toBe('undeclared');
+  });
+});

--- a/tests/corpus/AWS__Batch__ComputeEnvironment.HuntEc2Ce.json
+++ b/tests/corpus/AWS__Batch__ComputeEnvironment.HuntEc2Ce.json
@@ -157,7 +157,7 @@
       "constructPath": "CdkRealDriftIntegS3KmsDdbBatchMin/HuntEc2Ce"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntEc2Ce",
       "resourceType": "AWS::Batch::ComputeEnvironment",
       "path": "ComputeResources.DesiredvCpus",


### PR DESCRIPTION
## What

Remaining piece of #1501: a barest MANAGED/EC2 Batch `ComputeEnvironment` first-run-FP'd on `ComputeResources.DesiredvCpus` (`State` + `Ec2Configuration` were fixed in the hunt PR). For a MANAGED CE, Batch **owns** the desired vCPU count and scales it continuously with the job load (0 when idle, up to `MaxvCpus` as jobs run). No constant / `ONE_OF` / derivation can pin a moving target, and an equality-gate on the creation value (`0`) would false-positive on every busy environment's later checks after `record`.

## Fix

`VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` was top-level-only — no nested twin existed (issue option 1). Add **`VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS`** (`normalize/noise.ts`), the tier-3 "nested kin" that CLAUDE.md's fold-strategy already anticipates: `resourceType -> Set<schema-path>` (array indices collapsed to `.*`, the form `emitNested` computes). Wire it into `emitNested`'s `atDefault` disjunction in `diff/classify.ts`, suppressed when the path also has a `knownDefPaths` equality gate this run (matching the top-level `!(k in knownDef)` guard). First entry: `AWS::Batch::ComputeEnvironment` → `ComputeResources.DesiredvCpus`.

The invariant holds: undeclared `DesiredvCpus` on a MANAGED CE is never user intent (Batch owns it, and it moves), so folding value-independent is correct — a user who pins a starting count DECLARES it and is compared in the declared loop.

## Evidence

- Corpus case `AWS__Batch__ComputeEnvironment.HuntEc2Ce.json` (live-harvested 2026-07-12 us-east-1, barest MANAGED/EC2 CE, `MinvCpus: 0`) now replays `ComputeResources.DesiredvCpus` as `atDefault` — authoritative offline live evidence; its `expected` is updated in the same PR.
- New `classify-batch-desiredvcpus-1501.test.ts`: idle (`0`) and scaled (`3`) both fold `atDefault` (value-independent), while an unrelated nested scalar on the same resource (`BidPercentage`) still surfaces `undeclared` — the table is path-scoped.

`vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5304 tests) all green.

Closes #1501
