### PR TITLE
feat(check): add --no-prompt for exit-0 report-only runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,13 @@ CI (with `--yes`).
   the flag).
 - **`--fail`** (the `cdk diff --fail` / `cdk drift --fail` convention) exits `1` on
   drift and suppresses all prompts. It's the one flag for scripts and CI.
+- **`--no-prompt`** is the **prompt** axis, orthogonal to `--fail`'s exit-code axis:
+  it suppresses the interactive resolve menu (report-only) but keeps exit `0` on
+  drift. Reach for it when a script runs `check` **attached to a terminal** (both
+  stdin+stdout are a TTY, so the TTY gate alone would still prompt and could hang)
+  yet must not fail the job on drift. A non-TTY run (real CI, a pipe, redirected
+  output) never prompts anyway, so this only matters for the terminal-attached case;
+  combined with `--fail`, `--fail`'s exit `1` wins.
 - **`--strict`** is the orthogonal **coverage** axis: it exits `1` when a run was
   incomplete (a resource skipped for an ACTIONABLE reason — a CC-unsupported type
   with no override, a read error / throttle / AccessDenied — or a nested stack not
@@ -401,6 +408,7 @@ CI (with `--yes`).
 | `--all`                    | target every stack the app defines (the default when no `<stack>` is named; cannot be combined with named stacks — a `<stack> ... --all` invocation errors)                                                                                                                                                                                            |
 | `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                                                                                                                                                                                                                                                   |
 | `--fail`                   | (check) exit 1 on drift and never prompt; for scripts/CI. Without it, check reports drift but exits 0                                                                                                                                                                                                                                                  |
+| `--no-prompt`              | (check) never open the interactive resolve menu (report-only), but keep exit 0 on drift — the exit-0 twin of `--fail`'s prompt suppression, for a report-only script attached to a terminal. Non-TTY never prompts anyway; with `--fail`, `--fail`'s exit 1 wins                                                                                       |
 | `--strict`                 | (check) exit 1 when coverage is incomplete. A coverage gap is always surfaced loudly; `--strict` makes it CI-failing. Orthogonal to `--fail`                                                                                                                                                                                                           |
 | `--show-all`               | (check) inventory mode: show all current undeclared state, ignoring the baseline                                                                                                                                                                                                                                                                       |
 | `--verbose` / `-v`         | (check) expand the `info:` footer tiers / (revert) expand the not-revertable summary to full lists; (record) itemizes nested sub-keys in the multiselect. `-v` means `--verbose` **inside a verb** (`check -v`); a bare `cdkrd -v` (no verb) prints the version                                                                                        |
@@ -422,7 +430,7 @@ error (they select which comparison runs, so a combination is contradictory).
 ### Interactive prompts (TTY only, CI is never prompted)
 
 Every option runs exactly the same code as the standalone commands. Prompts are
-skipped under `--json`, `--show-all`, `--pre-deploy`, `--fail`, `--yes`, and the
+skipped under `--json`, `--show-all`, `--pre-deploy`, `--fail`, `--no-prompt`, `--yes`, and the
 scope filters `--declared-only` / `--undeclared-only` (a filtered finding set must
 never become a snapshot-complete baseline via the inline Record — use the standalone
 `record` verb, which sees the unfiltered state, #779). A non-TTY run

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -10,6 +10,7 @@ const VALUE_FLAGS = new Set(['--region', '--profile', '--app', '-a', '-c', '--co
 const BOOLEAN_FLAGS = new Set([
   '--json',
   '--fail',
+  '--no-prompt',
   '--show-all',
   '--yes',
   '-y',
@@ -54,6 +55,7 @@ const ALLOWED_FLAGS_BY_VERB: Record<Verb, Set<string>> = {
   check: new Set([
     ...GLOBAL_FLAGS,
     '--fail',
+    '--no-prompt',
     '--strict',
     '--show-all',
     '--pre-deploy',
@@ -101,6 +103,21 @@ export interface CommonArgs {
   // convention (R53): drift sets exit 1 and prompts are suppressed. Without it,
   // check REPORTS drift but exits 0 (report-only).
   fail: boolean;
+  // (check) prompt axis, ORTHOGONAL to --fail (which is the exit-code axis): force the
+  // run non-interactive — suppress the after-report resolve menu (Record / Revert / Ignore /
+  // day-1 establish) even in a TTY, WITHOUT changing the exit code. `--fail` already implies
+  // this (its automation contract suppresses prompts); `--no-prompt` is the exit-0 twin, for a
+  // report-only script that runs attached to a terminal (both stdin+stdout TTY, so the TTY
+  // gate alone would still prompt and could hang) and must not fail CI on drift. Passing both
+  // is harmless — `--fail`'s exit-1 wins, the suppression is identical. Non-TTY already never
+  // prompts, so this only bites the terminal-attached-script case.
+  //
+  // OPTIONAL + POST-ASSIGNED (see parseCommonArgs) rather than a required field IN the return
+  // literal: growing that ~28-property literal trips tsgolint's whole-program type-aware pass
+  // into cascading FALSE `no-base-to-string` lint errors on UNRELATED files (classify.ts /
+  // gather.ts) — `tsgo` typecheck is unaffected, but `vp check` and CI go red. Keeping the
+  // literal at its prior size + a separate assignment sidesteps it. Always set at runtime. (#683.)
+  noPrompt?: boolean;
   // (check) coverage axis, ORTHOGONAL to --fail (which is about drift): make a run
   // whose coverage was incomplete — any resource SKIPPED (CC-unsupported + no SDK
   // override, a read error, a missing physical id) or any nested stack not recursed
@@ -249,7 +266,11 @@ export function parseCommonArgs(args: string[], verb?: Verb): CommonArgs {
   // also export the resolved profile as $AWS_PROFILE; this marker is the "was it explicit?"
   // bit that export loses. Set only when `--profile` is actually present.
   if (values['--profile'] !== undefined) process.env.CDKRD_EXPLICIT_PROFILE = '1';
-  return {
+  // POST-ASSIGN noPrompt (below) rather than adding it to this return literal: growing this
+  // ~28-property literal trips tsgolint's whole-program type-aware pass into cascading false
+  // lint errors on UNRELATED files (tsgo typecheck is unaffected). Keeping the literal at its
+  // prior size + a separate assignment sidesteps it. (#683 — same pattern as loadDesired.)
+  const parsed: CommonArgs = {
     stackNames,
     all: has('--all'),
     context,
@@ -278,4 +299,6 @@ export function parseCommonArgs(args: string[], verb?: Verb): CommonArgs {
     verbose: has('--verbose') || has('-v'),
     waitMs,
   };
+  parsed.noPrompt = has('--no-prompt');
+  return parsed;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,12 @@ OPTIONS
   --fail                      (check) exit 1 on drift + never prompt — for
                               scripts/CI (same convention as \`cdk diff --fail\`);
                               without it, check REPORTS drift but exits 0
+  --no-prompt                 (check) never open the interactive resolve menu —
+                              report only, exit 0 even on drift. The exit-0 twin of
+                              --fail's suppression, for a report-only script run
+                              ATTACHED to a terminal (where the TTY gate alone would
+                              still prompt and could hang). Non-TTY runs never prompt
+                              anyway; with --fail, --fail's exit-1 wins
   --strict                    (check) exit 1 when coverage is INCOMPLETE — any
                               resource skipped (unread) or a nested stack not
                               recursed into. A loud coverage warning always prints;
@@ -89,8 +95,8 @@ OPTIONS
   --help, -h    --version, -v   (bare \`cdkrd -v\` prints the version; inside a verb,
                               \`-v\` is the short alias for --verbose, e.g. check -v)
 
-  Automation: check --fail / record --yes / ignore --yes / revert --yes (or
-  --dry-run); non-TTY runs never prompt.
+  Automation: check --fail (or --no-prompt for exit-0 report-only) / record --yes /
+  ignore --yes / revert --yes (or --dry-run); non-TTY runs never prompt.
 
 EXIT CODES
   check:  0 = clean (or drift without --fail)   1 = drift (--fail) / incomplete coverage (--strict)   2 = error

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -270,6 +270,9 @@ export function finalCheckExit(code: number, fail: boolean): number {
  * who can make the decision. It is gated OUT of every machine/automation mode:
  *   - --json / --show-all / --pre-deploy — machine output or baseline-untouched contracts,
  *   - --fail — the CI drift-exit path,
+ *   - --no-prompt — the exit-0 twin of --fail's suppression: force the run non-interactive
+ *     (report-only) even in a TTY, without failing CI on drift. Its whole job is this gate;
+ *     when it fires on a no-baseline stack the establish note below takes over (no hang).
  *   - #779: --declared-only / --undeclared-only — a SCOPE filter is active, so `findings`
  *     has been reduced to one tier (declared-only drops the whole undeclared/added/atDefault
  *     tier; undeclared-only drops declared plus its readGap/unresolved byproducts). The
@@ -294,7 +297,14 @@ export function finalCheckExit(code: number, fail: boolean): number {
 export function shouldOfferInteractiveResolve(
   a: Pick<
     CommonArgs,
-    'json' | 'showAll' | 'preDeploy' | 'fail' | 'yes' | 'declaredOnly' | 'undeclaredOnly'
+    | 'json'
+    | 'showAll'
+    | 'preDeploy'
+    | 'fail'
+    | 'noPrompt'
+    | 'yes'
+    | 'declaredOnly'
+    | 'undeclaredOnly'
   >,
   ctx: { code: number; hasUnrecorded: boolean; hasBaseline: boolean; interactive: boolean }
 ): boolean {
@@ -304,6 +314,7 @@ export function shouldOfferInteractiveResolve(
     !a.showAll &&
     !a.preDeploy &&
     !a.fail &&
+    !a.noPrompt &&
     !a.yes &&
     !a.declaredOnly &&
     !a.undeclaredOnly &&
@@ -853,7 +864,7 @@ export async function runCheck(args: string[]): Promise<number> {
           positionPrefix: posPrefix,
         });
       } else if (!baseline && !hasUnrecorded && !a.showAll && !a.preDeploy) {
-        // R142: no interactive establish prompt could fire (non-TTY, --fail, OR --json —
+        // R142: no interactive establish prompt could fire (non-TTY, --fail, --no-prompt, OR --json —
         // shouldOfferInteractiveResolve is false in all of those) and there is no baseline on
         // an otherwise-quiet stack — the report gave no record cue (nothing is unrecorded), so
         // point at how to create the day-1 baseline. #1095: emit UNCONDITIONALLY to stderr

--- a/tests/check-no-prompt-interactive-gate.test.ts
+++ b/tests/check-no-prompt-interactive-gate.test.ts
@@ -1,0 +1,62 @@
+// `--no-prompt` must suppress check's interactive after-report resolve menu even in a TTY,
+// WITHOUT changing the exit code (the exit-0 twin of --fail's prompt suppression). It is the
+// prompt axis, orthogonal to --fail's exit-code axis: a report-only script run ATTACHED to a
+// terminal (both stdin+stdout TTY, so the TTY gate alone would still prompt and could hang)
+// that must not fail CI on drift. This asserts the pure gate predicate.
+import { describe, expect, it } from 'vite-plus/test';
+import { shouldOfferInteractiveResolve } from '../src/commands/check.js';
+import type { CommonArgs } from '../src/cli-args.js';
+
+type GateArgs = Pick<
+  CommonArgs,
+  'json' | 'showAll' | 'preDeploy' | 'fail' | 'noPrompt' | 'yes' | 'declaredOnly' | 'undeclaredOnly'
+>;
+const args = (over: Partial<GateArgs> = {}): GateArgs => ({
+  json: false,
+  showAll: false,
+  preDeploy: false,
+  fail: false,
+  noPrompt: false,
+  yes: false,
+  declaredOnly: false,
+  undeclaredOnly: false,
+  ...over,
+});
+// A TTY run that found drift on a baselined stack — the canonical "offer the menu" case.
+const drift = { code: 1, hasUnrecorded: false, hasBaseline: true, interactive: true };
+
+describe('shouldOfferInteractiveResolve gates the menu on --no-prompt', () => {
+  it('offers the menu for an interactive drift run without --no-prompt', () => {
+    expect(shouldOfferInteractiveResolve(args(), drift)).toBe(true);
+  });
+
+  it('does NOT offer the menu under --no-prompt', () => {
+    expect(shouldOfferInteractiveResolve(args({ noPrompt: true }), drift)).toBe(false);
+  });
+
+  it('does NOT offer the menu under --no-prompt for the R141 no-baseline establish path', () => {
+    expect(
+      shouldOfferInteractiveResolve(args({ noPrompt: true }), {
+        code: 0,
+        hasUnrecorded: false,
+        hasBaseline: false,
+        interactive: true,
+      })
+    ).toBe(false);
+  });
+
+  it('does NOT offer the menu under --no-prompt even with unrecorded values present', () => {
+    expect(
+      shouldOfferInteractiveResolve(args({ noPrompt: true }), {
+        code: 0,
+        hasUnrecorded: true,
+        hasBaseline: true,
+        interactive: true,
+      })
+    ).toBe(false);
+  });
+
+  it('suppresses the menu when combined with --fail (both suppress; --fail wins the exit code elsewhere)', () => {
+    expect(shouldOfferInteractiveResolve(args({ noPrompt: true, fail: true }), drift)).toBe(false);
+  });
+});

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -175,6 +175,16 @@ describe('parseCommonArgs', () => {
     expect(parseCommonArgs(['S', '--fail']).fail).toBe(true);
   });
 
+  it('--no-prompt parses as a boolean, orthogonal to --fail (default false)', () => {
+    expect(parseCommonArgs(['S']).noPrompt).toBe(false);
+    expect(parseCommonArgs(['S', '--no-prompt']).noPrompt).toBe(true);
+    // orthogonal axes: --no-prompt does NOT set fail, and both may be combined
+    expect(parseCommonArgs(['S', '--no-prompt']).fail).toBe(false);
+    const both = parseCommonArgs(['S', '--no-prompt', '--fail']);
+    expect(both.noPrompt).toBe(true);
+    expect(both.fail).toBe(true);
+  });
+
   it('scope flags parse and are mutually exclusive (R59)', () => {
     expect(parseCommonArgs(['S', '--undeclared-only']).undeclaredOnly).toBe(true);
     expect(parseCommonArgs(['S', '--declared-only']).declaredOnly).toBe(true);
@@ -297,6 +307,12 @@ describe('parseCommonArgs per-verb flag applicability (#780)', () => {
     expect(() => parseCommonArgs(['--fail'], 'check')).not.toThrow();
   });
 
+  it('rejects `--no-prompt` outside check', () => {
+    for (const verb of ['record', 'ignore', 'revert'] as const)
+      expect(() => parseCommonArgs(['--no-prompt'], verb)).toThrow(/"--no-prompt" is not valid/);
+    expect(() => parseCommonArgs(['--no-prompt'], 'check')).not.toThrow();
+  });
+
   it('rejects check-only scope/coverage flags on other verbs', () => {
     for (const flag of [
       '--strict',
@@ -333,7 +349,7 @@ describe('parseCommonArgs per-verb flag applicability (#780)', () => {
   it('accepts each verb-appropriate flag set (no false rejection)', () => {
     expect(() =>
       parseCommonArgs(
-        ['--fail', '--strict', '--show-all', '--pre-deploy', '--json', '--verbose'],
+        ['--fail', '--no-prompt', '--strict', '--show-all', '--pre-deploy', '--json', '--verbose'],
         'check'
       )
     ).not.toThrow();


### PR DESCRIPTION
## What

Add `--no-prompt` (check-only): a report-only run that **never opens the interactive
resolve menu** yet keeps **exit 0** on drift.

## Why

`check` is report-only by default (drift exits 0), but it still opens the interactive
Record/Revert/Ignore menu whenever **both stdin and stdout are a TTY**. A shell script
that runs `cdkrd check` *attached to a terminal* (no redirect) therefore hangs on a
prompt the automation can't answer. The only existing escape was `--fail`, which also
flips the exit code to `1`. There was no single flag for **"report drift, exit 0, never
prompt."**

## The design: two orthogonal axes

| flag | exit on drift | prompt | role |
|------|---------------|--------|------|
| *(none)* | 0 | shown (TTY) | interactive human |
| `--fail` | **1** | suppressed | CI gate (`cdk diff --fail` convention) |
| `--no-prompt` | **0** | suppressed | report-only script attached to a terminal |
| `--no-prompt --fail` | 1 | suppressed | redundant — `--fail`'s exit 1 wins |

`--fail` keeps its bundled "CI mode" meaning (exit 1 **and** suppress prompts) — splitting
it would make `--fail` alone in a TTY prompt-then-exit-1, which is worse UX. `--no-prompt`
is the exit-0 twin of that suppression. Non-TTY runs (real CI, pipes, redirects) already
never prompt, so this only matters for the terminal-attached-script case.

## Implementation

- `src/cli-args.ts` — parse `--no-prompt` (check-only, rejected on other verbs).
- `src/commands/check.ts` — add `!a.noPrompt` to `shouldOfferInteractiveResolve`, right
  alongside `!a.fail`. When it fires on a no-baseline stack, the existing R142 establish
  **note** takes over, so the run never hangs.
- HELP + README (options table, exit-codes prose, interactive-skip list) updated.

## tsgolint cascade guard (#683 pattern)

`noPrompt` is **optional + post-assigned** in `parseCommonArgs`, not a field in the return
literal. Adding it directly to that ~28-property literal grows it past tsgolint's
whole-program type-aware budget and cascades false `no-base-to-string` lint errors onto
**unrelated** files (`classify.ts` / `gather.ts`) — `tsgo` typecheck is unaffected but
`vp check` and CI go red. Verified in a fresh cold-cache worktree: literal form → 19
phantom errors; post-assign form → 0. Same fix as `loadDesired`'s `stackTags`.

## Tests

- `tests/cli-args.test.ts` — `--no-prompt` parses as a boolean, is orthogonal to `--fail`
  (combinable, doesn't set `fail`), and is rejected outside `check`.
- `tests/check-no-prompt-interactive-gate.test.ts` — the gate predicate suppresses the
  menu under `--no-prompt` across the drift / no-baseline-establish / unrecorded paths,
  and when combined with `--fail`.

All 5346 unit tests pass; typecheck + `vp check` + build green.
