### PR TITLE
fix(diff): surface out-of-band Athena WorkGroup config off-flip (part of #660)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -226,6 +226,23 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
   // an untouched `false`), so an undeclared live `false` is unambiguously an out-of-band
   // disable of dual-stack delivery. Unconditionally meaningful when off.
   'AWS::CloudFront::Distribution': { 'DistributionConfig.IPV6Enabled': () => true },
+  // #660 item 3: an Athena WorkGroup enforces its config and publishes CloudWatch metrics by
+  // default on every clean deploy (the `WorkGroupConfiguration.EnforceWorkGroupConfiguration`
+  // and `.PublishCloudWatchMetricsEnabled` `true` pins). `WorkGroupConfiguration` is a
+  // `DESCEND_UNDECLARED_OBJECT_PATHS` object: an out-of-band `update-work-group` flipping either
+  // leaf `false` breaks the whole-object `KNOWN_DEFAULTS` equality, so the object descends
+  // per-leaf and the lone `false` leaf is swallowed by `isTrivialEmpty(false)` before the pin
+  // gate — the disable stays invisible (live-verified 2026-07-12 A/B on `Cdkrd660AthenaVerify`:
+  // base reports nothing after each flip, fix surfaces `actual=false`). Both are unconditionally
+  // meaningful when off: EnforceWorkGroupConfiguration=false lets clients override the
+  // workgroup's result-location/encryption settings, and PublishCloudWatchMetricsEnabled=false
+  // silently stops query metrics. A user who wants either off DECLARES it (compared in the
+  // declared loop); an undeclared `false` is an out-of-band relaxation. No restore/import path
+  // yields an untouched `false` (a WorkGroup has no snapshot lineage).
+  'AWS::Athena::WorkGroup': {
+    'WorkGroupConfiguration.EnforceWorkGroupConfiguration': () => true,
+    'WorkGroupConfiguration.PublishCloudWatchMetricsEnabled': () => true,
+  },
 };
 
 // #1092/#1485: GuardDuty protection Features (and their nested AdditionalConfiguration members)

