### PR TITLE
fix(read): read an added CC-gap child's full model via its SDK override (#1551)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -432,7 +432,12 @@ export async function readAddedModel(
   cfn: CloudFormationClient,
   c: AddedChild,
   schemas: Map<string, SchemaInfo>,
-  oaiCanonicalIds: Record<string, string>
+  oaiCanonicalIds: Record<string, string>,
+  // #1551: needed to drive the type's SDK_OVERRIDES reader on the CC-failure path;
+  // optional so identity-snippet-only callers/tests stay source-compatible (without
+  // them the override attempt is skipped and the snippet degrade stands).
+  region?: string,
+  accountId?: string
 ): Promise<{ model: Record<string, unknown>; ok: boolean }> {
   // Normalize a raw live model with the (cached) child-type schema. Only re-cache a SUCCESSFUL
   // fetch: a DescribeType failure returns an EMPTY schema (#751 — schema-strip itself does not
@@ -466,6 +471,27 @@ export async function readAddedModel(
     const raw = JSON.parse(g.ResourceDescription?.Properties ?? '{}') as Record<string, unknown>;
     return normalizeWith(raw);
   } catch {
+    // #1551: a CC-gap added child (a type whose declared reads go through SDK_OVERRIDES —
+    // observed on an out-of-band AWS::Glue::Table) always lands here, degrading to the
+    // identity snippet with `modelReadFailed` — so `record` could never snapshot its real
+    // model and a LATER change to the added child stayed invisible. Try the type's
+    // override reader before degrading: `physicalId` is the enumerator's CC-composite
+    // identifier (the same form the reader consumes for declared resources), and the
+    // snippet stands in for `declared` (readers only key on identity fields from it).
+    const override = SDK_OVERRIDES[c.resourceType];
+    if (override && region !== undefined && accountId !== undefined) {
+      try {
+        const raw = await override({
+          physicalId: c.identifier,
+          declared: c.live,
+          region,
+          accountId,
+        });
+        if (raw !== undefined) return normalizeWith(raw);
+      } catch {
+        // fall through to the snippet degrade below
+      }
+    }
     return { model: c.live, ok: false };
   }
 }
@@ -1643,7 +1669,15 @@ export async function gatherFindings(
           });
           continue;
         }
