### PR TITLE
feat(read): SDK override readers for Config ConfigurationRecorder + DeliveryChannel (#1553)

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,15 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   resource name, and `ListTagsForResource` reads each resource's tags, which the
   `Get*` responses omit — without it a declared `Tags` false-flagged as drift on
   every tagged MediaConvert resource),
+  `config:DescribeConfigurationRecorders` + `config:DescribeDeliveryChannels`
+  (read an `AWS::Config::ConfigurationRecorder` /
+  `AWS::Config::DeliveryChannel` — the account/region compliance-baseline
+  SINGLETONS a large fraction of accounts deploy, NON_PROVISIONABLE with Cloud
+  Control `UnsupportedActionException`; the physical id IS the recorder / channel
+  name, and the reader projects the CFn-declarable surface — the recorder's
+  undeclared `RecordingGroup.RecordingStrategy` mirror and `RecordingMode` default
+  fold to atDefault, so a fresh recorder is clean while a recording-scope change
+  still surfaces),
   `ssm:DescribeParameters` (supplements the Cloud Control read of an
   `AWS::SSM::Parameter` with its writeOnly `Description` / `AllowedPattern`),
   `elasticache:DescribeReplicationGroups` + `elasticache:DescribeCacheClusters`

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1475,6 +1475,40 @@ function dynamoGsiWarmThroughputAtDefault(
   );
 }
 
+// #1553: an AWS::Config::ConfigurationRecorder's undeclared
+// `RecordingGroup.RecordingStrategy` ({UseOnly:"…"}) is an AWS-DERIVED reflection of the
+// recording group, never an independent setting — AWS computes it from the group:
+// ALL_SUPPORTED_RESOURCE_TYPES when AllSupported, EXCLUSION_BY_RESOURCE_TYPES when an exclusion
+// list is set, else INCLUSION_BY_RESOURCE_TYPES (resourceTypes). Tier-2 DERIVED fold: compute
+// the expected UseOnly from the LIVE sibling RecordingGroup and equality-gate. A real
+// out-of-band recording-scope change flips AllSupported / ResourceTypes / ExclusionByResourceTypes
+// (which surface on their OWN paths) AND the strategy consistently — so the mirror keeps folding
+// while the meaningful change is still detected. Live-verified 2026-07-13 (us-west-2).
+function configRecordingStrategyAtDefault(
+  resourceType: string,
+  schemaPath: string,
+  value: unknown,
+  live: Record<string, unknown>
+): boolean {
+  if (resourceType !== 'AWS::Config::ConfigurationRecorder') return false;
+  if (schemaPath !== 'RecordingGroup.RecordingStrategy') return false;
+  const rg = live.RecordingGroup;
+  if (!isNestedObject(rg)) return false;
+  const group = rg as Record<string, unknown>;
+  const excl = isNestedObject(group.ExclusionByResourceTypes)
+    ? (group.ExclusionByResourceTypes as Record<string, unknown>).ResourceTypes
+    : undefined;
+  const useOnly =
+    group.AllSupported === true
+      ? 'ALL_SUPPORTED_RESOURCE_TYPES'
+      : Array.isArray(excl) && excl.length > 0
+        ? 'EXCLUSION_BY_RESOURCE_TYPES'
+        : Array.isArray(group.ResourceTypes) && group.ResourceTypes.length > 0
+          ? 'INCLUSION_BY_RESOURCE_TYPES'
+          : undefined;
+  return useOnly !== undefined && deepEqual(value, { UseOnly: useOnly });
+}
+
 // #705: a Classic ELB (ElasticLoadBalancing::LoadBalancer) with an HTTPS/SSL listener but no
 // declared SSL policy reads back an AWS-assigned SSL negotiation policy. The whole `Policies`
 // array was folded value-independently, which made an out-of-band SSL-policy DOWNGRADE (an older
@@ -3693,7 +3727,10 @@ export function classifyResource(
       (resourceType === 'AWS::Events::EventBusPolicy' &&
         schemaPath === 'Statement.*.Sid' &&
         typeof value === 'string' &&
-        value === declared['StatementId']);
+        value === declared['StatementId']) ||
+      // #1553: a Config recorder's undeclared RecordingGroup.RecordingStrategy mirror, derived
+      // from the live sibling RecordingGroup and equality-gated (helper above).
+      configRecordingStrategyAtDefault(resourceType, schemaPath, value, live);
     const tier = atDefault
       ? 'atDefault'
       : // R142: a GENERATED_PATHS value folds as `generated` ONLY when it echoes a

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -23,6 +23,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // out-of-band change away from 3600 still surfaces. Live-verified 2026-07-12 on
   // Cdkrd915MonSchedVerify (us-east-1). #1523.
   'AWS::SageMaker::DataQualityJobDefinition': { StoppingCondition: { MaxRuntimeInSeconds: 3600 } },
