### PR TITLE
feat(read): child enumerators for ASG, VPC NAT/flow-log, Cognito domain, Glue tables, TGW (#1540)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@aws-sdk/client-apigatewayv2": "^3.1069.0",
     "@aws-sdk/client-appconfig": "^3.1069.0",
     "@aws-sdk/client-appsync": "^3.1066.0",
+    "@aws-sdk/client-auto-scaling": "^3.1065.0",
     "@aws-sdk/client-budgets": "^3.1065.0",
     "@aws-sdk/client-cloudcontrol": "^3.1065.0",
     "@aws-sdk/client-cloudformation": "^3.1065.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@aws-sdk/client-appsync':
         specifier: ^3.1066.0
         version: 3.1066.0
+      '@aws-sdk/client-auto-scaling':
+        specifier: ^3.1065.0
+        version: 3.1085.0
       '@aws-sdk/client-budgets':
         specifier: ^3.1065.0
         version: 3.1066.0
@@ -348,6 +351,10 @@ packages:
 
   '@aws-sdk/client-appsync@3.1066.0':
     resolution: {integrity: sha512-zmdki3cV8TzcbiG5YqMmsrbGZj9POJjyfuOvVLaTDOZ6MOlI6pooLvw6RpzPmDIaIpSRIem+pfbRshISwWWMzg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-auto-scaling@3.1085.0':
+    resolution: {integrity: sha512-jy163P+qPc3iHnA1QIGKqK7j11yr1YkTqG53VLtkZnvxkk6n42BFp32nSJgZmRFij5b2j1QMEbI1nHf1b3RFUA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock-agentcore-control@3.1066.0':
@@ -2416,7 +2423,7 @@ packages:
     engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -3999,6 +4006,17 @@ snapshots:
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-auto-scaling@3.1085.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1115,8 +1115,19 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // vpc is the only value for a new EIP). Equality-gated constant.
     Domain: 'vpc',
   },
+  // #1540 hunt (CdkrdHunt0713cEnumChildren, 2026-07-13): a BAREST TGW (only Description
+  // declared — transitgateway-rich declared these leaves, hiding the undeclared-default
+  // path) first-run-FP'd all seven creation constants. Equality-gated: an out-of-band
+  // flip (auto-accept enable, DNS disable, an ASN change) no longer matches and surfaces.
   'AWS::EC2::TransitGateway': {
     SecurityGroupReferencingSupport: 'disable',
+    AmazonSideAsn: 64512,
+    AutoAcceptSharedAttachments: 'disable',
+    DefaultRouteTableAssociation: 'enable',
+    DefaultRouteTablePropagation: 'enable',
+    DnsSupport: 'enable',
+    VpnEcmpSupport: 'enable',
+    MulticastSupport: 'disable',
   },
   'AWS::EC2::FlowLog': {
     MaxAggregationInterval: 600,
@@ -3346,7 +3357,19 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   constant nor derived. Undeclared → whatever AZs AWS chose are not user intent; a user who
   //   wants specific AZs declares `AvailabilityZones` instead, compared in the declared loop.
   //   Exact twin of the classic-ELB AvailabilityZones fold above. Live, hunt 2026-07-08 #639.
-  'AWS::AutoScaling::AutoScalingGroup': new Set(['AvailabilityZones', 'AvailabilityZoneIds']),
+  //   LifecycleHookSpecificationList (#1540): a launch-time-only (create-only) template
+  //   property; the live model echoes the group's CURRENT hooks into it, including hooks
+  //   declared as SEPARATE AWS::AutoScaling::LifecycleHook resources and hooks added out of
+  //   band. Hook drift is OWNED by the child dimension (a declared hook compares as its own
+  //   resource; an out-of-band hook surfaces via the #1540 AutoScalingGroup child enumerator),
+  //   so folding the parent echo value-independently prevents the same hook from
+  //   double-reporting (#747 lesson) without losing detection. Live-proven on
+  //   CdkrdHunt0713cEnumChildren (2026-07-13): a sibling-declared hook FP'd this path.
+  'AWS::AutoScaling::AutoScalingGroup': new Set([
+    'AvailabilityZones',
+    'AvailabilityZoneIds',
+    'LifecycleHookSpecificationList',
+  ]),
   //   AWS::ApiGateway::Authorizer.AuthType — a REST-API authorizer's schema carries NO
   //   `AuthType` property (the template declares `Type`: TOKEN / REQUEST /
   //   COGNITO_USER_POOLS); AWS DERIVES and reads back AuthType from it ("custom" for
@@ -3890,6 +3913,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
 //   (#1501, live-repro'd 2026-07-12 on tests/integration/s3kms-ddb-batch-min).
 export const VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Batch::ComputeEnvironment': new Set(['ComputeResources.DesiredvCpus']),
+  // #1540 hunt (CdkrdHunt0713cEnumChildren, 2026-07-13): DescribeAutoScalingGroups
+  // augments every DECLARED tag entry with the read-only TagDescription echo fields
+  // ResourceId (the group's own name) and ResourceType ("auto-scaling-group") — pure
+  // reflections of the resource's identity, never user-settable per tag, which FP'd as
+  // nested undeclared on every tagged barest ASG. The tag's Key/Value/PropagateAtLaunch
+  // stay compared (a real tag change still surfaces).
+  'AWS::AutoScaling::AutoScalingGroup': new Set(['Tags.*.ResourceId', 'Tags.*.ResourceType']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -58,6 +58,13 @@ import {
   type Stage as ApiGwV2Stage,
 } from '@aws-sdk/client-apigatewayv2';
 import {
+  AutoScalingClient,
+  DescribeLifecycleHooksCommand,
+  DescribeScheduledActionsCommand,
+  type LifecycleHook as AsgLifecycleHook,
+  type ScheduledUpdateGroupAction as AsgScheduledUpdateGroupAction,
+} from '@aws-sdk/client-auto-scaling';
+import {
   CloudWatchLogsClient,
   DescribeMetricFiltersCommand,
   DescribeSubscriptionFiltersCommand,
@@ -66,6 +73,7 @@ import {
 } from '@aws-sdk/client-cloudwatch-logs';
 import {
   CognitoIdentityProviderClient,
+  DescribeUserPoolCommand,
   type GroupType,
   ListGroupsCommand,
   ListIdentityProvidersCommand,
@@ -76,15 +84,21 @@ import {
   type UserPoolClientDescription,
 } from '@aws-sdk/client-cognito-identity-provider';
 import {
+  DescribeFlowLogsCommand,
   DescribeInternetGatewaysCommand,
+  DescribeNatGatewaysCommand,
   DescribeNetworkAclsCommand,
   DescribeRouteTablesCommand,
   DescribeSecurityGroupsCommand,
   DescribeSubnetsCommand,
+  DescribeTransitGatewayAttachmentsCommand,
+  DescribeTransitGatewayRouteTablesCommand,
   DescribeVpcEndpointsCommand,
   DescribeVpcsCommand,
   EC2Client,
+  type FlowLog as Ec2FlowLog,
   type InternetGateway as Ec2InternetGateway,
+  type NatGateway as Ec2NatGateway,
   type NetworkAcl as Ec2NetworkAcl,
   type NetworkAclEntry as Ec2NetworkAclEntry,
   type Route as Ec2Route,
@@ -93,6 +107,8 @@ import {
   type SecurityGroup as Ec2SecurityGroup,
   type Subnet as Ec2Subnet,
   type Tag as Ec2Tag,
+  type TransitGatewayAttachment as Ec2TransitGatewayAttachment,
+  type TransitGatewayRouteTable as Ec2TransitGatewayRouteTable,
   type Vpc as Ec2Vpc,
   type VpcEndpoint as Ec2VpcEndpoint,
 } from '@aws-sdk/client-ec2';
@@ -114,6 +130,7 @@ import {
   ListRulesCommand,
   type Rule as EventBridgeRule,
 } from '@aws-sdk/client-eventbridge';
+import { GetTablesCommand, GlueClient, type Table as GlueTable } from '@aws-sdk/client-glue';
 import {
   type AliasListEntry,
   type GrantListEntry,
@@ -289,7 +306,11 @@ export type ChildEnumerator = (ctx: EnumeratorContext) => Promise<AddedChild[]>;
 // resource policy attached with no declared AWS::S3::BucketPolicy, #835) the twentieth;
 // SQS queues (an out-of-band access policy set with no declared AWS::SQS::QueuePolicy, #835)
 // the twenty-first; Secrets Manager secrets (an out-of-band resource policy attached with no
-// declared AWS::SecretsManager::ResourcePolicy, #835) the twenty-second.
+// declared AWS::SecretsManager::ResourcePolicy, #835) the twenty-second; AutoScaling groups
+// (scheduled actions + lifecycle hooks, #1540) the twenty-third; Glue databases (tables,
+// #1540) the twenty-fourth; EC2 transit gateways (VPC attachments + route tables, #1540) the
+// twenty-fifth. #1540 also extended existing parents: EC2 VPCs gained NAT gateways + flow
+// logs, Cognito User Pools gained the hosted-UI domain.
 export const CHILD_ENUMERATORS: Record<string, ChildEnumerator> = {
   'AWS::S3::Bucket': enumerateS3BucketChildren,
   'AWS::SQS::Queue': enumerateSqsQueueChildren,
@@ -313,6 +334,9 @@ export const CHILD_ENUMERATORS: Record<string, ChildEnumerator> = {
   'AWS::EFS::FileSystem': enumerateEfsFileSystemChildren,
   'AWS::RDS::DBCluster': enumerateRdsClusterChildren,
   'AWS::Route53::HostedZone': enumerateRoute53HostedZoneChildren,
+  'AWS::AutoScaling::AutoScalingGroup': enumerateAutoScalingGroupChildren,
+  'AWS::Glue::Database': enumerateGlueDatabaseChildren,
+  'AWS::EC2::TransitGateway': enumerateTransitGatewayChildren,
 };
 
 // ── API Gateway ────────────────────────────────────────────────────────────
@@ -2817,6 +2841,42 @@ async function pageUserPoolIdentityProviders(
   return out;
 }
 
+// A UserPool also owns at most one prefix hosted-UI domain and at most one custom hosted-UI
+// domain (`AWS::Cognito::UserPoolDomain`, #1540). A console / CLI `create-user-pool-domain`
+// (someone stands up an out-of-band hosted-UI / OAuth endpoint on a declared pool — a
+// phishing-adjacent auth surface) is invisible to cdk drift / CFn drift detection. The pool's
+// own DescribeUserPool response DOES carry the domains (`UserPool.Domain` for the prefix
+// domain, `UserPool.CustomDomain` for the custom one), but the CC UserPool model does not
+// surface them as declarable properties, so there is no double-report to suppress. The CC
+// primaryIdentifier for AWS::Cognito::UserPoolDomain is the composite
+// `["/properties/UserPoolId","/properties/Domain"]`, so the `identifier` is the composite
+// `UserPoolId|Domain` — the same parent-first shape router.ts's CC_IDENTIFIER_ADAPTERS entry
+// (`compositeWith('UserPoolId')`) builds for a DECLARED domain's read. A domain's CFn
+// physical id (Ref) IS its Domain string.
+
+// Pure diff: declared domain strings + live inventory -> the added hosted-UI domains.
+export interface UserPoolDomainChildInput {
+  userPoolId: string;
+  declaredDomains: string[]; // Domain values (Ref/physical id) of AWS::Cognito::UserPoolDomain on this pool
+  liveDomains: { domain: string; custom?: boolean }[];
+}
+
+export function diffUserPoolDomainChildren(input: UserPoolDomainChildInput): AddedChild[] {
+  const { userPoolId, declaredDomains, liveDomains } = input;
+  const declared = new Set(declaredDomains);
+  const added: AddedChild[] = [];
+  for (const d of liveDomains) {
+    if (declared.has(d.domain)) continue;
+    added.push({
+      resourceType: 'AWS::Cognito::UserPoolDomain',
+      identifier: `${userPoolId}|${d.domain}`, // CC composite UserPoolId|Domain
+      label: `${d.domain} (hosted UI domain)`,
+      live: { Domain: d.domain, UserPoolId: userPoolId },
+    });
+  }
+  return added;
+}
+
 // Live corroboration (#1265) that an OpenSearch/Elasticsearch domain enables Cognito
 // Dashboards auth against `userPoolId`. Lists the account's domains, describes them, and
 // checks each domain's `CognitoOptions.UserPoolId`. FAIL-SAFE toward no-false-positive:
@@ -2868,6 +2928,8 @@ async function enumerateUserPoolChildren(ctx: EnumeratorContext): Promise<AddedC
   const declaredResourceServerIdentifiers: string[] = [];
   // Declared identity providers of THIS pool. Matched by the ProviderName (Ref/physical id).
   const declaredProviderNames: string[] = [];
+  // Declared hosted-UI domains of THIS pool (#1540). Matched by the Domain value (Ref/physical id).
+  const declaredDomains: string[] = [];
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::Cognito::UserPoolClient' &&
@@ -2895,6 +2957,12 @@ async function enumerateUserPoolChildren(ctx: EnumeratorContext): Promise<AddedC
       const providerName =
         typeof r.declared.ProviderName === 'string' ? r.declared.ProviderName : r.physicalId;
       if (providerName) declaredProviderNames.push(providerName);
+    } else if (
+      r.resourceType === 'AWS::Cognito::UserPoolDomain' &&
+      parentRefMatches(r.declared.UserPoolId, userPoolId)
+    ) {
+      const domain = typeof r.declared.Domain === 'string' ? r.declared.Domain : r.physicalId;
+      if (domain) declaredDomains.push(domain);
     }
   }
 
@@ -2973,7 +3041,21 @@ async function enumerateUserPoolChildren(ctx: EnumeratorContext): Promise<AddedC
     liveProviders,
   });
 
-  return [...clientAdded, ...groupAdded, ...resourceServerAdded, ...idpAdded];
+  // Hosted-UI domains (#1540): the pool's own DescribeUserPool response carries the prefix
+  // domain (`UserPool.Domain`) and the custom domain (`UserPool.CustomDomain`) — no list API.
+  const describeRes = await client.send(new DescribeUserPoolCommand({ UserPoolId: userPoolId }));
+  const liveDomains: { domain: string; custom?: boolean }[] = [];
+  const prefixDomain = describeRes.UserPool?.Domain;
+  if (typeof prefixDomain === 'string' && prefixDomain.length > 0) {
+    liveDomains.push({ domain: prefixDomain });
+  }
+  const customDomain = describeRes.UserPool?.CustomDomain;
+  if (typeof customDomain === 'string' && customDomain.length > 0) {
+    liveDomains.push({ domain: customDomain, custom: true });
+  }
+  const domainAdded = diffUserPoolDomainChildren({ userPoolId, declaredDomains, liveDomains });
+
+  return [...clientAdded, ...groupAdded, ...resourceServerAdded, ...idpAdded, ...domainAdded];
 }
 
 // ── AppSync ──────────────────────────────────────────────────────────────────
@@ -3958,6 +4040,67 @@ export function diffVpcSecurityGroupChildren(input: VpcSecurityGroupChildInput):
   return added;
 }
 
+// NAT gateways (#1540). A VPC owns NatGateways, each a separate CloudFormation resource. A
+// console / CLI `create-nat-gateway` (someone stands up an out-of-band NAT — an egress path
+// plus an hourly bill no template describes) is invisible to cdk / CFn drift detection, and
+// the VPC's own model does NOT reflect its NAT gateways. The CC primaryIdentifier for
+// AWS::EC2::NatGateway is the bare NatGatewayId, consumed directly by CC GetResource /
+// DeleteResource. FP-safety: a deleted NAT gateway stays visible in DescribeNatGateways for
+// a while after deletion, so terminal/leaving states (`deleted` / `deleting` / `failed`) are
+// filtered — a lingering husk of a properly removed NAT must never surface as `added`.
+const NAT_GATEWAY_GONE_STATES = new Set(['deleted', 'deleting', 'failed']);
+
+// Pure diff: declared NAT-gateway ids + live inventory -> the added NAT gateways. The
+// gone-state filter lives HERE so it is unit-tested offline with the matching logic.
+export interface VpcNatGatewayChildInput {
+  declaredNatGatewayIds: string[]; // physical ids (NatGatewayIds) of AWS::EC2::NatGateway in the template
+  liveNatGateways: { id: string; state?: string | undefined; label?: string | undefined }[];
+}
+
+export function diffVpcNatGatewayChildren(input: VpcNatGatewayChildInput): AddedChild[] {
+  const declared = new Set(input.declaredNatGatewayIds);
+  const added: AddedChild[] = [];
+  for (const n of input.liveNatGateways) {
+    if (n.state !== undefined && NAT_GATEWAY_GONE_STATES.has(n.state)) continue;
+    if (declared.has(n.id)) continue;
+    added.push({
+      resourceType: 'AWS::EC2::NatGateway',
+      identifier: n.id, // NatGatewayId IS the CC primaryIdentifier
+      label: n.label ?? n.id,
+      live: { NatGatewayId: n.id },
+    });
+  }
+  return added;
+}
+
+// Flow logs (#1540). A VPC-level FlowLog is a separate CloudFormation resource
+// (`AWS::EC2::FlowLog` with ResourceType VPC). An out-of-band `create-flow-logs` (someone
+// wires traffic capture — or re-points where it lands — on a declared VPC) is invisible to
+// cdk / CFn drift detection, and the VPC's own model does NOT reflect its flow logs. The CC
+// primaryIdentifier for AWS::EC2::FlowLog is the bare Id (the FlowLogId), consumed directly
+// by CC GetResource / DeleteResource. DescribeFlowLogs is filtered by `resource-id` = this
+// VpcId, so only VPC-scoped flow logs are enumerated here (subnet / ENI / TGW flow logs
+// never reach this diff).
+export interface VpcFlowLogChildInput {
+  declaredFlowLogIds: string[]; // physical ids (FlowLogIds) of AWS::EC2::FlowLog on this VPC
+  liveFlowLogs: { id: string; label?: string | undefined }[];
+}
+
+export function diffVpcFlowLogChildren(input: VpcFlowLogChildInput): AddedChild[] {
+  const declared = new Set(input.declaredFlowLogIds);
+  const added: AddedChild[] = [];
+  for (const f of input.liveFlowLogs) {
+    if (declared.has(f.id)) continue;
+    added.push({
+      resourceType: 'AWS::EC2::FlowLog',
+      identifier: f.id, // Id (the FlowLogId) IS the CC primaryIdentifier
+      label: f.label ?? f.id,
+      live: { Id: f.id },
+    });
+  }
+  return added;
+}
+
 async function pageSecurityGroups(client: EC2Client, vpcId: string): Promise<Ec2SecurityGroup[]> {
   const out: Ec2SecurityGroup[] = [];
   let next: string | undefined;
@@ -4068,6 +4211,40 @@ async function pageInternetGateways(
   return out;
 }
 
+async function pageNatGateways(client: EC2Client, vpcId: string): Promise<Ec2NatGateway[]> {
+  const out: Ec2NatGateway[] = [];
+  let next: string | undefined;
+  do {
+    const res = await client.send(
+      new DescribeNatGatewaysCommand({
+        // NB: DescribeNatGateways names its filter list `Filter` (singular), unlike most EC2 APIs.
+        Filter: [{ Name: 'vpc-id', Values: [vpcId] }],
+        NextToken: next,
+      })
+    );
+    out.push(...(res.NatGateways ?? []));
+    next = res.NextToken;
+  } while (next);
+  return out;
+}
+
+async function pageFlowLogs(client: EC2Client, vpcId: string): Promise<Ec2FlowLog[]> {
+  const out: Ec2FlowLog[] = [];
+  let next: string | undefined;
+  do {
+    const res = await client.send(
+      new DescribeFlowLogsCommand({
+        // NB: DescribeFlowLogs names its filter list `Filter` (singular), unlike most EC2 APIs.
+        Filter: [{ Name: 'resource-id', Values: [vpcId] }],
+        NextToken: next,
+      })
+    );
+    out.push(...(res.FlowLogs ?? []));
+    next = res.NextToken;
+  } while (next);
+  return out;
+}
+
 async function describeVpc(client: EC2Client, vpcId: string): Promise<Ec2Vpc | undefined> {
   const res = await client.send(new DescribeVpcsCommand({ VpcIds: [vpcId] }));
   return res.Vpcs?.[0];
@@ -4098,6 +4275,26 @@ export async function enumerateVpcChildren(ctx: EnumeratorContext): Promise<Adde
       declaredNaclIds.push(r.physicalId);
     } else if (r.resourceType === 'AWS::EC2::SecurityGroup') {
       declaredSecurityGroupIds.push(r.physicalId);
+    }
+  }
+
+  // Declared NAT gateways + VPC-level flow logs (#1540). A NatGateway references its VPC only
+  // INDIRECTLY (its parent ref is SubnetId, not VpcId), so it cannot be scoped by VpcId here;
+  // like the SubnetRouteTableAssociation set above, the live diff is already scoped to THIS
+  // VPC (DescribeNatGateways vpc-id filter), so a NAT declared in ANOTHER VPC simply never
+  // matches a live id in this set (no false suppression). A FlowLog's parent ref IS the
+  // declared ResourceId (= the VpcId for a VPC-scoped flow log), so it is ref-matched.
+  const declaredNatGatewayIds: string[] = [];
+  const declaredFlowLogIds: string[] = [];
+  for (const r of desired.resources) {
+    if (!r.physicalId) continue;
+    if (r.resourceType === 'AWS::EC2::NatGateway') {
+      declaredNatGatewayIds.push(r.physicalId);
+    } else if (
+      r.resourceType === 'AWS::EC2::FlowLog' &&
+      parentRefMatches(r.declared.ResourceId, vpcId)
+    ) {
+      declaredFlowLogIds.push(r.physicalId);
     }
   }
 
@@ -4233,6 +4430,28 @@ export async function enumerateVpcChildren(ctx: EnumeratorContext): Promise<Adde
     )
     .map((g) => ({ id: g.GroupId, label: g.GroupName ?? g.GroupId }));
 
+  // NAT gateways (#1540): the gone-state (`deleted`/`deleting`/`failed`) filter is applied
+  // inside the pure diff so it is unit-tested with the matching logic.
+  const natGateways = await pageNatGateways(client, vpcId);
+  const liveNatGateways = natGateways
+    .filter(
+      (n): n is Ec2NatGateway & { NatGatewayId: string } => typeof n.NatGatewayId === 'string'
+    )
+    .map((n) => ({
+      id: n.NatGatewayId,
+      state: n.State as string | undefined,
+      label: n.SubnetId ? `${n.NatGatewayId} (${n.SubnetId})` : n.NatGatewayId,
+    }));
+
+  // VPC-level flow logs (#1540): DescribeFlowLogs filtered by `resource-id` = this VpcId.
+  const flowLogs = await pageFlowLogs(client, vpcId);
+  const liveFlowLogs = flowLogs
+    .filter((f): f is Ec2FlowLog & { FlowLogId: string } => typeof f.FlowLogId === 'string')
+    .map((f) => ({
+      id: f.FlowLogId,
+      label: f.LogDestination ?? f.LogGroupName ?? f.FlowLogId,
+    }));
+
   return [
     ...diffVpcChildren({ declaredSubnetIds, liveSubnets }),
     ...diffVpcEndpointChildren({ declaredEndpointIds, liveEndpoints }),
@@ -4246,6 +4465,8 @@ export async function enumerateVpcChildren(ctx: EnumeratorContext): Promise<Adde
     }),
     ...diffVpcCidrBlockChildren({ vpcId, declaredCidrs, liveCidrBlocks }),
     ...diffVpcSecurityGroupChildren({ declaredSecurityGroupIds, liveSecurityGroups }),
+    ...diffVpcNatGatewayChildren({ declaredNatGatewayIds, liveNatGateways }),
+    ...diffVpcFlowLogChildren({ declaredFlowLogIds, liveFlowLogs }),
   ];
 }
 
