### PR TITLE
fix(noise): fold SageMaker MonitoringSchedule AWS-managed runtime-state (#915)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3718,6 +3718,33 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   cfn-exec-role ARN shape: the `cdk-<qualifier>-cfn-exec-role-<acct>-<region>` role folds, any
   //   other RoleARN surfaces as undeclared (recordable, then watched).
   'AWS::CloudFormation::Stack': new Set(['TemplateBody', 'Capabilities']),
+  //   AWS::SageMaker::MonitoringSchedule — the resource schema marks ONLY
+  //   [MonitoringScheduleArn, CreationTime, LastModifiedTime] readOnly, so three AWS-managed
+  //   RUNTIME-STATE props leak as undeclared on a clean deploy (a schema gap — they are
+  //   effectively read-only status, never template intent):
+  //     * `MonitoringScheduleStatus` — the schedule's lifecycle state ("Scheduled" fresh, then
+  //       Pending / Stopped / Failed). A user never declares it; it is operational status, not
+  //       config. First-run FP on EVERY fresh MonitoringSchedule (live-verified 2026-07-12,
+  //       Cdkrd915MonSchedVerify: surfaces "Scheduled" undeclared before any execution).
+  //     * `LastMonitoringExecutionSummary` — the last execution's summary
+  //       ({ScheduledTime, MonitoringExecutionStatus, FailureReason, ...}). It is absent until the
+  //       first execution, then MOVES on every hourly run (ScheduledTime + status change each
+  //       tick) — the exact #847-class time-varying value #915 tracks: class (a) first-check FP AND
+  //       class (b) `record` never converges. The nested CreationTime/LastModifiedTime are already
+  //       ALWAYS_STRIPPED, but ScheduledTime/status/FailureReason are not, so the whole object
+  //       surfaces. Live-verified 2026-07-12 (same stack, after forcing one execution):
+  //       actual={"ScheduledTime":"…","MonitoringExecutionStatus":"Failed","FailureReason":"…"}.
+  //     * `FailureReason` — the schedule-level failure diagnostic (populated only when the
+  //       schedule itself fails); same undeclared-runtime-state class.
+  //   All three are undeclared → whatever AWS assigns is not user intent (the declared config —
+  //   MonitoringScheduleConfig / EndpointName / Tags — is compared in the declared loop, so a real
+  //   config change still surfaces). Fold value-independent: these are moving status/state, not a
+  //   pinnable constant. #915 (case 1).
+  'AWS::SageMaker::MonitoringSchedule': new Set([
+    'MonitoringScheduleStatus',
+    'LastMonitoringExecutionSummary',
+    'FailureReason',
+  ]),
 };
 
 // The NESTED twin of VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS (fold-strategy tier 3, "nested

--- a/tests/noise-sagemaker-monsched-915.test.ts
+++ b/tests/noise-sagemaker-monsched-915.test.ts
@@ -1,0 +1,108 @@
+// #915 (case 1) — AWS::SageMaker::MonitoringSchedule leaks AWS-managed RUNTIME-STATE props as
+// undeclared first-run false positives, because the CFN registry schema marks ONLY
+// [MonitoringScheduleArn, CreationTime, LastModifiedTime] readOnly. The offending props —
+// MonitoringScheduleStatus, LastMonitoringExecutionSummary, FailureReason — are effectively
+// read-only status/state (never template intent), so they fold value-independent via
+// VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS.
+//
+// Live-verified 2026-07-12 on Cdkrd915MonSchedVerify (us-east-1): a fresh MonitoringSchedule
+// surfaced MonitoringScheduleStatus="Scheduled" undeclared before any execution, and after
+// forcing one execution LastMonitoringExecutionSummary surfaced with the moving-value payload
+// asserted below. The nested CreationTime/LastModifiedTime are ALWAYS_STRIPPED; the remaining
+// leaf props (ScheduledTime/MonitoringExecutionStatus/FailureReason) move on every hourly run —
+// the #847-class time-varying value: class (a) first-check FP + class (b) record never converges.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'MonSched',
+  resourceType: 'AWS::SageMaker::MonitoringSchedule',
+  physicalId: 'cdkrd915-monsched',
+  declared,
+});
+
+// What a user's template declares for a MonitoringSchedule: the config + name (+ optional Tags).
+const declared = {
+  MonitoringScheduleName: 'cdkrd915-monsched',
+  MonitoringScheduleConfig: {
+    MonitoringType: 'DataQuality',
+    MonitoringJobDefinitionName: 'cdkrd915-monsched-jobdef',
+    ScheduleConfig: { ScheduleExpression: 'NOW' },
+  },
+};
+
+describe('#915 MonitoringSchedule AWS-managed runtime-state folds', () => {
+  it('folds an undeclared MonitoringScheduleStatus "Scheduled" to atDefault (fresh deploy)', () => {
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, MonitoringScheduleStatus: 'Scheduled' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('MonitoringScheduleStatus');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('MonitoringScheduleStatus');
+  });
+
+  it('folds the undeclared moving LastMonitoringExecutionSummary object to atDefault', () => {
+    // Exact live-harvested payload (post-execution) minus the ALWAYS_STRIPPED nested timestamps.
+    const summary = {
+      ScheduledTime: '2026-07-12T10:21:14Z',
+      MonitoringScheduleName: 'cdkrd915-monsched',
+      FailureReason: 'Job inputs had no data',
+      MonitoringExecutionStatus: 'Failed',
+    };
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, LastMonitoringExecutionSummary: summary },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('LastMonitoringExecutionSummary');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('LastMonitoringExecutionSummary');
+  });
+
+  it('folds an undeclared schedule-level FailureReason to atDefault', () => {
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, FailureReason: 'some failure' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('FailureReason');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('FailureReason');
+  });
+
+  it('a real change to the DECLARED config still surfaces as declared drift (fold does not swallow it)', () => {
+    const liveConfig = {
+      MonitoringType: 'DataQuality',
+      MonitoringJobDefinitionName: 'cdkrd915-monsched-jobdef',
+      // out-of-band edit of the declared schedule expression
+      ScheduleConfig: { ScheduleExpression: 'cron(0 * ? * * *)' },
+    };
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, MonitoringScheduleConfig: liveConfig, MonitoringScheduleStatus: 'Scheduled' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toContain(
+      'MonitoringScheduleConfig.ScheduleConfig.ScheduleExpression'
+    );
+    // the runtime-state fold still applies alongside a real declared-config drift
+    expect(pathsByTier(f, 'atDefault')).toContain('MonitoringScheduleStatus');
+  });
+});


