### PR TITLE
fix(check): fold 14 first-run FPs on minimal DMS ReplicationInstance/Endpoint/ReplicationTask (#1557)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -21,6 +21,10 @@ import {
   DescribeOptionGroupOptionsCommand,
   RDSClient,
 } from '@aws-sdk/client-rds';
+import {
+  DatabaseMigrationServiceClient,
+  DescribeOrderableReplicationInstancesCommand,
+} from '@aws-sdk/client-database-migration-service';
 import { GetServiceSettingCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
@@ -104,6 +108,10 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // default SG — registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch must fire when
   // a DAX cluster is present or the OOB-swap gate loses its default-SG ids.
   'AWS::DAX::Cluster',
+  // #1557: a DMS ReplicationInstance that declares no VpcSecurityGroupIds reads back its
+  // subnet-group VPC's default SG — registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch
+  // must fire when a replication instance is present or the OOB-swap gate loses its default-SG ids.
+  'AWS::DMS::ReplicationInstance',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —
@@ -281,6 +289,44 @@ async function fetchRdsDefaultCaIdentifier(region: string): Promise<string | und
   } catch {
     return undefined;
   }
+}
+
+// #1557: dms:DescribeOrderableReplicationInstances — the per-class DefaultAllocatedStorage a DMS
+// ReplicationInstance materializes when it declares no AllocatedStorage (dms.c6i.large → 100, NOT
+// the generic "50 GB" the docs cite). Paginates the orderable catalog once and maps each
+// ReplicationInstanceClass to its DefaultAllocatedStorage (the value is stable across engine
+// versions for a class, so last-seen wins). classify equality-gates the live storage against the
+// declared class's default. Cached per region, FAIL OPEN (empty map on error → the fold falls
+// through to plain `undeclared`, today's behavior).
+const dmsAllocatedStorageDefaultsCache = new Map<string, Record<string, number>>();
+export async function fetchDmsAllocatedStorageDefaults(
+  region: string
+): Promise<Record<string, number>> {
+  const cached = dmsAllocatedStorageDefaultsCache.get(region);
+  if (cached) return cached;
+  const map: Record<string, number> = {};
+  try {
+    const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
+    let marker: string | undefined;
+    do {
+      const r = await c.send(
+        new DescribeOrderableReplicationInstancesCommand({ Marker: marker, MaxRecords: 100 })
+      );
+      for (const o of r.OrderableReplicationInstances ?? []) {
+        if (
+          typeof o.ReplicationInstanceClass === 'string' &&
+          typeof o.DefaultAllocatedStorage === 'number'
+        ) {
+          map[o.ReplicationInstanceClass] = o.DefaultAllocatedStorage;
+        }
+      }
+      marker = r.Marker;
+    } while (marker);
+  } catch {
+    // fail open — leave whatever was collected (possibly empty)
+  }
+  dmsAllocatedStorageDefaultsCache.set(region, map);
+  return map;
 }
 
 // #1070 item 3: ec2:GetInstanceMetadataDefaults — the account-level IMDS defaults the owner set
