### PR TITLE
fix(noise): Redshift Cluster default-SG + ScheduledAction Enable first-run FPs (#1492)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -68,7 +68,7 @@ function liveModelMap(reads: Map<string, ReadResult>): Map<string, Record<string
 // GroupSet) is gated in classify against the VPC-default SG ids — mirror of
 // typeNeedsManagedKeyResolution. When a stack declares one, prefetch the account/region default
 // SGs so the classifier can DERIVE-gate the fold (single default SG folds; an append/swap surfaces).
-const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
+export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   'AWS::ElasticLoadBalancingV2::LoadBalancer',
   'AWS::EC2::NetworkInterface',
   // #976: Neptune DBCluster's undeclared VpcSecurityGroupIds default is the VPC default SG —
@@ -80,6 +80,10 @@ const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // #1269: RedshiftServerless Workgroup's undeclared SecurityGroupIds default is the default-VPC SG
   // — same gate, so the prefetch must fire when a workgroup is present too.
   'AWS::RedshiftServerless::Workgroup',
+  // #1492: a Redshift Cluster's undeclared VpcSecurityGroupIds default is the VPC default SG (the
+  // #976 Neptune shape) — registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch must fire
+  // when a cluster is present or the OOB-swap gate loses its default-SG ids (detection silently lost).
+  'AWS::Redshift::Cluster',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -196,6 +196,13 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // is an out-of-band DISABLE of transit encryption — unconditionally meaningful. Without this
   // gate the live `false` is dropped by isTrivialEmpty before the pin gate, hiding the disable.
   'AWS::MemoryDB::Cluster': { TLSEnabled: () => true },
+  // #1492: a Redshift ScheduledAction is created ENABLED — a fresh action that declares no
+  // Enable always reads back true (the KNOWN_DEFAULTS pin, live-confirmed 2026-07-12). There is
+  // no conditional clean-deploy shape that reads false undeclared (a user who wants it paused
+  // DECLARES Enable=false, compared in the declared loop). So an undeclared Enable=false is an
+  // out-of-band `modify-scheduled-action --disable` that silently stops the schedule — the live
+  // `false` would otherwise be dropped by isTrivialEmpty before the pin gate. Unconditional.
+  'AWS::Redshift::ScheduledAction': { Enable: () => true },
 };
 
 // #660 item 3: the NESTED twin of MEANINGFUL_WHEN_OFF. The table above gates TOP-LEVEL
@@ -310,6 +317,11 @@ const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // The DocDB twin (corpus-baked FP surfaced by the measure-noise sweep on the same hunt):
   // same OOB-mutable `docdb modify-db-cluster --vpc-security-group-ids` surface.
   'AWS::DocDB::DBCluster': 'VpcSecurityGroupIds',
+  // 2026-07-12 hunt (#1492): a single-node Redshift Cluster that declares no VpcSecurityGroupIds
+  // is placed into the VPC default security group — the same #976 Neptune/RDS shape. OOB-mutable
+  // (`redshift modify-cluster --vpc-security-group-ids`), so the derived VPC-default-SG gate folds
+  // the single default and surfaces an append/swap. Keep in sync with gather.ts DEFAULT_SG_LIST_TYPES.
+  'AWS::Redshift::Cluster': 'VpcSecurityGroupIds',
   // #1266: an AmazonMQ Broker that declares no SecurityGroups reads back the VPC default SG — the
   // same single-SG AWS first-run default the ALB/ENI/Neptune cases fold. It is OOB-mutable
   // (`mq update-broker --security-groups`; SecurityGroups is NOT in the schema createOnlyProperties,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1051,6 +1051,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     KmsKeyId: 'AWS_OWNED_KMS_KEY',
     NumberOfNodes: 1,
   },