+  // A Config ConfigurationRecorder that declares no RecordingMode reads back the AWS default
+  // `{RecordingFrequency:"CONTINUOUS"}` (a fully-undeclared top-level object, so KNOWN_DEFAULTS
+  // not KNOWN_DEFAULT_PATHS). Equality-gated (subset-tolerant): a user who sets DAILY recording
+  // DECLARES RecordingMode (compared in the declared loop), and an out-of-band switch away from
+  // CONTINUOUS — or an added per-type RecordingModeOverride — no longer matches and surfaces.
+  // Live-verified 2026-07-13 on CdkRealDriftIntegConfigRecorder (us-west-2). #1553.
+  'AWS::Config::ConfigurationRecorder': { RecordingMode: { RecordingFrequency: 'CONTINUOUS' } },
   // A server certificate declared without a Path reads back "/" (the IAM default),
   // exactly like Role/kin above. Equality-gated, so an out-of-band UpdateServerCertificate
   // path move still surfaces. Live-confirmed (#910).

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -133,6 +133,11 @@ import {
   MediaConvertClient,
 } from '@aws-sdk/client-mediaconvert';
 import {
+  ConfigServiceClient,
+  DescribeConfigurationRecordersCommand,
+  DescribeDeliveryChannelsCommand,
+} from '@aws-sdk/client-config-service';
+import {
   ElasticLoadBalancingV2Client,
   GetTrustStoreCaCertificatesBundleCommand,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
@@ -3213,6 +3218,84 @@ const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region
   return model;
 };
 
+// AWS::Config::ConfigurationRecorder — NON_PROVISIONABLE (Cloud Control returns
+// UnsupportedActionException for its read action; #1553). An account/region SINGLETON that a
+// large fraction of accounts deploy as a compliance baseline, previously SKIPPED (falsely
+// clean). The CFn physical id (Ref) IS the recorder Name, which
+// config:DescribeConfigurationRecorders accepts via ConfigurationRecorderNames. Project the
+// CFn-declarable surface (Name/RoleARN/RecordingGroup/RecordingMode), camelCase(SDK) ->
+// PascalCase(CFn). The SDK's `arn` and `recordingScope` are NOT in the CFn resource schema →
+// dropped. An empty ExclusionByResourceTypes / RecordingModeOverrides list is the same as
+// unset → omitted so undeclared recorders carry no empty-husk noise. RecordingStrategy.UseOnly
+// is an AWS-DERIVED reflection of the recording group (folded to atDefault via a derived default
+// when undeclared; still compared when the user declares it). Read-ONLY for now (a
+// PutConfigurationRecorder revert writer is deferred). A deleted recorder → empty list →
+// ResourceGoneError → the router maps it to `deleted`.
+const readConfigConfigurationRecorder: OverrideReader = async ({ physicalId, region }) => {
+  const name = str(physicalId);
+  if (!name) return undefined;
+  const c = new ConfigServiceClient({ region, ...READ_RETRY });
+  const r = (
+    await c.send(new DescribeConfigurationRecordersCommand({ ConfigurationRecorderNames: [name] }))
+  ).ConfigurationRecorders?.[0];
+  if (!r) throw new ResourceGoneError(`Config ConfigurationRecorder ${name} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(r.name)) model.Name = r.name;
+  if (str(r.roleARN)) model.RoleARN = r.roleARN;
+  if (r.recordingGroup) {
+    const g = r.recordingGroup;
+    const rg: Record<string, unknown> = {};
+    if (typeof g.allSupported === 'boolean') rg.AllSupported = g.allSupported;
+    if (typeof g.includeGlobalResourceTypes === 'boolean')
+      rg.IncludeGlobalResourceTypes = g.includeGlobalResourceTypes;
+    if (Array.isArray(g.resourceTypes)) rg.ResourceTypes = g.resourceTypes;
+    const excl = g.exclusionByResourceTypes?.resourceTypes;
+    if (Array.isArray(excl) && excl.length > 0)
+      rg.ExclusionByResourceTypes = { ResourceTypes: excl };
+    if (str(g.recordingStrategy?.useOnly))
+      rg.RecordingStrategy = { UseOnly: g.recordingStrategy?.useOnly };
+    model.RecordingGroup = rg;
+  }
+  if (r.recordingMode) {
+    const m = r.recordingMode;
+    const rm: Record<string, unknown> = {};
+    if (str(m.recordingFrequency)) rm.RecordingFrequency = m.recordingFrequency;
+    if (Array.isArray(m.recordingModeOverrides) && m.recordingModeOverrides.length > 0)
+      rm.RecordingModeOverrides = m.recordingModeOverrides.map((o) => ({
+        ResourceTypes: o.resourceTypes,
+        RecordingFrequency: o.recordingFrequency,
+        ...(str(o.description) ? { Description: o.description } : {}),
+      }));
+    if (Object.keys(rm).length > 0) model.RecordingMode = rm;
+  }
+  return model;
+};
+
+// AWS::Config::DeliveryChannel — NON_PROVISIONABLE (Cloud Control UnsupportedActionException;
+// #1553). Account/region SINGLETON paired with the recorder, previously SKIPPED. The CFn
+// physical id (Ref) IS the channel Name, which config:DescribeDeliveryChannels accepts via
+// DeliveryChannelNames. Project the CFn-declarable surface (Name/S3BucketName/S3KeyPrefix/
+// S3KmsKeyArn/SnsTopicARN/ConfigSnapshotDeliveryProperties), camelCase → PascalCase; absent
+// optional fields are omitted. Read-ONLY. A deleted channel → empty list → ResourceGoneError →
+// `deleted`.
+const readConfigDeliveryChannel: OverrideReader = async ({ physicalId, region }) => {
+  const name = str(physicalId);
+  if (!name) return undefined;
+  const c = new ConfigServiceClient({ region, ...READ_RETRY });
+  const d = (await c.send(new DescribeDeliveryChannelsCommand({ DeliveryChannelNames: [name] })))
+    .DeliveryChannels?.[0];
+  if (!d) throw new ResourceGoneError(`Config DeliveryChannel ${name} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(d.name)) model.Name = d.name;
+  if (str(d.s3BucketName)) model.S3BucketName = d.s3BucketName;
+  if (str(d.s3KeyPrefix)) model.S3KeyPrefix = d.s3KeyPrefix;
+  if (str(d.s3KmsKeyArn)) model.S3KmsKeyArn = d.s3KmsKeyArn;
+  if (str(d.snsTopicARN)) model.SnsTopicARN = d.snsTopicARN;
+  const freq = d.configSnapshotDeliveryProperties?.deliveryFrequency;
+  if (str(freq)) model.ConfigSnapshotDeliveryProperties = { DeliveryFrequency: freq };
+  return model;
+};
+
 export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::CertificateManager::Certificate': readAcmCertificate,
   'AWS::SES::ReceiptRuleSet': readSesReceiptRuleSet,