-        const read = await readAddedModel(cc, cfn, c, schemas, oaiCanonicalIds);
+        const read = await readAddedModel(
+          cc,
+          cfn,
+          c,
+          schemas,
+          oaiCanonicalIds,
+          region,
+          desired.accountId
+        );
         findings.push(addedFinding(r, c, read));
       }
     } catch (e) {

--- a/tests/added-model-override-1551.test.ts
+++ b/tests/added-model-override-1551.test.ts
@@ -1,0 +1,114 @@
+// #1551 — an out-of-band `added` child of a CC-gap type (a type whose declared reads go
+// through SDK_OVERRIDES) was detected but its model degraded to the identity snippet with
+// `modelReadFailed`: readAddedModel only tried Cloud Control GetResource. Observed live on
+// an out-of-band AWS::Glue::Table in the #1540 fixture ("live model unreadable this run"),
+// which meant `record` could never snapshot the child's real model and a LATER change to
+// the added child stayed invisible. The CC-failure path now tries the type's SDK_OVERRIDES
+// reader (physicalId = the enumerator's CC-composite identifier — the exact form
+// readGlueTable consumes) before degrading.
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { GetTableCommand, GlueClient } from '@aws-sdk/client-glue';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { readAddedModel } from '../src/commands/gather.js';
+import type { AddedChild } from '../src/read/child-enumerators.js';
+import type { SchemaInfo } from '../src/types.js';
+
+const EMPTY_SCHEMA: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const cc = mockClient(CloudControlClient);
+const cfn = mockClient(CloudFormationClient);
+const glue = mockClient(GlueClient);
+
+const glueTableChild = (): AddedChild => ({
+  resourceType: 'AWS::Glue::Table',
+  identifier: 'hunt_db|oob_table',
+  label: 'oob_table',
+  live: { DatabaseName: 'hunt_db', TableInput: { Name: 'oob_table' } },
+});
+
+const schemas = () => new Map([['AWS::Glue::Table', EMPTY_SCHEMA]]);
+
+beforeEach(() => {
+  cc.reset();
+  cfn.reset();
+  glue.reset();
+  cc.on(GetResourceCommand).rejects(
+    Object.assign(new Error('unsupported'), { name: 'UnsupportedActionException' })
+  );
+});
+
+describe('#1551 added-child model read via SDK_OVERRIDES on CC failure', () => {
+  it('reads the FULL model through the override reader and returns ok:true', async () => {
+    glue.on(GetTableCommand).resolves({
+      Table: {
+        Name: 'oob_table',
+        DatabaseName: 'hunt_db',
+        TableType: 'EXTERNAL_TABLE',
+        StorageDescriptor: { Columns: [{ Name: 'id', Type: 'string' }] },
+      },
+    });
+    const read = await readAddedModel(
+      cc as unknown as CloudControlClient,
+      cfn as unknown as CloudFormationClient,
+      glueTableChild(),
+      schemas(),
+      {},
+      'us-east-1',
+      '123456789012'
+    );
+    expect(read.ok).toBe(true);
+    expect(read.model).toMatchObject({
+      DatabaseName: 'hunt_db',
+      TableInput: {
+        Name: 'oob_table',
+        TableType: 'EXTERNAL_TABLE',
+        StorageDescriptor: { Columns: [{ Name: 'id', Type: 'string' }] },
+      },
+    });
+    expect(glue.commandCalls(GetTableCommand)[0]?.args[0].input).toMatchObject({
+      DatabaseName: 'hunt_db',
+      Name: 'oob_table',
+    });
+  });
+
+  it('still degrades to the identity snippet (ok:false) when the override ALSO fails', async () => {
+    glue.on(GetTableCommand).rejects(new Error('AccessDeniedException'));
+    const c = glueTableChild();
+    const read = await readAddedModel(
+      cc as unknown as CloudControlClient,
+      cfn as unknown as CloudFormationClient,
+      c,
+      schemas(),
+      {},
+      'us-east-1',
+      '123456789012'
+    );
+    expect(read.ok).toBe(false);
+    expect(read.model).toEqual(c.live);
+  });
+
+  it('without region/accountId (legacy call shape) the override is skipped — snippet degrade stands', async () => {
+    glue.on(GetTableCommand).resolves({ Table: { Name: 'oob_table' } });
+    const c = glueTableChild();
+    const read = await readAddedModel(
+      cc as unknown as CloudControlClient,
+      cfn as unknown as CloudFormationClient,
+      c,
+      schemas(),
+      {}
+    );
+    expect(read.ok).toBe(false);
+    expect(glue.commandCalls(GetTableCommand).length).toBe(0);
+  });
+});

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -245,6 +245,20 @@ resource_gone() {
           { [ "$nst" = "deleted" ] || [ "$nst" = "deleting" ] || [ "$nst" = "None" ]; } && return 0
           return 1
           ;;
+        *:transit-gateway/tgw-*)
+          # Same terminal-state lag for a deleted TRANSIT GATEWAY itself (2026-07-13
+          # follow-up: a TGW orphaned by an attachment-race delstack, then deleted, stayed
+          # visible as State "deleted" + in the tag index). The `-attachment` /
+          # `-route-table` ARNs use the segments `transit-gateway-attachment/` /
+          # `transit-gateway-route-table/`, which this `transit-gateway/` glob never
+          # matches, so their arms below stay reachable.
+          id="${arn##*/}"
+          local tgst
+          tgst="$(aws ec2 describe-transit-gateways --transit-gateway-ids "$id" --region "$REGION" \
+            --query 'TransitGateways[0].State' --output text 2>/dev/null)" || return 0
+          { [ "$tgst" = "deleted" ] || [ "$tgst" = "deleting" ] || [ "$tgst" = "None" ]; } && return 0
+          return 1
+          ;;
         *:transit-gateway-attachment/tgw-attach-*)
           # Same terminal-state lag for a deleted TGW attachment (2026-07-13 hunt).
           id="${arn##*/}"


### PR DESCRIPTION
## Summary

Follow-up to the 2026-07-13 hunt series (PRs #1543 / #1549 / #1550): fixes the known-minor left by the #1540 live test.

Closes #1551.

### Fix

**#1551 — added-child model read now routes through `SDK_OVERRIDES` on the CC-failure path.** An out-of-band `added` child of a CC-gap type (observed on `AWS::Glue::Table`) was detected but degraded to the identity-only snippet with `modelReadFailed` — `readAddedModel` only tried Cloud Control `GetResource`, so `record` could never snapshot the child's real model and a LATER out-of-band change to the added child stayed invisible. The CC-failure path now tries the type's `SDK_OVERRIDES` reader (`physicalId` = the enumerator's CC-composite identifier, the same form the reader consumes for declared resources) before degrading. The #1431 `CC_GET_UNSUPPORTED_ADDED_TYPES` snippet contract is untouched.

Live-proven (CdkrdHunt0713dGlue, us-east-1, 2026-07-13, stack deleted): an out-of-band Glue table previously reported "live model unreadable this run"; post-fix the same `added` finding carries the FULL model (`TableType`, `StorageDescriptor.Columns`, `Location`, …).

### Tests

- `tests/added-model-override-1551.test.ts` — full-model read via the override on CC failure; snippet degrade when the override also fails; legacy call shape (no region/accountId) skips the override.
- Full suite: 276 files / 5549 tests, typecheck, `vp check` 0 errors — green.

### Determination (no code change): `AWS::Config::ConfigurationRecorder` fixture stays deferred

Re-probed with the `AWS_ConfigRole` managed policy attached: the CC handler STILL hangs `CREATE_IN_PROGRESS` (both a bare S3-only role and the managed-policy role) — the earlier role hypothesis is refuted; the hang is the Config recorder CC handler's own stabilization in this account/region, not a cdkrd bug and not fixture-fixable. A regression fixture whose deploy hangs 45+ minutes is unusable; the type stays uncovered with this note as the record (`config-recorder-min` is NOT committed).
