### PR TITLE
feat(revert): PutConfigurationRecorder writer for AWS::Config::ConfigurationRecorder (#1553)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1121,6 +1121,10 @@ Description / State / ExecutionRoleArn / PolicyDetails shape is re-supplied in
 place, since Cloud Control has no handler for the type),
 `docdb:ModifyDBCluster` / `ModifyDBInstance`,
 `config:DescribeConfigRules` / `config:PutConfigRule`,
+`config:PutConfigurationRecorder` (reverts an
+`AWS::Config::ConfigurationRecorder` — a whole-recorder upsert re-supplying the
+declared RecordingGroup / RecordingMode / RoleARN, since Cloud Control cannot
+write the type),
 `ecs:UpdateService` (reverts an `AWS::ECS::Service` `ServiceConnectConfiguration` /
 `VolumeConfigurations` drift — the whole writeOnly prop is re-supplied, since Cloud
 Control cannot sub-path patch it),

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -3228,9 +3228,9 @@ const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region
 // dropped. An empty ExclusionByResourceTypes / RecordingModeOverrides list is the same as
 // unset → omitted so undeclared recorders carry no empty-husk noise. RecordingStrategy.UseOnly
 // is an AWS-DERIVED reflection of the recording group (folded to atDefault via a derived default
-// when undeclared; still compared when the user declares it). Read-ONLY for now (a
-// PutConfigurationRecorder revert writer is deferred). A deleted recorder → empty list →
-// ResourceGoneError → the router maps it to `deleted`.
+// when undeclared; still compared when the user declares it). Revertable via the
+// PutConfigurationRecorder SDK writer (SDK_WRITERS, revert/writers.ts). A deleted recorder →
+// empty list → ResourceGoneError → the router maps it to `deleted`.
 const readConfigConfigurationRecorder: OverrideReader = async ({ physicalId, region }) => {
   const name = str(physicalId);
   if (!name) return undefined;

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -125,9 +125,13 @@ import {
   PutUserPolicyCommand,
 } from '@aws-sdk/client-iam';
 import {
+  type ConfigurationRecorder,
   ConfigServiceClient,
   DescribeConfigRulesCommand,
   PutConfigRuleCommand,
+  PutConfigurationRecorderCommand,
+  type RecordingModeOverride,
+  type ResourceType,
 } from '@aws-sdk/client-config-service';
 import { KafkaClient, UpdateConfigurationCommand } from '@aws-sdk/client-kafka';
 import {
@@ -1302,6 +1306,61 @@ const writeConfigRuleInputParameters: SdkWriter = async (ctx, ops) => {
     new PutConfigRuleCommand({
       ConfigRule: { ...rest, InputParameters: configInputParametersString(op.value) },
     })
+  );
+};
+
+// AWS::Config::ConfigurationRecorder — NON_PROVISIONABLE: Cloud Control throws
+// UnsupportedActionException for its read AND write (#1553), so a declared drift (a changed
+// RecordingGroup / RecordingMode / RoleARN — e.g. someone widening what Config records out of
+// band) is reverted via config:PutConfigurationRecorder, a whole-recorder UPSERT. desiredModel
+// re-reads the live recorder (the SDK override) and applies the revert ops, so we PUT the
+// reverted-to-declared model, mapped PascalCase(CFn) -> camelCase(SDK). The recorder Name
+// (createOnly) and RoleARN are preserved from the live read. RecordingStrategy is OMITTED from
+// the PUT — AWS DERIVES it from the recording group and rejects an inconsistent one, so leaving
+// it out lets AWS recompute it (the same value the reader folds atDefault). Live-verified
+// 2026-07-13 (us-west-2). A whole-resource writer (SDK_WRITERS), so any declared-prop drift on
+// the recorder routes here.
+const writeConfigConfigurationRecorder: SdkWriter = async (ctx, ops) => {
+  const desired = await desiredModel('AWS::Config::ConfigurationRecorder', ctx, ops);
+  const name = str(desired.Name) ?? str(ctx.physicalId);
+  const roleARN = str(desired.RoleARN);
+  if (!name) throw new Error('cannot resolve Config recorder name for revert');
+  if (!roleARN) throw new Error('cannot resolve Config recorder RoleARN for revert');
+  const recorder: ConfigurationRecorder = { name, roleARN };
+  const rg = desired.RecordingGroup as Record<string, unknown> | undefined;
+  if (rg) {
+    const group: NonNullable<ConfigurationRecorder['recordingGroup']> = {};
+    if (typeof rg.AllSupported === 'boolean') group.allSupported = rg.AllSupported;
+    if (typeof rg.IncludeGlobalResourceTypes === 'boolean')
+      group.includeGlobalResourceTypes = rg.IncludeGlobalResourceTypes;
+    if (Array.isArray(rg.ResourceTypes)) group.resourceTypes = rg.ResourceTypes as ResourceType[];
+    const excl = rg.ExclusionByResourceTypes as Record<string, unknown> | undefined;
+    if (excl && Array.isArray(excl.ResourceTypes) && excl.ResourceTypes.length > 0)
+      group.exclusionByResourceTypes = { resourceTypes: excl.ResourceTypes as ResourceType[] };
+    // RecordingStrategy is intentionally omitted — AWS re-derives it from the group above.
+    recorder.recordingGroup = group;
+  }
+  const rm = desired.RecordingMode as Record<string, unknown> | undefined;
+  if (rm && str(rm.RecordingFrequency)) {
+    const mode: NonNullable<ConfigurationRecorder['recordingMode']> = {
+      recordingFrequency: rm.RecordingFrequency as NonNullable<
+        ConfigurationRecorder['recordingMode']
+      >['recordingFrequency'],
+    };
+    const overrides = rm.RecordingModeOverrides;
+    if (Array.isArray(overrides) && overrides.length > 0)
+      mode.recordingModeOverrides = overrides.map((o): RecordingModeOverride => {
+        const oo = o as Record<string, unknown>;
+        return {
+          resourceTypes: oo.ResourceTypes as ResourceType[],
+          recordingFrequency: oo.RecordingFrequency as RecordingModeOverride['recordingFrequency'],
+          ...(str(oo.Description) ? { description: oo.Description as string } : {}),
+        };
+      });
+    recorder.recordingMode = mode;
+  }
+  await new ConfigServiceClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+    new PutConfigurationRecorderCommand({ ConfigurationRecorder: recorder })
   );
 };
 
