### PR TITLE
fix(noise): fold first-run FPs for ELBv2 Listener SslPolicy + Glue Crawler policies + IoT TopicRule SQL version (#1559, #1562)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -541,6 +541,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // A listener that declares no mutual-TLS config reads back the "off" default.
     // Observed live on an HTTPS listener.
     MutualAuthentication: { Mode: 'off' },
+    // An HTTPS/TLS listener that declares no SslPolicy reads back the ELBv2 service
+    // default security policy "ELBSecurityPolicy-2016-08" (live-observed on a fresh
+    // 2026-07-13 HTTPS listener; the same default applies to an NLB TLS listener, and
+    // a GWLB / NLB-TCP listener never materializes SslPolicy). Equality-gated, so an
+    // out-of-band ModifyListener to a different policy (e.g. ELBSecurityPolicy-TLS13-
+    // 1-2-2021-06) no longer matches and re-surfaces (live-proven). #1559.
+    SslPolicy: 'ELBSecurityPolicy-2016-08',
   },
   'AWS::EC2::NatGateway': {
     ConnectivityType: 'public',
@@ -1397,6 +1404,15 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // Lake Formation still surfaces.
   'AWS::Glue::Crawler': {
     LakeFormationConfiguration: { AccountId: '', UseLakeFormationCredentials: false },
+    // A crawler that declares no SchemaChangePolicy / RecrawlPolicy reads back Glue's
+    // documented defaults: update-in-database + deprecate-in-database, and recrawl
+    // everything. Whole-object equality-gated, so configuring either (e.g. LOG delete
+    // behavior, or CRAWL_NEW_FOLDERS_ONLY) still surfaces. Observed live (#1562).
+    SchemaChangePolicy: {
+      UpdateBehavior: 'UPDATE_IN_DATABASE',
+      DeleteBehavior: 'DEPRECATE_IN_DATABASE',
+    },
+    RecrawlPolicy: { RecrawlBehavior: 'CRAWL_EVERYTHING' },
   },
   // A config-change-triggered ConfigRule reads back EvaluationModes [{Mode:"DETECTIVE"}]
   // (the default) when the template does not declare it. Observed live on the
@@ -1861,6 +1877,12 @@ export const KNOWN_DEFAULT_ONE_OF_PATHS: Record<string, Record<string, readonly 
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // An IoT TopicRule that declares TopicRulePayload with only Sql + Actions reads back the
+  // default `AwsIotSqlVersion: "2015-10-08"` — the older, stable compat default IoT assigns
+  // when the version is unspecified (NOT a moving GA value). TopicRulePayload is partially
+  // declared, so it is descended and the leaf folds per-leaf. Equality-gated, so a rule that
+  // declares (or is changed out of band to) 2016-03-23 still surfaces. Observed live (#1562).
+  'AWS::IoT::TopicRule': { 'TopicRulePayload.AwsIotSqlVersion': '2015-10-08' },
   // A DataQuality monitoring job whose (partially-declared) input reads back the two
   // AWS-filled transfer defaults the schema documents — `S3DataDistributionType`
   // ("Defaults to FullyReplicated") and `S3InputMode` ("Defaults to File") — under whichever

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.HuntHttpsListener.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.HuntHttpsListener.json
@@ -1,0 +1,187 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1559): fresh minimal HTTPS AWS::ElasticLoadBalancingV2::Listener (Port 443, one cert, fixed-response default action, NO SslPolicy declared). The service-default SslPolicy \"ELBSecurityPolicy-2016-08\" must fold to zero potential drift. A change in expected means the fold semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "HuntHttpsListener",
+    "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-HuntA-Golk3pFIpYJQ/44241ce06ca63b2f/8fb984eef60270b4",
+    "constructPath": "CdkrdHunt0713r2AlbCerts/HuntHttpsListener",
+    "declared": {
+      "Certificates": [
+        {
+          "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/8877b33a-0a0c-4f57-9bf5-43d68eac96df"
+        }
+      ],
+      "DefaultActions": [
+        {
+          "FixedResponseConfig": {
+            "ContentType": "text/plain",
+            "MessageBody": "cdkrd hunt",
+            "StatusCode": "200"
+          },
+          "Type": "fixed-response"
+        }
+      ],
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-HuntA-Golk3pFIpYJQ/44241ce06ca63b2f",
+      "Port": 443,
+      "Protocol": "HTTPS"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-HuntA-Golk3pFIpYJQ/44241ce06ca63b2f/8fb984eef60270b4",
+    "MutualAuthentication": {
+      "Mode": "off"
+    },
+    "ListenerAttributes": [
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_tls_cipher_suite.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_serial_number.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_origin.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.content_security_policy.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_leaf.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_tls_version.header_name"
+      },
+      {
+        "Value": "true",
+        "Key": "routing.http.response.server.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_frame_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_methods.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_issuer.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_validity.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_credentials.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_subject.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_content_type_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_expose_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.strict_transport_security.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_max_age.header_value"
+      }
+    ],
+    "SslPolicy": "ELBSecurityPolicy-2016-08",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-HuntA-Golk3pFIpYJQ/44241ce06ca63b2f",
+    "DefaultActions": [
+      {
+        "FixedResponseConfig": {
+          "ContentType": "text/plain",
+          "StatusCode": "200",
+          "MessageBody": "cdkrd hunt"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "Port": 443,
+    "Certificates": [
+      {
+        "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/8877b33a-0a0c-4f57-9bf5-43d68eac96df"
+      }
+    ],
+    "Protocol": "HTTPS"
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": ["DefaultActions.*.AuthenticateOidcConfig.ClientSecret"],
+    "createOnlyPaths": ["LoadBalancerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "DefaultActions.*.AuthenticateCognitoConfig.AuthenticationRequestExtraParams",
+      "DefaultActions.*.AuthenticateOidcConfig.AuthenticationRequestExtraParams"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpsListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "ListenerAttributes[routing.http.response.server.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-HuntA-Golk3pFIpYJQ/44241ce06ca63b2f/8fb984eef60270b4",
+      "constructPath": "CdkrdHunt0713r2AlbCerts/HuntHttpsListener"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpsListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "MutualAuthentication",
+      "actual": {
+        "Mode": "off"
+      },
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-HuntA-Golk3pFIpYJQ/44241ce06ca63b2f/8fb984eef60270b4",
+      "constructPath": "CdkrdHunt0713r2AlbCerts/HuntHttpsListener"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpsListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "SslPolicy",
+      "actual": "ELBSecurityPolicy-2016-08",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-HuntA-Golk3pFIpYJQ/44241ce06ca63b2f/8fb984eef60270b4",
+      "constructPath": "CdkrdHunt0713r2AlbCerts/HuntHttpsListener"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Crawler.HuntCrawler.json
+++ b/tests/corpus/AWS__Glue__Crawler.HuntCrawler.json
@@ -1,0 +1,137 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1562): fresh minimal AWS::Glue::Crawler (S3 target, no SchemaChangePolicy/RecrawlPolicy declared). Glue materializes the documented default SchemaChangePolicy + RecrawlPolicy which must fold to zero potential drift.",
+  "resource": {
+    "logicalId": "HuntCrawler",
+    "resourceType": "AWS::Glue::Crawler",
+    "physicalId": "HuntCrawler-7ULLvy2R5fPv",
+    "constructPath": "CdkrdHunt0713r2JsonDoc/HuntCrawler",
+    "declared": {
+      "Configuration": "{\"Version\":1,\"CrawlerOutput\":{\"Partitions\":{\"AddOrUpdateBehavior\":\"InheritFromTable\"}}}",
+      "DatabaseName": "cdkrd_hunt_db",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0713r2JsonDoc-HuntGlueRole-prdIcxQtJ9ir",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Targets": {
+        "S3Targets": [
+          {
+            "Path": "s3://cdkrdhunt0713r2jsondoc-huntcrawlbucket-xeniddvwohrj/data/"
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "Role": "CdkrdHunt0713r2JsonDoc-HuntGlueRole-prdIcxQtJ9ir",
+    "Classifiers": [],
+    "SchemaChangePolicy": {
+      "UpdateBehavior": "UPDATE_IN_DATABASE",
+      "DeleteBehavior": "DEPRECATE_IN_DATABASE"
+    },
+    "Configuration": "{\"Version\":1.0,\"CrawlerOutput\":{\"Partitions\":{\"AddOrUpdateBehavior\":\"InheritFromTable\"}}}",
+    "LakeFormationConfiguration": {
+      "AccountId": "",
+      "UseLakeFormationCredentials": false
+    },
+    "RecrawlPolicy": {
+      "RecrawlBehavior": "CRAWL_EVERYTHING"
+    },
+    "DatabaseName": "cdkrd_hunt_db",
+    "Targets": {
+      "HudiTargets": [],
+      "S3Targets": [
+        {
+          "Path": "s3://cdkrdhunt0713r2jsondoc-huntcrawlbucket-xeniddvwohrj/data/",
+          "Exclusions": []
+        }
+      ],
+      "CatalogTargets": [],
+      "DeltaTargets": [],
+      "MongoDBTargets": [],
+      "JdbcTargets": [],
+      "DynamoDBTargets": [],
+      "IcebergTargets": []
+    },
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "Name": "HuntCrawler-7ULLvy2R5fPv"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCrawler",
+      "resourceType": "AWS::Glue::Crawler",
+      "path": "LakeFormationConfiguration",
+      "actual": {
+        "AccountId": "",
+        "UseLakeFormationCredentials": false
+      },
+      "physicalId": "HuntCrawler-7ULLvy2R5fPv",
+      "constructPath": "CdkrdHunt0713r2JsonDoc/HuntCrawler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCrawler",
+      "resourceType": "AWS::Glue::Crawler",
+      "path": "RecrawlPolicy",
+      "actual": {
+        "RecrawlBehavior": "CRAWL_EVERYTHING"
+      },
+      "physicalId": "HuntCrawler-7ULLvy2R5fPv",
+      "constructPath": "CdkrdHunt0713r2JsonDoc/HuntCrawler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntCrawler",
+      "resourceType": "AWS::Glue::Crawler",
+      "path": "SchemaChangePolicy",
+      "actual": {
+        "UpdateBehavior": "UPDATE_IN_DATABASE",
+        "DeleteBehavior": "DEPRECATE_IN_DATABASE"
+      },
+      "physicalId": "HuntCrawler-7ULLvy2R5fPv",
+      "constructPath": "CdkrdHunt0713r2JsonDoc/HuntCrawler"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IoT__TopicRule.HuntTopicRule.json
+++ b/tests/corpus/AWS__IoT__TopicRule.HuntTopicRule.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (hunt 2026-07-13, #1562): fresh minimal AWS::IoT::TopicRule (TopicRulePayload with only Sql + one Action). The default AwsIotSqlVersion \"2015-10-08\" must fold to zero potential drift (nested per-leaf under the partially-declared TopicRulePayload).",
+  "resource": {
+    "logicalId": "HuntTopicRule",
+    "resourceType": "AWS::IoT::TopicRule",
+    "physicalId": "HuntTopicRule_qcEJ4WbkWaoh",
+    "constructPath": "CdkrdHunt0713r2JsonDoc/HuntTopicRule",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TopicRulePayload": {
+        "Actions": [
+          {
+            "CloudwatchLogs": {
+              "LogGroupName": "CdkrdHunt0713r2JsonDoc-HuntIotLg-szXXPa2PrGW3",
+              "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0713r2JsonDoc-HuntIotRole-nfbCIwRXVh13"
+            }
+          }
+        ],
+        "Sql": "SELECT * FROM 'cdkrd/hunt'"
+      }
+    }
+  },
+  "liveRaw": {
+    "TopicRulePayload": {
+      "RuleDisabled": false,
+      "AwsIotSqlVersion": "2015-10-08",
+      "Actions": [
+        {
+          "CloudwatchLogs": {
+            "LogGroupName": "CdkrdHunt0713r2JsonDoc-HuntIotLg-szXXPa2PrGW3",
+            "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0713r2JsonDoc-HuntIotRole-nfbCIwRXVh13"
+          }
+        }
+      ],
+      "Sql": "SELECT * FROM 'cdkrd/hunt'"
+    },
+    "Arn": "arn:aws:iot:us-east-1:111111111111:rule/HuntTopicRule_qcEJ4WbkWaoh",
+    "RuleName": "HuntTopicRule_qcEJ4WbkWaoh",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["RuleName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RuleName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "TopicRulePayload.Actions.*.Kafka.ClientProperties",
+      "TopicRulePayload.ErrorAction.Kafka.ClientProperties"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTopicRule",
+      "resourceType": "AWS::IoT::TopicRule",
+      "path": "TopicRulePayload.AwsIotSqlVersion",
+      "actual": "2015-10-08",
+      "nested": true,
+      "physicalId": "HuntTopicRule_qcEJ4WbkWaoh",
+      "constructPath": "CdkrdHunt0713r2JsonDoc/HuntTopicRule"
+    }
+  ]
+}

--- a/tests/first-run-elb-glue-iot-1559.test.ts
+++ b/tests/first-run-elb-glue-iot-1559.test.ts
@@ -1,0 +1,129 @@
+// #1559 + #1562 — three first-run FP folds (all tier-1 equality-gated service defaults):
+//   #1559 ELBv2 Listener.SslPolicy = "ELBSecurityPolicy-2016-08" (HTTPS/TLS listener default)
+//   #1562 Glue Crawler.SchemaChangePolicy / .RecrawlPolicy (documented Glue defaults)
+//   #1562 IoT TopicRule.TopicRulePayload.AwsIotSqlVersion = "2015-10-08" (nested per-leaf)
+// The end-to-end folds are locked by the golden corpus cases; these pin the table entries and
+// prove detection is PRESERVED (a change away from each default still surfaces).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { KNOWN_DEFAULTS, KNOWN_DEFAULT_PATHS } from '../src/normalize/noise.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierOf = (fs: Finding[], path: string) => fs.find((f) => f.path === path)?.tier;
+
+describe('#1559/#1562 first-run default folds', () => {
+  it('table entries are present', () => {
+    expect(KNOWN_DEFAULTS['AWS::ElasticLoadBalancingV2::Listener'].SslPolicy).toBe(
+      'ELBSecurityPolicy-2016-08'
+    );
+    expect(KNOWN_DEFAULTS['AWS::Glue::Crawler'].SchemaChangePolicy).toEqual({
+      UpdateBehavior: 'UPDATE_IN_DATABASE',
+      DeleteBehavior: 'DEPRECATE_IN_DATABASE',
+    });
+    expect(KNOWN_DEFAULTS['AWS::Glue::Crawler'].RecrawlPolicy).toEqual({
+      RecrawlBehavior: 'CRAWL_EVERYTHING',
+    });
+    expect(KNOWN_DEFAULT_PATHS['AWS::IoT::TopicRule']['TopicRulePayload.AwsIotSqlVersion']).toBe(
+      '2015-10-08'
+    );
+  });
+
+  it('Listener SslPolicy: default folds, an out-of-band policy change surfaces', () => {
+    const res: DesiredResource = {
+      logicalId: 'L',
+      resourceType: 'AWS::ElasticLoadBalancingV2::Listener',
+      physicalId: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/x/y/z',
+      declared: { Port: 443, Protocol: 'HTTPS' },
+    };
+    expect(
+      tierOf(
+        classifyResource(res, { SslPolicy: 'ELBSecurityPolicy-2016-08' }, emptySchema),
+        'SslPolicy'
+      )
+    ).toBe('atDefault');
+    expect(
+      tierOf(
+        classifyResource(res, { SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06' }, emptySchema),
+        'SslPolicy'
+      )
+    ).toBe('undeclared');
+  });
+
+  it('Glue Crawler policies: defaults fold, an out-of-band behavior change surfaces', () => {
+    const res: DesiredResource = {
+      logicalId: 'C',
+      resourceType: 'AWS::Glue::Crawler',
+      physicalId: 'huntcrawler',
+      declared: { Role: 'r', DatabaseName: 'db' },
+    };
+    const clean = classifyResource(
+      res,
+      {
+        SchemaChangePolicy: {
+          UpdateBehavior: 'UPDATE_IN_DATABASE',
+          DeleteBehavior: 'DEPRECATE_IN_DATABASE',
+        },
+        RecrawlPolicy: { RecrawlBehavior: 'CRAWL_EVERYTHING' },
+      },
+      emptySchema
+    );
+    expect(tierOf(clean, 'SchemaChangePolicy')).toBe('atDefault');
+    expect(tierOf(clean, 'RecrawlPolicy')).toBe('atDefault');
+    // an out-of-band delete-behavior change (LOG) no longer matches the whole-object default
+    const changed = classifyResource(
+      res,
+      {
+        SchemaChangePolicy: { UpdateBehavior: 'UPDATE_IN_DATABASE', DeleteBehavior: 'LOG' },
+        RecrawlPolicy: { RecrawlBehavior: 'CRAWL_NEW_FOLDERS_ONLY' },
+      },
+      emptySchema
+    );
+    expect(tierOf(changed, 'SchemaChangePolicy')).toBe('undeclared');
+    expect(tierOf(changed, 'RecrawlPolicy')).toBe('undeclared');
+  });
+
+  it('IoT TopicRule AwsIotSqlVersion: default folds, a version change surfaces', () => {
+    const res: DesiredResource = {
+      logicalId: 'T',
+      resourceType: 'AWS::IoT::TopicRule',
+      physicalId: 'huntrule',
+      // TopicRulePayload partially declared (Sql + Actions) so it is descended per-leaf
+      declared: { TopicRulePayload: { Sql: "SELECT * FROM 'x'", Actions: [{ Republish: {} }] } },
+    };
+    const clean = classifyResource(
+      res,
+      {
+        TopicRulePayload: {
+          Sql: "SELECT * FROM 'x'",
+          Actions: [{ Republish: {} }],
+          AwsIotSqlVersion: '2015-10-08',
+        },
+      },
+      emptySchema
+    );
+    expect(tierOf(clean, 'TopicRulePayload.AwsIotSqlVersion')).toBe('atDefault');
+    const changed = classifyResource(
+      res,
+      {
+        TopicRulePayload: {
+          Sql: "SELECT * FROM 'x'",
+          Actions: [{ Republish: {} }],
+          AwsIotSqlVersion: '2016-03-23',
+        },
+      },
+      emptySchema
+    );
+    expect(tierOf(changed, 'TopicRulePayload.AwsIotSqlVersion')).toBe('undeclared');
+  });
+});


### PR DESCRIPTION
## Summary

Bundles two `fix(noise)` issues (both land in `KNOWN_DEFAULTS`/`KNOWN_DEFAULT_PATHS`, so one lane): three first-run false positives on freshly deployed, un-mutated resources, all **tier-1 equality-gated service defaults**.

| Issue | Property | Default folded |
| --- | --- | --- |
| #1559 | `AWS::ElasticLoadBalancingV2::Listener.SslPolicy` | `ELBSecurityPolicy-2016-08` (HTTPS/TLS listener default; NLB TLS same; GWLB/NLB-TCP never materialize it) |
| #1562 | `AWS::Glue::Crawler.SchemaChangePolicy` | `{UPDATE_IN_DATABASE, DEPRECATE_IN_DATABASE}` |
| #1562 | `AWS::Glue::Crawler.RecrawlPolicy` | `{CRAWL_EVERYTHING}` |
| #1562 | `AWS::IoT::TopicRule.TopicRulePayload.AwsIotSqlVersion` | `2015-10-08` (nested per-leaf, partially-declared payload) |

All equality-gated → an out-of-band change away from any default still surfaces (asserted in the unit test; the SslPolicy detection direction was live-proven in the originating hunt).

## Tests / live evidence

- 3 harvested corpus cases (from the live hunt, 2026-07-13, us-east-1, v0.16.0) promoted — all now replay to **zero potential drift** (`expected` locked from the actual pipeline output).
- `tests/first-run-elb-glue-iot-1559.test.ts` — table pins + the fold/detection-preserved direction for each.
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5580 tests) all green.

Closes #1559, closes #1562.