+  // #1492: a Redshift ScheduledAction that declares no `Enable` reads back `true` — AWS enables a
+  // new schedule by default. Stable constant → equality-gated fold; an out-of-band
+  // `modify-scheduled-action --disable` (Enable=false) no longer matches and surfaces.
+  'AWS::Redshift::ScheduledAction': {
+    Enable: true,
+  },
   'AWS::EC2::VPCEndpoint': {
     IpAddressType: 'ipv4',
     // A Gateway endpoint that omits VpcEndpointType reads back the AWS service default

--- a/tests/classify-redshift-1492.test.ts
+++ b/tests/classify-redshift-1492.test.ts
@@ -1,0 +1,92 @@
+// #1492: a clean, un-mutated Redshift deploy produced two first-run [Potential Drift] (fold gaps)
+// before any record (live us-east-1, 2026-07-12):
+//   Cluster.VpcSecurityGroupIds   = ["sg-<default>"]   (the VPC default SG)
+//   PauseAction.Enable            = true               (AWS enables a new schedule by default)
+// FP1: AWS::Redshift::Cluster was simply not registered in the default-SG-list mechanism (the #976
+// Neptune shape). FP2: AWS::Redshift::ScheduledAction.Enable default true is a stable constant.
+import { describe, expect, it } from 'vite-plus/test';
+import { DEFAULT_SG_LIST_TYPES } from '../src/commands/gather.js';
+import { classifyResource, shouldFoldDefaultSgList } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const DEFAULT_SG = 'sg-0a26e23e2310ee0c9';
+const ROGUE_SG = 'sg-0deadbeefdeadbeef';
+const tierOf = (findings: Finding[], path: string) => findings.find((f) => f.path === path)?.tier;
+
+describe('#1492 FP1 Redshift::Cluster VpcSecurityGroupIds default-SG gate', () => {
+  const res: DesiredResource = {
+    logicalId: 'Cluster',
+    resourceType: 'AWS::Redshift::Cluster',
+    physicalId: 'huntredshift',
+    // A cluster that declares no VpcSecurityGroupIds (the barest shape).
+    declared: { NodeType: 'ra3.large', ClusterType: 'single-node' },
+  };
+  const defaultSgIds = new Set([DEFAULT_SG]);
+
+  it('folds a single VPC-default SG to atDefault (undeclared, gated)', () => {
+    const f = classifyResource(res, { VpcSecurityGroupIds: [DEFAULT_SG] }, emptySchema, {
+      defaultSgIds,
+    });
+    expect(tierOf(f, 'VpcSecurityGroupIds')).toBe('atDefault');
+  });
+
+  it('surfaces an out-of-band SG APPEND (2-element list)', () => {
+    const f = classifyResource(res, { VpcSecurityGroupIds: [DEFAULT_SG, ROGUE_SG] }, emptySchema, {
+      defaultSgIds,
+    });
+    expect(tierOf(f, 'VpcSecurityGroupIds')).toBe('undeclared');
+  });
+
+  it('surfaces an out-of-band SG SWAP (single non-default SG)', () => {
+    const f = classifyResource(res, { VpcSecurityGroupIds: [ROGUE_SG] }, emptySchema, {
+      defaultSgIds,
+    });
+    expect(tierOf(f, 'VpcSecurityGroupIds')).toBe('undeclared');
+  });
+
+  it('shouldFoldDefaultSgList: fold the default, surface the swap, fail open when unresolved', () => {
+    const t = 'AWS::Redshift::Cluster';
+    expect(shouldFoldDefaultSgList(t, 'VpcSecurityGroupIds', [DEFAULT_SG], defaultSgIds)).toBe(
+      true
+    );
+    expect(shouldFoldDefaultSgList(t, 'VpcSecurityGroupIds', [ROGUE_SG], defaultSgIds)).toBe(false);
+    expect(shouldFoldDefaultSgList(t, 'VpcSecurityGroupIds', [ROGUE_SG], undefined)).toBe(true);
+  });
+
+  it('gather registers Redshift::Cluster so the default-SG prefetch fires (classify/gather sync)', () => {
+    // Miss the gather side and the prefetch never fires → defaultSgIds empty → the fold fails open
+    // and an OOB swap/append is silently NOT detected. This guards that sync trap.
+    expect(DEFAULT_SG_LIST_TYPES.has('AWS::Redshift::Cluster')).toBe(true);
+  });
+});
+
+describe('#1492 FP2 Redshift::ScheduledAction Enable constant default', () => {
+  const res: DesiredResource = {
+    logicalId: 'PauseAction',
+    resourceType: 'AWS::Redshift::ScheduledAction',
+    physicalId: 'huntpause',
+    // A ScheduledAction that declares no Enable.
+    declared: { ScheduledActionName: 'pause', Schedule: 'cron(0 22 * * ? *)' },
+  };
+
+  it('folds the default Enable=true to atDefault', () => {
+    const f = classifyResource(res, { Enable: true }, emptySchema);
+    expect(tierOf(f, 'Enable')).toBe('atDefault');
+  });
+
+  it('surfaces an out-of-band disable (Enable=false)', () => {
+    const f = classifyResource(res, { Enable: false }, emptySchema);
+    expect(tierOf(f, 'Enable')).toBe('undeclared');
+  });
+});


### PR DESCRIPTION
## What

A clean, un-mutated Redshift deploy produced **two** first-run `[Potential Drift]` (fold gaps, zero-first-check invariant) before any `record` — live us-east-1, 2026-07-12 (spun off #915).

## FP1 — `AWS::Redshift::Cluster.VpcSecurityGroupIds`

A single-node cluster that declares no `VpcSecurityGroupIds` is placed into the VPC **default security group** (the same #976 Neptune/RDS shape). The type was simply not registered in the default-SG-list mechanism. Registered on **both** sides, kept in sync:

- `src/diff/classify.ts` `DEFAULT_SG_LIST_PATHS`: `'AWS::Redshift::Cluster': 'VpcSecurityGroupIds'` — the derived VPC-default-SG gate folds the single default and surfaces an append/swap.
- `src/commands/gather.ts` `DEFAULT_SG_LIST_TYPES`: `'AWS::Redshift::Cluster'` — so the default-SG prefetch fires. **Missing the gather side fails the fold open and silently loses OOB-swap detection**, so I exported `DEFAULT_SG_LIST_TYPES` and added a sync-guard test.

Detection preserved: a user who attaches a real SG DECLARES `VpcSecurityGroupIds` (declared loop); an OOB swap/append on an undeclared cluster fails the equality gate and surfaces.

## FP2 — `AWS::Redshift::ScheduledAction.Enable`

A fresh action reads back `Enable = true` (AWS enables the schedule by default). Two complementary entries (the established Lambda-ESM `Enabled` #660 / MemoryDB `TLSEnabled` #1503 pattern):

- `KNOWN_DEFAULTS` `{ Enable: true }` (`noise.ts`) — folds the clean default to `atDefault`.
- `MEANINGFUL_WHEN_OFF` `{ Enable: () => true }` (`classify.ts`) — **required**: without it the truthy pin lets `isTrivialEmpty` drop an undeclared `Enable=false` (an OOB `modify-scheduled-action --disable` that silently stops the schedule), AND it prevents the #929 masking of a declared `Enable=false`. The issue's "Enable=false surfaces" claim only holds with this companion — the `KNOWN_DEFAULTS` pin alone drops it (verified by the added test).

## Evidence

- Live-repro'd in the originating hunt (#1492, 2026-07-12 us-east-1); no committed corpus case for this exact FP, so regression coverage is `classify-redshift-1492.test.ts` built from the harvested live models: the single-default-SG fold + append/swap surfacing + fail-open, the gather sync-guard, and the `Enable` true-folds / false-surfaces pair.
- Existing Redshift Cluster corpus cases (`.Cluster`, `.sgreorder`, `.Warehouse`) all declare or omit `VpcSecurityGroupIds`, so registering the type does not regress them (full `vp test run` = 5311 green, incl. corpus-replay).

## Heads-up (out of scope, not fixed here)

While registering the gather side I noticed `AWS::RDS::DBCluster` / `AWS::RDS::DBInstance` / `AWS::DocDB::DBCluster` are in classify's `DEFAULT_SG_LIST_PATHS` but **missing** from gather's `DEFAULT_SG_LIST_TYPES` (added to classify in the #1499 in-hunt RDS work). For a stack containing only such a type, the default-SG prefetch never fires → the fold fails open → an OOB SG swap/append is not detected. Belongs to #1499's scope; flagging for follow-up.

`vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5311 tests) all green.

Closes #1492
