### PR TITLE
fix: fold barest Glue Job first-run FPs and fix Glue capacity-echo + ApiGatewayV2 SelectionExpression revert failures

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -538,6 +538,25 @@ Recorded]` breakdown with `--verbose`.
   readSageMakerMonitoringSchedule had already fixed exactly that (#1523) — the fix
   existed one function away. A physical-id shape is per-type but the MISTAKE is
   per-family; audit siblings before shipping a one-type fix.
+- **A revert bug's fix belongs in the route the plan ACTUALLY takes — check
+  `SDK_WRITERS[type]` FIRST.** A type with an SDK writer never sends the CC patch, so
+  a fix in the CC augmentation path (`augmentCcItemOps` strips) is dead code for it.
+  The #1568 Glue capacity-echo failure was first "fixed" in the CC layer before
+  discovering `writeGlueJob` existed — the real bug was the writer's non-WorkerType
+  branch re-sending BOTH GetJob capacity echoes. Corollary: a writer's unit-test mock
+  must mirror the REAL read echo shape (the old test's GetJob mock omitted the dual
+  `MaxCapacity`+`AllocatedCapacity` echo, so the always-failing branch looked green);
+  copy the mock model from a live read, not from the declared template.
+- **Post-update echo materialization is its own FP class — probe it with a neutral
+  update.** A clean FIRST-run check proves nothing about the post-update echo
+  surface: Glue normalizes sizing on EVERY UpdateJob (including a CFn stack update),
+  so undeclared `WorkerType`/`NumberOfWorkers` materialized out of nowhere after an
+  update that never mentioned them (#1569) — and the pair is irremovable (a `remove`
+  revert is a structural no-op). After the first-run check, run ANY update against
+  the resource (a service update API call or a trivial template change) and re-check:
+  every newly materialized undeclared field is a latent FP a real user hits on their
+  second deploy. Fold it with the same decision order (the sizing pair joined the
+  existing value-independent MaxCapacity trio).
 - **Immutable props can't drift.** Don't treat an `unresolved`/unverifiable
   create-only property (Subnet `AvailabilityZone` via `Fn::Select(Fn::GetAZs)`, NAT
   `AllocationId` via `Fn::GetAtt` EIP) as a bug — it's correctly classified. And

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1254,10 +1254,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Glue::Job': {
     JobMode: 'SCRIPT',
     MaxRetries: 0,
-    // A job that declares neither reads back Glue's constant defaults: a 2880-minute
-    // (48h) timeout and single-concurrency execution. Equality-gated: a custom timeout or
-    // concurrency no longer matches and surfaces.
-    Timeout: 2880,
+    // A job that declares no ExecutionProperty reads back Glue's constant single-concurrency
+    // default. Equality-gated: a custom concurrency no longer matches and surfaces.
+    // (Timeout — 2880 for jobs created in the 48h-default era, 480 for new jobs after AWS
+    // moved the create-time default — is era-dependent → KNOWN_DEFAULT_ONE_OF, #1566.)
     ExecutionProperty: { MaxConcurrentRuns: 1 },
   },
   // #653 corpus-mining batch — constant service defaults on clean deploys of covered types.
@@ -1795,6 +1795,16 @@ export const KNOWN_DEFAULT_ONE_OF: Record<string, Record<string, readonly unknow
   'AWS::SecurityHub::Hub': {
     ControlFindingGenerator: ['SECURITY_CONTROL', 'STANDARD_CONTROL'],
   },
+  // #1566: a Glue job that declares no Timeout reads back the create-time default, and AWS
+  // MOVED that default: jobs created in the original era read 2880 (48h), a fresh minimal
+  // glueetl job now reads 480 (live-proven 2026-07-13). Both are stable constants but the
+  // discriminator — when the job was created — is off the resource's model (the same era class
+  // as SecurityHub above / S3 TransitionDefaultMinimumObjectSize, #1249). Folding the set keeps
+  // clean jobs of either era at zero first-run drift; a user who DECLARES a timeout is compared
+  // in the declared dimension, and any THIRD value (a real out-of-band change) still surfaces.
+  'AWS::Glue::Job': {
+    Timeout: [2880, 480],
+  },
 };
 
 // The NESTED-path twin of KNOWN_DEFAULT_ONE_OF (#979): a nested undeclared value whose AWS
@@ -2160,6 +2170,14 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // (true) for EVERY container. Equality-gated: a container that sets Essential: false
     // no longer matches and surfaces, and an out-of-band change still surfaces. #711.
     'ContainerDefinitions.*.Essential': true,
+  },
+  'AWS::Glue::Job': {
+    // A glueetl job that declares no Command.PythonVersion reads back the vestigial stored
+    // constant "2" — even on a Glue 5.x job whose actual runtime is Python 3; the echo is a
+    // legacy stored marker, not the running interpreter. Equality-gated: a declared version is
+    // compared in the declared loop, and an out-of-band change away from "2" surfaces. #1566,
+    // live-proven on a barest glueetl job 2026-07-13.
+    'Command.PythonVersion': '2',
   },
   'AWS::Glue::Database': {
     'DatabaseInput.CreateTableDefaultPermissions': [
@@ -3584,7 +3602,30 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   value-independent so every DPU value folds without a table (a job that instead DECLARES
   //   MaxCapacity — a Python-shell job — goes through the declared loop, compared). Observed live
   //   first-run on my-app-Exporter (five G.1X ETL jobs + one G.025X streaming job), no edit.
-  'AWS::Glue::Job': new Set(['MaxCapacity', 'AllocatedCapacity']),
+  //   AWS::Glue::Job.GlueVersion — a job that declares no GlueVersion reads back the current GA
+  //   version AWS assigns at creation ("5.1" today), which AWS advances over time (4.0 → 5.0 →
+  //   5.1 …) — the GA-engine-version class: not a constant we can pin, not derivable from the
+  //   declared inputs. Undeclared → the user delegated the version to AWS, so whatever it
+  //   assigned is not user intent; a user who cares DECLARES GlueVersion (the existing corpus
+  //   case does exactly that), which is then compared in the declared loop. #1566, live-proven
+  //   on a barest glueetl job 2026-07-13.
+  //   AWS::Glue::Job.WorkerType / .NumberOfWorkers — the OTHER HALF of the sizing-echo set
+  //   (#1569): the service normalizes a job's capacity to the modern representation on EVERY
+  //   UpdateJob — including the one a normal CloudFormation stack update performs — so an
+  //   undeclared WorkerType/NumberOfWorkers pair materializes out of nowhere after any update
+  //   (live-proven 2026-07-13: a barest job reads back neither; both appeared right after an
+  //   update-job that did not mention them). The trio (MaxCapacity/AllocatedCapacity/
+  //   WorkerType/NumberOfWorkers) is ONE service-normalized sizing; folding the pair loses no
+  //   detection the MaxCapacity fold above has not already traded away, and it is irremovable
+  //   anyway (a `remove` revert is a structural no-op — the sizing cannot be unset). A user
+  //   who cares DECLARES the sizing, compared in the declared loop.
+  'AWS::Glue::Job': new Set([
+    'MaxCapacity',
+    'AllocatedCapacity',
+    'GlueVersion',
+    'WorkerType',
+    'NumberOfWorkers',
+  ]),
   //   AWS::EC2::SecurityGroupIngress.SourceSecurityGroupName / ::SecurityGroupEgress
   //   .DestinationSecurityGroupName — a rule that references its peer group by id
   //   (`SourceSecurityGroupId` / `DestinationSecurityGroupId`, the CDK default) declares no peer

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -357,6 +357,15 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // Live-proven 2026-07-12: an out-of-band query-ttl-millis=60000 was detected but the
   // `remove` revert failed with "cannot be cleared"; the set-default write converges.
   'AWS::DAX::ParameterGroup\0ParameterNameValues',
+  // #1567: the ApiGatewayV2 Response-type update handlers keep an omitted
+  // *SelectionExpression — a bare `remove` revert of an out-of-band expression reports
+  // SUCCESS yet the live value persists (live-proven on a WebSocket API 2026-07-13:
+  // TemplateSelectionExpression "200" and ModelSelectionExpression "huntexpr" both survived
+  // a `remove`). Writing an explicit empty string clears the value to null (also
+  // live-proven), so revert as a set-'' — the value comes from REVERT_SET_DEFAULT_VALUES
+  // (the fields default to ABSENT, so KNOWN_DEFAULTS has no source).
+  'AWS::ApiGatewayV2::IntegrationResponse\0TemplateSelectionExpression',
+  'AWS::ApiGatewayV2::RouteResponse\0ModelSelectionExpression',
 ]);
 
 // Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant
@@ -374,6 +383,10 @@ const REVERT_SET_DEFAULT_VALUES: Record<string, unknown> = {
   // (no KNOWN_DEFAULTS source); its revert set-default value is the plain constant `false` so
   // the endpoint patch keeps both access flags (EKS rejects a partial endpoint update).
   'AWS::EKS::Cluster\0ResourcesVpcConfig.EndpointPrivateAccess': false,
+  // #1567: an explicit '' clears an ApiGatewayV2 *SelectionExpression the provider refuses
+  // to reset on absence (both fields default to absent — no KNOWN_DEFAULTS source).
+  'AWS::ApiGatewayV2::IntegrationResponse\0TemplateSelectionExpression': '',
+  'AWS::ApiGatewayV2::RouteResponse\0ModelSelectionExpression': '',
 };
 
 /**

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -888,10 +888,16 @@ const writeGlueJob: SdkWriter = async (ctx, ops) => {
   const update: Record<string, unknown> = {};
   for (const k of GLUE_JOB_UPDATE_FIELDS) if (m[k] !== undefined) update[k] = m[k];
   // MaxCapacity / AllocatedCapacity are mutually exclusive with WorkerType — include
-  // them ONLY for a non-WorkerType job (else update-job rejects sending both).
+  // capacity ONLY for a non-WorkerType job (else update-job rejects sending both). And
+  // even then include only ONE of the pair: GetJob echoes BOTH (AllocatedCapacity is the
+  // deprecated duplicate of MaxCapacity), and update-job rejects "Please set only
+  // Allocated Capacity or Max Capacity." when the JobUpdate carries both — which made
+  // EVERY revert on a non-WorkerType job fail (#1568, live-proven 2026-07-13 on a barest
+  // glueetl job). Prefer MaxCapacity; fall back to AllocatedCapacity only for an ancient
+  // job that carries nothing else.
   if (m.WorkerType === undefined) {
     if (m.MaxCapacity !== undefined) update.MaxCapacity = m.MaxCapacity;
-    if (m.AllocatedCapacity !== undefined) update.AllocatedCapacity = m.AllocatedCapacity;
+    else if (m.AllocatedCapacity !== undefined) update.AllocatedCapacity = m.AllocatedCapacity;
   }
   await c.send(new UpdateJobCommand({ JobName: name, JobUpdate: update as never }));
   // #804 — an op on a prop outside the JobUpdate field set (e.g. read-only CreatedOn, or a

--- a/tests/corpus/AWS__ApiGatewayV2__Api.WsApi.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.WsApi.json
@@ -1,0 +1,103 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WsApi",
+    "resourceType": "AWS::ApiGatewayV2::Api",
+    "physicalId": "jt9zvy5llc",
+    "constructPath": "CdkrdHuntWsApi0713/WsApi",
+    "declared": {
+      "Name": "cdkrd-hunt-ws-0713",
+      "ProtocolType": "WEBSOCKET",
+      "RouteSelectionExpression": "$request.body.action",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "RouteSelectionExpression": "$request.body.action",
+    "ProtocolType": "WEBSOCKET",
+    "ApiEndpoint": "wss://jt9zvy5llc.execute-api.us-east-1.amazonaws.com",
+    "DisableExecuteApiEndpoint": false,
+    "ApiId": "jt9zvy5llc",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdHuntWsApi0713",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntWsApi0713/b62adc60-7ea2-11f1-9653-12831bddd0eb",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "WsApi"
+    },
+    "Name": "cdkrd-hunt-ws-0713",
+    "ApiKeySelectionExpression": "$request.header.x-api-key"
+  },
+  "schema": {
+    "readOnly": ["ApiEndpoint", "ApiId"],
+    "writeOnly": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnly": ["ProtocolType"],
+    "readOnlyPaths": ["ApiEndpoint", "ApiId"],
+    "writeOnlyPaths": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "BodyS3Location.Bucket",
+      "BodyS3Location.Etag",
+      "BodyS3Location.Key",
+      "BodyS3Location.Version",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnlyPaths": ["ProtocolType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WsApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "jt9zvy5llc",
+      "constructPath": "CdkrdHuntWsApi0713/WsApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WsApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
+      "physicalId": "jt9zvy5llc",
+      "constructPath": "CdkrdHuntWsApi0713/WsApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WsApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "ApiKeySelectionExpression",
+      "actual": "$request.header.x-api-key",
+      "physicalId": "jt9zvy5llc",
+      "constructPath": "CdkrdHuntWsApi0713/WsApi"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Integration.WsInteg.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Integration.WsInteg.json
@@ -1,0 +1,88 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WsInteg",
+    "resourceType": "AWS::ApiGatewayV2::Integration",
+    "physicalId": "ic5d7an",
+    "constructPath": "CdkrdHuntWsApi0713/WsInteg",
+    "declared": {
+      "ApiId": "jt9zvy5llc",
+      "IntegrationType": "MOCK",
+      "RequestTemplates": {
+        "200": "{\"statusCode\":200}"
+      },
+      "TemplateSelectionExpression": "200"
+    }
+  },
+  "liveRaw": {
+    "PayloadFormatVersion": "1.0",
+    "TemplateSelectionExpression": "200",
+    "ConnectionType": "INTERNET",
+    "RequestTemplates": {
+      "200": "{\"statusCode\":200}"
+    },
+    "ResponseParameters": {},
+    "TimeoutInMillis": 29000,
+    "IntegrationId": "ic5d7an",
+    "ApiId": "jt9zvy5llc",
+    "IntegrationType": "MOCK",
+    "PassthroughBehavior": "WHEN_NO_MATCH"
+  },
+  "schema": {
+    "readOnly": ["IntegrationId"],
+    "writeOnly": [],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["IntegrationId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["RequestParameters", "RequestTemplates", "ResponseParameters"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WsInteg",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "PayloadFormatVersion",
+      "actual": "1.0",
+      "physicalId": "ic5d7an",
+      "constructPath": "CdkrdHuntWsApi0713/WsInteg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WsInteg",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "ConnectionType",
+      "actual": "INTERNET",
+      "physicalId": "ic5d7an",
+      "constructPath": "CdkrdHuntWsApi0713/WsInteg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WsInteg",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "TimeoutInMillis",
+      "actual": 29000,
+      "physicalId": "ic5d7an",
+      "constructPath": "CdkrdHuntWsApi0713/WsInteg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WsInteg",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "PassthroughBehavior",
+      "actual": "WHEN_NO_MATCH",
+      "physicalId": "ic5d7an",
+      "constructPath": "CdkrdHuntWsApi0713/WsInteg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGatewayV2__IntegrationResponse.WsIntegResp.json
+++ b/tests/corpus/AWS__ApiGatewayV2__IntegrationResponse.WsIntegResp.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WsIntegResp",
+    "resourceType": "AWS::ApiGatewayV2::IntegrationResponse",
+    "physicalId": "236eb93",
+    "constructPath": "CdkrdHuntWsApi0713/WsIntegResp",
+    "declared": {
+      "ApiId": "jt9zvy5llc",
+      "IntegrationId": "ic5d7an",
+      "IntegrationResponseKey": "$default"
+    }
+  },
+  "liveRaw": {
+    "ResponseTemplates": {},
+    "ResponseParameters": {},
+    "IntegrationResponseId": "236eb93",
+    "IntegrationId": "ic5d7an",
+    "IntegrationResponseKey": "$default",
+    "ApiId": "jt9zvy5llc"
+  },
+  "schema": {
+    "readOnly": ["IntegrationResponseId"],
+    "writeOnly": [],
+    "createOnly": ["ApiId", "IntegrationId"],
+    "readOnlyPaths": ["IntegrationResponseId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId", "IntegrationId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Route.WsRoute.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Route.WsRoute.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WsRoute",
+    "resourceType": "AWS::ApiGatewayV2::Route",
+    "physicalId": "lf89px5",
+    "constructPath": "CdkrdHuntWsApi0713/WsRoute",
+    "declared": {
+      "ApiId": "jt9zvy5llc",
+      "RouteKey": "$default",
+      "RouteResponseSelectionExpression": "$default",
+      "Target": "integrations/ic5d7an"
+    }
+  },
+  "liveRaw": {
+    "Target": "integrations/ic5d7an",
+    "RouteResponseSelectionExpression": "$default",
+    "RequestModels": {},
+    "AuthorizationScopes": [],
+    "ApiKeyRequired": false,
+    "RouteKey": "$default",
+    "RouteId": "lf89px5",
+    "AuthorizationType": "NONE",
+    "ApiId": "jt9zvy5llc"
+  },
+  "schema": {
+    "readOnly": ["RouteId"],
+    "writeOnly": ["AuthorizerId", "RequestParameters"],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["RouteId"],
+    "writeOnlyPaths": ["AuthorizerId", "RequestParameters"],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WsRoute",
+      "resourceType": "AWS::ApiGatewayV2::Route",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "lf89px5",
+      "constructPath": "CdkrdHuntWsApi0713/WsRoute"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WsRoute",
+      "resourceType": "AWS::ApiGatewayV2::Route",
+      "path": "AuthorizationType",
+      "actual": "NONE",
+      "physicalId": "lf89px5",
+      "constructPath": "CdkrdHuntWsApi0713/WsRoute"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGatewayV2__RouteResponse.WsRouteResp.json
+++ b/tests/corpus/AWS__ApiGatewayV2__RouteResponse.WsRouteResp.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WsRouteResp",
+    "resourceType": "AWS::ApiGatewayV2::RouteResponse",
+    "physicalId": "ysm3tp",
+    "constructPath": "CdkrdHuntWsApi0713/WsRouteResp",
+    "declared": {
+      "ApiId": "jt9zvy5llc",
+      "RouteId": "lf89px5",
+      "RouteResponseKey": "$default"
+    }
+  },
+  "liveRaw": {
+    "RouteResponseKey": "$default",
+    "ResponseParameters": {},
+    "RouteResponseId": "ysm3tp",
+    "RouteId": "lf89px5",
+    "ApiId": "jt9zvy5llc",
+    "ResponseModels": {}
+  },
+  "schema": {
+    "readOnly": ["RouteResponseId"],
+    "writeOnly": [],
+    "createOnly": ["ApiId", "RouteId"],
+    "readOnlyPaths": ["RouteResponseId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId", "RouteId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Stage.WsStage.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Stage.WsStage.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WsStage",
+    "resourceType": "AWS::ApiGatewayV2::Stage",
+    "physicalId": "hunt",
+    "constructPath": "CdkrdHuntWsApi0713/WsStage",
+    "declared": {
+      "ApiId": "jt9zvy5llc",
+      "StageName": "hunt",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "RouteSettings": {},
+    "StageName": "hunt",
+    "StageVariables": {},
+    "ApiId": "jt9zvy5llc",
+    "DefaultRouteSettings": {
+      "LoggingLevel": "OFF",
+      "DataTraceEnabled": false,
+      "DetailedMetricsEnabled": false
+    },
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdHuntWsApi0713",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntWsApi0713/b62adc60-7ea2-11f1-9653-12831bddd0eb",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "WsStage"
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ApiId", "StageName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId", "StageName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WsStage",
+      "resourceType": "AWS::ApiGatewayV2::Stage",
+      "path": "DefaultRouteSettings",
+      "actual": {
+        "LoggingLevel": "OFF",
+        "DataTraceEnabled": false,
+        "DetailedMetricsEnabled": false
+      },
+      "physicalId": "hunt",
+      "constructPath": "CdkrdHuntWsApi0713/WsStage"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Athena__WorkGroup.AthenaWg.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.AthenaWg.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AthenaWg",
+    "resourceType": "AWS::Athena::WorkGroup",
+    "physicalId": "cdkrd-hunt-wg-0713",
+    "constructPath": "CdkrdHuntGrabBag0713/AthenaWg",
+    "declared": {
+      "Name": "cdkrd-hunt-wg-0713",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "WorkGroupConfiguration": {
+      "EnforceWorkGroupConfiguration": true,
+      "EngineVersion": {
+        "SelectedEngineVersion": "AUTO",
+        "EffectiveEngineVersion": "Athena engine version 3"
+      },
+      "PublishCloudWatchMetricsEnabled": true,
+      "RequesterPaysEnabled": false
+    },
+    "State": "ENABLED",
+    "CreationTime": "1783937287",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-wg-0713"
+  },
+  "schema": {
+    "readOnly": ["CreationTime"],
+    "writeOnly": ["RecursiveDeleteOption", "WorkGroupConfigurationUpdates"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "CreationTime",
+      "WorkGroupConfiguration.EngineVersion.EffectiveEngineVersion",
+      "WorkGroupConfigurationUpdates.EngineVersion.EffectiveEngineVersion"
+    ],
+    "writeOnlyPaths": [
+      "RecursiveDeleteOption",
+      "WorkGroupConfiguration.AdditionalConfiguration",
+      "WorkGroupConfiguration.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfiguration.EngineConfiguration.CoordinatorDpuSize",
+      "WorkGroupConfiguration.EngineConfiguration.DefaultExecutorDpuSize",
+      "WorkGroupConfiguration.EngineConfiguration.MaxConcurrentDpus",
+      "WorkGroupConfiguration.EngineConfiguration.SparkProperties",
+      "WorkGroupConfigurationUpdates"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "WorkGroupConfiguration.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfiguration.EngineConfiguration.Classifications.*.Properties",
+      "WorkGroupConfiguration.EngineConfiguration.SparkProperties",
+      "WorkGroupConfiguration.MonitoringConfiguration.CloudWatchLoggingConfiguration.LogTypes",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.Classifications.*.Properties",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.SparkProperties",
+      "WorkGroupConfigurationUpdates.MonitoringConfiguration.CloudWatchLoggingConfiguration.LogTypes"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AthenaWg",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "WorkGroupConfiguration",
+      "actual": {
+        "EnforceWorkGroupConfiguration": true,
+        "EngineVersion": {
+          "SelectedEngineVersion": "AUTO"
+        },
+        "PublishCloudWatchMetricsEnabled": true,
+        "RequesterPaysEnabled": false
+      },
+      "physicalId": "cdkrd-hunt-wg-0713",
+      "constructPath": "CdkrdHuntGrabBag0713/AthenaWg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AthenaWg",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "cdkrd-hunt-wg-0713",
+      "constructPath": "CdkrdHuntGrabBag0713/AthenaWg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECR__RepositoryCreationTemplate.EcrTemplate.json
+++ b/tests/corpus/AWS__ECR__RepositoryCreationTemplate.EcrTemplate.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EcrTemplate",
+    "resourceType": "AWS::ECR::RepositoryCreationTemplate",
+    "physicalId": "cdkrd-hunt-0713",
+    "constructPath": "CdkrdHuntGrabBag0713/EcrTemplate",
+    "declared": {
+      "AppliedFor": ["PULL_THROUGH_CACHE"],
+      "Prefix": "cdkrd-hunt-0713"
+    }
+  },
+  "liveRaw": {
+    "EncryptionConfiguration": {
+      "EncryptionType": "AES256"
+    },
+    "CreatedAt": "2026-07-13T10:08:06.764Z",
+    "AppliedFor": ["PULL_THROUGH_CACHE"],
+    "Prefix": "cdkrd-hunt-0713",
+    "UpdatedAt": "2026-07-13T10:08:06.764Z",
+    "ImageTagMutability": "MUTABLE"
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "UpdatedAt"],
+    "writeOnly": [],
+    "createOnly": ["Prefix"],
+    "readOnlyPaths": ["CreatedAt", "UpdatedAt"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Prefix"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["AppliedFor"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EcrTemplate",
+      "resourceType": "AWS::ECR::RepositoryCreationTemplate",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "EncryptionType": "AES256"
+      },
+      "physicalId": "cdkrd-hunt-0713",
+      "constructPath": "CdkrdHuntGrabBag0713/EcrTemplate"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EcrTemplate",
+      "resourceType": "AWS::ECR::RepositoryCreationTemplate",
+      "path": "ImageTagMutability",
+      "actual": "MUTABLE",
+      "physicalId": "cdkrd-hunt-0713",
+      "constructPath": "CdkrdHuntGrabBag0713/EcrTemplate"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__Rule.RateRule.json
+++ b/tests/corpus/AWS__Events__Rule.RateRule.json
@@ -1,0 +1,88 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RateRule",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "CdkrdHuntGrabBag0713-RateRule-yCBB2Cf88Ugv",
+    "constructPath": "CdkrdHuntGrabBag0713/RateRule",
+    "declared": {
+      "ScheduleExpression": "rate(1 hour)",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "ScheduleExpression": "rate(1 hour)",
+    "State": "ENABLED",
+    "Targets": [],
+    "Id": "CdkrdHuntGrabBag0713-RateRule-yCBB2Cf88Ugv",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/CdkrdHuntGrabBag0713-RateRule-yCBB2Cf88Ugv",
+    "Tags": [
+      {
+        "Value": "CdkrdHuntGrabBag0713",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "RateRule",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntGrabBag0713/b7465e80-7ea2-11f1-9f99-0eb114bf7ab9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "CdkrdHuntGrabBag0713-RateRule-yCBB2Cf88Ugv"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "Targets.*.HttpParameters.HeaderParameters",
+      "Targets.*.HttpParameters.QueryStringParameters",
+      "Targets.*.InputTransformer.InputPathsMap"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RateRule",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "CdkrdHuntGrabBag0713-RateRule-yCBB2Cf88Ugv",
+      "constructPath": "CdkrdHuntGrabBag0713/RateRule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RateRule",
+      "resourceType": "AWS::Events::Rule",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "CdkrdHuntGrabBag0713-RateRule-yCBB2Cf88Ugv",
+      "constructPath": "CdkrdHuntGrabBag0713/RateRule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Job.GlueJobHunt0713.json
+++ b/tests/corpus/AWS__Glue__Job.GlueJobHunt0713.json
@@ -1,0 +1,157 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GlueJob",
+    "resourceType": "AWS::Glue::Job",
+    "physicalId": "GlueJob-llQDNP1s162l",
+    "constructPath": "CdkrdHuntGrabBag0713/GlueJob",
+    "declared": {
+      "Command": {
+        "Name": "glueetl",
+        "ScriptLocation": "s3://cdkrd-hunt-nonexistent/script.py"
+      },
+      "Role": "arn:aws:iam::111111111111:role/CdkrdHuntGrabBag0713-GlueRole-9x7azuFIo3ht",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "MaxRetries": 0,
+    "JobMode": "SCRIPT",
+    "Timeout": 480,
+    "AllocatedCapacity": 10,
+    "JobRunQueuingEnabled": false,
+    "Name": "GlueJob-llQDNP1s162l",
+    "Role": "arn:aws:iam::111111111111:role/CdkrdHuntGrabBag0713-GlueRole-9x7azuFIo3ht",
+    "WorkerType": "G.1X",
+    "Command": {
+      "PythonVersion": "2",
+      "ScriptLocation": "s3://cdkrd-hunt-nonexistent/script.py",
+      "Name": "glueetl"
+    },
+    "GlueVersion": "5.1",
+    "ExecutionProperty": {
+      "MaxConcurrentRuns": 1
+    },
+    "NumberOfWorkers": 10,
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "MaxCapacity": 10
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "MaxRetries",
+      "actual": 0,
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "JobMode",
+      "actual": "SCRIPT",
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "Timeout",
+      "actual": 480,
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "AllocatedCapacity",
+      "actual": 10,
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "WorkerType",
+      "actual": "G.1X",
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "GlueVersion",
+      "actual": "5.1",
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "ExecutionProperty",
+      "actual": {
+        "MaxConcurrentRuns": 1
+      },
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "NumberOfWorkers",
+      "actual": 10,
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "MaxCapacity",
+      "actual": 10,
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "Command.PythonVersion",
+      "actual": "2",
+      "nested": true,
+      "physicalId": "GlueJob-llQDNP1s162l",
+      "constructPath": "CdkrdHuntGrabBag0713/GlueJob"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.FifoTopic.json
+++ b/tests/corpus/AWS__SNS__Topic.FifoTopic.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FifoTopic",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0713.fifo",
+    "constructPath": "CdkrdHuntGrabBag0713/FifoTopic",
+    "declared": {
+      "FifoTopic": true,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TopicName": "cdkrd-hunt-0713.fifo"
+    }
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0713.fifo",
+    "FifoTopic": true,
+    "ContentBasedDeduplication": false,
+    "Tags": [
+      {
+        "Value": "CdkrdHuntGrabBag0713",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "FifoTopic",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntGrabBag0713/b7465e80-7ea2-11f1-9f99-0eb114bf7ab9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "cdkrd-hunt-0713.fifo"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["DeliveryStatusLogging", "Subscription"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__MaintenanceWindow.WindowHunt0713.json
+++ b/tests/corpus/AWS__SSM__MaintenanceWindow.WindowHunt0713.json
@@ -1,0 +1,68 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Window",
+    "resourceType": "AWS::SSM::MaintenanceWindow",
+    "physicalId": "mw-02f08595f3853346e",
+    "constructPath": "CdkrdHuntSsmMw0713/Window",
+    "declared": {
+      "AllowUnassociatedTargets": false,
+      "Cutoff": 1,
+      "Duration": 2,
+      "Name": "cdkrd-hunt-mw-0713",
+      "Schedule": "rate(7 days)",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "WindowId": "mw-02f08595f3853346e",
+    "AllowUnassociatedTargets": false,
+    "Cutoff": 1,
+    "Schedule": "rate(7 days)",
+    "Duration": 2,
+    "Tags": [
+      {
+        "Value": "CdkrdHuntSsmMw0713",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Window",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntSsmMw0713/b8285a10-7ea2-11f1-855c-0e071378db9b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-mw-0713"
+  },
+  "schema": {
+    "readOnly": ["WindowId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["WindowId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__MaintenanceWindowTarget.Target.json
+++ b/tests/corpus/AWS__SSM__MaintenanceWindowTarget.Target.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Target",
+    "resourceType": "AWS::SSM::MaintenanceWindowTarget",
+    "physicalId": "9640c104-5555-4d3c-b816-3d6f77750f59",
+    "constructPath": "CdkrdHuntSsmMw0713/Target",
+    "declared": {
+      "ResourceType": "INSTANCE",
+      "Targets": [
+        {
+          "Key": "tag:cdkrd",
+          "Values": ["hunt"]
+        }
+      ],
+      "WindowId": "mw-02f08595f3853346e"
+    }
+  },
+  "liveRaw": {
+    "WindowId": "mw-02f08595f3853346e",
+    "ResourceType": "INSTANCE",
+    "Targets": [
+      {
+        "Values": ["hunt"],
+        "Key": "tag:cdkrd"
+      }
+    ],
+    "WindowTargetId": "9640c104-5555-4d3c-b816-3d6f77750f59"
+  },
+  "schema": {
+    "readOnly": ["WindowTargetId"],
+    "writeOnly": [],
+    "createOnly": ["WindowId"],
+    "readOnlyPaths": ["WindowTargetId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["WindowId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__MaintenanceWindowTask.Task.json
+++ b/tests/corpus/AWS__SSM__MaintenanceWindowTask.Task.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Task",
+    "resourceType": "AWS::SSM::MaintenanceWindowTask",
+    "physicalId": "6c58f90f-3400-48c3-b662-47bcbc8b8d0a",
+    "constructPath": "CdkrdHuntSsmMw0713/Task",
+    "declared": {
+      "MaxConcurrency": "1",
+      "MaxErrors": "1",
+      "Priority": 1,
+      "Targets": [
+        {
+          "Key": "WindowTargetIds",
+          "Values": ["9640c104-5555-4d3c-b816-3d6f77750f59"]
+        }
+      ],
+      "TaskArn": "AWS-RunShellScript",
+      "TaskType": "RUN_COMMAND",
+      "WindowId": "mw-02f08595f3853346e"
+    }
+  },
+  "liveRaw": {
+    "MaxErrors": "1",
+    "WindowTaskId": "6c58f90f-3400-48c3-b662-47bcbc8b8d0a",
+    "ServiceRoleArn": "arn:aws:iam::111111111111:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM",
+    "WindowId": "mw-02f08595f3853346e",
+    "Priority": 1,
+    "TaskParameters": {},
+    "TaskType": "RUN_COMMAND",
+    "MaxConcurrency": "1",
+    "Targets": [
+      {
+        "Values": ["9640c104-5555-4d3c-b816-3d6f77750f59"],
+        "Key": "WindowTargetIds"
+      }
+    ],
+    "TaskArn": "AWS-RunShellScript"
+  },
+  "schema": {
+    "readOnly": ["WindowTaskId"],
+    "writeOnly": [],
+    "createOnly": ["TaskType", "WindowId"],
+    "readOnlyPaths": ["WindowTaskId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TaskType", "WindowId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::SSM::MaintenanceWindowTask",
+      "path": "ServiceRoleArn",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM",
+      "physicalId": "6c58f90f-3400-48c3-b662-47bcbc8b8d0a",
+      "constructPath": "CdkrdHuntSsmMw0713/Task"
+    }
+  ]
+}

--- a/tests/glue-job-firstrun-folds-1566.test.ts
+++ b/tests/glue-job-firstrun-folds-1566.test.ts
@@ -1,0 +1,129 @@
+// #1566: a barest AWS::Glue::Job (only Role + Command.Name + Command.ScriptLocation declared)
+// first-ran three [Potential Drift] entries (live 2026-07-13, us-east-1,
+// CdkrdHuntGrabBag0713). These tests pin the folds per the fold-strategy decision order:
+//   - Timeout — AWS MOVED the create-time default (2880-minute era → 480 for new jobs), so the
+//     stale KNOWN_DEFAULTS constant becomes an era KNOWN_DEFAULT_ONE_OF {2880, 480};
+//   - GlueVersion — the GA version AWS assigns and advances over time ("5.1" today) →
+//     value-independent (tier 3);
+//   - Command.PythonVersion — the vestigial stored constant "2" a glueetl job echoes when the
+//     version is undeclared → nested equality-gated constant (KNOWN_DEFAULT_PATHS).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const res: DesiredResource = {
+  logicalId: 'GlueJob',
+  resourceType: 'AWS::Glue::Job',
+  physicalId: 'GlueJob-abc123',
+  declared: {
+    Role: 'arn:aws:iam::111111111111:role/glue',
+    Command: { Name: 'glueetl', ScriptLocation: 's3://bucket/script.py' },
+  },
+};
+
+// The harvested live shape of the barest glueetl job (account id sanitized).
+const live = (over: Record<string, unknown> = {}) => ({
+  Role: 'arn:aws:iam::111111111111:role/glue',
+  Command: { Name: 'glueetl', ScriptLocation: 's3://bucket/script.py', PythonVersion: '2' },
+  Timeout: 480,
+  GlueVersion: '5.1',
+  MaxRetries: 0,
+  ...over,
+});
+
+describe('#1566 Glue::Job barest first-run folds', () => {
+  it('folds the full barest live shape to zero potential drift', () => {
+    const f = classifyResource(res, live(), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['Timeout', 'GlueVersion', 'Command.PythonVersion'])
+    );
+  });
+
+  it('folds BOTH Timeout eras (2880 legacy, 480 current) via ONE_OF', () => {
+    for (const timeout of [2880, 480]) {
+      const f = classifyResource(res, live({ Timeout: timeout }), emptySchema);
+      expect(pathsByTier(f, 'atDefault')).toContain('Timeout');
+      expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    }
+  });
+
+  it('surfaces a THIRD out-of-band Timeout value (equality gate keeps detection)', () => {
+    const f = classifyResource(res, live({ Timeout: 999 }), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Timeout']);
+  });
+
+  it('folds any undeclared GlueVersion value-independently (AWS advances the GA version)', () => {
+    for (const v of ['4.0', '5.0', '5.1', '6.0']) {
+      const f = classifyResource(res, live({ GlueVersion: v }), emptySchema);
+      expect(pathsByTier(f, 'atDefault')).toContain('GlueVersion');
+      expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    }
+  });
+
+  it('still compares a DECLARED GlueVersion in the declared dimension', () => {
+    const declaredRes: DesiredResource = {
+      ...res,
+      declared: { ...res.declared, GlueVersion: '4.0' },
+    };
+    const f = classifyResource(declaredRes, live({ GlueVersion: '5.1' }), emptySchema);
+    expect(pathsByTier(f, 'declared')).toContain('GlueVersion');
+  });
+
+  it('#1569: folds the WorkerType/NumberOfWorkers sizing echo any UpdateJob materializes', () => {
+    // The service normalizes capacity to the modern representation on EVERY UpdateJob
+    // (including a CFn stack update), so the pair appears undeclared after any update.
+    const f = classifyResource(
+      res,
+      live({ WorkerType: 'G.1X', NumberOfWorkers: 10, MaxCapacity: 10, AllocatedCapacity: 10 }),
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['WorkerType', 'NumberOfWorkers'])
+    );
+  });
+
+  it('#1569: a DECLARED WorkerType is still compared in the declared dimension', () => {
+    const declaredRes: DesiredResource = {
+      ...res,
+      declared: { ...res.declared, WorkerType: 'G.2X', NumberOfWorkers: 4 },
+    };
+    const f = classifyResource(
+      declaredRes,
+      live({ WorkerType: 'G.1X', NumberOfWorkers: 10 }),
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toEqual(
+      expect.arrayContaining(['NumberOfWorkers', 'WorkerType'])
+    );
+  });
+
+  it('surfaces an out-of-band Command.PythonVersion change away from the "2" echo', () => {
+    const f = classifyResource(
+      res,
+      live({
+        Command: { Name: 'glueetl', ScriptLocation: 's3://bucket/script.py', PythonVersion: '3' },
+      }),
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Command.PythonVersion']);
+  });
+});

--- a/tests/integration/grabbag-hunt/app.ts
+++ b/tests/integration/grabbag-hunt/app.ts
@@ -1,0 +1,87 @@
+// CDK app for the cdk-real-drift grabbag-hunt false-positive integration test.
+// A grab-bag of BAREST minimal configs for cheap, common types whose
+// undeclared-default first-run path has never been exercised live:
+//   - AWS::ECR::RepositoryCreationTemplate — zero corpus/fixture; its Prefix
+//     trailing-slash CC identifier adapter has never run against real AWS.
+//   - AWS::SNS::Topic FIFO variant — corpus has only FifoTopic:false topics.
+//   - AWS::Events::Rule with a rate() schedule and no targets — barest form.
+//   - AWS::Glue::Job barest (role + command only) — many optional props with
+//     service defaults.
+//   - AWS::Athena::WorkGroup barest (name only) — existing corpus cases all
+//     declare configuration.
+//   - AWS::Lambda::Function barest L1 (no L2 defaults) — probes the SnapStart /
+//     RuntimeManagementConfig undeclared surface.
+// A clean first `check` (before `record`) must show ZERO potential drift.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnWorkGroup } from "aws-cdk-lib/aws-athena";
+import { CfnRepositoryCreationTemplate } from "aws-cdk-lib/aws-ecr";
+import { CfnRule } from "aws-cdk-lib/aws-events";
+import { CfnJob } from "aws-cdk-lib/aws-glue";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntGrabBag0713");
+
+new CfnRepositoryCreationTemplate(stack, "EcrTemplate", {
+  prefix: "cdkrd-hunt-0713",
+  appliedFor: ["PULL_THROUGH_CACHE"],
+});
+
+new CfnTopic(stack, "FifoTopic", {
+  topicName: "cdkrd-hunt-0713.fifo",
+  fifoTopic: true,
+});
+
+new CfnRule(stack, "RateRule", {
+  scheduleExpression: "rate(1 hour)",
+});
+
+const glueRole = new CfnRole(stack, "GlueRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "glue.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+
+new CfnJob(stack, "GlueJob", {
+  role: glueRole.attrArn,
+  command: {
+    name: "glueetl",
+    scriptLocation: "s3://cdkrd-hunt-nonexistent/script.py",
+  },
+});
+
+new CfnWorkGroup(stack, "AthenaWg", {
+  name: "cdkrd-hunt-wg-0713",
+});
+
+const lambdaRole = new CfnRole(stack, "LambdaRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+
+new CfnFunction(stack, "BareFn", {
+  role: lambdaRole.attrArn,
+  runtime: "nodejs20.x",
+  handler: "index.handler",
+  code: { zipFile: "exports.handler = async () => ({ statusCode: 200 });" },
+});
+
+app.synth();

--- a/tests/integration/grabbag-hunt/cdk.json
+++ b/tests/integration/grabbag-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/grabbag-hunt/package.json
+++ b/tests/integration/grabbag-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-grabbag-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift grabbag-hunt false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/grabbag-hunt/verify.sh
+++ b/tests/integration/grabbag-hunt/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): a grab-bag of BAREST minimal configs
+# for cheap common types with unexercised undeclared-default first-run paths:
+# ECR::RepositoryCreationTemplate, SNS FIFO topic, Events::Rule rate() schedule,
+# Glue::Job barest, Athena::WorkGroup barest, Lambda::Function barest (L1).
+# The FIRST check (no baseline) must be CLEAN, and check after record must stay
+# CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntGrabBag0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ssmmw-hunt/app.ts
+++ b/tests/integration/ssmmw-hunt/app.ts
@@ -1,0 +1,43 @@
+// CDK app for the cdk-real-drift ssmmw-hunt false-positive integration test.
+// First live exercise of AWS::SSM::MaintenanceWindowTarget and
+// AWS::SSM::MaintenanceWindowTask — both have CC identifier adapters but zero
+// corpus cases and zero fixtures, so their composite-identifier read paths have
+// never run against real AWS. The parent MaintenanceWindow has a corpus case
+// but no live fixture. A clean first `check` (before `record`) must show ZERO
+// potential drift.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnMaintenanceWindow,
+  CfnMaintenanceWindowTarget,
+  CfnMaintenanceWindowTask,
+} from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntSsmMw0713");
+
+const window = new CfnMaintenanceWindow(stack, "Window", {
+  name: "cdkrd-hunt-mw-0713",
+  allowUnassociatedTargets: false,
+  cutoff: 1,
+  duration: 2,
+  schedule: "rate(7 days)",
+});
+
+const target = new CfnMaintenanceWindowTarget(stack, "Target", {
+  windowId: window.ref,
+  resourceType: "INSTANCE",
+  targets: [{ key: "tag:cdkrd", values: ["hunt"] }],
+});
+
+new CfnMaintenanceWindowTask(stack, "Task", {
+  windowId: window.ref,
+  taskType: "RUN_COMMAND",
+  taskArn: "AWS-RunShellScript",
+  priority: 1,
+  targets: [{ key: "WindowTargetIds", values: [target.ref] }],
+  maxConcurrency: "1",
+  maxErrors: "1",
+});
+
+app.synth();

--- a/tests/integration/ssmmw-hunt/cdk.json
+++ b/tests/integration/ssmmw-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ssmmw-hunt/package.json
+++ b/tests/integration/ssmmw-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ssmmw-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ssmmw-hunt false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ssmmw-hunt/verify.sh
+++ b/tests/integration/ssmmw-hunt/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): an SSM MaintenanceWindow with a
+# MaintenanceWindowTarget and a targetless-safe RUN_COMMAND MaintenanceWindowTask.
+# Target and Task exercise composite CC identifier adapters that had zero
+# corpus/fixture coverage. The FIRST check (no baseline) must be CLEAN, and check
+# after record must stay CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntSsmMw0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/wsapi-hunt/app.ts
+++ b/tests/integration/wsapi-hunt/app.ts
@@ -1,0 +1,58 @@
+// CDK app for the cdk-real-drift wsapi-hunt false-positive integration test.
+// First live exercise of a WEBSOCKET ApiGatewayV2 Api and, critically, of the
+// AWS::ApiGatewayV2::IntegrationResponse and AWS::ApiGatewayV2::RouteResponse
+// composite-identifier adapters — both have zero corpus cases and zero fixtures,
+// so their CC_IDENTIFIER_ADAPTERS paths have never run against real AWS. A clean
+// first `check` (before `record`) must show ZERO potential drift.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnApi,
+  CfnIntegration,
+  CfnIntegrationResponse,
+  CfnRoute,
+  CfnRouteResponse,
+  CfnStage,
+} from "aws-cdk-lib/aws-apigatewayv2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntWsApi0713");
+
+const api = new CfnApi(stack, "WsApi", {
+  name: "cdkrd-hunt-ws-0713",
+  protocolType: "WEBSOCKET",
+  routeSelectionExpression: "$request.body.action",
+});
+
+const integration = new CfnIntegration(stack, "WsInteg", {
+  apiId: api.ref,
+  integrationType: "MOCK",
+  requestTemplates: { "200": '{"statusCode":200}' },
+  templateSelectionExpression: "200",
+});
+
+new CfnIntegrationResponse(stack, "WsIntegResp", {
+  apiId: api.ref,
+  integrationId: integration.ref,
+  integrationResponseKey: "$default",
+});
+
+const route = new CfnRoute(stack, "WsRoute", {
+  apiId: api.ref,
+  routeKey: "$default",
+  target: `integrations/${integration.ref}`,
+  routeResponseSelectionExpression: "$default",
+});
+
+new CfnRouteResponse(stack, "WsRouteResp", {
+  apiId: api.ref,
+  routeId: route.ref,
+  routeResponseKey: "$default",
+});
+
+new CfnStage(stack, "WsStage", {
+  apiId: api.ref,
+  stageName: "hunt",
+});
+
+app.synth();

--- a/tests/integration/wsapi-hunt/cdk.json
+++ b/tests/integration/wsapi-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wsapi-hunt/package.json
+++ b/tests/integration/wsapi-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wsapi-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wsapi-hunt false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wsapi-hunt/verify.sh
+++ b/tests/integration/wsapi-hunt/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): a WEBSOCKET ApiGatewayV2 Api with a
+# MOCK integration, an IntegrationResponse, a Route, a RouteResponse, and a Stage.
+# IntegrationResponse and RouteResponse exercise composite CC identifier adapters
+# that had zero corpus/fixture coverage. The FIRST check (no baseline) must be
+# CLEAN, and check after record must stay CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntWsApi0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -968,9 +968,11 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULTS['AWS::Glue::Job']).toEqual({
       JobMode: 'SCRIPT',
       MaxRetries: 0,
-      Timeout: 2880,
       ExecutionProperty: { MaxConcurrentRuns: 1 },
     });
+    // Timeout moved to the era ONE_OF — AWS advanced the create-time default 2880 -> 480
+    // (#1566); both eras fold, a third value surfaces.
+    expect(KNOWN_DEFAULT_ONE_OF['AWS::Glue::Job'].Timeout).toEqual([2880, 480]);
     // nested
     expect(KNOWN_DEFAULT_PATHS['AWS::WAFv2::WebACL']).toEqual({
       'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,

--- a/tests/revert-apigwv2-selectionexpr-1567.test.ts
+++ b/tests/revert-apigwv2-selectionexpr-1567.test.ts
@@ -1,0 +1,57 @@
+// #1567: the ApiGatewayV2 Response-type update handlers keep an omitted *SelectionExpression,
+// so a bare `remove` revert of an out-of-band expression is a silent no-op (live-proven on a
+// WebSocket API 2026-07-13: TemplateSelectionExpression "200" on an IntegrationResponse and
+// ModelSelectionExpression "huntexpr" on a RouteResponse both survived a `remove` that
+// reported success). An explicit empty string clears the value to null (also live-proven), so
+// the plan must emit an `add ''` set-default write instead of a `remove` — the
+// REVERT_SET_DEFAULT_PATHS + REVERT_SET_DEFAULT_VALUES ('') pair.
+import { describe, expect, it } from 'vite-plus/test';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+const unrecordedUndeclared = (resourceType: string, path: string, actual: unknown): Finding => ({
+  tier: 'undeclared',
+  logicalId: 'R',
+  resourceType,
+  path,
+  physicalId: 'api|parent|child',
+  actual,
+});
+
+describe('#1567 ApiGatewayV2 SelectionExpression revert plans an explicit empty-string write', () => {
+  it("IntegrationResponse.TemplateSelectionExpression -> add ''", () => {
+    const f = unrecordedUndeclared(
+      'AWS::ApiGatewayV2::IntegrationResponse',
+      'TemplateSelectionExpression',
+      '200'
+    );
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/TemplateSelectionExpression',
+      value: '',
+    });
+  });
+
+  it("RouteResponse.ModelSelectionExpression -> add ''", () => {
+    const f = unrecordedUndeclared(
+      'AWS::ApiGatewayV2::RouteResponse',
+      'ModelSelectionExpression',
+      'huntexpr'
+    );
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ModelSelectionExpression',
+      value: '',
+    });
+  });
+
+  it('an unrelated ApiGatewayV2 undeclared path still plans a plain remove', () => {
+    const f = unrecordedUndeclared('AWS::ApiGatewayV2::RouteResponse', 'ResponseModels', {
+      x: 'y',
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/ResponseModels' });
+  });
+});

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -933,6 +933,78 @@ describe('Glue Job writer (CC UpdateResource rejects MaxCapacity+WorkerType)', (
     expect(input.JobUpdate.MaxCapacity).toBe(10);
   });
 
+  it('#1568: sends only ONE capacity form for a non-WorkerType job — GetJob echoes BOTH', async () => {
+    // A real GetJob returns BOTH MaxCapacity and its deprecated duplicate
+    // AllocatedCapacity (live-proven on a barest glueetl job), and UpdateJob rejects a
+    // JobUpdate carrying both ("Please set only Allocated Capacity or Max Capacity."),
+    // which made EVERY revert on a non-WorkerType job fail. The writer must keep
+    // MaxCapacity and drop the AllocatedCapacity duplicate.
+    glue.on(GetJobCommand).resolves({
+      Job: {
+        Name: 'j',
+        Role: 'arn:aws:iam::111111111111:role/r',
+        Command: { Name: 'glueetl', ScriptLocation: 's3://b/s.py' },
+        Timeout: 999,
+        MaxCapacity: 10,
+        AllocatedCapacity: 10, // deprecated duplicate — must NOT be re-sent
+      },
+    } as never);
+    glue.on(UpdateJobCommand).resolves({});
+    await SDK_WRITERS['AWS::Glue::Job'](ctx({ physicalId: 'j' }), [timeoutOp(480)]);
+    const input = glue.commandCalls(UpdateJobCommand)[0]!.args[0].input as unknown as {
+      JobUpdate: Record<string, unknown>;
+    };
+    expect(input.JobUpdate.MaxCapacity).toBe(10);
+    expect('AllocatedCapacity' in input.JobUpdate).toBe(false);
+  });
+
+  it('#1568: an op REMOVING WorkerType lands in the fixed one-capacity branch', async () => {
+    // Reverting an out-of-band WorkerType (undeclared, not in baseline) removes it from
+    // the model — the post-ops job is a non-WorkerType job, whose GetJob echo pair must
+    // still collapse to a single capacity form.
+    glue.on(GetJobCommand).resolves({
+      Job: {
+        Name: 'j',
+        Role: 'arn:aws:iam::111111111111:role/r',
+        Command: { Name: 'glueetl', ScriptLocation: 's3://b/s.py' },
+        WorkerType: 'G.1X',
+        NumberOfWorkers: 10,
+        MaxCapacity: 10,
+        AllocatedCapacity: 10,
+      },
+    } as never);
+    glue.on(UpdateJobCommand).resolves({});
+    await SDK_WRITERS['AWS::Glue::Job'](ctx({ physicalId: 'j' }), [
+      { op: 'remove', path: '/WorkerType', human: 'WorkerType -> remove' },
+      { op: 'remove', path: '/NumberOfWorkers', human: 'NumberOfWorkers -> remove' },
+    ]);
+    const input = glue.commandCalls(UpdateJobCommand)[0]!.args[0].input as unknown as {
+      JobUpdate: Record<string, unknown>;
+    };
+    expect('WorkerType' in input.JobUpdate).toBe(false);
+    expect(input.JobUpdate.MaxCapacity).toBe(10);
+    expect('AllocatedCapacity' in input.JobUpdate).toBe(false);
+  });
+
+  it('#1568: an ancient AllocatedCapacity-only job still round-trips its capacity', async () => {
+    glue.on(GetJobCommand).resolves({
+      Job: {
+        Name: 'j',
+        Role: 'arn:aws:iam::111111111111:role/r',
+        Command: { Name: 'glueetl' },
+        Timeout: 20,
+        AllocatedCapacity: 2,
+      },
+    } as never);
+    glue.on(UpdateJobCommand).resolves({});
+    await SDK_WRITERS['AWS::Glue::Job'](ctx({ physicalId: 'j' }), [timeoutOp(10)]);
+    const input = glue.commandCalls(UpdateJobCommand)[0]!.args[0].input as unknown as {
+      JobUpdate: Record<string, unknown>;
+    };
+    expect(input.JobUpdate.AllocatedCapacity).toBe(2);
+    expect('MaxCapacity' in input.JobUpdate).toBe(false);
+  });
+
   it('throws when the job name is unresolvable', async () => {
     await expect(
       SDK_WRITERS['AWS::Glue::Job'](ctx({ physicalId: '', declared: {} }), [timeoutOp(10)])


### PR DESCRIPTION
## Summary

Bug-hunt 2026-07-13 (5 angles: offline reader/allowlist/coverage audits, barest first-run FP wave, out-of-band FN + revert convergence, post-update echo class, corpus + noise mining). Three stacks deployed against real AWS (`CdkrdHuntWsApi0713` / `CdkrdHuntSsmMw0713` / `CdkrdHuntGrabBag0713`), 4 bugs found — all fixed, unit-tested, and re-proven live with the fixed binary. All stacks deleted, SWEEP CLEAN.

Closes #1566
Closes #1567
Closes #1568
Closes #1569

## Fixes (each live-proven end to end)

- **#1566 fix(noise) — barest Glue Job first-ran 3 FPs.** `Timeout` → era `KNOWN_DEFAULT_ONE_OF [2880, 480]` (AWS moved the create-time default; live 480 on a fresh job, legacy pin kept); `GlueVersion` → value-independent (GA-engine-version class, "5.1" today); `Command.PythonVersion` → `KNOWN_DEFAULT_PATHS` `"2"` (vestigial stored echo even on Glue 5.x). Live: first check went 3 FPs → CLEAN; Timeout=999 and PythonVersion="3" still surface (equality gates hold).
- **#1568 fix(revert) — every revert on a non-WorkerType Glue Job failed.** `writeGlueJob`'s non-WorkerType branch re-sent BOTH GetJob capacity echoes (`MaxCapacity` + deprecated `AllocatedCapacity`) in one JobUpdate — `InvalidInputException: Please set only Allocated Capacity or Max Capacity.` Collapse to one capacity form (prefer MaxCapacity, fall back to AllocatedCapacity for ancient jobs). Live: the failing revert now converges (incl. the `Command.PythonVersion` set-default write "3"→"2").
- **#1569 fix(noise) — WorkerType/NumberOfWorkers echo FP after any update.** Glue normalizes sizing to the modern representation on EVERY UpdateJob (including a CFn stack update) — the undeclared pair materialized out of nowhere (live-proven) and its removal is structurally inexpressible. Fold both value-independent, completing the sizing trio with the existing MaxCapacity/AllocatedCapacity folds (no detection lost that those folds had not already traded; a declared sizing is still compared).
- **#1567 fix(revert) — ApiGatewayV2 Response-type SelectionExpression remove-revert was a silent no-op.** The update handlers keep an omitted `*SelectionExpression` (live: `"200"` / `"huntexpr"` both survived a `remove` that reported success). An explicit `''` clears the value (live-proven) → `REVERT_SET_DEFAULT_PATHS` + `REVERT_SET_DEFAULT_VALUES ('')` for `IntegrationResponse.TemplateSelectionExpression` and `RouteResponse.ModelSelectionExpression`. Live: mutate → revert → "CLEAN after revert", value null.

## Clean results (assets kept)

- `AWS::ApiGatewayV2::IntegrationResponse` / `RouteResponse` composite CC identifier adapters (zero prior corpus/fixture coverage) read, detect, and now revert correctly on a live WEBSOCKET API.
- `AWS::SSM::MaintenanceWindowTarget` / `MaintenanceWindowTask` composite adapters (zero prior coverage): first check CLEAN; declared `Duration` OOB mutation detect → revert → converged.
- Barest ECR RepositoryCreationTemplate / SNS FIFO topic / Events rate() rule / Athena WorkGroup / L1 Lambda: zero first-run FPs.

## Regression assets

- 3 committed integration fixtures with first-check-CLEAN oracles (`wsapi-hunt`, `ssmmw-hunt`, `grabbag-hunt`).
- 14 new golden-corpus cases (incl. 4 first-ever types + the post-update Glue echo shape pinning #1569); corpus-replay green, no baked FPs (eyeballed each `expected`).
- 20 new/updated unit tests; full suite 283 files / 5616 tests green after rebase onto 0.17.0.

## Cleanup

All 3 stacks deleted via `delstack`; `sweep-orphans.sh` reports **SWEEP CLEAN**; bughunt-clean gate released (session + autoarm owners).
