### PR TITLE
fix(diff): sibling-gated fold for Subnet Ipv6CidrBlock echo (#1498)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -671,6 +671,7 @@ interface ClassifyOpts {
   siblingManagedPolicyAttachments: Record<string, string[]>;
   siblingUserGroups: Record<string, string[]>;
   siblingEipAssociations: Set<string>;
+  siblingSubnetCidrBlocks: Set<string>;
   siblingTargetGroupRegistrars: Set<string>;
   bucketNotificationManaged: Set<string>;
   // #1283: per managed-bucket physical id, the CR's DECLARED NotificationConfiguration (S3 API
@@ -1045,6 +1046,50 @@ export function buildSiblingEipAssociations(desired: Desired): Set<string> {
     }
   }
   return associated;
+}
+
+// #1498: the set of Subnet identities (logicalId + physicalId) whose IPv6 CIDR is assigned by a
+// sibling AWS::EC2::SubnetCidrBlock (the normal dual-stack CDK shape). The Subnet's own live model
+// echoes an undeclared Ipv6CidrBlock/Ipv6CidrBlocks that the SubnetCidrBlock sibling declares — so
+// classify drops that reflected echo when a sibling targets THIS subnet (mirrors the
+// siblingEipAssociations reflection drop). With NO sibling the echo is KEPT and surfaces: an
+// out-of-band associate-subnet-cidr-block that silently opened an IPv6 surface.
+export function buildSiblingSubnetCidrBlocks(desired: Desired): Set<string> {
+  // Map every Subnet's logicalId to its identities so a sibling referencing the subnet by
+  // `{Ref: <subnetLogicalId>}`/`{Fn::GetAtt}` (unresolved) OR by its resolved physical id (the
+  // deployed-template form) resolves to the identities classify looks the Subnet up by.
+  const subnetIdentities = new Map<string, string[]>();
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::EC2::Subnet') continue;
+    const ids = [r.logicalId];
+    if (r.physicalId) ids.push(r.physicalId);
+    subnetIdentities.set(r.logicalId, ids);
+  }
+  const withSibling = new Set<string>();
+  const markSubnet = (ref: unknown): void => {
+    let subnetLogicalId: string | undefined;
+    if (ref && typeof ref === 'object') {
+      if ('Ref' in ref && typeof (ref as { Ref: unknown }).Ref === 'string') {
+        subnetLogicalId = (ref as { Ref: string }).Ref;
+      } else if ('Fn::GetAtt' in ref) {
+        const g = (ref as { 'Fn::GetAtt': unknown })['Fn::GetAtt'];
+        if (Array.isArray(g) && typeof g[0] === 'string') subnetLogicalId = g[0];
+      }
+    }
+    if (subnetLogicalId !== undefined) {
+      const ids = subnetIdentities.get(subnetLogicalId);
+      if (ids) for (const id of ids) withSibling.add(id);
+      return;
+    }
+    // A resolved physical subnet id string (the deployed-template form) — mark it directly.
+    if (typeof ref === 'string' && ref) withSibling.add(ref);
+  };
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::EC2::SubnetCidrBlock') continue;
+    const decl = r.declared;
+    if (decl && typeof decl === 'object') markSubnet((decl as Record<string, unknown>).SubnetId);
+  }
+  return withSibling;
 }
 
 // An AWS::ElasticLoadBalancingV2::TargetGroup's live `Targets` reflects whatever is REGISTERED into