@@ -3265,6 +3348,8 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::SageMaker::MonitoringSchedule': readSageMakerMonitoringSchedule,
   'AWS::Logs::MetricFilter': readMetricFilter,
   'AWS::Scheduler::Schedule': readSchedulerSchedule,
+  'AWS::Config::ConfigurationRecorder': readConfigConfigurationRecorder,
+  'AWS::Config::DeliveryChannel': readConfigDeliveryChannel,
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/classify-config-recorder-1553.test.ts
+++ b/tests/classify-config-recorder-1553.test.ts
@@ -1,0 +1,161 @@
+// #1553 — AWS::Config::ConfigurationRecorder undeclared AWS-assigned defaults fold to
+// atDefault so a freshly deployed recorder is CLEAN, while a real out-of-band change still
+// surfaces:
+//   - RecordingGroup.RecordingStrategy ({UseOnly:"…"}) is an AWS-DERIVED reflection of the
+//     recording group (tier-2 derived, computed from the live sibling RecordingGroup — a
+//     constant pin would false-positive on an AllSupported recorder). Its UseOnly is
+//     ALL_SUPPORTED_RESOURCE_TYPES when AllSupported, EXCLUSION_BY_RESOURCE_TYPES when an
+//     exclusion list is set, else INCLUSION_BY_RESOURCE_TYPES.
+//   - RecordingMode defaults to the whole-object constant {RecordingFrequency:"CONTINUOUS"}
+//     (KNOWN_DEFAULTS, tier-1) — a switch to DAILY still surfaces.
+// The INCLUSION shape is covered by the golden corpus (AWS__Config__ConfigurationRecorder);
+// this pins the ALL_SUPPORTED / EXCLUSION branches (a constant pin cannot express them) and
+// the detection direction.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Recorder',
+  resourceType: 'AWS::Config::ConfigurationRecorder',
+  physicalId: 'rec-phys',
+  declared,
+});
+
+describe('#1553 Config recorder RecordingGroup.RecordingStrategy derived fold', () => {
+  it('folds INCLUSION_BY_RESOURCE_TYPES for a resourceTypes recorder', () => {
+    const f = classifyResource(
+      mk({
+        RoleARN: 'role',
+        RecordingGroup: { AllSupported: false, ResourceTypes: ['AWS::S3::Bucket'] },
+      }),
+      {
+        RoleARN: 'role',
+        RecordingGroup: {
+          AllSupported: false,
+          ResourceTypes: ['AWS::S3::Bucket'],
+          RecordingStrategy: { UseOnly: 'INCLUSION_BY_RESOURCE_TYPES' },
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('RecordingGroup.RecordingStrategy');
+    expect(tier(f, 'undeclared')).not.toContain('RecordingGroup.RecordingStrategy');
+  });
+
+  it('folds ALL_SUPPORTED_RESOURCE_TYPES for an AllSupported recorder (a constant INCLUSION pin would FP here)', () => {
+    const f = classifyResource(
+      mk({ RoleARN: 'role', RecordingGroup: { AllSupported: true } }),
+      {
+        RoleARN: 'role',
+        RecordingGroup: {
+          AllSupported: true,
+          RecordingStrategy: { UseOnly: 'ALL_SUPPORTED_RESOURCE_TYPES' },
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('RecordingGroup.RecordingStrategy');
+    expect(tier(f, 'undeclared')).not.toContain('RecordingGroup.RecordingStrategy');
+  });
+
+  it('folds EXCLUSION_BY_RESOURCE_TYPES for an exclusion recorder', () => {
+    const f = classifyResource(
+      mk({
+        RoleARN: 'role',
+        RecordingGroup: {
+          AllSupported: false,
+          ExclusionByResourceTypes: { ResourceTypes: ['AWS::EC2::Instance'] },
+        },
+      }),
+      {
+        RoleARN: 'role',
+        RecordingGroup: {
+          AllSupported: false,
+          ExclusionByResourceTypes: { ResourceTypes: ['AWS::EC2::Instance'] },
+          RecordingStrategy: { UseOnly: 'EXCLUSION_BY_RESOURCE_TYPES' },
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('RecordingGroup.RecordingStrategy');
+    expect(tier(f, 'undeclared')).not.toContain('RecordingGroup.RecordingStrategy');
+  });
+
+  it('surfaces a RecordingStrategy that does NOT match the derived value — detection preserved', () => {
+    const f = classifyResource(
+      mk({
+        RoleARN: 'role',
+        RecordingGroup: { AllSupported: false, ResourceTypes: ['AWS::S3::Bucket'] },
+      }),
+      {
+        RoleARN: 'role',
+        RecordingGroup: {
+          AllSupported: false,
+          ResourceTypes: ['AWS::S3::Bucket'],
+          // Inconsistent with the inclusion group — a value the derivation does not produce.
+          RecordingStrategy: { UseOnly: 'ALL_SUPPORTED_RESOURCE_TYPES' },
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('RecordingGroup.RecordingStrategy');
+    expect(tier(f, 'atDefault')).not.toContain('RecordingGroup.RecordingStrategy');
+  });
+});
+
+describe('#1553 Config recorder RecordingMode default fold', () => {
+  const declared = {
+    RoleARN: 'role',
+    RecordingGroup: { AllSupported: false, ResourceTypes: ['AWS::S3::Bucket'] },
+  };
+  it('folds the AWS default {RecordingFrequency:"CONTINUOUS"} to atDefault', () => {
+    const f = classifyResource(
+      mk(declared),
+      {
+        RoleARN: 'role',
+        RecordingGroup: {
+          AllSupported: false,
+          ResourceTypes: ['AWS::S3::Bucket'],
+          RecordingStrategy: { UseOnly: 'INCLUSION_BY_RESOURCE_TYPES' },
+        },
+        RecordingMode: { RecordingFrequency: 'CONTINUOUS' },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('RecordingMode');
+    expect(tier(f, 'undeclared')).not.toContain('RecordingMode');
+  });
+  it('surfaces a DAILY recording mode out of band — detection preserved', () => {
+    const f = classifyResource(
+      mk(declared),
+      {
+        RoleARN: 'role',
+        RecordingGroup: {
+          AllSupported: false,
+          ResourceTypes: ['AWS::S3::Bucket'],
+          RecordingStrategy: { UseOnly: 'INCLUSION_BY_RESOURCE_TYPES' },
+        },
+        RecordingMode: { RecordingFrequency: 'DAILY' },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('RecordingMode');
+    expect(tier(f, 'atDefault')).not.toContain('RecordingMode');
+  });
+});

--- a/tests/corpus/AWS__Config__ConfigurationRecorder.Recorder.json
+++ b/tests/corpus/AWS__Config__ConfigurationRecorder.Recorder.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Recorder",
+    "resourceType": "AWS::Config::ConfigurationRecorder",
+    "physicalId": "CdkRealDriftIntegConfigRecorder-Recorder-11JKN8BB1LDO8",
+    "constructPath": "CdkRealDriftIntegConfigRecorder/Recorder",
+    "declared": {
+      "RecordingGroup": {
+        "AllSupported": false,
+        "IncludeGlobalResourceTypes": false,
+        "ResourceTypes": ["AWS::S3::Bucket"]
+      },
+      "RoleARN": "arn:aws:iam::111111111111:role/CdkRealDriftIntegConfigRecorde-RecorderRoleE29397B0-8nzdDo2XvvTT"
+    }
+  },
+  "liveRaw": {
+    "Name": "CdkRealDriftIntegConfigRecorder-Recorder-11JKN8BB1LDO8",
+    "RoleARN": "arn:aws:iam::111111111111:role/CdkRealDriftIntegConfigRecorde-RecorderRoleE29397B0-8nzdDo2XvvTT",
+    "RecordingGroup": {
+      "AllSupported": false,
+      "IncludeGlobalResourceTypes": false,
+      "ResourceTypes": ["AWS::S3::Bucket"],
+      "RecordingStrategy": {
+        "UseOnly": "INCLUSION_BY_RESOURCE_TYPES"
+      }
+    },
+    "RecordingMode": {
+      "RecordingFrequency": "CONTINUOUS"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-west-2",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Recorder",
+      "resourceType": "AWS::Config::ConfigurationRecorder",
+      "path": "RecordingMode",
+      "actual": {
+        "RecordingFrequency": "CONTINUOUS"
+      },
+      "physicalId": "CdkRealDriftIntegConfigRecorder-Recorder-11JKN8BB1LDO8",
+      "constructPath": "CdkRealDriftIntegConfigRecorder/Recorder"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Recorder",
+      "resourceType": "AWS::Config::ConfigurationRecorder",
+      "path": "RecordingGroup.RecordingStrategy",
+      "actual": {
+        "UseOnly": "INCLUSION_BY_RESOURCE_TYPES"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegConfigRecorder-Recorder-11JKN8BB1LDO8",
+      "constructPath": "CdkRealDriftIntegConfigRecorder/Recorder"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Config__DeliveryChannel.Channel.json
+++ b/tests/corpus/AWS__Config__DeliveryChannel.Channel.json
@@ -1,0 +1,36 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Channel",
+    "resourceType": "AWS::Config::DeliveryChannel",
+    "physicalId": "CdkRealDriftIntegConfigRecorder-Channel-K3WG0CKR7OZD",
+    "constructPath": "CdkRealDriftIntegConfigRecorder/Channel",
+    "declared": {
+      "S3BucketName": "cdkrealdriftintegconfigreco-deliverybucketa9ae6474-btwqtarrrrrf"
+    }
+  },
+  "liveRaw": {
+    "Name": "CdkRealDriftIntegConfigRecorder-Channel-K3WG0CKR7OZD",
+    "S3BucketName": "cdkrealdriftintegconfigreco-deliverybucketa9ae6474-btwqtarrrrrf"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-west-2",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/config-recorder-min/app.ts
+++ b/tests/integration/config-recorder-min/app.ts
@@ -1,0 +1,102 @@
+// CDK app for the cdk-real-drift AWS Config recorder coverage test (#1553).
+//
+// Unlike the config-rule-rich fixture — which provisions the recorder + delivery
+// channel via the SDK so the ConfigRule has an active recorder without CloudFormation
+// ever owning the recorder — this fixture makes the recorder AND delivery channel
+// CFn-managed L1 resources, so cdkrd reads them as DECLARED resources via Cloud
+// Control. That is the coverage gap #1553 tracks: AWS::Config::ConfigurationRecorder
+// and AWS::Config::DeliveryChannel first-run FP behaviour, record->check cleanliness,
+// and detection were all unverified.
+//
+// The recorder + delivery channel are account/region SINGLETONS: verify.sh MUST abort
+// unless the target region has neither, so this fixture never fights a real recorder.
+//
+// The recorder's CFn handler is known to hang CREATE_IN_PROGRESS 20-45+ min in some
+// account/region combos (see #1553); deploy in an alternate region (AWS_REGION) and
+// cap the wait if it stalls.
+import { App, type CfnResource, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  CfnConfigurationRecorder,
+  CfnDeliveryChannel,
+} from "aws-cdk-lib/aws-config";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketEncryption,
+} from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegConfigRecorder");
+
+// Delivery bucket Config writes configuration snapshots to. The bucket policy grants
+// the config.amazonaws.com service the documented permissions-check + delivery grants.
+const bucket = new Bucket(stack, "DeliveryBucket", {
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+  encryption: BucketEncryption.S3_MANAGED,
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+// The recorder's service-linked-style role. AWS_ConfigRole is the AWS-managed policy
+// AWS Config expects for the recorder.
+const role = new Role(stack, "RecorderRole", {
+  assumedBy: new ServicePrincipal("config.amazonaws.com"),
+  managedPolicies: [
+    { managedPolicyArn: "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole" },
+  ],
+});
+
+const account = Stack.of(stack).account;
+bucket.addToResourcePolicy(
+  new PolicyStatement({
+    sid: "AWSConfigBucketPermissionsCheck",
+    principals: [new ServicePrincipal("config.amazonaws.com")],
+    actions: ["s3:GetBucketAcl", "s3:ListBucket"],
+    resources: [bucket.bucketArn],
+  }),
+);
+bucket.addToResourcePolicy(
+  new PolicyStatement({
+    sid: "AWSConfigBucketDelivery",
+    principals: [new ServicePrincipal("config.amazonaws.com")],
+    actions: ["s3:PutObject"],
+    resources: [`${bucket.bucketArn}/AWSLogs/${account}/Config/*`],
+    conditions: {
+      StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
+    },
+  }),
+);
+
+// A minimal recording group: record only S3 buckets (not allSupported) to keep the
+// blast radius tiny. This is a declared, mutable property cdkrd should be able to read
+// and detect drift on.
+const recorder = new CfnConfigurationRecorder(stack, "Recorder", {
+  roleArn: role.roleArn,
+  recordingGroup: {
+    allSupported: false,
+    includeGlobalResourceTypes: false,
+    resourceTypes: ["AWS::S3::Bucket"],
+  },
+});
+
+const channel = new CfnDeliveryChannel(stack, "Channel", {
+  s3BucketName: bucket.bucketName,
+});
+
+// Ordering is the crux of the recorder's create-stabilization deadlock (#1553): the
+// recorder resource does not report CREATE_COMPLETE until it can record, which needs a
+// delivery channel — but a delivery channel's put requires the recorder to already
+// exist. Chaining channel-after-recorder (or recorder-after-channel) deadlocks. The
+// canonical AWS pattern instead creates BOTH concurrently, each depending only on the
+// bucket policy, so the recorder's put and the channel's put interleave and the
+// recorder can stabilize. So: NO recorder<->channel dependency; both wait on the
+// bucket policy (the channel needs it to write; ordering the recorder behind it too
+// keeps the two puts close together).
+const bucketPolicy = bucket.policy;
+if (bucketPolicy) {
+  recorder.addDependency(bucketPolicy.node.defaultChild as CfnResource);
+  channel.addDependency(bucketPolicy.node.defaultChild as CfnResource);
+}
+
+app.synth();

--- a/tests/integration/config-recorder-min/cdk.json
+++ b/tests/integration/config-recorder-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/config-recorder-min/package.json
+++ b/tests/integration/config-recorder-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-config-recorder-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift config-recorder-min integration test (#1553): a CFn-managed AWS::Config::ConfigurationRecorder + AWS::Config::DeliveryChannel. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/config-recorder-min/verify-detect.sh
+++ b/tests/integration/config-recorder-min/verify-detect.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Detect integration test (real AWS) for a CFn-managed AWS Config recorder (#1553).
+# Deploy -> record -> broaden the recorder's recordingGroup.resourceTypes out of band
+# (someone widens what Config records) -> check MUST DETECT the declared drift ->
+# revert reports NOT-revertable (the recorder reader is READ-ONLY; a
+# PutConfigurationRecorder revert writer is deferred).
+#
+# recordingGroup is a declared, mutable property; a live put-configuration-recorder
+# change is exactly the divergence cdkrd should catch. Singleton pre-check + capped
+# deploy as in verify.sh.
+set -uo pipefail
+export AWS_CLI_AUTO_PROMPT=off
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegConfigRecorder
+REGION="${AWS_REGION:-us-west-2}"
+CLI="node $ROOT/dist/cli.js"
+DEPLOY_TIMEOUT="${DEPLOY_TIMEOUT:-1500}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  aws cloudformation cancel-update-stack --stack-name "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 \
+    || aws cloudformation delete-stack --stack-name "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out /tmp/cdkrd-recorder-*.json
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] singleton pre-check (region $REGION) ==="
+rec="$(aws configservice describe-configuration-recorders --region "$REGION" --query 'ConfigurationRecorders[].name' --output text 2>/dev/null)"
+chan="$(aws configservice describe-delivery-channels --region "$REGION" --query 'DeliveryChannels[].name' --output text 2>/dev/null)"
+if [ -n "$rec" ] || [ -n "$chan" ]; then
+  fail "region $REGION already has a Config recorder [$rec] / channel [$chan] — aborting (singletons)."
+fi
+
+echo "=== [$STACK] deploy fixture (cap ${DEPLOY_TIMEOUT}s) ==="
+timeout "$DEPLOY_TIMEOUT" npx cdk deploy -f "$STACK" --require-approval never
+rc=$?
+[ "$rc" -eq 124 ] && fail "deploy exceeded ${DEPLOY_TIMEOUT}s — recorder CC handler likely hung (#1553)."
+[ "$rc" -eq 0 ] || fail "deploy (rc=$rc)"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+# The recorder's CFn-generated name + role ARN, needed to re-PUT it out of band.
+REC_NAME="$(aws configservice describe-configuration-recorders --region "$REGION" --query 'ConfigurationRecorders[0].name' --output text)"
+REC_ROLE="$(aws configservice describe-configuration-recorders --region "$REGION" --query 'ConfigurationRecorders[0].roleARN' --output text)"
+[ -n "$REC_NAME" ] && [ "$REC_NAME" != "None" ] || fail "could not read recorder name"
+
+echo "=== [$STACK] out-of-band: widen recordingGroup.resourceTypes (add AWS::IAM::User) ==="
+cat > /tmp/cdkrd-recorder-drift.json <<JSON
+{ "name": "${REC_NAME}", "roleARN": "${REC_ROLE}",
+  "recordingGroup": { "allSupported": false, "includeGlobalResourceTypes": false,
+    "resourceTypes": ["AWS::S3::Bucket", "AWS::IAM::User"] } }
+JSON
+aws configservice put-configuration-recorder --region "$REGION" \
+  --configuration-recorder "file:///tmp/cdkrd-recorder-drift.json" || fail "inject drift"
+
+echo "=== [$STACK] check MUST DETECT the widened recording group ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-recorder-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "IAM::User\|ResourceTypes\|recordingGroup" /tmp/cdkrd-recorder-detect.out || fail "widened recordingGroup not reported"
+
+echo "=== [$STACK] revert reports NOT-revertable (reader is read-only, #1553) ==="
+$CLI revert "$STACK" --region "$REGION" --dry-run | tee /tmp/cdkrd-recorder-revert.out
+grep -qi "NOT revertable" /tmp/cdkrd-recorder-revert.out || fail "expected a NOT-revertable report (recorder revert writer is deferred)"
+
+echo "=== [$STACK] restore recordingGroup to declared state (SDK) ==="
+cat > /tmp/cdkrd-recorder-clean.json <<JSON
+{ "name": "${REC_NAME}", "roleARN": "${REC_ROLE}",
+  "recordingGroup": { "allSupported": false, "includeGlobalResourceTypes": false,
+    "resourceTypes": ["AWS::S3::Bucket"] } }
+JSON
+aws configservice put-configuration-recorder --region "$REGION" \
+  --configuration-recorder "file:///tmp/cdkrd-recorder-clean.json" || fail "restore"
+
+echo "=== [$STACK] check MUST be CLEAN after restore ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after restore"
+
+echo "INTEG PASS ($STACK detect)"

--- a/tests/integration/config-recorder-min/verify.sh
+++ b/tests/integration/config-recorder-min/verify.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS) for a CFn-managed AWS Config recorder +
+# delivery channel (#1553). Deploy the fixture, record baseline, check MUST be CLEAN.
+# Any [Potential Drift] on a freshly deployed + recorded recorder/channel is a fold gap.
+#
+# The recorder + delivery channel are account/region SINGLETONS: this aborts unless the
+# target region has NEITHER, so it never fights a real recorder. The recorder's CFn
+# handler is known to hang CREATE_IN_PROGRESS 20-45+ min in some account/region combos
+# (see #1553) — deploy defaults to us-west-2 (us-east-1 hung during filing) and caps the
+# wait at DEPLOY_TIMEOUT so a hang fails loudly instead of blocking forever.
+set -uo pipefail
+export AWS_CLI_AUTO_PROMPT=off
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegConfigRecorder
+REGION="${AWS_REGION:-us-west-2}"
+CLI="node $ROOT/dist/cli.js"
+DEPLOY_TIMEOUT="${DEPLOY_TIMEOUT:-1500}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  # A stack stuck CREATE_IN_PROGRESS cannot be delstack'd; cancel it first (the
+  # documented exception), then force-delete + sweep.
+  aws cloudformation cancel-update-stack --stack-name "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 \
+    || aws cloudformation delete-stack --stack-name "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] singleton pre-check (region $REGION) ==="
+rec="$(aws configservice describe-configuration-recorders --region "$REGION" --query 'ConfigurationRecorders[].name' --output text 2>/dev/null)"
+chan="$(aws configservice describe-delivery-channels --region "$REGION" --query 'DeliveryChannels[].name' --output text 2>/dev/null)"
+if [ -n "$rec" ] || [ -n "$chan" ]; then
+  fail "region $REGION already has a Config recorder [$rec] / delivery channel [$chan] — aborting (these are account/region singletons; never fight a real one). Pick an empty region via AWS_REGION."
+fi
+
+echo "=== [$STACK] deploy fixture (cap ${DEPLOY_TIMEOUT}s — recorder CC handler may hang, #1553) ==="
+timeout "$DEPLOY_TIMEOUT" npx cdk deploy -f "$STACK" --require-approval never
+rc=$?
+[ "$rc" -eq 124 ] && fail "deploy exceeded ${DEPLOY_TIMEOUT}s — the recorder CC handler likely hung CREATE_IN_PROGRESS (#1553). Retry a different region."
+[ "$rc" -eq 0 ] || fail "deploy (rc=$rc)"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
Closes #1553.

## Problem

`AWS::Config::ConfigurationRecorder` + `AWS::Config::DeliveryChannel` — the
account/region compliance-baseline **singletons** a large fraction of accounts
deploy — were **uncovered**. Cloud Control returns `UnsupportedActionException`
for both, so cdkrd **SKIPPED** them: a deployed recorder read as falsely CLEAN
(coverage hollow), and any drift on it was invisible.

Two prior hunt attempts (#1553) couldn't even land a fixture: the recorder's CFn
handler hung `CREATE_IN_PROGRESS` 20–45+ min in us-east-1.

## What this does

**Fixes the deploy hang** — the recorder's create-stabilization needs a delivery
channel, but the prior attempts ordered the channel *after* the recorder (a true
deadlock). The fixture instead creates the recorder + channel **concurrently**
(each depends only on the bucket policy, neither on the other, the canonical AWS
pattern). Deployed cleanly in us-west-2 in ~48s.

**Adds SDK override readers** (`readConfigConfigurationRecorder` /
`readConfigDeliveryChannel`) that project the CFn-declarable surface via
`config:DescribeConfigurationRecorders` / `config:DescribeDeliveryChannels` — the
physical id IS the recorder / channel name, which the Describe calls accept
directly.

**Folds the undeclared AWS-assigned defaults** so a fresh recorder is CLEAN
(zero potential drift) with detection preserved:
- `RecordingMode` → `KNOWN_DEFAULTS` whole-object `{RecordingFrequency:"CONTINUOUS"}`
  (tier-1 constant); a switch to `DAILY` still surfaces.
- `RecordingGroup.RecordingStrategy` → **tier-2 derived** from the live sibling
  `RecordingGroup` (`ALL_SUPPORTED` / `EXCLUSION` / `INCLUSION`). A constant pin
  would false-positive on an `AllSupported` recorder, so it is computed and
  equality-gated.

Read-only for now: a `PutConfigurationRecorder` revert writer is deferred; revert
reports `NOT revertable` (honest degrade).

## Live verification (us-west-2, 2026-07-13)

- **First `check` before `record`: CLEAN** — `atDefault=16, generated=2, skipped=1`
  (the only skip is the S3 auto-delete custom resource). Recorder + channel are
  genuinely read (no longer `UnsupportedActionException` skips).
- **Detection**: an out-of-band `put-configuration-recorder` widening
  `recordingGroup.resourceTypes` (+`AWS::IAM::User`) → `check --fail` **exits 1**
  and reports `Recorder.RecordingGroup.ResourceTypes`.
- **Teardown**: `delstack` + `sweep-orphans.sh` → **SWEEP CLEAN**; recorder/channel
  singletons released, no orphan IAM role.

## Tests

- Golden corpus: `AWS__Config__ConfigurationRecorder` + `AWS__Config__DeliveryChannel`
  (real harvested inputs; the INCLUSION shape).
- `tests/classify-config-recorder-1553.test.ts` (6 tests) pins the ALL_SUPPORTED /
  EXCLUSION derivation branches (a constant pin cannot express them) + the
  detection direction.
- Full suite: 5558 tests pass. typecheck / lint+format / build green.

## Fixture

`tests/integration/config-recorder-min` — a CFn-managed recorder + channel with a
**singleton pre-check** (aborts unless the region has neither) and a **capped
deploy wait** (`DEPLOY_TIMEOUT`, defaults to us-west-2 since us-east-1 hung).
`verify.sh` = first-run FP; `verify-detect.sh` = detect.
