### PR TITLE
fix(read): sync classify/gather default-SG registration + guard (#1499, #640)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -84,6 +84,22 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // #976 Neptune shape) — registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch must fire
   // when a cluster is present or the OOB-swap gate loses its default-SG ids (detection silently lost).
   'AWS::Redshift::Cluster',
+  // #1499: the RDS/DocDB twins of the #976 Neptune shape — a barest DBCluster/DBInstance/DocDB
+  // cluster that declares no security groups reads back the VPC default SG. These are registered in
+  // classify DEFAULT_SG_LIST_PATHS (VpcSecurityGroupIds / VPCSecurityGroups) but were MISSING here,
+  // so for a stack containing only such a type the prefetch never fired → defaultSgIds empty →
+  // shouldFoldDefaultSgList failed OPEN and an OOB `rds/docdb modify-db-cluster|instance
+  // --vpc-security-group-ids` swap/append was silently NOT detected. Register them so the prefetch
+  // fires and the derived VPC-default-SG gate keeps its swap/append detection.
+  'AWS::RDS::DBCluster',
+  'AWS::RDS::DBInstance',
+  'AWS::DocDB::DBCluster',
+  // #640: an EC2::Instance that declares no security group reads back its VPC default SG in
+  // SecurityGroupIds (registered in classify DEFAULT_SG_LIST_PATHS by PR #1449). It too was MISSING
+  // here, so a stack whose only default-SG-gated resource is a bare instance (no ENI/ALB present)
+  // never fired the prefetch → defaultSgIds empty → an OOB `ec2 modify-instance-attribute --groups`
+  // swap/append was silently NOT detected. Register it so the derived gate keeps its detection.
+  'AWS::EC2::Instance',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -297,7 +297,7 @@ function guardDutyFeaturesAllAtDefault(features: unknown[]): boolean {
 // ec2:DescribeSecurityGroups / lookup failed → `defaultSgIds` undefined or empty) KEEP folding, so
 // a clean deploy never gains a first-run false positive; the derived detection is best-effort and
 // requires the DescribeSecurityGroups permission.
-const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
+export const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   'AWS::ElasticLoadBalancingV2::LoadBalancer': 'SecurityGroups',
   'AWS::EC2::NetworkInterface': 'GroupSet',
   // #976: a Neptune DBCluster that declares no VpcSecurityGroupIds reads back the VPC's DEFAULT

--- a/tests/gather-rds-sg-sync-1499.test.ts
+++ b/tests/gather-rds-sg-sync-1499.test.ts
@@ -1,0 +1,102 @@
+// #1499 / #640: the RDS/DocDB (and, discovered on the same lane, EC2::Instance) VPC-default-SG folds
+// were registered in classify DEFAULT_SG_LIST_PATHS (AWS::RDS::DBCluster VpcSecurityGroupIds /
+// AWS::RDS::DBInstance VPCSecurityGroups / AWS::DocDB::DBCluster VpcSecurityGroupIds /
+// AWS::EC2::Instance SecurityGroupIds) but MISSING from gather DEFAULT_SG_LIST_TYPES. For a stack
+// containing only such a type the default-SG prefetch never fired → opts.defaultSgIds stayed empty →
+// shouldFoldDefaultSgList failed OPEN (folds any value) → an out-of-band SG swap/append was silently
+// NOT detected. This is the classify/gather sync twin of the #1492 Redshift fix (PR #1511). The
+// mechanical sync-guard at the bottom asserts the whole class (every classify path key ⊆ the gather
+// prefetch set) so a future addition to one table that forgets the other cannot recur.
+import { describe, expect, it } from 'vite-plus/test';
+import { DEFAULT_SG_LIST_TYPES } from '../src/commands/gather.js';
+import {
+  classifyResource,
+  DEFAULT_SG_LIST_PATHS,
+  shouldFoldDefaultSgList,
+} from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const DEFAULT_SG = 'sg-0a26e23e2310ee0c9';
+const ROGUE_SG = 'sg-0deadbeefdeadbeef';
+const tierOf = (findings: Finding[], path: string) => findings.find((f) => f.path === path)?.tier;
+
+// Each newly-registered type + its API SG-list property key (RDS DBInstance uses the legacy plural).
+const CASES: { type: string; key: string }[] = [
+  { type: 'AWS::RDS::DBCluster', key: 'VpcSecurityGroupIds' },
+  { type: 'AWS::RDS::DBInstance', key: 'VPCSecurityGroups' },
+  { type: 'AWS::DocDB::DBCluster', key: 'VpcSecurityGroupIds' },
+  { type: 'AWS::EC2::Instance', key: 'SecurityGroupIds' },
+];
+
+describe('#1499 RDS/DocDB default-SG gate: classify/gather sync', () => {
+  for (const { type, key } of CASES) {
+    describe(type, () => {
+      const res: DesiredResource = {
+        logicalId: 'Db',
+        resourceType: type,
+        physicalId: 'huntdb',
+        // A resource that declares no security groups (the barest shape).
+        declared: {},
+      };
+      const defaultSgIds = new Set([DEFAULT_SG]);
+
+      it('gather registers the type so the default-SG prefetch fires (classify/gather sync)', () => {
+        // Miss the gather side and the prefetch never fires → defaultSgIds empty → the fold fails
+        // open → an OOB SG swap/append is silently NOT detected. Keep classify + gather in sync.
+        expect(DEFAULT_SG_LIST_TYPES.has(type)).toBe(true);
+      });
+
+      it('folds a single VPC-default SG to atDefault (undeclared, gated)', () => {
+        const f = classifyResource(res, { [key]: [DEFAULT_SG] }, emptySchema, { defaultSgIds });
+        expect(tierOf(f, key)).toBe('atDefault');
+      });
+
+      it('surfaces an out-of-band SG APPEND (2-element list)', () => {
+        const f = classifyResource(res, { [key]: [DEFAULT_SG, ROGUE_SG] }, emptySchema, {
+          defaultSgIds,
+        });
+        expect(tierOf(f, key)).toBe('undeclared');
+      });
+
+      it('surfaces an out-of-band SG SWAP (single non-default SG)', () => {
+        const f = classifyResource(res, { [key]: [ROGUE_SG] }, emptySchema, { defaultSgIds });
+        expect(tierOf(f, key)).toBe('undeclared');
+      });
+
+      it('shouldFoldDefaultSgList: fold the default, surface the swap, fail open when unresolved', () => {
+        expect(shouldFoldDefaultSgList(type, key, [DEFAULT_SG], defaultSgIds)).toBe(true);
+        expect(shouldFoldDefaultSgList(type, key, [DEFAULT_SG, ROGUE_SG], defaultSgIds)).toBe(
+          false
+        );
+        expect(shouldFoldDefaultSgList(type, key, [ROGUE_SG], defaultSgIds)).toBe(false);
+        // Fail open: no prefetched ids (empty set) → keep folding so a clean deploy gains no FP.
+        expect(shouldFoldDefaultSgList(type, key, [ROGUE_SG], new Set())).toBe(true);
+      });
+    });
+  }
+});
+
+// Mechanical sync-guard for the WHOLE class (#1499/#640 root cause): the derived VPC-default-SG
+// gate only preserves OOB swap/append detection if gather PREFETCHES the default-SG ids, which it
+// does exactly when a declared resource type is in DEFAULT_SG_LIST_TYPES. So every type classify
+// gates in DEFAULT_SG_LIST_PATHS MUST also be in gather DEFAULT_SG_LIST_TYPES — otherwise the
+// prefetch never fires for a single-such-type stack and the gate silently fails open (the FN this
+// lane fixed for RDS/DocDB/EC2::Instance). Assert the subset so adding a type to one table but
+// forgetting the other fails here instead of shipping a silent detection gap.
+describe('classify/gather default-SG registration sync-guard', () => {
+  it('every DEFAULT_SG_LIST_PATHS type is registered in gather DEFAULT_SG_LIST_TYPES', () => {
+    const missing = Object.keys(DEFAULT_SG_LIST_PATHS).filter((t) => !DEFAULT_SG_LIST_TYPES.has(t));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Fix a **classify/gather sync gap** in the derived VPC-default-SG gate: several types are registered in classify `DEFAULT_SG_LIST_PATHS` but were **missing** from gather `DEFAULT_SG_LIST_TYPES`, so the default-SG prefetch never fired for a stack whose only such resource was one of them.

| type | classify `DEFAULT_SG_LIST_PATHS` key | in gather `DEFAULT_SG_LIST_TYPES`? | issue |
| --- | --- | --- | --- |
| `AWS::RDS::DBCluster` | `VpcSecurityGroupIds` | ❌ → ✅ (this PR) | #1499 |
| `AWS::RDS::DBInstance` | `VPCSecurityGroups` (legacy plural) | ❌ → ✅ (this PR) | #1499 |
| `AWS::DocDB::DBCluster` | `VpcSecurityGroupIds` | ❌ → ✅ (this PR) | #1499 |
| `AWS::EC2::Instance` | `SecurityGroupIds` | ❌ → ✅ (this PR) | #640 |
| `AWS::Redshift::Cluster` | `VpcSecurityGroupIds` | ✅ (PR #1511) | #1492 |

The RDS/DocDB gap was flagged on #1499; the `AWS::EC2::Instance` gap (registered in classify by PR #1449) was discovered on this lane and is the identical class, so it is folded in here.

## Why (a real security FN)

For a stack containing **only** such a type, the prefetch guard
(`desired.resources.some(r => DEFAULT_SG_LIST_TYPES.has(r.resourceType))`) was
false → `fetchDefaultSgIds` never ran → `opts.defaultSgIds` stayed empty →
`shouldFoldDefaultSgList` **failed OPEN** (folds any value) → an out-of-band SG
swap/append (`rds/docdb modify-db-cluster|instance --vpc-security-group-ids`,
`ec2 modify-instance-attribute --groups`) was **silently NOT detected**. The
clean-deploy fold still worked (fail-open), so this never surfaced as a first-run
FP — only as a missed OOB detection, the class memory
[[fold-corpus-green-but-live-broken-gather-path]] describes.

Registering the types makes the prefetch fire, restoring the derived gate's
swap/append detection (fold the single default SG, surface an append/swap). This
is the classify/gather sync twin of the #1492 Redshift fix (PR #1511).

## Mechanical guard against recurrence

Adds a sync-guard test asserting **every classify `DEFAULT_SG_LIST_PATHS` key is
present in gather `DEFAULT_SG_LIST_TYPES`**. This whole class recurred twice
(RDS/DocDB in the hunt PR, EC2::Instance in #1449) because the two tables live in
different files and a comment ("keep in sync") does not enforce. The guard now
fails the suite if a future type is added to one table but not the other, instead
of shipping a silent detection gap.

## Test

`tests/gather-rds-sg-sync-1499.test.ts` — for each of the four types: gather
registration (fails without this fix), single-default fold → `atDefault`, APPEND
+ SWAP → `undeclared`, `shouldFoldDefaultSgList` fail-open on an empty prefetch
set; plus the mechanical sync-guard. 21 tests. Full suite: 251 files / 5339 pass.

## Live-test (deferred, logged)

Pure gather-prefetch **wiring** fix — the classify gate it feeds is already
live-proven across the twin types (#976 Neptune, #1492 Redshift shipped
identically in PR #1511), and the wiring is deterministic and directly
unit-asserted. corpus-replay can't exercise the prefetch (it passes `defaultSgIds`
directly), so the gather unit test is the correct evidence for this class (per
[[fold-corpus-green-but-live-broken-gather-path]]). A fresh real-AWS deploy purely
to confirm a Set registration makes the prefetch fire is disproportionate → fresh
live deploy deferred, not silently skipped.

## Scope

`src/commands/gather.ts` (4-entry table add) + `src/diff/classify.ts` (export
`DEFAULT_SG_LIST_PATHS` for the guard) + the new test. Does **not** touch #1499's
remaining `PubliclyAccessible` `DBSubnetGroupName`-derived fold or any other #640
work — both issues keep their non-sync work open, so this PR uses `Refs`.

Refs #1499, #640