@@ -2804,6 +2863,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::Events::EventBusPolicy': writeEventBusPolicy,
   'AWS::IAM::Policy': writeIamPolicy,
   'AWS::IAM::ManagedPolicy': writeIamManagedPolicy,
+  'AWS::Config::ConfigurationRecorder': writeConfigConfigurationRecorder,
 };
 
 // Property-scoped SDK writers: CC-writable types where ONE property must be

--- a/tests/integration/config-recorder-min/verify-detect.sh
+++ b/tests/integration/config-recorder-min/verify-detect.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Detect integration test (real AWS) for a CFn-managed AWS Config recorder (#1553).
+# Detect+revert integration test (real AWS) for a CFn-managed AWS Config recorder (#1553).
 # Deploy -> record -> broaden the recorder's recordingGroup.resourceTypes out of band
 # (someone widens what Config records) -> check MUST DETECT the declared drift ->
-# revert reports NOT-revertable (the recorder reader is READ-ONLY; a
-# PutConfigurationRecorder revert writer is deferred).
+# revert MUST restore ["AWS::S3::Bucket"] via the PutConfigurationRecorder SDK writer
+# (Cloud Control cannot write this type: UnsupportedActionException) -> check MUST be CLEAN.
 #
 # recordingGroup is a declared, mutable property; a live put-configuration-recorder
 # change is exactly the divergence cdkrd should catch. Singleton pre-check + capped
@@ -65,21 +65,12 @@ rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -qi "IAM::User\|ResourceTypes\|recordingGroup" /tmp/cdkrd-recorder-detect.out || fail "widened recordingGroup not reported"
 
-echo "=== [$STACK] revert reports NOT-revertable (reader is read-only, #1553) ==="
-$CLI revert "$STACK" --region "$REGION" --dry-run | tee /tmp/cdkrd-recorder-revert.out
-grep -qi "NOT revertable" /tmp/cdkrd-recorder-revert.out || fail "expected a NOT-revertable report (recorder revert writer is deferred)"
+echo "=== [$STACK] revert MUST restore [AWS::S3::Bucket] (PutConfigurationRecorder SDK writer) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-recorder-revert.out
+grep -qi "reverted:" /tmp/cdkrd-recorder-revert.out || fail "revert did not report success"
 
-echo "=== [$STACK] restore recordingGroup to declared state (SDK) ==="
-cat > /tmp/cdkrd-recorder-clean.json <<JSON
-{ "name": "${REC_NAME}", "roleARN": "${REC_ROLE}",
-  "recordingGroup": { "allSupported": false, "includeGlobalResourceTypes": false,
-    "resourceTypes": ["AWS::S3::Bucket"] } }
-JSON
-aws configservice put-configuration-recorder --region "$REGION" \
-  --configuration-recorder "file:///tmp/cdkrd-recorder-clean.json" || fail "restore"
-
-echo "=== [$STACK] check MUST be CLEAN after restore ==="
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
 $CLI check "$STACK" --region "$REGION" --fail
-[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after restore"
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
 
-echo "INTEG PASS ($STACK detect)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/revert-plan-config-recorder-1553.test.ts
+++ b/tests/revert-plan-config-recorder-1553.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+// #1553 follow-up: AWS::Config::ConfigurationRecorder is a CC-gap type (Cloud Control throws
+// UnsupportedActionException for read AND write), read via an SDK override. Before the
+// PutConfigurationRecorder writer it was reported "type not revertable yet" (plan.ts CC-gap bar).
+// Registering it in SDK_WRITERS makes a declared drift (a changed RecordingGroup / RecordingMode)
+// route to a kind='sdk' item that the whole-resource writer PUTs, instead of not-revertable.
+const F = (over: Partial<Finding>): Finding => ({
+  tier: 'declared',
+  logicalId: 'Recorder',
+  physicalId: 'CdkRealDriftIntegConfigRecorder-Recorder-ABC',
+  resourceType: 'AWS::Config::ConfigurationRecorder',
+  path: 'RecordingGroup.ResourceTypes',
+  ...over,
+});
+
+describe('buildRevertPlan — Config recorder is SDK-revertable (#1553)', () => {
+  it('a declared RecordingGroup.ResourceTypes drift builds a kind=sdk item (not "not revertable")', () => {
+    const f = F({
+      desired: ['AWS::S3::Bucket'],
+      actual: ['AWS::S3::Bucket', 'AWS::IAM::User'],
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.resourceType).toBe('AWS::Config::ConfigurationRecorder');
+  });
+
+  it('a whole-object RecordingGroup drift also routes to the whole-resource SDK writer', () => {
+    const f = F({
+      path: 'RecordingGroup',
+      desired: { AllSupported: false, ResourceTypes: ['AWS::S3::Bucket'] },
+      actual: { AllSupported: true },
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+  });
+});


### PR DESCRIPTION
Follow-up to #1554 (issue #1553) — completes the revert dimension for the Config recorder.

## Problem

#1554 added the SDK **read** override + folds for `AWS::Config::ConfigurationRecorder`, but left revert deferred: Cloud Control cannot **write** the type either (`UnsupportedActionException`), so a declared drift on a recorder (a changed `RecordingGroup` / `RecordingMode` / `RoleARN` — e.g. someone widening what Config records out of band) was reported `type not revertable yet`.

## What this does

Adds a whole-resource SDK writer (`config:PutConfigurationRecorder`, a whole-recorder upsert):
- `desiredModel` re-reads the live recorder (the SDK override) and applies the revert ops, and the writer PUTs the reverted-to-declared model, mapped PascalCase→camelCase.
- The `Name` (createOnly) and `RoleARN` are preserved from the live read.
- `RecordingStrategy` is **omitted** from the PUT — AWS derives it from the recording group and rejects an inconsistent one, so leaving it out lets AWS recompute it (the value the reader already folds atDefault).
- Registered in `SDK_WRITERS`, so the plan.ts CC-gap "not revertable" bar no longer applies and any declared-prop drift on the recorder routes to a `kind='sdk'` item.

## Live verification (us-west-2, 2026-07-13)

deploy → record → widen `recordingGroup.resourceTypes` (+`AWS::IAM::User`) out of band →
- `check --fail` detects it (**exit 1**, `Recorder.RecordingGroup.ResourceTypes`)
- `revert --yes` → `reverted: Recorder`, and cdkrd's convergence re-read reports CLEAN
- live recorder `resourceTypes` restored to `["AWS::S3::Bucket"]`; AWS re-derived `recordingStrategy=INCLUSION_BY_RESOURCE_TYPES` (proving the omit-and-let-AWS-derive approach)
- independent `check` CLEAN (**exit 0**)
- teardown `delstack` + `sweep-orphans.sh` → **SWEEP CLEAN**

## Tests

- `tests/revert-plan-config-recorder-1553.test.ts` (2 tests): a declared recorder drift now routes to a `kind='sdk'` plan item (not `notRevertable`).
- `verify-detect.sh` updated to assert the real revert (was: reports NOT-revertable).
- Full suite: 5560 tests pass. typecheck / lint+format / build green.
