### PR TITLE
fix(noise): fold undeclared Firehose DeliveryStreamType + BufferingHints defaults (#1556)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -16,6 +16,12 @@ import { TAG_PROPERTY_NAMES } from './cc-api-strip.js';
 // entries were all OBSERVED on real default-config stacks during dogfooding.
 export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Role': { MaxSessionDuration: 3600, Path: '/', Description: '' },
+  // A DeliveryStream that declares no source configuration reads back DeliveryStreamType
+  // "DirectPut" (the service default). CloudFormation requires declaring the type whenever a
+  // Kinesis/MSK source configuration is present, so the undeclared case is always DirectPut —
+  // a tier-1 constant. Equality-gated, so an out-of-band type change still surfaces. Observed
+  // live (hunt 2026-07-13, #1556).
+  'AWS::KinesisFirehose::DeliveryStream': { DeliveryStreamType: 'DirectPut' },
   // A DataQuality monitoring job definition that declares no StoppingCondition reads back the
   // AWS default `{MaxRuntimeInSeconds:3600}` (a fully-undeclared top-level object, so
   // KNOWN_DEFAULTS not KNOWN_DEFAULT_PATHS). Equality-gated: a user who caps the runtime to a
@@ -2202,6 +2208,13 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'ExtendedS3DestinationConfiguration.CompressionFormat': 'UNCOMPRESSED',
     'ExtendedS3DestinationConfiguration.EncryptionConfiguration': {
       NoEncryptionConfig: 'NoEncryption',
+    },
+    // A destination declaring no BufferingHints reads back the documented Firehose
+    // buffering defaults: 300 s / 5 MB. Equality-gated, so an out-of-band buffering
+    // change still surfaces. Observed live (hunt 2026-07-13, #1556).
+    'ExtendedS3DestinationConfiguration.BufferingHints': {
+      IntervalInSeconds: 300,
+      SizeInMBs: 5,
     },
   },
   'AWS::Athena::WorkGroup': {

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.HuntStream.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.HuntStream.json
@@ -1,0 +1,152 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1556): fresh-deploy minimal AWS::KinesisFirehose::DeliveryStream declaring ONLY the two required nested props (BucketARN + RoleARN inside S3DestinationConfiguration) and NO DeliveryStreamType. The undeclared-default first-run path no other fixture exercised: live reads back DeliveryStreamType=\"DirectPut\" (service default) and ExtendedS3DestinationConfiguration.BufferingHints={300,5} (documented Firehose buffering defaults), both of which must fold atDefault. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "HuntStream",
+    "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+    "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+    "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream",
+    "declared": {
+      "S3DestinationConfiguration": {
+        "BucketARN": "arn:aws:s3:::cdkrdhunt0713cfirehosemin-huntbucket-uznwhjxebzxy",
+        "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHunt0713cFirehoseMin-HuntFhRole-pTvsbEFAnRrY"
+      }
+    }
+  },
+  "liveRaw": {
+    "DeliveryStreamType": "DirectPut",
+    "DeliveryStreamName": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+    "Arn": "arn:aws:firehose:us-east-1:111111111111:deliverystream/CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+    "ExtendedS3DestinationConfiguration": {
+      "BucketARN": "arn:aws:s3:::cdkrdhunt0713cfirehosemin-huntbucket-uznwhjxebzxy",
+      "BufferingHints": {
+        "IntervalInSeconds": 300,
+        "SizeInMBs": 5
+      },
+      "CompressionFormat": "UNCOMPRESSED",
+      "EncryptionConfiguration": {
+        "NoEncryptionConfig": "NoEncryption"
+      },
+      "CloudWatchLoggingOptions": {
+        "Enabled": false
+      },
+      "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHunt0713cFirehoseMin-HuntFhRole-pTvsbEFAnRrY",
+      "S3BackupMode": "Disabled"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "ElasticsearchDestinationConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration"
+    ],
+    "createOnly": [
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration"
+    ],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "DirectPutSourceConfiguration.ThroughputHintInMBs",
+      "ElasticsearchDestinationConfiguration",
+      "ElasticsearchDestinationConfiguration.CloudWatchLoggingOptions.Enabled",
+      "ExtendedS3DestinationConfiguration.CustomTimeZone",
+      "ExtendedS3DestinationConfiguration.FileExtension",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration"
+    ],
+    "createOnlyPaths": [
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntStream",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "DeliveryStreamType",
+      "actual": "DirectPut",
+      "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntStream",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "ExtendedS3DestinationConfiguration.BufferingHints",
+      "actual": {
+        "IntervalInSeconds": 300,
+        "SizeInMBs": 5
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntStream",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "ExtendedS3DestinationConfiguration.CompressionFormat",
+      "actual": "UNCOMPRESSED",
+      "nested": true,
+      "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntStream",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "ExtendedS3DestinationConfiguration.EncryptionConfiguration",
+      "actual": {
+        "NoEncryptionConfig": "NoEncryption"
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntStream",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "ExtendedS3DestinationConfiguration.S3BackupMode",
+      "actual": "Disabled",
+      "nested": true,
+      "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntStream",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "S3DestinationConfiguration",
+      "note": "write-only — cannot be read back",
+      "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
+      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream"
+    }
+  ]
+}

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -596,7 +596,25 @@ describe('noise suppressors', () => {
       'ExtendedS3DestinationConfiguration.EncryptionConfiguration': {
         NoEncryptionConfig: 'NoEncryption',
       },
+      'ExtendedS3DestinationConfiguration.BufferingHints': {
+        IntervalInSeconds: 300,
+        SizeInMBs: 5,
+      },
     });
