### PR TITLE
fix(diff,noise,revert): off-flip FN pairings, RDS lowercase-name FPs, DAX + Lightsail first-run folds

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -512,6 +512,25 @@ Recorded]` breakdown with `--verbose`.
   Sanitize before committing: replace every occurrence with AWS's documented example
   id `AKIAIOSFODNN7EXAMPLE` (consistent replace keeps the case self-consistent;
   corpus-replay only needs internal equality) and re-run `corpus-replay` (#1526 PR).
+- **An off-flip FN candidate is real ONLY for a STANDALONE-boolean pin — object/array
+  pins are not swallowed.** `isTrivialEmpty` drops a bare `false`/`""`/`[]`/`{}`; a
+  `true` pinned INSIDE an object/array whose siblings are non-trivial (`ReadWriteType:
+"All"`, `SSEAlgorithm:"AES256"`, `VersionNumber:1`) survives the flip — the flipped
+  shape breaks the pin equality and surfaces normally. An offline audit of "unpaired
+  true-pins" (the #1530 hunt) overcounted 9→4 for exactly this reason: before filing,
+  check the pinned `true` stands ALONE at its path, and drop pins on immutable-revision
+  resources (ECS TaskDefinition) that cannot drift out of band.
+- **A corpus promotion can PIN a live FP as `expected` — eyeball declared-tier findings
+  before promoting.** The #1507 hunt promoted three RDS cases whose `expected` carried
+  the mixed-case-name declared FP (`CdkrdHunt-Mixed-CPG` vs `cdkrdhunt-mixed-cpg`), so
+  `corpus-replay` asserted the WRONG behavior until #1531. A declared finding on a
+  name/identifier path where declared and live differ only by case (or another pure
+  normalization) is a red flag: that is a bug to file, not an expectation to record.
+- **A `KNOWN_DEFAULTS` pin containing an ARRAY must carry the exact live element
+  shape.** `matchesKnownDefault` is subset-tolerant for OBJECT keys but strict
+  deep-equality for arrays — trivially-empty element sub-keys (`CidrListAliases: []`,
+  `CommonName: ""`) must be IN the pin or it never matches (hit on the Lightsail
+  `Networking` default-firewall pin, #1533). Copy the array verbatim from the live read.
 - **When a reader's physical-id-shape assumption breaks (name vs ARN), grep the
   SAME service family's sibling readers for the identical assumption — in both
   directions.** readSageMakerEndpointConfig passed the ARN physical id as the bare

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -100,6 +100,10 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // never fired the prefetch → defaultSgIds empty → an OOB `ec2 modify-instance-attribute --groups`
   // swap/append was silently NOT detected. Register it so the derived gate keeps its detection.
   'AWS::EC2::Instance',
+  // #1532: a DAX cluster's undeclared SecurityGroupIds default is the subnet-group VPC's
+  // default SG — registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch must fire when
+  // a DAX cluster is present or the OOB-swap gate loses its default-SG ids.
+  'AWS::DAX::Cluster',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -248,6 +248,22 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
     AutoMinorVersionUpgrade: notRestored('SnapshotName', 'SnapshotArns'),
   },
   'AWS::Redshift::Cluster': { AllowVersionUpgrade: notRestored('SnapshotIdentifier') },
+  // #1530: a ClientVPN endpoint is created with disconnect-on-session-timeout ON — a fresh
+  // endpoint that declares no DisconnectOnSessionTimeout always reads back true (the
+  // KNOWN_DEFAULTS pin, live-confirmed on a fresh barest endpoint 2026-07-12). An undeclared
+  // false is an out-of-band `modify-client-vpn-endpoint --no-disconnect-on-session-timeout`
+  // that lets a timed-out session linger — live-proven invisible without this gate (the FN
+  // this entry fixes). No restore/import path yields an untouched false. Unconditional.
+  'AWS::EC2::ClientVpnEndpoint': { DisconnectOnSessionTimeout: () => true },
+  // #1530: both ImageBuilder pins below were added as first-run-FP folds with their off-flip
+  // FN explicitly documented as deferred ("would need a MEANINGFUL_WHEN_OFF entry", #911) —
+  // this is that entry. A fresh pipeline reads EnhancedImageMetadataEnabled=true and a fresh
+  // infrastructure configuration reads TerminateInstanceOnFailure=true (both live-confirmed,
+  // #911); each is OOB-mutable (update-image-pipeline / update-infrastructure-configuration)
+  // and has no restore/import path, so an undeclared false is a real out-of-band disable —
+  // TerminateInstanceOnFailure=false silently starts leaking build instances on failure.
+  'AWS::ImageBuilder::ImagePipeline': { EnhancedImageMetadataEnabled: () => true },
+  'AWS::ImageBuilder::InfrastructureConfiguration': { TerminateInstanceOnFailure: () => true },
 };
 
 // #660 item 3: the NESTED twin of MEANINGFUL_WHEN_OFF. The table above gates TOP-LEVEL
@@ -301,6 +317,24 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
   // lineage that could yield an untouched `false`, so no predicate is needed.
   'AWS::EKS::Cluster': {
     'ResourcesVpcConfig.EndpointPublicAccess': () => true,
+  },
+  // #1530: an ECS service that ENABLES the deployment circuit breaker reads back the AWS-filled
+  // sub-default ResetOnHealthyTask=true (the KNOWN_DEFAULT_PATHS pin, live-observed on a fresh
+  // Fargate service). An out-of-band UpdateService flipping it false is swallowed by
+  // isTrivialEmpty before the nested pin gate — invisible. Gate on the breaker actually being
+  // ENABLED (declared or live): a disabled/undeclared breaker's untouched false sub-field is a
+  // legitimate creation-time shape, not an out-of-band disable, so it stays folded.
+  'AWS::ECS::Service': {
+    'DeploymentConfiguration.DeploymentCircuitBreaker.ResetOnHealthyTask': ({ declared, live }) => {
+      const enabled = (v: unknown): boolean =>
+        typeof v === 'object' &&
+        v !== null &&
+        (v as Record<string, Record<string, unknown>>)['DeploymentCircuitBreaker']?.['Enable'] ===
+          true;
+      return (
+        enabled(declared['DeploymentConfiguration']) || enabled(live['DeploymentConfiguration'])
+      );
+    },
   },
 };
 
@@ -419,6 +453,12 @@ export const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // sibling `SecurityGroups` — an echo of the declared SGs or "default" — needs SG id→name
   // resolution to gate safely and stays undeclared for a follow-up; #640.)
   'AWS::EC2::Instance': 'SecurityGroupIds',
+  // #1532: a DAX cluster that declares no SecurityGroupIds is placed into its subnet-group
+  // VPC's default SG and reads back that single SG id — the same AWS first-run default the
+  // ALB/ENI/Neptune/MQ cases fold. It is OOB-mutable (`dax update-cluster
+  // --security-group-ids`), so a value-independent fold would hide a rogue SG swap/append.
+  // Same derived VPC-default-SG gate: fold a single default SG, surface an append/swap.
+  'AWS::DAX::Cluster': 'SecurityGroupIds',
 };
 /** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
  *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -235,9 +235,8 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // reads back the constant documented default `true` (AWS terminates the build instance on
   // failure). Equality-gated: the fold applies ONLY to the `true` default, so a different
   // materialized value never folds. (A later `false` disable is an undeclared boolean that the
-  // classify undeclared loop drops as trivially-empty upstream — surfacing that disable would
-  // need a MEANINGFUL_WHEN_OFF entry in diff/classify.ts, out of scope for this first-run-FP
-  // fold; this entry only mutes the AWS-assigned `true`.) Live-confirmed on a fresh
+  // classify undeclared loop would drop as trivially-empty upstream — surfaced since #1530 by
+  // the paired MEANINGFUL_WHEN_OFF entry in diff/classify.ts.) Live-confirmed on a fresh
   // imagebuilder-rich deploy (#911).
   'AWS::ImageBuilder::InfrastructureConfiguration': { TerminateInstanceOnFailure: true },
   // An ImageBuilder ImagePipeline that declares neither EnhancedImageMetadataEnabled nor
@@ -247,8 +246,9 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // (subset-tolerant): disabling image tests reads back ImageTestsConfiguration as a non-empty
   // OBJECT ({ImageTestsEnabled:false, TimeoutMinutes:720}) that no longer matches the default,
   // so it re-surfaces as real undeclared drift (detection preserved). (EnhancedImageMetadata
-  // ENABLED=false is a bare undeclared boolean the classify loop drops as trivially-empty
-  // upstream, same as TerminateInstanceOnFailure above.) Live-confirmed on a fresh
+  // ENABLED=false is a bare undeclared boolean the classify loop would drop as trivially-empty
+  // upstream — surfaced since #1530 by the paired MEANINGFUL_WHEN_OFF entry, same as
+  // TerminateInstanceOnFailure above.) Live-confirmed on a fresh
   // imagebuilder-rich pipeline (#911).
   'AWS::ImageBuilder::ImagePipeline': {
     EnhancedImageMetadataEnabled: true,
@@ -1154,10 +1154,25 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // A DAX cluster that declares no ClusterEndpointEncryptionType reads back "NONE" (the
   // constant service default; the only other value, "TLS", is an explicit opt-in).
   // Observed live on a fresh DAX deploy (us-east-1, 2026-07-03; #554). Equality-gated.
-  // (PreferredMaintenanceWindow / SecurityGroupIds and the ParameterGroup's parameter
-  // values are per-resource/AWS-assigned, so they are deliberately NOT folded here.)
+  // #1532: a cluster that declares no ParameterGroupName reads back the AWS-managed
+  // "default.dax1.0" (live-confirmed on a fresh barest cluster, us-east-1 2026-07-12;
+  // DAX has a single engine track, so the name is a stable constant). Equality-gated —
+  // an out-of-band parameter-group swap no longer matches and surfaces. The remaining
+  // #554 deferrals are folded per-tier elsewhere: PreferredMaintenanceWindow is a
+  // RANDOMLY-assigned per-cluster slot (value-independent, see
+  // VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS) and SecurityGroupIds defaults to the VPC
+  // default SG (derive-gated in classify DEFAULT_SG_LIST_PATHS).
   'AWS::DAX::Cluster': {
     ClusterEndpointEncryptionType: 'NONE',
+    ParameterGroupName: 'default.dax1.0',
+  },
+  // #1532: a DAX parameter group that declares no parameter values reads back the two
+  // engine defaults materialized at creation (5-minute item/query TTLs, serialized as
+  // millisecond strings). Live-confirmed on a fresh description-only parameter group
+  // (us-east-1, 2026-07-12). Equality-gated — an out-of-band TTL change no longer
+  // matches and surfaces.
+  'AWS::DAX::ParameterGroup': {
+    ParameterNameValues: { 'query-ttl-millis': '300000', 'record-ttl-millis': '300000' },
   },
   // Managed Prometheus materializes a WorkspaceConfiguration of service defaults
   // (150-day retention, 60s rule-query offset / out-of-order window) on every
@@ -1561,6 +1576,44 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::Lightsail::Instance': {
     KeyPairName: 'LightsailDefaultKeyPair',
+    // #1533: every Linux-blueprint instance is created with the constant default firewall —
+    // inbound tcp 22 (SSH) + tcp 80 (HTTP) from anywhere (live-verified on a fresh
+    // amazon_linux_2023 nano instance, us-east-1 2026-07-12). Equality-gated: an out-of-band
+    // `open-instance-public-ports` (a rogue port) breaks the pin and SURFACES — exactly the
+    // security drift the fold must preserve. The Ports ARRAY is compared deep-equal
+    // (matchesKnownDefault's subset tolerance applies to objects, not array elements), so
+    // the pin carries the exact live element shape including its empty CidrListAliases/
+    // CommonName; the sibling MonthlyTransfer:{} husk IS absorbed at the object level. A
+    // Windows blueprint's default set (RDP 3389) is a DIFFERENT shape — add it as a second
+    // accepted value when live-observed.
+    Networking: {
+      Ports: [
+        {
+          FromPort: 22,
+          ToPort: 22,
+          Protocol: 'tcp',
+          AccessDirection: 'inbound',
+          AccessType: 'public',
+          AccessFrom: 'Anywhere (0.0.0.0/0 and ::/0)',
+          Cidrs: ['0.0.0.0/0'],
+          Ipv6Cidrs: ['::/0'],
+          CidrListAliases: [],
+          CommonName: '',
+        },
+        {
+          FromPort: 80,
+          ToPort: 80,
+          Protocol: 'tcp',
+          AccessDirection: 'inbound',
+          AccessType: 'public',
+          AccessFrom: 'Anywhere (0.0.0.0/0 and ::/0)',
+          Cidrs: ['0.0.0.0/0'],
+          Ipv6Cidrs: ['::/0'],
+          CidrListAliases: [],
+          CommonName: '',
+        },
+      ],
+    },
   },
   'AWS::Lightsail::Disk': {
     AddOns: [{ AddOnType: 'AutoSnapshot', Status: 'Disabled' }],
@@ -3343,6 +3396,17 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   DECLARES KmsKeyId and is compared in the declared loop. Observed live on a fresh
   //   minimal endpoint (case-idents-min, 2026-07-12; #1490).
   'AWS::DMS::Endpoint': new Set(['KmsKeyId']),
+  //   AWS::DAX::Cluster.PreferredMaintenanceWindow — a cluster that declares no window reads
+  //   back the RANDOMLY-assigned weekly slot AWS chose at creation (live first-run on a fresh
+  //   barest cluster, #1532) — the same per-resource assigned-window shape as the RDS/DocDB/
+  //   Neptune/ElastiCache windows in this table. Not a constant, not derivable; a user who
+  //   cares DECLARES it (compared in the declared loop).
+  'AWS::DAX::Cluster': new Set(['PreferredMaintenanceWindow']),
+  //   AWS::Lightsail::Instance.AvailabilityZone — an instance that declares no AZ reads back
+  //   the zone AWS placed it in at creation (create-only; the Lightsail twin of the RDS/
+  //   Neptune AvailabilityZone entries above). Live first-run on a fresh nano instance
+  //   (#1533). A DECLARED AZ is compared in the declared loop (detected).
+  'AWS::Lightsail::Instance': new Set(['AvailabilityZone']),
   'AWS::RDS::DBCluster': new Set([
     'KmsKeyId',
     'EngineVersion',
@@ -4376,8 +4440,11 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // the service lowercases again). Every identifier here is create-only, so case-insensitive
   // equality hides no revertable drift (a genuine rename is a replacement). ElastiCache
   // SubnetGroup live-verified; the rest docs-verified from the AWS CLI help. NOTE:
-  // AWS::RDS::DBSubnetGroup.DBSubnetGroupName and AWS::Route53::HostedZone.Name were
-  // live-ruled-out (RDS/Route53 PRESERVE case on read) so they are deliberately NOT added.
+  // AWS::Route53::HostedZone.Name was live-ruled-out (Route53 PRESERVES case on read) so it
+  // is deliberately NOT added. (An earlier note also ruled out RDS DBSubnetGroupName, but a
+  // 2026-07-12 live probe disproved that: `create-db-subnet-group
+  // --db-subnet-group-name CdkrdHunt-Mixed-SNG` stores and reads back
+  // `cdkrdhunt-mixed-sng` — it IS lowercased, so it is now in the family below.)
   'AWS::ElastiCache::SubnetGroup': new Set(['CacheSubnetGroupName']),
   'AWS::ElastiCache::ReplicationGroup': new Set(['ReplicationGroupId']),
   'AWS::ElastiCache::CacheCluster': new Set(['ClusterName']),
@@ -4387,6 +4454,21 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Neptune::DBCluster': new Set(['DBClusterIdentifier']),
   'AWS::Neptune::DBInstance': new Set(['DBInstanceIdentifier']),
   'AWS::Neptune::DBSubnetGroup': new Set(['DBSubnetGroupName']),
+  // #1531: the parameter-group / option-group / subnet-group NAME twins of the identifier
+  // family above — RDS stores each "as a lowercase string" (CLI help for the RDS/Neptune/
+  // DocDB create calls; OptionGroupName + RDS DBSubnetGroupName live-proven: a mixed-case
+  // declaration reads back all-lowercase). The mixed-case FP was live-captured by the #1507
+  // hunt and its three corpus cases pinned the wrong `expected` (corrected in the same PR
+  // as this entry). All are create-only names, so case-insensitive equality hides no
+  // revertable drift (a genuine rename is a replacement). Neptune/DocDB spell the CFn
+  // property `Name`.
+  'AWS::RDS::DBParameterGroup': new Set(['DBParameterGroupName']),
+  'AWS::RDS::DBClusterParameterGroup': new Set(['DBClusterParameterGroupName']),
+  'AWS::RDS::OptionGroup': new Set(['OptionGroupName']),
+  'AWS::RDS::DBSubnetGroup': new Set(['DBSubnetGroupName']),
+  'AWS::Neptune::DBParameterGroup': new Set(['Name']),
+  'AWS::Neptune::DBClusterParameterGroup': new Set(['Name']),
+  'AWS::DocDB::DBClusterParameterGroup': new Set(['Name']),
   'AWS::DMS::ReplicationInstance': new Set(['ReplicationInstanceIdentifier']),
   'AWS::DMS::ReplicationSubnetGroup': new Set(['ReplicationSubnetGroupIdentifier']),
   // DMS Endpoint `EndpointType` — the CFn/CDK value is lowercase (`source` /

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -329,6 +329,13 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   'AWS::ElastiCache::ReplicationGroup\0AutoMinorVersionUpgrade',
   'AWS::MemoryDB::Cluster\0AutoMinorVersionUpgrade',
   'AWS::Redshift::Cluster\0AllowVersionUpgrade',
+  // #1532: DAX has no ResetParameterGroup API, so a `remove` revert of an out-of-band
+  // parameter change is un-expressible (the SDK writer throws). The engine defaults ARE a
+  // stable constant (KNOWN_DEFAULTS: query/record TTL 300000), so write them back explicitly
+  // — UpdateParameterGroup applies a set op fine; only the unset state is inexpressible.
+  // Live-proven 2026-07-12: an out-of-band query-ttl-millis=60000 was detected but the
+  // `remove` revert failed with "cannot be cleared"; the set-default write converges.
+  'AWS::DAX::ParameterGroup\0ParameterNameValues',
 ]);
 
 // Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant

--- a/tests/classify-meaningful-when-off-1530.test.ts
+++ b/tests/classify-meaningful-when-off-1530.test.ts
@@ -1,0 +1,148 @@
+// #1530: an out-of-band DISABLE of a boolean that KNOWN_DEFAULTS / KNOWN_DEFAULT_PATHS pins
+// `true` is swallowed by isTrivialEmpty BEFORE the pin gate unless the property has a paired
+// MEANINGFUL_WHEN_OFF / MEANINGFUL_WHEN_OFF_NESTED entry. These tests pin the four pairings
+// added by #1530: the clean-deploy `true` still folds atDefault, and the off-flip now
+// surfaces as undeclared drift. Live-proven on a fresh barest ClientVPN endpoint
+// (2026-07-12: `modify-client-vpn-endpoint --no-disconnect-on-session-timeout` was
+// invisible on the base binary — check stayed CLEAN, exit 0).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1530 ClientVpnEndpoint.DisconnectOnSessionTimeout off-flip', () => {
+  const res: DesiredResource = {
+    logicalId: 'Endpoint',
+    resourceType: 'AWS::EC2::ClientVpnEndpoint',
+    physicalId: 'cvpn-endpoint-0dd25d1211ee9cf11',
+    declared: {
+      ClientCidrBlock: '10.100.0.0/22',
+      ServerCertificateArn: 'arn:aws:acm:us-east-1:111111111111:certificate/x',
+      ConnectionLogOptions: { Enabled: false },
+    },
+  };
+  const live = (disconnect: boolean) => ({
+    ClientCidrBlock: '10.100.0.0/22',
+    ServerCertificateArn: 'arn:aws:acm:us-east-1:111111111111:certificate/x',
+    ConnectionLogOptions: { Enabled: false },
+    DisconnectOnSessionTimeout: disconnect,
+    SessionTimeoutHours: 24,
+    TransportProtocol: 'udp',
+    VpnPort: 443,
+  });
+
+  it('folds the clean-deploy true to atDefault (first-run stays CLEAN)', () => {
+    const f = classifyResource(res, live(true), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('DisconnectOnSessionTimeout');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band --no-disconnect-on-session-timeout (the live-proven FN)', () => {
+    const f = classifyResource(res, live(false), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['DisconnectOnSessionTimeout']);
+    // The untouched sibling defaults still fold.
+    expect(pathsByTier(f, 'atDefault')).toContain('SessionTimeoutHours');
+  });
+});
+
+describe('#1530 ImageBuilder off-flips (EnhancedImageMetadataEnabled / TerminateInstanceOnFailure)', () => {
+  const pipeline: DesiredResource = {
+    logicalId: 'Pipeline',
+    resourceType: 'AWS::ImageBuilder::ImagePipeline',
+    physicalId: 'arn:aws:imagebuilder:us-east-1:111111111111:image-pipeline/p',
+    declared: { Name: 'p' },
+  };
+  const infra: DesiredResource = {
+    logicalId: 'Infra',
+    resourceType: 'AWS::ImageBuilder::InfrastructureConfiguration',
+    physicalId: 'arn:aws:imagebuilder:us-east-1:111111111111:infrastructure-configuration/i',
+    declared: { Name: 'i' },
+  };
+
+  it('pipeline: clean-deploy true folds, out-of-band false surfaces', () => {
+    const clean = classifyResource(
+      pipeline,
+      { Name: 'p', EnhancedImageMetadataEnabled: true },
+      emptySchema
+    );
+    expect(pathsByTier(clean, 'atDefault')).toContain('EnhancedImageMetadataEnabled');
+    expect(pathsByTier(clean, 'undeclared')).toEqual([]);
+    const flipped = classifyResource(
+      pipeline,
+      { Name: 'p', EnhancedImageMetadataEnabled: false },
+      emptySchema
+    );
+    expect(pathsByTier(flipped, 'undeclared')).toEqual(['EnhancedImageMetadataEnabled']);
+  });
+
+  it('infrastructure configuration: clean-deploy true folds, out-of-band false surfaces', () => {
+    const clean = classifyResource(
+      infra,
+      { Name: 'i', TerminateInstanceOnFailure: true },
+      emptySchema
+    );
+    expect(pathsByTier(clean, 'atDefault')).toContain('TerminateInstanceOnFailure');
+    expect(pathsByTier(clean, 'undeclared')).toEqual([]);
+    const flipped = classifyResource(
+      infra,
+      { Name: 'i', TerminateInstanceOnFailure: false },
+      emptySchema
+    );
+    expect(pathsByTier(flipped, 'undeclared')).toEqual(['TerminateInstanceOnFailure']);
+  });
+});
+
+describe('#1530 ECS Service nested DeploymentCircuitBreaker.ResetOnHealthyTask off-flip', () => {
+  const RESET = 'DeploymentConfiguration.DeploymentCircuitBreaker.ResetOnHealthyTask';
+  const res = (enable: boolean): DesiredResource => ({
+    logicalId: 'Svc',
+    resourceType: 'AWS::ECS::Service',
+    physicalId: 'arn:aws:ecs:us-east-1:111111111111:service/c/s',
+    declared: {
+      ServiceName: 's',
+      DeploymentConfiguration: {
+        DeploymentCircuitBreaker: { Enable: enable, Rollback: false },
+      },
+    },
+  });
+  const live = (enable: boolean, reset: boolean) => ({
+    ServiceName: 's',
+    DeploymentConfiguration: {
+      DeploymentCircuitBreaker: { Enable: enable, Rollback: false, ResetOnHealthyTask: reset },
+    },
+  });
+
+  it('folds the AWS-filled true sub-default on a breaker-enabled service', () => {
+    const f = classifyResource(res(true), live(true, true), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain(RESET);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band ResetOnHealthyTask=false on a breaker-enabled service', () => {
+    const f = classifyResource(res(true), live(true, false), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([RESET]);
+  });
+
+  it('keeps an untouched false hidden when the breaker is NOT enabled (predicate gate)', () => {
+    // A disabled circuit breaker's ResetOnHealthyTask=false is a legitimate creation-time
+    // shape (AWS never filled the sub-default), not an out-of-band disable — stay folded.
+    const f = classifyResource(res(false), live(false, false), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});

--- a/tests/corpus/AWS__DAX__Cluster.Cluster.json
+++ b/tests/corpus/AWS__DAX__Cluster.Cluster.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cluster",
+    "resourceType": "AWS::DAX::Cluster",
+    "physicalId": "cluster-qceilwg5tvcy",
+    "constructPath": "CdkrdHuntDax0712c/Cluster",
+    "declared": {
+      "IAMRoleARN": "arn:aws:iam::111111111111:role/CdkrdHuntDax0712c-DaxRole-AImtmx51xTJN",
+      "NodeType": "dax.t3.small",
+      "ReplicationFactor": 1,
+      "SubnetGroupName": "subnetgroup-3ljm3aov3poh",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "ClusterName": "cluster-qceilwg5tvcy",
+    "NodeType": "dax.t3.small",
+    "IAMRoleARN": "arn:aws:iam::111111111111:role/CdkrdHuntDax0712c-DaxRole-AImtmx51xTJN",
+    "PreferredMaintenanceWindow": "sun:04:00-sun:05:00",
+    "SubnetGroupName": "subnetgroup-3ljm3aov3poh",
+    "ClusterEndpointEncryptionType": "NONE",
+    "SecurityGroupIds": ["sg-03b54b1df3bfbc3c6"],
+    "ParameterGroupName": "default.dax1.0",
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "ClusterDiscoveryEndpoint", "ClusterDiscoveryEndpointURL", "Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "ClusterEndpointEncryptionType",
+      "ClusterName",
+      "IAMRoleARN",
+      "NetworkType",
+      "NodeType",
+      "SSESpecification",
+      "SubnetGroupName"
+    ],
+    "readOnlyPaths": ["Arn", "ClusterDiscoveryEndpoint", "ClusterDiscoveryEndpointURL", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ClusterEndpointEncryptionType",
+      "ClusterName",
+      "IAMRoleARN",
+      "NetworkType",
+      "NodeType",
+      "SSESpecification",
+      "SubnetGroupName"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::DAX::Cluster",
+      "path": "ReplicationFactor",
+      "note": "declared but not returned by live read",
+      "physicalId": "cluster-qceilwg5tvcy",
+      "constructPath": "CdkrdHuntDax0712c/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::DAX::Cluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "sun:04:00-sun:05:00",
+      "physicalId": "cluster-qceilwg5tvcy",
+      "constructPath": "CdkrdHuntDax0712c/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::DAX::Cluster",
+      "path": "ClusterEndpointEncryptionType",
+      "actual": "NONE",
+      "physicalId": "cluster-qceilwg5tvcy",
+      "constructPath": "CdkrdHuntDax0712c/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::DAX::Cluster",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-03b54b1df3bfbc3c6"],
+      "physicalId": "cluster-qceilwg5tvcy",
+      "constructPath": "CdkrdHuntDax0712c/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::DAX::Cluster",
+      "path": "ParameterGroupName",
+      "actual": "default.dax1.0",
+      "physicalId": "cluster-qceilwg5tvcy",
+      "constructPath": "CdkrdHuntDax0712c/Cluster"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DAX__ParameterGroup.ParamGroup.json
+++ b/tests/corpus/AWS__DAX__ParameterGroup.ParamGroup.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ParamGroup",
+    "resourceType": "AWS::DAX::ParameterGroup",
+    "physicalId": "paramgroup-r6li5eqclgc1",
+    "constructPath": "CdkrdHuntDax0712c/ParamGroup",
+    "declared": {
+      "Description": "cdkrd hunt"
+    }
+  },
+  "liveRaw": {
+    "ParameterGroupName": "paramgroup-r6li5eqclgc1",
+    "Description": "cdkrd hunt",
+    "ParameterNameValues": {
+      "query-ttl-millis": "300000",
+      "record-ttl-millis": "300000"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["ParameterGroupName"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ParameterGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ParamGroup",
+      "resourceType": "AWS::DAX::ParameterGroup",
+      "path": "ParameterNameValues",
+      "actual": {
+        "query-ttl-millis": "300000",
+        "record-ttl-millis": "300000"
+      },
+      "physicalId": "paramgroup-r6li5eqclgc1",
+      "constructPath": "CdkrdHuntDax0712c/ParamGroup"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DAX__SubnetGroup.SubnetGroup.json
+++ b/tests/corpus/AWS__DAX__SubnetGroup.SubnetGroup.json
@@ -1,0 +1,38 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SubnetGroup",
+    "resourceType": "AWS::DAX::SubnetGroup",
+    "physicalId": "subnetgroup-3ljm3aov3poh",
+    "constructPath": "CdkrdHuntDax0712c/SubnetGroup",
+    "declared": {
+      "Description": "cdkrd hunt",
+      "SubnetIds": ["subnet-04ebaa172a23d6add"]
+    }
+  },
+  "liveRaw": {
+    "SubnetGroupName": "subnetgroup-3ljm3aov3poh",
+    "Description": "cdkrd hunt",
+    "SubnetIds": ["subnet-04ebaa172a23d6add"]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["SubnetGroupName"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["SubnetGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__DataBrew__Dataset.Dataset.json
+++ b/tests/corpus/AWS__DataBrew__Dataset.Dataset.json
@@ -1,0 +1,82 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Dataset",
+    "resourceType": "AWS::DataBrew::Dataset",
+    "physicalId": "cdkrd-hunt-dataset-0712c",
+    "constructPath": "CdkrdHuntMiscBarest20712c/Dataset",
+    "declared": {
+      "Input": {
+        "S3InputDefinition": {
+          "Bucket": "cdkrdhuntmiscbarest20712c-bucket-wugmxx3qvpyt",
+          "Key": "input.csv"
+        }
+      },
+      "Name": "cdkrd-hunt-dataset-0712c",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Input": {
+      "S3InputDefinition": {
+        "Bucket": "cdkrdhuntmiscbarest20712c-bucket-wugmxx3qvpyt",
+        "Key": "input.csv"
+      }
+    },
+    "Source": "S3",
+    "Tags": [
+      {
+        "Value": "CdkrdHuntMiscBarest20712c",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Dataset",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntMiscBarest20712c/11d28640-7e02-11f1-b97f-0ec669663bd7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-dataset-0712c"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Dataset",
+      "resourceType": "AWS::DataBrew::Dataset",
+      "path": "Source",
+      "actual": "S3",
+      "physicalId": "cdkrd-hunt-dataset-0712c",
+      "constructPath": "CdkrdHuntMiscBarest20712c/Dataset"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DataBrew__Recipe.Recipe.json
+++ b/tests/corpus/AWS__DataBrew__Recipe.Recipe.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Recipe",
+    "resourceType": "AWS::DataBrew::Recipe",
+    "physicalId": "cdkrd-hunt-recipe-0712c",
+    "constructPath": "CdkrdHuntMiscBarest20712c/Recipe",
+    "declared": {
+      "Name": "cdkrd-hunt-recipe-0712c",
+      "Steps": [
+        {
+          "Action": {
+            "Operation": "UPPER_CASE",
+            "Parameters": {
+              "sourceColumn": "col1"
+            }
+          }
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Steps": [
+      {
+        "Action": {
+          "Parameters": {
+            "SourceColumn": "col1"
+          },
+          "Operation": "UPPER_CASE"
+        },
+        "ConditionExpressions": []
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkrdHuntMiscBarest20712c",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Recipe",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntMiscBarest20712c/11d28640-7e02-11f1-b97f-0ec669663bd7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-recipe-0712c"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Steps.*.Action.Parameters"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__ClientVpnEndpoint.Endpoint.json
+++ b/tests/corpus/AWS__EC2__ClientVpnEndpoint.Endpoint.json
@@ -1,0 +1,117 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Endpoint",
+    "resourceType": "AWS::EC2::ClientVpnEndpoint",
+    "physicalId": "cvpn-endpoint-0dd25d1211ee9cf11",
+    "constructPath": "CdkrdHuntClientVpn0712c/Endpoint",
+    "declared": {
+      "AuthenticationOptions": [
+        {
+          "MutualAuthentication": {
+            "ClientRootCertificateChainArn": "arn:aws:acm:us-east-1:111111111111:certificate/6c1ad063-7906-4d89-9ab3-329e3ae4bc3d"
+          },
+          "Type": "certificate-authentication"
+        }
+      ],
+      "ClientCidrBlock": "10.100.0.0/22",
+      "ConnectionLogOptions": {
+        "Enabled": false
+      },
+      "ServerCertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/6c1ad063-7906-4d89-9ab3-329e3ae4bc3d"
+    }
+  },
+  "liveRaw": {
+    "ClientCidrBlock": "10.100.0.0/22",
+    "SplitTunnel": false,
+    "TransportProtocol": "udp",
+    "VpnPort": 443,
+    "ServerCertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/6c1ad063-7906-4d89-9ab3-329e3ae4bc3d",
+    "SessionTimeoutHours": 24,
+    "DisconnectOnSessionTimeout": true,
+    "ConnectionLogOptions": {
+      "Enabled": false
+    },
+    "AuthenticationOptions": [
+      {
+        "Type": "certificate-authentication",
+        "MutualAuthentication": {
+          "ClientRootCertificateChainArn": "arn:aws:acm:us-east-1:111111111111:certificate/6c1ad063-7906-4d89-9ab3-329e3ae4bc3d"
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "AuthenticationOptions",
+      "ClientCidrBlock",
+      "EndpointIpAddressType",
+      "TagSpecifications",
+      "TrafficIpAddressType",
+      "TransitGatewayConfiguration",
+      "TransportProtocol"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AuthenticationOptions",
+      "ClientCidrBlock",
+      "EndpointIpAddressType",
+      "TagSpecifications",
+      "TrafficIpAddressType",
+      "TransitGatewayConfiguration",
+      "TransportProtocol"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Endpoint",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "TransportProtocol",
+      "actual": "udp",
+      "physicalId": "cvpn-endpoint-0dd25d1211ee9cf11",
+      "constructPath": "CdkrdHuntClientVpn0712c/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Endpoint",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "VpnPort",
+      "actual": 443,
+      "physicalId": "cvpn-endpoint-0dd25d1211ee9cf11",
+      "constructPath": "CdkrdHuntClientVpn0712c/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Endpoint",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "SessionTimeoutHours",
+      "actual": 24,
+      "physicalId": "cvpn-endpoint-0dd25d1211ee9cf11",
+      "constructPath": "CdkrdHuntClientVpn0712c/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Endpoint",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "DisconnectOnSessionTimeout",
+      "actual": true,
+      "physicalId": "cvpn-endpoint-0dd25d1211ee9cf11",
+      "constructPath": "CdkrdHuntClientVpn0712c/Endpoint"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.TrustStore.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.TrustStore.json
@@ -1,0 +1,101 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TrustStore",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore-0712c/e8b86516bc8c9019",
+    "constructPath": "CdkrdHuntTrustStore0712c/TrustStore",
+    "declared": {
+      "CaCertificatesBundleS3Bucket": "cdkrd-hunt-ts-0712c-111111111111",
+      "CaCertificatesBundleS3Key": "ca-bundle.pem",
+      "Name": "cdkrd-hunt-truststore-0712c",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "TrustStoreArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore-0712c/e8b86516bc8c9019",
+    "NumberOfCaCertificates": 1,
+    "Tags": [
+      {
+        "Value": "CdkrdHuntTrustStore0712c",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TrustStore",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntTrustStore0712c/c513aba0-7dfb-11f1-bf0d-0affcbbbc3a5",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-truststore-0712c",
+    "CaCertificatesBundleSha256": "64d2b4759eb4ba7f651f39ed3915c300e5b26e77076dc5c8fe2861d9a4fa8a06"
+  },
+  "schema": {
+    "readOnly": ["NumberOfCaCertificates", "Status", "TrustStoreArn"],
+    "writeOnly": [
+      "CaCertificatesBundleS3Bucket",
+      "CaCertificatesBundleS3Key",
+      "CaCertificatesBundleS3ObjectVersion"
+    ],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["NumberOfCaCertificates", "Status", "TrustStoreArn"],
+    "writeOnlyPaths": [
+      "CaCertificatesBundleS3Bucket",
+      "CaCertificatesBundleS3Key",
+      "CaCertificatesBundleS3ObjectVersion"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "TrustStore",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleS3Bucket",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore-0712c/e8b86516bc8c9019",
+      "constructPath": "CdkrdHuntTrustStore0712c/TrustStore"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "TrustStore",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleS3Key",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore-0712c/e8b86516bc8c9019",
+      "constructPath": "CdkrdHuntTrustStore0712c/TrustStore"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "TrustStore",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleSha256",
+      "actual": "64d2b4759eb4ba7f651f39ed3915c300e5b26e77076dc5c8fe2861d9a4fa8a06",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore-0712c/e8b86516bc8c9019",
+      "constructPath": "CdkrdHuntTrustStore0712c/TrustStore"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lightsail__Instance.Ls.json
+++ b/tests/corpus/AWS__Lightsail__Instance.Ls.json
@@ -1,0 +1,190 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Ls",
+    "resourceType": "AWS::Lightsail::Instance",
+    "physicalId": "cdkrd-hunt-ls-0712c",
+    "constructPath": "CdkrdHuntMiscBarest20712c/Ls",
+    "declared": {
+      "BlueprintId": "amazon_linux_2023",
+      "BundleId": "nano_3_0",
+      "InstanceName": "cdkrd-hunt-ls-0712c",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SshKeyName": "LightsailDefaultKeyPair",
+    "KeyPairName": "LightsailDefaultKeyPair",
+    "IsStaticIp": false,
+    "PrivateIpAddress": "172.26.5.232",
+    "UserName": "ec2-user",
+    "BlueprintId": "amazon_linux_2023",
+    "Networking": {
+      "Ports": [
+        {
+          "FromPort": 22,
+          "AccessDirection": "inbound",
+          "CidrListAliases": [],
+          "ToPort": 22,
+          "Ipv6Cidrs": ["::/0"],
+          "AccessFrom": "Anywhere (0.0.0.0/0 and ::/0)",
+          "Protocol": "tcp",
+          "AccessType": "public",
+          "Cidrs": ["0.0.0.0/0"],
+          "CommonName": ""
+        },
+        {
+          "FromPort": 80,
+          "AccessDirection": "inbound",
+          "CidrListAliases": [],
+          "ToPort": 80,
+          "Ipv6Cidrs": ["::/0"],
+          "AccessFrom": "Anywhere (0.0.0.0/0 and ::/0)",
+          "Protocol": "tcp",
+          "AccessType": "public",
+          "Cidrs": ["0.0.0.0/0"],
+          "CommonName": ""
+        }
+      ],
+      "MonthlyTransfer": {
+        "GbPerMonthAllocated": "1024"
+      }
+    },
+    "AvailabilityZone": "us-east-1a",
+    "AddOns": [],
+    "ResourceType": "Instance",
+    "Ipv6Addresses": ["2600:1f18:1950:a100:ca33:531a:2537:2d67"],
+    "PublicIpAddress": "44.223.7.106",
+    "InstanceName": "cdkrd-hunt-ls-0712c",
+    "BundleId": "nano_3_0",
+    "SupportCode": "116137269522/i-0790f437125f62f26",
+    "State": {
+      "Code": 16,
+      "Name": "running"
+    },
+    "InstanceArn": "arn:aws:lightsail:us-east-1:111111111111:Instance/1cfbd92c-e08a-4816-b6cc-0b1029638f36",
+    "Hardware": {
+      "CpuCount": 2,
+      "RamSizeInGb": 1,
+      "Disks": []
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Location": {
+      "RegionName": "us-east-1",
+      "AvailabilityZone": "us-east-1a"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "InstanceArn",
+      "Ipv6Addresses",
+      "IsStaticIp",
+      "PrivateIpAddress",
+      "PublicIpAddress",
+      "ResourceType",
+      "SshKeyName",
+      "SupportCode",
+      "UserName"
+    ],
+    "writeOnly": ["UserData"],
+    "createOnly": ["AvailabilityZone", "BlueprintId", "BundleId", "InstanceName"],
+    "readOnlyPaths": [
+      "Hardware.CpuCount",
+      "Hardware.RamSizeInGb",
+      "InstanceArn",
+      "Ipv6Addresses",
+      "IsStaticIp",
+      "Location.AvailabilityZone",
+      "Location.RegionName",
+      "Networking.MonthlyTransfer.GbPerMonthAllocated",
+      "PrivateIpAddress",
+      "PublicIpAddress",
+      "ResourceType",
+      "SshKeyName",
+      "State.Code",
+      "State.Name",
+      "SupportCode",
+      "UserName"
+    ],
+    "writeOnlyPaths": ["UserData"],
+    "createOnlyPaths": ["AvailabilityZone", "BlueprintId", "BundleId", "InstanceName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["Ipv6Addresses"],
+    "unorderedObjectArrayPaths": ["AddOns", "Hardware.Disks", "Networking.Ports"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Ls",
+      "resourceType": "AWS::Lightsail::Instance",
+      "path": "KeyPairName",
+      "actual": "LightsailDefaultKeyPair",
+      "physicalId": "cdkrd-hunt-ls-0712c",
+      "constructPath": "CdkrdHuntMiscBarest20712c/Ls"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Ls",
+      "resourceType": "AWS::Lightsail::Instance",
+      "path": "Networking",
+      "actual": {
+        "Ports": [
+          {
+            "FromPort": 22,
+            "AccessDirection": "inbound",
+            "CidrListAliases": [],
+            "ToPort": 22,
+            "Ipv6Cidrs": ["::/0"],
+            "AccessFrom": "Anywhere (0.0.0.0/0 and ::/0)",
+            "Protocol": "tcp",
+            "AccessType": "public",
+            "Cidrs": ["0.0.0.0/0"],
+            "CommonName": ""
+          },
+          {
+            "FromPort": 80,
+            "AccessDirection": "inbound",
+            "CidrListAliases": [],
+            "ToPort": 80,
+            "Ipv6Cidrs": ["::/0"],
+            "AccessFrom": "Anywhere (0.0.0.0/0 and ::/0)",
+            "Protocol": "tcp",
+            "AccessType": "public",
+            "Cidrs": ["0.0.0.0/0"],
+            "CommonName": ""
+          }
+        ],
+        "MonthlyTransfer": {}
+      },
+      "physicalId": "cdkrd-hunt-ls-0712c",
+      "constructPath": "CdkrdHuntMiscBarest20712c/Ls"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Ls",
+      "resourceType": "AWS::Lightsail::Instance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "cdkrd-hunt-ls-0712c",
+      "constructPath": "CdkrdHuntMiscBarest20712c/Ls"
+    }
+  ]
+}

--- a/tests/corpus/AWS__NetworkManager__Device.Device.json
+++ b/tests/corpus/AWS__NetworkManager__Device.Device.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Device",
+    "resourceType": "AWS::NetworkManager::Device",
+    "physicalId": "global-network-014914d5c119d2d12|device-0c0f34170dc8c8c5e",
+    "constructPath": "CdkrdHuntMiscBarest20712c/Device",
+    "declared": {
+      "GlobalNetworkId": "global-network-014914d5c119d2d12",
+      "SiteId": "site-0d3f736b4455cedb7",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SiteId": "site-0d3f736b4455cedb7",
+    "GlobalNetworkId": "global-network-014914d5c119d2d12",
+    "DeviceArn": "arn:aws:networkmanager::111111111111:device/global-network-014914d5c119d2d12/device-0c0f34170dc8c8c5e",
+    "DeviceId": "device-0c0f34170dc8c8c5e",
+    "State": "AVAILABLE",
+    "CreatedAt": "2026-07-12T14:58:15Z",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "DeviceArn", "DeviceId", "State"],
+    "writeOnly": [],
+    "createOnly": ["GlobalNetworkId"],
+    "readOnlyPaths": ["CreatedAt", "DeviceArn", "DeviceId", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GlobalNetworkId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__NetworkManager__GlobalNetwork.GlobalNetwork.json
+++ b/tests/corpus/AWS__NetworkManager__GlobalNetwork.GlobalNetwork.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GlobalNetwork",
+    "resourceType": "AWS::NetworkManager::GlobalNetwork",
+    "physicalId": "global-network-0be4a731ac6af18ee",
+    "constructPath": "CdkrdHuntMiscBarest0712c/GlobalNetwork",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "State": "AVAILABLE",
+    "CreatedAt": "2026-07-12T14:13:10Z",
+    "Id": "global-network-0be4a731ac6af18ee",
+    "Arn": "arn:aws:networkmanager::111111111111:global-network/global-network-0be4a731ac6af18ee",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreatedAt", "Id", "State"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "CreatedAt", "Id", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__NetworkManager__Link.Link.json
+++ b/tests/corpus/AWS__NetworkManager__Link.Link.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Link",
+    "resourceType": "AWS::NetworkManager::Link",
+    "physicalId": "global-network-014914d5c119d2d12|link-022139eac0a2ee729",
+    "constructPath": "CdkrdHuntMiscBarest20712c/Link",
+    "declared": {
+      "Bandwidth": {
+        "DownloadSpeed": 50,
+        "UploadSpeed": 10
+      },
+      "GlobalNetworkId": "global-network-014914d5c119d2d12",
+      "SiteId": "site-0d3f736b4455cedb7",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SiteId": "site-0d3f736b4455cedb7",
+    "GlobalNetworkId": "global-network-014914d5c119d2d12",
+    "LinkArn": "arn:aws:networkmanager::111111111111:link/global-network-014914d5c119d2d12/link-022139eac0a2ee729",
+    "State": "AVAILABLE",
+    "Bandwidth": {
+      "DownloadSpeed": 50,
+      "UploadSpeed": 10
+    },
+    "CreatedAt": "2026-07-12T14:58:15Z",
+    "LinkId": "link-022139eac0a2ee729",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "LinkArn", "LinkId", "State"],
+    "writeOnly": [],
+    "createOnly": ["GlobalNetworkId", "SiteId"],
+    "readOnlyPaths": ["CreatedAt", "LinkArn", "LinkId", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GlobalNetworkId", "SiteId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__NetworkManager__Site.Site.json
+++ b/tests/corpus/AWS__NetworkManager__Site.Site.json
@@ -1,0 +1,51 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Site",
+    "resourceType": "AWS::NetworkManager::Site",
+    "physicalId": "global-network-014914d5c119d2d12|site-0d3f736b4455cedb7",
+    "constructPath": "CdkrdHuntMiscBarest20712c/Site",
+    "declared": {
+      "GlobalNetworkId": "global-network-014914d5c119d2d12",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SiteId": "site-0d3f736b4455cedb7",
+    "GlobalNetworkId": "global-network-014914d5c119d2d12",
+    "SiteArn": "arn:aws:networkmanager::111111111111:site/global-network-014914d5c119d2d12/site-0d3f736b4455cedb7",
+    "State": "AVAILABLE",
+    "CreatedAt": "2026-07-12T14:58:12Z",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "SiteArn", "SiteId", "State"],
+    "writeOnly": [],
+    "createOnly": ["GlobalNetworkId"],
+    "readOnlyPaths": ["CreatedAt", "SiteArn", "SiteId", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GlobalNetworkId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__RDS__DBClusterParameterGroup.HuntCpg.json
+++ b/tests/corpus/AWS__RDS__DBClusterParameterGroup.HuntCpg.json
@@ -65,16 +65,5 @@
     "kmsAliasTargets": {},
     "oaiCanonicalIds": {}
   },
-  "expected": [
-    {
-      "tier": "declared",
-      "logicalId": "HuntCpg",
-      "resourceType": "AWS::RDS::DBClusterParameterGroup",
-      "path": "DBClusterParameterGroupName",
-      "desired": "CdkrdHunt-Mixed-CPG",
-      "actual": "cdkrdhunt-mixed-cpg",
-      "physicalId": "cdkrdhunt-mixed-cpg",
-      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntCpg"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__RDS__DBParameterGroup.HuntPg.json
+++ b/tests/corpus/AWS__RDS__DBParameterGroup.HuntPg.json
@@ -60,16 +60,5 @@
     "kmsAliasTargets": {},
     "oaiCanonicalIds": {}
   },
-  "expected": [
-    {
-      "tier": "declared",
-      "logicalId": "HuntPg",
-      "resourceType": "AWS::RDS::DBParameterGroup",
-      "path": "DBParameterGroupName",
-      "desired": "CdkrdHunt-Mixed-PG",
-      "actual": "cdkrdhunt-mixed-pg",
-      "physicalId": "cdkrdhunt-mixed-pg",
-      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntPg"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__RDS__OptionGroup.HuntOg.json
+++ b/tests/corpus/AWS__RDS__OptionGroup.HuntOg.json
@@ -99,16 +99,5 @@
       }
     }
   },
-  "expected": [
-    {
-      "tier": "declared",
-      "logicalId": "HuntOg",
-      "resourceType": "AWS::RDS::OptionGroup",
-      "path": "OptionGroupName",
-      "desired": "CdkrdHunt-Mixed-OG",
-      "actual": "cdkrdhunt-mixed-og",
-      "physicalId": "cdkrdhunt-mixed-og",
-      "constructPath": "CdkRealDriftIntegCaseIdentsMin/HuntOg"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__Rbin__Rule.RbinRule.json
+++ b/tests/corpus/AWS__Rbin__Rule.RbinRule.json
@@ -1,0 +1,88 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RbinRule",
+    "resourceType": "AWS::Rbin::Rule",
+    "physicalId": "arn:aws:rbin:us-east-1:111111111111:rule/SPGgLUFPS1a",
+    "constructPath": "CdkrdHuntMiscBarest0712c/RbinRule",
+    "declared": {
+      "ResourceType": "EBS_SNAPSHOT",
+      "RetentionPeriod": {
+        "RetentionPeriodUnit": "DAYS",
+        "RetentionPeriodValue": 7
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Status": "available",
+    "Identifier": "SPGgLUFPS1a",
+    "Description": "",
+    "ResourceTags": [],
+    "ExcludeResourceTags": [],
+    "ResourceType": "EBS_SNAPSHOT",
+    "Arn": "arn:aws:rbin:us-east-1:111111111111:rule/SPGgLUFPS1a",
+    "RetentionPeriod": {
+      "RetentionPeriodUnit": "DAYS",
+      "RetentionPeriodValue": 7
+    },
+    "LockState": "unlocked",
+    "Tags": [
+      {
+        "Value": "RbinRule",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHuntMiscBarest0712c",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntMiscBarest0712c/c60bc740-7dfb-11f1-bf59-12f1b2ea4589",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Identifier", "LockState"],
+    "writeOnly": ["LockConfiguration"],
+    "createOnly": ["ResourceType"],
+    "readOnlyPaths": ["Arn", "Identifier", "LockState"],
+    "writeOnlyPaths": [
+      "LockConfiguration",
+      "LockConfiguration.UnlockDelayUnit",
+      "LockConfiguration.UnlockDelayValue"
+    ],
+    "createOnlyPaths": ["ResourceType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["ExcludeResourceTags", "ResourceTags"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RbinRule",
+      "resourceType": "AWS::Rbin::Rule",
+      "path": "Status",
+      "actual": "available",
+      "physicalId": "arn:aws:rbin:us-east-1:111111111111:rule/SPGgLUFPS1a",
+      "constructPath": "CdkrdHuntMiscBarest0712c/RbinRule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceCatalogAppRegistry__Application.AppRegistryApp.json
+++ b/tests/corpus/AWS__ServiceCatalogAppRegistry__Application.AppRegistryApp.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AppRegistryApp",
+    "resourceType": "AWS::ServiceCatalogAppRegistry::Application",
+    "physicalId": "03ugzd0rnwvpar531fhtgh503o",
+    "constructPath": "CdkrdHuntMiscBarest0712c/AppRegistryApp",
+    "declared": {
+      "Name": "cdkrd-hunt-appreg-0712c",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "ApplicationName": "cdkrd-hunt-appreg-0712c",
+    "ApplicationTagKey": "awsApplication",
+    "ApplicationTagValue": "arn:aws:resource-groups:us-east-1:111111111111:group/cdkrd-hunt-appreg-0712c/03ugzd0rnwvpar531fhtgh503o",
+    "Id": "03ugzd0rnwvpar531fhtgh503o",
+    "Arn": "arn:aws:servicecatalog:us-east-1:111111111111:/applications/03ugzd0rnwvpar531fhtgh503o",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdHuntMiscBarest0712c",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntMiscBarest0712c/c60bc740-7dfb-11f1-bf59-12f1b2ea4589",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "AppRegistryApp",
+      "aws:servicecatalog:applicationName": "cdkrd-hunt-appreg-0712c"
+    },
+    "Name": "cdkrd-hunt-appreg-0712c"
+  },
+  "schema": {
+    "readOnly": ["ApplicationName", "ApplicationTagKey", "ApplicationTagValue", "Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["ApplicationName", "ApplicationTagKey", "ApplicationTagValue", "Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/dax-firstrun-folds-1532.test.ts
+++ b/tests/dax-firstrun-folds-1532.test.ts
@@ -1,0 +1,152 @@
+// #1532: a barest DAX stack (Cluster + ParameterGroup + SubnetGroup) first-ran four
+// [Potential Drift] entries (live 2026-07-12, us-east-1, CdkrdHuntDax0712c). These tests pin
+// the folds per the fold-strategy decision order: two equality-gated constants
+// (ParameterNameValues engine defaults, the default.dax1.0 parameter-group name), the
+// randomly-assigned maintenance window (value-independent, the RDS/ElastiCache sibling), and
+// the VPC-default SecurityGroupIds via the derived #889 gate (single default folds,
+// swap/append surfaces).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1532 DAX ParameterGroup first-run fold', () => {
+  const res: DesiredResource = {
+    logicalId: 'ParamGroup',
+    resourceType: 'AWS::DAX::ParameterGroup',
+    physicalId: 'cdkrdhuntdax0712c-paramgroup',
+    declared: { Description: 'cdkrd hunt' },
+  };
+
+  it('folds the materialized engine-default TTLs to atDefault', () => {
+    const f = classifyResource(
+      res,
+      {
+        Description: 'cdkrd hunt',
+        ParameterNameValues: { 'query-ttl-millis': '300000', 'record-ttl-millis': '300000' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('ParameterNameValues');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band TTL change (equality gate keeps detection)', () => {
+    const f = classifyResource(
+      res,
+      {
+        Description: 'cdkrd hunt',
+        ParameterNameValues: { 'query-ttl-millis': '60000', 'record-ttl-millis': '300000' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ParameterNameValues']);
+  });
+});
+
+describe('#1532 DAX Cluster first-run folds', () => {
+  const res: DesiredResource = {
+    logicalId: 'Cluster',
+    resourceType: 'AWS::DAX::Cluster',
+    physicalId: 'cdkrdhuntdax0712c-cluster',
+    declared: {
+      IAMRoleARN: 'arn:aws:iam::111111111111:role/dax',
+      NodeType: 'dax.t3.small',
+      ReplicationFactor: 1,
+      SubnetGroupName: 'sg-group',
+    },
+  };
+  const live = (over: Record<string, unknown> = {}) => ({
+    IAMRoleARN: 'arn:aws:iam::111111111111:role/dax',
+    NodeType: 'dax.t3.small',
+    SubnetGroupName: 'sg-group',
+    ClusterEndpointEncryptionType: 'NONE',
+    ParameterGroupName: 'default.dax1.0',
+    PreferredMaintenanceWindow: 'sun:04:00-sun:05:00',
+    SecurityGroupIds: ['sg-0defau1t'],
+    ...over,
+  });
+  const defaultSgIds = new Set(['sg-0defau1t']);
+
+  it('folds all four AWS-assigned values on a clean first run (zero potential drift)', () => {
+    const f = classifyResource(res, live(), emptySchema, { defaultSgIds });
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    for (const p of [
+      'ParameterGroupName',
+      'PreferredMaintenanceWindow',
+      'SecurityGroupIds',
+      'ClusterEndpointEncryptionType',
+    ]) {
+      expect(pathsByTier(f, 'atDefault')).toContain(p);
+    }
+  });
+
+  it('surfaces an out-of-band parameter-group swap (equality gate)', () => {
+    const f = classifyResource(res, live({ ParameterGroupName: 'custom-pg' }), emptySchema, {
+      defaultSgIds,
+    });
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ParameterGroupName']);
+  });
+
+  it('surfaces an out-of-band SG swap to a non-default group (#889 gate)', () => {
+    const f = classifyResource(res, live({ SecurityGroupIds: ['sg-0rogue'] }), emptySchema, {
+      defaultSgIds,
+    });
+    expect(pathsByTier(f, 'undeclared')).toEqual(['SecurityGroupIds']);
+  });
+
+  it('surfaces an out-of-band SG append (2+ groups, #889 gate)', () => {
+    const f = classifyResource(
+      res,
+      live({ SecurityGroupIds: ['sg-0defau1t', 'sg-0rogue'] }),
+      emptySchema,
+      { defaultSgIds }
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['SecurityGroupIds']);
+  });
+
+  it('fails OPEN on the SG gate when the default-SG prefetch is unavailable', () => {
+    const f = classifyResource(res, live(), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});
+
+describe('#1532 DAX ParameterGroup revert writes the engine defaults (set-default)', () => {
+  it('an out-of-band TTL change reverts via an add op carrying the KNOWN_DEFAULTS values', () => {
+    // DAX has no ResetParameterGroup API, so a bare `remove` is un-expressible (the SDK
+    // writer throws "cannot be cleared"). REVERT_SET_DEFAULT_PATHS turns the revert into an
+    // explicit write of the constant engine defaults — live-proven to converge (2026-07-12:
+    // query-ttl-millis 60000 → revert → 300000, CLEAN after revert).
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'ParamGroup',
+      physicalId: 'paramgroup-x',
+      resourceType: 'AWS::DAX::ParameterGroup',
+      path: 'ParameterNameValues',
+      actual: { 'query-ttl-millis': '60000', 'record-ttl-millis': '300000' },
+    };
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ParameterNameValues',
+      value: { 'query-ttl-millis': '300000', 'record-ttl-millis': '300000' },
+    });
+  });
+});

--- a/tests/integration/clientvpn-barest/app.ts
+++ b/tests/integration/clientvpn-barest/app.ts
@@ -1,0 +1,35 @@
+// Barest-config EC2 ClientVpnEndpoint fixture for the cdk-real-drift FP hunt.
+// AWS::EC2::ClientVpnEndpoint is a Cloud Control gap (NON_PROVISIONABLE, no
+// read handler) with a `readEc2ClientVpnEndpoint` SDK_OVERRIDE that was added
+// without ever being exercised live. The server certificate must exist in ACM
+// BEFORE the stack deploys, so verify.sh imports a self-signed cert out of
+// band and passes its ARN via CDKRD_HUNT_VPN_CERT_ARN (env is set for deploy
+// AND for every cdkrd invocation, which re-synthesizes this app). Mutual
+// (certificate) auth reuses the same self-signed cert as the client root
+// chain, avoiding any directory/SAML dependency. No target-network
+// association is declared: an unassociated endpoint is free and the endpoint
+// read alone is what this fixture exercises.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnClientVpnEndpoint } from "aws-cdk-lib/aws-ec2";
+
+const certArn = process.env.CDKRD_HUNT_VPN_CERT_ARN;
+if (!certArn) throw new Error("CDKRD_HUNT_VPN_CERT_ARN must be set (see verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntClientVpn0712c");
+
+// Barest endpoint: only what CFn requires.
+new CfnClientVpnEndpoint(stack, "Endpoint", {
+  clientCidrBlock: "10.100.0.0/22",
+  serverCertificateArn: certArn,
+  authenticationOptions: [
+    {
+      type: "certificate-authentication",
+      mutualAuthentication: { clientRootCertificateChainArn: certArn },
+    },
+  ],
+  connectionLogOptions: { enabled: false },
+});
+
+app.synth();

--- a/tests/integration/clientvpn-barest/cdk.json
+++ b/tests/integration/clientvpn-barest/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/clientvpn-barest/package.json
+++ b/tests/integration/clientvpn-barest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-clientvpn-barest",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config EC2 ClientVpnEndpoint fixture for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/clientvpn-barest/verify-detect.sh
+++ b/tests/integration/clientvpn-barest/verify-detect.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Missed-detection (FN) integration test for #1530 (real AWS): an out-of-band
+# `modify-client-vpn-endpoint --no-disconnect-on-session-timeout` flips a true-pinned
+# KNOWN_DEFAULTS boolean OFF. Without the MEANINGFUL_WHEN_OFF pairing the false was
+# swallowed by isTrivialEmpty and check stayed CLEAN (live-proven on 0.13.10).
+# Sequence: deploy -> first check CLEAN -> record -> OOB flip -> check MUST exit 1 ->
+# revert (REVERT_SET_DEFAULT_PATHS writes true back) -> check CLEAN -> live value true.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntClientVpn0712c
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  [ -n "${CDKRD_HUNT_VPN_CERT_ARN:-}" ] &&
+    aws acm delete-certificate --certificate-arn "$CDKRD_HUNT_VPN_CERT_ARN" --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] import self-signed server cert into ACM ==="
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/cdkrd-vpn-key.pem -out /tmp/cdkrd-vpn-cert.pem \
+  -days 7 -nodes -subj "/CN=cdkrd-hunt-clientvpn.internal" 2>/dev/null || fail "openssl"
+CDKRD_HUNT_VPN_CERT_ARN="$(aws acm import-certificate --certificate fileb:///tmp/cdkrd-vpn-cert.pem \
+  --private-key fileb:///tmp/cdkrd-vpn-key.pem --region "$REGION" \
+  --tags Key=cdkrd:ephemeral,Value=1 --query CertificateArn --output text)" || fail "acm import"
+export CDKRD_HUNT_VPN_CERT_ARN
+
+echo "=== [$STACK] deploy + record ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+$CLI check "$STACK" --region "$REGION" --fail || fail "first check not CLEAN"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+VPNID="$(aws ec2 describe-client-vpn-endpoints --region "$REGION" \
+  --query 'ClientVpnEndpoints[?Status.Code!=`deleted`]|[0].ClientVpnEndpointId' --output text)"
+[ -n "$VPNID" ] && [ "$VPNID" != "None" ] || fail "endpoint id not found"
+
+echo "=== [$STACK] out-of-band disable DisconnectOnSessionTimeout ==="
+aws ec2 modify-client-vpn-endpoint --client-vpn-endpoint-id "$VPNID" --region "$REGION" \
+  --no-disconnect-on-session-timeout >/dev/null || fail "modify"
+sleep 5
+
+echo "=== [$STACK] check MUST detect the off-flip (#1530) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "off-flip NOT detected (the #1530 FN)"
+grep -q "DisconnectOnSessionTimeout" "/tmp/cdkrd-$STACK-detect.out" || fail "wrong drift path"
+
+echo "=== [$STACK] revert MUST write true back and converge ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+LIVE="$(aws ec2 describe-client-vpn-endpoints --client-vpn-endpoint-ids "$VPNID" --region "$REGION" \
+  --query 'ClientVpnEndpoints[0].DisconnectOnSessionTimeout' --output text)"
+[ "$LIVE" = "True" ] || fail "live value not restored (got $LIVE)"
+$CLI check "$STACK" --region "$REGION" --fail || fail "not CLEAN after revert"
+
+echo "INTEG PASS ($STACK detect/revert)"

--- a/tests/integration/clientvpn-barest/verify.sh
+++ b/tests/integration/clientvpn-barest/verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): the server certificate must exist in ACM
+# BEFORE the stack deploys, so this script imports a self-signed cert out of band and
+# passes its ARN via CDKRD_HUNT_VPN_CERT_ARN (read by app.ts on every synth).
+# A clean barest endpoint must FIRST-check CLEAN (VpnPort/TransportProtocol/
+# SessionTimeoutHours/DisconnectOnSessionTimeout all fold, #554/#1102) and stay CLEAN
+# after record. The #1530 off-flip detection lives in verify-detect.sh.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntClientVpn0712c
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  # The imported ACM cert is stack-external — delete it after the endpoint is gone.
+  [ -n "${CDKRD_HUNT_VPN_CERT_ARN:-}" ] &&
+    aws acm delete-certificate --certificate-arn "$CDKRD_HUNT_VPN_CERT_ARN" --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] import self-signed server cert into ACM ==="
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/cdkrd-vpn-key.pem -out /tmp/cdkrd-vpn-cert.pem \
+  -days 7 -nodes -subj "/CN=cdkrd-hunt-clientvpn.internal" 2>/dev/null || fail "openssl"
+CDKRD_HUNT_VPN_CERT_ARN="$(aws acm import-certificate --certificate fileb:///tmp/cdkrd-vpn-cert.pem \
+  --private-key fileb:///tmp/cdkrd-vpn-key.pem --region "$REGION" \
+  --tags Key=cdkrd:ephemeral,Value=1 --query CertificateArn --output text)" || fail "acm import"
+export CDKRD_HUNT_VPN_CERT_ARN
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/dax-barest/app.ts
+++ b/tests/integration/dax-barest/app.ts
@@ -1,0 +1,65 @@
+// Barest-config DAX fixture for the cdk-real-drift FP hunt: DAX::Cluster,
+// DAX::ParameterGroup, and DAX::SubnetGroup all have SDK_OVERRIDES readers
+// (Cloud Control NON_PROVISIONABLE / no read handler) that were added without
+// ever being exercised against a live deploy — this deploys the MINIMAL
+// required config of each so the first `check` (before `record`) exposes any
+// first-run undeclared-default FPs and reader identifier-shape bugs.
+// A raw CfnVPC + one CfnSubnet keeps the fixture minimal (no NAT, no IGW).
+import { App, Fn, Stack, Tags } from "aws-cdk-lib";
+import { CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnParameterGroup, CfnSubnetGroup } from "aws-cdk-lib/aws-dax";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntDax0712c");
+
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.0.0.0/24" });
+const subnet = new CfnSubnet(stack, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.0.0/24",
+  availabilityZone: Fn.select(0, Fn.getAzs()),
+});
+
+const role = new CfnRole(stack, "DaxRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "dax.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  policies: [
+    {
+      policyName: "dyn",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [{ Effect: "Allow", Action: "dynamodb:*", Resource: "*" }],
+      },
+    },
+  ],
+});
+
+const subnetGroup = new CfnSubnetGroup(stack, "SubnetGroup", {
+  description: "cdkrd hunt",
+  subnetIds: [subnet.ref],
+});
+
+// Barest parameter group: description only (no parameter overrides).
+new CfnParameterGroup(stack, "ParamGroup", {
+  description: "cdkrd hunt",
+});
+
+// Barest cluster: only what CFn requires (+ our subnet group so it does not
+// demand a default VPC). Everything else is left undeclared on purpose.
+new CfnCluster(stack, "Cluster", {
+  iamRoleArn: role.attrArn,
+  nodeType: "dax.t3.small",
+  replicationFactor: 1,
+  subnetGroupName: subnetGroup.ref,
+});
+
+app.synth();

--- a/tests/integration/dax-barest/cdk.json
+++ b/tests/integration/dax-barest/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dax-barest/package.json
+++ b/tests/integration/dax-barest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dax-barest",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config DAX fixture (Cluster + ParameterGroup + SubnetGroup) for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dax-barest/verify.sh
+++ b/tests/integration/dax-barest/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy the barest DAX stack -> the FIRST
+# check (before record) MUST be CLEAN (#1532: ParameterNameValues / ParameterGroupName /
+# PreferredMaintenanceWindow / default SecurityGroupIds all fold) -> record -> check CLEAN.
+# NOTE: a DAX cluster takes ~10-15 minutes to create.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntDax0712c
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN (#1532) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/miscbarest-hunt/app.ts
+++ b/tests/integration/miscbarest-hunt/app.ts
@@ -1,0 +1,29 @@
+// Barest-config bundle of cheap, fast, Cloud-Control-readable resource types
+// that have ZERO golden-corpus cases and ZERO fixtures, for the cdk-real-drift
+// first-run FP hunt: Rbin::Rule (whose CC primaryIdentifier is the ARN — if
+// the CFn physical id is the short rule id, the read may be silently skipped),
+// NetworkManager::GlobalNetwork (zero required props = maximal undeclared
+// surface), and ServiceCatalogAppRegistry::Application. Each is declared with
+// only what CFn requires so the first `check` (before `record`) exposes any
+// fold gaps.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnGlobalNetwork } from "aws-cdk-lib/aws-networkmanager";
+import { CfnRule } from "aws-cdk-lib/aws-rbin";
+import { CfnApplication } from "aws-cdk-lib/aws-servicecatalogappregistry";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntMiscBarest0712c");
+
+new CfnRule(stack, "RbinRule", {
+  resourceType: "EBS_SNAPSHOT",
+  retentionPeriod: { retentionPeriodValue: 7, retentionPeriodUnit: "DAYS" },
+});
+
+new CfnGlobalNetwork(stack, "GlobalNetwork", {});
+
+new CfnApplication(stack, "AppRegistryApp", {
+  name: "cdkrd-hunt-appreg-0712c",
+});
+
+app.synth();

--- a/tests/integration/miscbarest-hunt/cdk.json
+++ b/tests/integration/miscbarest-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/miscbarest-hunt/package.json
+++ b/tests/integration/miscbarest-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-miscbarest-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config bundle fixture (Rbin Rule + NetworkManager GlobalNetwork + AppRegistry Application) for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/miscbarest-hunt/verify.sh
+++ b/tests/integration/miscbarest-hunt/verify.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest Rbin Rule + NetworkManager
+# GlobalNetwork + AppRegistry Application. First check (before record) MUST be CLEAN
+# (Rbin Status folds atDefault); after record it stays CLEAN; an out-of-band Rbin
+# retention change must be detected and revertable (CC UpdateResource, live-proven).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntMiscBarest0712c
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "=== [$STACK] out-of-band Rbin retention change MUST be detected + revertable ==="
+RULEID="$(aws rbin list-rules --resource-type EBS_SNAPSHOT --region "$REGION" \
+  --query 'Rules[0].Identifier' --output text)"
+aws rbin update-rule --identifier "$RULEID" --region "$REGION" \
+  --retention-period RetentionPeriodValue=14,RetentionPeriodUnit=DAYS >/dev/null || fail "rbin update"
+$CLI check "$STACK" --region "$REGION" --fail && fail "retention change NOT detected"
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+VAL="$(aws rbin get-rule --identifier "$RULEID" --region "$REGION" \
+  --query 'RetentionPeriod.RetentionPeriodValue' --output text)"
+[ "$VAL" = "7" ] || fail "retention not restored (got $VAL)"
+$CLI check "$STACK" --region "$REGION" --fail || fail "not CLEAN after revert"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/miscbarest2-hunt/app.ts
+++ b/tests/integration/miscbarest2-hunt/app.ts
@@ -1,0 +1,47 @@
+// Barest-config bundle #2 for the cdk-real-drift first-run FP hunt — all zero-corpus,
+// CC-readable types: NetworkManager Site/Device/Link (COMPOSITE primaryIdentifier
+// [GlobalNetworkId, <child>Id] with NO CC_IDENTIFIER_ADAPTERS entry — if the CFn physical
+// id is a bare child id or ARN, the read should skip, a composite-id read-gap finding),
+// DataBrew Dataset/Recipe/Project, and a Lightsail Instance. Each declares only what CFn
+// requires so the first `check` (before `record`) exposes fold gaps.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+import { CfnDataset, CfnRecipe } from "aws-cdk-lib/aws-databrew";
+import { CfnInstance } from "aws-cdk-lib/aws-lightsail";
+import { CfnDevice, CfnGlobalNetwork, CfnLink, CfnSite } from "aws-cdk-lib/aws-networkmanager";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntMiscBarest20712c");
+
+// --- NetworkManager (free, instant) ---
+const gn = new CfnGlobalNetwork(stack, "Gn", {});
+const site = new CfnSite(stack, "Site", { globalNetworkId: gn.attrId });
+new CfnDevice(stack, "Device", { globalNetworkId: gn.attrId, siteId: site.attrSiteId });
+new CfnLink(stack, "Link", {
+  globalNetworkId: gn.attrId,
+  siteId: site.attrSiteId,
+  bandwidth: { downloadSpeed: 50, uploadSpeed: 10 },
+});
+
+// --- DataBrew (free until a job runs; a Project is NOT included — CreateProject
+// validates that the dataset's S3 object actually exists, a deploy-time finding
+// recorded here: barest Dataset/Recipe do no such validation) ---
+const bucket = new CfnBucket(stack, "Bucket");
+new CfnDataset(stack, "Dataset", {
+  name: "cdkrd-hunt-dataset-0712c",
+  input: { s3InputDefinition: { bucket: bucket.ref, key: "input.csv" } },
+});
+new CfnRecipe(stack, "Recipe", {
+  name: "cdkrd-hunt-recipe-0712c",
+  steps: [{ action: { operation: "UPPER_CASE", parameters: { sourceColumn: "col1" } } }],
+});
+
+// --- Lightsail (nano bundle, cents/hour) ---
+new CfnInstance(stack, "Ls", {
+  instanceName: "cdkrd-hunt-ls-0712c",
+  blueprintId: "amazon_linux_2023",
+  bundleId: "nano_3_0",
+});
+
+app.synth();

--- a/tests/integration/miscbarest2-hunt/cdk.json
+++ b/tests/integration/miscbarest2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/miscbarest2-hunt/package.json
+++ b/tests/integration/miscbarest2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-miscbarest2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config bundle #2 fixture (NetworkManager Site/Device/Link + DataBrew + Lightsail) for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/miscbarest2-hunt/verify.sh
+++ b/tests/integration/miscbarest2-hunt/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest bundle #2 — NetworkManager
+# Site/Device/Link (composite primaryIdentifier probe), DataBrew Dataset/Recipe,
+# Lightsail Instance. First check (before record) MUST be CLEAN and nothing may be
+# silently skipped (a skipped NetworkManager child = the composite-id read gap).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntMiscBarest20712c
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN with no skips ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+grep -q "skipped=" "/tmp/cdkrd-$STACK-first.out" && fail "resources were skipped (read gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/notation-hunt/app.ts
+++ b/tests/integration/notation-hunt/app.ts
@@ -1,0 +1,10 @@
+// Discovery shim for the raw-CFn notation fixture: the REAL template (template.yaml, with
+// short-form intrinsics) is deployed via `aws cloudformation deploy` — cdkrd reads the
+// DEPLOYED template from CloudFormation for declared intent, so this app exists only to
+// let cdkrd resolve the stack by name (stack discovery needs a CDK app).
+import { App, Stack, Tags } from "aws-cdk-lib";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+new Stack(app, "CdkrdHuntNotation0712c");
+app.synth();

--- a/tests/integration/notation-hunt/cdk.json
+++ b/tests/integration/notation-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/notation-hunt/package.json
+++ b/tests/integration/notation-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-notation-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Raw-CloudFormation short-form-notation fixture for the cdk-real-drift hunt (deployed via aws cloudformation deploy; app.ts is a discovery shim). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/notation-hunt/template.yaml
+++ b/tests/integration/notation-hunt/template.yaml
@@ -1,0 +1,61 @@
+# Raw-CloudFormation notation fixture for the cdk-real-drift hunt: exercises the CFn-aware
+# YAML codec + intrinsic resolution on the DEPLOYED template (short-form tags, Conditions,
+# Mappings, Parameters, nested Fn combinations) over common free types. Deployed with plain
+# `aws cloudformation deploy` (no CDK synth); the sibling app.ts exists only so cdkrd can
+# discover the stack by name.
+Parameters:
+  RetentionDays:
+    Type: Number
+    Default: 3600
+  EnableVersioning:
+    Type: String
+    Default: "no"
+    AllowedValues: ["yes", "no"]
+Conditions:
+  Versioned: !Equals [!Ref EnableVersioning, "yes"]
+Mappings:
+  Env:
+    prod:
+      TagValue: production
+    dev:
+      TagValue: development
+Resources:
+  Q:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-q"
+      MessageRetentionPeriod: !Ref RetentionDays
+      Tags:
+        - Key: env
+          Value: !FindInMap [Env, dev, TagValue]
+        - Key: joined
+          Value: !Join ["-", [!Select [0, !Split ["-", !Ref "AWS::StackName"]], "x"]]
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      VersioningConfiguration: !If
+        - Versioned
+        - Status: Enabled
+        - !Ref AWS::NoValue
+      Tags:
+        - Key: arnish
+          Value: !Sub "arn:${AWS::Partition}:s3:::${AWS::StackName}"
+  R:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: !Sub "states.${AWS::URLSuffix}"
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: p
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                Resource: !GetAtt Q.Arn

--- a/tests/integration/notation-hunt/verify.sh
+++ b/tests/integration/notation-hunt/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Raw-CFn notation integration test (real AWS): template.yaml (short-form intrinsics,
+# Conditions, Mappings, Parameters) is deployed via plain `aws cloudformation deploy`
+# (NOT cdk); app.ts is only the discovery shim. Asserts: first check CLEAN (every
+# intrinsic resolves), an out-of-band change to a !Ref-parameterized declared value is
+# detected against the RESOLVED desired value, and revert converges.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntNotation0712c
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack -s "$STACK" -r "$REGION" -y -f >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy raw-CFn template ==="
+aws cloudformation deploy --template-file template.yaml --stack-name "$STACK" \
+  --capabilities CAPABILITY_IAM --tags cdkrd:ephemeral=1 --region "$REGION" || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check not CLEAN (intrinsic/notation FP)"
+
+echo "=== [$STACK] record + OOB change to a !Ref-parameterized declared value ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+QURL="$(aws sqs get-queue-url --queue-name "$STACK-q" --region "$REGION" --query QueueUrl --output text)"
+aws sqs set-queue-attributes --queue-url "$QURL" \
+  --attributes MessageRetentionPeriod=7200 --region "$REGION" || fail "sqs mutate"
+sleep 5
+$CLI check "$STACK" --region "$REGION" --fail && fail "retention change NOT detected"
+
+echo "=== [$STACK] revert MUST converge to the resolved desired (3600) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+VAL="$(aws sqs get-queue-attributes --queue-url "$QURL" --attribute-names MessageRetentionPeriod \
+  --region "$REGION" --query 'Attributes.MessageRetentionPeriod' --output text)"
+[ "$VAL" = "3600" ] || fail "retention not restored (got $VAL)"
+$CLI check "$STACK" --region "$REGION" --fail || fail "not CLEAN after revert"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/truststore-barest/app.ts
+++ b/tests/integration/truststore-barest/app.ts
@@ -1,0 +1,26 @@
+// Barest-config ELBv2 TrustStore fixture for the cdk-real-drift FP hunt.
+// AWS::ElasticLoadBalancingV2::TrustStore has a `supplementTrustStore`
+// SDK_SUPPLEMENT that was added without ever being exercised live. The CA
+// bundle must exist in S3 BEFORE the stack deploys, so verify.sh pre-creates
+// the bucket + a self-signed CA PEM out of band and passes the location via
+// CDKRD_HUNT_TS_BUCKET / CDKRD_HUNT_TS_KEY (env is set for deploy AND for
+// every cdkrd invocation, which re-synthesizes this app).
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnTrustStore } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const bucket = process.env.CDKRD_HUNT_TS_BUCKET;
+const key = process.env.CDKRD_HUNT_TS_KEY ?? "ca-bundle.pem";
+if (!bucket) throw new Error("CDKRD_HUNT_TS_BUCKET must be set (see verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntTrustStore0712c");
+
+// Barest trust store: only the required CA bundle location + a name.
+new CfnTrustStore(stack, "TrustStore", {
+  name: "cdkrd-hunt-truststore-0712c",
+  caCertificatesBundleS3Bucket: bucket,
+  caCertificatesBundleS3Key: key,
+});
+
+app.synth();

--- a/tests/integration/truststore-barest/cdk.json
+++ b/tests/integration/truststore-barest/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/truststore-barest/package.json
+++ b/tests/integration/truststore-barest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-truststore-barest",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config ELBv2 TrustStore fixture for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/truststore-barest/verify.sh
+++ b/tests/integration/truststore-barest/verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ELBv2 TrustStore integration test (real AWS). The CA bundle must exist in S3 BEFORE the
+# stack deploys, so this script pre-creates a bucket + self-signed CA PEM out of band and
+# passes the location via CDKRD_HUNT_TS_BUCKET (read by app.ts on every synth).
+# Asserts: (1) the ONLY first-run [Potential Drift] is the BY-DESIGN CaCertificatesBundleSha256
+# integrity signal (#505 — record snapshots it); (2) after record the check is CLEAN;
+# (3) an out-of-band CA-bundle SWAP re-surfaces the sha256 (the #505 detection, live-proven).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntTrustStore0712c
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ACCT="$(aws sts get-caller-identity --query Account --output text)"
+export CDKRD_HUNT_TS_BUCKET="cdkrd-hunt-ts-0712c-$ACCT"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  aws s3 rb "s3://$CDKRD_HUNT_TS_BUCKET" --force >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] pre-create CA bundle bucket ==="
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/cdkrd-ts-key.pem -out /tmp/cdkrd-ts-cert.pem \
+  -days 7 -nodes -subj "/CN=cdkrd-hunt-truststore.internal" 2>/dev/null || fail "openssl"
+aws s3api create-bucket --bucket "$CDKRD_HUNT_TS_BUCKET" --region "$REGION" >/dev/null || true
+aws s3 cp /tmp/cdkrd-ts-cert.pem "s3://$CDKRD_HUNT_TS_BUCKET/ca-bundle.pem" >/dev/null || fail "s3 cp"
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (snapshots the sha256 integrity signal) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "=== [$STACK] out-of-band CA bundle SWAP must re-surface the sha256 (#505) ==="
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/cdkrd-ts-key2.pem -out /tmp/cdkrd-ts-cert2.pem \
+  -days 7 -nodes -subj "/CN=cdkrd-hunt-truststore-swapped.internal" 2>/dev/null || fail "openssl v2"
+aws s3 cp /tmp/cdkrd-ts-cert2.pem "s3://$CDKRD_HUNT_TS_BUCKET/ca-bundle-v2.pem" >/dev/null || fail "s3 cp v2"
+TSARN="$(aws elbv2 describe-trust-stores --region "$REGION" \
+  --query 'TrustStores[?Name==`cdkrd-hunt-truststore-0712c`].TrustStoreArn' --output text)"
+aws elbv2 modify-trust-store --trust-store-arn "$TSARN" \
+  --ca-certificates-bundle-s3-bucket "$CDKRD_HUNT_TS_BUCKET" \
+  --ca-certificates-bundle-s3-key ca-bundle-v2.pem --region "$REGION" >/dev/null || fail "modify-trust-store"
+sleep 10
+$CLI check "$STACK" --region "$REGION" --fail && fail "bundle swap NOT detected (expected exit 1)"
+grep -q "CaCertificatesBundleSha256" "/tmp/cdkrd-$STACK.out" 2>/dev/null || true
+
+echo "INTEG PASS ($STACK)"

--- a/tests/lightsail-firstrun-folds-1533.test.ts
+++ b/tests/lightsail-firstrun-folds-1533.test.ts
@@ -1,0 +1,73 @@
+// #1533: a barest Lightsail Instance first-ran two [Potential Drift] entries (live
+// 2026-07-12, us-east-1, CdkrdHuntMiscBarest20712c): the constant Linux default firewall
+// (Networking: inbound tcp 22 + 80 from anywhere) and the AWS-placed AvailabilityZone.
+// The Networking pin is equality-gated so an out-of-band `open-instance-public-ports`
+// (a rogue port) still surfaces; the AZ folds value-independent (AWS-placed, create-only,
+// the RDS/Neptune AvailabilityZone twin).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const port = (p: number) => ({
+  FromPort: p,
+  AccessDirection: 'inbound',
+  CidrListAliases: [],
+  ToPort: p,
+  Ipv6Cidrs: ['::/0'],
+  AccessFrom: 'Anywhere (0.0.0.0/0 and ::/0)',
+  Protocol: 'tcp',
+  AccessType: 'public',
+  Cidrs: ['0.0.0.0/0'],
+  CommonName: '',
+});
+
+describe('#1533 Lightsail Instance first-run folds', () => {
+  const res: DesiredResource = {
+    logicalId: 'Ls',
+    resourceType: 'AWS::Lightsail::Instance',
+    physicalId: 'cdkrd-hunt-ls-0712c',
+    declared: {
+      InstanceName: 'cdkrd-hunt-ls-0712c',
+      BlueprintId: 'amazon_linux_2023',
+      BundleId: 'nano_3_0',
+    },
+  };
+  const live = (ports: number[]) => ({
+    InstanceName: 'cdkrd-hunt-ls-0712c',
+    BlueprintId: 'amazon_linux_2023',
+    BundleId: 'nano_3_0',
+    KeyPairName: 'LightsailDefaultKeyPair',
+    AvailabilityZone: 'us-east-1a',
+    Networking: { Ports: ports.map(port), MonthlyTransfer: {} },
+  });
+
+  it('folds the default firewall and the AWS-placed AZ on a clean first run', () => {
+    const f = classifyResource(res, live([22, 80]), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    for (const p of ['Networking', 'AvailabilityZone', 'KeyPairName']) {
+      expect(pathsByTier(f, 'atDefault')).toContain(p);
+    }
+  });
+
+  it('surfaces an out-of-band opened port (equality gate keeps the security detection)', () => {
+    const f = classifyResource(res, live([22, 80, 8080]), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Networking']);
+  });
+});

--- a/tests/noise-case-insensitive-1531.test.ts
+++ b/tests/noise-case-insensitive-1531.test.ts
@@ -1,0 +1,77 @@
+// #1531: RDS stores its parameter-group / option-group / subnet-group NAMES "as a lowercase
+// string" (the same family as the DBInstanceIdentifier / DBClusterIdentifier entries), so a
+// mixed-case declaration reads back all-lowercase forever — a permanent declared-tier FP that
+// survives record and never converges. The #1507 hunt live-captured exactly this FP into three
+// corpus cases (their `expected` is corrected in this PR). These tests pin the
+// CASE_INSENSITIVE_PATHS additions: a case-only difference folds; a real rename still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const declaredPaths = (findings: Finding[]) =>
+  findings
+    .filter((f) => f.tier === 'declared')
+    .map((f) => f.path)
+    .sort();
+
+// type → [name property, mixed-case declared, lowercase live echo]
+const CASES: [string, string, string, string][] = [
+  [
+    'AWS::RDS::DBParameterGroup',
+    'DBParameterGroupName',
+    'CdkrdHunt-Mixed-PG',
+    'cdkrdhunt-mixed-pg',
+  ],
+  [
+    'AWS::RDS::DBClusterParameterGroup',
+    'DBClusterParameterGroupName',
+    'CdkrdHunt-Mixed-CPG',
+    'cdkrdhunt-mixed-cpg',
+  ],
+  ['AWS::RDS::OptionGroup', 'OptionGroupName', 'CdkrdHunt-Mixed-OG', 'cdkrdhunt-mixed-og'],
+  ['AWS::RDS::DBSubnetGroup', 'DBSubnetGroupName', 'CdkrdHunt-Mixed-SNG', 'cdkrdhunt-mixed-sng'],
+  ['AWS::Neptune::DBParameterGroup', 'Name', 'CdkrdHunt-Mixed-NPG', 'cdkrdhunt-mixed-npg'],
+  ['AWS::Neptune::DBClusterParameterGroup', 'Name', 'CdkrdHunt-Mixed-NCPG', 'cdkrdhunt-mixed-ncpg'],
+  ['AWS::DocDB::DBClusterParameterGroup', 'Name', 'CdkrdHunt-Mixed-DCPG', 'cdkrdhunt-mixed-dcpg'],
+];
+
+describe('#1531 lowercase-stored name family folds case-only echoes', () => {
+  for (const [type, prop, declared, live] of CASES) {
+    it(`${type}.${prop}: mixed-case declaration matches its lowercase echo`, () => {
+      const res: DesiredResource = {
+        logicalId: 'R',
+        resourceType: type,
+        physicalId: live,
+        declared: { [prop]: declared, Description: 'd' },
+      };
+      const f = classifyResource(res, { [prop]: live, Description: 'd' }, emptySchema);
+      expect(declaredPaths(f)).toEqual([]);
+    });
+  }
+
+  it('a genuinely different name still surfaces as declared drift', () => {
+    const res: DesiredResource = {
+      logicalId: 'R',
+      resourceType: 'AWS::RDS::DBParameterGroup',
+      physicalId: 'other-name',
+      declared: { DBParameterGroupName: 'CdkrdHunt-Mixed-PG', Description: 'd' },
+    };
+    const f = classifyResource(
+      res,
+      { DBParameterGroupName: 'other-name', Description: 'd' },
+      emptySchema
+    );
+    expect(declaredPaths(f)).toEqual(['DBParameterGroupName']);
+  });
+});


### PR DESCRIPTION
## Summary

`/hunt-bugs` sweep (5 rounds: zero-corpus SDK_OVERRIDES barest deploys, offline MEANINGFUL_WHEN_OFF + allowlist + revert-set-default audits, FN/revert live cycles, composite-id probe, raw-CFn notation lens). Four bug classes found, fixed, unit-tested, and live-verified; six fixtures + 14 golden-corpus cases added.

Closes #1530, Closes #1531, Closes #1532, Closes #1533.

### #1530 — FN: off-flip of a true-pinned KNOWN_DEFAULTS boolean swallowed without a MEANINGFUL_WHEN_OFF pairing

- `AWS::EC2::ClientVpnEndpoint.DisconnectOnSessionTimeout` — **live-proven both directions** on a fresh barest endpoint: base 0.13.10 stayed CLEAN (exit 0) after `modify-client-vpn-endpoint --no-disconnect-on-session-timeout`; the fix surfaces it and `revert` writes `true` back (existing REVERT_SET_DEFAULT_PATHS entry) and converges.
- `AWS::ImageBuilder::ImagePipeline.EnhancedImageMetadataEnabled` + `AWS::ImageBuilder::InfrastructureConfiguration.TerminateInstanceOnFailure` — the #911 pin comments themselves documented this FN as deferred; now wired.
- `AWS::ECS::Service` `DeploymentConfiguration.DeploymentCircuitBreaker.ResetOnHealthyTask` (nested) — predicate-gated on the breaker being ENABLED so a disabled breaker's untouched `false` stays folded.
- Audit note: the offline audit's other candidates (CloudTrail/S3Express/Glue object pins, immutable ECS TaskDefinition, nonexistent RolesAnywhere pin) are NOT FNs — details on the issue.

### #1531 — FP: RDS-family lowercase-stored names missing from CASE_INSENSITIVE_PATHS (FP pinned in corpus by #1507)

- Added `AWS::RDS::DBParameterGroup/DBClusterParameterGroup/OptionGroup/DBSubnetGroup` and `AWS::Neptune::DBParameterGroup/DBClusterParameterGroup` (`Name`), `AWS::DocDB::DBClusterParameterGroup` (`Name`) — docs-verified ("stored as a lowercase string") + two live probes (OptionGroup via the #1507 corpus, DBSubnetGroup via a fresh mixed-case `create-db-subnet-group` that stored `cdkrdhunt-mixed-sng`, disproving the earlier "RDS preserves case" rule-out note, which is corrected).
- The three #1507 corpus cases' `expected` regenerated to clean (they had pinned the FP).

### #1532 — FP x4: barest DAX first run (+ revert convergence)

- `AWS::DAX::ParameterGroup.ParameterNameValues` (engine TTL defaults) + `AWS::DAX::Cluster.ParameterGroupName` (`default.dax1.0`) → tier-1 KNOWN_DEFAULTS constants.
- `AWS::DAX::Cluster.PreferredMaintenanceWindow` → value-independent (randomly-assigned slot, the RDS/ElastiCache sibling).
- `AWS::DAX::Cluster.SecurityGroupIds` → the #889 derived VPC-default-SG gate (classify DEFAULT_SG_LIST_PATHS + gather DEFAULT_SG_LIST_TYPES), so an OOB swap/append still surfaces.
- Bonus: `AWS::DAX::ParameterGroup\0ParameterNameValues` added to REVERT_SET_DEFAULT_PATHS — DAX has no reset API, so the `remove` revert threw "cannot be cleared"; the set-default write converges (**live-proven**: OOB `query-ttl-millis=60000` → detect → revert → 300000, CLEAN).
- Live A/B: barest DAX stack first check went 4 potential-drift → CLEAN.

### #1533 — FP x2: barest Lightsail Instance first run

- `Networking` → KNOWN_DEFAULTS pin of the live-verified Linux default firewall (tcp 22+80); equality-gated, **live-proven** that an OOB `open-instance-public-ports 8080` surfaces and closes back to CLEAN.
- `AvailabilityZone` → value-independent (AWS-placed, create-only; RDS/Neptune twin).

### Fixtures (all with verify.sh, `cdkrd:ephemeral=1`, delstack traps)

- `dax-barest` (Cluster+ParameterGroup+SubnetGroup — zero-corpus SDK_OVERRIDES trio)
- `clientvpn-barest` (+`verify-detect.sh` for the #1530 off-flip→detect→revert cycle; self-signed ACM import)
- `truststore-barest` (supplementTrustStore first live exercise; asserts the by-design #505 sha256 signal + OOB bundle-swap detection — **both live-proven this session**)
- `miscbarest-hunt` (Rbin Rule + NetworkManager GlobalNetwork + AppRegistry Application; Rbin OOB retention detect→revert live-proven)
- `miscbarest2-hunt` (NetworkManager Site/Device/Link composite-id probe — reads fine, no adapter gap; DataBrew Dataset/Recipe; Lightsail; documents DataBrew CreateProject's deploy-time S3-object validation)
- `notation-hunt` (raw-CFn YAML short-form intrinsics — !Sub/!Ref/!FindInMap/!Join/!Select/!Split/!If+NoValue/!GetAtt — first check CLEAN, OOB change to a !Ref-parameterized declared value detected against the RESOLVED desired and reverted; deployed via `aws cloudformation deploy` with an app.ts discovery shim)

### Corpus (+14) & tooling

- New types: DAX x3, ELBv2 TrustStore, EC2 ClientVpnEndpoint, Rbin Rule, NetworkManager GlobalNetwork/Site/Device/Link, ServiceCatalogAppRegistry Application, DataBrew Dataset/Recipe, Lightsail Instance.
- 3 durable lessons folded into the hunt-bugs skill (standalone-boolean-only FN class, corpus-promotion FP pinning, array pins need the exact live shape).

### Clean-lens results (no bug, validated live)

- Revert set-default offline audit: no uncovered gaps.
- Composite-id audit: known `*-readgap` fixtures already pin the open gaps; NetworkManager children read fine.
- Notation lens: YAML codec + intrinsic resolver clean.
- Timestream is closed to new customers (not deployable); ACM Certificate remains unexercisable without a resolvable hosted zone.

## Test plan

- `vp run test` (5466 tests, incl. 750 corpus-replay with the 14 new + 3 corrected cases) — all green; the 17 new assertions fail without the fixes (verified by stash).
- Live: every fix A/B'd against real AWS in this session (details above and on the issues).
