### PR TITLE
docs(readme): document adopting drift into CDK code via --pre-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,34 @@ result: 1 drift(s) (undeclared=1)
 `record` covers live-only state only, not a `[CFn-Declared Drift]`; the other
 verbs are in [The model](#the-model-one-verb-you-run-three-it-offers).
 
+### Fixing it in code instead
+
+record / revert / ignore all treat your CDK code as fixed. The fourth remedy —
+often the right one for a change you want to _keep_ — is to **adopt the drift
+into your CDK code**: if someone bumped a Lambda's memory to 2048 during an
+incident and that's simply correct now, declare it.
+
+[`--pre-deploy`](#--pre-deploy) is the verification loop for that edit, because
+it compares live state against your **local synth** instead of the deployed
+template:
+
+```console
+$ npx cdkrd check                # 1. drift: Handler.MemorySize desired=1024 actual=2048
+# 2. the live value is right → set memorySize: 2048 in your CDK code
+$ npx cdkrd check --pre-deploy   # 3. finding gone: local code now matches reality
+$ npx cdk deploy                 # 4. now a no-op for that property — nothing clobbered
+$ npx cdkrd check                # 5. clean against the updated deployed template
+```
+
+If step 3 still shows the finding, your code doesn't match live yet (`desired`
+is what your code would set) — fix and re-run before deploying. The deploy in
+step 4 is what updates the **deployed** template to declare the value, so the
+day-to-day `check` (which compares against it) comes back clean in step 5.
+
+This also works for a `[Potential / CFn-Undeclared Drift]` value you'd rather
+own in code than `record`: declaring the property moves it into the declared
+tier, and step 3 confirms your declaration matches what's live.
+
 ### In CI
 
 Run `npx cdkrd check --fail`. It's read-only, never prompts, and exits 1 on drift;
@@ -501,8 +529,9 @@ result: 1 drift(s) (declared=1)
 ```
 
 `desired` is what your local code is about to set; `actual` is live now: someone
-bumped memory to 2048 out of band. Port it into code (or decide it should go away)
-before deploying. As a pipeline gate:
+bumped memory to 2048 out of band. Port it into code (the step-by-step loop is in
+[Fixing it in code instead](#fixing-it-in-code-instead)) or decide it should go
+away before deploying. As a pipeline gate:
 
 ```yaml
 - run: npx cdkrd check --pre-deploy --fail # block the deploy on clobber risk


### PR DESCRIPTION
## Summary

- Add a **"Fixing it in code instead"** subsection to README's "How to use", documenting the fourth drift remedy alongside record / revert / ignore: adopting a drifted value you want to keep into your CDK code.
- Show the 5-step verification loop built around `--pre-deploy`:
  1. `cdkrd check` finds the drift
  2. edit the CDK code to declare the live value
  3. `cdkrd check --pre-deploy` verifies the local synth now matches reality (nothing will be clobbered)
  4. `cdk deploy` — a no-op for the property, but it updates the **deployed** template to declare the value
  5. `cdkrd check` is clean against the updated deployed template
- Note that the same loop promotes a `[Potential / CFn-Undeclared Drift]` value into the declared tier for users who would rather own it in code than `record` it.
- Cross-link the new section from the existing `--pre-deploy` section's "Port it into code" sentence.

## Why

This remedy was only hinted at in two places ("without editing code" in the model section, "Port it into code" under `--pre-deploy`) with no procedure, even though record / revert / ignore each have one. `--pre-deploy` is exactly the tool that verifies such a code edit before deploying, so the two belong together.

## Verification

- Docs-only change (no `src/**`): `/check` (typecheck, lint+format, build, 5466 unit tests) and `/check-docs` pass; markers set.
- New section's claims match the documented `--pre-deploy` semantics (local-synth comparison, declared-only, baseline untouched) and reuse the existing MemorySize 1024→2048 example for continuity.