--- a/tests/classify-athena-workgroup-offflip-660.test.ts
+++ b/tests/classify-athena-workgroup-offflip-660.test.ts
@@ -1,0 +1,72 @@
+// #660 item 3 (nested MEANINGFUL_WHEN_OFF): an Athena WorkGroup declares no
+// WorkGroupConfiguration, so the object is DESCENDED leaf-by-leaf
+// (DESCEND_UNDECLARED_OBJECT_PATHS). Its `EnforceWorkGroupConfiguration` and
+// `PublishCloudWatchMetricsEnabled` `true` defaults fold atDefault via KNOWN_DEFAULT_PATHS
+// on a clean deploy, but an out-of-band `update-work-group` flipping either `false` would be
+// swallowed by isTrivialEmpty(false) BEFORE the pin gate — invisible. The nested off-state
+// twin surfaces the disable as `undeclared` while the clean `true` still folds. Live-verified
+// A/B 2026-07-12 on `Cdkrd660AthenaVerify` (base blind, fix surfaces `actual=false`).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#660 Athena WorkGroup nested off-flip (EnforceWorkGroupConfiguration / PublishCloudWatchMetricsEnabled)', () => {
+  // A workgroup that declares NO WorkGroupConfiguration — AWS materializes the whole default
+  // config, which DESCENDS leaf-by-leaf (DESCEND_UNDECLARED_OBJECT_PATHS).
+  const res: DesiredResource = {
+    logicalId: 'Wg',
+    resourceType: 'AWS::Athena::WorkGroup',
+    physicalId: 'cdkrd-660-athena',
+    declared: { Name: 'cdkrd-660-athena', State: 'ENABLED' },
+  };
+  const live = (over: { enforce?: unknown; publish?: unknown }) => ({
+    Name: 'cdkrd-660-athena',
+    State: 'ENABLED',
+    WorkGroupConfiguration: {
+      EnforceWorkGroupConfiguration: over.enforce ?? true,
+      EngineVersion: { SelectedEngineVersion: 'AUTO' },
+      PublishCloudWatchMetricsEnabled: over.publish ?? true,
+      RequesterPaysEnabled: false,
+    },
+  });
+  const ENFORCE = 'WorkGroupConfiguration.EnforceWorkGroupConfiguration';
+  const PUBLISH = 'WorkGroupConfiguration.PublishCloudWatchMetricsEnabled';
+
+  it('folds the undeclared WorkGroupConfiguration defaults to atDefault (zero first-run drift)', () => {
+    // A clean workgroup whose whole default config matches folds the object atDefault as ONE
+    // entry (the off-flips below break that equality and descend leaf-by-leaf).
+    const f = classifyResource(res, live({}), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('WorkGroupConfiguration');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band undeclared EnforceWorkGroupConfiguration=false disable (#660)', () => {
+    const f = classifyResource(res, live({ enforce: false }), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain(ENFORCE);
+    // The sibling default still folds — only the disabled flag surfaces.
+    expect(pathsByTier(f, 'atDefault')).toContain(PUBLISH);
+  });
+
+  it('surfaces an out-of-band undeclared PublishCloudWatchMetricsEnabled=false disable (#660)', () => {
+    const f = classifyResource(res, live({ publish: false }), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain(PUBLISH);
+    expect(pathsByTier(f, 'atDefault')).toContain(ENFORCE);
+  });
+});


### PR DESCRIPTION
Part of #660 (item 3, the remaining nested `MEANINGFUL_WHEN_OFF_NESTED` paths).

## What

Surface an out-of-band **Athena WorkGroup** config disable that was previously invisible:

- `WorkGroupConfiguration.EnforceWorkGroupConfiguration`
- `WorkGroupConfiguration.PublishCloudWatchMetricsEnabled`

`WorkGroupConfiguration` is a `DESCEND_UNDECLARED_OBJECT_PATHS` object. Both leaves have `true` `KNOWN_DEFAULT_PATHS` pins, so they fold `atDefault` on a clean deploy. But an out-of-band `update-work-group` flipping either `false` breaks the whole-object equality → the object descends leaf-by-leaf → the lone `false` leaf is swallowed by `isTrivialEmpty(false)` **before** the pin gate runs. The disable stays invisible — the exact class the nested mechanism was built for (CloudFront `IPV6Enabled`, #1459/#1484).

Both are unconditionally meaningful when off:
- `EnforceWorkGroupConfiguration=false` lets clients override the workgroup's result-location / encryption settings.
- `PublishCloudWatchMetricsEnabled=false` silently stops query metrics.

A user who wants either off **declares** it (compared in the declared loop); an undeclared `false` is an out-of-band relaxation. A WorkGroup has no snapshot/restore lineage, so no clean-deploy path reads an untouched `false`.

## Live verification (A/B)

`Cdkrd660AthenaVerify` (us-east-1, 2026-07-12), a WorkGroup declaring no `WorkGroupConfiguration`:

| | clean | Enforce=false OOB | Publish=false OOB |
| --- | --- | --- | --- |
| **base 0.13.1** | CLEAN | CLEAN (FN — invisible) | CLEAN (FN — invisible) |
| **fix** | CLEAN | surfaces `WorkGroupConfiguration.EnforceWorkGroupConfiguration` (sibling folds atDefault) | surfaces `WorkGroupConfiguration.PublishCloudWatchMetricsEnabled` (sibling folds atDefault) |

Clean deploy stays zero-drift on both binaries (invariant holds). Stack torn down + swept clean (ephemeral).

## Tests

`tests/classify-athena-workgroup-offflip-660.test.ts` — clean folds whole-object; each off-flip surfaces its leaf as `undeclared` while the sibling folds `atDefault`. Fix-gated (both off-flip cases fail without the classify entry).

## Scope note on the other #660 item-3 candidates

The `MEANINGFUL_WHEN_OFF_NESTED` gate requires `schemaPath in knownDefPaths` and only runs inside `emitNested` (descended / partially-declared objects). The following fold **whole-object** via `KNOWN_DEFAULTS` equality, so an off-flip breaks the equality and re-surfaces the whole object already — **no nested entry needed**: S3 `PublicAccessBlockConfiguration.*`, S3Express `BucketKeyEnabled`, Cognito `Policies.PasswordPolicy.Require*`, CloudTrail `IncludeManagementEvents`. EKS `ResourcesVpcConfig.EndpointPublicAccess` (mechanism-eligible but slow to deploy) and the item-1 restore-path booleans remain deferred. #660 stays open for those.
