### PR TITLE
fix(diff): fold non-burstable EC2::Instance CreditSpecification standard echo (#640)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -3279,13 +3279,13 @@ export function classifyResource(
       knownDef = { ...knownDef, ...twins };
     }
   }
-  // #640: an EC2 Instance on a BURSTABLE (T-family) InstanceType reads back an undeclared
-  // CreditSpecification.CPUCredits whose default depends on the family — the T2 family
-  // defaults to "standard", every later burstable family (t3 / t3a / t4g) defaults to
-  // "unlimited". Derive the expected default from the declared InstanceType family and
-  // equality-gate the whole {CPUCredits} object (fold tier 2): a user who pins the other
-  // credit mode still surfaces. Non-burstable families carry no CreditSpecification, so
-  // leave the default unset there (nothing to fold).
+  // #640: an EC2 Instance reads back an undeclared CreditSpecification.CPUCredits whose default
+  // depends on the InstanceType family — a BURSTABLE (T-family) instance defaults to "standard"
+  // (t2) or "unlimited" (t3 / t3a / t4g), while a NON-burstable family (m5, c6i, …) cannot use CPU
+  // credits yet AWS still echoes a meaningless CreditSpecification={CPUCredits:"standard"} on first
+  // read (live-confirmed 2026-07-12 on a fresh m5.large). Derive the expected default from the
+  // declared InstanceType family and equality-gate the whole {CPUCredits} object (fold tier 2): a
+  // user who pins the other credit mode still surfaces.
   if (resourceType === 'AWS::EC2::Instance') {
     const instanceType = declared['InstanceType'];
     const family = typeof instanceType === 'string' ? instanceType.split('.')[0] : undefined;
@@ -3295,12 +3295,17 @@ export function classifyResource(
     // it. Prefer gather.ts's prefetched account-effective default for the declared family; fall back
     // to the AWS factory default (t2 standard, t3/t3a/t4g unlimited) when the lookup was
     // denied/unavailable. Equality-gated below → an out-of-band credit-mode change still surfaces.
+    // #640 (non-burstable): any family that is NOT a T-family echoes the meaningless "standard" —
+    // fold it too. A T-family we do not recognize (a future burstable generation) stays undefined so
+    // the account-default prefetch decides rather than mislabelling it "standard".
     const factoryDefault =
       family === 't2'
         ? 'standard'
         : family === 't3' || family === 't3a' || family === 't4g'
           ? 'unlimited'
-          : undefined;
+          : family !== undefined && !family.startsWith('t')
+            ? 'standard'
+            : undefined;
     const acctDefault =
       family !== undefined ? opts.accountDefaults?.ec2FamilyCreditDefaults?.[family] : undefined;
     const creditDefault = acctDefault ?? factoryDefault;

--- a/tests/classify-640-derived.test.ts
+++ b/tests/classify-640-derived.test.ts
@@ -64,14 +64,27 @@ describe('#640 EC2 Instance CreditSpecification derived from InstanceType family
     );
     expect(tier(f, 'undeclared')).toContain('CreditSpecification');
   });
-  it('does NOT fold a non-burstable (m5) instance — no default is set', () => {
+  it('folds "standard" on a non-burstable (m5) instance — the meaningless echo AWS returns', () => {
+    // #640 (2026-07-12): a fresh non-burstable m5.large echoes an undeclared
+    // CreditSpecification={CPUCredits:"standard"} on first check — fold it (non-T families default
+    // "standard"), else a clean deploy shows a first-run false positive.
+    const res = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 'm5.large' });
+    const f = classifyResource(
+      res,
+      { CreditSpecification: { CPUCredits: 'standard' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('CreditSpecification');
+    expect(tier(f, 'undeclared')).not.toContain('CreditSpecification');
+  });
+  it('surfaces a non-burstable (m5) instance reading a non-"standard" value — detection preserved', () => {
     const res = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 'm5.large' });
     const f = classifyResource(
       res,
       { CreditSpecification: { CPUCredits: 'unlimited' } },
       emptySchema
     );
-    expect(tier(f, 'atDefault')).not.toContain('CreditSpecification');
+    expect(tier(f, 'undeclared')).toContain('CreditSpecification');
   });
 });
 

--- a/tests/corpus/AWS__EC2__Instance.HuntM5.json
+++ b/tests/corpus/AWS__EC2__Instance.HuntM5.json
@@ -396,7 +396,7 @@
       "constructPath": "CdkRealDriftIntegEc2EbsOptMin/HuntM5"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntM5",
       "resourceType": "AWS::EC2::Instance",
       "path": "CreditSpecification",


### PR DESCRIPTION
## Problem

A fresh **non-burstable** EC2 instance (m5, c6i, …) cannot use CPU credits, yet
AWS still echoes an undeclared `CreditSpecification={CPUCredits:"standard"}` on the
first read — live-confirmed 2026-07-12 on a fresh `m5.large` (the `ec2-ebsopt-min`
hunt, harvested as `AWS__EC2__Instance.HuntM5.json`).

The `#640` CreditSpecification derivation only covered the burstable **T-family**
(t2 → `standard`, t3/t3a/t4g → `unlimited`); a non-T family returned `undefined`,
so the meaningless `standard` echo surfaced as a first-run `undeclared` false
positive, breaking the core zero-first-check invariant on the commonest instance
families.

## Fix

Extend the derivation in `src/diff/classify.ts`: any family that is **not** a
T-family folds `CPUCredits` to `"standard"`. It stays **equality-gated** on the
whole `{CPUCredits}` object, so a non-`"standard"` value still surfaces (detection
preserved). An unrecognized T-family (a future burstable generation) stays
`undefined` so the account-default prefetch decides rather than being mislabelled
`"standard"`.

Non-burstable families can't be targeted by
`ec2:modify-default-credit-specification` (that command is burstable-only), so
`"standard"` is the invariant echo — folding it loses no meaningful drift signal.

## Evidence (no fresh deploy — harvested corpus is authoritative)

`AWS__EC2__Instance.HuntM5.json` (a real `m5.large` from the 2026-07-12 hunt) is
pinned by `corpus-replay` and previously carried the `CreditSpecification` finding
at tier `undeclared`. After this fix the case folds it to `atDefault`, leaving the
whole HuntM5 case **zero potential drift** — the invariant target for that fixture.

## Tests

- `tests/classify-640-derived.test.ts`: m5 reading `"standard"` folds `atDefault`;
  m5 reading `"unlimited"` still surfaces `undeclared` (detection preserved).
- `tests/corpus/AWS__EC2__Instance.HuntM5.json`: `CreditSpecification` pin moved
  `undeclared` → `atDefault`.

Closes #640
