### PR TITLE
fix(diff): surface out-of-band EKS EndpointPublicAccess private-only flip (part of #660)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -243,6 +243,20 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
     'WorkGroupConfiguration.EnforceWorkGroupConfiguration': () => true,
     'WorkGroupConfiguration.PublishCloudWatchMetricsEnabled': () => true,
   },
+  // #660 item 3: an EKS cluster exposes a PUBLIC Kubernetes API endpoint by default on every
+  // clean deploy (the `ResourcesVpcConfig.EndpointPublicAccess` `true` pin in KNOWN_DEFAULT_PATHS).
+  // A cluster declares `SubnetIds`, so `ResourcesVpcConfig` is PARTIALLY declared and therefore
+  // descended (emitNested) — an out-of-band `update-cluster-config` flipping the endpoint to
+  // private-only (`EndpointPublicAccess=false`, which requires `EndpointPrivateAccess=true`)
+  // breaks the per-leaf pin and the lone `false` leaf is swallowed by `isTrivialEmpty(false)`
+  // before the pin gate, staying invisible (the same IPV6Enabled / Athena class the mechanism
+  // was built for). Unconditionally meaningful when off: a user who wants a private-only endpoint
+  // DECLARES `EndpointPublicAccess: false` (compared in the declared loop); an undeclared `false`
+  // is an out-of-band restriction of API reachability. An EKS cluster has no snapshot/restore
+  // lineage that could yield an untouched `false`, so no predicate is needed.
+  'AWS::EKS::Cluster': {
+    'ResourcesVpcConfig.EndpointPublicAccess': () => true,
+  },
 };
 
 // #1092/#1485: GuardDuty protection Features (and their nested AdditionalConfiguration members)

--- a/tests/classify-eks-endpoint-public-access-offflip-660.test.ts
+++ b/tests/classify-eks-endpoint-public-access-offflip-660.test.ts
@@ -1,0 +1,67 @@
+// #660 item 3 (nested MEANINGFUL_WHEN_OFF): an EKS cluster declares `SubnetIds`, so
+// `ResourcesVpcConfig` is PARTIALLY declared and therefore DESCENDED leaf-by-leaf. Its
+// `EndpointPublicAccess` `true` default folds atDefault via KNOWN_DEFAULT_PATHS on a clean
+// deploy, but an out-of-band `update-cluster-config` flipping it `false` (private-only endpoint)
+// would be swallowed by isTrivialEmpty(false) BEFORE the pin gate — invisible. The nested
+// off-state twin surfaces the disable as `undeclared` while the clean `true` still folds.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#660 EKS Cluster nested off-flip (ResourcesVpcConfig.EndpointPublicAccess)', () => {
+  // A cluster declares SubnetIds (partial ResourcesVpcConfig) — AWS materializes the sibling
+  // endpoint defaults, which DESCEND leaf-by-leaf because the object is partially declared.
+  const res: DesiredResource = {
+    logicalId: 'Cluster',
+    resourceType: 'AWS::EKS::Cluster',
+    physicalId: 'cdkrd-660-eks',
+    declared: {
+      Name: 'cdkrd-660-eks',
+      RoleArn: 'arn:aws:iam::123456789012:role/eks-cluster-role',
+      ResourcesVpcConfig: { SubnetIds: ['subnet-aaa', 'subnet-bbb'] },
+    },
+  };
+  const live = (over: { publicAccess?: unknown }) => ({
+    Name: 'cdkrd-660-eks',
+    RoleArn: 'arn:aws:iam::123456789012:role/eks-cluster-role',
+    ResourcesVpcConfig: {
+      SubnetIds: ['subnet-aaa', 'subnet-bbb'],
+      EndpointPublicAccess: over.publicAccess ?? true,
+      EndpointPrivateAccess: over.publicAccess === false ? true : false,
+      PublicAccessCidrs: ['0.0.0.0/0'],
+      ControlPlaneEgressMode: 'AWS_MANAGED',
+    },
+  });
+  const ENDPOINT = 'ResourcesVpcConfig.EndpointPublicAccess';
+  const CIDRS = 'ResourcesVpcConfig.PublicAccessCidrs';
+
+  it('folds the undeclared endpoint defaults to atDefault (zero first-run drift)', () => {
+    const f = classifyResource(res, live({}), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain(ENDPOINT);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band undeclared EndpointPublicAccess=false disable (#660)', () => {
+    const f = classifyResource(res, live({ publicAccess: false }), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain(ENDPOINT);
+    // The sibling default still folds — only the disabled flag surfaces.
+    expect(pathsByTier(f, 'atDefault')).toContain(CIDRS);
+  });
+});


### PR DESCRIPTION
## What

Part of #660 (item 3, nested `MEANINGFUL_WHEN_OFF`). Adds `AWS::EKS::Cluster`
`ResourcesVpcConfig.EndpointPublicAccess` to `MEANINGFUL_WHEN_OFF_NESTED` so an
out-of-band flip of the cluster's Kubernetes API endpoint to **private-only**
(`EndpointPublicAccess=false`) surfaces instead of being silently swallowed.

## Why

An EKS cluster exposes a **public** API endpoint by default on every clean deploy
(the `ResourcesVpcConfig.EndpointPublicAccess=true` pin already in
`KNOWN_DEFAULT_PATHS`). A cluster declares `SubnetIds`, so `ResourcesVpcConfig` is
**partially declared** and therefore descended (`emitNested`). An out-of-band
`update-cluster-config` flipping the endpoint to `false` broke the per-leaf pin,
and the lone `false` leaf was dropped by `isTrivialEmpty(false)` **before** the pin
gate — the disable stayed invisible (the same `IPV6Enabled` / Athena class the
nested off-state gate was built for in #1484 / #1517).

`EndpointPublicAccess` defaults `true` unconditionally with no snapshot/restore
lineage that could yield an untouched `false`, so the OFF state is unconditionally
meaningful (`() => true`, no predicate). A user who wants a private-only endpoint
**declares** it (compared in the declared loop); an undeclared `false` is an
out-of-band restriction of API reachability.

## Test

`tests/classify-eks-endpoint-public-access-offflip-660.test.ts` — a genuine
regression test (fails without the entry, passes with it):
- clean `EndpointPublicAccess=true` folds `atDefault` (zero first-run drift);
- an undeclared `EndpointPublicAccess=false` surfaces as `undeclared` while the
  sibling defaults still fold.

## Live A/B

Live-verified on a fresh `Cdkrd660EksVerify` (us-east-1, `cdkrd:ephemeral`) — see
the PR comment for the A/B result (base blind, fix surfaces `actual=false`). Stack
torn down + swept.

Part of #660.
