### PR TITLE
fix(diff): surface out-of-band disable of restore-risk version-upgrade booleans (part of #660)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -133,6 +133,24 @@ const ELB_ATTRIBUTE_BAGS: Record<string, string> = {
 // state is a genuine divergence in THIS resource's config. Add an entry ONLY after a live
 // confirm that the OFF state is meaningful in EVERY clean-deploy configuration of the type.
 type OffStateContext = { declared: Record<string, unknown>; live: Record<string, unknown> };
+// #660 item 1: a MEANINGFUL_WHEN_OFF predicate for a `true`-default switch that a snapshot /
+// point-in-time RESTORE can carry over as an untouched `false`. A fresh, NON-restored resource
+// always reads the pin back `true` (so an undeclared `false` is a real out-of-band disable), but
+// a restore INHERITS the source's value — a restore of a source that had the flag `false` reads
+// back `false` UNTOUCHED (live-proven on RDS::DBInstance 2026-07-12: restore-db-instance-from-db-
+// snapshot inherits the source's AutoMinorVersionUpgrade, it does NOT default to `true`). That
+// inherited `false` is a creation-time value AWS assigned for an undeclared prop, NOT a
+// divergence (the core invariant), so it must NOT surface. Gate OFF-meaningfulness on the
+// resource NOT being a restore, keyed on the type's restore-source property(s) — which stay in
+// the template for the resource's life. Conservative on the restore path (a restored-then-
+// disabled resource stays folded rather than risk a first-check FP), FP-free on every clean
+// deploy. The predicate is uniformly SAFE for every restore-capable sibling: where a sibling's
+// restore likewise inherits `false` it prevents the FP; where it defaults to `true` the gate is
+// merely over-conservative — it never itself produces an FP.
+const notRestored =
+  (...restoreSourceKeys: string[]) =>
+  ({ declared }: OffStateContext): boolean =>
+    restoreSourceKeys.every((k) => declared[k] === undefined);
 const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) => boolean>> = {
   // A KMS key is always created enabled; `disable-key` (Enabled=false) is always meaningful.
   'AWS::KMS::Key': { Enabled: () => true },
@@ -195,7 +213,12 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // TLS off DECLARES TLSEnabled=false (compared in the declared loop), so an UNDECLARED false
   // is an out-of-band DISABLE of transit encryption — unconditionally meaningful. Without this
   // gate the live `false` is dropped by isTrivialEmpty before the pin gate, hiding the disable.
-  'AWS::MemoryDB::Cluster': { TLSEnabled: () => true },
+  'AWS::MemoryDB::Cluster': {
+    TLSEnabled: () => true,
+    // #660 item 1: automatic minor-version upgrades default ON; an undeclared false is an
+    // out-of-band disable — except a snapshot/point-in-time restore inherits the source's value.
+    AutoMinorVersionUpgrade: notRestored('SnapshotName', 'SnapshotArns'),
+  },
   // #1492: a Redshift ScheduledAction is created ENABLED — a fresh action that declares no
   // Enable always reads back true (the KNOWN_DEFAULTS pin, live-confirmed 2026-07-12). There is
   // no conditional clean-deploy shape that reads false undeclared (a user who wants it paused
@@ -203,6 +226,28 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // out-of-band `modify-scheduled-action --disable` that silently stops the schedule — the live
   // `false` would otherwise be dropped by isTrivialEmpty before the pin gate. Unconditional.
   'AWS::Redshift::ScheduledAction': { Enable: () => true },
+  // #660 item 1 — the restore-risk `true`-default switches (AutoMinorVersionUpgrade /
+  // AllowVersionUpgrade). Each is pinned `true` in KNOWN_DEFAULTS and a fresh deploy reads it
+  // back `true` across every engine variant (corpus-confirmed: redis/memcached/valkey/postgres/
+  // sqlserver/Neptune/Redshift), so an undeclared `false` is a real out-of-band DISABLE of
+  // automatic patching that isTrivialEmpty otherwise hides. The `notRestored(...)` gate excludes
+  // a snapshot-restored resource, whose undeclared `false` is an inherited creation-time value
+  // (see the `notRestored` note above) — live-proven on RDS::DBInstance.
+  'AWS::RDS::DBInstance': { AutoMinorVersionUpgrade: notRestored('DBSnapshotIdentifier') },
+  'AWS::RDS::DBCluster': {
+    AutoMinorVersionUpgrade: notRestored('SnapshotIdentifier', 'SourceDBClusterIdentifier'),
+  },
+  // A Neptune DBInstance has no instance-level restore source (only AWS::Neptune::DBCluster
+  // restores from a snapshot; its member instances are always CREATED fresh and read the flag
+  // back `true`), so there is no clean-deploy path to an untouched `false` — unconditional.
+  'AWS::Neptune::DBInstance': { AutoMinorVersionUpgrade: () => true },
+  'AWS::ElastiCache::CacheCluster': {
+    AutoMinorVersionUpgrade: notRestored('SnapshotName', 'SnapshotArns'),
+  },
+  'AWS::ElastiCache::ReplicationGroup': {
+    AutoMinorVersionUpgrade: notRestored('SnapshotName', 'SnapshotArns'),
+  },
+  'AWS::Redshift::Cluster': { AllowVersionUpgrade: notRestored('SnapshotIdentifier') },
 };
 
 // #660 item 3: the NESTED twin of MEANINGFUL_WHEN_OFF. The table above gates TOP-LEVEL

