### PR TITLE
fix(revert): converge out-of-band disable of restore-risk version-upgrade booleans (part of #660)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -311,6 +311,24 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // REVERT_SET_DEFAULT_VALUES — it folds `atDefault` as trivial-empty, so no KNOWN_DEFAULTS
   // source) so the patch carries both flags and converges to {public:true, private:false}.
   'AWS::EKS::Cluster\0ResourcesVpcConfig.EndpointPrivateAccess',
+  // #660 item 1 revert follow-up to #1520: the restore-risk version-upgrade booleans
+  // (AutoMinorVersionUpgrade / AllowVersionUpgrade) are now DETECTED when disabled out of band
+  // (MEANINGFUL_WHEN_OFF), but their update APIs KEEP the existing value on an omitted flag, so a
+  // bare `remove` revert is a silent no-op — `check` flags the disable yet `revert` can't fix it.
+  // The modify APIs (modify-db-instance / modify-db-cluster / modify-cache-cluster /
+  // modify-replication-group / update-cluster (MemoryDB) / modify-cluster (Redshift)) only change
+  // a flag when it is PRESENT in the request, so write the `true` default (from KNOWN_DEFAULTS)
+  // back explicitly. Live-proven on RDS::DBInstance (Cdkrd660RevertVerify): pre-fix `revert` bare
+  // `remove` reported success yet the live value stayed false; post-fix the set-default `add true`
+  // converges. The set-default value resolves from KNOWN_DEFAULTS (the same `true` pin that folds
+  // the clean read atDefault) — no REVERT_SET_DEFAULT_VALUES entry needed.
+  'AWS::RDS::DBInstance\0AutoMinorVersionUpgrade',
+  'AWS::RDS::DBCluster\0AutoMinorVersionUpgrade',
+  'AWS::Neptune::DBInstance\0AutoMinorVersionUpgrade',
+  'AWS::ElastiCache::CacheCluster\0AutoMinorVersionUpgrade',
+  'AWS::ElastiCache::ReplicationGroup\0AutoMinorVersionUpgrade',
+  'AWS::MemoryDB::Cluster\0AutoMinorVersionUpgrade',
+  'AWS::Redshift::Cluster\0AllowVersionUpgrade',
 ]);
 
 // Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant

--- a/tests/revert-restore-booleans-660.test.ts
+++ b/tests/revert-restore-booleans-660.test.ts
@@ -1,0 +1,47 @@
+// #660 item 1 revert follow-up to PR #1520: detecting an out-of-band DISABLE of a restore-risk
+// version-upgrade boolean (AutoMinorVersionUpgrade / AllowVersionUpgrade) is only half the fix —
+// `revert` must also CONVERGE. Their modify APIs KEEP the existing value on an omitted flag, so a
+// bare `remove` revert of the undeclared `false` is a silent no-op (`check` flags it, `revert`
+// can't fix it). REVERT_SET_DEFAULT_PATHS routes each through the set-default fallback: write the
+// `true` default (from KNOWN_DEFAULTS) explicitly instead of a `remove`. LIVE-PROVEN on
+// RDS::DBInstance (Cdkrd660RevertVerify, us-east-1, 2026-07-12): pre-fix bare `remove` reported
+// success yet `describe-db-instances` stayed AutoMinorVersionUpgrade=false; post-fix the
+// set-default `add true` converged the live value back to true.
+import { describe, expect, it } from 'vite-plus/test';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+const CASES: { resourceType: string; flag: string }[] = [
+  { resourceType: 'AWS::RDS::DBInstance', flag: 'AutoMinorVersionUpgrade' },
+  { resourceType: 'AWS::RDS::DBCluster', flag: 'AutoMinorVersionUpgrade' },
+  { resourceType: 'AWS::Neptune::DBInstance', flag: 'AutoMinorVersionUpgrade' },
+  { resourceType: 'AWS::ElastiCache::CacheCluster', flag: 'AutoMinorVersionUpgrade' },
+  { resourceType: 'AWS::ElastiCache::ReplicationGroup', flag: 'AutoMinorVersionUpgrade' },
+  { resourceType: 'AWS::MemoryDB::Cluster', flag: 'AutoMinorVersionUpgrade' },
+  { resourceType: 'AWS::Redshift::Cluster', flag: 'AllowVersionUpgrade' },
+];
+
+describe('#660 item 1 revert: restore-risk booleans converge via set-default, not remove', () => {
+  for (const c of CASES) {
+    it(`${c.resourceType} ${c.flag}=false reverts as set-default \`add true\`, NOT a remove`, () => {
+      const f: Finding = {
+        tier: 'undeclared',
+        unrecorded: true,
+        logicalId: 'R',
+        physicalId: 'r-phys',
+        resourceType: c.resourceType,
+        path: c.flag,
+        actual: false,
+      };
+      const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+      expect(plan.items).toHaveLength(1);
+      // Without the REVERT_SET_DEFAULT_PATHS entry this would be `{ op: 'remove' }`, which the
+      // modify API ignores (a silent no-op) — the live disable would stay disabled.
+      expect(plan.items[0]!.ops[0]).toMatchObject({
+        op: 'add',
+        path: `/${c.flag}`,
+        value: true,
+      });
+    });
+  }
+});


