### PR TITLE
fix(noise): fold SageMaker DataQualityJobDefinition constant defaults (#1523)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -16,6 +16,13 @@ import { TAG_PROPERTY_NAMES } from './cc-api-strip.js';
 // entries were all OBSERVED on real default-config stacks during dogfooding.
 export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Role': { MaxSessionDuration: 3600, Path: '/', Description: '' },
+  // A DataQuality monitoring job definition that declares no StoppingCondition reads back the
+  // AWS default `{MaxRuntimeInSeconds:3600}` (a fully-undeclared top-level object, so
+  // KNOWN_DEFAULTS not KNOWN_DEFAULT_PATHS). Equality-gated: a user who caps the runtime to a
+  // different value DECLARES StoppingCondition (compared in the declared loop), and an
+  // out-of-band change away from 3600 still surfaces. Live-verified 2026-07-12 on
+  // Cdkrd915MonSchedVerify (us-east-1). #1523.
+  'AWS::SageMaker::DataQualityJobDefinition': { StoppingCondition: { MaxRuntimeInSeconds: 3600 } },
   // A server certificate declared without a Path reads back "/" (the IAM default),
   // exactly like Role/kin above. Equality-gated, so an out-of-band UpdateServerCertificate
   // path move still surfaces. Live-confirmed (#910).
@@ -1743,6 +1750,19 @@ export const KNOWN_DEFAULT_ONE_OF_PATHS: Record<string, Record<string, readonly 
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // A DataQuality monitoring job whose (partially-declared) input reads back the two
+  // AWS-filled transfer defaults the schema documents — `S3DataDistributionType`
+  // ("Defaults to FullyReplicated") and `S3InputMode` ("Defaults to File") — under whichever
+  // input variant is used. Equality-gated, so a user who declares `ShardedByS3Key` / `Pipe`
+  // (or an out-of-band change to one) still surfaces. Live-verified 2026-07-12 on
+  // Cdkrd915MonSchedVerify (BatchTransformInput); the EndpointInput variant shares the
+  // identical schema-documented defaults. #1523.
+  'AWS::SageMaker::DataQualityJobDefinition': {
+    'DataQualityJobInput.BatchTransformInput.S3DataDistributionType': 'FullyReplicated',
+    'DataQualityJobInput.BatchTransformInput.S3InputMode': 'File',
+    'DataQualityJobInput.EndpointInput.S3DataDistributionType': 'FullyReplicated',
+    'DataQualityJobInput.EndpointInput.S3InputMode': 'File',
+  },
   // A lambda TargetGroup's declared `Targets` element reads back an AWS-filled
   // `AvailabilityZone: "all"` husk (a lambda target has no AZ) that the template never declares —
   // the #618 in-element husk class. Equality-gated: a real target with a specific AZ still

--- a/tests/noise-sagemaker-jobdef-1523.test.ts
+++ b/tests/noise-sagemaker-jobdef-1523.test.ts
@@ -1,0 +1,135 @@
+// #1523 (part 1) — AWS::SageMaker::DataQualityJobDefinition materializes three undeclared
+// CONSTANT defaults that FP on a clean deploy:
+//   * StoppingCondition = {MaxRuntimeInSeconds:3600}   (fully-undeclared top-level → KNOWN_DEFAULTS)
+//   * DataQualityJobInput.<Batch|Endpoint>Input.S3DataDistributionType = "FullyReplicated"
+//   * DataQualityJobInput.<Batch|Endpoint>Input.S3InputMode           = "File"
+//     (nested defaults under a partially-declared input → KNOWN_DEFAULT_PATHS)
+// All three are stable schema-documented constants → fold-strategy tier 1 (equality-gated):
+// each folds the exact default and still surfaces any change away from it.
+// Live-verified 2026-07-12 on Cdkrd915MonSchedVerify (us-east-1, BatchTransformInput variant).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const T = 'AWS::SageMaker::DataQualityJobDefinition';
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'JobDef',
+  resourceType: T,
+  physicalId: 'cdkrd915-monsched-jobdef',
+  declared,
+});
+
+// A minimal DataQuality job def: the user declares the required app-spec/input/output/resources,
+// but NOT StoppingCondition and NOT the input's S3* transfer knobs.
+const declaredBatch = {
+  DataQualityAppSpecification: { ImageUri: 'x.dkr.ecr.us-east-1.amazonaws.com/analyzer:latest' },
+  DataQualityJobInput: {
+    BatchTransformInput: {
+      DataCapturedDestinationS3Uri: 's3://b/captured/',
+      DatasetFormat: { Csv: { Header: true } },
+      LocalPath: '/opt/ml/processing/input',
+    },
+  },
+  RoleArn: 'arn:aws:iam::111111111111:role/r',
+};
+
+describe('#1523 DataQualityJobDefinition constant defaults', () => {
+  it('folds an undeclared StoppingCondition {MaxRuntimeInSeconds:3600} to atDefault', () => {
+    const f = classifyResource(
+      mk(declaredBatch),
+      { ...declaredBatch, StoppingCondition: { MaxRuntimeInSeconds: 3600 } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('StoppingCondition');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('StoppingCondition');
+  });
+
+  it('a non-default undeclared StoppingCondition still surfaces (equality gate)', () => {
+    const f = classifyResource(
+      mk(declaredBatch),
+      { ...declaredBatch, StoppingCondition: { MaxRuntimeInSeconds: 7200 } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).not.toContain('StoppingCondition');
+    expect(pathsByTier(f, 'undeclared')).toContain('StoppingCondition');
+  });
+
+  it('folds the undeclared BatchTransformInput S3 transfer defaults to atDefault', () => {
+    const live = {
+      ...declaredBatch,
+      DataQualityJobInput: {
+        BatchTransformInput: {
+          ...declaredBatch.DataQualityJobInput.BatchTransformInput,
+          S3DataDistributionType: 'FullyReplicated',
+          S3InputMode: 'File',
+        },
+      },
+    };
+    const f = classifyResource(mk(declaredBatch), live, emptySchema);
+    const atDefault = pathsByTier(f, 'atDefault');
+    expect(atDefault).toContain('DataQualityJobInput.BatchTransformInput.S3DataDistributionType');
+    expect(atDefault).toContain('DataQualityJobInput.BatchTransformInput.S3InputMode');
+    expect(pathsByTier(f, 'undeclared')).toHaveLength(0);
+  });
+
+  it('a non-default S3DataDistributionType still surfaces (equality gate)', () => {
+    const live = {
+      ...declaredBatch,
+      DataQualityJobInput: {
+        BatchTransformInput: {
+          ...declaredBatch.DataQualityJobInput.BatchTransformInput,
+          S3DataDistributionType: 'ShardedByS3Key',
+          S3InputMode: 'File',
+        },
+      },
+    };
+    const f = classifyResource(mk(declaredBatch), live, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain(
+      'DataQualityJobInput.BatchTransformInput.S3DataDistributionType'
+    );
+    // the sibling File default still folds
+    expect(pathsByTier(f, 'atDefault')).toContain(
+      'DataQualityJobInput.BatchTransformInput.S3InputMode'
+    );
+  });
+
+  it('folds the EndpointInput variant S3 transfer defaults too', () => {
+    const declaredEndpoint = {
+      ...declaredBatch,
+      DataQualityJobInput: {
+        EndpointInput: { EndpointName: 'ep', LocalPath: '/opt/ml/processing/input' },
+      },
+    };
+    const live = {
+      ...declaredEndpoint,
+      DataQualityJobInput: {
+        EndpointInput: {
+          ...declaredEndpoint.DataQualityJobInput.EndpointInput,
+          S3DataDistributionType: 'FullyReplicated',
+          S3InputMode: 'File',
+        },
+      },
+    };
+    const f = classifyResource(mk(declaredEndpoint), live, emptySchema);
+    const atDefault = pathsByTier(f, 'atDefault');
+    expect(atDefault).toContain('DataQualityJobInput.EndpointInput.S3DataDistributionType');
+    expect(atDefault).toContain('DataQualityJobInput.EndpointInput.S3InputMode');
+  });
+});


### PR DESCRIPTION
Closes #1523 (part 1 — DataQualityJobDefinition constant defaults). Part 2 (suspected MonitoringSchedule Tags read-gap) stays open — it needs a fresh live probe.

## What

A minimal `AWS::SageMaker::DataQualityJobDefinition` materializes three undeclared **constant** defaults that surface as `[Potential Drift]` on a clean first check:

| Path | Default | Fold |
|---|---|---|
| `StoppingCondition` | `{MaxRuntimeInSeconds:3600}` | `KNOWN_DEFAULTS` (whole object — fully undeclared top-level) |
| `DataQualityJobInput.<Batch\|Endpoint>Input.S3DataDistributionType` | `"FullyReplicated"` | `KNOWN_DEFAULT_PATHS` (nested, partially-declared input) |
| `DataQualityJobInput.<Batch\|Endpoint>Input.S3InputMode` | `"File"` | `KNOWN_DEFAULT_PATHS` |

All three are stable, schema-documented constants → **fold-strategy tier 1 (equality-gated)**: each folds the exact default and still surfaces any change away from it (a user who declares `ShardedByS3Key` / `Pipe`, or an out-of-band edit).

## Live evidence

Observed 2026-07-12 on `Cdkrd915MonSchedVerify` (us-east-1) during the #915 case-1 probe — the harvested values are recorded on #1523. `cdkrd check` reported exactly:
```
JobDef.StoppingCondition                                          {"MaxRuntimeInSeconds":3600}
JobDef.DataQualityJobInput.BatchTransformInput.S3DataDistributionType   "FullyReplicated"
JobDef.DataQualityJobInput.BatchTransformInput.S3InputMode              "File"
```
The `BatchTransformInput` variant is live-proven; the `EndpointInput` variant shares the identical schema-documented defaults (`"Defaults to FullyReplicated"` / `"Defaults to File"`), folded by the same equality gate.

## Test

`tests/noise-sagemaker-jobdef-1523.test.ts` — folds each default (from the live values) AND asserts a non-default (`{MaxRuntimeInSeconds:7200}`, `ShardedByS3Key`) still surfaces, for both input variants.

## Out of scope

The sibling `ModelQuality/ModelBias/ModelExplainabilityJobDefinition` types very likely share these `BatchTransformInput`/`StoppingCondition` shapes but are not live-proven here — left for a future probe. #1523 part 2 (MonitoringSchedule Tags read-gap) needs its own live confirmation.