+  });
+
+  it('#1556 Firehose undeclared-default folds: DeliveryStreamType + BufferingHints', () => {
+    // A minimal DeliveryStream declaring only the two required nested props (BucketARN +
+    // RoleARN) and NO DeliveryStreamType reads back the service defaults DirectPut and the
+    // 300 s / 5 MB buffering hints — both must fold, tier-1 equality-gated constants.
+    expect(KNOWN_DEFAULTS['AWS::KinesisFirehose::DeliveryStream']).toEqual({
+      DeliveryStreamType: 'DirectPut',
+    });
+    expect(
+      KNOWN_DEFAULT_PATHS['AWS::KinesisFirehose::DeliveryStream'][
+        'ExtendedS3DestinationConfiguration.BufferingHints'
+      ]
+    ).toEqual({ IntervalInSeconds: 300, SizeInMBs: 5 });
   });
 
   it('DocDB + VolumeAttachment constant defaults (offline measure-noise sweep)', () => {


### PR DESCRIPTION
## Summary

Fixes #1556 — a freshly deployed, un-mutated minimal `AWS::KinesisFirehose::DeliveryStream` (declaring only the two required nested props `BucketARN` + `RoleARN` inside `S3DestinationConfiguration`, no `DeliveryStreamType`) surfaced **2 `[Potential Drift]` entries on a first `check`**, both fold gaps per the core invariant.

## Root cause

`KNOWN_DEFAULT_PATHS` already folded the sibling `ExtendedS3DestinationConfiguration` defaults (`S3BackupMode`, `CompressionFormat`, `EncryptionConfiguration`), but two undeclared AWS-materialized defaults had no fold — every existing fixture declared the full destination block and/or `DeliveryStreamType`, so this undeclared-default path was never exercised.

## Fix (tier-1 equality-gated constants)

- `KNOWN_DEFAULTS['AWS::KinesisFirehose::DeliveryStream'] = { DeliveryStreamType: 'DirectPut' }` — CloudFormation requires declaring the type whenever a Kinesis/MSK source config is present, so the undeclared case is always `DirectPut`.
- `KNOWN_DEFAULT_PATHS[...]` += `'ExtendedS3DestinationConfiguration.BufferingHints': { IntervalInSeconds: 300, SizeInMBs: 5 }` — the documented Firehose buffering defaults.

Both stay detection-preserving: an out-of-band type/buffering change no longer matches the pin and re-surfaces.

## Tests

- New minimal corpus case `AWS__KinesisFirehose__DeliveryStream.HuntStream.json` — modeled on the real live read (declared = `{BucketARN, RoleARN}` only). `classifyResource` output is now **all `atDefault`/`readGap`, zero potential drift** (`expected` locked from the actual pipeline output). Without the fold, `DeliveryStreamType` + `BufferingHints` surface as `undeclared`.
- `noise-and-strip.test.ts` — updated the Firehose `KNOWN_DEFAULT_PATHS` table-pin and added a dedicated `#1556` assertion.

`vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5562 tests) all green.