@@ -5345,4 +5566,454 @@ export async function enumerateRoute53HostedZoneChildren(
     });
 
   return diffRoute53HostedZoneChildren({ hostedZoneId, zoneApex, declaredRecords, liveRecords });
+}
+
+// ── AutoScaling ──────────────────────────────────────────────────────────────
+// An `AWS::AutoScaling::AutoScalingGroup` owns ScheduledActions (time-based scaling) and
+// LifecycleHooks (launch/terminate pause points), each a separate CloudFormation resource
+// (#1540). A console / CLI `put-scheduled-update-group-action` (someone schedules an
+// out-of-band scale-to-zero — or a surprise scale-out bill) or `put-lifecycle-hook`
+// (someone wires a pause point that can hold instances in Pending:Wait) is invisible to
+// cdk drift / CFn drift detection, and the ASG's own live model does NOT reflect either
+// inline, so there is no double-report to suppress. The CC primaryIdentifiers (both
+// mirrored by router.ts's CC_IDENTIFIER_ADAPTERS, verified live there):
+//   - AWS::AutoScaling::ScheduledAction is `[ScheduledActionName, AutoScalingGroupName]` —
+//     CHILD-first, so the `identifier` is `<ScheduledActionName>|<AutoScalingGroupName>`
+//     (the adapter builds `${pid}|${asg}`; the reverse order returns NotFound).
+//   - AWS::AutoScaling::LifecycleHook is `[AutoScalingGroupName, LifecycleHookName]` —
+//     PARENT-first, so the `identifier` is `<AutoScalingGroupName>|<LifecycleHookName>`
+//     (the adapter is `compositeWith('AutoScalingGroupName')`).
+// NotificationConfigurations are deliberately NOT enumerated for now: the matching CFn type
+// (`AWS::AutoScaling::NotificationConfiguration`) is a legacy type with no Cloud Control
+// read/delete support and no CC primaryIdentifier to carry on an `added` finding, so there
+// is no identifier fit — revisit if the type gains a registry schema (#1540).
+
+// Pure diff: declared scheduled-action names + live inventory -> the added scheduled actions.
+export interface AsgScheduledActionChildInput {
+  asgName: string;
+  declaredActionNames: string[]; // ScheduledActionNames (Ref/physical id) of AWS::AutoScaling::ScheduledAction on this ASG
+  liveActions: { name: string; label?: string | undefined }[];
+}
+
+export function diffAsgScheduledActionChildren(input: AsgScheduledActionChildInput): AddedChild[] {
+  const { asgName, declaredActionNames, liveActions } = input;
+  const declared = new Set(declaredActionNames);
+  const added: AddedChild[] = [];
+  for (const a of liveActions) {
+    if (declared.has(a.name)) continue;
+    added.push({
+      resourceType: 'AWS::AutoScaling::ScheduledAction',
+      identifier: `${a.name}|${asgName}`, // CC composite ScheduledActionName|AutoScalingGroupName (CHILD-first)
+      label: a.label ?? a.name,
+      live: { ScheduledActionName: a.name, AutoScalingGroupName: asgName },
+    });
+  }
+  return added;
+}
+
+// Pure diff: declared lifecycle-hook names + live inventory -> the added lifecycle hooks.
+export interface AsgLifecycleHookChildInput {
+  asgName: string;
+  declaredHookNames: string[]; // LifecycleHookNames (declared or Ref/physical id) of AWS::AutoScaling::LifecycleHook on this ASG
+  liveHooks: { name: string; label?: string | undefined }[];
+}
+
+export function diffAsgLifecycleHookChildren(input: AsgLifecycleHookChildInput): AddedChild[] {
+  const { asgName, declaredHookNames, liveHooks } = input;
+  const declared = new Set(declaredHookNames);
+  const added: AddedChild[] = [];
+  for (const h of liveHooks) {
+    if (declared.has(h.name)) continue;
+    added.push({
+      resourceType: 'AWS::AutoScaling::LifecycleHook',
+      identifier: `${asgName}|${h.name}`, // CC composite AutoScalingGroupName|LifecycleHookName (PARENT-first)
+      label: h.label ?? h.name,
+      live: { LifecycleHookName: h.name, AutoScalingGroupName: asgName },
+    });
+  }
+  return added;
+}
+
+async function pageScheduledActions(
+  client: AutoScalingClient,
+  asgName: string
+): Promise<AsgScheduledUpdateGroupAction[]> {
+  const out: AsgScheduledUpdateGroupAction[] = [];
+  let next: string | undefined;
+  do {
+    const res = await client.send(
+      new DescribeScheduledActionsCommand({ AutoScalingGroupName: asgName, NextToken: next })
+    );
+    out.push(...(res.ScheduledUpdateGroupActions ?? []));
+    next = res.NextToken;
+  } while (next);
+  return out;
+}
+
+// DescribeLifecycleHooks returns the full set in one response (no pagination — an ASG holds
+// at most 50 hooks).
+async function describeLifecycleHooks(
+  client: AutoScalingClient,
+  asgName: string
+): Promise<AsgLifecycleHook[]> {
+  const res = await client.send(
+    new DescribeLifecycleHooksCommand({ AutoScalingGroupName: asgName })
+  );
+  return res.LifecycleHooks ?? [];
+}
+
+async function enumerateAutoScalingGroupChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+  const { parent, desired, region } = ctx;
+  const asgName = parent.physicalId; // an ASG's physical id IS its AutoScalingGroupName
+  if (!asgName) return [];
+
+  // Declared scheduled actions + lifecycle hooks of THIS ASG (Ref AutoScalingGroupName
+  // already resolved to the physical id by gather). A ScheduledAction's CFn physical id
+  // (Ref) IS its bare ScheduledActionName (the name is CFn-generated, not declarable); a
+  // LifecycleHook's is its bare LifecycleHookName (declarable via LifecycleHookName).
+  const declaredActionNames: string[] = [];
+  const declaredHookNames: string[] = [];
+  for (const r of desired.resources) {
+    if (
+      r.resourceType === 'AWS::AutoScaling::ScheduledAction' &&
+      parentRefMatches(r.declared.AutoScalingGroupName, asgName) &&
+      r.physicalId
+    ) {
+      declaredActionNames.push(r.physicalId);
+    } else if (
+      r.resourceType === 'AWS::AutoScaling::LifecycleHook' &&
+      parentRefMatches(r.declared.AutoScalingGroupName, asgName)
+    ) {
+      const name =
+        typeof r.declared.LifecycleHookName === 'string'
+          ? r.declared.LifecycleHookName
+          : r.physicalId;
+      if (name) declaredHookNames.push(name);
+    }
+  }
+
+  const client = new AutoScalingClient({ region, ...READ_RETRY });
+
+  const actions = await pageScheduledActions(client, asgName);
+  const liveActions = actions
+    .filter(
+      (a): a is AsgScheduledUpdateGroupAction & { ScheduledActionName: string } =>
+        typeof a.ScheduledActionName === 'string'
+    )
+    .map((a) => ({
+      name: a.ScheduledActionName,
+      label: a.Recurrence ? `${a.ScheduledActionName} (${a.Recurrence})` : a.ScheduledActionName,
+    }));
+
+  const hooks = await describeLifecycleHooks(client, asgName);
+  const liveHooks = hooks
+    .filter(
+      (h): h is AsgLifecycleHook & { LifecycleHookName: string } =>
+        typeof h.LifecycleHookName === 'string'
+    )
+    .map((h) => ({
+      name: h.LifecycleHookName,
+      label: h.LifecycleTransition
+        ? `${h.LifecycleHookName} (${h.LifecycleTransition})`
+        : h.LifecycleHookName,
+    }));
+
+  return [
+    ...diffAsgScheduledActionChildren({ asgName, declaredActionNames, liveActions }),
+    ...diffAsgLifecycleHookChildren({ asgName, declaredHookNames, liveHooks }),
+  ];
+}
+
+// ── Glue ─────────────────────────────────────────────────────────────────────
+// An `AWS::Glue::Database` owns Tables, each a separate CloudFormation resource
+// (`AWS::Glue::Table`, #1540). A console / CLI / crawler-side `create-table` (someone
+// registers an out-of-band table over data the template never exposed — a data-exposure
+// surface once Lake Formation / Athena grants apply to the database) is invisible to cdk
+// drift / CFn drift detection, and the Database's own model does NOT reflect its tables
+// inline, so there is no double-report to suppress. AWS::Glue::Table is a CC-gap type (CC
+// GetResource throws UnsupportedActionException — the reason readGlueTable exists in
+// SDK_OVERRIDES), so like Route53 RecordSet the primary value here is DETECTION; the
+// `identifier` carries the `DatabaseName|TableName` composite (parent-first) — the exact
+// physical-id shape the readGlueTable override splits on, and the CFn physical id (Ref) is
+// the bare TableName (the last segment).
+
+// Pure diff: declared table names + live inventory -> the added tables.
+export interface GlueDatabaseChildInput {
+  databaseName: string;
+  declaredTableNames: string[]; // TableInput.Name values (or Ref/physical id) of AWS::Glue::Table on this database
+  liveTables: { name: string; label?: string | undefined }[];
+}
+
+export function diffGlueDatabaseChildren(input: GlueDatabaseChildInput): AddedChild[] {
+  const { databaseName, declaredTableNames, liveTables } = input;
+  const declared = new Set(declaredTableNames);
+  const added: AddedChild[] = [];
+  for (const t of liveTables) {
+    if (declared.has(t.name)) continue;
+    added.push({
+      resourceType: 'AWS::Glue::Table',
+      identifier: `${databaseName}|${t.name}`, // DatabaseName|TableName — the composite readGlueTable consumes
+      label: t.label ?? t.name,
+      live: { DatabaseName: databaseName, TableInput: { Name: t.name } },
+    });
+  }
+  return added;
+}
+
+async function pageGlueTables(
+  client: GlueClient,
+  databaseName: string,
+  catalogId: string | undefined
+): Promise<GlueTable[]> {
+  const out: GlueTable[] = [];
+  let next: string | undefined;
+  do {
+    const res = await client.send(
+      new GetTablesCommand({
+        DatabaseName: databaseName,
+        NextToken: next,
+        ...(catalogId !== undefined && { CatalogId: catalogId }),
+      })
+    );
+    out.push(...(res.TableList ?? []));
+    next = res.NextToken;
+  } while (next);
+  return out;
+}
+
+async function enumerateGlueDatabaseChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+  const { parent, desired, region } = ctx;
+  const databaseName = parent.physicalId; // a Glue Database's physical id IS its name
+  if (!databaseName) return [];
+
+  // Declared tables of THIS database (Ref DatabaseName already resolved to the physical id
+  // by gather). A table's identity is its TableInput.Name; fall back to the CFn physical id
+  // (Ref = the bare table name — defensively take the last `|` segment in case a composite
+  // form leaked through, mirroring readGlueTable's split).
+  const declaredTableNames: string[] = [];
+  for (const r of desired.resources) {
+    if (
+      r.resourceType !== 'AWS::Glue::Table' ||
+      !parentRefMatches(r.declared.DatabaseName, databaseName)
+    ) {
+      continue;
+    }
+    const tableInput = r.declared.TableInput as { Name?: unknown } | undefined;
+    const name =
+      typeof tableInput?.Name === 'string' ? tableInput.Name : r.physicalId?.split('|').pop();
+    if (name) declaredTableNames.push(name);
+  }
+
+  // The catalog scoping GetTables needs when the database sits in a non-default catalog —
+  // same optional pass-through readGlueTable uses.
+  const catalogId =
+    typeof parent.declared.CatalogId === 'string' ? parent.declared.CatalogId : undefined;
+
+  const client = new GlueClient({ region, ...READ_RETRY });
+  const tables = await pageGlueTables(client, databaseName, catalogId);
+  const liveTables = tables
+    .filter((t): t is GlueTable & { Name: string } => typeof t.Name === 'string')
+    .map((t) => ({ name: t.Name, label: t.TableType ? `${t.Name} (${t.TableType})` : t.Name }));
+
+  return diffGlueDatabaseChildren({ databaseName, declaredTableNames, liveTables });
+}
+
+// ── EC2 (TransitGateway) ─────────────────────────────────────────────────────
+// An `AWS::EC2::TransitGateway` owns VPC attachments and route tables, each a separate
+// CloudFormation resource (#1540). A console / CLI `create-transit-gateway-vpc-attachment`
+// (someone bridges an out-of-band VPC into the shared network — a lateral-movement path no
+// template describes) or `create-transit-gateway-route-table` (someone stands up an
+// out-of-band routing domain) is invisible to cdk drift / CFn drift detection, and the
+// TGW's own live model does NOT reflect either inline, so there is no double-report to
+// suppress. The CC primaryIdentifiers are the bare Id (`tgw-attach-…`) for
+// AWS::EC2::TransitGatewayAttachment and the bare TransitGatewayRouteTableId (`tgw-rtb-…`)
+// for AWS::EC2::TransitGatewayRouteTable — both consumed directly by CC GetResource /
+// DeleteResource.
+//
+// FP-safety:
+//   - DescribeTransitGatewayAttachments returns ALL attachment kinds (vpc / vpn / peering /
+//     direct-connect-gateway / connect); only ResourceType `vpc` maps to the CFn
+//     TransitGatewayAttachment / TransitGatewayVpcAttachment types diffed here, so the rest
+//     are filtered. Gone-state (`deleted`/`deleting`/`failed`) attachments linger in the
+//     describe output after removal and are filtered too.
+//   - A TGW created with DefaultRouteTableAssociation/Propagation `enable` (the default)
+//     AUTO-CREATES one route table (flagged `DefaultAssociationRouteTable` /
+//     `DefaultPropagationRouteTable` on the describe response) — a built-in default, never
+//     an out-of-band addition, so it is filtered exactly like the VPC MAIN route table /
+//     default NACL precedent. Every non-default, non-declared route table IS a real
+//     out-of-band addition.
+// Both CFn attachment flavors (`AWS::EC2::TransitGatewayAttachment` AND
+// `AWS::EC2::TransitGatewayVpcAttachment`) declare the same underlying attachment and Ref
+// the same `tgw-attach-…` id, so a declared resource of EITHER type excludes the live one.
+
+// Live attachment / route-table entries in these states are leaving or gone — lingering
+// describe-output husks, never an out-of-band addition.
+const TGW_GONE_STATES = new Set(['deleted', 'deleting', 'failed']);
+
+// Pure diff: declared attachment ids + live inventory -> the added VPC attachments. The
+// vpc-kind and gone-state filters live HERE so they are unit-tested offline.
+export interface TransitGatewayAttachmentChildInput {
+  // Physical ids (`tgw-attach-…`, Ref) of AWS::EC2::TransitGatewayAttachment AND
+  // AWS::EC2::TransitGatewayVpcAttachment on this TGW (both CFn types Ref the same id).
+  declaredAttachmentIds: string[];
+  liveAttachments: {
+    id: string;
+    resourceType?: string | undefined; // DescribeTransitGatewayAttachments ResourceType (vpc / vpn / …)
+    state?: string | undefined;
+    label?: string | undefined;
+  }[];
+}
+
+export function diffTransitGatewayAttachmentChildren(
+  input: TransitGatewayAttachmentChildInput
+): AddedChild[] {
+  const declared = new Set(input.declaredAttachmentIds);
+  const added: AddedChild[] = [];
+  for (const a of input.liveAttachments) {
+    // Only `vpc` attachments map to the CFn TransitGatewayAttachment / VpcAttachment types;
+    // vpn / peering / direct-connect-gateway / connect attachments belong to other CFn types.
+    if (a.resourceType !== 'vpc') continue;
+    if (a.state !== undefined && TGW_GONE_STATES.has(a.state)) continue;
+    if (declared.has(a.id)) continue;
+    added.push({
+      resourceType: 'AWS::EC2::TransitGatewayAttachment',
+      identifier: a.id, // Id (the TransitGatewayAttachmentId) IS the CC primaryIdentifier
+      label: a.label ?? a.id,
+      live: { Id: a.id },
+    });
+  }
+  return added;
+}
+
+// Pure diff: declared route-table ids + live inventory -> the added route tables. The
+// auto-created-default and gone-state filters live HERE so they are unit-tested offline.
+export interface TransitGatewayRouteTableChildInput {
+  declaredRouteTableIds: string[]; // physical ids (`tgw-rtb-…`, Ref) of AWS::EC2::TransitGatewayRouteTable on this TGW
+  liveRouteTables: {
+    id: string;
+    // DescribeTransitGatewayRouteTables flags the TGW's auto-created default table directly
+    // on the response — the association/propagation twin of the VPC MAIN route table.
+    isDefaultAssociation?: boolean | undefined;
+    isDefaultPropagation?: boolean | undefined;
+    state?: string | undefined;
+    label?: string | undefined;
+  }[];
+}
+
+export function diffTransitGatewayRouteTableChildren(
+  input: TransitGatewayRouteTableChildInput
+): AddedChild[] {
+  const declared = new Set(input.declaredRouteTableIds);
+  const added: AddedChild[] = [];
+  for (const rt of input.liveRouteTables) {
+    // Drop the TGW's auto-created DEFAULT association/propagation route table — a built-in
+    // default (created WITH the TGW), never an out-of-band addition.
+    if (rt.isDefaultAssociation === true || rt.isDefaultPropagation === true) continue;
+    if (rt.state !== undefined && TGW_GONE_STATES.has(rt.state)) continue;
+    if (declared.has(rt.id)) continue;
+    added.push({
+      resourceType: 'AWS::EC2::TransitGatewayRouteTable',
+      identifier: rt.id, // TransitGatewayRouteTableId IS the CC primaryIdentifier
+      label: rt.label ?? rt.id,
+      live: { TransitGatewayRouteTableId: rt.id },
+    });
+  }
+  return added;
+}
+
+async function pageTransitGatewayAttachments(
+  client: EC2Client,
+  tgwId: string
+): Promise<Ec2TransitGatewayAttachment[]> {
+  const out: Ec2TransitGatewayAttachment[] = [];
+  let next: string | undefined;
+  do {
+    const res = await client.send(
+      new DescribeTransitGatewayAttachmentsCommand({
+        Filters: [{ Name: 'transit-gateway-id', Values: [tgwId] }],
+        NextToken: next,
+      })
+    );
+    out.push(...(res.TransitGatewayAttachments ?? []));
+    next = res.NextToken;
+  } while (next);
+  return out;
+}
+
+async function pageTransitGatewayRouteTables(
+  client: EC2Client,
+  tgwId: string
+): Promise<Ec2TransitGatewayRouteTable[]> {
+  const out: Ec2TransitGatewayRouteTable[] = [];
+  let next: string | undefined;
+  do {
+    const res = await client.send(
+      new DescribeTransitGatewayRouteTablesCommand({
+        Filters: [{ Name: 'transit-gateway-id', Values: [tgwId] }],
+        NextToken: next,
+      })
+    );
+    out.push(...(res.TransitGatewayRouteTables ?? []));
+    next = res.NextToken;
+  } while (next);
+  return out;
+}
+
+async function enumerateTransitGatewayChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+  const { parent, desired, region } = ctx;
+  const tgwId = parent.physicalId; // a TransitGateway's physical id IS its TransitGatewayId
+  if (!tgwId) return [];
+
+  // Declared attachments (EITHER CFn flavor) + route tables of THIS TGW (Ref
+  // TransitGatewayId already resolved to the physical id by gather). Each child's CFn
+  // physical id (Ref) IS its bare `tgw-attach-…` / `tgw-rtb-…` id.
+  const declaredAttachmentIds: string[] = [];
+  const declaredRouteTableIds: string[] = [];
+  for (const r of desired.resources) {
+    if (!parentRefMatches(r.declared.TransitGatewayId, tgwId) || !r.physicalId) continue;
+    if (
+      r.resourceType === 'AWS::EC2::TransitGatewayAttachment' ||
+      r.resourceType === 'AWS::EC2::TransitGatewayVpcAttachment'
+    ) {
+      declaredAttachmentIds.push(r.physicalId);
+    } else if (r.resourceType === 'AWS::EC2::TransitGatewayRouteTable') {
+      declaredRouteTableIds.push(r.physicalId);
+    }
+  }
+
+  const client = new EC2Client({ region, ...READ_RETRY });
+
+  const attachments = await pageTransitGatewayAttachments(client, tgwId);
+  const liveAttachments = attachments
+    .filter(
+      (a): a is Ec2TransitGatewayAttachment & { TransitGatewayAttachmentId: string } =>
+        typeof a.TransitGatewayAttachmentId === 'string'
+    )
+    .map((a) => ({
+      id: a.TransitGatewayAttachmentId,
+      resourceType: a.ResourceType as string | undefined,
+      state: a.State as string | undefined,
+      label: a.ResourceId
+        ? `${a.TransitGatewayAttachmentId} (${a.ResourceType ?? '?'} ${a.ResourceId})`
+        : a.TransitGatewayAttachmentId,
+    }));
+
+  const routeTables = await pageTransitGatewayRouteTables(client, tgwId);
+  const liveRouteTables = routeTables
+    .filter(
+      (rt): rt is Ec2TransitGatewayRouteTable & { TransitGatewayRouteTableId: string } =>
+        typeof rt.TransitGatewayRouteTableId === 'string'
+    )
+    .map((rt) => ({
+      id: rt.TransitGatewayRouteTableId,
+      isDefaultAssociation: rt.DefaultAssociationRouteTable,
+      isDefaultPropagation: rt.DefaultPropagationRouteTable,
+      state: rt.State as string | undefined,
+      label: rt.TransitGatewayRouteTableId,
+    }));
+
+  return [
+    ...diffTransitGatewayAttachmentChildren({ declaredAttachmentIds, liveAttachments }),
+    ...diffTransitGatewayRouteTableChildren({ declaredRouteTableIds, liveRouteTables }),
+  ];
 }

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   DescribeInternetGatewaysCommand,
   DescribeNetworkAclsCommand,