### PR DESCRIPTION
Revert follow-up to #1520 (part of #660 item 1).

## Problem

#1520 made cdkrd **detect** an out-of-band disable of the restore-risk version-upgrade booleans (RDS/ElastiCache/MemoryDB/Neptune `AutoMinorVersionUpgrade`, Redshift `AllowVersionUpgrade`). But detection without a working revert is only half the fix: their modify APIs (`modify-db-instance` / `modify-db-cluster` / `modify-cache-cluster` / `modify-replication-group` / MemoryDB `update-cluster` / Redshift `modify-cluster`) **keep the existing value when the flag is omitted**, so cdkrd's bare `remove` revert is a silent no-op — `check` flags the disable yet `revert` can't fix it.

## Fix

Add the 7 `Type\0Prop` paths to `REVERT_SET_DEFAULT_PATHS` so revert plans an explicit set-default (`add true`) instead of a `remove`. The write value resolves from `KNOWN_DEFAULTS` (the same `true` pin that folds the clean read `atDefault`), so no `REVERT_SET_DEFAULT_VALUES` entry is needed. Same mechanism as the #1519 EKS `EndpointPrivateAccess` and the Cognito/Transfer/AppRunner set-default entries.

## Live A/B (RDS::DBInstance, `Cdkrd660RevertVerify`, us-east-1, 2026-07-12)

Deploy (AutoMinorVersionUpgrade undeclared, reads `true`) → clean `check` CLEAN → `modify-db-instance --no-auto-minor-version-upgrade` (live `false`) → `check` detects `Db.AutoMinorVersionUpgrade`.

- **Pre-fix (installed 0.13.5):** revert planned `AutoMinorVersionUpgrade -> remove`; cdkrd's own convergence re-read reported **`NOT reverted … removal was a no-op (the provider ignored the omitted property … REVERT_SET_DEFAULT_PATHS)`**; `describe-db-instances` stayed `AutoMinorVersionUpgrade=false`.
- **Post-fix (this branch):** revert planned `AutoMinorVersionUpgrade -> AWS default`; convergence re-read did **not** list it as unreverted; `describe-db-instances` read back **`AutoMinorVersionUpgrade=True`** — converged.

RDS::DBInstance is the representative; the sibling types share the same "modify API ignores an omitted flag" behavior and the same set-default resolution (value from KNOWN_DEFAULTS).

## Tests

`tests/revert-restore-booleans-660.test.ts` — per type, asserts the plan is `{ op: 'add', path: '/<flag>', value: true }`, not a `remove`. 7 pass; **all 7 fail without the fix** (they'd plan a `remove`). Full suite 258 files / 5387 tests green.