### PR DESCRIPTION
Closes #915 (case 1).

## What

`AWS::SageMaker::MonitoringSchedule` leaks three AWS-managed **runtime-state** props as undeclared first-run false positives, because the CFN registry schema marks only `[MonitoringScheduleArn, CreationTime, LastModifiedTime]` readOnly. They are effectively read-only status/state, never template intent:

| Prop | Class |
|---|---|
| `MonitoringScheduleStatus` | lifecycle state (`"Scheduled"` → Pending/Stopped/Failed); FPs on **every** fresh schedule |
| `LastMonitoringExecutionSummary` | last-execution summary (`{ScheduledTime, MonitoringExecutionStatus, FailureReason, …}`) — the **#847-class time-varying** value #915 case 1 names: moves every hourly execution → class (a) first-check FP + class (b) `record` never converges |
| `FailureReason` | schedule-level failure diagnostic; same undeclared-state class |

Fold **value-independent** (fold-strategy tier 3, `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`): all three are undeclared moving status/state — not a pinnable constant, and never user intent. The declared config (`MonitoringScheduleConfig` / `EndpointName` / `Tags`) is still compared in the declared loop, so a real config change (e.g. a `ScheduleExpression` edit) still surfaces — asserted in the test.

## Live verification

Deployed `Cdkrd915MonSchedVerify` (us-east-1, 2026-07-12): an endpoint-less DataQuality monitor (`DataQualityJobDefinition` + `BatchTransformInput` + a `NOW` `MonitoringSchedule`).

- **Before** (prev binary): `[Potential Drift]` included `MonitoringScheduleStatus="Scheduled"` on the fresh deploy, and after forcing one execution `LastMonitoringExecutionSummary={"ScheduledTime":"2026-07-12T10:21:14Z","MonitoringExecutionStatus":"Failed","FailureReason":"Job inputs had no data"}`.
- **After** (this PR's binary): both fold to `atDefault` (atDefault 7→9, potential drift 5→3) — no longer surfaced.

The nested `CreationTime`/`LastModifiedTime` inside the summary were already stripped by `ALWAYS_STRIPPED`; the remaining leaf props (`ScheduledTime`/status/`FailureReason`) are what moved.

## Test

`tests/noise-sagemaker-monsched-915.test.ts` — folds each of the three (exact live-harvested `LastMonitoringExecutionSummary` payload) and asserts a real declared-config drift still surfaces.

## Not in this PR (found in the same probe, separate class)

The probe also surfaced 3 `DataQualityJobDefinition` undeclared **constant** defaults (`StoppingCondition={MaxRuntimeInSeconds:3600}`, `S3DataDistributionType="FullyReplicated"`, `S3InputMode="File"` — tier-1 `KNOWN_DEFAULT_PATHS` candidates) and a suspected MonitoringSchedule Tags read-gap. Filed separately to keep this PR focused (the harvested live values are recorded there, so no re-deploy is needed).
