### PR TITLE
fix(diff): derive RDS DBInstance PubliclyAccessible default from subnet-group placement (#1499)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -4809,6 +4809,31 @@ export function classifyResource(
         continue;
       }
     }
+    // #1499: an AWS::RDS::DBInstance that declares no `PubliclyAccessible` reads back the value
+    // RDS DERIVES at creation from its subnet-group/VPC placement: `true` for a default-VPC
+    // instance (its subnet group is the account's `default` group), `false` for a custom
+    // subnet-group / private-VPC placement (per the RDS docs). Neither a constant nor a
+    // value-independent fold is right — pinning `true` FPs every custom-VPC instance (the common
+    // production shape); value-independent HIDES the security-DANGEROUS out-of-band flip. Tier-2
+    // derived and equality-gated on the effective DBSubnetGroupName (declared preferred, else the
+    // live echo, which KNOWN_DEFAULTS folds to "default"): `"default"` → true, any custom group →
+    // false. The dangerous transition — a private/custom-VPC instance made public out of band
+    // (`modify-db-instance --publicly-accessible`) — reads live `true`, never matches the derived
+    // `false`, so it surfaces as undeclared. (A default-VPC instance disabled to `false` is a bare
+    // undeclared `false` swallowed by isTrivialEmpty below like any non-MEANINGFUL_WHEN_OFF
+    // off-state — the safe direction, and #660 territory, not this derived fold's concern.)
+    if (resourceType === 'AWS::RDS::DBInstance' && k === 'PubliclyAccessible') {
+      const subnetGroup =
+        (declared.DBSubnetGroupName as string | undefined) ??
+        (live.DBSubnetGroupName as string | undefined);
+      if (typeof subnetGroup === 'string') {
+        const derived = subnetGroup === 'default';
+        if (v === derived) {
+          findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+          continue;
+        }
+      }
+    }
     // A live value that is an AWS-MANAGED default resource NAME, recognized by its reserved
     // `default.` / `default:` prefix (an RDS instance's default parameter/option group) rather
     // than a constant — a CUSTOM group name never carries the prefix, so it still surfaces.

--- a/tests/classify-rds-publiclyaccessible-1499.test.ts
+++ b/tests/classify-rds-publiclyaccessible-1499.test.ts
@@ -1,0 +1,96 @@
+// #1499 — an AWS::RDS::DBInstance that omits PubliclyAccessible reads back the value RDS derives
+// at creation from its subnet-group/VPC placement: `true` for a default-VPC instance (subnet group
+// "default"), `false` for a custom subnet-group placement. classify derives + equality-gates the
+// undeclared value from the effective DBSubnetGroupName (declared preferred, else the live echo).
+// Assert the clean-deploy fold to atDefault on BOTH branches AND that a flip away from the derived
+// value still surfaces as undeclared (out-of-band `modify-db-instance --publicly-accessible`
+// detection preserved — a security-relevant, OOB-mutable boundary).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Db',
+  resourceType: 'AWS::RDS::DBInstance',
+  physicalId: 'cdkrd-db-1499',
+  declared,
+});
+
+describe('#1499 RDS DBInstance PubliclyAccessible derived from DBSubnetGroupName placement', () => {
+  it('folds true on a default-VPC instance (live DBSubnetGroupName "default")', () => {
+    const f = classifyResource(
+      mk({ Engine: 'postgres' }),
+      { DBSubnetGroupName: 'default', PubliclyAccessible: true },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'atDefault')).toContain('PubliclyAccessible');
+    expect(tier(f, 'undeclared')).not.toContain('PubliclyAccessible');
+  });
+
+  it('folds false on a custom subnet-group instance (the common production shape)', () => {
+    const f = classifyResource(
+      mk({ Engine: 'postgres' }),
+      { DBSubnetGroupName: 'my-private-subnet-group', PubliclyAccessible: false },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'atDefault')).toContain('PubliclyAccessible');
+    expect(tier(f, 'undeclared')).not.toContain('PubliclyAccessible');
+  });
+
+  // The SECURITY-DANGEROUS transition (a private/custom-VPC instance made public) is the one the
+  // derived fold must not hide — a live `true` never matches the custom-VPC derived `false`, so it
+  // surfaces. The opposite direction (a default-VPC instance disabled to `false` = hardening) is a
+  // bare undeclared `false`, swallowed by isTrivialEmpty like every off-state that is not a curated
+  // MEANINGFUL_WHEN_OFF path (the #660 class); PubliclyAccessible is a DERIVED default (not a
+  // KNOWN_DEFAULTS constant), so it is out of scope for that mechanism and the safe direction.
+  it('does NOT surface a default-VPC instance disabled to false (safe direction, #660 trivial-empty)', () => {
+    const f = classifyResource(
+      mk({ Engine: 'postgres' }),
+      { DBSubnetGroupName: 'default', PubliclyAccessible: false },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'undeclared')).not.toContain('PubliclyAccessible');
+    expect(tier(f, 'atDefault')).not.toContain('PubliclyAccessible');
+  });
+
+  it('surfaces an out-of-band flip to true on a custom subnet-group instance (internet exposure)', () => {
+    const f = classifyResource(
+      mk({ Engine: 'postgres' }),
+      { DBSubnetGroupName: 'my-private-subnet-group', PubliclyAccessible: true },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'undeclared')).toContain('PubliclyAccessible');
+    expect(tier(f, 'atDefault')).not.toContain('PubliclyAccessible');
+  });
+
+  it('derives from the DECLARED DBSubnetGroupName when present (declared preferred)', () => {
+    const f = classifyResource(
+      mk({ Engine: 'postgres', DBSubnetGroupName: 'my-private-subnet-group' }),
+      { DBSubnetGroupName: 'my-private-subnet-group', PubliclyAccessible: false },
+      emptySchema,
+      {}
+    );
+    expect(tier(f, 'atDefault')).toContain('PubliclyAccessible');
+    expect(tier(f, 'undeclared')).not.toContain('PubliclyAccessible');
+  });
+});

