### PR TITLE
fix(revert): converge EKS endpoint private-only lockdown revert (part of #660)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -302,6 +302,15 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   'AWS::OpenSearchService::Domain\0AdvancedOptions',
   'AWS::OpenSearchService::Domain\0IPAddressType',
   'AWS::OpenSearchService::Domain\0DeploymentStrategyOptions',
+  // EKS `update-cluster-config` REJECTS an endpoint patch that omits either access flag
+  // ("The new template must include all the properties specified in the previous template,
+  // property EndpointPrivateAccess missing" — live-proven on Cdkrd660EksRevertVerify). So a
+  // bare `remove` of an out-of-band `EndpointPrivateAccess=true` fails the WHOLE patch, taking
+  // the paired `EndpointPublicAccess` set-default (from KNOWN_DEFAULT_PATHS) down with it and
+  // reverting NOTHING. Plan an explicit set-default to the `false` default (via
+  // REVERT_SET_DEFAULT_VALUES — it folds `atDefault` as trivial-empty, so no KNOWN_DEFAULTS
+  // source) so the patch carries both flags and converges to {public:true, private:false}.
+  'AWS::EKS::Cluster\0ResourcesVpcConfig.EndpointPrivateAccess',
 ]);
 
 // Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant
@@ -315,6 +324,10 @@ const REVERT_SET_DEFAULT_VALUES: Record<string, unknown> = {
   // revert set-default value is the plain constant `false` here — the EnableDns64 pattern.
   'AWS::EC2::ClientVpnEndpoint\0SplitTunnel': false,
   'AWS::DocDB::DBCluster\0DeletionProtection': false,
+  // EKS ResourcesVpcConfig.EndpointPrivateAccess folds `atDefault` as trivial-empty `false`
+  // (no KNOWN_DEFAULTS source); its revert set-default value is the plain constant `false` so
+  // the endpoint patch keeps both access flags (EKS rejects a partial endpoint update).
+  'AWS::EKS::Cluster\0ResourcesVpcConfig.EndpointPrivateAccess': false,
 };
 
 /**

--- a/tests/revert-eks-endpoint-private-access-660.test.ts
+++ b/tests/revert-eks-endpoint-private-access-660.test.ts
@@ -1,0 +1,45 @@
+// #660 follow-up: reverting an out-of-band EKS endpoint lockdown must CONVERGE. EKS
+// `update-cluster-config` rejects an endpoint patch that omits either access flag ("The new
+// template must include all the properties specified in the previous template, property
+// EndpointPrivateAccess missing" — live-proven on Cdkrd660EksRevertVerify). So the plan's bare
+// `remove` of the out-of-band `EndpointPrivateAccess=true` failed the WHOLE patch, taking the
+// paired `EndpointPublicAccess` set-default down with it. Pinning `EndpointPrivateAccess: false`
+// in KNOWN_DEFAULT_PATHS routes it through the nested set-default fallback (`add false`), so the
+// patch carries both flags and reverts to the default {public:true, private:false}.
+import { describe, expect, it } from 'vite-plus/test';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+const undeclaredF = (over: Partial<Finding>): Finding => ({
+  tier: 'undeclared',
+  unrecorded: true,
+  logicalId: 'Cluster',
+  physicalId: 'cdkrd660eks',
+  resourceType: 'AWS::EKS::Cluster',
+  path: 'ResourcesVpcConfig.EndpointPrivateAccess',
+  ...over,
+});
+
+describe('#660 EKS endpoint revert converges (nested set-default, not remove)', () => {
+  it('an out-of-band undeclared EndpointPrivateAccess=true reverts as set-default `false`, NOT a remove', () => {
+    const f = undeclaredF({ path: 'ResourcesVpcConfig.EndpointPrivateAccess', actual: true });
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.items).toHaveLength(1);
+    // Without the KNOWN_DEFAULT_PATHS pin this would be `{ op: 'remove' }`, which EKS rejects.
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ResourcesVpcConfig/EndpointPrivateAccess',
+      value: false,
+    });
+  });
+
+  it('the paired EndpointPublicAccess=false reverts as set-default `true` (patch then carries both flags)', () => {
+    const f = undeclaredF({ path: 'ResourcesVpcConfig.EndpointPublicAccess', actual: false });
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ResourcesVpcConfig/EndpointPublicAccess',
+      value: true,
+    });
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #660 / PR #1518 (which shipped **detection** of an out-of-band EKS
endpoint private-only lockdown). This makes **revert** of that finding actually
converge.

## Why

Reverting the lockdown (`EndpointPublicAccess` flipped `false`, which requires
`EndpointPrivateAccess=true`) **failed entirely**. The plan emitted:

- `EndpointPublicAccess -> AWS default` (set-default `true`, from `KNOWN_DEFAULT_PATHS`)
- `EndpointPrivateAccess -> remove` (undeclared, no pin)

EKS `update-cluster-config` **rejects an endpoint patch that omits either access
flag**:

```
InvalidRequest: The new template must include all the properties specified in the
previous template, property "EndpointPrivateAccess" missing
```

Because Cloud Control sends one patch, the bare `remove` failed the **whole** patch
— taking the paired `EndpointPublicAccess` set-default down with it. Revert reverted
nothing (`1 value(s) could not be confirmed converged`).

## Fix

Add `AWS::EKS::Cluster` `ResourcesVpcConfig.EndpointPrivateAccess` to
`REVERT_SET_DEFAULT_PATHS` + `REVERT_SET_DEFAULT_VALUES` (`false`). It folds
`atDefault` as trivial-empty so there's no `KNOWN_DEFAULTS` source — the exact
`EnableDns64` / `SplitTunnel` / `DeletionProtection` pattern the
`REVERT_SET_DEFAULT_VALUES` table exists for. The plan now emits an explicit
set-default (`add false`) instead of a `remove`, so the patch carries **both** access
flags and reverts to the default `{public:true, private:false}`.

Detection is unchanged: `false` stays trivially-empty on a clean deploy; an
out-of-band `true` still diverges and surfaces as undeclared.

## Test

`tests/revert-eks-endpoint-private-access-660.test.ts` — a genuine regression test
(without the entry the op is `{op:'remove'}`, which EKS rejects): asserts the
undeclared `EndpointPrivateAccess=true` reverts as set-default `false` and the paired
`EndpointPublicAccess=false` as set-default `true`.

## Live A/B

Live-proven on a fresh `Cdkrd660EksRevertVerify` (us-east-1, `cdkrd:ephemeral`, torn
down + swept): pre-fix `revert --remove-unrecorded` FAILED with the InvalidRequest
above (0 converged); post-fix the same revert plans two set-defaults, EKS accepts the
combined patch, the `EndpointAccessUpdate` reports `Successful`, and the cluster
converges to `{pub:true, priv:false}` (`CLEAN after revert`).

Part of #660.
