### PR TITLE
fix(read): unskip SageMaker EndpointConfig ARN physical id + fold MediaConvert/SageMaker Model first-run defaults

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -500,6 +500,25 @@ the sentinel by hand to bypass the gate.
   DECLARED dimension is FP-free; undeclared mis-classification is snapshotted away.
   To probe it, `check` BEFORE record and read the `atDefault`/`unresolved`/`[Not
 Recorded]` breakdown with `--verbose`.
+- **An FN detect-test needs a `record` between the clean first check and the
+  out-of-band mutation.** Without a baseline, the mutated value surfaces only as
+  `[Potential Drift]` and `check --fail` still exits 0 — the test false-fails on the
+  exit-code assert even though detection worked (hit live on the MediaConvert Queue
+  pause, #1526). Sequence: deploy → first check CLEAN → `record --yes` → mutate →
+  `check --fail` MUST exit 1 (confirmed drift) → restore → CLEAN.
+- **A harvested corpus case can embed a credential-shaped physical id that
+  git-secrets rightly blocks at commit.** An `AWS::IAM::AccessKey` case's physicalId
+  IS a real `AKIA…` id (the corpus recorder strips account ids, not access-key ids).
+  Sanitize before committing: replace every occurrence with AWS's documented example
+  id `AKIAIOSFODNN7EXAMPLE` (consistent replace keeps the case self-consistent;
+  corpus-replay only needs internal equality) and re-run `corpus-replay` (#1526 PR).
+- **When a reader's physical-id-shape assumption breaks (name vs ARN), grep the
+  SAME service family's sibling readers for the identical assumption — in both
+  directions.** readSageMakerEndpointConfig passed the ARN physical id as the bare
+  name and ValidationExceptioned on every read (#1527) while its sibling
+  readSageMakerMonitoringSchedule had already fixed exactly that (#1523) — the fix
+  existed one function away. A physical-id shape is per-type but the MISTAKE is
+  per-family; audit siblings before shipping a one-type fix.
 - **Immutable props can't drift.** Don't treat an `unresolved`/unverifiable
   create-only property (Subnet `AvailabilityZone` via `Fn::Select(Fn::GetAZs)`, NAT
   `AllocationId` via `Fn::GetAtt` EIP) as a bug — it's correctly classified. And

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -94,6 +94,26 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // undeclared drift. Observed live on a fresh minimal mysql source endpoint
   // (case-idents-min, 2026-07-12; #1490).
   'AWS::DMS::Endpoint': { SslMode: 'none' },
+  // A MediaConvert queue that declares only its Name reads back the two constant
+  // creation defaults: PricingPlan "ON_DEMAND" (the only value CreateQueue assigns
+  // undeclared; RESERVED requires an explicit reservation plan) and Status "ACTIVE".
+  // Equality-gated, so the classic console pause (Status -> PAUSED) or a reserved-queue
+  // conversion still surfaces as real undeclared drift. Observed live on a fresh barest
+  // queue (mediaconvert-min, 2026-07-12).
+  'AWS::MediaConvert::Queue': { PricingPlan: 'ON_DEMAND', Status: 'ACTIVE' },
+  // A MediaConvert job template that declares only Name + SettingsJson reads back three
+  // constant creation defaults: Priority 0, StatusUpdateInterval "SECONDS_60" (the
+  // documented CloudWatch STATUS_UPDATE cadence default), and the fully-undeclared
+  // AccelerationSettings {Mode: "DISABLED"} husk (a whole live-only object, so
+  // KNOWN_DEFAULTS not KNOWN_DEFAULT_PATHS; subset-tolerant deep equality gates it).
+  // Equality-gated, so an out-of-band priority bump, a faster update cadence, or
+  // enabling accelerated transcoding still surfaces. Observed live on a fresh barest
+  // template (mediaconvert-min, 2026-07-12).
+  'AWS::MediaConvert::JobTemplate': {
+    Priority: 0,
+    StatusUpdateInterval: 'SECONDS_60',
+    AccelerationSettings: { Mode: 'DISABLED' },
+  },
   // A SELF_MANAGED StackSet that declares no ExecutionRoleName reads back the documented
   // conventional default. Equality-gated: an out-of-band switch to a custom execution
   // role no longer matches and re-surfaces. (The AdministrationRoleARN sibling is
@@ -1762,6 +1782,16 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'DataQualityJobInput.BatchTransformInput.S3InputMode': 'File',
     'DataQualityJobInput.EndpointInput.S3DataDistributionType': 'FullyReplicated',
     'DataQualityJobInput.EndpointInput.S3InputMode': 'File',
+  },
+  // A SageMaker model whose container definition declares only the Image reads back the
+  // AWS-filled `Mode: "SingleModel"` — the constant creation default for a container that
+  // never declares it (the only other value, MultiModel, is an explicit opt-in). Both the
+  // single-container (PrimaryContainer) and multi-container (Containers, identity-keyed)
+  // shapes share the definition. Equality-gated, so an out-of-band MultiModel flip still
+  // surfaces. Observed live on a fresh barest model (sagemaker-epc-min, 2026-07-12).
+  'AWS::SageMaker::Model': {
+    'PrimaryContainer.Mode': 'SingleModel',
+    'Containers.*.Mode': 'SingleModel',
   },
   // A lambda TargetGroup's declared `Targets` element reads back an AWS-filled
   // `AvailabilityZone: "all"` husk (a lambda target has no AZ) that the template never declares —

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -2114,8 +2114,15 @@ const readSageMakerEndpointConfig: OverrideReader = async ({
   region,
   accountId,
 }) => {
-  const name = str(physicalId) ?? str(declared.EndpointConfigName);
-  if (!name) return undefined;
+  // The CFn PhysicalResourceId is the endpoint-config ARN
+  // (arn:…:endpoint-config/<name>), but DescribeEndpointConfig requires the BARE name —
+  // passing the ARN ValidationExceptions and the whole resource skips (the reader never
+  // worked for a CFn-created config; live-confirmed 2026-07-12). Extract the last ARN
+  // segment — the readSageMakerMonitoringSchedule (#1523) shape; a non-ARN physical id
+  // (or the declared name) passes through unchanged.
+  const raw = str(physicalId) ?? str(declared.EndpointConfigName);
+  if (!raw) return undefined;
+  const name = raw.startsWith('arn:') ? (raw.split('/').pop() ?? raw) : raw;
   const c = new SageMakerClient({ region, ...READ_RETRY });
   // A deleted config throws ValidationException ("Could not find endpoint configuration") →
   // the router maps it to `deleted`; it is not swallowed as an empty model.

--- a/tests/corpus/AWS__CodeBuild__ReportGroup.HuntReportGroup.json
+++ b/tests/corpus/AWS__CodeBuild__ReportGroup.HuntReportGroup.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntReportGroup",
+    "resourceType": "AWS::CodeBuild::ReportGroup",
+    "physicalId": "arn:aws:codebuild:us-east-1:111111111111:report-group/HuntReportGroup-iovthJjjZgUG",
+    "constructPath": "CdkRealDriftIntegReportGroupSecConfigMin/HuntReportGroup",
+    "declared": {
+      "ExportConfig": {
+        "ExportConfigType": "NO_EXPORT"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Type": "TEST"
+    }
+  },
+  "liveRaw": {
+    "Name": "HuntReportGroup-iovthJjjZgUG",
+    "Type": "TEST",
+    "ExportConfig": {
+      "ExportConfigType": "NO_EXPORT"
+    },
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkRealDriftIntegReportGroupSecConfigMin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntReportGroup"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegReportGroupSecConfigMin/af10afa0-7df2-11f1-a89c-0affd06347cb"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Type"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "HuntReportGroup",
+      "resourceType": "AWS::CodeBuild::ReportGroup",
+      "path": "Name",
+      "actual": "HuntReportGroup-iovthJjjZgUG",
+      "physicalId": "arn:aws:codebuild:us-east-1:111111111111:report-group/HuntReportGroup-iovthJjjZgUG",
+      "constructPath": "CdkRealDriftIntegReportGroupSecConfigMin/HuntReportGroup"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__SecurityConfiguration.HuntSecConfig.json
+++ b/tests/corpus/AWS__Glue__SecurityConfiguration.HuntSecConfig.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntSecConfig",
+    "resourceType": "AWS::Glue::SecurityConfiguration",
+    "physicalId": "cdkrd-hunt-glue-secconfig",
+    "constructPath": "CdkRealDriftIntegReportGroupSecConfigMin/HuntSecConfig",
+    "declared": {
+      "EncryptionConfiguration": {
+        "S3Encryptions": [
+          {
+            "S3EncryptionMode": "SSE-S3"
+          }
+        ]
+      },
+      "Name": "cdkrd-hunt-glue-secconfig"
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt-glue-secconfig",
+    "EncryptionConfiguration": {
+      "S3Encryptions": [
+        {
+          "S3EncryptionMode": "SSE-S3"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__AccessKey.HuntAccessKey.json
+++ b/tests/corpus/AWS__IAM__AccessKey.HuntAccessKey.json
@@ -1,0 +1,46 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntAccessKey",
+    "resourceType": "AWS::IAM::AccessKey",
+    "physicalId": "AKIAIOSFODNN7EXAMPLE",
+    "constructPath": "CdkRealDriftIntegIamAccessKeyMin/HuntAccessKey",
+    "declared": {
+      "UserName": "cdkrd-hunt-accesskey-user"
+    }
+  },
+  "liveRaw": {
+    "UserName": "cdkrd-hunt-accesskey-user",
+    "Status": "Active"
+  },
+  "schema": {
+    "readOnly": ["Id", "SecretAccessKey"],
+    "writeOnly": [],
+    "createOnly": ["Serial", "UserName"],
+    "readOnlyPaths": ["Id", "SecretAccessKey"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Serial", "UserName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAccessKey",
+      "resourceType": "AWS::IAM::AccessKey",
+      "path": "Status",
+      "actual": "Active",
+      "physicalId": "AKIAIOSFODNN7EXAMPLE",
+      "constructPath": "CdkRealDriftIntegIamAccessKeyMin/HuntAccessKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__MediaConvert__JobTemplate.HuntJobTemplate.json
+++ b/tests/corpus/AWS__MediaConvert__JobTemplate.HuntJobTemplate.json
@@ -1,0 +1,139 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntJobTemplate",
+    "resourceType": "AWS::MediaConvert::JobTemplate",
+    "physicalId": "cdkrd-hunt-mc-jobtemplate",
+    "constructPath": "CdkRealDriftIntegMediaConvertMin/HuntJobTemplate",
+    "declared": {
+      "Name": "cdkrd-hunt-mc-jobtemplate",
+      "SettingsJson": {
+        "OutputGroups": [
+          {
+            "Name": "File Group",
+            "OutputGroupSettings": {
+              "Type": "FILE_GROUP_SETTINGS",
+              "FileGroupSettings": {}
+            },
+            "Outputs": [
+              {
+                "ContainerSettings": {
+                  "Container": "MP4"
+                },
+                "AudioDescriptions": [
+                  {
+                    "CodecSettings": {
+                      "Codec": "AAC",
+                      "AacSettings": {
+                        "Bitrate": 96000,
+                        "CodingMode": "CODING_MODE_2_0",
+                        "SampleRate": 48000
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt-mc-jobtemplate",
+    "Priority": 0,
+    "StatusUpdateInterval": "SECONDS_60",
+    "AccelerationSettings": {
+      "Mode": "DISABLED"
+    },
+    "SettingsJson": {
+      "OutputGroups": [
+        {
+          "Name": "File Group",
+          "OutputGroupSettings": {
+            "FileGroupSettings": {},
+            "Type": "FILE_GROUP_SETTINGS"
+          },
+          "Outputs": [
+            {
+              "AudioDescriptions": [
+                {
+                  "CodecSettings": {
+                    "AacSettings": {
+                      "Bitrate": 96000,
+                      "CodingMode": "CODING_MODE_2_0",
+                      "SampleRate": 48000
+                    },
+                    "Codec": "AAC"
+                  }
+                }
+              ],
+              "ContainerSettings": {
+                "Container": "MP4"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Tags": {
+      "aws:cloudformation:logical-id": "HuntJobTemplate",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMediaConvertMin/542a0180-7df3-11f1-adce-0e08da467277",
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegMediaConvertMin",
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJobTemplate",
+      "resourceType": "AWS::MediaConvert::JobTemplate",
+      "path": "Priority",
+      "actual": 0,
+      "physicalId": "cdkrd-hunt-mc-jobtemplate",
+      "constructPath": "CdkRealDriftIntegMediaConvertMin/HuntJobTemplate"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJobTemplate",
+      "resourceType": "AWS::MediaConvert::JobTemplate",
+      "path": "StatusUpdateInterval",
+      "actual": "SECONDS_60",
+      "physicalId": "cdkrd-hunt-mc-jobtemplate",
+      "constructPath": "CdkRealDriftIntegMediaConvertMin/HuntJobTemplate"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJobTemplate",
+      "resourceType": "AWS::MediaConvert::JobTemplate",
+      "path": "AccelerationSettings",
+      "actual": {
+        "Mode": "DISABLED"
+      },
+      "physicalId": "cdkrd-hunt-mc-jobtemplate",
+      "constructPath": "CdkRealDriftIntegMediaConvertMin/HuntJobTemplate"
+    }
+  ]
+}

--- a/tests/corpus/AWS__MediaConvert__Queue.HuntQueue.json
+++ b/tests/corpus/AWS__MediaConvert__Queue.HuntQueue.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntQueue",
+    "resourceType": "AWS::MediaConvert::Queue",
+    "physicalId": "cdkrd-hunt-mc-queue",
+    "constructPath": "CdkRealDriftIntegMediaConvertMin/HuntQueue",
+    "declared": {
+      "Name": "cdkrd-hunt-mc-queue",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt-mc-queue",
+    "PricingPlan": "ON_DEMAND",
+    "Status": "ACTIVE",
+    "Tags": {
+      "aws:cloudformation:logical-id": "HuntQueue",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMediaConvertMin/542a0180-7df3-11f1-adce-0e08da467277",
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegMediaConvertMin",
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntQueue",
+      "resourceType": "AWS::MediaConvert::Queue",
+      "path": "PricingPlan",
+      "actual": "ON_DEMAND",
+      "physicalId": "cdkrd-hunt-mc-queue",
+      "constructPath": "CdkRealDriftIntegMediaConvertMin/HuntQueue"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntQueue",
+      "resourceType": "AWS::MediaConvert::Queue",
+      "path": "Status",
+      "actual": "ACTIVE",
+      "physicalId": "cdkrd-hunt-mc-queue",
+      "constructPath": "CdkRealDriftIntegMediaConvertMin/HuntQueue"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SageMaker__EndpointConfig.HuntEpc.json
+++ b/tests/corpus/AWS__SageMaker__EndpointConfig.HuntEpc.json
@@ -1,0 +1,108 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEpc",
+    "resourceType": "AWS::SageMaker::EndpointConfig",
+    "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:endpoint-config/HuntEpc-DhHc8drF9UQu",
+    "constructPath": "CdkRealDriftIntegSmEpcMin/HuntEpc",
+    "declared": {
+      "ProductionVariants": [
+        {
+          "InitialInstanceCount": 1,
+          "InstanceType": "ml.t2.medium",
+          "ModelName": "HuntModel-gv2gcUBdX0FA",
+          "VariantName": "AllTraffic"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EndpointConfigName": "HuntEpc-DhHc8drF9UQu",
+    "ProductionVariants": [
+      {
+        "VariantName": "AllTraffic",
+        "ModelName": "HuntModel-gv2gcUBdX0FA",
+        "InitialInstanceCount": 1,
+        "InstanceType": "ml.t2.medium",
+        "InitialVariantWeight": 1
+      }
+    ],
+    "EnableNetworkIsolation": false,
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkRealDriftIntegSmEpcMin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntEpc"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSmEpcMin/6b395e10-7df4-11f1-b579-123782941c49"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "AsyncInferenceConfig",
+      "DataCaptureConfig",
+      "EnableNetworkIsolation",
+      "EndpointConfigName",
+      "ExecutionRoleArn",
+      "ExplainerConfig",
+      "KmsKeyId",
+      "ProductionVariants",
+      "ShadowProductionVariants",
+      "VpcConfig"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AsyncInferenceConfig",
+      "DataCaptureConfig",
+      "EnableNetworkIsolation",
+      "EndpointConfigName",
+      "ExecutionRoleArn",
+      "ExplainerConfig",
+      "KmsKeyId",
+      "ProductionVariants",
+      "ShadowProductionVariants",
+      "VpcConfig"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "HuntEpc",
+      "resourceType": "AWS::SageMaker::EndpointConfig",
+      "path": "EndpointConfigName",
+      "actual": "HuntEpc-DhHc8drF9UQu",
+      "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:endpoint-config/HuntEpc-DhHc8drF9UQu",
+      "constructPath": "CdkRealDriftIntegSmEpcMin/HuntEpc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SageMaker__Model.HuntModel.json
+++ b/tests/corpus/AWS__SageMaker__Model.HuntModel.json
@@ -1,0 +1,105 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntModel",
+    "resourceType": "AWS::SageMaker::Model",
+    "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:model/HuntModel-gv2gcUBdX0FA",
+    "constructPath": "CdkRealDriftIntegSmEpcMin/HuntModel",
+    "declared": {
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSmEpcMin-HuntSmRole222CBC48-OLqxsu6oCblL",
+      "PrimaryContainer": {
+        "Image": "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-scikit-learn:1.2-1-cpu-py3"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ModelArn": "arn:aws:sagemaker:us-east-1:111111111111:model/HuntModel-gv2gcUBdX0FA",
+    "EnableNetworkIsolation": false,
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSmEpcMin-HuntSmRole222CBC48-OLqxsu6oCblL",
+    "PrimaryContainer": {
+      "Mode": "SingleModel",
+      "Image": "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-scikit-learn:1.2-1-cpu-py3"
+    },
+    "ModelName": "HuntModel-gv2gcUBdX0FA",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegSmEpcMin",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntModel",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSmEpcMin/6b395e10-7df4-11f1-b579-123782941c49",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ModelArn"],
+    "writeOnly": [],
+    "createOnly": [
+      "Containers",
+      "EnableNetworkIsolation",
+      "ExecutionRoleArn",
+      "InferenceExecutionConfig",
+      "ModelName",
+      "PrimaryContainer",
+      "VpcConfig"
+    ],
+    "readOnlyPaths": ["ModelArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "Containers",
+      "EnableNetworkIsolation",
+      "ExecutionRoleArn",
+      "InferenceExecutionConfig",
+      "ModelName",
+      "PrimaryContainer",
+      "VpcConfig"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["VpcConfig.SecurityGroupIds", "VpcConfig.Subnets"],
+    "unorderedObjectArrayPaths": ["Containers"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "HuntModel",
+      "resourceType": "AWS::SageMaker::Model",
+      "path": "ModelName",
+      "actual": "HuntModel-gv2gcUBdX0FA",
+      "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:model/HuntModel-gv2gcUBdX0FA",
+      "constructPath": "CdkRealDriftIntegSmEpcMin/HuntModel"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntModel",
+      "resourceType": "AWS::SageMaker::Model",
+      "path": "PrimaryContainer.Mode",
+      "actual": "SingleModel",
+      "nested": true,
+      "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:model/HuntModel-gv2gcUBdX0FA",
+      "constructPath": "CdkRealDriftIntegSmEpcMin/HuntModel"
+    }
+  ]
+}

--- a/tests/integration/iam-accesskey-min/app.ts
+++ b/tests/integration/iam-accesskey-min/app.ts
@@ -1,0 +1,20 @@
+// CDK app for the cdk-real-drift iam-accesskey-min false-positive integration
+// test. BAREST-possible IAM AccessKey — the SDK override reader
+// (readIamAccessKey, #716) was added from a live FN report and has ZERO corpus
+// cases and ZERO fixtures, so its barest first-run path (undeclared Status
+// defaulting to Active) has never been exercised live. A first `check`
+// (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnAccessKey, CfnUser } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegIamAccessKeyMin");
+
+const user = new CfnUser(stack, "HuntUser", {
+  userName: "cdkrd-hunt-accesskey-user",
+});
+
+new CfnAccessKey(stack, "HuntAccessKey", {
+  userName: user.ref,
+});

--- a/tests/integration/iam-accesskey-min/cdk.json
+++ b/tests/integration/iam-accesskey-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/iam-accesskey-min/package.json
+++ b/tests/integration/iam-accesskey-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-iam-accesskey-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift iam-accesskey-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/iam-accesskey-min/verify.sh
+++ b/tests/integration/iam-accesskey-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamAccessKeyMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-iam-accesskey-min $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/mediaconvert-min/app.ts
+++ b/tests/integration/mediaconvert-min/app.ts
@@ -1,0 +1,54 @@
+// CDK app for the cdk-real-drift mediaconvert-min false-positive integration
+// test. BAREST-possible MediaConvert Queue + JobTemplate — both types are
+// NON_PROVISIONABLE via Cloud Control (issue #497) and read through SDK
+// overrides that have ZERO corpus cases and ZERO fixtures, so the barest
+// first-run path (undeclared PricingPlan/Status/Priority defaults) has never
+// been exercised live. A JobTemplate is deliberately PARTIAL (job templates
+// merge into jobs, so a minimal settings body is valid). A first `check`
+// (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnJobTemplate, CfnQueue } from "aws-cdk-lib/aws-mediaconvert";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegMediaConvertMin");
+
+new CfnQueue(stack, "HuntQueue", {
+  name: "cdkrd-hunt-mc-queue",
+});
+
+new CfnJobTemplate(stack, "HuntJobTemplate", {
+  name: "cdkrd-hunt-mc-jobtemplate",
+  // MediaConvert templates may be PARTIAL, but the API still requires at least
+  // one output group ("outputGroups is a required property" on create).
+  settingsJson: {
+    OutputGroups: [
+      {
+        Name: "File Group",
+        OutputGroupSettings: {
+          Type: "FILE_GROUP_SETTINGS",
+          FileGroupSettings: {},
+        },
+        // Each output must carry video, audio, or captions — audio-only AAC is
+        // the smallest valid output.
+        Outputs: [
+          {
+            ContainerSettings: { Container: "MP4" },
+            AudioDescriptions: [
+              {
+                CodecSettings: {
+                  Codec: "AAC",
+                  AacSettings: {
+                    Bitrate: 96000,
+                    CodingMode: "CODING_MODE_2_0",
+                    SampleRate: 48000,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+});

--- a/tests/integration/mediaconvert-min/cdk.json
+++ b/tests/integration/mediaconvert-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/mediaconvert-min/package.json
+++ b/tests/integration/mediaconvert-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-mediaconvert-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift mediaconvert-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/mediaconvert-min/verify-detect.sh
+++ b/tests/integration/mediaconvert-min/verify-detect.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Detection (FN-half) integration test (real AWS): deploy -> first check must be
+# CLEAN -> record -> out-of-band queue pause -> check MUST detect (exit 1) ->
+# restore -> CLEAN. The record step matters: without a baseline an undeclared
+# divergence is only [Potential Drift] and `--fail` stays exit 0.
+# MediaConvert has no SDK writer yet, so this stops at detection (no revert leg).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMediaConvertMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+QUEUE=cdkrd-hunt-mc-queue
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  aws mediaconvert update-queue --name "$QUEUE" --status ACTIVE --region "$REGION" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check must be CLEAN (folds in place) ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "first check not CLEAN"
+
+echo "=== [$STACK] record (baseline — a later divergence is then CONFIRMED drift, exit 1) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] OOB: pause the queue ==="
+aws mediaconvert update-queue --name "$QUEUE" --status PAUSED --region "$REGION" >/dev/null || fail "update-queue PAUSED"
+
+echo "=== [$STACK] check MUST detect the Status drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected detect (exit 1), got $rc"
+grep -q 'Status' "/tmp/cdkrd-$STACK.detect.out" || fail "Status drift not in output"
+
+echo "=== [$STACK] restore ACTIVE ==="
+aws mediaconvert update-queue --name "$QUEUE" --status ACTIVE --region "$REGION" >/dev/null || fail "restore ACTIVE"
+
+echo "=== [$STACK] check MUST be CLEAN again ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-restore not CLEAN"
+
+echo "INTEG PASS ($STACK detect)"

--- a/tests/integration/mediaconvert-min/verify.sh
+++ b/tests/integration/mediaconvert-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMediaConvertMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-mediaconvert-min $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/reportgroup-secconfig-min/app.ts
+++ b/tests/integration/reportgroup-secconfig-min/app.ts
@@ -1,0 +1,28 @@
+// CDK app for the cdk-real-drift reportgroup-secconfig-min false-positive
+// integration test. BAREST-possible CodeBuild ReportGroup + Glue
+// SecurityConfiguration — both read through SDK overrides that have ZERO
+// corpus cases and ZERO fixtures, so the barest first-run path has never been
+// exercised live. The ReportGroup deliberately leaves Name undeclared (the
+// CFn-generated-name fold path) and declares only what the API requires.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnReportGroup } from "aws-cdk-lib/aws-codebuild";
+import { CfnSecurityConfiguration } from "aws-cdk-lib/aws-glue";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegReportGroupSecConfigMin");
+
+new CfnReportGroup(stack, "HuntReportGroup", {
+  type: "TEST",
+  exportConfig: {
+    exportConfigType: "NO_EXPORT",
+  },
+});
+
+new CfnSecurityConfiguration(stack, "HuntSecConfig", {
+  name: "cdkrd-hunt-glue-secconfig",
+  encryptionConfiguration: {
+    s3Encryptions: [{ s3EncryptionMode: "SSE-S3" }],
+  },
+});

--- a/tests/integration/reportgroup-secconfig-min/cdk.json
+++ b/tests/integration/reportgroup-secconfig-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/reportgroup-secconfig-min/package.json
+++ b/tests/integration/reportgroup-secconfig-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-reportgroup-secconfig-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift reportgroup-secconfig-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/reportgroup-secconfig-min/verify.sh
+++ b/tests/integration/reportgroup-secconfig-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegReportGroupSecConfigMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-reportgroup-secconfig-min $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sagemaker-epc-min/app.ts
+++ b/tests/integration/sagemaker-epc-min/app.ts
@@ -1,0 +1,37 @@
+// CDK app for the cdk-real-drift sagemaker-epc-min false-positive integration
+// test. BAREST-possible SageMaker EndpointConfig — its SDK override reader has
+// ZERO corpus cases and ZERO fixtures, so the barest first-run path
+// (undeclared InitialVariantWeight and friends) has never been exercised live.
+// The Model is metadata-only (no Endpoint is created, so nothing is billed and
+// the container image is never pulled). The image URI is the us-east-1 AWS
+// scikit-learn DLC, so this fixture is pinned to us-east-1.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnEndpointConfig, CfnModel } from "aws-cdk-lib/aws-sagemaker";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkRealDriftIntegSmEpcMin");
+
+const role = new Role(stack, "HuntSmRole", {
+  assumedBy: new ServicePrincipal("sagemaker.amazonaws.com"),
+});
+
+const model = new CfnModel(stack, "HuntModel", {
+  executionRoleArn: role.roleArn,
+  primaryContainer: {
+    image: "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-scikit-learn:1.2-1-cpu-py3",
+  },
+});
+
+new CfnEndpointConfig(stack, "HuntEpc", {
+  productionVariants: [
+    {
+      modelName: model.attrModelName,
+      variantName: "AllTraffic",
+      instanceType: "ml.t2.medium",
+      initialInstanceCount: 1,
+    },
+  ],
+});

--- a/tests/integration/sagemaker-epc-min/cdk.json
+++ b/tests/integration/sagemaker-epc-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sagemaker-epc-min/package.json
+++ b/tests/integration/sagemaker-epc-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sagemaker-epc-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sagemaker-epc-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sagemaker-epc-min/verify.sh
+++ b/tests/integration/sagemaker-epc-min/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record)
+# must show ZERO [Potential Drift] -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSmEpcMin
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-sagemaker-epc-min $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-mediaconvert-sagemaker-defaults-1526.test.ts
+++ b/tests/noise-mediaconvert-sagemaker-defaults-1526.test.ts
@@ -1,0 +1,135 @@
+// #1526 / #1528 — barest-config first-run false positives on MediaConvert Queue / JobTemplate
+// and SageMaker Model, live-observed 2026-07-12 (us-east-1, fresh un-mutated deploys; the
+// SDK_OVERRIDES readers for the MediaConvert pair had zero corpus cases and zero fixtures):
+//
+//   HuntQueue.PricingPlan                       actual ="ON_DEMAND"
+//   HuntQueue.Status                            actual ="ACTIVE"
+//   HuntJobTemplate.Priority                    actual =0
+//   HuntJobTemplate.StatusUpdateInterval        actual ="SECONDS_60"
+//   HuntJobTemplate.AccelerationSettings        actual ={"Mode":"DISABLED"}
+//   HuntModel.PrimaryContainer.Mode             actual ="SingleModel"
+//
+// All are AWS creation defaults for properties the template never declares, so they fold as
+// equality-gated constants (KNOWN_DEFAULTS / KNOWN_DEFAULT_PATHS) — an out-of-band change away
+// from any default (a console queue pause, a priority bump, a MultiModel flip) still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'hunt-res'
+): DesiredResource => ({ logicalId: 'Hunt', resourceType, physicalId, declared });
+
+describe('#1526 MediaConvert barest first-run defaults fold', () => {
+  it('folds an undeclared Queue PricingPlan=ON_DEMAND / Status=ACTIVE to atDefault', () => {
+    const declared = { Name: 'cdkrd-hunt-mc-queue' };
+    const f = classifyResource(
+      mk('AWS::MediaConvert::Queue', declared),
+      { ...declared, PricingPlan: 'ON_DEMAND', Status: 'ACTIVE' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual(['PricingPlan', 'Status']);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('still surfaces the classic out-of-band console pause (Status=PAUSED)', () => {
+    const declared = { Name: 'cdkrd-hunt-mc-queue' };
+    const f = classifyResource(
+      mk('AWS::MediaConvert::Queue', declared),
+      { ...declared, PricingPlan: 'ON_DEMAND', Status: 'PAUSED' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Status']);
+    expect(pathsByTier(f, 'atDefault')).toEqual(['PricingPlan']);
+  });
+
+  it('folds the undeclared JobTemplate Priority/StatusUpdateInterval/AccelerationSettings trio', () => {
+    const declared = { Name: 'cdkrd-hunt-mc-jobtemplate', SettingsJson: { OutputGroups: [] } };
+    const f = classifyResource(
+      mk('AWS::MediaConvert::JobTemplate', declared),
+      {
+        ...declared,
+        Priority: 0,
+        StatusUpdateInterval: 'SECONDS_60',
+        AccelerationSettings: { Mode: 'DISABLED' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual([
+      'AccelerationSettings',
+      'Priority',
+      'StatusUpdateInterval',
+    ]);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('still surfaces an out-of-band JobTemplate change away from each default', () => {
+    const declared = { Name: 'cdkrd-hunt-mc-jobtemplate', SettingsJson: { OutputGroups: [] } };
+    const f = classifyResource(
+      mk('AWS::MediaConvert::JobTemplate', declared),
+      {
+        ...declared,
+        Priority: 25,
+        StatusUpdateInterval: 'SECONDS_10',
+        AccelerationSettings: { Mode: 'ENABLED' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([
+      'AccelerationSettings',
+      'Priority',
+      'StatusUpdateInterval',
+    ]);
+  });
+});
+
+describe('#1528 SageMaker Model undeclared container Mode fold', () => {
+  const declared = {
+    ExecutionRoleArn: 'arn:aws:iam::123456789012:role/hunt-role',
+    PrimaryContainer: { Image: '123456789012.dkr.ecr.us-east-1.amazonaws.com/img:1' },
+  };
+
+  it('folds an undeclared PrimaryContainer.Mode=SingleModel to atDefault (fresh deploy)', () => {
+    const f = classifyResource(
+      mk('AWS::SageMaker::Model', declared),
+      {
+        ...declared,
+        PrimaryContainer: { ...declared.PrimaryContainer, Mode: 'SingleModel' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('PrimaryContainer.Mode');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('still surfaces an out-of-band MultiModel flip', () => {
+    const f = classifyResource(
+      mk('AWS::SageMaker::Model', declared),
+      {
+        ...declared,
+        PrimaryContainer: { ...declared.PrimaryContainer, Mode: 'MultiModel' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['PrimaryContainer.Mode']);
+  });
+});

--- a/tests/overrides-sagemaker-epc-1527.test.ts
+++ b/tests/overrides-sagemaker-epc-1527.test.ts
@@ -1,0 +1,97 @@
+import {
+  DescribeEndpointConfigCommand,
+  ListTagsCommand as SageMakerListTagsCommand,
+  SageMakerClient,
+} from '@aws-sdk/client-sagemaker';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+// #1527 — the AWS::SageMaker::EndpointConfig SDK override passed the CFn physical id VERBATIM
+// as EndpointConfigName to DescribeEndpointConfig, but the CFn PhysicalResourceId is the ARN
+// (arn:…:endpoint-config/<name>), so the describe call ValidationExceptioned and the whole
+// resource silently skipped — the reader never worked for a CFn-created config (the exact #857
+// read gap it was added to close). Live-confirmed 2026-07-12 (sagemaker-epc-min: skipped=1,
+// "SDK override (AWS::SageMaker::EndpointConfig): ValidationException 1"). The fix mirrors the
+// readSageMakerMonitoringSchedule (#1523) shape: extract the last ARN segment; a non-ARN
+// physical id (or the declared-name fallback) passes through unchanged.
+
+const sagemaker = mockClient(SageMakerClient);
+const read = SDK_OVERRIDES['AWS::SageMaker::EndpointConfig']!;
+const ARN = 'arn:aws:sagemaker:us-east-1:123456789012:endpoint-config/hunt-epc';
+const ctx = (physicalId: string, declared: Record<string, unknown> = {}) => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId: '123456789012',
+});
+
+const RESPONSE = {
+  EndpointConfigName: 'hunt-epc',
+  EndpointConfigArn: ARN,
+  ProductionVariants: [
+    {
+      VariantName: 'AllTraffic',
+      ModelName: 'hunt-model',
+      InitialInstanceCount: 1,
+      InstanceType: 'ml.t2.medium' as const,
+      InitialVariantWeight: 1,
+    },
+  ],
+  CreationTime: new Date(0),
+};
+
+beforeEach(() => {
+  sagemaker.reset();
+  sagemaker.on(SageMakerListTagsCommand).resolves({ Tags: [] });
+});
+
+describe('SageMaker EndpointConfig override ARN physical id (#1527)', () => {
+  it('extracts the bare name from an ARN physical id before DescribeEndpointConfig', async () => {
+    sagemaker.on(DescribeEndpointConfigCommand).resolves(RESPONSE);
+
+    const model = await read(ctx(ARN));
+
+    const call = sagemaker.commandCalls(DescribeEndpointConfigCommand)[0]!;
+    expect((call.args[0].input as { EndpointConfigName?: string }).EndpointConfigName).toBe(
+      'hunt-epc'
+    );
+    expect(model).toMatchObject({
+      EndpointConfigName: 'hunt-epc',
+      ProductionVariants: [
+        {
+          VariantName: 'AllTraffic',
+          ModelName: 'hunt-model',
+          InitialInstanceCount: 1,
+          InstanceType: 'ml.t2.medium',
+          InitialVariantWeight: 1,
+        },
+      ],
+    });
+    // readOnly response fields stay dropped
+    expect(model).not.toHaveProperty('EndpointConfigArn');
+    expect(model).not.toHaveProperty('CreationTime');
+  });
+
+  it('passes a bare-name physical id through unchanged', async () => {
+    sagemaker.on(DescribeEndpointConfigCommand).resolves(RESPONSE);
+
+    await read(ctx('hunt-epc'));
+
+    const call = sagemaker.commandCalls(DescribeEndpointConfigCommand)[0]!;
+    expect((call.args[0].input as { EndpointConfigName?: string }).EndpointConfigName).toBe(
+      'hunt-epc'
+    );
+  });
+
+  it('falls back to the declared EndpointConfigName when the physical id is empty', async () => {
+    sagemaker.on(DescribeEndpointConfigCommand).resolves(RESPONSE);
+
+    await read(ctx('', { EndpointConfigName: 'hunt-epc' }));
+
+    const call = sagemaker.commandCalls(DescribeEndpointConfigCommand)[0]!;
+    expect((call.args[0].input as { EndpointConfigName?: string }).EndpointConfigName).toBe(
+      'hunt-epc'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

/hunt-bugs round (goal: fix + PR; angle: zero-corpus `SDK_OVERRIDES` audit + barest-config first-run FP sweep). 4 barest fixtures deployed live (us-east-1); **8 bugs found across 2 stacks, all fixed + live re-verified A/B with the fixed binary**; the 2 clean stacks ship as regression assets.

Closes #1526, Closes #1527, Closes #1528.

## Bugs fixed

### #1527 — SageMaker EndpointConfig SDK override never worked (read gap)
`readSageMakerEndpointConfig` passed the CFn physical id verbatim to `DescribeEndpointConfig`, but the PhysicalResourceId is the **ARN** → `ValidationException` → the resource silently `skipped` on every check (the exact #857 gap the reader was added to close). Fix mirrors the sibling `readSageMakerMonitoringSchedule` (#1523): extract the last ARN segment.
**Live A/B**: base `skipped=1 (ValidationException)` → fix `skipped=0`, first check CLEAN, corpus case harvested.

### #1526 — MediaConvert barest deploy: 5 first-run FPs (fold gaps)
Queue `PricingPlan="ON_DEMAND"` / `Status="ACTIVE"`, JobTemplate `Priority=0` / `StatusUpdateInterval="SECONDS_60"` / `AccelerationSettings={Mode:"DISABLED"}` — all constant creation defaults → equality-gated `KNOWN_DEFAULTS`.
**Live A/B + FN test** (`verify-detect.sh`): first check CLEAN → `record` → OOB `update-queue --status PAUSED` → **detected as confirmed drift (exit 1)** → restore → CLEAN. Detection preserved by the equality gate; MediaConvert has no SDK writer yet, so the FN leg stops at detection (future `SDK_WRITERS` candidate).

### #1528 — SageMaker Model `PrimaryContainer.Mode="SingleModel"` first-run FP
AWS creation default for an undeclared container Mode → `KNOWN_DEFAULT_PATHS` (`PrimaryContainer.Mode` + `Containers.*.Mode` twin).
**Live A/B**: base surfaced 1 potential drift → fix folds to `atDefault`, CLEAN.

## Clean results (regression assets)

- `iam-accesskey-min` (IAM User + AccessKey, barest): first check CLEAN (`Status=Active` already folded by #716).
- `reportgroup-secconfig-min` (CodeBuild ReportGroup undeclared-Name + Glue SecurityConfiguration, barest): first check CLEAN.

## Assets

- 4 new integ fixtures under `tests/integration/` (incl. the MediaConvert detect-leg `verify-detect.sh`).
- 7 promoted golden-corpus cases — **6 first-covered types**: IAM AccessKey, CodeBuild ReportGroup, Glue SecurityConfiguration, MediaConvert Queue + JobTemplate, SageMaker EndpointConfig (+ a barest SageMaker Model case pinning the Mode fold). The AccessKey case's real `AKIA…` physical id is sanitized to AWS's documented example id (git-secrets).
- Unit tests fail without the fixes, pass with them (verified by stashing the src diff: 5 fail → 0).
- hunt-bugs SKILL.md gotchas: FN test needs `record` for exit 1; sanitize credential-shaped corpus ids; audit service-family sibling readers for shared physical-id-shape assumptions.

## Verification

- `/check`: typecheck / lint+format / build / **5420 tests, 263 files** all pass.
- `/check-docs`: no docs-visible surface change (reader projection + IAM permission surface unchanged; fold tables not enumerated in docs).
- `/verify-pr`: live-test = the A/B runs above; **shared CORE suite deferred** — diff fully covered by unit tests + corpus replay AND live-proven in the originating hunt (per the deferral clause); measure-noise sweep run (no new candidates — remaining CANDIDATEs are intentional mutation-case pins).
- Cleanup: all 4 stacks deleted (verify.sh traps + delstack), `sweep-orphans.sh` **SWEEP CLEAN**, bughunt gate released (session + autoarm owners).