--- a/tests/corpus/AWS__RDS__DBInstance.HuntPostgres.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntPostgres.json
@@ -477,7 +477,7 @@
       "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntPostgres",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PubliclyAccessible",

--- a/tests/corpus/AWS__RDS__DBInstance.HuntSqlServer.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntSqlServer.json
@@ -476,7 +476,7 @@
       "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntSqlServer",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PubliclyAccessible",


### PR DESCRIPTION
## What

Closes the **remaining** piece of #1499 — the RDS `DBInstance` `PubliclyAccessible`
tier-2 derived fold. (The default-VPC SG/DBSubnetGroupName/parameter-group folds and
the sqlserver `ENGINE_DEFAULTS` arms already shipped in the hunt PR; the classify/gather
default-SG sync-gap shipped in v0.12.108 / #1513.)

## Why

A `DBInstance` that declares no `PubliclyAccessible` reads back the value RDS **derives**
at creation from its subnet-group/VPC placement:
- **default-VPC** instance (subnet group `"default"`) → `true`
- **custom subnet-group / private-VPC** placement → `false`

Neither fold tier below tier-2 fits:
- pinning a constant `true` first-run-FPs **every custom-VPC instance** (the common
  production shape);
- a value-independent fold **hides the security-dangerous out-of-band flip** (exposing a
  private DB to the internet).

## How

A sibling-gated **derived** fold in `classify.ts` (next to the Kinesis `ShardCount` /
DynamoDB `WarmThroughput` folds), equality-gated on the **effective** `DBSubnetGroupName`
(declared preferred, else the live echo, which `KNOWN_DEFAULTS` folds to `"default"`):
`"default"` → `true`, any custom group → `false`.

Out-of-band detection preserved where it matters: the **dangerous** transition — a
private/custom-VPC instance made public out of band (`modify-db-instance
--publicly-accessible`) — reads live `true`, never matches the derived `false`, and
**surfaces as undeclared**. (A default-VPC instance *disabled* to `false` is the safe
direction; it is a bare undeclared `false` swallowed by `isTrivialEmpty` like any
non-`MEANINGFUL_WHEN_OFF` off-state — #660 territory, out of scope for this derived fold.)

## Tests

- Flips the `HuntPostgres` / `HuntSqlServer` corpus `PubliclyAccessible` finding from
  `undeclared` → `atDefault` (both fixtures are default-VPC, live-proven `true` in the
  originating hunt).
- New `tests/classify-rds-publiclyaccessible-1499.test.ts`: folds `true` on default-VPC,
  folds `false` on custom subnet-group, surfaces the dangerous custom-VPC→`true` OOB flip,
  and derives from the declared `DBSubnetGroupName` when present.
- Full suite green (5345 tests), typecheck + lint/format clean.

## Live verification

The default-VPC branch (`"default"` → `true`) is corpus-live-proven (both harvested
fixtures). The custom-subnet-group branch (→ `false`) will be live-confirmed via
`/verify-pr` (a minimal DBInstance in a custom subnet group reading back `false`) before
merge, per the issue's request.

Closes #1499.
