### PR TITLE
feat(read): SDK override reader for AWS::ElasticLoadBalancingV2::ListenerCertificate (#1560)

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,14 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   undeclared `RecordingGroup.RecordingStrategy` mirror and `RecordingMode` default
   fold to atDefault, so a fresh recorder is clean while a recording-scope change
   still surfaces),
+  `elasticloadbalancing:DescribeListenerCertificates` (reads an
+  `AWS::ElasticLoadBalancingV2::ListenerCertificate` — the SNI extra-cert
+  attachment whose registry type ships NO read handler at all, so Cloud Control
+  returns `UnsupportedActionException` and it was silently skipped; the reader
+  derives the listener ARN from the declared `ListenerArn` and projects this
+  resource's declared certs still present in the live non-default set, so a
+  declared cert removed out of band surfaces as drift while multiple attachments
+  on one listener stay false-positive-free),
   `ssm:DescribeParameters` (supplements the Cloud Control read of an
   `AWS::SSM::Parameter` with its writeOnly `Description` / `AllowedPattern`),
   `elasticache:DescribeReplicationGroups` + `elasticache:DescribeCacheClusters`

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -138,6 +138,7 @@ import {
   DescribeDeliveryChannelsCommand,
 } from '@aws-sdk/client-config-service';
 import {
+  DescribeListenerCertificatesCommand,
   ElasticLoadBalancingV2Client,
   GetTrustStoreCaCertificatesBundleCommand,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
@@ -3296,7 +3297,63 @@ const readConfigDeliveryChannel: OverrideReader = async ({ physicalId, region })
   return model;
 };
 
