### PR TITLE
fix(read): SDK override for SageMaker MonitoringSchedule to read Tags (#1523)

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,10 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `AWS::SageMaker::EndpointConfig` — its production-variant model wiring, plus the
   tags a separate `ListTags` call supplies since `DescribeEndpointConfig` omits
   them),
+  `sagemaker:DescribeMonitoringSchedule` + `sagemaker:ListTags` (read an
+  `AWS::SageMaker::MonitoringSchedule` — the Cloud Control read omits `Tags`, so
+  a declared `Tags` false-flagged as drift on every tagged schedule; a separate
+  `ListTags` call supplies them),
   `codebuild:BatchGetProjects` (reads an `AWS::CodeBuild::Project`) +
   `codebuild:BatchGetReportGroups` (reads an `AWS::CodeBuild::ReportGroup`),
   `dax:DescribeClusters` + `dax:DescribeParameterGroups` + `dax:DescribeParameters` +

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -168,6 +168,7 @@ import {
 import { DescribeParametersCommand, SSMClient } from '@aws-sdk/client-ssm';
 import {
   DescribeEndpointConfigCommand,
+  DescribeMonitoringScheduleCommand,
   ListTagsCommand as SageMakerListTagsCommand,
   type ProductionVariant,
   SageMakerClient,
@@ -2160,6 +2161,72 @@ const readSageMakerEndpointConfig: OverrideReader = async ({
   return model;
 };
 
+// AWS::SageMaker::MonitoringSchedule — the CC API read handler DOES return the resource, but its
+// response OMITS `Tags` (a fresh DescribeMonitoringSchedule returns no Tags field), so a declared
+// non-empty Tags array read back as Tags=undefined → a false `declared`-tier `desired=[…]
+// actual=undefined` drift on every tagged monitoring schedule (a `Tags.of(app)` app tags them
+// all). Live-confirmed 2026-07-12 (Cdkrd1523TagsVerify: declared team=drift-probe + cdkrd:ephemeral,
+// live via sagemaker:ListTags, cdkrd reported Tags actual=undefined). #1523 (part 2).
+//
+// Read via DescribeMonitoringSchedule + a separate sagemaker:ListTags, projecting ONLY the
+// CFn-declarable surface: MonitoringScheduleName, MonitoringScheduleConfig (the SDK shape is 1:1
+// with the CFn definition — MonitoringType / MonitoringJobDefinitionName-or-inline
+// MonitoringJobDefinition / ScheduleConfig — verified live), EndpointName, and Tags. The
+// AWS-managed readOnly response fields the registry schema marks readOnly (MonitoringScheduleArn /
+// CreationTime / LastModifiedTime) AND the runtime-STATE fields it UNDER-marks as non-readOnly
+// (MonitoringScheduleStatus / FailureReason / LastMonitoringExecutionSummary, plus the top-level
+// MonitoringType echo) are dropped — projecting them would be a permanent undeclared false
+// inventory (the #1522 value-independent fold that previously swallowed them from the CC read is
+// now moot for this resource, but harmless as a fallback). On a ListTags failure, MIRROR declared
+// Tags + warn (the readSageMakerEndpointConfig / #1086 degrade shape) so a permission gap does not
+// false-flag. A deleted schedule throws ValidationException → ResourceGoneError → router maps to
+// `deleted`.
+const readSageMakerMonitoringSchedule: OverrideReader = async ({
+  physicalId,
+  declared,
+  region,
+  accountId,
+}) => {
+  // The CFn PhysicalResourceId is the schedule ARN
+  // (arn:…:monitoring-schedule/<name>), but DescribeMonitoringSchedule requires the BARE name
+  // (≤63 chars) — passing the ARN ValidationExceptions and the whole resource skips. Extract the
+  // last ARN segment; a non-ARN physical id (or the declared name) passes through unchanged.
+  const raw = str(physicalId) ?? str(declared.MonitoringScheduleName);
+  if (!raw) return undefined;
+  const name = raw.startsWith('arn:') ? (raw.split('/').pop() ?? raw) : raw;
+  const c = new SageMakerClient({ region, ...READ_RETRY });
+  const r = await c.send(new DescribeMonitoringScheduleCommand({ MonitoringScheduleName: name }));
+  if (!r.MonitoringScheduleName)
+    throw new ResourceGoneError(`SageMaker MonitoringSchedule ${name} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(r.MonitoringScheduleName)) model.MonitoringScheduleName = r.MonitoringScheduleName;
+  if (r.MonitoringScheduleConfig !== undefined)
+    model.MonitoringScheduleConfig = r.MonitoringScheduleConfig;
+  if (str(r.EndpointName)) model.EndpointName = r.EndpointName;
+  // Tags — a separate SageMaker sagemaker:ListTags call keyed on the MonitoringScheduleArn (the
+  // response's ARN, else synthesize it). On failure, mirror declared Tags + warn (see note).
+  const tagArn =
+    str(r.MonitoringScheduleArn) ??
+    (accountId
+      ? `arn:${partitionForRegion(region).partition}:sagemaker:${region}:${accountId}:monitoring-schedule/${name}`
+      : undefined);
+  if (tagArn) {
+    try {
+      const t = await c.send(new SageMakerListTagsCommand({ ResourceArn: tagArn }));
+      const tags = projectTagList(t.Tags);
+      if (tags) model.Tags = tags;
+    } catch (err) {
+      const mirrored = mirrorDeclaredTags(declared.Tags);
+      if (mirrored) model.Tags = mirrored;
+      const call = (err as Error)?.name || 'unknown error';
+      process.stderr.write(
+        `[cdkrd] warning: SageMaker ListTags for MonitoringSchedule (${tagArn}) failed (${call}) — mirroring declared Tags to avoid a false drift; grant sagemaker:ListTags to detect out-of-band tag changes\n`
+      );
+    }
+  }
+  return model;
+};
+
 // AWS::Logs::MetricFilter — CC API GetResource throws ValidationException. Read via
 // CloudWatch Logs DescribeMetricFilters. The CFn physical id IS the filter name;
 // the log group comes from the declared (GetAtt-resolved) LogGroupName.
@@ -3169,6 +3236,7 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::Glue::Connection': readGlueConnection,
   'AWS::Glue::SecurityConfiguration': readGlueSecurityConfiguration,
   'AWS::SageMaker::EndpointConfig': readSageMakerEndpointConfig,
+  'AWS::SageMaker::MonitoringSchedule': readSageMakerMonitoringSchedule,
   'AWS::Logs::MetricFilter': readMetricFilter,
   'AWS::Scheduler::Schedule': readSchedulerSchedule,
 };

--- a/tests/overrides-sagemaker-monsched-1523.test.ts
+++ b/tests/overrides-sagemaker-monsched-1523.test.ts
@@ -1,0 +1,101 @@
+import {
+  DescribeMonitoringScheduleCommand,
+  ListTagsCommand as SageMakerListTagsCommand,
+  type MonitoringScheduleConfig,
+  SageMakerClient,
+} from '@aws-sdk/client-sagemaker';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+// #1523 (part 2) — AWS::SageMaker::MonitoringSchedule IS readable via Cloud Control, but the CC
+// response OMITS Tags, so a declared Tags array read back as undefined → a false declared-tier
+// `desired=[…] actual=undefined` drift on every tagged schedule. The SDK override reads it via
+// DescribeMonitoringSchedule + a separate sagemaker:ListTags, projecting only the CFn-declarable
+// surface (name / config / EndpointName / Tags) and dropping the runtime-STATE fields. Live-proven
+// 2026-07-12 on Cdkrd1523TagsVerify: old surfaced Tags actual=undefined, the override reads them
+// back (matching → CLEAN) and a real out-of-band tag change still surfaces.
+
+const sagemaker = mockClient(SageMakerClient);
+const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId,
+});
+const read = SDK_OVERRIDES['AWS::SageMaker::MonitoringSchedule']!;
+
+const CONFIG: MonitoringScheduleConfig = {
+  MonitoringType: 'DataQuality',
+  MonitoringJobDefinitionName: 'jd',
+  ScheduleConfig: { ScheduleExpression: 'cron(0 * ? * * *)' },
+};
+
+beforeEach(() => {
+  sagemaker.reset();
+  sagemaker.on(SageMakerListTagsCommand).resolves({ Tags: [] });
+});
+
+describe('SageMaker MonitoringSchedule override (#1523)', () => {
+  it('extracts the bare name from an ARN physical id and projects only the CFn surface + Tags', async () => {
+    sagemaker.on(DescribeMonitoringScheduleCommand).resolves({
+      MonitoringScheduleName: 'ms',
+      MonitoringScheduleArn: 'arn:aws:sagemaker:us-east-1:123456789012:monitoring-schedule/ms',
+      MonitoringScheduleConfig: CONFIG,
+      // runtime-STATE + readOnly response fields that must NOT be projected:
+      MonitoringScheduleStatus: 'Scheduled',
+      MonitoringType: 'DataQuality',
+      CreationTime: new Date(0),
+      LastModifiedTime: new Date(0),
+    });
+    sagemaker
+      .on(SageMakerListTagsCommand)
+      .resolves({ Tags: [{ Key: 'team', Value: 'drift-probe' }] });
+
+    const model = await read(
+      ctx(
+        { MonitoringScheduleName: 'ms', Tags: [{ Key: 'team', Value: 'drift-probe' }] },
+        'arn:aws:sagemaker:us-east-1:123456789012:monitoring-schedule/ms'
+      )
+    );
+
+    // the DescribeMonitoringSchedule call received the BARE name, not the ARN
+    const call = sagemaker.commandCalls(DescribeMonitoringScheduleCommand)[0]!;
+    expect((call.args[0].input as { MonitoringScheduleName?: string }).MonitoringScheduleName).toBe(
+      'ms'
+    );
+
+    expect(model).toStrictEqual({
+      MonitoringScheduleName: 'ms',
+      MonitoringScheduleConfig: CONFIG,
+      Tags: [{ Key: 'team', Value: 'drift-probe' }],
+    });
+    // runtime-state / readOnly response fields are dropped
+    expect(model).not.toHaveProperty('MonitoringScheduleStatus');
+    expect(model).not.toHaveProperty('MonitoringType');
+    expect(model).not.toHaveProperty('CreationTime');
+  });
+
+  it('omits Tags when there are none (absent stays absent = FP-safe)', async () => {
+    sagemaker.on(DescribeMonitoringScheduleCommand).resolves({
+      MonitoringScheduleName: 'ms',
+      MonitoringScheduleArn: 'arn:aws:sagemaker:us-east-1:123456789012:monitoring-schedule/ms',
+      MonitoringScheduleConfig: CONFIG,
+    });
+    const model = await read(ctx({ MonitoringScheduleName: 'ms' }, 'ms'));
+    expect(model).not.toHaveProperty('Tags');
+  });
+
+  it('mirrors declared Tags (no false drift) when ListTags fails', async () => {
+    sagemaker.on(DescribeMonitoringScheduleCommand).resolves({
+      MonitoringScheduleName: 'ms',
+      MonitoringScheduleArn: 'arn:aws:sagemaker:us-east-1:123456789012:monitoring-schedule/ms',
+      MonitoringScheduleConfig: CONFIG,
+    });
+    sagemaker.on(SageMakerListTagsCommand).rejects(new Error('AccessDenied'));
+    const declaredTags = [{ Key: 'team', Value: 'drift-probe' }];
+    const model = await read(ctx({ MonitoringScheduleName: 'ms', Tags: declaredTags }, 'ms'));
+    // degrade path: mirror the declared Tags so a permission gap does not false-flag
+    expect((model as { Tags?: unknown }).Tags).toStrictEqual(declaredTags);
+  });
+});


### PR DESCRIPTION
Closes #1523 (part 2 — MonitoringSchedule Tags read-gap). This closes #1523 fully (part 1 shipped in #1524 / v0.13.8).

## The bug

`AWS::SageMaker::MonitoringSchedule` **is** readable via Cloud Control, but the CC response **omits `Tags`**. So a declared `Tags` array reads back as `undefined` → a false `[CFn-Declared Drift]` `desired=[…] actual=undefined` on **every tagged schedule** (a `Tags.of(app)` app tags them all). Confirmed live 2026-07-12 (`Cdkrd1523TagsVerify`: live tags `[cdkrd:ephemeral, team=drift-probe]` via `sagemaker:ListTags`, cdkrd reported `Tags actual=undefined`).

## The fix

An `SDK_OVERRIDES` reader (`DescribeMonitoringSchedule` + a separate `sagemaker:ListTags`) that projects **only the CFn-declarable surface** — `MonitoringScheduleName` / `MonitoringScheduleConfig` (SDK shape is 1:1 with the CFn definition, verified live) / `EndpointName` / `Tags` — and drops the AWS-managed readOnly fields **and** the runtime-STATE fields the schema under-marks as non-readOnly (`MonitoringScheduleStatus` / `FailureReason` / `LastMonitoringExecutionSummary`).

Key subtlety: the CFn `PhysicalResourceId` is the schedule **ARN**, but `DescribeMonitoringSchedule` needs the **bare name** (≤63 chars) — passing the ARN `ValidationException`s and the whole resource **skips** (silently masking the very drift we're detecting). The reader extracts the last ARN segment. On a `ListTags` failure it mirrors declared Tags + warns (the `EndpointConfig` / #1086 degrade shape).

## Live verification (both directions)

`Cdkrd1523TagsVerify` (us-east-1), a MonitoringSchedule with `Tags` declared via CFN:

| | v0.13.8 (CC) | this PR |
|---|---|---|
| declared Tags match live | `MonSched.Tags actual=undefined` (false drift) | **CLEAN** |
| out-of-band `team` value change | (masked) | **DETECTED** — `MonSched.Tags.1.Value desired="drift-probe" actual="hijacked"` |

FP fixed, detection preserved, no skip-masking, no new FPs on the other schedule props.

## Test

`tests/overrides-sagemaker-monsched-1523.test.ts` — mocks the SageMaker client: asserts the ARN→bare-name extraction (the `DescribeMonitoringSchedule` call receives the name, not the ARN), the CFn-surface projection (state/readOnly fields dropped), Tags projection, and the mirror-declared-Tags degrade on a `ListTags` failure.

Docs: README's SDK-override IAM permission list gains `sagemaker:DescribeMonitoringSchedule`.