@@ -1711,6 +1756,7 @@ export async function gatherFindings(
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     siblingListenerPorts: buildSiblingListenerPorts(desired),
     siblingEipAssociations: buildSiblingEipAssociations(desired),
+    siblingSubnetCidrBlocks: buildSiblingSubnetCidrBlocks(desired),
     siblingTargetGroupRegistrars: buildSiblingTargetGroupRegistrars(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     bucketNotificationConfigs: buildBucketNotificationConfigs(desired),
@@ -1823,6 +1869,7 @@ export async function regatherTouched(
     siblingLifecycleHooks: buildSiblingLifecycleHooks(desired),
     siblingListenerPorts: buildSiblingListenerPorts(desired),
     siblingEipAssociations: buildSiblingEipAssociations(desired),
+    siblingSubnetCidrBlocks: buildSiblingSubnetCidrBlocks(desired),
     siblingTargetGroupRegistrars: buildSiblingTargetGroupRegistrars(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
     bucketNotificationConfigs: buildBucketNotificationConfigs(desired),

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -87,6 +87,11 @@ export interface CorpusCase {
     // atDefault exactly as a real check does. Stored as an array (JSON has no Set); replay revives
     // it to a Set. Optional for back-compat (pre-#892 cases and non-EIP cases lack it).
     siblingEipAssociations?: string[];
+    // #1498: this Subnet's own identity (physicalId, else logicalId), present only when a declared
+    // sibling AWS::EC2::SubnetCidrBlock assigns its IPv6 CIDR, so replay reproduces the reflected
+    // Ipv6CidrBlock echo drop. Stored as an array (JSON has no Set); replay revives it to a Set.
+    // Optional for back-compat (pre-#1498 cases and non-Subnet cases lack it).
+    siblingSubnetCidrBlocks?: string[];
     // This TargetGroup's own identity (physicalId, else logicalId), present only when a declared
     // sibling dynamically registers into it (an ECS Service, an ASG, or its own lambda TargetType),
     // so replay reproduces the `generated` Targets fold and the case folds exactly as a real check
@@ -139,6 +144,7 @@ export function buildCorpusCase(
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
     bucketNotificationManaged?: Set<string>;
     siblingEipAssociations?: Set<string>;
+    siblingSubnetCidrBlocks?: Set<string>;
     siblingTargetGroupRegistrars?: Set<string>;
     clusterEchoModel?: Record<string, Record<string, unknown>>;
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
@@ -174,6 +180,15 @@ export function buildCorpusCase(
     resource.physicalId && opts.siblingTargetGroupRegistrars?.has(resource.physicalId)
       ? resource.physicalId
       : opts.siblingTargetGroupRegistrars?.has(resource.logicalId)
+        ? resource.logicalId
+        : undefined;
+  // #1498: carry ONLY this Subnet's own identity from the stack-wide sibling-SubnetCidrBlock set.
+  // classify keys the reflected Ipv6CidrBlock drop on the physicalId first, else the logicalId —
+  // carry the same one that is present, so replay drops the echo the same way the live check did.
+  const subnetSiblingId =
+    resource.physicalId && opts.siblingSubnetCidrBlocks?.has(resource.physicalId)
+      ? resource.physicalId
+      : opts.siblingSubnetCidrBlocks?.has(resource.logicalId)
         ? resource.logicalId
         : undefined;
   const echoModel =
@@ -231,6 +246,7 @@ export function buildCorpusCase(
         : {}),
       ...(bucketNotif ? { bucketNotificationManaged: bucketNotif } : {}),
       ...(eipSiblingId ? { siblingEipAssociations: [eipSiblingId] } : {}),
+      ...(subnetSiblingId ? { siblingSubnetCidrBlocks: [subnetSiblingId] } : {}),
       ...(tgRegistrarId ? { siblingTargetGroupRegistrars: [tgRegistrarId] } : {}),
       ...(echoModel && resource.physicalId
         ? { clusterEchoModel: { [resource.physicalId]: echoModel } }
@@ -269,15 +285,20 @@ export function reviveSchema(s: CorpusCase['schema']): SchemaInfo {
  *  lockstep. */
 export function reviveOpts(o: CorpusCase['opts']): Omit<
   CorpusCase['opts'],
-  'bucketNotificationManaged' | 'siblingEipAssociations' | 'siblingTargetGroupRegistrars'
+  | 'bucketNotificationManaged'
+  | 'siblingEipAssociations'
+  | 'siblingSubnetCidrBlocks'
+  | 'siblingTargetGroupRegistrars'
 > & {
   bucketNotificationManaged?: Set<string>;
   siblingEipAssociations?: Set<string>;
+  siblingSubnetCidrBlocks?: Set<string>;
   siblingTargetGroupRegistrars?: Set<string>;
 } {
   const {
     bucketNotificationManaged,
     siblingEipAssociations,
+    siblingSubnetCidrBlocks,
     siblingTargetGroupRegistrars,
     ...rest
   } = o;
@@ -287,6 +308,9 @@ export function reviveOpts(o: CorpusCase['opts']): Omit<
       ? { bucketNotificationManaged: new Set(bucketNotificationManaged) }
       : {}),
     ...(siblingEipAssociations ? { siblingEipAssociations: new Set(siblingEipAssociations) } : {}),
+    ...(siblingSubnetCidrBlocks
+      ? { siblingSubnetCidrBlocks: new Set(siblingSubnetCidrBlocks) }
+      : {}),
     ...(siblingTargetGroupRegistrars
       ? { siblingTargetGroupRegistrars: new Set(siblingTargetGroupRegistrars) }
       : {}),

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -2516,6 +2516,12 @@ export function classifyResource(
     // `associate-address` HIJACK of the static IP and SURFACES (#892). The ENI value is AWS-assigned
     // at association time, so the fold is presence-gated (a declaring sibling explains any binding).
     siblingEipAssociations?: Set<string>;
+    // #1498: identities (logicalId + physicalId) of every AWS::EC2::Subnet whose IPv6 CIDR is
+    // assigned by a DECLARED sibling AWS::EC2::SubnetCidrBlock (see buildSiblingSubnetCidrBlocks). The
+    // Subnet's live model echoes an undeclared Ipv6CidrBlock/Ipv6CidrBlocks the sibling declares; a
+    // sibling-explained echo is dropped (the assignment is IaC intent, tracked on the sibling), but an
+    // IPv6 CIDR with NO declaring sibling is an out-of-band associate-subnet-cidr-block and SURFACES.
+    siblingSubnetCidrBlocks?: Set<string>;
     // Identities (logicalId + physicalId == the TG ARN) of every AWS::ElasticLoadBalancingV2::
     // TargetGroup a DECLARED sibling dynamically registers into — an AWS::ECS::Service
     // (LoadBalancers[].TargetGroupArn), an AWS::AutoScaling::AutoScalingGroup (TargetGroupARNs), or
@@ -2702,6 +2708,24 @@ export function classifyResource(
     const selfDeclared =
       declaresTarget(declared.InstanceId) || declaresTarget(declared.NetworkInterfaceId);
     if (explained || selfDeclared) delete live.NetworkInterfaceId;
+  }
+  // #1498: a Subnet whose IPv6 CIDR is assigned by a sibling AWS::EC2::SubnetCidrBlock echoes an
+  // undeclared Ipv6CidrBlock (and the plural Ipv6CidrBlocks) on its OWN live model. The assignment is
+  // IaC intent — the SubnetCidrBlock is tracked + compared as its own resource (its declared
+  // Ipv6CidrBlock carries detection; here it was an Fn::cidr → unresolved) — so drop the reflected
+  // echo when a sibling targets THIS subnet (keyed by physical/logical id in
+  // opts.siblingSubnetCidrBlocks). Only drop when the Subnet does not declare the value itself (a
+  // self-declared IPv6 CIDR is compared in the declared loop). With NO sibling the echo is KEPT and
+  // surfaces: an out-of-band `associate-subnet-cidr-block` on a subnet no sibling explains silently
+  // opened an IPv6 surface — the exact real drift a blanket value-independent fold would hide.
+  if (resourceType === 'AWS::EC2::Subnet') {
+    const explained =
+      (physicalId !== undefined && opts.siblingSubnetCidrBlocks?.has(physicalId)) ||
+      opts.siblingSubnetCidrBlocks?.has(logicalId);
+    if (explained) {
+      if (!('Ipv6CidrBlock' in declared)) delete live.Ipv6CidrBlock;
+      if (!('Ipv6CidrBlocks' in declared)) delete live.Ipv6CidrBlocks;
+    }
   }
   // A bucket whose notifications are managed by a Custom::S3BucketNotifications CR reflects
   // the CR-applied NotificationConfiguration it never declares itself (CDK renders

--- a/tests/classify-subnet-ipv6-1498.test.ts
+++ b/tests/classify-subnet-ipv6-1498.test.ts
@@ -1,0 +1,121 @@
+// #1498: a Subnet whose IPv6 CIDR is assigned by a separate sibling AWS::EC2::SubnetCidrBlock (the
+// normal dual-stack CDK shape) echoes an undeclared Ipv6CidrBlock/Ipv6CidrBlocks on its OWN live
+// model — a first-run [Potential Drift] fold gap. The clean fold is SIBLING-GATED: drop the echo
+// only when a SubnetCidrBlock sibling targets THIS subnet; an out-of-band associate-subnet-cidr-block
+// on a subnet with NO sibling still surfaces (a silently-opened IPv6 surface). Mirrors the #892
+// siblingEipAssociations reflection drop. Live-repro'd 2026-07-12 (us-east-1, vpc-attach-min).
+import { describe, expect, it } from 'vite-plus/test';
+import { buildSiblingSubnetCidrBlocks } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const SUBNET_PHYS = 'subnet-00c26f3fb4ea65291';
+const IPV6 = '2600:1f18:2de0:6e00::/64';
+const subnet: DesiredResource = {
+  logicalId: 'PublicSubnet1',
+  resourceType: 'AWS::EC2::Subnet',
+  physicalId: SUBNET_PHYS,
+  declared: { CidrBlock: '10.0.0.0/24', VpcId: 'vpc-1' },
+};
+const tierOf = (findings: Finding[], path: string) => findings.find((f) => f.path === path)?.tier;
+
+describe('#1498 buildSiblingSubnetCidrBlocks', () => {
+  it('marks a subnet targeted by a resolved physical SubnetId', () => {
+    const desired: Desired = {
+      resources: [
+        subnet,
+        {
+          logicalId: 'HuntSubnetIpv6',
+          resourceType: 'AWS::EC2::SubnetCidrBlock',
+          declared: { SubnetId: SUBNET_PHYS, Ipv6CidrBlock: IPV6 },
+        },
+      ],
+    } as unknown as Desired;
+    const set = buildSiblingSubnetCidrBlocks(desired);
+    expect(set.has(SUBNET_PHYS)).toBe(true);
+  });
+
+  it('marks a subnet targeted by an unresolved {Ref} (both logical + physical identities)', () => {
+    const desired: Desired = {
+      resources: [
+        subnet,
+        {
+          logicalId: 'Cidr',
+          resourceType: 'AWS::EC2::SubnetCidrBlock',
+          declared: { SubnetId: { Ref: 'PublicSubnet1' }, Ipv6CidrBlock: IPV6 },
+        },
+      ],
+    } as unknown as Desired;
+    const set = buildSiblingSubnetCidrBlocks(desired);
+    expect(set.has('PublicSubnet1')).toBe(true);
+    expect(set.has(SUBNET_PHYS)).toBe(true);
+  });
+
+  it('does not mark a subnet with no SubnetCidrBlock sibling', () => {
+    const desired: Desired = { resources: [subnet] } as unknown as Desired;
+    expect(buildSiblingSubnetCidrBlocks(desired).size).toBe(0);
+  });
+});
+
+describe('#1498 Subnet Ipv6CidrBlock sibling-gated echo drop', () => {
+  const live = {
+    CidrBlock: '10.0.0.0/24',
+    VpcId: 'vpc-1',
+    Ipv6CidrBlock: IPV6,
+    Ipv6CidrBlocks: [IPV6],
+  };
+
+  it('drops the reflected Ipv6CidrBlock/Ipv6CidrBlocks when a sibling targets the subnet', () => {
+    const f = classifyResource(subnet, structuredClone(live), emptySchema, {
+      siblingSubnetCidrBlocks: new Set([SUBNET_PHYS]),
+    });
+    expect(tierOf(f, 'Ipv6CidrBlock')).toBeUndefined();
+    expect(tierOf(f, 'Ipv6CidrBlocks')).toBeUndefined();
+  });
+
+  it('SURFACES the undeclared Ipv6CidrBlock when NO sibling explains it (OOB associate-subnet-cidr-block)', () => {
+    const f = classifyResource(subnet, structuredClone(live), emptySchema, {
+      siblingSubnetCidrBlocks: new Set(),
+    });
+    expect(tierOf(f, 'Ipv6CidrBlock')).toBe('undeclared');
+  });
+
+  it('matches on the subnet logicalId too (unresolved-Ref sibling)', () => {
+    const f = classifyResource(subnet, structuredClone(live), emptySchema, {
+      siblingSubnetCidrBlocks: new Set(['PublicSubnet1']),
+    });
+    expect(tierOf(f, 'Ipv6CidrBlock')).toBeUndefined();
+  });
+
+  it('KEEPS a self-declared Ipv6CidrBlock (compared in the declared loop, not dropped from live)', () => {
+    const selfDeclared: DesiredResource = {
+      ...subnet,
+      declared: { ...subnet.declared, Ipv6CidrBlock: IPV6 },
+    };
+    const f = classifyResource(selfDeclared, structuredClone(live), emptySchema, {
+      siblingSubnetCidrBlocks: new Set([SUBNET_PHYS]),
+    });
+    // Declared == live → no drift finding, but it was NOT dropped as a sibling echo (it is intent).
+    expect(tierOf(f, 'Ipv6CidrBlock')).toBeUndefined();
+    // A DIVERGENT self-declared value still surfaces as declared drift.
+    const g = classifyResource(
+      selfDeclared,
+      { ...structuredClone(live), Ipv6CidrBlock: '2600:1f18:dead:beef::/64' },
+      emptySchema,
+      { siblingSubnetCidrBlocks: new Set([SUBNET_PHYS]) }
+    );
+    expect(tierOf(g, 'Ipv6CidrBlock')).toBe('declared');
+  });
+});

--- a/tests/corpus/AWS__EC2__Subnet.Ipv6AttachHunt.json
+++ b/tests/corpus/AWS__EC2__Subnet.Ipv6AttachHunt.json
@@ -131,7 +131,8 @@
     "accountId": "111111111111",
     "region": "us-east-1",
     "kmsAliasTargets": {},
-    "oaiCanonicalIds": {}
+    "oaiCanonicalIds": {},
+    "siblingSubnetCidrBlocks": ["subnet-00c26f3fb4ea65291"]
   },
   "expected": [
     {
@@ -171,15 +172,6 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
-      "physicalId": "subnet-00c26f3fb4ea65291",
-      "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "Ipv6CidrBlock",
-      "actual": "2600:1f18:2de0:6e00::/64",
       "physicalId": "subnet-00c26f3fb4ea65291",
       "constructPath": "CdkRealDriftIntegVpcAttachMin/Vpc/publicSubnet1/Subnet"
     },


### PR DESCRIPTION
## What

Remaining piece of #1498: a Subnet whose IPv6 CIDR is assigned by a separate sibling `AWS::EC2::SubnetCidrBlock` (the normal dual-stack CDK shape) echoes an undeclared `Ipv6CidrBlock` / `Ipv6CidrBlocks` on its **own** live model — a first-run `[Potential Drift]` fold gap (live us-east-1, 2026-07-12, `vpc-attach-min`).

## Fix — sibling-gated (not value-independent)

A blanket value-independent fold on `Subnet.Ipv6CidrBlock` would hide a **real** drift: an out-of-band `associate-subnet-cidr-block` on a subnet with **no** `SubnetCidrBlock` sibling silently opens an IPv6 surface. So the fold is **sibling-gated**, mirroring the same-hunt #892 `siblingEipAssociations` reflection drop:

- `src/commands/gather.ts` — new `buildSiblingSubnetCidrBlocks(desired)`: an identity set (subnet logicalId + physicalId) built from every `SubnetCidrBlock`'s `SubnetId` — a resolved physical id (the deployed-template form) **or** an unresolved `{Ref}` / `{Fn::GetAtt}`. Threaded via `opts.siblingSubnetCidrBlocks`.
- `src/diff/classify.ts` — drop the reflected `Ipv6CidrBlock` / `Ipv6CidrBlocks` from `live` **only** when a sibling targets THIS subnet (keyed by physical, else logical id) **and** the subnet does not self-declare the value (a self-declared IPv6 CIDR is compared in the declared loop). With no sibling the echo is KEPT and surfaces.
- `src/corpus/record.ts` — carry/serialize/revive the per-subnet identity, same array↔Set pattern as `siblingEipAssociations`.

Detection preserved: the `SubnetCidrBlock` sibling is tracked + compared as its own resource (its declared `Ipv6CidrBlock` carries detection; in this fixture it was an `Fn::cidr` → `unresolved`), and an OOB CIDR on an unexplained subnet surfaces.

## Evidence

- The `AWS__EC2__Subnet.Ipv6AttachHunt.json` corpus case (live-harvested, the `subnet-00c26f3fb4ea65291` subnet targeted by the `HuntSubnetIpv6` `SubnetCidrBlock`) now drops the echo — the sibling opts field is added (as a fresh harvest would produce it) and the `undeclared Ipv6CidrBlock` finding removed from `expected`. Offline `corpus-replay` reproduces it.
- New `classify-subnet-ipv6-1498.test.ts`: the builder resolves both physical-id and `{Ref}` forms; the echo drops with a sibling, **surfaces** with none (OOB detection preserved), matches on logicalId, and a self-declared IPv6 CIDR is kept and its divergence still surfaces as `declared` drift.

`vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5318 tests) all green.

Closes #1498