@@ -1793,6 +1839,14 @@ export async function gatherFindings(
   ) {
     const v = await fetchRdsDefaultCaIdentifier(region);
     if (v !== undefined) accountDefaults.rdsDefaultCaIdentifier = v;
+  }
+  // #1557: prefetch the per-class DefaultAllocatedStorage when the stack declares any DMS
+  // ReplicationInstance, so classify can DERIVE-gate the undeclared AllocatedStorage fold against
+  // the declared class's real default (fold a clean deploy, surface an OOB storage change). Empty
+  // (denied/unavailable) → the fold falls through to plain `undeclared`.
+  if (desired.resources.some((r) => r.resourceType === 'AWS::DMS::ReplicationInstance')) {
+    const m = await fetchDmsAllocatedStorageDefaults(region);
+    if (Object.keys(m).length > 0) accountDefaults.dmsAllocatedStorageDefaults = m;
   }
   const classifyOpts = {
     accountId: desired.accountId,

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -111,6 +111,11 @@ export interface CorpusCase {
     // AWS::GlobalAccelerator::EndpointGroup case (carried by its declared ListenerArn), so replay
     // reproduces the HealthCheckPort derive. Optional for back-compat (non-EndpointGroup cases lack it).
     siblingListenerPorts?: Record<string, number>;
+    // #1557: the per-class DMS DefaultAllocatedStorage (dms:DescribeOrderableReplicationInstances),
+    // present only on an AWS::DMS::ReplicationInstance case and carrying ONLY the declared class's
+    // entry, so replay reproduces the derived AllocatedStorage fold. Without it a fresh-harvested RI
+    // replays the undeclared default storage as false drift. Optional for back-compat.
+    accountDefaults?: { dmsAllocatedStorageDefaults?: Record<string, number> };
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -149,6 +154,7 @@ export function buildCorpusCase(
     clusterEchoModel?: Record<string, Record<string, unknown>>;
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
     siblingListenerPorts?: Record<string, number>;
+    accountDefaults?: { dmsAllocatedStorageDefaults?: Record<string, number> };
   },
   findings: Finding[]
 ): CorpusCase {
@@ -210,6 +216,21 @@ export function buildCorpusCase(
     typeof listenerArn === 'string' && opts.siblingListenerPorts?.[listenerArn] !== undefined
       ? { [listenerArn]: opts.siblingListenerPorts[listenerArn] }
       : undefined;
+  // #1557: carry ONLY this ReplicationInstance's declared-class DefaultAllocatedStorage entry, so
+  // replay reproduces the derived AllocatedStorage fold without bloating the case with the full map.
+  const dmsClass =
+    resource.resourceType === 'AWS::DMS::ReplicationInstance'
+      ? (resource.declared as Record<string, unknown>)?.ReplicationInstanceClass
+      : undefined;
+  const dmsStorageDefault =
+    typeof dmsClass === 'string' &&
+    opts.accountDefaults?.dmsAllocatedStorageDefaults?.[dmsClass] !== undefined
+      ? {
+          dmsAllocatedStorageDefaults: {
+            [dmsClass]: opts.accountDefaults.dmsAllocatedStorageDefaults[dmsClass],
+          },
+        }
+      : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
     resource: {
@@ -255,6 +276,7 @@ export function buildCorpusCase(
         ? { rdsOptionSettingDefaults: { [resource.physicalId]: rdsOptCatalog } }
         : {}),
       ...(gaListenerPort ? { siblingListenerPorts: gaListenerPort } : {}),
+      ...(dmsStorageDefault ? { accountDefaults: dmsStorageDefault } : {}),
     },
     expected: findings,
   };

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -230,6 +230,16 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // the same default). An undeclared Enabled=false is an out-of-band DISABLE that silently
   // stops the pipeline, so it is unconditionally meaningful.
   'AWS::Lambda::EventSourceMapping': { Enabled: () => true },
+  // #1557: a fresh DMS ReplicationInstance is ALWAYS created with AutoMinorVersionUpgrade=true and
+  // PubliclyAccessible=true (the KNOWN_DEFAULTS pins). Unlike an RDS/Neptune DBInstance there is NO
+  // snapshot/restore source for a replication instance, so no clean-deploy path yields an untouched
+  // `false` — an undeclared `false` is unambiguously an out-of-band disable (a privacy tightening,
+  // or an auto-upgrade opt-out), so both are unconditionally meaningful when off. A user who wants
+  // either off DECLARES it (compared in the declared loop). Live-confirmed (hunt 2026-07-13).
+  'AWS::DMS::ReplicationInstance': {
+    AutoMinorVersionUpgrade: () => true,
+    PubliclyAccessible: () => true,
+  },
   // #660: health checks can only be disabled for LAMBDA target groups — ModifyTargetGroup
   // rejects HealthCheckEnabled=false for every other target type ("Health check enabled
   // must be true for target groups with target type 'instance'", live-confirmed
@@ -492,6 +502,13 @@ export const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // --security-group-ids`), so a value-independent fold would hide a rogue SG swap/append.
   // Same derived VPC-default-SG gate: fold a single default SG, surface an append/swap.
   'AWS::DAX::Cluster': 'SecurityGroupIds',
+  // #1557: a DMS ReplicationInstance that declares no VpcSecurityGroupIds is placed into its
+  // subnet-group VPC's default SG and reads back that single SG id — the same AWS first-run
+  // default the ALB/ENI/Neptune/RDS cases fold. It is OOB-mutable (`dms
+  // modify-replication-instance --vpc-security-group-ids`), so a value-independent fold would
+  // hide a rogue SG swap/append. Same derived VPC-default-SG gate: fold a single default SG,
+  // surface an append/swap. Keep in sync with gather.ts DEFAULT_SG_LIST_TYPES.
+  'AWS::DMS::ReplicationInstance': 'VpcSecurityGroupIds',
 };
 /** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
  *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into
@@ -588,6 +605,14 @@ export interface AccountDefaults {
   // MetadataOptions — a hardened account (hop limit 1, tokens enforced, …) folds its clean deploy.
   // Undefined when nothing is set at account level → the constant stands.
   instanceMetadataDefaults?: Record<string, string | number>;
+  // dms:DescribeOrderableReplicationInstances `DefaultAllocatedStorage` keyed by
+  // ReplicationInstanceClass — a DMS ReplicationInstance that declares no AllocatedStorage reads
+  // back a class-dependent default (dms.c6i.large → 100), NOT the generic "50 GB" the docs cite.
+  // classify equality-gates the live AllocatedStorage against this DERIVED value for the declared
+  // class (folding a clean deploy but surfacing an out-of-band storage change). A class absent
+  // here (lookup denied/unavailable) → the fold falls through to plain `undeclared` — today's
+  // behavior. #1557.
+  dmsAllocatedStorageDefaults?: Record<string, number>;
 }
 
 // #1070: for a handful of undeclared properties the value AWS assigns at creation is a function of
@@ -4876,6 +4901,30 @@ export function classifyResource(
       if (rgDerived !== undefined) {
         findings.push({
           tier: matchesKnownDefault(v, rgDerived.value) ? 'atDefault' : 'undeclared',
+          logicalId,
+          resourceType,
+          path: k,
+          actual: v,
+        });
+        continue;
+      }
+    }
+    // #1557: a DMS ReplicationInstance's undeclared AllocatedStorage is a DETERMINISTIC FUNCTION of
+    // the declared ReplicationInstanceClass (dms.c6i.large → 100), NOT a fixed constant — the docs'
+    // generic "50 GB" is not per-class truth. gather.ts prefetched the per-class
+    // DefaultAllocatedStorage via dms:DescribeOrderableReplicationInstances; fold atDefault when the
+    // live value equals the derived default (equality-gated — an out-of-band `modify-replication-
+    // instance --allocated-storage` still surfaces). Authoritative when the lookup resolved; a class
+    // absent (denied/unavailable) falls through to plain `undeclared` — today's behavior.
+    if (resourceType === 'AWS::DMS::ReplicationInstance' && k === 'AllocatedStorage') {
+      const cls = declared['ReplicationInstanceClass'];
+      const derived =
+        typeof cls === 'string'
+          ? opts.accountDefaults?.dmsAllocatedStorageDefaults?.[cls]
+          : undefined;
+      if (derived !== undefined) {
+        findings.push({
+          tier: matchesKnownDefault(v, derived) ? 'atDefault' : 'undeclared',
           logicalId,
           resourceType,
           path: k,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -107,6 +107,20 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // undeclared drift. Observed live on a fresh minimal mysql source endpoint
   // (case-idents-min, 2026-07-12; #1490).
   'AWS::DMS::Endpoint': { SslMode: 'none' },
+  // A DMS replication instance that declares no NetworkType reads back "IPV4" (the constant
+  // service default; IPV6 is an explicit opt-in). The two `true` booleans are always-on
+  // creation defaults — CreateReplicationInstance materializes AutoMinorVersionUpgrade=true
+  // and PubliclyAccessible=true on every fresh instance (create even fails without an
+  // IGW-attached VPC because PubliclyAccessible defaults true). ReplicationInstance has NO
+  // restore-from-snapshot source, so an undeclared `false` is unambiguously an out-of-band
+  // disable — the MEANINGFUL_WHEN_OFF companions below surface it unconditionally. All three
+  // equality-gated: a user who pins a different value DECLARES it (compared in the declared
+  // loop). Observed live (hunt 2026-07-13, #1557).
+  'AWS::DMS::ReplicationInstance': {
+    AutoMinorVersionUpgrade: true,
+    PubliclyAccessible: true,
+    NetworkType: 'IPV4',
+  },
   // A MediaConvert queue that declares only its Name reads back the two constant
   // creation defaults: PricingPlan "ON_DEMAND" (the only value CreateQueue assigns
   // undeclared; RESERVED requires an explicit reservation plan) and Status "ACTIVE".
@@ -2766,6 +2780,18 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // AWS-minted identity, not user intent; a Secret that DECLARES a Name carries it in the
   // template and never reaches this loop.
   'AWS::SecretsManager::Secret': new Set(['Name']),
+  // A DMS ReplicationInstance / Endpoint / ReplicationTask whose *Identifier the template omits
+  // reads back a CloudFormation-generated `<logicalId-lowercased>-<random>` name. The generic
+  // isGeneratedName rule keys on the resource's CFn PhysicalResourceId, but these DMS types'
+  // physical id is an ARN (`arn:aws:dms:…:rep|endpoint|task:…`), not the identifier, so it never
+  // matches and the echoed identifier floods the first run as undeclared — the same per-type gap
+  // AWS::ElasticLoadBalancingV2::TargetGroup.Name solved. The identifier is the AWS-minted
+  // identity, never user intent when undeclared (a user who pins one DECLARES it and it is
+  // compared in the declared loop). ReplicationSubnetGroup is absent here: its physical id IS the
+  // identifier, so isGeneratedName already folds it. Observed live (hunt 2026-07-13, #1557).
+  'AWS::DMS::ReplicationInstance': new Set(['ReplicationInstanceIdentifier']),
+  'AWS::DMS::Endpoint': new Set(['EndpointIdentifier']),
+  'AWS::DMS::ReplicationTask': new Set(['ReplicationTaskIdentifier']),
   // NOTE: AWS::ElasticLoadBalancingV2::TargetGroup.Targets is NOT folded here (#891). A blanket
   // fold hid an out-of-band `elbv2 register-targets` pointing a listener's production traffic at
   // an attacker-controlled instance/IP — a live (non-empty) Targets membership read CLEAN and
@@ -3448,6 +3474,32 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   DECLARES KmsKeyId and is compared in the declared loop. Observed live on a fresh
   //   minimal endpoint (case-idents-min, 2026-07-12; #1490).
   'AWS::DMS::Endpoint': new Set(['KmsKeyId']),
+  //   AWS::DMS::ReplicationInstance — a fresh instance materializes four undeclared values that
+  //   cannot be pinned or derived:
+  //     EngineVersion — the current GA DMS engine (e.g. "3.5.4"), which AWS moves over time
+  //       (the DocDB/Neptune/RDS GA-version class). A DECLARED version is compared in the
+  //       declared loop.
+  //     AvailabilityZone — the zone AWS placed the instance in at creation (the RDS/Neptune/
+  //       Lightsail AvailabilityZone class).
+  //     PreferredMaintenanceWindow — the RANDOMLY-assigned weekly slot (the RDS/DAX window class).
+  //     KmsKeyId — the AWS-managed `aws/dms` key ARN materialized at creation (create-only), the
+  //       exact twin of the DMS::Endpoint.KmsKeyId entry above and the #533 assigned-KmsKeyId class.
+  //   Each is never user intent when undeclared; a user who cares DECLARES it (compared in the
+  //   declared loop). Observed live (hunt 2026-07-13, #1557).
+  'AWS::DMS::ReplicationInstance': new Set([
+    'EngineVersion',
+    'AvailabilityZone',
+    'PreferredMaintenanceWindow',
+    'KmsKeyId',
+  ]),
+  //   AWS::DMS::ReplicationTask.ReplicationTaskSettings — a task that declares no settings reads
+  //   back the FULL AWS-materialized task-settings document (Logging.LogComponents, StreamBuffer
+  //   /ErrorBehavior/FullLoad/TargetMetadata/ControlTables/ChangeProcessing sub-objects, ~150
+  //   leaves) whose content and shape vary by engine version — not a fixed constant, and a
+  //   per-leaf pin would churn on every engine bump. A user who tunes any setting DECLARES
+  //   ReplicationTaskSettings (compared in the declared loop). Observed live (hunt 2026-07-13,
+  //   #1557).
+  'AWS::DMS::ReplicationTask': new Set(['ReplicationTaskSettings']),
   //   AWS::DAX::Cluster.PreferredMaintenanceWindow — a cluster that declares no window reads
   //   back the RANDOMLY-assigned weekly slot AWS chose at creation (live first-run on a fresh
   //   barest cluster, #1532) — the same per-resource assigned-window shape as the RDS/DocDB/

--- a/tests/corpus/AWS__DMS__Endpoint.HuntDmsSrcEp.json
+++ b/tests/corpus/AWS__DMS__Endpoint.HuntDmsSrcEp.json
@@ -1,0 +1,109 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1557): fresh minimal AWS::DMS::Endpoint (source). The generated EndpointIdentifier must fold; SslMode/KmsKeyId already fold; declared write-only Password is a readGap.",
+  "resource": {
+    "logicalId": "HuntDmsSrcEp",
+    "resourceType": "AWS::DMS::Endpoint",
+    "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:3NI442UVUJEFPJRAM3RET3BPHI",
+    "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsSrcEp",
+    "declared": {
+      "EndpointType": "source",
+      "EngineName": "mysql",
+      "Password": "hunt-dummy-password",
+      "Port": 3306,
+      "ServerName": "src.cdkrd-hunt.invalid",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Username": "hunt"
+    }
+  },
+  "liveRaw": {
+    "EndpointIdentifier": "huntdmssrcep-lbryjkqclhziemmf",
+    "EndpointType": "SOURCE",
+    "EngineName": "mysql",
+    "Username": "hunt",
+    "ServerName": "src.cdkrd-hunt.invalid",
+    "Port": 3306,
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+    "SslMode": "none",
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0713cVpcKin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntDmsSrcEp"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713cVpcKin/040c5620-7e8a-11f1-9687-1252ffbd3b8f"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ExternalId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["KmsKeyId", "ResourceIdentifier"],
+    "readOnlyPaths": ["ExternalId", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KmsKeyId", "ResourceIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsSrcEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:3NI442UVUJEFPJRAM3RET3BPHI",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsSrcEp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsSrcEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "SslMode",
+      "actual": "none",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:3NI442UVUJEFPJRAM3RET3BPHI",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsSrcEp"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntDmsSrcEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "EndpointIdentifier",
+      "actual": "huntdmssrcep-lbryjkqclhziemmf",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:3NI442UVUJEFPJRAM3RET3BPHI",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsSrcEp"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntDmsSrcEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "Password",
+      "note": "declared but not returned by live read",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:3NI442UVUJEFPJRAM3RET3BPHI",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsSrcEp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DMS__Endpoint.HuntDmsTgtEp.json
+++ b/tests/corpus/AWS__DMS__Endpoint.HuntDmsTgtEp.json
@@ -1,0 +1,109 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1557): fresh minimal AWS::DMS::Endpoint (target). Twin of HuntDmsSrcEp — the generated EndpointIdentifier must fold.",
+  "resource": {
+    "logicalId": "HuntDmsTgtEp",
+    "resourceType": "AWS::DMS::Endpoint",
+    "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:MWT6C3BEIZEXRN6TOYFPHG3DO4",
+    "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTgtEp",
+    "declared": {
+      "EndpointType": "target",
+      "EngineName": "mysql",
+      "Password": "hunt-dummy-password",
+      "Port": 3306,
+      "ServerName": "tgt.cdkrd-hunt.invalid",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Username": "hunt"
+    }
+  },
+  "liveRaw": {
+    "EndpointIdentifier": "huntdmstgtep-ldkuxwu271r866iu",
+    "EndpointType": "TARGET",
+    "EngineName": "mysql",
+    "Username": "hunt",
+    "ServerName": "tgt.cdkrd-hunt.invalid",
+    "Port": 3306,
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+    "SslMode": "none",
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0713cVpcKin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntDmsTgtEp"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713cVpcKin/040c5620-7e8a-11f1-9687-1252ffbd3b8f"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ExternalId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["KmsKeyId", "ResourceIdentifier"],
+    "readOnlyPaths": ["ExternalId", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KmsKeyId", "ResourceIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsTgtEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:MWT6C3BEIZEXRN6TOYFPHG3DO4",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTgtEp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsTgtEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "SslMode",
+      "actual": "none",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:MWT6C3BEIZEXRN6TOYFPHG3DO4",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTgtEp"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntDmsTgtEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "EndpointIdentifier",
+      "actual": "huntdmstgtep-ldkuxwu271r866iu",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:MWT6C3BEIZEXRN6TOYFPHG3DO4",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTgtEp"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntDmsTgtEp",
+      "resourceType": "AWS::DMS::Endpoint",
+      "path": "Password",
+      "note": "declared but not returned by live read",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:endpoint:MWT6C3BEIZEXRN6TOYFPHG3DO4",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTgtEp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DMS__ReplicationInstance.HuntDmsRi.json
+++ b/tests/corpus/AWS__DMS__ReplicationInstance.HuntDmsRi.json
@@ -1,0 +1,189 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1557): fresh minimal AWS::DMS::ReplicationInstance (only ReplicationInstanceClass + ReplicationSubnetGroupIdentifier declared). Exercises the full undeclared-default surface a fresh instance materializes: the generated ReplicationInstanceIdentifier, the NetworkType/AutoMinorVersionUpgrade/PubliclyAccessible constant defaults, the class-derived AllocatedStorage (opts.accountDefaults.dmsAllocatedStorageDefaults), the default-VPC SG, the AWS-assigned KmsKeyId, and the moving EngineVersion/AvailabilityZone/PreferredMaintenanceWindow. All must fold to zero potential drift. A change in expected means the fold semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "HuntDmsRi",
+    "resourceType": "AWS::DMS::ReplicationInstance",
+    "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+    "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi",
+    "declared": {
+      "ReplicationInstanceClass": "dms.c6i.large",
+      "ReplicationSubnetGroupIdentifier": "huntdmssng-epnnheykqkgw4fho",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ReplicationInstanceIdentifier": "huntdmsri-q2z2kglbegpum1mf",
+    "ReplicationInstanceClass": "dms.c6i.large",
+    "AllocatedStorage": 100,
+    "MultiAZ": false,
+    "EngineVersion": "3.5.4",
+    "AutoMinorVersionUpgrade": true,
+    "PubliclyAccessible": true,
+    "AvailabilityZone": "us-east-1a",
+    "PreferredMaintenanceWindow": "fri:08:20-fri:08:50",
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+    "NetworkType": "IPV4",
+    "ReplicationSubnetGroupIdentifier": "huntdmssng-epnnheykqkgw4fho",
+    "VpcSecurityGroupIds": ["sg-0394d4b516f73dee8"],
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0713cVpcKin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntDmsRi"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713cVpcKin/040c5620-7e8a-11f1-9687-1252ffbd3b8f"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "Id",
+      "ReplicationInstancePrivateIpAddresses",
+      "ReplicationInstancePublicIpAddresses"
+    ],
+    "writeOnly": [],
+    "createOnly": [
+      "DnsNameServers",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "ReplicationSubnetGroupIdentifier",
+      "ResourceIdentifier"
+    ],
+    "readOnlyPaths": [
+      "Id",
+      "ReplicationInstancePrivateIpAddresses",
+      "ReplicationInstancePublicIpAddresses"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DnsNameServers",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "ReplicationSubnetGroupIdentifier",
+      "ResourceIdentifier"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "accountDefaults": {
+      "dmsAllocatedStorageDefaults": {
+        "dms.c6i.large": 100
+      }
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "AllocatedStorage",
+      "actual": 100,
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "EngineVersion",
+      "actual": "3.5.4",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "fri:08:20-fri:08:50",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "PubliclyAccessible",
+      "actual": true,
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "VpcSecurityGroupIds",
+      "actual": ["sg-0394d4b516f73dee8"],
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntDmsRi",
+      "resourceType": "AWS::DMS::ReplicationInstance",
+      "path": "ReplicationInstanceIdentifier",
+      "actual": "huntdmsri-q2z2kglbegpum1mf",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsRi"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DMS__ReplicationSubnetGroup.HuntDmsSng.json
+++ b/tests/corpus/AWS__DMS__ReplicationSubnetGroup.HuntDmsSng.json
@@ -1,0 +1,51 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1557): fresh minimal AWS::DMS::ReplicationSubnetGroup — already first-run clean (its physical id IS the identifier, so isGeneratedName folds it). Locked as a regression guard alongside the #1557 DMS family.",
+  "resource": {
+    "logicalId": "HuntDmsSng",
+    "resourceType": "AWS::DMS::ReplicationSubnetGroup",
+    "physicalId": "huntdmssng-epnnheykqkgw4fho",
+    "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsSng",
+    "declared": {
+      "ReplicationSubnetGroupDescription": "cdkrd hunt minimal subnet group",
+      "SubnetIds": ["subnet-0f109dac292613e2e", "subnet-084af4a709de7def4"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ReplicationSubnetGroupIdentifier": "huntdmssng-epnnheykqkgw4fho",
+    "ReplicationSubnetGroupDescription": "cdkrd hunt minimal subnet group",
+    "SubnetIds": ["subnet-084af4a709de7def4", "subnet-0f109dac292613e2e"],
+    "Tags": [
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["ReplicationSubnetGroupIdentifier"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ReplicationSubnetGroupIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__DMS__ReplicationTask.HuntDmsTask.json
+++ b/tests/corpus/AWS__DMS__ReplicationTask.HuntDmsTask.json
@@ -1,0 +1,462 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1557): fresh minimal AWS::DMS::ReplicationTask (full-load). The generated ReplicationTaskIdentifier and the full AWS-materialized ReplicationTaskSettings document must fold to zero potential drift.",
+  "resource": {
+    "logicalId": "HuntDmsTask",
+    "resourceType": "AWS::DMS::ReplicationTask",
+    "physicalId": "arn:aws:dms:us-east-1:111111111111:task:JAZD5FLSEZBIJJPPVDPAE7VLHA",
+    "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTask",
+    "declared": {
+      "MigrationType": "full-load",
+      "ReplicationInstanceArn": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+      "SourceEndpointArn": "arn:aws:dms:us-east-1:111111111111:endpoint:3NI442UVUJEFPJRAM3RET3BPHI",
+      "TableMappings": "{\"rules\":[{\"rule-type\":\"selection\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"object-locator\":{\"schema-name\":\"huntdb\",\"table-name\":\"%\"},\"rule-action\":\"include\"}]}",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TargetEndpointArn": "arn:aws:dms:us-east-1:111111111111:endpoint:MWT6C3BEIZEXRN6TOYFPHG3DO4"
+    }
+  },
+  "liveRaw": {
+    "ReplicationTaskIdentifier": "huntdmstask-vkhanmzzirlw5tqn",
+    "SourceEndpointArn": "arn:aws:dms:us-east-1:111111111111:endpoint:3NI442UVUJEFPJRAM3RET3BPHI",
+    "TargetEndpointArn": "arn:aws:dms:us-east-1:111111111111:endpoint:MWT6C3BEIZEXRN6TOYFPHG3DO4",
+    "ReplicationInstanceArn": "arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA",
+    "MigrationType": "full-load",
+    "TableMappings": {
+      "rules": [
+        {
+          "rule-type": "selection",
+          "rule-id": "1",
+          "rule-name": "1",
+          "object-locator": {
+            "schema-name": "huntdb",
+            "table-name": "%"
+          },
+          "rule-action": "include"
+        }
+      ]
+    },
+    "ReplicationTaskSettings": {
+      "Logging": {
+        "EnableLogging": false,
+        "EnableLogContext": false,
+        "LogComponents": [
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "DATA_STRUCTURE"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "COMMUNICATION"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "IO"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "COMMON"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "FILE_FACTORY"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "FILE_TRANSFER"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "REST_SERVER"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "ADDONS"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "TARGET_LOAD"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "TARGET_APPLY"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "SOURCE_UNLOAD"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "SOURCE_CAPTURE"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "TRANSFORMATION"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "SORTER"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "TASK_MANAGER"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "TABLES_MANAGER"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "METADATA_MANAGER"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "PERFORMANCE"
+          },
+          {
+            "Severity": "LOGGER_SEVERITY_DEFAULT",
+            "Id": "VALIDATOR_EXT"
+          }
+        ],
+        "CloudWatchLogGroup": null,
+        "CloudWatchLogStream": null
+      },
+      "StreamBufferSettings": {
+        "StreamBufferCount": 3,
+        "CtrlStreamBufferSizeInMB": 5,
+        "StreamBufferSizeInMB": 8
+      },
+      "ErrorBehavior": {
+        "FailOnNoTablesCaptured": true,
+        "ApplyErrorUpdatePolicy": "LOG_ERROR",
+        "FailOnTransactionConsistencyBreached": false,
+        "RecoverableErrorThrottlingMax": 1800,
+        "DataErrorEscalationPolicy": "SUSPEND_TABLE",
+        "ApplyErrorEscalationCount": 0,
+        "RecoverableErrorStopRetryAfterThrottlingMax": true,
+        "RecoverableErrorThrottling": true,
+        "ApplyErrorFailOnTruncationDdl": false,
+        "DataMaskingErrorPolicy": "STOP_TASK",
+        "DataTruncationErrorPolicy": "LOG_ERROR",
+        "ApplyErrorInsertPolicy": "LOG_ERROR",
+        "EventErrorPolicy": "IGNORE",
+        "ApplyErrorEscalationPolicy": "LOG_ERROR",
+        "RecoverableErrorCount": -1,
+        "DataErrorEscalationCount": 0,
+        "TableErrorEscalationPolicy": "STOP_TASK",
+        "RecoverableErrorInterval": 5,
+        "ApplyErrorDeletePolicy": "IGNORE_RECORD",
+        "TableErrorEscalationCount": 0,
+        "FullLoadIgnoreConflicts": true,
+        "DataErrorPolicy": "LOG_ERROR",
+        "TableErrorPolicy": "SUSPEND_TABLE"
+      },
+      "TTSettings": null,
+      "FullLoadSettings": {
+        "CommitRate": 10000,
+        "StopTaskCachedChangesApplied": false,
+        "StopTaskCachedChangesNotApplied": false,
+        "MaxFullLoadSubTasks": 8,
+        "TransactionConsistencyTimeout": 600,
+        "CreatePkAfterFullLoad": false,
+        "TargetTablePrepMode": "DROP_AND_CREATE"
+      },
+      "TargetMetadata": {
+        "ParallelApplyBufferSize": 0,
+        "ParallelApplyQueuesPerThread": 0,
+        "ParallelApplyThreads": 0,
+        "TargetSchema": "",
+        "InlineLobMaxSize": 0,
+        "ParallelLoadQueuesPerThread": 0,
+        "SupportLobs": true,
+        "LobChunkSize": 64,
+        "TaskRecoveryTableEnabled": false,
+        "ParallelLoadThreads": 0,
+        "LobMaxSize": 32,
+        "BatchApplyEnabled": false,
+        "FullLobMode": false,
+        "LimitedSizeLobMode": true,
+        "LoadMaxFileSize": 0,
+        "ParallelLoadBufferSize": 0
+      },
+      "BeforeImageSettings": null,
+      "ControlTablesSettings": {
+        "historyTimeslotInMinutes": 5,
+        "HistoryTimeslotInMinutes": 5,
+        "StatusTableEnabled": false,
+        "SuspendedTablesTableEnabled": false,
+        "HistoryTableEnabled": false,
+        "ControlSchema": "",
+        "FullLoadExceptionTableEnabled": false
+      },
+      "LoopbackPreventionSettings": null,
+      "CharacterSetSettings": null,
+      "FailTaskWhenCleanTaskResourceFailed": false,
+      "ChangeProcessingTuning": {
+        "StatementCacheSize": 50,
+        "CommitTimeout": 1,
+        "RecoveryTimeout": -1,
+        "BatchApplyPreserveTransaction": true,
+        "BatchApplyTimeoutMin": 1,
+        "BatchSplitSize": 0,
+        "BatchApplyTimeoutMax": 30,
+        "MinTransactionSize": 1000,
+        "MemoryKeepTime": 60,
+        "BatchApplyMemoryLimit": 500,
+        "MemoryLimitTotal": 1024
+      },
+      "ChangeProcessingDdlHandlingPolicy": {
+        "HandleSourceTableDropped": true,
+        "HandleSourceTableTruncated": true,
+        "HandleSourceTableAltered": true
+      },
+      "PostProcessingRules": null
+    },
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0713cVpcKin"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntDmsTask"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0713cVpcKin/040c5620-7e8a-11f1-9687-1252ffbd3b8f"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "ReplicationInstanceArn",
+      "ResourceIdentifier",
+      "SourceEndpointArn",
+      "TargetEndpointArn"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ReplicationInstanceArn",
+      "ResourceIdentifier",
+      "SourceEndpointArn",
+      "TargetEndpointArn"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDmsTask",
+      "resourceType": "AWS::DMS::ReplicationTask",
+      "path": "ReplicationTaskSettings",
+      "actual": {
+        "Logging": {
+          "EnableLogging": false,
+          "EnableLogContext": false,
+          "LogComponents": [
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "ADDONS"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "COMMON"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "COMMUNICATION"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "DATA_STRUCTURE"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "FILE_FACTORY"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "FILE_TRANSFER"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "IO"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "METADATA_MANAGER"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "PERFORMANCE"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "REST_SERVER"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "SORTER"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "SOURCE_CAPTURE"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "SOURCE_UNLOAD"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "TABLES_MANAGER"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "TARGET_APPLY"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "TARGET_LOAD"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "TASK_MANAGER"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "TRANSFORMATION"
+            },
+            {
+              "Severity": "LOGGER_SEVERITY_DEFAULT",
+              "Id": "VALIDATOR_EXT"
+            }
+          ],
+          "CloudWatchLogGroup": null,
+          "CloudWatchLogStream": null
+        },
+        "StreamBufferSettings": {
+          "StreamBufferCount": 3,
+          "CtrlStreamBufferSizeInMB": 5,
+          "StreamBufferSizeInMB": 8
+        },
+        "ErrorBehavior": {
+          "FailOnNoTablesCaptured": true,
+          "ApplyErrorUpdatePolicy": "LOG_ERROR",
+          "FailOnTransactionConsistencyBreached": false,
+          "RecoverableErrorThrottlingMax": 1800,
+          "DataErrorEscalationPolicy": "SUSPEND_TABLE",
+          "ApplyErrorEscalationCount": 0,
+          "RecoverableErrorStopRetryAfterThrottlingMax": true,
+          "RecoverableErrorThrottling": true,
+          "ApplyErrorFailOnTruncationDdl": false,
+          "DataMaskingErrorPolicy": "STOP_TASK",
+          "DataTruncationErrorPolicy": "LOG_ERROR",
+          "ApplyErrorInsertPolicy": "LOG_ERROR",
+          "EventErrorPolicy": "IGNORE",
+          "ApplyErrorEscalationPolicy": "LOG_ERROR",
+          "RecoverableErrorCount": -1,
+          "DataErrorEscalationCount": 0,
+          "TableErrorEscalationPolicy": "STOP_TASK",
+          "RecoverableErrorInterval": 5,
+          "ApplyErrorDeletePolicy": "IGNORE_RECORD",
+          "TableErrorEscalationCount": 0,
+          "FullLoadIgnoreConflicts": true,
+          "DataErrorPolicy": "LOG_ERROR",
+          "TableErrorPolicy": "SUSPEND_TABLE"
+        },
+        "TTSettings": null,
+        "FullLoadSettings": {
+          "CommitRate": 10000,
+          "StopTaskCachedChangesApplied": false,
+          "StopTaskCachedChangesNotApplied": false,
+          "MaxFullLoadSubTasks": 8,
+          "TransactionConsistencyTimeout": 600,
+          "CreatePkAfterFullLoad": false,
+          "TargetTablePrepMode": "DROP_AND_CREATE"
+        },
+        "TargetMetadata": {
+          "ParallelApplyBufferSize": 0,
+          "ParallelApplyQueuesPerThread": 0,
+          "ParallelApplyThreads": 0,
+          "TargetSchema": "",
+          "InlineLobMaxSize": 0,
+          "ParallelLoadQueuesPerThread": 0,
+          "SupportLobs": true,
+          "LobChunkSize": 64,
+          "TaskRecoveryTableEnabled": false,
+          "ParallelLoadThreads": 0,
+          "LobMaxSize": 32,
+          "BatchApplyEnabled": false,
+          "FullLobMode": false,
+          "LimitedSizeLobMode": true,
+          "LoadMaxFileSize": 0,
+          "ParallelLoadBufferSize": 0
+        },
+        "BeforeImageSettings": null,
+        "ControlTablesSettings": {
+          "historyTimeslotInMinutes": 5,
+          "HistoryTimeslotInMinutes": 5,
+          "StatusTableEnabled": false,
+          "SuspendedTablesTableEnabled": false,
+          "HistoryTableEnabled": false,
+          "ControlSchema": "",
+          "FullLoadExceptionTableEnabled": false
+        },
+        "LoopbackPreventionSettings": null,
+        "CharacterSetSettings": null,
+        "FailTaskWhenCleanTaskResourceFailed": false,
+        "ChangeProcessingTuning": {
+          "StatementCacheSize": 50,
+          "CommitTimeout": 1,
+          "RecoveryTimeout": -1,
+          "BatchApplyPreserveTransaction": true,
+          "BatchApplyTimeoutMin": 1,
+          "BatchSplitSize": 0,
+          "BatchApplyTimeoutMax": 30,
+          "MinTransactionSize": 1000,
+          "MemoryKeepTime": 60,
+          "BatchApplyMemoryLimit": 500,
+          "MemoryLimitTotal": 1024
+        },
+        "ChangeProcessingDdlHandlingPolicy": {
+          "HandleSourceTableDropped": true,
+          "HandleSourceTableTruncated": true,
+          "HandleSourceTableAltered": true
+        },
+        "PostProcessingRules": null
+      },
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:task:JAZD5FLSEZBIJJPPVDPAE7VLHA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTask"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntDmsTask",
+      "resourceType": "AWS::DMS::ReplicationTask",
+      "path": "ReplicationTaskIdentifier",
+      "actual": "huntdmstask-vkhanmzzirlw5tqn",
+      "physicalId": "arn:aws:dms:us-east-1:111111111111:task:JAZD5FLSEZBIJJPPVDPAE7VLHA",
+      "constructPath": "CdkrdHunt0713cVpcKin/HuntDmsTask"
+    }
+  ]
+}

--- a/tests/dms-first-run-1557.test.ts
+++ b/tests/dms-first-run-1557.test.ts
@@ -1,0 +1,189 @@
+// #1557 — a freshly deployed, un-mutated minimal DMS stack (ReplicationInstance + Endpoints +
+// ReplicationTask, only required props declared) surfaced 14 [Potential Drift] entries on a first
+// check. All are AWS-materialized creation defaults that must fold to zero potential drift, across
+// four fold tiers. These tests pin the table entries AND prove detection is PRESERVED (an
+// out-of-band change away from each folded default still surfaces). The end-to-end fold is
+// additionally locked by the golden corpus cases (AWS__DMS__ReplicationInstance.HuntDmsRi etc.).
+import {
+  DatabaseMigrationServiceClient,
+  DescribeOrderableReplicationInstancesCommand,
+} from '@aws-sdk/client-database-migration-service';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { classifyResource, DEFAULT_SG_LIST_PATHS } from '../src/diff/classify.js';
+import { fetchDmsAllocatedStorageDefaults } from '../src/commands/gather.js';
+import {
+  GENERATED_TOPLEVEL_PATHS,
+  KNOWN_DEFAULTS,
+  VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS,
+} from '../src/normalize/noise.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const byTierPath = (fs: Finding[]) => fs.map((f) => `${f.tier} ${f.path}`).sort();
+const pathTier = (fs: Finding[], path: string) => fs.find((f) => f.path === path)?.tier;
+
+// The AWS-assigned identity + defaults a fresh dms.c6i.large replication instance reads back.
+const riLive = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  ReplicationInstanceIdentifier: 'huntdmsri-q2z2kglbegpum1mf',
+  ReplicationInstanceClass: 'dms.c6i.large',
+  AllocatedStorage: 100,
+  MultiAZ: false,
+  EngineVersion: '3.5.4',
+  AutoMinorVersionUpgrade: true,
+  PubliclyAccessible: true,
+  AvailabilityZone: 'us-east-1a',
+  PreferredMaintenanceWindow: 'fri:08:20-fri:08:50',
+  KmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6',
+  NetworkType: 'IPV4',
+  ReplicationSubnetGroupIdentifier: 'huntdmssng-epnnheykqkgw4fho',
+  VpcSecurityGroupIds: ['sg-0394d4b516f73dee8'],
+  ...over,
+});
+
+const riResource: DesiredResource = {
+  logicalId: 'HuntDmsRi',
+  resourceType: 'AWS::DMS::ReplicationInstance',
+  physicalId: 'arn:aws:dms:us-east-1:111111111111:rep:2AWWXYNVBFCVPAC4SBILMZXHCA',
+  declared: {
+    ReplicationInstanceClass: 'dms.c6i.large',
+    ReplicationSubnetGroupIdentifier: 'huntdmssng-epnnheykqkgw4fho',
+  },
+};
+
+const riOpts = {
+  accountId: '111111111111',
+  region: 'us-east-1',
+  kmsAliasTargets: {},
+  accountDefaults: { dmsAllocatedStorageDefaults: { 'dms.c6i.large': 100 } },
+  defaultSgIds: new Set(['sg-0394d4b516f73dee8']),
+};
+
+describe('#1557 DMS first-run default folds', () => {
+  it('table entries are present', () => {
+    expect(KNOWN_DEFAULTS['AWS::DMS::ReplicationInstance']).toEqual({
+      AutoMinorVersionUpgrade: true,
+      PubliclyAccessible: true,
+      NetworkType: 'IPV4',
+    });
+    expect(GENERATED_TOPLEVEL_PATHS['AWS::DMS::ReplicationInstance']).toEqual(
+      new Set(['ReplicationInstanceIdentifier'])
+    );
+    expect(GENERATED_TOPLEVEL_PATHS['AWS::DMS::Endpoint']).toEqual(new Set(['EndpointIdentifier']));
+    expect(GENERATED_TOPLEVEL_PATHS['AWS::DMS::ReplicationTask']).toEqual(
+      new Set(['ReplicationTaskIdentifier'])
+    );
+    expect(VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::DMS::ReplicationInstance']).toEqual(
+      new Set(['EngineVersion', 'AvailabilityZone', 'PreferredMaintenanceWindow', 'KmsKeyId'])
+    );
+    expect(VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::DMS::ReplicationTask']).toEqual(
+      new Set(['ReplicationTaskSettings'])
+    );
+    expect(DEFAULT_SG_LIST_PATHS['AWS::DMS::ReplicationInstance']).toBe('VpcSecurityGroupIds');
+  });
+
+  it('a clean fresh ReplicationInstance produces ZERO potential drift', () => {
+    const f = classifyResource(riResource, riLive(), emptySchema, riOpts);
+    expect(f.filter((x) => x.tier === 'undeclared')).toEqual([]);
+    // every AWS-assigned value folds (atDefault) or is the generated identity (generated)
+    expect(byTierPath(f)).toEqual([
+      'atDefault AllocatedStorage',
+      'atDefault AutoMinorVersionUpgrade',
+      'atDefault AvailabilityZone',
+      'atDefault EngineVersion',
+      'atDefault KmsKeyId',
+      'atDefault NetworkType',
+      'atDefault PreferredMaintenanceWindow',
+      'atDefault PubliclyAccessible',
+      'atDefault VpcSecurityGroupIds',
+      'generated ReplicationInstanceIdentifier',
+    ]);
+  });
+
+  it('detection preserved: an out-of-band disable / change away from a folded default surfaces', () => {
+    // AutoMinorVersionUpgrade / PubliclyAccessible OFF (MEANINGFUL_WHEN_OFF — RI has no restore source)
+    const off = classifyResource(
+      riResource,
+      riLive({ AutoMinorVersionUpgrade: false, PubliclyAccessible: false }),
+      emptySchema,
+      riOpts
+    );
+    expect(pathTier(off, 'AutoMinorVersionUpgrade')).toBe('undeclared');
+    expect(pathTier(off, 'PubliclyAccessible')).toBe('undeclared');
+
+    // NetworkType flipped to IPV6 (equality-gated constant)
+    const net = classifyResource(riResource, riLive({ NetworkType: 'DUAL' }), emptySchema, riOpts);
+    expect(pathTier(net, 'NetworkType')).toBe('undeclared');
+
+    // AllocatedStorage grown out of band (derived default — no longer == the class default 100)
+    const stor = classifyResource(
+      riResource,
+      riLive({ AllocatedStorage: 200 }),
+      emptySchema,
+      riOpts
+    );
+    expect(pathTier(stor, 'AllocatedStorage')).toBe('undeclared');
+
+    // A SG append (a rogue second group) surfaces; the lone default still folds
+    const sg = classifyResource(
+      riResource,
+      riLive({ VpcSecurityGroupIds: ['sg-0394d4b516f73dee8', 'sg-rogue'] }),
+      emptySchema,
+      riOpts
+    );
+    expect(pathTier(sg, 'VpcSecurityGroupIds')).toBe('undeclared');
+  });
+
+  it('AllocatedStorage falls through to undeclared when the class default was not resolved', () => {
+    // gather lookup denied/unavailable → dmsAllocatedStorageDefaults absent → no derived fold
+    const f = classifyResource(riResource, riLive(), emptySchema, {
+      ...riOpts,
+      accountDefaults: {},
+    });
+    expect(pathTier(f, 'AllocatedStorage')).toBe('undeclared');
+  });
+});
+
+describe('#1557 fetchDmsAllocatedStorageDefaults (live wiring)', () => {
+  const dms = mockClient(DatabaseMigrationServiceClient);
+  afterEach(() => dms.reset());
+
+  it('maps each ReplicationInstanceClass to its DefaultAllocatedStorage (paginated)', async () => {
+    dms
+      .on(DescribeOrderableReplicationInstancesCommand)
+      .resolvesOnce({
+        OrderableReplicationInstances: [
+          { ReplicationInstanceClass: 'dms.c6i.large', DefaultAllocatedStorage: 100 },
+          { ReplicationInstanceClass: 'dms.t3.medium', DefaultAllocatedStorage: 50 },
+        ],
+        Marker: 'next',
+      })
+      .resolves({
+        OrderableReplicationInstances: [
+          { ReplicationInstanceClass: 'dms.r5.large', DefaultAllocatedStorage: 100 },
+        ],
+      });
+    const m = await fetchDmsAllocatedStorageDefaults('us-west-1');
+    expect(m).toEqual({
+      'dms.c6i.large': 100,
+      'dms.t3.medium': 50,
+      'dms.r5.large': 100,
+    });
+  });
+
+  it('fails open (returns {}) when the API call throws', async () => {
+    dms.on(DescribeOrderableReplicationInstancesCommand).rejects(new Error('AccessDenied'));
+    const m = await fetchDmsAllocatedStorageDefaults('eu-west-3');
+    expect(m).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1557 — a freshly deployed, un-mutated minimal DMS stack (ReplicationInstance + 2 Endpoints + ReplicationTask, only required props declared) surfaced **14 `[Potential Drift]` entries on a first `check`**. All are AWS-materialized creation defaults the DMS SDK override readers had zero fold coverage for. Now **zero potential drift** — every value folds across the four fold-strategy tiers.

## Folds by tier

| Tier | Property | Mechanism |
| --- | --- | --- |
| 0 generated | `ReplicationInstanceIdentifier` / `EndpointIdentifier` / `ReplicationTaskIdentifier` | `GENERATED_TOPLEVEL_PATHS` — these types' physical id is an ARN, so the generic `isGeneratedName` missed the echoed identifier (the ELBv2 `TargetGroup.Name` gap) |
| 1 constant | `AutoMinorVersionUpgrade`=true, `PubliclyAccessible`=true, `NetworkType`="IPV4" | `KNOWN_DEFAULTS['AWS::DMS::ReplicationInstance']`; the two bools get `MEANINGFUL_WHEN_OFF` companions (RI has **no** snapshot/restore source, so an undeclared `false` is unconditionally an OOB disable) |
| 2 derived | `AllocatedStorage` (dms.c6i.large → 100, not the docs' 50) | `gather.ts` prefetches per-class `DefaultAllocatedStorage` via `dms:DescribeOrderableReplicationInstances` (fail-open, cached); classify equality-gates against the declared class's default |
| 2 derived | `VpcSecurityGroupIds` (VPC default SG) | `DEFAULT_SG_LIST_PATHS` — folds the lone default SG, surfaces an OOB swap/append |
| 3 value-independent | `EngineVersion` (GA moves), `AvailabilityZone`, `PreferredMaintenanceWindow`, `KmsKeyId` (aws/dms), `ReplicationTaskSettings` (full engine-dependent doc) | `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` |

Detection is preserved for every tier-0/1/2 fold: an out-of-band disable, storage change, SG swap/append, or NetworkType/type change still surfaces (asserted in the unit test).

## Live wiring / "corpus-green but live-broken" guard

`accountDefaults.dmsAllocatedStorageDefaults` is threaded through the **corpus recorder** (`src/corpus/record.ts`) so a future RI re-harvest keeps the derived fold, and `AWS::DMS::ReplicationInstance` is registered in `gather.ts` `DEFAULT_SG_LIST_TYPES` so the SG prefetch fires. The `fetchDmsAllocatedStorageDefaults` builder has a dedicated mock test.

## Tests / live evidence

- **5 harvested corpus cases** (RI / 2× Endpoint / Task / SubnetGroup) promoted from the originating live hunt (2026-07-13, us-east-1, v0.16.0) — all now replay to **zero potential drift** (`expected` locked from the actual pipeline output). Sanitized (account `111111111111`, dummy password).
- `tests/dms-first-run-1557.test.ts` — table pins, the clean-instance zero-drift assertion, the detection-preserved OOB direction, and the fetch live wiring.
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5573 tests) all green.