+  DescribeFlowLogsCommand,
+  DescribeNatGatewaysCommand,
   DescribeRouteTablesCommand,
   DescribeSecurityGroupsCommand,
   DescribeSubnetsCommand,
@@ -3114,7 +3116,12 @@ describe('enumerateVpcChildren (EC2 VPC sub-resources, end-to-end) — #1315', (
       // The security-group dimension (#835) also calls DescribeSecurityGroups; default to none
       // so the sub-resource (#1315) assertions below are unaffected.
       .on(DescribeSecurityGroupsCommand)
-      .resolves({ SecurityGroups: [] });
+      .resolves({ SecurityGroups: [] })
+      // #1540: the VPC enumerator now also scans NAT gateways + flow logs; default to none.
+      .on(DescribeNatGatewaysCommand)
+      .resolves({ NatGateways: [] })
+      .on(DescribeFlowLogsCommand)
+      .resolves({ FlowLogs: [] });
     return ec2;
   };
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4832,10 +4832,17 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
       expect(t.declared).toEqual([]);
     });
 
-    it('out-of-band hook (matching no sibling) still surfaces as undeclared', () => {
+    it('out-of-band hook in the parent echo folds atDefault — the ADDED tier owns it (#1540)', () => {
+      // #1540 superseded the old "surfaces as undeclared on the parent property" contract:
+      // an out-of-band hook now surfaces as an `added` AWS::AutoScaling::LifecycleHook via
+      // the AutoScalingGroup child enumerator (gather), and the parent's create-only
+      // LifecycleHookSpecificationList echo folds value-independently so the SAME hook is
+      // not double-reported (#747 lesson). Live-proven on CdkrdHunt0713cEnumChildren
+      // (2026-07-13): the OOB hook appeared exactly once, as `added`.
       const live = { LifecycleHookSpecificationList: [hook('rogue-oob')] };
       const t = tiers(classifyResource(asg({}), live, bare, { siblingLifecycleHooks: {} }));
-      expect(t.undeclared).toContain('LifecycleHookSpecificationList');
+      expect(t.undeclared).toEqual([]);
+      expect(t.atDefault).toContain('LifecycleHookSpecificationList');
     });
 
     it('out-of-band hook alongside a sibling hook is NOT hidden (declared list still differs)', () => {

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.HuntAsg.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.HuntAsg.json
@@ -1,0 +1,278 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntAsg",
+    "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+    "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+    "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg",
+    "declared": {
+      "DesiredCapacity": "0",
+      "LaunchTemplate": {
+        "LaunchTemplateId": "lt-05f8afdf5631165c2",
+        "Version": "__cdkrd_corpus_unresolved__"
+      },
+      "MaxSize": "1",
+      "MinSize": "0",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "PropagateAtLaunch": true,
+          "Value": "1"
+        }
+      ],
+      "VPCZoneIdentifier": ["subnet-09b6fdc3f3e9e9175", "subnet-00e8c6eb745df1190"]
+    }
+  },
+  "liveRaw": {
+    "LifecycleHookSpecificationList": [
+      {
+        "LifecycleHookName": "CdkrdHunt0713cEnumChildren-HuntDeclaredHook-EByW42VjluPf",
+        "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "HeartbeatTimeout": 120,
+        "DefaultResult": "CONTINUE"
+      }
+    ],
+    "LoadBalancerNames": [],
+    "ServiceLinkedRoleARN": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+    "TargetGroupARNs": [],
+    "AvailabilityZoneIds": ["use1-az1", "use1-az2"],
+    "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:111111111111:autoScalingGroup:a3a367fd-15a1-42d2-9e4a-2ee87f07b75b:autoScalingGroupName/CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+    "Cooldown": "300",
+    "AvailabilityZones": ["us-east-1a", "us-east-1b"],
+    "AvailabilityZoneDistribution": {
+      "CapacityDistributionStrategy": "balanced-best-effort"
+    },
+    "DesiredCapacity": "0",
+    "HealthCheckGracePeriod": 0,
+    "MetricsCollection": [],
+    "InstanceLifecyclePolicy": {
+      "RetentionTriggers": {
+        "TerminateHookAbandon": "terminate"
+      }
+    },
+    "MaxSize": "1",
+    "NewInstancesProtectedFromScaleIn": false,
+    "MinSize": "0",
+    "TerminationPolicies": ["Default"],
+    "LaunchTemplate": {
+      "LaunchTemplateName": "HuntLt_vPubgWMJJ8VE",
+      "Version": "1",
+      "LaunchTemplateId": "lt-05f8afdf5631165c2"
+    },
+    "AutoScalingGroupName": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+    "VPCZoneIdentifier": ["subnet-09b6fdc3f3e9e9175", "subnet-00e8c6eb745df1190"],
+    "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "default"
+    },
+    "Tags": [
+      {
+        "ResourceId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+        "Value": "HuntAsg",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:logical-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713cEnumChildren/199ce4e0-7e1d-11f1-8e73-12f1b6c413f7",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+        "Value": "CdkrdHunt0713cEnumChildren",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-name",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+        "Value": "1",
+        "ResourceType": "auto-scaling-group",
+        "Key": "cdkrd:ephemeral",
+        "PropagateAtLaunch": true
+      }
+    ],
+    "HealthCheckType": "EC2"
+  },
+  "schema": {
+    "readOnly": ["AutoScalingGroupARN"],
+    "writeOnly": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnly": ["AutoScalingGroupName", "InstanceId"],
+    "readOnlyPaths": ["AutoScalingGroupARN"],
+    "writeOnlyPaths": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnlyPaths": ["AutoScalingGroupName", "InstanceId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AvailabilityZoneIds",
+      "AvailabilityZones",
+      "NotificationConfiguration.NotificationTypes",
+      "TargetGroupARNs",
+      "VPCZoneIdentifier"
+    ],
+    "unorderedObjectArrayPaths": ["LifecycleHookSpecificationList", "TrafficSources"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "LaunchTemplate",
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "LifecycleHookSpecificationList",
+      "actual": [
+        {
+          "LifecycleHookName": "CdkrdHunt0713cEnumChildren-HuntDeclaredHook-EByW42VjluPf",
+          "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING",
+          "HeartbeatTimeout": 120,
+          "DefaultResult": "CONTINUE"
+        }
+      ],
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "ServiceLinkedRoleARN",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneIds",
+      "actual": ["use1-az1", "use1-az2"],
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Cooldown",
+      "actual": "300",
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1b"],
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneDistribution",
+      "actual": {
+        "CapacityDistributionStrategy": "balanced-best-effort"
+      },
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckGracePeriod",
+      "actual": 0,
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "InstanceLifecyclePolicy",
+      "actual": {
+        "RetentionTriggers": {
+          "TerminateHookAbandon": "terminate"
+        }
+      },
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "TerminationPolicies",
+      "actual": ["Default"],
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "CapacityReservationSpecification",
+      "actual": {
+        "CapacityReservationPreference": "default"
+      },
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckType",
+      "actual": "EC2",
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "LaunchTemplate.LaunchTemplateName",
+      "actual": "HuntLt_vPubgWMJJ8VE",
+      "nested": true,
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Tags[cdkrd:ephemeral].ResourceId",
+      "actual": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "nested": true,
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Tags[cdkrd:ephemeral].ResourceType",
+      "actual": "auto-scaling-group",
+      "nested": true,
+      "physicalId": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntAsg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__AutoScaling__LifecycleHook.HuntDeclaredHook.json
+++ b/tests/corpus/AWS__AutoScaling__LifecycleHook.HuntDeclaredHook.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDeclaredHook",
+    "resourceType": "AWS::AutoScaling::LifecycleHook",
+    "physicalId": "CdkrdHunt0713cEnumChildren-HuntDeclaredHook-EByW42VjluPf",
+    "constructPath": "CdkrdHunt0713cEnumChildren/HuntDeclaredHook",
+    "declared": {
+      "AutoScalingGroupName": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "DefaultResult": "CONTINUE",
+      "HeartbeatTimeout": 120,
+      "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING"
+    }
+  },
+  "liveRaw": {
+    "LifecycleHookName": "CdkrdHunt0713cEnumChildren-HuntDeclaredHook-EByW42VjluPf",
+    "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING",
+    "AutoScalingGroupName": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+    "HeartbeatTimeout": 120,
+    "DefaultResult": "CONTINUE"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["AutoScalingGroupName", "LifecycleHookName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AutoScalingGroupName", "LifecycleHookName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AutoScaling__ScheduledAction.HuntDeclaredSched.json
+++ b/tests/corpus/AWS__AutoScaling__ScheduledAction.HuntDeclaredSched.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDeclaredSched",
+    "resourceType": "AWS::AutoScaling::ScheduledAction",
+    "physicalId": "CdkrdH-HuntD-Z647VGBFAWJX",
+    "constructPath": "CdkrdHunt0713cEnumChildren/HuntDeclaredSched",
+    "declared": {
+      "AutoScalingGroupName": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+      "MaxSize": 1,
+      "MinSize": 0,
+      "Recurrence": "0 3 * * *"
+    }
+  },
+  "liveRaw": {
+    "MinSize": 0,
+    "Recurrence": "0 3 * * *",
+    "ScheduledActionName": "CdkrdH-HuntD-Z647VGBFAWJX",
+    "EndTime": "null",
+    "AutoScalingGroupName": "CdkrdHunt0713cEnumChildren-HuntAsg-8Q82rIWWU8Ij",
+    "StartTime": "2026-07-14T03:00:00Z",
+    "MaxSize": 1
+  },
+  "schema": {
+    "readOnly": ["ScheduledActionName"],
+    "writeOnly": [],
+    "createOnly": ["AutoScalingGroupName"],
+    "readOnlyPaths": ["ScheduledActionName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AutoScalingGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDeclaredSched",
+      "resourceType": "AWS::AutoScaling::ScheduledAction",
+      "path": "EndTime",
+      "actual": "null",
+      "physicalId": "CdkrdH-HuntD-Z647VGBFAWJX",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntDeclaredSched"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDeclaredSched",
+      "resourceType": "AWS::AutoScaling::ScheduledAction",
+      "path": "StartTime",
+      "actual": "2026-07-14T03:00:00Z",
+      "physicalId": "CdkrdH-HuntD-Z647VGBFAWJX",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntDeclaredSched"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__TransitGateway.HuntTgw.json
+++ b/tests/corpus/AWS__EC2__TransitGateway.HuntTgw.json
@@ -1,0 +1,164 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTgw",
+    "resourceType": "AWS::EC2::TransitGateway",
+    "physicalId": "tgw-0c75b1629b5f66059",
+    "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw",
+    "declared": {
+      "Description": "cdkrd hunt enum-children TGW",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt enum-children TGW",
+    "EncryptionSupportState": "disabled",
+    "AssociationDefaultRouteTableId": "tgw-rtb-0b7ada86e8fbe9bac",
+    "AutoAcceptSharedAttachments": "disable",
+    "TransitGatewayArn": "arn:aws:ec2:us-east-1:111111111111:transit-gateway/tgw-0c75b1629b5f66059",
+    "DefaultRouteTablePropagation": "enable",
+    "TransitGatewayCidrBlocks": [],
+    "PropagationDefaultRouteTableId": "tgw-rtb-0b7ada86e8fbe9bac",
+    "DefaultRouteTableAssociation": "enable",
+    "Id": "tgw-0c75b1629b5f66059",
+    "VpnEcmpSupport": "enable",
+    "SecurityGroupReferencingSupport": "disable",
+    "DnsSupport": "enable",
+    "MulticastSupport": "disable",
+    "AmazonSideAsn": 64512,
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0713cEnumChildren",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntTgw",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713cEnumChildren/199ce4e0-7e1d-11f1-8e73-12f1b6c413f7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["EncryptionSupportState", "Id", "TransitGatewayArn"],
+    "writeOnly": ["EncryptionSupport"],
+    "createOnly": ["AmazonSideAsn", "MulticastSupport"],
+    "readOnlyPaths": ["EncryptionSupportState", "Id", "TransitGatewayArn"],
+    "writeOnlyPaths": ["EncryptionSupport"],
+    "createOnlyPaths": ["AmazonSideAsn", "MulticastSupport"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "AssociationDefaultRouteTableId",
+      "actual": "tgw-rtb-0b7ada86e8fbe9bac",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "AutoAcceptSharedAttachments",
+      "actual": "disable",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "DefaultRouteTablePropagation",
+      "actual": "enable",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "PropagationDefaultRouteTableId",
+      "actual": "tgw-rtb-0b7ada86e8fbe9bac",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "DefaultRouteTableAssociation",
+      "actual": "enable",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "VpnEcmpSupport",
+      "actual": "enable",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "SecurityGroupReferencingSupport",
+      "actual": "disable",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "DnsSupport",
+      "actual": "enable",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "MulticastSupport",
+      "actual": "disable",
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "AmazonSideAsn",
+      "actual": 64512,
+      "physicalId": "tgw-0c75b1629b5f66059",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntTgw"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Database.HuntGlueDb.json
+++ b/tests/corpus/AWS__Glue__Database.HuntGlueDb.json
@@ -1,0 +1,69 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntGlueDb",
+    "resourceType": "AWS::Glue::Database",
+    "physicalId": "cdkrd_hunt_enum_db",
+    "constructPath": "CdkrdHunt0713cEnumChildren/HuntGlueDb",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseInput": {
+        "Name": "cdkrd_hunt_enum_db"
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_hunt_enum_db",
+    "DatabaseInput": {
+      "CreateTableDefaultPermissions": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "Parameters": {},
+      "Name": "cdkrd_hunt_enum_db"
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DatabaseName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DatabaseName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["DatabaseInput.CreateTableDefaultPermissions"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntGlueDb",
+      "resourceType": "AWS::Glue::Database",
+      "path": "DatabaseInput.CreateTableDefaultPermissions",
+      "actual": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "nested": true,
+      "physicalId": "cdkrd_hunt_enum_db",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntGlueDb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Table.HuntDeclaredTable.json
+++ b/tests/corpus/AWS__Glue__Table.HuntDeclaredTable.json
@@ -1,0 +1,87 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDeclaredTable",
+    "resourceType": "AWS::Glue::Table",
+    "physicalId": "cdkrd_hunt_declared_table",
+    "constructPath": "CdkrdHunt0713cEnumChildren/HuntDeclaredTable",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseName": "cdkrd_hunt_enum_db",
+      "TableInput": {
+        "Name": "cdkrd_hunt_declared_table",
+        "StorageDescriptor": {
+          "Columns": [
+            {
+              "Name": "id",
+              "Type": "string"
+            }
+          ],
+          "Location": "s3://cdkrd-hunt-flowlog-x9z7q/decl/"
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_hunt_enum_db",
+    "TableInput": {
+      "Name": "cdkrd_hunt_declared_table",
+      "Retention": 0,
+      "StorageDescriptor": {
+        "Columns": [
+          {
+            "Name": "id",
+            "Type": "string"
+          }
+        ],
+        "Location": "s3://cdkrd-hunt-flowlog-x9z7q/decl/",
+        "Compressed": false,
+        "NumberOfBuckets": 0,
+        "SortColumns": [],
+        "StoredAsSubDirectories": false
+      }
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["CatalogId", "DatabaseName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["CatalogId", "DatabaseName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDeclaredTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.Retention",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_hunt_declared_table",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntDeclaredTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDeclaredTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.StorageDescriptor.NumberOfBuckets",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_hunt_declared_table",
+      "constructPath": "CdkrdHunt0713cEnumChildren/HuntDeclaredTable"
+    }
+  ]
+}

--- a/tests/enumerators-1540.test.ts
+++ b/tests/enumerators-1540.test.ts
@@ -1,0 +1,153 @@
+// #1540 — five parents added to CHILD_ENUMERATORS so their out-of-band-added children
+// surface in the `added` tier: AutoScalingGroup (ScheduledAction / LifecycleHook), VPC
+// (NatGateway / FlowLog), Cognito UserPool (UserPoolDomain), Glue Database (Table), and
+// TransitGateway (VpcAttachment / RouteTable). Pure-diff units below; the full cycle was
+// live-proven on CdkrdHunt0713cEnumChildren (us-east-1, 2026-07-13): 8 out-of-band
+// children (one per family plus NAT + flow log) were INVISIBLE pre-fix and all 8
+// surfaced `added` post-fix, with the declared siblings (a declared ScheduledAction /
+// LifecycleHook / Glue Table) NOT flagged and the TGW's auto-created default route
+// table excluded.
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  diffAsgLifecycleHookChildren,
+  diffAsgScheduledActionChildren,
+  diffGlueDatabaseChildren,
+  diffTransitGatewayAttachmentChildren,
+  diffTransitGatewayRouteTableChildren,
+  diffUserPoolDomainChildren,
+  diffVpcFlowLogChildren,
+  diffVpcNatGatewayChildren,
+} from '../src/read/child-enumerators.js';
+
+const ASG = 'CdkrdHunt-Asg';
+
+describe('#1540 ASG scheduled-action / lifecycle-hook children', () => {
+  it('emits an undeclared scheduled action with the CHILD-first composite id (router.ts order)', () => {
+    const added = diffAsgScheduledActionChildren({
+      asgName: ASG,
+      declaredActionNames: ['declared-sched'],
+      liveActions: [
+        { name: 'declared-sched' },
+        { name: 'oob-sched', label: 'oob-sched (30 4 * * *)' },
+      ],
+    });
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::AutoScaling::ScheduledAction',
+        identifier: `oob-sched|${ASG}`,
+        label: 'oob-sched (30 4 * * *)',
+        live: { ScheduledActionName: 'oob-sched', AutoScalingGroupName: ASG },
+      },
+    ]);
+  });
+
+  it('emits an undeclared lifecycle hook with the PARENT-first composite id (compositeWith order)', () => {
+    const added = diffAsgLifecycleHookChildren({
+      asgName: ASG,
+      declaredHookNames: ['declared-hook'],
+      liveHooks: [{ name: 'declared-hook' }, { name: 'oob-hook' }],
+    });
+    expect(added.map((a) => a.identifier)).toEqual([`${ASG}|oob-hook`]);
+    expect(added[0]!.resourceType).toBe('AWS::AutoScaling::LifecycleHook');
+  });
+});
+
+describe('#1540 VPC NAT gateway / flow log children', () => {
+  it('emits an undeclared NAT gateway and excludes gone states', () => {
+    const added = diffVpcNatGatewayChildren({
+      declaredNatGatewayIds: ['nat-declared'],
+      liveNatGateways: [
+        { id: 'nat-declared', state: 'available' },
+        { id: 'nat-oob', state: 'available' },
+        { id: 'nat-dead', state: 'deleted' },
+        { id: 'nat-dying', state: 'deleting' },
+        { id: 'nat-failed', state: 'failed' },
+      ],
+    });
+    expect(added.map((a) => a.identifier)).toEqual(['nat-oob']);
+    expect(added[0]!.resourceType).toBe('AWS::EC2::NatGateway');
+  });
+
+  it('emits an undeclared flow log and excludes declared ones', () => {
+    const added = diffVpcFlowLogChildren({
+      declaredFlowLogIds: ['fl-declared'],
+      liveFlowLogs: [{ id: 'fl-declared' }, { id: 'fl-oob' }],
+    });
+    expect(added.map((a) => a.identifier)).toEqual(['fl-oob']);
+    expect(added[0]!.resourceType).toBe('AWS::EC2::FlowLog');
+  });
+});
+
+describe('#1540 Cognito hosted-UI domain child', () => {
+  it('emits an undeclared prefix domain with the UserPoolId|Domain composite id', () => {
+    const added = diffUserPoolDomainChildren({
+      userPoolId: 'us-east-1_abc',
+      declaredDomains: [],
+      liveDomains: [{ domain: 'oob-domain' }],
+    });
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::Cognito::UserPoolDomain',
+        identifier: 'us-east-1_abc|oob-domain',
+        label: 'oob-domain (hosted UI domain)',
+        live: { Domain: 'oob-domain', UserPoolId: 'us-east-1_abc' },
+      },
+    ]);
+  });
+
+  it('a declared domain is not flagged', () => {
+    expect(
+      diffUserPoolDomainChildren({
+        userPoolId: 'us-east-1_abc',
+        declaredDomains: ['declared-domain'],
+        liveDomains: [{ domain: 'declared-domain' }],
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('#1540 Glue database table children', () => {
+  it('emits an undeclared table with the DatabaseName|TableName composite id and skips declared ones', () => {
+    const added = diffGlueDatabaseChildren({
+      databaseName: 'hunt_db',
+      declaredTableNames: ['declared_table'],
+      liveTables: [{ name: 'declared_table' }, { name: 'oob_table' }],
+    });
+    expect(added.map((a) => a.identifier)).toEqual(['hunt_db|oob_table']);
+    expect(added[0]!.resourceType).toBe('AWS::Glue::Table');
+  });
+});
+
+describe('#1540 transit gateway children', () => {
+  it('emits an undeclared vpc attachment, excluding non-vpc types and gone states', () => {
+    const added = diffTransitGatewayAttachmentChildren({
+      declaredAttachmentIds: ['tgw-attach-declared'],
+      liveAttachments: [
+        { id: 'tgw-attach-declared', resourceType: 'vpc', state: 'available' },
+        { id: 'tgw-attach-oob', resourceType: 'vpc', state: 'available' },
+        { id: 'tgw-attach-vpn', resourceType: 'vpn', state: 'available' },
+        { id: 'tgw-attach-dead', resourceType: 'vpc', state: 'deleted' },
+      ],
+    });
+    expect(added.map((a) => a.identifier)).toEqual(['tgw-attach-oob']);
+    expect(added[0]!.resourceType).toBe('AWS::EC2::TransitGatewayAttachment');
+  });
+
+  it('emits an undeclared route table and excludes the TGW default route table', () => {
+    const added = diffTransitGatewayRouteTableChildren({
+      declaredRouteTableIds: ['tgw-rtb-declared'],
+      liveRouteTables: [
+        { id: 'tgw-rtb-declared', state: 'available' },
+        {
+          id: 'tgw-rtb-default',
+          state: 'available',
+          isDefaultAssociation: true,
+          isDefaultPropagation: true,
+        },
+        { id: 'tgw-rtb-oob', state: 'available' },
+      ],
+    });
+    expect(added.map((a) => a.identifier)).toEqual(['tgw-rtb-oob']);
+    expect(added[0]!.resourceType).toBe('AWS::EC2::TransitGatewayRouteTable');
+  });
+});

--- a/tests/integration/enum-children-min/app.ts
+++ b/tests/integration/enum-children-min/app.ts
@@ -1,0 +1,87 @@
+// CDK app for the cdk-real-drift enum-children-min integration test (#1540).
+// Declares the five parents whose out-of-band-added children the new
+// CHILD_ENUMERATORS entries must surface — with one DECLARED child per family
+// where cheap (ScheduledAction, LifecycleHook, Glue Table), so the enumerators'
+// "declared children are NOT flagged" half is exercised too:
+// - AWS::AutoScaling::AutoScalingGroup (desired 0 — no instance cost) with a
+//   declared ScheduledAction + LifecycleHook; OOB adds probed by verify.sh.
+// - AWS::EC2::VPC (no NAT declared; OOB NAT gateway + flow log probed).
+// - AWS::Cognito::UserPool (no domain declared; OOB hosted-UI domain probed).
+// - AWS::Glue::Database with one declared Table (OOB table probed).
+// - AWS::EC2::TransitGateway (no attachments declared; OOB VPC attachment +
+//   route table probed; the AWS-default TGW route table must NOT surface).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Aws, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnAutoScalingGroup, CfnLifecycleHook, CfnScheduledAction } from "aws-cdk-lib/aws-autoscaling";
+import { CfnLaunchTemplate, CfnTransitGateway, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnDatabase, CfnTable } from "aws-cdk-lib/aws-glue";
+import { UserPool } from "aws-cdk-lib/aws-cognito";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0713cEnumChildren");
+
+const vpc = new Vpc(stack, "HuntVpc", { maxAzs: 2, natGateways: 0 });
+
+// Flow-log destination for the OOB create-flow-logs probe (bucket only; the
+// flow log itself is deliberately NOT declared).
+new Bucket(stack, "HuntFlowLogBucket", {
+  bucketName: "cdkrd-hunt-flowlog-x9z7q",
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const lt = new CfnLaunchTemplate(stack, "HuntLt", {
+  launchTemplateData: {
+    instanceType: "t4g.nano",
+    imageId: "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}",
+  },
+});
+
+const asg = new CfnAutoScalingGroup(stack, "HuntAsg", {
+  minSize: "0",
+  maxSize: "1",
+  desiredCapacity: "0",
+  vpcZoneIdentifier: vpc.selectSubnets({ subnetType: SubnetType.PUBLIC }).subnetIds,
+  launchTemplate: { launchTemplateId: lt.ref, version: lt.attrLatestVersionNumber },
+});
+
+new CfnScheduledAction(stack, "HuntDeclaredSched", {
+  autoScalingGroupName: asg.ref,
+  recurrence: "0 3 * * *",
+  minSize: 0,
+  maxSize: 1,
+});
+
+new CfnLifecycleHook(stack, "HuntDeclaredHook", {
+  autoScalingGroupName: asg.ref,
+  lifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING",
+  heartbeatTimeout: 120,
+  defaultResult: "CONTINUE",
+});
+
+new UserPool(stack, "HuntPool", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const db = new CfnDatabase(stack, "HuntGlueDb", {
+  catalogId: Aws.ACCOUNT_ID,
+  databaseInput: { name: "cdkrd_hunt_enum_db" },
+});
+
+new CfnTable(stack, "HuntDeclaredTable", {
+  catalogId: Aws.ACCOUNT_ID,
+  databaseName: "cdkrd_hunt_enum_db",
+  tableInput: {
+    name: "cdkrd_hunt_declared_table",
+    storageDescriptor: {
+      columns: [{ name: "id", type: "string" }],
+      location: "s3://cdkrd-hunt-flowlog-x9z7q/decl/",
+    },
+  },
+}).addDependency(db);
+
+new CfnTransitGateway(stack, "HuntTgw", {
+  description: "cdkrd hunt enum-children TGW",
+});

--- a/tests/integration/enum-children-min/cdk.json
+++ b/tests/integration/enum-children-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/enum-children-min/package.json
+++ b/tests/integration/enum-children-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-enum-children-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift enum-children-min (#1540) integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/enum-children-min/verify.sh
+++ b/tests/integration/enum-children-min/verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Added-children integration test (real AWS), #1540: deploy the five parents
+# (ASG / VPC / UserPool / Glue Database / TransitGateway) with declared children
+# -> FIRST check (pre-record) must show ZERO drift (declared children NOT
+# flagged; TGW default route table excluded) -> out-of-band ScheduledAction +
+# hosted-UI domain must surface as `added` -> remove them -> CLEAN again.
+# (The full 8-child matrix incl. NAT gateway / flow log / Glue table / TGW
+# attachment+route table was live-proven in the 2026-07-13 hunt; this committed
+# regression keeps the cheap, fast pair.)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0713cEnumChildren
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): declared children must NOT flag ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out" && fail "first check must be drift-free (#1540 fixture)"
+
+ASG=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" --query "StackResources[?ResourceType=='AWS::AutoScaling::AutoScalingGroup'].PhysicalResourceId|[0]" --output text)
+POOL=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" --query "StackResources[?ResourceType=='AWS::Cognito::UserPool'].PhysicalResourceId|[0]" --output text)
+
+echo "=== [$STACK] out-of-band ScheduledAction + hosted-UI domain MUST surface as added ==="
+aws autoscaling put-scheduled-update-group-action --auto-scaling-group-name "$ASG" --scheduled-action-name cdkrd-hunt-oob-sched --recurrence "30 4 * * *" --min-size 0 --max-size 1 --region "$REGION" || fail "oob sched"
+aws cognito-idp create-user-pool-domain --domain cdkrd-hunt-oob-verify --user-pool-id "$POOL" --region "$REGION" >/dev/null || fail "oob domain"
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.oob.out"
+grep -q "cdkrd-hunt-oob-sched" "/tmp/cdkrd-$STACK.oob.out" || fail "OOB scheduled action not surfaced as added (#1540 regression)"
+grep -q "cdkrd-hunt-oob-verify" "/tmp/cdkrd-$STACK.oob.out" || fail "OOB hosted-UI domain not surfaced as added (#1540 regression)"
+
+echo "=== [$STACK] remove the OOB children -> CLEAN again ==="
+aws autoscaling delete-scheduled-action --auto-scaling-group-name "$ASG" --scheduled-action-name cdkrd-hunt-oob-sched --region "$REGION" || fail "cleanup sched"
+aws cognito-idp delete-user-pool-domain --domain cdkrd-hunt-oob-verify --user-pool-id "$POOL" --region "$REGION" || fail "cleanup domain"
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after removing OOB children"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -233,6 +233,36 @@ resource_gone() {
           printf '%s' "$err" | grep -q 'InvalidSubnetID.NotFound' && return 0
           return 1
           ;;
+        *:natgateway/nat-*)
+          # arn:aws:ec2:<region>:<acct>:natgateway/nat-<id> — a deleted NAT gateway stays
+          # visible in DescribeNatGateways with State "deleted" for ~an hour AND in the tag
+          # index (2026-07-13 hunt, #1540 fixture). deleted/deleting counts as gone;
+          # NotFound too. Any other state keeps the ORPHAN RED.
+          id="${arn##*/}"
+          local nst
+          nst="$(aws ec2 describe-nat-gateways --nat-gateway-ids "$id" --region "$REGION" \
+            --query 'NatGateways[0].State' --output text 2>/dev/null)" || return 0
+          { [ "$nst" = "deleted" ] || [ "$nst" = "deleting" ] || [ "$nst" = "None" ]; } && return 0
+          return 1
+          ;;
+        *:transit-gateway-attachment/tgw-attach-*)
+          # Same terminal-state lag for a deleted TGW attachment (2026-07-13 hunt).
+          id="${arn##*/}"
+          local tast
+          tast="$(aws ec2 describe-transit-gateway-attachments --transit-gateway-attachment-ids "$id" \
+            --region "$REGION" --query 'TransitGatewayAttachments[0].State' --output text 2>/dev/null)" || return 0
+          { [ "$tast" = "deleted" ] || [ "$tast" = "deleting" ] || [ "$tast" = "None" ]; } && return 0
+          return 1
+          ;;
+        *:transit-gateway-route-table/tgw-rtb-*)
+          # Same terminal-state lag for a deleted TGW route table (2026-07-13 hunt).
+          id="${arn##*/}"
+          local trst
+          trst="$(aws ec2 describe-transit-gateway-route-tables --transit-gateway-route-table-ids "$id" \
+            --region "$REGION" --query 'TransitGatewayRouteTables[0].State' --output text 2>/dev/null)" || return 0
+          { [ "$trst" = "deleted" ] || [ "$trst" = "deleting" ] || [ "$trst" = "None" ]; } && return 0
+          return 1
+          ;;
         *) return 1 ;;
       esac
       ;;


### PR DESCRIPTION
## Summary

Implements #1540: five parents added to `CHILD_ENUMERATORS`, so out-of-band-added children — previously structurally invisible — surface in the `added` tier.

Closes #1540.

### New enumerators

| Parent | Children | Notes |
|---|---|---|
| `AWS::AutoScaling::AutoScalingGroup` | ScheduledAction, LifecycleHook | composite CC ids verified against `router.ts` (ScheduledAction child-first, LifecycleHook parent-first); NotificationConfiguration skipped (no CC-readable CFn identifier) |
| `AWS::EC2::VPC` (extended) | NatGateway, FlowLog | gone-states (deleted/deleting/failed) excluded |
| `AWS::Cognito::UserPool` (extended) | UserPoolDomain | `DescribeUserPool` `Domain`/`CustomDomain` (no list API) |
| `AWS::Glue::Database` | Table | `DatabaseName\|TableName` composite (the `readGlueTable` form) |
| `AWS::EC2::TransitGateway` | TransitGatewayAttachment (vpc), TransitGatewayRouteTable | AWS's auto-created default association/propagation route table excluded (the VPC MAIN-route-table precedent); non-vpc attachment types and gone states excluded |

### Live proof (CdkrdHunt0713cEnumChildren, us-east-1, 2026-07-13; stack deleted + SWEEP CLEAN)

8 out-of-band children (scheduled action, lifecycle hook, NAT gateway, flow log, hosted-UI domain, Glue table, TGW VPC attachment, TGW route table) were INVISIBLE pre-fix (FN proven) and **all 8 surfaced `added`** post-fix — with the declared siblings (a declared ScheduledAction / LifecycleHook / Glue Table) NOT flagged and zero FPs; removing the OOB children returned the check to CLEAN.

### Fold companions (first-run FPs the same fixture exposed)

- Barest TGW constant defaults ×7 (`AmazonSideAsn` 64512, `AutoAcceptSharedAttachments` disable, `DefaultRouteTableAssociation`/`Propagation` enable, `DnsSupport`/`VpnEcmpSupport` enable, `MulticastSupport` disable) — `transitgateway-rich` had declared these leaves, hiding the undeclared path.
- ASG `Tags[*].ResourceId`/`ResourceType` — read-only `TagDescription` echo fields on declared tags (nested value-independent).
- ASG `LifecycleHookSpecificationList` parent echo now folds value-independently: hook drift is owned by the CHILD dimension (declared hooks compare as their own resources; OOB hooks surface `added`), preventing the #747 double-report. This supersedes the old #700 parent-property contract — the `classify.test.ts` case is updated with the rationale in-place.
- sweep-orphans: `natgateway` / `transit-gateway-attachment` / `transit-gateway-route-table` terminal-state `resource_gone` arms (deleted EC2 network resources linger ~1h in describe + the RGT tag index and deadlocked the gate).

### Tests

- `tests/enumerators-1540.test.ts` — 9 pure-diff units (declared-excluded / gone-state / default-route-table / composite-id-order assertions).
- Existing VPC end-to-end enumerator tests extended with the two new API mocks.
- New committed fixture `tests/integration/enum-children-min` (deploy → first-check zero → OOB ScheduledAction + hosted-UI domain must surface `added` → remove → CLEAN).
- 6 new golden-corpus cases (barest TGW, barest ASG + declared hook/scheduled action, Glue Database/Table).
- Full suite: 275 files / 5545 tests, typecheck, `vp check` 0 errors — green.

Known minor: the `added` Glue Table's live-model read falls back to the declared shape ("live model unreadable this run") — detection and identifier are correct; the model read goes through the standard added-model fallback.

Implementation note: the enumerator bodies were largely produced by a session-limit-killed subagent and finished/verified inline (per the resume-from-worktree playbook).