--- a/tests/classify-restore-booleans-660.test.ts
+++ b/tests/classify-restore-booleans-660.test.ts
@@ -1,0 +1,144 @@
+// #660 item 1: the restore-risk `true`-default switches — RDS/ElastiCache/MemoryDB/Neptune
+// `AutoMinorVersionUpgrade` and Redshift `AllowVersionUpgrade`. Each is a `true` KNOWN_DEFAULTS
+// pin, so an undeclared out-of-band flip to `false` used to be swallowed by isTrivialEmpty
+// before the pin gate (invisible / unrecordable / unrevertable — the #632 class). They now join
+// MEANINGFUL_WHEN_OFF so the disable surfaces, BUT gated on the resource NOT being a snapshot
+// restore: a restore INHERITS the source's flag, so a restore of a source that had it `false`
+// reads back `false` UNTOUCHED — a creation-time value AWS assigned for an undeclared prop, not
+// a divergence. LIVE-PROVEN 2026-07-12 (us-east-1): a MariaDB source with
+// `--no-auto-minor-version-upgrade`, snapshotted, then `restore-db-instance-from-db-snapshot`
+// with the flag UNDECLARED read back `AutoMinorVersionUpgrade=false` — restore inherits, it does
+// NOT default to `true`. So the fix requires a `notRestored(...)` predicate, not `() => true`.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+// Per type: the flag name and the restore-source property that, when declared, marks the
+// resource as a snapshot/point-in-time restore (folds the inherited off-state instead of
+// surfacing). Neptune::DBInstance has no instance-level restore source (undefined).
+type Case = {
+  resourceType: string;
+  flag: string;
+  restoreProp?: string;
+  restoreValue?: unknown;
+  baseDeclared: Record<string, unknown>;
+};
+
+const CASES: Case[] = [
+  {
+    resourceType: 'AWS::RDS::DBInstance',
+    flag: 'AutoMinorVersionUpgrade',
+    restoreProp: 'DBSnapshotIdentifier',
+    restoreValue: 'my-snap',
+    baseDeclared: { DBInstanceClass: 'db.t3.micro', Engine: 'mariadb' },
+  },
+  {
+    resourceType: 'AWS::RDS::DBCluster',
+    flag: 'AutoMinorVersionUpgrade',
+    restoreProp: 'SnapshotIdentifier',
+    restoreValue: 'my-cluster-snap',
+    baseDeclared: { Engine: 'aurora-mysql' },
+  },
+  {
+    resourceType: 'AWS::Neptune::DBInstance',
+    flag: 'AutoMinorVersionUpgrade',
+    // No instance-level restore source: unconditional, no restore case.
+    baseDeclared: { DBInstanceClass: 'db.r5.large' },
+  },
+  {
+    resourceType: 'AWS::ElastiCache::CacheCluster',
+    flag: 'AutoMinorVersionUpgrade',
+    restoreProp: 'SnapshotName',
+    restoreValue: 'my-cache-snap',
+    baseDeclared: { Engine: 'redis', CacheNodeType: 'cache.t3.micro' },
+  },
+  {
+    resourceType: 'AWS::ElastiCache::ReplicationGroup',
+    flag: 'AutoMinorVersionUpgrade',
+    restoreProp: 'SnapshotName',
+    restoreValue: 'my-rg-snap',
+    baseDeclared: { Engine: 'redis', CacheNodeType: 'cache.t3.micro' },
+  },
+  {
+    resourceType: 'AWS::MemoryDB::Cluster',
+    flag: 'AutoMinorVersionUpgrade',
+    restoreProp: 'SnapshotName',
+    restoreValue: 'my-mdb-snap',
+    baseDeclared: { NodeType: 'db.t4g.small', ACLName: 'open-access' },
+  },
+  {
+    resourceType: 'AWS::Redshift::Cluster',
+    flag: 'AllowVersionUpgrade',
+    restoreProp: 'SnapshotIdentifier',
+    restoreValue: 'my-redshift-snap',
+    baseDeclared: { NodeType: 'ra3.large', ClusterType: 'single-node' },
+  },
+];
+
+describe('#660 item 1 restore-risk version-upgrade booleans', () => {
+  for (const c of CASES) {
+    const mkRes = (declared: Record<string, unknown>): DesiredResource => ({
+      logicalId: 'R',
+      resourceType: c.resourceType,
+      physicalId: 'r-phys',
+      declared,
+    });
+
+    it(`${c.resourceType}: clean undeclared true folds atDefault (no first-run FP)`, () => {
+      const f = classifyResource(
+        mkRes(c.baseDeclared),
+        { ...c.baseDeclared, [c.flag]: true },
+        emptySchema
+      );
+      expect(pathsByTier(f, 'atDefault')).toContain(c.flag);
+      expect(pathsByTier(f, 'undeclared')).not.toContain(c.flag);
+    });
+
+    it(`${c.resourceType}: out-of-band undeclared ${c.flag}=false surfaces (FN fix)`, () => {
+      const f = classifyResource(
+        mkRes(c.baseDeclared),
+        { ...c.baseDeclared, [c.flag]: false },
+        emptySchema
+      );
+      expect(pathsByTier(f, 'undeclared')).toContain(c.flag);
+    });
+
+    if (c.restoreProp) {
+      const restoreProp = c.restoreProp;
+      it(`${c.resourceType}: restored (${restoreProp} declared) undeclared ${c.flag}=false does NOT surface`, () => {
+        // A restore inherits the source's false — a creation-time value, not a divergence.
+        const declared = { ...c.baseDeclared, [restoreProp]: c.restoreValue };
+        const f = classifyResource(mkRes(declared), { ...declared, [c.flag]: false }, emptySchema);
+        expect(pathsByTier(f, 'undeclared')).not.toContain(c.flag);
+      });
+    } else {
+      it(`${c.resourceType}: has no restore source — the disable always surfaces`, () => {
+        // Neptune instances are created fresh even into a restored cluster, so false is always
+        // an out-of-band disable.
+        const f = classifyResource(
+          mkRes(c.baseDeclared),
+          { ...c.baseDeclared, [c.flag]: false },
+          emptySchema
+        );
+        expect(pathsByTier(f, 'undeclared')).toContain(c.flag);
+      });
+    }
+  }
+});