+// AWS::ElasticLoadBalancingV2::ListenerCertificate — the registry schema has NO handlers at all
+// (`describe-type` → Schema.handlers absent), so Cloud Control throws UnsupportedActionException and
+// the resource is silently Skipped (#1560). The CFn physical id is a composite, NOT the listener
+// ARN, so the reader derives the listener ARN from the resolved declared `ListenerArn` and reads the
+// live cert set via elbv2:DescribeListenerCertificates.
+//
+// SCOPING (FP-safe): DescribeListenerCertificates returns the listener's FULL cert set including its
+// DEFAULT cert (IsDefault=true) and EVERY extra (SNI) cert — and multiple ListenerCertificate
+// resources can target one listener, so echoing the whole live set per resource would false-positive
+// (each resource declares only its own subset). The model therefore projects ONLY this resource's
+// DECLARED certs that are still present in the live NON-DEFAULT set (declared ∩ live) — so a clean
+// deploy folds, and a declared cert REMOVED out of band (`elbv2 remove-listener-certificates`) drops
+// from the model and surfaces as declared drift. Detecting an ADDED rogue cert is deferred to a
+// CHILD_ENUMERATORS follow-up (the `added` tier), which the issue notes is the right home for it.
+const declaredCertArns = (declared: Record<string, unknown>): string[] => {
+  const list = Array.isArray(declared.Certificates) ? declared.Certificates : [];
+  const arns: string[] = [];
+  for (const c of list) {
+    const arn =
+      c && typeof c === 'object' ? str((c as Record<string, unknown>).CertificateArn) : undefined;
+    if (arn) arns.push(arn);
+  }
+  return arns;
+};
+const readElbv2ListenerCertificate: OverrideReader = async ({ declared, region }) => {
+  const listenerArn = str(declared.ListenerArn);
+  if (!listenerArn) return undefined; // unresolved parent ref → skip (unchanged behavior)
+  const c = new ElasticLoadBalancingV2Client({ region, ...READ_RETRY });
+  // PAGINATE: a listener can hold many certs; reading only page 1 could misread a PRESENT cert (on a
+  // later page) as absent → a FALSE removal. Follow Marker until exhausted.
+  const liveNonDefault = new Set<string>();
+  let marker: string | undefined;
+  do {
+    const r = await c.send(
+      new DescribeListenerCertificatesCommand({ ListenerArn: listenerArn, Marker: marker })
+    );
+    for (const cert of r.Certificates ?? []) {
+      if (cert.IsDefault !== true && str(cert.CertificateArn)) {
+        liveNonDefault.add(cert.CertificateArn as string);
+      }
+    }
+    marker = r.NextMarker;
+  } while (marker);
+  const model: Record<string, unknown> = {};
+  // Echo the parent listener arn (declared, resolved) so a declared ListenerArn compares rather than
+  // read-gapping — the describe call is scoped to it, so it is authoritative.
+  model.ListenerArn = listenerArn;
+  // Project this resource's declared certs that are still attached (live non-default set). Order-
+  // preserving against the declared list so the array compare is stable.
+  model.Certificates = declaredCertArns(declared)
+    .filter((arn) => liveNonDefault.has(arn))
+    .map((arn) => ({ CertificateArn: arn }));
+  return model;
+};
+
 export const SDK_OVERRIDES: Record<string, OverrideReader> = {
+  'AWS::ElasticLoadBalancingV2::ListenerCertificate': readElbv2ListenerCertificate,
   'AWS::CertificateManager::Certificate': readAcmCertificate,
   'AWS::SES::ReceiptRuleSet': readSesReceiptRuleSet,
   'AWS::SES::ReceiptRule': readSesReceiptRule,

--- a/tests/listenercertificate-reader-1560.test.ts
+++ b/tests/listenercertificate-reader-1560.test.ts
@@ -1,0 +1,104 @@
+// #1560 — AWS::ElasticLoadBalancingV2::ListenerCertificate has NO registry read handler, so Cloud
+// Control throws UnsupportedActionException and the resource is silently Skipped. This SDK override
+// reads elbv2:DescribeListenerCertificates (deriving the listener ARN from the declared ListenerArn)
+// and projects ONLY this resource's DECLARED certs that are still in the live NON-DEFAULT set
+// (FP-safe when multiple ListenerCertificate resources target one listener). A declared cert removed
+// out of band drops from the model → declared drift; the listener's default cert is excluded.
+import {
+  DescribeListenerCertificatesCommand,
+  ElasticLoadBalancingV2Client,
+} from '@aws-sdk/client-elastic-load-balancing-v2';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+const elbv2 = mockClient(ElasticLoadBalancingV2Client);
+
+const LARN = 'arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/HuntAlb/abc/def';
+const A = 'arn:aws:acm:us-east-1:111111111111:certificate/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const B = 'arn:aws:acm:us-east-1:111111111111:certificate/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const C = 'arn:aws:acm:us-east-1:111111111111:certificate/cccccccc-cccc-cccc-cccc-cccccccccccc';
+const DEFAULT_CERT =
+  'arn:aws:acm:us-east-1:111111111111:certificate/dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+const ctx = (declared: Record<string, unknown>, physicalId = 'lc-composite-id') => ({
+  physicalId,
+  declared,
+  region: 'us-east-1',
+  accountId: '111111111111',
+});
+const read = (c: ReturnType<typeof ctx>) =>
+  SDK_OVERRIDES['AWS::ElasticLoadBalancingV2::ListenerCertificate'](c);
+
+beforeEach(() => elbv2.reset());
+
+describe('AWS::ElasticLoadBalancingV2::ListenerCertificate SDK override (#1560)', () => {
+  it('projects the declared extra cert(s), echoes ListenerArn, excludes the default cert', async () => {
+    elbv2.on(DescribeListenerCertificatesCommand).resolves({
+      Certificates: [
+        { CertificateArn: DEFAULT_CERT, IsDefault: true },
+        { CertificateArn: A, IsDefault: false },
+      ],
+    });
+    const out = await read(ctx({ ListenerArn: LARN, Certificates: [{ CertificateArn: A }] }));
+    expect(out).toEqual({ ListenerArn: LARN, Certificates: [{ CertificateArn: A }] });
+    // scoped to the derived listener ARN
+    expect(elbv2.commandCalls(DescribeListenerCertificatesCommand)[0].args[0].input).toEqual({
+      ListenerArn: LARN,
+      Marker: undefined,
+    });
+  });
+
+  it('drops a declared cert that was removed out of band (→ surfaces as declared drift)', async () => {
+    // declared [A,B] but live non-default only has A (B removed via remove-listener-certificates)
+    elbv2.on(DescribeListenerCertificatesCommand).resolves({
+      Certificates: [
+        { CertificateArn: DEFAULT_CERT, IsDefault: true },
+        { CertificateArn: A, IsDefault: false },
+      ],
+    });
+    const out = await read(
+      ctx({ ListenerArn: LARN, Certificates: [{ CertificateArn: A }, { CertificateArn: B }] })
+    );
+    expect(out).toEqual({ ListenerArn: LARN, Certificates: [{ CertificateArn: A }] });
+  });
+
+  it('is FP-safe when multiple ListenerCertificate resources target one listener', async () => {
+    // this resource declares only A; the live listener also carries B + C (other resources / OOB)
+    elbv2.on(DescribeListenerCertificatesCommand).resolves({
+      Certificates: [
+        { CertificateArn: DEFAULT_CERT, IsDefault: true },
+        { CertificateArn: A, IsDefault: false },
+        { CertificateArn: B, IsDefault: false },
+        { CertificateArn: C, IsDefault: false },
+      ],
+    });
+    const out = await read(ctx({ ListenerArn: LARN, Certificates: [{ CertificateArn: A }] }));
+    // only A (declared ∩ live) — B/C are NOT attributed to this resource, so no false positive
+    expect(out).toEqual({ ListenerArn: LARN, Certificates: [{ CertificateArn: A }] });
+  });
+
+  it('paginates the Marker so a cert on a later page is not misread as removed', async () => {
+    elbv2
+      .on(DescribeListenerCertificatesCommand)
+      .resolvesOnce({
+        Certificates: [{ CertificateArn: A, IsDefault: false }],
+        NextMarker: 'page2',
+      })
+      .resolves({ Certificates: [{ CertificateArn: B, IsDefault: false }] });
+    const out = await read(
+      ctx({ ListenerArn: LARN, Certificates: [{ CertificateArn: A }, { CertificateArn: B }] })
+    );
+    expect(out).toEqual({
+      ListenerArn: LARN,
+      Certificates: [{ CertificateArn: A }, { CertificateArn: B }],
+    });
+    expect(elbv2.commandCalls(DescribeListenerCertificatesCommand)).toHaveLength(2);
+  });
+
+  it('returns undefined (skip) when the declared ListenerArn is unresolved', async () => {
+    const out = await read(ctx({ Certificates: [{ CertificateArn: A }] }));
+    expect(out).toBeUndefined();
+    expect(elbv2.commandCalls(DescribeListenerCertificatesCommand)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1560 — `AWS::ElasticLoadBalancingV2::ListenerCertificate` (the SNI extra-cert attachment for an HTTPS/TLS listener) has **no registry read handler at all**, so Cloud Control throws `UnsupportedActionException` and the resource was silently **Skipped** on every check — the declared `Certificates` were never verified and an out-of-band `remove-listener-certificates` was invisible.

## Reader

Adds an `elbv2:DescribeListenerCertificates` SDK override (`src/read/overrides.ts`):

- Derives the listener ARN from the **resolved declared `ListenerArn`** (the CFn physical id is a composite, not the listener ARN); paginates the `Marker`.
- **FP-safe scoping:** `DescribeListenerCertificates` returns the listener's FULL cert set (default + every extra), and multiple ListenerCertificate resources can target one listener, so the model projects ONLY this resource's DECLARED certs still present in the live **non-default** set (`declared ∩ live`). A clean deploy folds; a declared cert removed out of band drops from the model → **declared drift**. The listener's default cert (`IsDefault=true`) is excluded. Detecting an ADDED rogue cert is deferred to a `CHILD_ENUMERATORS` follow-up (the `added` tier), which the issue notes is its right home.

## Live-verified (both directions)

Deployed `Cdkrd1560LcVerify` (internal ALB + HTTPS listener + 2 imported self-signed certs, us-east-1):
- Fresh deploy → `HuntExtraCert` is now **READ, not Skipped**, and CLEAN (no UnsupportedActionException in the output).
- `aws elbv2 remove-listener-certificates` (drop the extra cert) → `[CFn-Declared Drift: 1] HuntExtraCert.Certificates`, exit 1.
- Torn down (`delstack` + ACM cert deletes); `sweep-orphans.sh` → SWEEP CLEAN.

## Tests / docs

- `tests/listenercertificate-reader-1560.test.ts` — mocked-client unit tests: declared projection + default-cert exclusion, out-of-band removal, multi-resource FP-safety, `Marker` pagination, unresolved-`ListenerArn` skip.
- README: documents the `elasticloadbalancing:DescribeListenerCertificates` read permission.
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (5585 tests) all green.

Closes #1560.
