### PR TITLE
fix(hunt): fold MediaConvert/CloudMap/DDB-warm/re-case first-run FPs, unskip LakeFormation reader, converge RDS BackupRetentionPeriod revert

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -518,6 +518,34 @@ Recorded]` breakdown with `--verbose`.
   TransitEncryptionEnabled, both unlike redis; observed 2026-07-12). Record the
   difference in the fixture comment (it documents the axis) and declare the minimum
   to proceed — the surviving undeclared surface is still the probe.
+- **Raw-API acceptance ≠ CloudFormation reachability — probe the CFn HANDLER before
+  concluding a case-echo FP risk.** Several CC handlers add CLIENT-side validation the
+  raw service API does not have: `elasticache create-user` and `memorydb
+create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercased —
+  the FP trigger), yet the CFn/CC handlers REJECT the same input
+  (`InvalidRequest: must contain only lowercase…`), making the FP unreachable via
+  CloudFormation — no allowlist entry needed (2026-07-13, #1539 determinations). The
+  cheap sequence: probe the raw API by CLI create+delete first (it answers "does the
+  service lowercase?"), but only a CFn DEPLOY proves reachability; a handler rejection
+  is itself the determination (record it in the fixture comment). The inverse also
+  held: Redshift's and Batch's handlers pass mixed case through, and both FP'd.
+- **An undeclared-revert "proof" is void if the CDK L2 declares the leaf.** Before
+  claiming a revert no-op / convergence proof for an UNDECLARED property, read the
+  DEPLOYED template: mutating a value the L2 silently declared (RDS
+  `CopyTagsToSnapshot: true`) produces NO divergence (live == declared), so the revert
+  never plans it and the "proof" proves nothing — the fixture-side twin of the
+  "corpus that declares the target leaf can't stand in" lesson. Live-proof each
+  REVERT_SET_DEFAULT sibling individually with a template that genuinely omits it
+  (#1541: BackupRetentionPeriod proven; CopyTagsToSnapshot stays unproven for exactly
+  this reason).
+- **An in-stack scalable target is a cheap real-drift generator.** A ScalableTarget
+  scheduled action (min/max below the declared capacity) makes App Auto Scaling clamp
+  the resource within minutes of deploy — producing a REAL capacity divergence with no
+  out-of-band CLI call. That accident exposed the WarmThroughput creation-echo FP
+  (#1538: warm throughput echoes CREATION capacity and never follows a scale-in, so a
+  derived fold gated only on the CURRENT live sibling FPs after any scale-in). Pattern
+  to reuse: derived folds for creation-echo values must ALSO gate against the
+  DECLARED-derived value, and autoscaling-governed fixtures probe that class for free.
 - **`example.com` / `.test` / `.example` are AWS-RESERVED for Route53 hosted zones**
   (`InvalidDomainNameException` on create). A Route53 fixture must use a non-reserved
   placeholder domain (e.g. `cdkrd-fphunt-x9z7q.com.`) — a public hosted zone for a

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1324,37 +1324,56 @@ const isNestedObject = (x: unknown): x is Record<string, unknown> =>
 // So it is a DERIVED default keyed on the sibling ProvisionedThroughput, unifying both cases:
 // compute it and equality-gate, so an out-of-band warm-throughput change (which auto-ratchets
 // upward under load and never decreases) still surfaces — the same trade-off the type accepts.
+// #1538: warm throughput echoes the capacity at CREATION and never follows a scale-in, so a
+// table whose live capacity dropped below the template's initial capacity (the everyday
+// Application-Auto-Scaling scale-in) no longer matches the live-derived value — callers must
+// ALSO gate against the derivation from the DECLARED ProvisionedThroughput (the creation
+// value). A table that warmed UP under traffic (warm > both) still surfaces, unchanged.
 const DDB_TABLE_TYPES = new Set(['AWS::DynamoDB::Table', 'AWS::DynamoDB::GlobalTable']);
+// Template numbers can arrive as strings (raw-YAML templates); tolerate both.
+function capacityUnit(x: unknown): number | undefined {
+  if (typeof x === 'number') return x;
+  if (typeof x === 'string' && x.trim() !== '' && !Number.isNaN(Number(x))) return Number(x);
+  return undefined;
+}
 function warmThroughputDefault(provisionedThroughput: unknown): Record<string, number> {
-  if (
-    isNestedObject(provisionedThroughput) &&
-    typeof provisionedThroughput.ReadCapacityUnits === 'number' &&
-    typeof provisionedThroughput.WriteCapacityUnits === 'number'
-  ) {
-    return {
-      ReadUnitsPerSecond: provisionedThroughput.ReadCapacityUnits,
-      WriteUnitsPerSecond: provisionedThroughput.WriteCapacityUnits,
-    };
+  if (isNestedObject(provisionedThroughput)) {
+    const read = capacityUnit(provisionedThroughput.ReadCapacityUnits);
+    const write = capacityUnit(provisionedThroughput.WriteCapacityUnits);
+    if (read !== undefined && write !== undefined)
+      return { ReadUnitsPerSecond: read, WriteUnitsPerSecond: write };
   }
   return { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 };
 }
 // A GSI-nested WarmThroughput path (`GlobalSecondaryIndexes[<IndexName>].WarmThroughput`) that
 // echoes THAT GSI's effective capacity. Resolves the GSI's own ProvisionedThroughput from the
-// live model by IndexName so the derived default is per-GSI.
+// live model by IndexName — and, per #1538, from the DECLARED model too (the creation echo
+// survives a later autoscaling scale-in) — so the derived default is per-GSI.
+function gsiByName(model: unknown, indexName: string): Record<string, unknown> | undefined {
+  if (!isNestedObject(model) || !Array.isArray(model.GlobalSecondaryIndexes)) return undefined;
+  const gsi = (model.GlobalSecondaryIndexes as unknown[]).find(
+    (g) => isNestedObject(g) && g.IndexName === indexName
+  );
+  return isNestedObject(gsi) ? gsi : undefined;
+}
 function dynamoGsiWarmThroughputAtDefault(
   resourceType: string,
   path: string,
   value: unknown,
-  live: Record<string, unknown>
+  live: Record<string, unknown>,
+  declared: Record<string, unknown>
 ): boolean {
   if (!DDB_TABLE_TYPES.has(resourceType)) return false;
   const m = /^GlobalSecondaryIndexes\[(.*)\]\.WarmThroughput$/.exec(path);
-  if (m === null || !Array.isArray(live.GlobalSecondaryIndexes)) return false;
-  const gsi = (live.GlobalSecondaryIndexes as unknown[]).find(
-    (g) => isNestedObject(g) && g.IndexName === m[1]
+  if (m === null) return false;
+  const liveGsi = gsiByName(live, m[1] as string);
+  const declaredGsi = gsiByName(declared, m[1] as string);
+  return (
+    (liveGsi !== undefined &&
+      deepEqual(value, warmThroughputDefault(liveGsi.ProvisionedThroughput))) ||
+    (declaredGsi !== undefined &&
+      deepEqual(value, warmThroughputDefault(declaredGsi.ProvisionedThroughput)))
   );
-  if (!isNestedObject(gsi)) return false;
-  return deepEqual(value, warmThroughputDefault(gsi.ProvisionedThroughput));
 }
 
 // #705: a Classic ELB (ElasticLoadBalancing::LoadBalancer) with an HTTPS/SSL listener but no
@@ -3553,7 +3572,7 @@ export function classifyResource(
         !(schemaPath in knownDefPaths)) ||
       // #627: a GSI's undeclared WarmThroughput echoing that GSI's effective capacity
       // (on-demand constant or its own ProvisionedThroughput) — a per-GSI derived default.
-      dynamoGsiWarmThroughputAtDefault(resourceType, path, value, live) ||
+      dynamoGsiWarmThroughputAtDefault(resourceType, path, value, live, declared) ||
       // #1314: an AWS::Events::EventBusPolicy's live `Statement[n].Sid` (the resource's OWN
       // read) is the service stamping the declared top-level `StatementId` into the stored
       // statement — the registry `propertyTransform` `Statement: $merge([{"Sid":StatementId},
@@ -4860,11 +4879,28 @@ export function classifyResource(
     // #627: a provisioned DynamoDB table's top-level WarmThroughput echoes its own
     // ProvisionedThroughput (an on-demand table's {12000,4000} constant is already folded by
     // KNOWN_DEFAULTS above). Derived from the sibling ProvisionedThroughput and equality-gated,
-    // so an out-of-band warm-throughput change still surfaces.
+    // so an out-of-band warm-throughput change still surfaces. #1538: ALSO gate against the
+    // DECLARED capacity — warm throughput echoes the CREATION capacity and never follows a
+    // scale-in, so after an autoscaling scale-in below the template's initial capacity only
+    // the declared-derived value matches.
     if (
       DDB_TABLE_TYPES.has(resourceType) &&
       k === 'WarmThroughput' &&
-      deepEqual(v, warmThroughputDefault(live.ProvisionedThroughput))
+      (deepEqual(v, warmThroughputDefault(live.ProvisionedThroughput)) ||
+        deepEqual(v, warmThroughputDefault(declared.ProvisionedThroughput)))
+    ) {
+      findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+      continue;
+    }
+    // #1537: Cloud Map derives a Service's `Type` at creation from the declared shape — a
+    // service with a DnsConfig is DNS+API discoverable (`DNS_HTTP`); one without (an
+    // HTTP-namespace service) is `HTTP`. A deterministic function of the declared inputs
+    // (fold tier 2), equality-gated so a genuinely different mode (a DNS-only service
+    // created out of band) still surfaces.
+    if (
+      resourceType === 'AWS::ServiceDiscovery::Service' &&
+      k === 'Type' &&
+      v === (declared.DnsConfig !== undefined ? 'DNS_HTTP' : 'HTTP')
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -910,6 +910,21 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // (NumShards≠1), a replica change, a snapshot enable, or a TLS DISABLE still surfaces (the
   // TLSEnabled truthy-bool disable via the AWS::MemoryDB::Cluster MEANINGFUL_WHEN_OFF gate in
   // diff/classify.ts, so a live `false` is not swallowed by isTrivialEmpty).
+  // #1535: a barest on-demand MediaConvert Queue / JobTemplate first-run-FP'd all five of
+  // these creation-time constants (the #497 SDK-override readers were never exercised in
+  // their barest form). Equality-gated: `Status` is the classic console-toggled prop (pause
+  // a queue), so an out-of-band PAUSED no longer matches and surfaces — the very detection
+  // the reader exists for; likewise a priority bump, a faster status-update cadence, or an
+  // acceleration enable on the template.
+  'AWS::MediaConvert::Queue': {
+    PricingPlan: 'ON_DEMAND',
+    Status: 'ACTIVE',
+  },
+  'AWS::MediaConvert::JobTemplate': {
+    Priority: 0,
+    StatusUpdateInterval: 'SECONDS_60',
+    AccelerationSettings: { Mode: 'DISABLED' },
+  },
   'AWS::MemoryDB::Cluster': {
     Port: 6379,
     AutoMinorVersionUpgrade: true,
@@ -2446,6 +2461,15 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string
   'AWS::SSM::MaintenanceWindowTask': {
     ServiceRoleArn:
       'arn:{partition}:iam::{accountId}:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM',
+  },
+  // A LakeFormation Resource registered with `UseServiceLinkedRole: true` (RoleArn
+  // undeclared) reads back the account's LakeFormation service-linked role ARN —
+  // f(partition, accountId). Twin of the ASG / Batch / SSM SLR folds; equality-gated, so an
+  // out-of-band re-registration under a CUSTOM role still surfaces (the drift the #1536
+  // reader unskip exists to catch). Live-confirmed (misc-readers-min, 2026-07-13; #1536).
+  'AWS::LakeFormation::Resource': {
+    RoleArn:
+      'arn:{partition}:iam::{accountId}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess',
   },
   // A LakeFormation Tag that declares no CatalogId reads back the deploying account id — the
   // default (own-account) Data Catalog. The bare `{accountId}` placeholder substitutes to the
@@ -4320,6 +4344,12 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // two valid values differ beyond case, so case-insensitive equality hides no real
   // drift. Observed live on a fresh batch-rich deploy.
   'AWS::Batch::ComputeEnvironment': new Set(['Type']),
+  // Batch JobDefinition `Type` — the same enum re-case echo as ComputeEnvironment above:
+  // the handler accepts `Container`, the service echoes the canonical lowercase
+  // `container`. The valid values (container / multinode) differ beyond case, so a real
+  // change still surfaces. Observed live on a fresh mixed-case job definition
+  // (case-idents2-min, 2026-07-13; #1539).
+  'AWS::Batch::JobDefinition': new Set(['Type']),
   // EMR Serverless Application `Type` — the CFn schema enum is UPPERCASE
   // (`SPARK`/`HIVE`) but the EMR Serverless API canonicalizes to mixed case on
   // read (`Spark`/`Hive`), so a case-sensitive compare false-flags declared drift
@@ -4357,6 +4387,14 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Neptune::DBCluster': new Set(['DBClusterIdentifier']),
   'AWS::Neptune::DBInstance': new Set(['DBInstanceIdentifier']),
   'AWS::Neptune::DBSubnetGroup': new Set(['DBSubnetGroupName']),
+  // Redshift lowercases a cluster parameter group's name on creation (the CFn handler
+  // accepts the mixed-case input): a template declaring "CdkrdHunt-RsCpg" reads back
+  // "cdkrdhunt-rscpg" — the same stored-lowercased identifier family as the RDS
+  // parameter/option groups (#1531). Two names differing beyond case are a genuine
+  // replacement and still surface. Observed live (case-idents2-min, 2026-07-13; #1539).
+  // ClusterSubnetGroup has no declarable name; Cluster's ClusterIdentifier is CDK-lowered
+  // already and unprobed — add it here only with live proof.
+  'AWS::Redshift::ClusterParameterGroup': new Set(['ParameterGroupName']),
   'AWS::DMS::ReplicationInstance': new Set(['ReplicationInstanceIdentifier']),
   'AWS::DMS::ReplicationSubnetGroup': new Set(['ReplicationSubnetGroupIdentifier']),
   // DMS Endpoint `EndpointType` — the CFn/CDK value is lowercase (`source` /

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -1119,9 +1119,16 @@ const readDmsReplicationTask: OverrideReader = async ({ physicalId, declared, re
 // be permanent first-run noise). Read-ONLY. A deregistered/absent location surfaces as
 // EntityNotFoundException (or an empty ResourceInfo) → ResourceGoneError, which the router maps
 // to `deleted`.
+// #1536: the CFn physical id is NOT the bare ResourceArn — CloudFormation prefixes it
+// (`LakeFormation-arn:aws:s3:::bucket`), so passing it verbatim threw InvalidInputException
+// and the resource silently SKIPPED (a falsely-CLEAN read on the exact type this reader was
+// added to watch — the same ARN-vs-physical-id skip-mask class as #1523). Strip everything
+// before the first `arn:`.
 const readLakeFormationResource: OverrideReader = async ({ physicalId, region }) => {
-  const arn = str(physicalId);
-  if (!arn) return undefined;
+  const raw = str(physicalId);
+  if (!raw) return undefined;
+  const arnStart = raw.indexOf('arn:');
+  const arn = arnStart >= 0 ? raw.slice(arnStart) : raw;
   const c = new LakeFormationClient({ region, ...READ_RETRY });
   let info;
   try {
@@ -2667,10 +2674,15 @@ const readServiceDiscoveryNamespace: OverrideReader = async ({ physicalId, decla
 
 // AWS::ServiceDiscovery::Service — same CC read gap. Read via Cloud Map GetService;
 // the CFn physical id IS the service Id (srv-xxxx). Project the CFn-modeled props,
-// mapping the SDK shapes back to CFn PascalCase. DnsConfig.NamespaceId is a
-// deprecated/read-only echo, deliberately not projected (a service in an HTTP
-// namespace has no DnsConfig at all). HealthCheck* are projected only when present
-// so an HTTP service stays CLEAN. Id / Arn / InstanceCount / CreateDate are noise.
+// mapping the SDK shapes back to CFn PascalCase. GetService's DnsConfig omits the
+// deprecated NamespaceId echo, but the CDK L2 Service ALWAYS declares it inside
+// DnsConfig — so when the DECLARED model carries DnsConfig.NamespaceId, mirror the
+// live top-level Service.NamespaceId into the projected DnsConfig (#1537; without
+// this every CDK L2 DNS service false-flagged declared drift `desired=ns-…
+// actual=undefined`). A raw-CFn template that omits it stays unprojected (a service
+// in an HTTP namespace has no DnsConfig at all). HealthCheck* are projected only
+// when present so an HTTP service stays CLEAN. Id / Arn / InstanceCount /
+// CreateDate are noise.
 const readServiceDiscoveryService: OverrideReader = async ({ physicalId, declared, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
@@ -2683,13 +2695,20 @@ const readServiceDiscoveryService: OverrideReader = async ({ physicalId, declare
   if (s.Description !== undefined) model.Description = s.Description;
   if (s.NamespaceId !== undefined) model.NamespaceId = s.NamespaceId;
   if (s.Type !== undefined) model.Type = s.Type;
-  if (s.DnsConfig)
+  if (s.DnsConfig) {
+    const declaredDnsConfig = (declared as Record<string, unknown> | undefined)?.DnsConfig;
+    const declaresNamespaceId =
+      declaredDnsConfig !== null &&
+      typeof declaredDnsConfig === 'object' &&
+      (declaredDnsConfig as Record<string, unknown>).NamespaceId !== undefined;
     model.DnsConfig = {
+      ...(declaresNamespaceId && s.NamespaceId !== undefined && { NamespaceId: s.NamespaceId }),
       ...(s.DnsConfig.RoutingPolicy !== undefined && { RoutingPolicy: s.DnsConfig.RoutingPolicy }),
       ...(s.DnsConfig.DnsRecords !== undefined && {
         DnsRecords: s.DnsConfig.DnsRecords.map((d) => ({ Type: d.Type, TTL: d.TTL })),
       }),
     };
+  }
   if (s.HealthCheckConfig)
     model.HealthCheckConfig = {
       ...(s.HealthCheckConfig.Type !== undefined && { Type: s.HealthCheckConfig.Type }),

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -323,6 +323,17 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // converges. The set-default value resolves from KNOWN_DEFAULTS (the same `true` pin that folds
   // the clean read atDefault) — no REVERT_SET_DEFAULT_VALUES entry needed.
   'AWS::RDS::DBInstance\0AutoMinorVersionUpgrade',
+  // #1541: ModifyDBInstance keeps the existing value for ANY omitted property — the same
+  // selective-modify semantics as the #660 upgrade booleans above, live-proven beyond them
+  // on CdkrdHunt0713RdsMariadb (us-east-1, 2026-07-13): an out-of-band undeclared
+  // BackupRetentionPeriod 1->3 survived a bare-`remove` revert that reported success (the
+  // convergence re-read flagged it NOT reverted); with this entry the set-default `add 1`
+  // (from KNOWN_DEFAULTS) converges — live re-verified to 1. The remaining folded siblings
+  // on the same API (MultiAZ, CopyTagsToSnapshot, EnablePerformanceInsights,
+  // CACertificateIdentifier, MonitoringInterval) are expected twins — add each ONLY with
+  // its own live proof (note the CDK L2 declares CopyTagsToSnapshot, so proving it needs a
+  // raw-CFn/L1 fixture that leaves it undeclared).
+  'AWS::RDS::DBInstance\0BackupRetentionPeriod',
   'AWS::RDS::DBCluster\0AutoMinorVersionUpgrade',
   'AWS::Neptune::DBInstance\0AutoMinorVersionUpgrade',
   'AWS::ElastiCache::CacheCluster\0AutoMinorVersionUpgrade',

--- a/tests/classify-cloudmap-service-1537.test.ts
+++ b/tests/classify-cloudmap-service-1537.test.ts
@@ -1,0 +1,135 @@
+// #1537 — Cloud Map DNS Service double FP on a barest CDK L2 PublicDnsNamespace + Service
+// (live-proven on CdkrdHunt0713CloudmapPub, us-east-1, 2026-07-13):
+//   1. declared-tier: the CDK L2 Service ALWAYS declares DnsConfig.NamespaceId, but
+//      GetService's DnsConfig omits the deprecated echo — the reader now mirrors the live
+//      top-level Service.NamespaceId into the projected DnsConfig when the DECLARED model
+//      carries it (and only then, so raw-CFn templates without it stay unprojected).
+//   2. undeclared-tier: Cloud Map derives `Type` at creation from the declared shape —
+//      DnsConfig present -> "DNS_HTTP", absent -> "HTTP" — a fold-tier-2 derived default,
+//      equality-gated so a genuinely different mode still surfaces.
+import {
+  GetServiceCommand,
+  type Service,
+  ServiceDiscoveryClient,
+} from '@aws-sdk/client-servicediscovery';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const sd = mockClient(ServiceDiscoveryClient);
+
+const ctx = (physicalId: string, declared: Record<string, unknown> = {}) => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId: '123456789012',
+});
+
+const read = (c: ReturnType<typeof ctx>) => SDK_OVERRIDES['AWS::ServiceDiscovery::Service'](c);
+
+beforeEach(() => {
+  sd.reset();
+});
+
+const liveService = {
+  Id: 'srv-1234567890abcdef',
+  Name: 'hunt-svc',
+  NamespaceId: 'ns-tn6g37nbeg3jrbke',
+  Type: 'DNS_HTTP',
+  DnsConfig: {
+    RoutingPolicy: 'MULTIVALUE',
+    DnsRecords: [{ Type: 'A', TTL: 60 }],
+  },
+} as Service;
+
+describe('#1537 ServiceDiscovery Service reader — DnsConfig.NamespaceId mirror', () => {
+  it('projects the live top-level NamespaceId into DnsConfig when the template declares it (CDK L2 shape)', async () => {
+    sd.on(GetServiceCommand).resolves({ Service: liveService });
+    const out = await read(
+      ctx('srv-1234567890abcdef', {
+        Name: 'hunt-svc',
+        DnsConfig: {
+          NamespaceId: 'ns-tn6g37nbeg3jrbke',
+          DnsRecords: [{ Type: 'A', TTL: 60 }],
+          RoutingPolicy: 'MULTIVALUE',
+        },
+      })
+    );
+    expect((out as Record<string, unknown>).DnsConfig).toEqual({
+      NamespaceId: 'ns-tn6g37nbeg3jrbke',
+      RoutingPolicy: 'MULTIVALUE',
+      DnsRecords: [{ Type: 'A', TTL: 60 }],
+    });
+  });
+
+  it('keeps DnsConfig unprojected of NamespaceId when the template omits it (raw-CFn shape)', async () => {
+    sd.on(GetServiceCommand).resolves({ Service: liveService });
+    const out = await read(
+      ctx('srv-1234567890abcdef', {
+        Name: 'hunt-svc',
+        DnsConfig: { DnsRecords: [{ Type: 'A', TTL: 60 }], RoutingPolicy: 'MULTIVALUE' },
+      })
+    );
+    expect((out as Record<string, unknown>).DnsConfig).toEqual({
+      RoutingPolicy: 'MULTIVALUE',
+      DnsRecords: [{ Type: 'A', TTL: 60 }],
+    });
+  });
+});
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'HuntService',
+  resourceType: 'AWS::ServiceDiscovery::Service',
+  physicalId: 'srv-1234567890abcdef',
+  declared,
+});
+
+describe('#1537 ServiceDiscovery Service Type derived default', () => {
+  const dnsDeclared = {
+    Name: 'hunt-svc',
+    DnsConfig: {
+      NamespaceId: 'ns-tn6g37nbeg3jrbke',
+      DnsRecords: [{ Type: 'A', TTL: 60 }],
+      RoutingPolicy: 'MULTIVALUE',
+    },
+  };
+
+  it('folds the DNS_HTTP echo of a DNS-config service to atDefault', () => {
+    const f = classifyResource(mk(dnsDeclared), { ...dnsDeclared, Type: 'DNS_HTTP' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Type');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'declared')).toEqual([]);
+  });
+
+  it('folds the HTTP echo of an HTTP-namespace service (no DnsConfig) to atDefault', () => {
+    const declared = { Name: 'hunt-http-svc' };
+    const f = classifyResource(mk(declared), { ...declared, Type: 'HTTP' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Type');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a Type that does not match the derivation still surfaces (equality gate)', () => {
+    const declared = { Name: 'hunt-http-svc' };
+    const f = classifyResource(mk(declared), { ...declared, Type: 'DNS_HTTP' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Type']);
+  });
+});

--- a/tests/classify-ddb-warmthroughput-1538.test.ts
+++ b/tests/classify-ddb-warmthroughput-1538.test.ts
@@ -1,0 +1,114 @@
+// #1538 — WarmThroughput echoes the capacity at CREATION and never follows a scale-in, so a
+// provisioned table whose live capacity dropped below the template's initial capacity (the
+// everyday Application-Auto-Scaling scale-in) FP'd: the #627 derived fold only gated against
+// the CURRENT live sibling. It now ALSO gates against the derivation from the DECLARED
+// ProvisionedThroughput (the creation value) — top-level and per-GSI. A table that warmed UP
+// under traffic (warm > both) still surfaces, unchanged. Live-proven on
+// CdkrdHunt0713FormatProbes (us-east-1, 2026-07-13; RCU 5 -> 3 via a scheduled action).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'HuntTable',
+  resourceType: 'AWS::DynamoDB::Table',
+  physicalId: 'cdkrd-hunt-table',
+  declared,
+});
+
+const declared = {
+  KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+  AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+  ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+};
+
+describe('#1538 DynamoDB WarmThroughput creation echo after a scale-in', () => {
+  it('folds the creation-capacity echo when live capacity scaled below the declared capacity', () => {
+    const f = classifyResource(
+      mk(declared),
+      {
+        ...declared,
+        // Application Auto Scaling scaled RCU 5 -> 3; warm throughput stays at creation 5/5.
+        ProvisionedThroughput: { ReadCapacityUnits: 3, WriteCapacityUnits: 5 },
+        WarmThroughput: { ReadUnitsPerSecond: 5, WriteUnitsPerSecond: 5 },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('WarmThroughput');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('still folds the current-capacity echo (the original #627 case)', () => {
+    const f = classifyResource(
+      mk(declared),
+      {
+        ...declared,
+        WarmThroughput: { ReadUnitsPerSecond: 5, WriteUnitsPerSecond: 5 },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('WarmThroughput');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a warm value matching NEITHER derivation still surfaces (equality gate)', () => {
+    const f = classifyResource(
+      mk(declared),
+      {
+        ...declared,
+        ProvisionedThroughput: { ReadCapacityUnits: 3, WriteCapacityUnits: 5 },
+        WarmThroughput: { ReadUnitsPerSecond: 50, WriteUnitsPerSecond: 50 },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['WarmThroughput']);
+  });
+
+  it('per-GSI: folds the GSI creation-capacity echo after that GSI scaled in', () => {
+    const gsiDeclared = {
+      ...declared,
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: 'gsi1',
+          KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+          Projection: { ProjectionType: 'ALL' },
+          ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+        },
+      ],
+    };
+    const f = classifyResource(
+      mk(gsiDeclared),
+      {
+        ...gsiDeclared,
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: 'gsi1',
+            KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+            Projection: { ProjectionType: 'ALL' },
+            ProvisionedThroughput: { ReadCapacityUnits: 3, WriteCapacityUnits: 5 },
+            WarmThroughput: { ReadUnitsPerSecond: 5, WriteUnitsPerSecond: 5 },
+          },
+        ],
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.HuntScalableTarget.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.HuntScalableTarget.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntScalableTarget",
+    "resourceType": "AWS::ApplicationAutoScaling::ScalableTarget",
+    "physicalId": "table/CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I|dynamodb:table:ReadCapacityUnits|dynamodb",
+    "constructPath": "CdkrdHunt0713FormatProbes/HuntScalableTarget",
+    "declared": {
+      "MaxCapacity": 3,
+      "MinCapacity": 1,
+      "ResourceId": "table/CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+      "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHunt0713FormatProbes-HuntScalingRoleB2CBE2D5-JgbEROqjmCIl",
+      "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+      "ScheduledActions": [
+        {
+          "ScalableTargetAction": {
+            "MaxCapacity": 3,
+            "MinCapacity": 1
+          },
+          "Schedule": "rate(60 minutes)",
+          "ScheduledActionName": "cdkrd-hunt-sched"
+        }
+      ],
+      "ServiceNamespace": "dynamodb"
+    }
+  },
+  "liveRaw": {
+    "ScheduledActions": [
+      {
+        "ScheduledActionName": "cdkrd-hunt-sched",
+        "Schedule": "rate(60 minutes)",
+        "ScalableTargetAction": {
+          "MinCapacity": 1,
+          "MaxCapacity": 3
+        }
+      }
+    ],
+    "ResourceId": "table/CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+    "ServiceNamespace": "dynamodb",
+    "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+    "SuspendedState": {
+      "DynamicScalingOutSuspended": false,
+      "ScheduledScalingSuspended": false,
+      "DynamicScalingInSuspended": false
+    },
+    "Id": "table/CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I|dynamodb:table:ReadCapacityUnits|dynamodb",
+    "MinCapacity": 1,
+    "MaxCapacity": 3
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["RoleARN"],
+    "createOnly": ["ResourceId", "ScalableDimension", "ServiceNamespace"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["RoleARN"],
+    "createOnlyPaths": ["ResourceId", "ScalableDimension", "ServiceNamespace"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["ScheduledActions"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntScalableTarget",
+      "resourceType": "AWS::ApplicationAutoScaling::ScalableTarget",
+      "path": "RoleARN",
+      "note": "write-only — cannot be read back",
+      "physicalId": "table/CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I|dynamodb:table:ReadCapacityUnits|dynamodb",
+      "constructPath": "CdkrdHunt0713FormatProbes/HuntScalableTarget"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Batch__JobDefinition.HuntJobDef.json
+++ b/tests/corpus/AWS__Batch__JobDefinition.HuntJobDef.json
@@ -1,0 +1,97 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntJobDef",
+    "resourceType": "AWS::Batch::JobDefinition",
+    "physicalId": "arn:aws:batch:us-east-1:111111111111:job-definition/CdkrdHunt-JobDef:1",
+    "constructPath": "CdkrdHunt0713CaseIdents2/HuntJobDef",
+    "declared": {
+      "ContainerProperties": {
+        "Command": ["true"],
+        "Image": "public.ecr.aws/amazonlinux/amazonlinux:2023",
+        "Memory": 2048,
+        "Vcpus": 1
+      },
+      "JobDefinitionName": "CdkrdHunt-JobDef",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Type": "Container"
+    }
+  },
+  "liveRaw": {
+    "Type": "container",
+    "Parameters": {},
+    "JobDefinitionArn": "arn:aws:batch:us-east-1:111111111111:job-definition/CdkrdHunt-JobDef:1",
+    "ContainerProperties": {
+      "MountPoints": [],
+      "Volumes": [],
+      "Secrets": [],
+      "Command": ["true"],
+      "Memory": 2048,
+      "Environment": [],
+      "Ulimits": [],
+      "Vcpus": 1,
+      "Image": "public.ecr.aws/amazonlinux/amazonlinux:2023",
+      "ResourceRequirements": []
+    },
+    "JobDefinitionName": "CdkrdHunt-JobDef",
+    "PropagateTags": false,
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdHunt0713CaseIdents2",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713CaseIdents2/f375cad0-7e07-11f1-b041-0affcaf0bffd",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "HuntJobDef"
+    }
+  },
+  "schema": {
+    "readOnly": ["JobDefinitionArn"],
+    "writeOnly": ["ResourceRetentionPolicy"],
+    "createOnly": ["JobDefinitionName"],
+    "readOnlyPaths": ["JobDefinitionArn"],
+    "writeOnlyPaths": ["ResourceRetentionPolicy", "ResourceRetentionPolicy.SkipDeregisterOnUpdate"],
+    "createOnlyPaths": ["JobDefinitionName"],
+    "defaults": {},
+    "defaultPaths": {
+      "ResourceRetentionPolicy.SkipDeregisterOnUpdate": false
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [
+      "ContainerProperties.LinuxParameters.Devices",
+      "ContainerProperties.LinuxParameters.Tmpfs",
+      "ContainerProperties.MountPoints",
+      "ContainerProperties.ResourceRequirements",
+      "EcsProperties.TaskProperties",
+      "NodeProperties.NodeRangeProperties",
+      "RetryStrategy.EvaluateOnExit"
+    ],
+    "freeFormMapPaths": [
+      "ContainerProperties.LogConfiguration.Options",
+      "EcsProperties.TaskProperties.*.Containers.*.FirelensConfiguration.Options",
+      "EcsProperties.TaskProperties.*.Containers.*.LogConfiguration.Options",
+      "EksProperties.PodProperties.Containers.*.Resources.Limits",
+      "EksProperties.PodProperties.Containers.*.Resources.Requests",
+      "EksProperties.PodProperties.InitContainers.*.Resources.Limits",
+      "EksProperties.PodProperties.InitContainers.*.Resources.Requests",
+      "EksProperties.PodProperties.Metadata.Annotations",
+      "EksProperties.PodProperties.Metadata.Labels",
+      "NodeProperties.NodeRangeProperties.*.Container.LogConfiguration.Options",
+      "NodeProperties.NodeRangeProperties.*.EcsProperties.TaskProperties.*.Containers.*.FirelensConfiguration.Options",
+      "NodeProperties.NodeRangeProperties.*.EcsProperties.TaskProperties.*.Containers.*.LogConfiguration.Options",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Containers.*.Resources.Limits",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Containers.*.Resources.Requests",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.InitContainers.*.Resources.Limits",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.InitContainers.*.Resources.Requests",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Metadata.Annotations",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Metadata.Labels",
+      "Parameters"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__DynamoDB__Table.HuntTable71D348F5.json
+++ b/tests/corpus/AWS__DynamoDB__Table.HuntTable71D348F5.json
@@ -1,0 +1,158 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTable71D348F5",
+    "resourceType": "AWS::DynamoDB::Table",
+    "physicalId": "CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+    "constructPath": "CdkrdHunt0713FormatProbes/HuntTable",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        }
+      ],
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        }
+      ],
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 5,
+        "WriteCapacityUnits": 5
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SSESpecification": {
+      "SSEEnabled": false
+    },
+    "ContributorInsightsSpecification": {
+      "Enabled": false
+    },
+    "PointInTimeRecoverySpecification": {
+      "PointInTimeRecoveryEnabled": false
+    },
+    "ProvisionedThroughput": {
+      "WriteCapacityUnits": 5,
+      "ReadCapacityUnits": 3
+    },
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 5,
+      "WriteUnitsPerSecond": 5
+    },
+    "TableName": "CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      }
+    ],
+    "BillingMode": "PROVISIONED",
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      }
+    ],
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "TimeToLiveSpecification": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn"],
+    "writeOnly": ["ImportSourceSpecification"],
+    "createOnly": ["ImportSourceSpecification", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn"],
+    "writeOnlyPaths": ["ImportSourceSpecification"],
+    "createOnlyPaths": ["ImportSourceSpecification", "TableName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "HuntTable71D348F5",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "ProvisionedThroughput.ReadCapacityUnits",
+      "desired": 5,
+      "actual": 3,
+      "physicalId": "CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+      "constructPath": "CdkrdHunt0713FormatProbes/HuntTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTable71D348F5",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 5,
+        "WriteUnitsPerSecond": 5
+      },
+      "physicalId": "CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+      "constructPath": "CdkrdHunt0713FormatProbes/HuntTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTable71D348F5",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "BillingMode",
+      "actual": "PROVISIONED",
+      "physicalId": "CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+      "constructPath": "CdkrdHunt0713FormatProbes/HuntTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTable71D348F5",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I",
+      "constructPath": "CdkrdHunt0713FormatProbes/HuntTable"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.HuntTrustStore.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.HuntTrustStore.json
@@ -1,0 +1,101 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTrustStore",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore/befed9e5159d260e",
+    "constructPath": "CdkrdHunt0713TrustStore/HuntTrustStore",
+    "declared": {
+      "CaCertificatesBundleS3Bucket": "cdkrd-hunt-ca-x9z7q",
+      "CaCertificatesBundleS3Key": "cdkrd-hunt-ca.pem",
+      "Name": "cdkrd-hunt-truststore",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "TrustStoreArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore/befed9e5159d260e",
+    "NumberOfCaCertificates": 1,
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0713TrustStore",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntTrustStore",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713TrustStore/0ad327b0-7e06-11f1-84b0-0ead0d2d9e45",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-truststore",
+    "CaCertificatesBundleSha256": "8e3b996e3b0e01bd4e75b9ddbbae1f0a672b52a4b0b1c38af0119c9aa826567f"
+  },
+  "schema": {
+    "readOnly": ["NumberOfCaCertificates", "Status", "TrustStoreArn"],
+    "writeOnly": [
+      "CaCertificatesBundleS3Bucket",
+      "CaCertificatesBundleS3Key",
+      "CaCertificatesBundleS3ObjectVersion"
+    ],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["NumberOfCaCertificates", "Status", "TrustStoreArn"],
+    "writeOnlyPaths": [
+      "CaCertificatesBundleS3Bucket",
+      "CaCertificatesBundleS3Key",
+      "CaCertificatesBundleS3ObjectVersion"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntTrustStore",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleS3Bucket",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore/befed9e5159d260e",
+      "constructPath": "CdkrdHunt0713TrustStore/HuntTrustStore"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntTrustStore",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleS3Key",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore/befed9e5159d260e",
+      "constructPath": "CdkrdHunt0713TrustStore/HuntTrustStore"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HuntTrustStore",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleSha256",
+      "actual": "8e3b996e3b0e01bd4e75b9ddbbae1f0a672b52a4b0b1c38af0119c9aa826567f",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore/befed9e5159d260e",
+      "constructPath": "CdkrdHunt0713TrustStore/HuntTrustStore"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__AccessKey.HuntAccessKey.json
+++ b/tests/corpus/AWS__IAM__AccessKey.HuntAccessKey.json
@@ -1,0 +1,46 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntAccessKey",
+    "resourceType": "AWS::IAM::AccessKey",
+    "physicalId": "AKIAIOSFODNN7EXAMPLE",
+    "constructPath": "CdkrdHunt0713MiscReaders/HuntAccessKey",
+    "declared": {
+      "UserName": "cdkrd-hunt-accesskey-user"
+    }
+  },
+  "liveRaw": {
+    "UserName": "cdkrd-hunt-accesskey-user",
+    "Status": "Active"
+  },
+  "schema": {
+    "readOnly": ["Id", "SecretAccessKey"],
+    "writeOnly": [],
+    "createOnly": ["Serial", "UserName"],
+    "readOnlyPaths": ["Id", "SecretAccessKey"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Serial", "UserName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAccessKey",
+      "resourceType": "AWS::IAM::AccessKey",
+      "path": "Status",
+      "actual": "Active",
+      "physicalId": "AKIAIOSFODNN7EXAMPLE",
+      "constructPath": "CdkrdHunt0713MiscReaders/HuntAccessKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__LakeFormation__Resource.HuntLfResource.json
+++ b/tests/corpus/AWS__LakeFormation__Resource.HuntLfResource.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntLfResource",
+    "resourceType": "AWS::LakeFormation::Resource",
+    "physicalId": "LakeFormation-arn:aws:s3:::cdkrd-hunt-lf-bucket-x9z7q",
+    "constructPath": "CdkrdHunt0713MiscReaders/HuntLfResource",
+    "declared": {
+      "ResourceArn": "arn:aws:s3:::cdkrd-hunt-lf-bucket-x9z7q",
+      "UseServiceLinkedRole": true
+    }
+  },
+  "liveRaw": {
+    "RoleArn": "arn:aws:iam::111111111111:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess",
+    "HybridAccessEnabled": false
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["ResourceArn"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ResourceArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntLfResource",
+      "resourceType": "AWS::LakeFormation::Resource",
+      "path": "ResourceArn",
+      "note": "declared but not returned by live read",
+      "physicalId": "LakeFormation-arn:aws:s3:::cdkrd-hunt-lf-bucket-x9z7q",
+      "constructPath": "CdkrdHunt0713MiscReaders/HuntLfResource"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntLfResource",
+      "resourceType": "AWS::LakeFormation::Resource",
+      "path": "UseServiceLinkedRole",
+      "note": "declared but not returned by live read",
+      "physicalId": "LakeFormation-arn:aws:s3:::cdkrd-hunt-lf-bucket-x9z7q",
+      "constructPath": "CdkrdHunt0713MiscReaders/HuntLfResource"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntLfResource",
+      "resourceType": "AWS::LakeFormation::Resource",
+      "path": "RoleArn",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess",
+      "physicalId": "LakeFormation-arn:aws:s3:::cdkrd-hunt-lf-bucket-x9z7q",
+      "constructPath": "CdkrdHunt0713MiscReaders/HuntLfResource"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.HuntDotnetE883D1C5.json
+++ b/tests/corpus/AWS__Lambda__Function.HuntDotnetE883D1C5.json
@@ -1,0 +1,213 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDotnetE883D1C5",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+    "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet",
+    "declared": {
+      "Code": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "7cb8d80102ee1e1791ef95e5fc193f7cc0f74dcc4cf5b581c8aab6f0bbaffba9.zip"
+      },
+      "Handler": "App::App.Function::Handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0713LambdaRuntim-HuntDotnetServiceRoleDAD3-RXlgCsaba7yL",
+      "Runtime": "dotnet8",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "App::App.Function::Handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0713LambdaRuntim-HuntDotnetServiceRoleDAD3-RXlgCsaba7yL",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+    "Runtime": "dotnet8",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "HuntDotnetE883D1C5",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0713LambdaRuntimes",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713LambdaRuntimes/a9184680-7e06-11f1-ae77-129b37054889",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["x86_64"],
+    "CodeSha256": "oVuPGs6ZSqhRhMOw6q4PWulcs9C2DN1HTcJ57D/2fwE="
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectStorageMode",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntDotnetE883D1C5",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "CodeSha256",
+      "actual": "oVuPGs6ZSqhRhMOw6q4PWulcs9C2DN1HTcJ57D/2fwE=",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntDotnetE883D1C5-ew73Xk96vwwX",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntDotnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.HuntProvidedEEA94FE4.json
+++ b/tests/corpus/AWS__Lambda__Function.HuntProvidedEEA94FE4.json
@@ -1,0 +1,213 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntProvidedEEA94FE4",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+    "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided",
+    "declared": {
+      "Code": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "7cb8d80102ee1e1791ef95e5fc193f7cc0f74dcc4cf5b581c8aab6f0bbaffba9.zip"
+      },
+      "Handler": "bootstrap",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0713LambdaRuntim-HuntProvidedServiceRole1A-vVCGrkyEQPvM",
+      "Runtime": "provided.al2023",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "bootstrap",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0713LambdaRuntim-HuntProvidedServiceRole1A-vVCGrkyEQPvM",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+    "Runtime": "provided.al2023",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "HuntProvidedEEA94FE4",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0713LambdaRuntimes",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713LambdaRuntimes/a9184680-7e06-11f1-ae77-129b37054889",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["x86_64"],
+    "CodeSha256": "oVuPGs6ZSqhRhMOw6q4PWulcs9C2DN1HTcJ57D/2fwE="
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectStorageMode",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntProvidedEEA94FE4",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "CodeSha256",
+      "actual": "oVuPGs6ZSqhRhMOw6q4PWulcs9C2DN1HTcJ57D/2fwE=",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntProvidedEEA94FE4-IhEjxm6tKVEs",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntProvided"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.HuntRubyB2F34A71.json
+++ b/tests/corpus/AWS__Lambda__Function.HuntRubyB2F34A71.json
@@ -1,0 +1,218 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRubyB2F34A71",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+    "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby",
+    "declared": {
+      "Code": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "7cb8d80102ee1e1791ef95e5fc193f7cc0f74dcc4cf5b581c8aab6f0bbaffba9.zip"
+      },
+      "Handler": "handler.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0713LambdaRuntim-HuntRubyServiceRole024203-iV1rjhuOXmXz",
+      "Runtime": "ruby3.3",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "VpcConfig": {
+      "Ipv6AllowedForDualStack": false,
+      "SecurityGroupIds": [],
+      "SubnetIds": []
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "handler.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0713LambdaRuntim-HuntRubyServiceRole024203-iV1rjhuOXmXz",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+    "Runtime": "ruby3.3",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0713LambdaRuntimes",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713LambdaRuntimes/a9184680-7e06-11f1-ae77-129b37054889",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "HuntRubyB2F34A71",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["x86_64"],
+    "CodeSha256": "oVuPGs6ZSqhRhMOw6q4PWulcs9C2DN1HTcJ57D/2fwE="
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectStorageMode",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43"
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntRubyB2F34A71",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "CodeSha256",
+      "actual": "oVuPGs6ZSqhRhMOw6q4PWulcs9C2DN1HTcJ57D/2fwE=",
+      "physicalId": "CdkrdHunt0713LambdaRuntimes-HuntRubyB2F34A71-AEbxzXafpd43",
+      "constructPath": "CdkrdHunt0713LambdaRuntimes/HuntRuby"
+    }
+  ]
+}

--- a/tests/corpus/AWS__MediaConvert__JobTemplate.HuntJobTemplate.json
+++ b/tests/corpus/AWS__MediaConvert__JobTemplate.HuntJobTemplate.json
@@ -1,0 +1,145 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntJobTemplate",
+    "resourceType": "AWS::MediaConvert::JobTemplate",
+    "physicalId": "cdkrd-hunt-mc-jobtemplate",
+    "constructPath": "CdkrdHunt0713MediaConv/HuntJobTemplate",
+    "declared": {
+      "Name": "cdkrd-hunt-mc-jobtemplate",
+      "SettingsJson": {
+        "OutputGroups": [
+          {
+            "Name": "File Group",
+            "OutputGroupSettings": {
+              "Type": "FILE_GROUP_SETTINGS",
+              "FileGroupSettings": {
+                "Destination": "s3://cdkrd-hunt-placeholder-output/"
+              }
+            },
+            "Outputs": [
+              {
+                "ContainerSettings": {
+                  "Container": "MP4",
+                  "Mp4Settings": {}
+                },
+                "VideoDescription": {
+                  "CodecSettings": {
+                    "Codec": "H_264",
+                    "H264Settings": {
+                      "RateControlMode": "QVBR",
+                      "QvbrSettings": {
+                        "QvbrQualityLevel": 7
+                      },
+                      "MaxBitrate": 5000000
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt-mc-jobtemplate",
+    "Priority": 0,
+    "StatusUpdateInterval": "SECONDS_60",
+    "AccelerationSettings": {
+      "Mode": "DISABLED"
+    },
+    "SettingsJson": {
+      "OutputGroups": [
+        {
+          "Name": "File Group",
+          "OutputGroupSettings": {
+            "FileGroupSettings": {
+              "Destination": "s3://cdkrd-hunt-placeholder-output/"
+            },
+            "Type": "FILE_GROUP_SETTINGS"
+          },
+          "Outputs": [
+            {
+              "ContainerSettings": {
+                "Container": "MP4",
+                "Mp4Settings": {}
+              },
+              "VideoDescription": {
+                "CodecSettings": {
+                  "Codec": "H_264",
+                  "H264Settings": {
+                    "MaxBitrate": 5000000,
+                    "QvbrSettings": {
+                      "QvbrQualityLevel": 7
+                    },
+                    "RateControlMode": "QVBR"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Tags": {
+      "aws:cloudformation:logical-id": "HuntJobTemplate",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713MediaConv/e1cb7660-7e05-11f1-8222-0affcab5baff",
+      "aws:cloudformation:stack-name": "CdkrdHunt0713MediaConv",
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJobTemplate",
+      "resourceType": "AWS::MediaConvert::JobTemplate",
+      "path": "Priority",
+      "actual": 0,
+      "physicalId": "cdkrd-hunt-mc-jobtemplate",
+      "constructPath": "CdkrdHunt0713MediaConv/HuntJobTemplate"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJobTemplate",
+      "resourceType": "AWS::MediaConvert::JobTemplate",
+      "path": "StatusUpdateInterval",
+      "actual": "SECONDS_60",
+      "physicalId": "cdkrd-hunt-mc-jobtemplate",
+      "constructPath": "CdkrdHunt0713MediaConv/HuntJobTemplate"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJobTemplate",
+      "resourceType": "AWS::MediaConvert::JobTemplate",
+      "path": "AccelerationSettings",
+      "actual": {
+        "Mode": "DISABLED"
+      },
+      "physicalId": "cdkrd-hunt-mc-jobtemplate",
+      "constructPath": "CdkrdHunt0713MediaConv/HuntJobTemplate"
+    }
+  ]
+}

--- a/tests/corpus/AWS__MediaConvert__Queue.HuntQueue.json
+++ b/tests/corpus/AWS__MediaConvert__Queue.HuntQueue.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntQueue",
+    "resourceType": "AWS::MediaConvert::Queue",
+    "physicalId": "cdkrd-hunt-mc-queue",
+    "constructPath": "CdkrdHunt0713MediaConv/HuntQueue",
+    "declared": {
+      "Name": "cdkrd-hunt-mc-queue",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt-mc-queue",
+    "PricingPlan": "ON_DEMAND",
+    "Status": "ACTIVE",
+    "Tags": {
+      "aws:cloudformation:logical-id": "HuntQueue",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713MediaConv/e1cb7660-7e05-11f1-8222-0affcab5baff",
+      "aws:cloudformation:stack-name": "CdkrdHunt0713MediaConv",
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntQueue",
+      "resourceType": "AWS::MediaConvert::Queue",
+      "path": "PricingPlan",
+      "actual": "ON_DEMAND",
+      "physicalId": "cdkrd-hunt-mc-queue",
+      "constructPath": "CdkrdHunt0713MediaConv/HuntQueue"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntQueue",
+      "resourceType": "AWS::MediaConvert::Queue",
+      "path": "Status",
+      "actual": "ACTIVE",
+      "physicalId": "cdkrd-hunt-mc-queue",
+      "constructPath": "CdkrdHunt0713MediaConv/HuntQueue"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.HuntMariaDbFC079FD5.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntMariaDbFC079FD5.json
@@ -1,0 +1,449 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntMariaDbFC079FD5",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+    "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb",
+    "declared": {
+      "AllocatedStorage": "100",
+      "CopyTagsToSnapshot": true,
+      "DBInstanceClass": "db.t4g.micro",
+      "DBSubnetGroupName": "cdkrdhunt0713rdsmariadb-huntmariadbsubnetgroup3bb9d0fd-e8i3czpv08rs",
+      "DeleteAutomatedBackups": true,
+      "Engine": "mariadb",
+      "MasterUserPassword": "CdkrdHuntPassw0rd!",
+      "MasterUsername": "huntadmin",
+      "PubliclyAccessible": false,
+      "StorageType": "gp2",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VPCSecurityGroups": ["sg-052cf0fcf27208fa0"]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-07-12T15:56:38Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "3306",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-NDJGN7WYVTPF4QYA2BNQM4SAUY",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.mariadb11.8",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+    "Endpoint": {
+      "Address": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "3306",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "LatestRestorableTime": "2026-07-12T16:00:02Z",
+    "MultiAZ": false,
+    "Engine": "mariadb",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0713RdsMariadb",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntMariaDbFC079FD5",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713RdsMariadb/e10850a0-7e09-11f1-96ab-129bac179cd9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "IsStorageConfigUpgradeAvailable": false,
+    "EngineVersion": "11.8.6",
+    "StorageType": "gp2",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.t4g.micro",
+    "AvailabilityZone": "us-east-1a",
+    "OptionGroupName": "default:mariadb-11-8",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "cdkrdhunt0713rdsmariadb-huntmariadbsubnetgroup3bb9d0fd-e8i3czpv08rs",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+    "AllocatedStorage": "100",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "huntadmin",
+    "PubliclyAccessible": false,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-07-12T15:57:51.093Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "04:18-04:48",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": true,
+    "LicenseModel": "general-public-license",
+    "PreferredMaintenanceWindow": "mon:09:13-mon:09:43",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-052cf0fcf27208fa0"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DeleteAutomatedBackups",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "3306",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.mariadb11.8",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineVersion",
+      "actual": "11.8.6",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:mariadb-11-8",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "04:18-04:48",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "general-public-license",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "mon:09:13-mon:09:43",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntMariaDbFC079FD5",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Redshift__ClusterParameterGroup.HuntRsCpg.json
+++ b/tests/corpus/AWS__Redshift__ClusterParameterGroup.HuntRsCpg.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRsCpg",
+    "resourceType": "AWS::Redshift::ClusterParameterGroup",
+    "physicalId": "cdkrdhunt-rscpg",
+    "constructPath": "CdkrdHunt0713CaseIdents2/HuntRsCpg",
+    "declared": {
+      "Description": "cdkrd hunt mixed-case redshift cluster parameter group",
+      "ParameterGroupFamily": "redshift-1.0",
+      "ParameterGroupName": "CdkrdHunt-RsCpg",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt mixed-case redshift cluster parameter group",
+    "Parameters": [],
+    "ParameterGroupName": "cdkrdhunt-rscpg",
+    "ParameterGroupFamily": "redshift-1.0",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Description", "ParameterGroupFamily", "ParameterGroupName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Description", "ParameterGroupFamily", "ParameterGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["Parameters"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SNS__Subscription.HuntRawSub.json
+++ b/tests/corpus/AWS__SNS__Subscription.HuntRawSub.json
@@ -1,0 +1,90 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRawSub",
+    "resourceType": "AWS::SNS::Subscription",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0713FormatProbes-HuntTopic8B69DF49-EyL9xsAO5VA4:7447fa8d-bc3c-4c60-bab1-581fa58f8a67",
+    "constructPath": "CdkrdHunt0713FormatProbes/HuntRawSub",
+    "declared": {
+      "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0713FormatProbes-HuntSubQueue5638A0BE-0TpNq8S0SE5k",
+      "FilterPolicy": {
+        "eventType": ["order_placed", "order_cancelled"],
+        "priceUsd": [
+          {
+            "numeric": [">=", 100]
+          }
+        ],
+        "store": ["example_corp"]
+      },
+      "Protocol": "sqs",
+      "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0713FormatProbes-HuntTopic8B69DF49-EyL9xsAO5VA4"
+    }
+  },
+  "liveRaw": {
+    "RawMessageDelivery": false,
+    "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0713FormatProbes-HuntSubQueue5638A0BE-0TpNq8S0SE5k",
+    "FilterPolicy": {
+      "priceUsd": [
+        {
+          "numeric": [">=", 100]
+        }
+      ],
+      "eventType": ["order_placed", "order_cancelled"],
+      "store": ["example_corp"]
+    },
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0713FormatProbes-HuntTopic8B69DF49-EyL9xsAO5VA4",
+    "FilterPolicyScope": "MessageAttributes",
+    "Arn": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0713FormatProbes-HuntTopic8B69DF49-EyL9xsAO5VA4:7447fa8d-bc3c-4c60-bab1-581fa58f8a67",
+    "Protocol": "sqs"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["Region"],
+    "createOnly": ["Endpoint", "Protocol", "TopicArn"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["Region"],
+    "createOnlyPaths": ["Endpoint", "Protocol", "TopicArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRawSub",
+      "resourceType": "AWS::SNS::Subscription",
+      "path": "FilterPolicyScope",
+      "actual": "MessageAttributes",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0713FormatProbes-HuntTopic8B69DF49-EyL9xsAO5VA4:7447fa8d-bc3c-4c60-bab1-581fa58f8a67",
+      "constructPath": "CdkrdHunt0713FormatProbes/HuntRawSub"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceDiscovery__PublicDnsNamespace.HuntPublicNs5EFC76F3.json
+++ b/tests/corpus/AWS__ServiceDiscovery__PublicDnsNamespace.HuntPublicNs5EFC76F3.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPublicNs5EFC76F3",
+    "resourceType": "AWS::ServiceDiscovery::PublicDnsNamespace",
+    "physicalId": "ns-tn6g37nbeg3jrbke",
+    "constructPath": "CdkrdHunt0713CloudmapPub/HuntPublicNs",
+    "declared": {
+      "Name": "cdkrd-hunt-x9z7q.com",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt-x9z7q.com",
+    "Arn": "arn:aws:servicediscovery:us-east-1:111111111111:namespace/ns-tn6g37nbeg3jrbke",
+    "Id": "ns-tn6g37nbeg3jrbke",
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0713CloudmapPub"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntPublicNs5EFC76F3"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713CloudmapPub/0ad74660-7e06-11f1-b367-12a157b5d713"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "HostedZoneId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "HostedZoneId", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ServiceDiscovery__Service.HuntPublicNsHuntService1926FAC1.json
+++ b/tests/corpus/AWS__ServiceDiscovery__Service.HuntPublicNsHuntService1926FAC1.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPublicNsHuntService1926FAC1",
+    "resourceType": "AWS::ServiceDiscovery::Service",
+    "physicalId": "srv-q2zaznfivbb4usfe",
+    "constructPath": "CdkrdHunt0713CloudmapPub/HuntPublicNs/HuntService",
+    "declared": {
+      "DnsConfig": {
+        "DnsRecords": [
+          {
+            "TTL": 60,
+            "Type": "A"
+          }
+        ],
+        "NamespaceId": "ns-tn6g37nbeg3jrbke",
+        "RoutingPolicy": "MULTIVALUE"
+      },
+      "Name": "hunt-svc",
+      "NamespaceId": "ns-tn6g37nbeg3jrbke",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Name": "hunt-svc",
+    "NamespaceId": "ns-tn6g37nbeg3jrbke",
+    "Type": "DNS_HTTP",
+    "DnsConfig": {
+      "NamespaceId": "ns-tn6g37nbeg3jrbke",
+      "RoutingPolicy": "MULTIVALUE",
+      "DnsRecords": [
+        {
+          "Type": "A",
+          "TTL": 60
+        }
+      ]
+    },
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0713CloudmapPub"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntPublicNsHuntService1926FAC1"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713CloudmapPub/0ad74660-7e06-11f1-b367-12a157b5d713"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["HealthCheckCustomConfig", "Name", "NamespaceId", "Type"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HealthCheckCustomConfig", "Name", "NamespaceId", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPublicNsHuntService1926FAC1",
+      "resourceType": "AWS::ServiceDiscovery::Service",
+      "path": "Type",
+      "actual": "DNS_HTTP",
+      "physicalId": "srv-q2zaznfivbb4usfe",
+      "constructPath": "CdkrdHunt0713CloudmapPub/HuntPublicNs/HuntService"
+    }
+  ]
+}

--- a/tests/integration/case-idents2-min/app.ts
+++ b/tests/integration/case-idents2-min/app.ts
@@ -1,0 +1,37 @@
+// CDK app for the cdk-real-drift case-idents2-min false-positive integration test.
+// Mixed-case identifier echo probes — the exact analog of the proven RDS
+// parameter/option-group lowercase-echo FP family (#1531), on siblings with
+// ZERO CASE_INSENSITIVE_PATHS coverage today. Live determinations (2026-07-13):
+// - AWS::Redshift::ClusterParameterGroup ParameterGroupName: raw API accepts
+//   mixed case and stores lowercase ("CdkrdHunt-RsCpg" -> "cdkrdhunt-rscpg").
+// - AWS::ElastiCache::User: raw API lowercases UserId (UserName KEEPS case),
+//   but the CFn/CC handler REJECTS a mixed-case UserId client-side
+//   (InvalidRequest) — unreachable via CloudFormation, so no FP risk. Same for
+//   AWS::MemoryDB::ParameterGroup names. NOT probed via CFn.
+// - AWS::Batch::JobDefinition Type enum case: "Container" (vs canonical
+//   "container") passes the handler; probes the enum re-case echo.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnJobDefinition } from "aws-cdk-lib/aws-batch";
+import { CfnClusterParameterGroup } from "aws-cdk-lib/aws-redshift";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713CaseIdents2");
+
+new CfnClusterParameterGroup(stack, "HuntRsCpg", {
+  parameterGroupName: "CdkrdHunt-RsCpg",
+  parameterGroupFamily: "redshift-1.0",
+  description: "cdkrd hunt mixed-case redshift cluster parameter group",
+});
+
+new CfnJobDefinition(stack, "HuntJobDef", {
+  type: "Container",
+  jobDefinitionName: "CdkrdHunt-JobDef",
+  containerProperties: {
+    image: "public.ecr.aws/amazonlinux/amazonlinux:2023",
+    vcpus: 1,
+    memory: 2048,
+    command: ["true"],
+  },
+});

--- a/tests/integration/case-idents2-min/cdk.json
+++ b/tests/integration/case-idents2-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/case-idents2-min/package.json
+++ b/tests/integration/case-idents2-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-case-idents2-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift case-idents2-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/case-idents2-min/verify.sh
+++ b/tests/integration/case-idents2-min/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS), #1539: mixed-case identifier echoes
+# (Redshift ClusterParameterGroup name, Batch JobDefinition Type) -> FIRST check
+# (pre-record) must show ZERO drift -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713CaseIdents2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (#1539 re-case echo regression)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cloudmap-public-min/app.ts
+++ b/tests/integration/cloudmap-public-min/app.ts
@@ -1,0 +1,24 @@
+// CDK app for the cdk-real-drift cloudmap-public-min false-positive integration test.
+// BAREST-possible AWS::ServiceDiscovery::PublicDnsNamespace (+ a DNS Service):
+// the namespace's SDK-override reader exists but only the Private/Http variants
+// were ever exercised. The FQDN-shaped Name also probes the trailing-dot echo
+// (only the Route53 family is in TRAILING_DOT_PATHS today).
+// NOTE: the domain is a placeholder we do not own — the public hosted zone
+// creates fine and is simply non-authoritative ($0.50, deleted with the stack).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Duration, Stack, Tags } from "aws-cdk-lib";
+import { DnsRecordType, PublicDnsNamespace } from "aws-cdk-lib/aws-servicediscovery";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713CloudmapPub");
+
+const ns = new PublicDnsNamespace(stack, "HuntPublicNs", {
+  name: "cdkrd-hunt-x9z7q.com",
+});
+
+ns.createService("HuntService", {
+  name: "hunt-svc",
+  dnsRecordType: DnsRecordType.A,
+  dnsTtl: Duration.seconds(60),
+});

--- a/tests/integration/cloudmap-public-min/cdk.json
+++ b/tests/integration/cloudmap-public-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudmap-public-min/package.json
+++ b/tests/integration/cloudmap-public-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudmap-public-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cloudmap-public-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudmap-public-min/verify.sh
+++ b/tests/integration/cloudmap-public-min/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS), #1537: deploy a CDK L2
+# PublicDnsNamespace + DNS Service -> FIRST check (pre-record) must show ZERO
+# drift (DnsConfig.NamespaceId mirror + Type derived default) -> record ->
+# check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713CloudmapPub
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (#1537 regression)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/elbv2-truststore-min/app.ts
+++ b/tests/integration/elbv2-truststore-min/app.ts
@@ -1,0 +1,24 @@
+// CDK app for the cdk-real-drift elbv2-truststore-min false-positive integration test.
+// BAREST-possible AWS::ElasticLoadBalancingV2::TrustStore — the ONLY
+// SDK_SUPPLEMENTS entry with zero fixture/corpus coverage: its writeOnly
+// CaCertificatesBundle* supplement path has never been exercised live.
+// The CA bundle object must exist BEFORE the TrustStore is created, so the
+// runner pre-creates the bucket + uploads a self-signed CA PEM (see verify.sh)
+// and passes the location via CA_BUNDLE_BUCKET / CA_BUNDLE_KEY.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnTrustStore } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const bucket = process.env.CA_BUNDLE_BUCKET;
+const key = process.env.CA_BUNDLE_KEY ?? "cdkrd-hunt-ca.pem";
+if (!bucket) throw new Error("CA_BUNDLE_BUCKET env var is required (see verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713TrustStore");
+
+new CfnTrustStore(stack, "HuntTrustStore", {
+  name: "cdkrd-hunt-truststore",
+  caCertificatesBundleS3Bucket: bucket,
+  caCertificatesBundleS3Key: key,
+});

--- a/tests/integration/elbv2-truststore-min/cdk.json
+++ b/tests/integration/elbv2-truststore-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elbv2-truststore-min/package.json
+++ b/tests/integration/elbv2-truststore-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elbv2-truststore-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elbv2-truststore-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elbv2-truststore-min/verify.sh
+++ b/tests/integration/elbv2-truststore-min/verify.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest ELBv2 TrustStore — the only
+# SDK_SUPPLEMENTS entry that had zero fixture/corpus coverage. The supplement
+# synthesizes the CaCertificatesBundleSha256 integrity signal (#505), which is a
+# DESIGNED undeclared first-run surface (the same shape as Lambda CodeSha256), so
+# the pre-record check must show EXACTLY that one potential-drift entry and
+# nothing else; record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713TrustStore
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+CA_BUCKET="${CA_BUNDLE_BUCKET:-cdkrd-hunt-ca-$RANDOM$RANDOM}"
+CA_KEY="${CA_BUNDLE_KEY:-cdkrd-hunt-ca.pem}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  aws s3 rb "s3://$CA_BUCKET" --force >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out ca.key ca.pem
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] pre-step: CA bundle bucket ==="
+if ! aws s3api head-bucket --bucket "$CA_BUCKET" >/dev/null 2>&1; then
+  aws s3 mb "s3://$CA_BUCKET" --region "$REGION" || fail "mb"
+  aws s3api put-bucket-tagging --bucket "$CA_BUCKET" --tagging 'TagSet=[{Key=cdkrd:ephemeral,Value=1}]' || true
+fi
+openssl req -x509 -newkey rsa:2048 -nodes -keyout ca.key -out ca.pem -days 7 -subj "/CN=cdkrd-hunt-ca" 2>/dev/null || fail "openssl"
+aws s3 cp ca.pem "s3://$CA_BUCKET/$CA_KEY" --region "$REGION" >/dev/null || fail "upload"
+
+echo "=== [$STACK] deploy fixture ==="
+CA_BUNDLE_BUCKET="$CA_BUCKET" CA_BUNDLE_KEY="$CA_KEY" npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): only the designed Sha256 signal may surface ==="
+CA_BUNDLE_BUCKET="$CA_BUCKET" CA_BUNDLE_KEY="$CA_KEY" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+grep -q "CaCertificatesBundleSha256" "/tmp/cdkrd-$STACK.first.out" || fail "expected the CA-bundle Sha256 integrity signal (supplement not running?)"
+grep -q "Potential Drift: 1" "/tmp/cdkrd-$STACK.first.out" || fail "expected EXACTLY one potential-drift entry (new fold gap?)"
+grep -q "Declared Drift" "/tmp/cdkrd-$STACK.first.out" && fail "declared drift on a clean deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+CA_BUNDLE_BUCKET="$CA_BUCKET" CA_BUNDLE_KEY="$CA_KEY" $CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+CA_BUNDLE_BUCKET="$CA_BUCKET" CA_BUNDLE_KEY="$CA_KEY" $CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/format-probes-min/app.ts
+++ b/tests/integration/format-probes-min/app.ts
@@ -1,0 +1,69 @@
+// CDK app for the cdk-real-drift format-probes-min false-positive integration test.
+// Declared-tier normalization probes (allowlist-gap predictions):
+// - AWS::SNS::Subscription FilterPolicy: multi-key JSON — does SNS reorder /
+//   reformat the echoed policy (object<->JSON-string shape divergence)?
+// - AWS::ApplicationAutoScaling::ScalableTarget ScheduledActions.*.Schedule:
+//   does the service canonicalize `rate(60 minutes)` (Synthetics does)?
+// - A bare SQS queue + PROVISIONED DynamoDB table ride along as the round-3
+//   revert-convergence mutation targets (undeclared VisibilityTimeout /
+//   DeletionProtectionEnabled).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnScalableTarget } from "aws-cdk-lib/aws-applicationautoscaling";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnSubscription, Topic } from "aws-cdk-lib/aws-sns";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713FormatProbes");
+
+// -- SNS multi-key FilterPolicy probe (raw L1 so the declared JSON is exactly ours) --
+const topic = new Topic(stack, "HuntTopic");
+const subQueue = new Queue(stack, "HuntSubQueue", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+new CfnSubscription(stack, "HuntRawSub", {
+  topicArn: topic.topicArn,
+  protocol: "sqs",
+  endpoint: subQueue.queueArn,
+  filterPolicy: {
+    eventType: ["order_placed", "order_cancelled"],
+    priceUsd: [{ numeric: [">=", 100] }],
+    store: ["example_corp"],
+  },
+});
+
+// -- ApplicationAutoScaling ScheduledActions rate() probe --
+const table = new Table(stack, "HuntTable", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  billingMode: BillingMode.PROVISIONED,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const scalingRole = new Role(stack, "HuntScalingRole", {
+  assumedBy: new ServicePrincipal("application-autoscaling.amazonaws.com"),
+});
+
+new CfnScalableTarget(stack, "HuntScalableTarget", {
+  serviceNamespace: "dynamodb",
+  resourceId: `table/${table.tableName}`,
+  scalableDimension: "dynamodb:table:ReadCapacityUnits",
+  minCapacity: 1,
+  maxCapacity: 3,
+  roleArn: scalingRole.roleArn,
+  scheduledActions: [
+    {
+      scheduledActionName: "cdkrd-hunt-sched",
+      schedule: "rate(60 minutes)",
+      scalableTargetAction: { minCapacity: 1, maxCapacity: 3 },
+    },
+  ],
+});
+
+// -- round-3 mutation targets (kept barest) --
+new Queue(stack, "HuntBareQueue", {
+  queueName: "cdkrd-hunt-bare-queue",
+  removalPolicy: RemovalPolicy.DESTROY,
+});

--- a/tests/integration/format-probes-min/cdk.json
+++ b/tests/integration/format-probes-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/format-probes-min/package.json
+++ b/tests/integration/format-probes-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-format-probes-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift format-probes-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/format-probes-min/verify.sh
+++ b/tests/integration/format-probes-min/verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS), #1538: SNS multi-key FilterPolicy +
+# App-Auto-Scaling rate() schedule + a provisioned DynamoDB table whose scalable
+# target scales RCU below the declared capacity (WarmThroughput creation echo).
+# FIRST check (pre-record) must show ZERO drift -> record -> check MUST be CLEAN.
+# NOTE: the in-stack scheduled action clamps RCU 5 -> 3 within the hour; the #688
+# band fold covers the capacity and the #1538 declared-derivation covers the warm
+# echo, so the check is CLEAN both before and after the clamp.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713FormatProbes
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (#1538 WarmThroughput regression)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/lambda-runtimes-min/app.ts
+++ b/tests/integration/lambda-runtimes-min/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift lambda-runtimes-min false-positive integration test.
+// BAREST-possible Lambda functions on the runtimes with ZERO corpus coverage
+// (covered today: nodejs18/20/24, java21, python3.12): dotnet8, ruby3.3,
+// provided.al2023. Runtime-specific live defaults (e.g. SnapStart on dotnet)
+// are exactly where first-run FPs hide. The asset is a dummy zip — Lambda
+// does not validate handler existence at create time and is never invoked.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713LambdaRuntimes");
+
+new LambdaFunction(stack, "HuntDotnet", {
+  runtime: Runtime.DOTNET_8,
+  handler: "App::App.Function::Handler",
+  code: Code.fromAsset("./handler"),
+});
+
+new LambdaFunction(stack, "HuntRuby", {
+  runtime: Runtime.RUBY_3_3,
+  handler: "handler.handler",
+  code: Code.fromAsset("./handler"),
+});
+
+new LambdaFunction(stack, "HuntProvided", {
+  runtime: Runtime.PROVIDED_AL2023,
+  handler: "bootstrap",
+  code: Code.fromAsset("./handler"),
+});

--- a/tests/integration/lambda-runtimes-min/cdk.json
+++ b/tests/integration/lambda-runtimes-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-runtimes-min/handler/bootstrap
+++ b/tests/integration/lambda-runtimes-min/handler/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Dummy bootstrap for the cdkrd lambda-runtimes-min fixture — never invoked.
+exit 0

--- a/tests/integration/lambda-runtimes-min/handler/handler.rb
+++ b/tests/integration/lambda-runtimes-min/handler/handler.rb
@@ -1,0 +1,4 @@
+# Dummy Ruby handler for the cdkrd lambda-runtimes-min fixture — never invoked.
+def handler(event:, context:)
+  nil
+end

--- a/tests/integration/lambda-runtimes-min/package.json
+++ b/tests/integration/lambda-runtimes-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-runtimes-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-runtimes-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-runtimes-min/verify.sh
+++ b/tests/integration/lambda-runtimes-min/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest Lambda functions on the
+# runtimes with no prior corpus coverage (dotnet8, ruby3.3, provided.al2023) ->
+# FIRST check (pre-record) must show ZERO drift -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713LambdaRuntimes
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (runtime-specific fold gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/mediaconvert-min/app.ts
+++ b/tests/integration/mediaconvert-min/app.ts
@@ -1,0 +1,48 @@
+// CDK app for the cdk-real-drift mediaconvert-min false-positive integration test.
+// BAREST-possible configs of the two MediaConvert SDK-override readers (#497),
+// which were added from a live report but never exercised by any fixture/corpus:
+// - AWS::MediaConvert::Queue: on-demand queue, name only.
+// - AWS::MediaConvert::JobTemplate: minimal H.264/MP4 file-group settings.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnJobTemplate, CfnQueue } from "aws-cdk-lib/aws-mediaconvert";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713MediaConv");
+
+new CfnQueue(stack, "HuntQueue", {
+  name: "cdkrd-hunt-mc-queue",
+});
+
+new CfnJobTemplate(stack, "HuntJobTemplate", {
+  name: "cdkrd-hunt-mc-jobtemplate",
+  settingsJson: {
+    OutputGroups: [
+      {
+        Name: "File Group",
+        OutputGroupSettings: {
+          Type: "FILE_GROUP_SETTINGS",
+          FileGroupSettings: {
+            Destination: "s3://cdkrd-hunt-placeholder-output/",
+          },
+        },
+        Outputs: [
+          {
+            ContainerSettings: { Container: "MP4", Mp4Settings: {} },
+            VideoDescription: {
+              CodecSettings: {
+                Codec: "H_264",
+                H264Settings: {
+                  RateControlMode: "QVBR",
+                  QvbrSettings: { QvbrQualityLevel: 7 },
+                  MaxBitrate: 5000000,
+                },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+});

--- a/tests/integration/mediaconvert-min/cdk.json
+++ b/tests/integration/mediaconvert-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/mediaconvert-min/package.json
+++ b/tests/integration/mediaconvert-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-mediaconvert-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift mediaconvert-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/mediaconvert-min/verify.sh
+++ b/tests/integration/mediaconvert-min/verify.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# False-positive + detection integration test (real AWS), #1535:
+# deploy -> FIRST check (pre-record) must show ZERO drift of any tier ->
+# record -> check CLEAN -> out-of-band queue PAUSE must be DETECTED ->
+# restore ACTIVE -> check CLEAN again.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713MediaConv
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (#1535 fold gap regression)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "=== [$STACK] out-of-band pause MUST be detected (equality gate) ==="
+aws mediaconvert update-queue --name cdkrd-hunt-mc-queue --status PAUSED --region "$REGION" >/dev/null || fail "mutate"
+$CLI check "$STACK" --region "$REGION" --fail
+[ "$?" -eq 1 ] || fail "expected drift exit 1 after out-of-band PAUSED"
+
+echo "=== [$STACK] restore ACTIVE -> CLEAN ==="
+aws mediaconvert update-queue --name cdkrd-hunt-mc-queue --status ACTIVE --region "$REGION" >/dev/null || fail "restore"
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after restore"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/misc-readers-min/app.ts
+++ b/tests/integration/misc-readers-min/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift misc-readers-min false-positive integration test.
+// BAREST-possible configs of zero-coverage SDK-override readers:
+// - AWS::IAM::AccessKey (#716): reader exists, never exercised by any fixture.
+// - AWS::LakeFormation::Resource: DescribeResource-based reader, zero coverage.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnAccessKey, User } from "aws-cdk-lib/aws-iam";
+import { CfnResource as LakeFormationCfnResource } from "aws-cdk-lib/aws-lakeformation";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713MiscReaders");
+
+const user = new User(stack, "HuntUser", {
+  userName: "cdkrd-hunt-accesskey-user",
+});
+
+new CfnAccessKey(stack, "HuntAccessKey", {
+  userName: user.userName,
+});
+
+const bucket = new Bucket(stack, "HuntLfBucket", {
+  bucketName: "cdkrd-hunt-lf-bucket-x9z7q",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new LakeFormationCfnResource(stack, "HuntLfResource", {
+  resourceArn: bucket.bucketArn,
+  useServiceLinkedRole: true,
+});

--- a/tests/integration/misc-readers-min/cdk.json
+++ b/tests/integration/misc-readers-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/misc-readers-min/package.json
+++ b/tests/integration/misc-readers-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-misc-readers-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift misc-readers-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/misc-readers-min/verify.sh
+++ b/tests/integration/misc-readers-min/verify.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# False-positive + detection integration test (real AWS), #1536:
+# deploy -> FIRST check (pre-record) must show ZERO drift AND ZERO skipped
+# (the LakeFormation physical-id prefix regression skips the resource) ->
+# record -> check CLEAN -> out-of-band hybrid-access re-registration must be
+# DETECTED -> restore -> check CLEAN again.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713MiscReaders
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+LF_ARN="arn:aws:s3:::cdkrd-hunt-lf-bucket-x9z7q"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): zero drift, zero skipped ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out" && fail "first check must be drift-free"
+grep -q "skipped=" "/tmp/cdkrd-$STACK.first.out" && fail "LakeFormation Resource skipped — #1536 physical-id prefix regression"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "=== [$STACK] out-of-band hybrid-access re-registration MUST be detected ==="
+aws lakeformation deregister-resource --resource-arn "$LF_ARN" --region "$REGION" >/dev/null || fail "deregister"
+aws lakeformation register-resource --resource-arn "$LF_ARN" --use-service-linked-role --hybrid-access-enabled --region "$REGION" >/dev/null || fail "re-register"
+$CLI check "$STACK" --region "$REGION" --fail
+[ "$?" -eq 1 ] || fail "expected drift exit 1 after hybrid-access re-registration"
+
+echo "=== [$STACK] restore -> CLEAN ==="
+aws lakeformation deregister-resource --resource-arn "$LF_ARN" --region "$REGION" >/dev/null || fail "deregister-2"
+aws lakeformation register-resource --resource-arn "$LF_ARN" --use-service-linked-role --region "$REGION" >/dev/null || fail "restore"
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after restore"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/rds-mariadb-min/app.ts
+++ b/tests/integration/rds-mariadb-min/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift rds-mariadb-min false-positive integration test.
+// BAREST-possible non-Aurora provisioned DBInstance on the ONE engine with zero
+// corpus coverage: mariadb (#1477 proved the folds were Aurora/postgres/mysql/
+// sqlserver-derived; a variant you did not deploy is an unguarded gap). Declares
+// only what CFn requires — engine / class / storage / creds — so the MOST
+// properties ride the undeclared-default folds. Doubles as the round-3 revert-
+// convergence probe for the ModifyDBInstance omitted-property family
+// (BackupRetentionPeriod / CopyTagsToSnapshot).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, SecretValue, Stack, Tags } from "aws-cdk-lib";
+import { InstanceClass, InstanceSize, InstanceType, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Credentials, DatabaseInstance, DatabaseInstanceEngine, MariaDbEngineVersion } from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713RdsMariadb");
+
+const vpc = new Vpc(stack, "HuntVpc", {
+  maxAzs: 2,
+  natGateways: 0,
+});
+
+new DatabaseInstance(stack, "HuntMariaDb", {
+  engine: DatabaseInstanceEngine.mariaDb({ version: MariaDbEngineVersion.VER_11_4 }),
+  instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  credentials: Credentials.fromPassword("huntadmin", SecretValue.unsafePlainText("CdkrdHuntPassw0rd!")),
+  removalPolicy: RemovalPolicy.DESTROY,
+  deleteAutomatedBackups: true,
+});

--- a/tests/integration/rds-mariadb-min/cdk.json
+++ b/tests/integration/rds-mariadb-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rds-mariadb-min/package.json
+++ b/tests/integration/rds-mariadb-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-rds-mariadb-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift rds-mariadb-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/rds-mariadb-min/verify.sh
+++ b/tests/integration/rds-mariadb-min/verify.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# False-positive + revert-convergence integration test (real AWS), #1541:
+# barest non-Aurora mariadb DBInstance (the engine variant with no prior corpus
+# coverage) -> FIRST check (pre-record) must show ZERO drift -> record -> check
+# CLEAN -> out-of-band undeclared BackupRetentionPeriod 1->3 must be DETECTED ->
+# revert must CONVERGE the live value back to 1 (ModifyDBInstance ignores an
+# omitted property, so this pins the REVERT_SET_DEFAULT_PATHS entry).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713RdsMariadb
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~10 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (mariadb variant fold gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+DBID=$(aws rds describe-db-instances --region "$REGION" \
+  --query "DBInstances[?contains(DBInstanceIdentifier,'cdkrdhunt0713rdsmariadb')].DBInstanceIdentifier|[0]" --output text)
+[ -n "$DBID" ] && [ "$DBID" != "None" ] || fail "resolve DBID"
+
+echo "=== [$STACK] out-of-band BackupRetentionPeriod 1->3 MUST be detected ==="
+aws rds modify-db-instance --db-instance-identifier "$DBID" --backup-retention-period 3 --apply-immediately --region "$REGION" >/dev/null || fail "mutate"
+for i in $(seq 1 30); do
+  ST=$(aws rds describe-db-instances --db-instance-identifier "$DBID" --region "$REGION" --query 'DBInstances[0].[DBInstanceStatus,BackupRetentionPeriod]' --output text)
+  case "$ST" in available*3) break;; esac
+  sleep 20
+done
+$CLI check "$STACK" --region "$REGION" --fail
+[ "$?" -eq 1 ] || fail "expected drift exit 1 after out-of-band retention change"
+
+echo "=== [$STACK] revert MUST converge the live value back to 1 (#1541) ==="
+$CLI revert "$STACK" --region "$REGION" --remove-unrecorded --yes || fail "revert"
+for i in $(seq 1 30); do
+  V=$(aws rds describe-db-instances --db-instance-identifier "$DBID" --region "$REGION" --query 'DBInstances[0].[DBInstanceStatus,BackupRetentionPeriod]' --output text)
+  case "$V" in available*1) break;; esac
+  sleep 20
+done
+V=$(aws rds describe-db-instances --db-instance-identifier "$DBID" --region "$REGION" --query 'DBInstances[0].BackupRetentionPeriod' --output text)
+[ "$V" = "1" ] || fail "live BackupRetentionPeriod is $V, expected 1 — #1541 silent no-op regression"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -292,6 +292,28 @@ resource_gone() {
         *) return 1 ;;
       esac
       ;;
+    rds)
+      # arn:aws:rds:<region>:<acct>:snapshot:rds:<instance>-<ts> — the sixth RGT-lag
+      # subtype (2026-07-13 hunt): a SYSTEM (automated) snapshot is removed together
+      # with its deleted instance, yet its tagged mapping lingered in the index and
+      # kept the gate RED. DescribeDBSnapshots answers DBSnapshotNotFound once gone;
+      # an EXISTING snapshot (manual or automated-retained) stays RED — a real orphan
+      # that needs an explicit delete.
+      case "$arn" in
+        *:snapshot:*)
+          id="${arn#*:snapshot:}"
+          [ -n "$id" ] || return 1
+          err="$(aws rds describe-db-snapshots --db-snapshot-identifier "$id" \
+            --region "$REGION" --query 'DBSnapshots[0].Status' --output text 2>&1)" || {
+              printf '%s' "$err" | grep -q 'DBSnapshotNotFound' && return 0
+              return 1
+            }
+          [ "$err" = "None" ] && return 0
+          return 1
+          ;;
+        *) return 1 ;;
+      esac
+      ;;
     *)
       return 1 ;;
   esac

--- a/tests/lakeformation-reader-1536.test.ts
+++ b/tests/lakeformation-reader-1536.test.ts
@@ -1,0 +1,50 @@
+// #1536 — AWS::LakeFormation::Resource was ALWAYS silently skipped: the CFn physical id is
+// NOT the bare ResourceArn (CloudFormation prefixes it, `LakeFormation-arn:aws:s3:::bucket`),
+// so the reader passed it verbatim to DescribeResource -> InvalidInputException -> skip ->
+// a falsely-CLEAN read on the exact type the reader was added to watch (#930) — the same
+// ARN-vs-physical-id skip-mask class as #1523. The reader now strips everything before the
+// first `arn:`. Live-verified both directions on CdkrdHunt0713MiscReaders (us-east-1,
+// 2026-07-13): fresh deploy reads CLEAN (SLR RoleArn folds via CONTEXT_ARN_DEFAULTS), an
+// out-of-band hybrid-access re-registration surfaces HybridAccessEnabled=true.
+import { DescribeResourceCommand, LakeFormationClient } from '@aws-sdk/client-lakeformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+const lf = mockClient(LakeFormationClient);
+
+const ARN = 'arn:aws:s3:::cdkrd-hunt-lf-bucket';
+const SLR =
+  'arn:aws:iam::123456789012:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess';
+
+const read = (physicalId: string) =>
+  SDK_OVERRIDES['AWS::LakeFormation::Resource']({
+    physicalId,
+    declared: { ResourceArn: ARN, UseServiceLinkedRole: true },
+    region: 'us-east-1',
+    accountId: '123456789012',
+  });
+
+beforeEach(() => {
+  lf.reset();
+  lf.on(DescribeResourceCommand).resolves({
+    ResourceInfo: { ResourceArn: ARN, RoleArn: SLR, HybridAccessEnabled: false },
+  });
+});
+
+describe('#1536 LakeFormation Resource reader physical-id handling', () => {
+  it('strips the CloudFormation `LakeFormation-` prefix before calling DescribeResource', async () => {
+    const out = await read(`LakeFormation-${ARN}`);
+    expect(lf.commandCalls(DescribeResourceCommand)[0]?.args[0].input).toEqual({
+      ResourceArn: ARN,
+    });
+    expect(out).toEqual({ ResourceArn: ARN, RoleArn: SLR, HybridAccessEnabled: false });
+  });
+
+  it('still accepts a bare ARN physical id', async () => {
+    await read(ARN);
+    expect(lf.commandCalls(DescribeResourceCommand)[0]?.args[0].input).toEqual({
+      ResourceArn: ARN,
+    });
+  });
+});

--- a/tests/noise-caseidents2-1539.test.ts
+++ b/tests/noise-caseidents2-1539.test.ts
@@ -1,0 +1,80 @@
+// #1539 — two more members of the lowercase/re-case echo FP family (#1531 class),
+// live-proven on case-idents2-min (us-east-1, 2026-07-13):
+//   * AWS::Redshift::ClusterParameterGroup ParameterGroupName: the handler accepts a
+//     mixed-case name, the service stores/echoes it lowercased
+//     ("CdkrdHunt-RsCpg" -> "cdkrdhunt-rscpg").
+//   * AWS::Batch::JobDefinition Type: "Container" echoes as the canonical "container"
+//     (the same enum re-case as the already-guarded ComputeEnvironment Type).
+// Both fold via CASE_INSENSITIVE_PATHS — values differing beyond case still surface.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1539 Redshift ClusterParameterGroup lowercase-stored name', () => {
+  const mk = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'HuntRsCpg',
+    resourceType: 'AWS::Redshift::ClusterParameterGroup',
+    physicalId: 'cdkrdhunt-rscpg',
+    declared,
+  });
+  const declared = {
+    ParameterGroupName: 'CdkrdHunt-RsCpg',
+    ParameterGroupFamily: 'redshift-1.0',
+    Description: 'd',
+  };
+
+  it('a pure case-fold echo is not declared drift', () => {
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, ParameterGroupName: 'cdkrdhunt-rscpg' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toEqual([]);
+  });
+
+  it('a name differing beyond case still surfaces as declared drift', () => {
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, ParameterGroupName: 'cdkrdhunt-other' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toEqual(['ParameterGroupName']);
+  });
+});
+
+describe('#1539 Batch JobDefinition Type enum re-case echo', () => {
+  const mk = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'HuntJobDef',
+    resourceType: 'AWS::Batch::JobDefinition',
+    physicalId: 'CdkrdHunt-JobDef:1',
+    declared,
+  });
+  const declared = { Type: 'Container', JobDefinitionName: 'CdkrdHunt-JobDef' };
+
+  it('the canonical lowercase echo is not declared drift', () => {
+    const f = classifyResource(mk(declared), { ...declared, Type: 'container' }, emptySchema);
+    expect(pathsByTier(f, 'declared')).toEqual([]);
+  });
+
+  it('a genuinely different type still surfaces', () => {
+    const f = classifyResource(mk(declared), { ...declared, Type: 'multinode' }, emptySchema);
+    expect(pathsByTier(f, 'declared')).toEqual(['Type']);
+  });
+});

--- a/tests/noise-mediaconvert-1535.test.ts
+++ b/tests/noise-mediaconvert-1535.test.ts
@@ -1,0 +1,99 @@
+// #1535 — a barest on-demand MediaConvert Queue / JobTemplate first-run-FP'd five
+// creation-time constants (the #497 SDK-override readers were never exercised barest):
+//   * Queue:       PricingPlan "ON_DEMAND", Status "ACTIVE"
+//   * JobTemplate: Priority 0, StatusUpdateInterval "SECONDS_60",
+//                  AccelerationSettings {Mode:"DISABLED"}
+// All stable constants → fold-strategy tier 1 (KNOWN_DEFAULTS, equality-gated): each folds
+// the exact default and still surfaces any change away from it — `Status` is the classic
+// console-pause, live-verified both directions on CdkrdHunt0713MediaConv (us-east-1,
+// 2026-07-13): fresh deploy folds CLEAN, an out-of-band PAUSED re-surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Hunt',
+  resourceType,
+  physicalId: 'cdkrd-hunt-mc',
+  declared,
+});
+
+describe('#1535 MediaConvert Queue constant defaults', () => {
+  const declared = { Name: 'cdkrd-hunt-mc-queue' };
+
+  it('folds undeclared PricingPlan/Status creation defaults to atDefault (zero first-run noise)', () => {
+    const f = classifyResource(
+      mk('AWS::MediaConvert::Queue', declared),
+      { ...declared, PricingPlan: 'ON_DEMAND', Status: 'ACTIVE' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual(['PricingPlan', 'Status']);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'declared')).toEqual([]);
+  });
+
+  it('an out-of-band PAUSED queue still surfaces (equality gate keeps detection)', () => {
+    const f = classifyResource(
+      mk('AWS::MediaConvert::Queue', declared),
+      { ...declared, PricingPlan: 'ON_DEMAND', Status: 'PAUSED' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Status']);
+    expect(pathsByTier(f, 'atDefault')).toEqual(['PricingPlan']);
+  });
+});
+
+describe('#1535 MediaConvert JobTemplate constant defaults', () => {
+  const declared = { Name: 'cdkrd-hunt-mc-jobtemplate' };
+
+  it('folds undeclared Priority/StatusUpdateInterval/AccelerationSettings to atDefault', () => {
+    const f = classifyResource(
+      mk('AWS::MediaConvert::JobTemplate', declared),
+      {
+        ...declared,
+        Priority: 0,
+        StatusUpdateInterval: 'SECONDS_60',
+        AccelerationSettings: { Mode: 'DISABLED' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual([
+      'AccelerationSettings',
+      'Priority',
+      'StatusUpdateInterval',
+    ]);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a non-default priority / enabled acceleration still surfaces', () => {
+    const f = classifyResource(
+      mk('AWS::MediaConvert::JobTemplate', declared),
+      {
+        ...declared,
+        Priority: 50,
+        StatusUpdateInterval: 'SECONDS_60',
+        AccelerationSettings: { Mode: 'ENABLED' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['AccelerationSettings', 'Priority']);
+    expect(pathsByTier(f, 'atDefault')).toEqual(['StatusUpdateInterval']);
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -556,6 +556,26 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#1541: RDS DBInstance BackupRetentionPeriod (SET-DEFAULT) -> add op writing the 1 default, not a no-op remove', () => {
+    // ModifyDBInstance keeps the existing value for any omitted property, so a bare
+    // `remove` of an out-of-band undeclared BackupRetentionPeriod is a silent no-op
+    // (live-proven on CdkrdHunt0713RdsMariadb: value stayed 3). Revert must write the
+    // KNOWN_DEFAULTS `1` explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RDS::DBInstance',
+      path: 'BackupRetentionPeriod',
+      actual: 3,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/BackupRetentionPeriod',
+      value: 1,
+      prior: 3,
+    });
+  });
+
   it('Lambda Alias Description (SET-DEFAULT) -> add op writing the empty-string default, not a no-op remove', () => {
     // AWS::Lambda::Alias Description is in REVERT_SET_DEFAULT_PATHS: UpdateAlias leaves the
     // description UNCHANGED when it is OMITTED, so a bare `remove` is a silent no-op (Cloud


### PR DESCRIPTION
## Summary

/hunt-bugs sweep (2026-07-13, 5 rounds, 8 ephemeral stacks in us-east-1, all deleted + SWEEP CLEAN). 7 bugs found across 5 issues — every fix live-verified in BOTH directions (fold folds a clean deploy to zero; the equality gate still detects the out-of-band mutation) on the fixture stacks before teardown.

Closes #1535, closes #1536, closes #1537, closes #1538, closes #1539, closes #1541.

### Fixes

- **#1535 MediaConvert first-run FP ×5** — `KNOWN_DEFAULTS` for `Queue.PricingPlan/Status` and `JobTemplate.Priority/StatusUpdateInterval/AccelerationSettings` (all stable creation constants; the OOB queue PAUSE re-surfaces — live-proven).
- **#1536 LakeFormation Resource always skipped (falsely CLEAN)** — the CFn physical id is `LakeFormation-arn:…`, not the bare ARN; the reader now strips to the first `arn:` (the #1523 skip-mask class). Plus a `CONTEXT_ARN_DEFAULTS` SLR fold for the `UseServiceLinkedRole: true` RoleArn echo. OOB hybrid-access re-registration now detected — live-proven.
- **#1537 Cloud Map DNS Service double FP** — every CDK L2 DNS service false-flagged `DnsConfig.NamespaceId` declared drift (GetService omits the deprecated echo; the reader now mirrors the live top-level `NamespaceId` when the template declares it) and surfaced the derived `Type=DNS_HTTP` (now a tier-2 derived fold: DnsConfig present → `DNS_HTTP`, absent → `HTTP`).
- **#1538 DynamoDB WarmThroughput FP after autoscaling scale-in** — warm throughput echoes CREATION capacity and never follows a scale-in; the #627 derived fold now also gates against the DECLARED `ProvisionedThroughput` (top-level + per-GSI).
- **#1539 re-case echo FPs** — `CASE_INSENSITIVE_PATHS` additions: `Redshift::ClusterParameterGroup.ParameterGroupName` (stored lowercased), `Batch::JobDefinition.Type` (`Container` → `container`). Bounded live: ElastiCache `UserId` / MemoryDB parameter-group names are CFn-handler-rejected in mixed case (raw API accepts) — unreachable, no entries.
- **#1541 RDS revert silent no-op** — `ModifyDBInstance` keeps omitted properties, so a bare-`remove` revert of an OOB undeclared `BackupRetentionPeriod` reported success while the live value stayed 3; `REVERT_SET_DEFAULT_PATHS` entry writes the `1` default explicitly (live re-verified converging to 1).

### Benign determinations (no code change)

- SQS `VisibilityTimeout` / DynamoDB `DeletionProtectionEnabled` / Lambda `MemorySize`: bare-`remove` reverts DO converge live (30 / false / 128 confirmed) — those CC handlers do full desired-state updates.
- Lambda dotnet8 / ruby3.3 / provided.al2023, mariadb `DBInstance`, SNS multi-key `FilterPolicy`, App-Auto-Scaling `rate(60 minutes)`: first-run CLEAN, no FPs.
- ELBv2 TrustStore `CaCertificatesBundleSha256`: works as designed (synthetic integrity signal, #505).

### Also

- 8 new committed integ fixtures (`mediaconvert-min`, `misc-readers-min`, `cloudmap-public-min`, `elbv2-truststore-min`, `case-idents2-min`, `format-probes-min`, `lambda-runtimes-min`, `rds-mariadb-min`) with first-check-zero + detection/revert cycles in `verify.sh`.
- 16 new golden-corpus cases (first coverage for MediaConvert ×2, LakeFormation Resource, IAM AccessKey, ServiceDiscovery PublicDnsNamespace, ELBv2 TrustStore; variant coverage for Lambda dotnet8/ruby/provided, RDS mariadb, DDB warm-scale-in, SNS FilterPolicy, ScalableTarget, Redshift CPG, Batch JobDefinition, Cloud Map DNS Service).
- 20 new unit tests (12 fail without the fixes; the rest pin the detection direction).
- /hunt-bugs skill: 3 new gotchas (CFn-handler vs raw-API validation, L2-declared leaf voids an undeclared proof, in-stack scalable target as a drift generator).
- #1540 filed (missing CHILD_ENUMERATORS parents) as future per-parent work — not in this PR.

## Test plan

- `vp run test` (all suites incl. corpus-replay 745 cases), `vp run typecheck`, `vp check` — green.
- Live A/B on all 8 stacks pre-teardown: pre-fix binary surfaced every FP / skip; post-fix binary folds clean AND detects each OOB mutation; RDS revert converges live.