### PR DESCRIPTION
Part of #660 — **item 1 (restore/import-path booleans)**, the last mechanism-eligible slice left open on the issue.

## What

`AWS::RDS::DBInstance` / `DBCluster`, `AWS::Neptune::DBInstance`, `AWS::ElastiCache::CacheCluster` / `ReplicationGroup`, `AWS::MemoryDB::Cluster` `AutoMinorVersionUpgrade`, and `AWS::Redshift::Cluster` `AllowVersionUpgrade` are `true` `KNOWN_DEFAULTS` pins. An undeclared out-of-band flip to `false` was swallowed by `isTrivialEmpty` before the pin gate — the #632 invisible-disable class (undetectable / unrecordable / unrevertable). They now join `MEANINGFUL_WHEN_OFF` so the disable surfaces.

## The restore gate (why not `() => true`)

The issue flagged that a snapshot-restored resource can read `false` untouched, so a blanket `() => true` would first-run-FP on a clean restore deploy. **Live-verified 2026-07-12 (us-east-1):** a MariaDB source created with `--no-auto-minor-version-upgrade`, snapshotted, then `restore-db-instance-from-db-snapshot` with the flag **undeclared** read back `AutoMinorVersionUpgrade=false` — **a restore INHERITS the source's value; it does NOT default to `true`.** That inherited `false` is a creation-time value AWS assigned for an undeclared prop, not a divergence (core invariant), so it must not surface.

So each entry uses a `notRestored(...)` predicate keyed on the type's restore-source property (`DBSnapshotIdentifier`, `SnapshotIdentifier`/`SourceDBClusterIdentifier`, `SnapshotName`/`SnapshotArns`), which stays in the template for the resource's life. Conservative on the restore path, FP-free on every clean deploy. The predicate is uniformly safe for every restore-capable sibling: where a sibling's restore likewise inherits `false` it prevents the FP; where it defaults to `true` the gate is merely over-conservative and never itself produces an FP. `Neptune::DBInstance` has no instance-level restore source (its cluster restores; member instances are created fresh reading `true`), so it is unconditional.

## Evidence

- **Fresh-deploy direction** (undeclared reads `true`): corpus-confirmed across every engine variant — redis / memcached / valkey / postgres / sqlserver / Neptune / Redshift. No false-on-clean case, so `corpus-replay` does not regress.
- **Restore-inheritance** (the FP the predicate prevents): live-proven on RDS::DBInstance (above); the sibling restore APIs carry the same inheritance semantics and the predicate is conservative regardless.

## Tests

`tests/classify-restore-booleans-660.test.ts` — per type: (a) clean undeclared `true` folds `atDefault` (no first-run FP), (b) out-of-band undeclared `false` surfaces (the FN fix), (c) restored (restore-source declared) undeclared `false` does **not** surface (FP prevention). 21 pass; **8 fail without the fix**. Full suite: 257 files / 5380 tests green.

## Still open on #660

item 1's restored resources are now folded (not surfaced); the remaining truly-open work on #660 is nil for the mechanism-eligible set — only future no-corpus paths would remain.
