### PR TITLE
fix(revert): converge Kinesis Stream RetentionPeriodHours revert (#1571)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -297,6 +297,21 @@ is to add `${resourceType}\0${path}` to `REVERT_SET_DEFAULT_PATHS`
 converges — otherwise you ship a revert that claims success but leaves the value
 unchanged.
 
+**The revert-no-op class is NON-UNIFORM — a dedicated-toggle-API does NOT imply a
+no-op; live-prove EACH candidate, never predict from the API shape.** It is tempting
+to assume that a property changed only by a dedicated sub-API (Enable/DisableRule,
+Increase/DecreaseStreamRetentionPeriod, PutBackupPolicy, SetQueueAttributes) must
+no-op on an omitted `remove` — but the Cloud Control HANDLER often RECONCILES the full
+desired state and resets the property to its default when omitted. Live-proven
+2026-07-13 (#1571): of four dedicated-toggle siblings, only **`Kinesis::Stream`
+`RetentionPeriodHours`** actually no-oped (CC leaves it unchanged) and needed the RSDP
+entry; **`Events::Rule` State, `SQS::Queue` VisibilityTimeout, `EFS::FileSystem`
+BackupPolicy all CONVERGED via the bare `remove`** (the CC handler reset them). So a
+cheap combined fixture (several folded toggles in one stack) that mutates each out of
+band and asserts the LIVE value after revert is the only reliable test — the API shape
+is not a predictor. The `revert-toggle-converge` fixture is the reference (one fixed
+case + converge-via-remove controls).
+
 ### 5. Harvest the live read into the golden corpus (EVERY round — bug or not)
 
 This is the asset a hunt leaves behind even when it finds no bug. Every live read
@@ -568,6 +583,19 @@ Recorded]` breakdown with `--verbose`.
   `|| fail`), or guard with `set +e`.
 - **Always `npm install` + `cdk synth` before deploy** — a synth-time TS error is
   free to catch; a half-failed deploy is not.
+- **A container-image Lambda fixture MUST build with `docker build --provenance=false
+--sbom=false`.** Docker 24+ buildkit attaches OCI provenance/SBOM attestation layers
+  by default; Lambda rejects them at CREATE with `InvalidImage:
+UnsupportedImageLayerDetected` (the stack rolls back). The failure is NON-DETERMINISTIC
+  (a prior build sometimes slips through), so it reads as flakiness — pin the flags. Also
+  build `--platform linux/amd64` unless the function declares `Architectures: [arm64]` (a
+  barest function defaults to x86_64 and rejects an arm64 image). Push the image to a
+  dedicated ECR repo out of band and pass the `registry/repo@sha256:…` digest via env —
+  the barest `CfnFunction` then declares only `Code.ImageUri` + `PackageType: Image` +
+  `Role`, leaving the Image-variant defaults (Architectures, EphemeralStorage,
+  RecursiveLoop, LoggingConfig, RuntimeManagementConfig) undeclared to probe the fold
+  (`lambda-container-barest` is the reference; container Lambdas were a whole uncovered
+  variant axis until #1572).
 - **Deploy-time API validation differences across engine/mode variants are
   FINDINGS, not mere fixture bugs.** A minimal variant deploy that FAILS validation
   is telling you the variant's defaults differ (valkey RGs default

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -366,6 +366,16 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // (the fields default to ABSENT, so KNOWN_DEFAULTS has no source).
   'AWS::ApiGatewayV2::IntegrationResponse\0TemplateSelectionExpression',
   'AWS::ApiGatewayV2::RouteResponse\0ModelSelectionExpression',
+  // Kinesis RetentionPeriodHours is changed only by the dedicated
+  // Increase/DecreaseStreamRetentionPeriod APIs — the Cloud Control Stream update handler
+  // ignores an OMITTED RetentionPeriodHours, so a bare `remove` revert of an out-of-band
+  // retention increase is a silent no-op (live-proven 2026-07-13: an out-of-band
+  // increase-stream-retention-period to 48 was detected but the `remove` revert left the
+  // live value at 48). Writing the KNOWN_DEFAULTS default (24) explicitly makes the handler
+  // call DecreaseStreamRetentionPeriod and converge. (Contrast Events::Rule State, whose CC
+  // handler DOES re-enable on an omitted State — proven in the same fixture — so it needs no
+  // entry here.)
+  'AWS::Kinesis::Stream\0RetentionPeriodHours',
 ]);
 
 // Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerCertificate.SniCert.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerCertificate.SniCert.json
@@ -1,0 +1,45 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SniCert",
+    "resourceType": "AWS::ElasticLoadBalancingV2::ListenerCertificate",
+    "physicalId": "Cdkrd-SniCe-OSCKIRJQLDAF",
+    "constructPath": "CdkrdHuntListenerCert0713/SniCert",
+    "declared": {
+      "Certificates": [
+        {
+          "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/81992ef5-85de-4419-8aec-1036293c4133"
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdHun-Alb-n6TSDuPfX7Fd/e16caa1be9d9cba5/e55c237a5c74c07a"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdHun-Alb-n6TSDuPfX7Fd/e16caa1be9d9cba5/e55c237a5c74c07a",
+    "Certificates": [
+      {
+        "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/81992ef5-85de-4419-8aec-1036293c4133"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["ListenerArn"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ListenerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__Function.ContainerImgFn.json
+++ b/tests/corpus/AWS__Lambda__Function.ContainerImgFn.json
@@ -1,0 +1,186 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Fn",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+    "constructPath": "CdkrdHuntLambdaImg0713/Fn",
+    "declared": {
+      "Code": {
+        "ImageUri": "111111111111.dkr.ecr.us-east-1.amazonaws.com/cdkrd-hunt-lambdaimg0713@sha256:4b4fdd3135d850561e19abd904d2b35f452b1e17dc8702c06601c9ac022a306e"
+      },
+      "PackageType": "Image",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdHuntLambdaImg0713-FnRole-iahlIwfJp0PE",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdHuntLambdaImg0713-FnRole-iahlIwfJp0PE",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+    "PackageType": "Image",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "Fn",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHuntLambdaImg0713",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntLambdaImg0713/e7f9f250-7eaf-11f1-a115-0e1cc0145a99",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["x86_64"],
+    "CodeSha256": "4b4fdd3135d850561e19abd904d2b35f452b1e17dc8702c06601c9ac022a306e"
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectStorageMode",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY"
+      },
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Fn",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "CodeSha256",
+      "actual": "4b4fdd3135d850561e19abd904d2b35f452b1e17dc8702c06601c9ac022a306e",
+      "physicalId": "CdkrdHuntLambdaImg0713-Fn-Hcv0zV8RdoHY",
+      "constructPath": "CdkrdHuntLambdaImg0713/Fn"
+    }
+  ]
+}

--- a/tests/integration/elbv2-listenercert-barest/app.ts
+++ b/tests/integration/elbv2-listenercert-barest/app.ts
@@ -1,0 +1,94 @@
+// Barest-config ELBv2 ListenerCertificate fixture for the cdk-real-drift FP hunt.
+// AWS::ElasticLoadBalancingV2::ListenerCertificate is a Cloud Control gap (the
+// registry schema has NO handlers) → a `readElbv2ListenerCertificate` SDK_OVERRIDE
+// added in #1560 that had ZERO corpus / fixture coverage (never run against a real
+// listener). This exercises the reader's declared∩live projection: an internet-facing
+// ALB with an HTTPS listener (default cert = one imported self-signed cert) plus a
+// SECOND imported cert attached via CfnListenerCertificate. A clean deploy must
+// FIRST-check CLEAN (the reader projects only the declared cert still present in the
+// live non-default set), and removing the attached cert out of band must SURFACE as
+// declared drift (verify-detect.sh). The default cert must be EXCLUDED from the model
+// so it never FPs against the ListenerCertificate resource, which declares only the
+// SNI (extra) cert. Both certs are imported out of band by verify.sh (self-signed, no
+// ACM validation wait — the #1559/#1560 precedent) and passed via env.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnVPC, CfnSubnet, CfnInternetGateway, CfnVPCGatewayAttachment, CfnRouteTable, CfnRoute, CfnSubnetRouteTableAssociation, CfnSecurityGroup } from "aws-cdk-lib/aws-ec2";
+import { CfnLoadBalancer, CfnListener, CfnListenerCertificate } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const defaultCertArn = process.env.CDKRD_HUNT_DEFAULT_CERT_ARN;
+const sniCertArn = process.env.CDKRD_HUNT_SNI_CERT_ARN;
+if (!defaultCertArn || !sniCertArn) {
+  throw new Error("CDKRD_HUNT_DEFAULT_CERT_ARN and CDKRD_HUNT_SNI_CERT_ARN must be set (see verify.sh)");
+}
+const region = process.env.CDK_DEFAULT_REGION || process.env.AWS_REGION || "us-east-1";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntListenerCert0713", {
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region },
+});
+
+// Minimal VPC with two public subnets in two AZs (an ALB requires >=2 AZs). No NAT.
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.60.0.0/16" });
+const igw = new CfnInternetGateway(stack, "Igw");
+new CfnVPCGatewayAttachment(stack, "IgwAttach", { vpcId: vpc.ref, internetGatewayId: igw.ref });
+const rt = new CfnRouteTable(stack, "PublicRt", { vpcId: vpc.ref });
+new CfnRoute(stack, "PublicRoute", {
+  routeTableId: rt.ref,
+  destinationCidrBlock: "0.0.0.0/0",
+  gatewayId: igw.ref,
+});
+const azs = [`${region}a`, `${region}b`];
+const subnetRefs: string[] = [];
+azs.forEach((az, i) => {
+  const subnet = new CfnSubnet(stack, `PublicSubnet${i}`, {
+    vpcId: vpc.ref,
+    cidrBlock: `10.60.${i}.0/24`,
+    availabilityZone: az,
+    mapPublicIpOnLaunch: true,
+  });
+  new CfnSubnetRouteTableAssociation(stack, `PublicSubnetRta${i}`, {
+    subnetId: subnet.ref,
+    routeTableId: rt.ref,
+  });
+  subnetRefs.push(subnet.ref);
+});
+
+const sg = new CfnSecurityGroup(stack, "AlbSg", {
+  groupDescription: "cdkrd hunt ALB sg",
+  vpcId: vpc.ref,
+  securityGroupIngress: [
+    { ipProtocol: "tcp", fromPort: 443, toPort: 443, cidrIp: "0.0.0.0/0" },
+  ],
+});
+
+const alb = new CfnLoadBalancer(stack, "Alb", {
+  type: "application",
+  scheme: "internet-facing",
+  subnets: subnetRefs,
+  securityGroups: [sg.attrGroupId],
+});
+
+// HTTPS listener: default cert declared inline; a fixed-response default action avoids
+// needing a target group / targets (this fixture is only about the cert set).
+const listener = new CfnListener(stack, "HttpsListener", {
+  loadBalancerArn: alb.ref,
+  port: 443,
+  protocol: "HTTPS",
+  certificates: [{ certificateArn: defaultCertArn }],
+  defaultActions: [
+    {
+      type: "fixed-response",
+      fixedResponseConfig: { statusCode: "200", contentType: "text/plain", messageBody: "ok" },
+    },
+  ],
+});
+
+// The resource under test: attach a SECOND (SNI) cert to the listener. The reader must
+// project THIS cert (declared∩live) and exclude the listener's default cert.
+new CfnListenerCertificate(stack, "SniCert", {
+  listenerArn: listener.ref,
+  certificates: [{ certificateArn: sniCertArn }],
+});
+
+app.synth();

--- a/tests/integration/elbv2-listenercert-barest/cdk.json
+++ b/tests/integration/elbv2-listenercert-barest/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elbv2-listenercert-barest/package.json
+++ b/tests/integration/elbv2-listenercert-barest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elbv2-listenercert-barest",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config ELBv2 ListenerCertificate fixture for the cdk-real-drift first-run FP hunt (#1560 reader). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elbv2-listenercert-barest/verify-detect.sh
+++ b/tests/integration/elbv2-listenercert-barest/verify-detect.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Detection (FN) integration test for the #1560 ListenerCertificate reader: after a clean
+# record, REMOVE the declared SNI cert from the listener out of band. The reader's
+# declared∩live projection must then drop it → check DETECTS declared drift (exit 1).
+# ListenerCertificate has no SDK writer, so revert is not exercised; the cert is
+# re-attached manually to restore before cleanup. Deploy is assumed already done by
+# verify.sh in the same run (this reuses the deployed stack + cdk.out + certs).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntListenerCert0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+fail() { echo "DETECT FAIL ($STACK): $*"; exit 1; }
+
+: "${CDKRD_HUNT_SNI_CERT_ARN:?set CDKRD_HUNT_SNI_CERT_ARN (the attached SNI cert arn)}"
+
+# Resolve the listener arn from the deployed stack.
+LISTENER_ARN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::ElasticLoadBalancingV2::Listener'].PhysicalResourceId" \
+  --output text)"
+[ -n "$LISTENER_ARN" ] || fail "could not resolve listener arn"
+
+echo "=== [$STACK] record clean baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "=== [$STACK] remove SNI cert out of band ==="
+aws elbv2 remove-listener-certificates --listener-arn "$LISTENER_ARN" \
+  --certificates CertificateArn="$CDKRD_HUNT_SNI_CERT_ARN" --region "$REGION" || fail "remove-listener-certificates"
+
+echo "=== [$STACK] check MUST DETECT the removed cert (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+RC="${PIPESTATUS[0]}"
+
+echo "=== restore SNI cert ==="
+aws elbv2 add-listener-certificates --listener-arn "$LISTENER_ARN" \
+  --certificates CertificateArn="$CDKRD_HUNT_SNI_CERT_ARN" --region "$REGION" || true
+
+[ "$RC" -eq 1 ] || fail "check did NOT detect the removed SNI cert (FN)"
+echo "DETECT PASS ($STACK)"

--- a/tests/integration/elbv2-listenercert-barest/verify.sh
+++ b/tests/integration/elbv2-listenercert-barest/verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS) for the #1560 ListenerCertificate reader.
+# Two self-signed certs are imported into ACM out of band BEFORE deploy (no ACM DNS
+# validation wait): one is the listener's DEFAULT cert, the other is attached as an SNI
+# ListenerCertificate. A clean barest deploy must FIRST-check CLEAN (the reader projects
+# only this resource's declared cert from the live NON-default set, excluding the default
+# cert) and stay CLEAN after record. The removed-cert FN lives in verify-detect.sh.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntListenerCert0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  [ -n "${CDKRD_HUNT_DEFAULT_CERT_ARN:-}" ] &&
+    aws acm delete-certificate --certificate-arn "$CDKRD_HUNT_DEFAULT_CERT_ARN" --region "$REGION" >/dev/null 2>&1 || true
+  [ -n "${CDKRD_HUNT_SNI_CERT_ARN:-}" ] &&
+    aws acm delete-certificate --certificate-arn "$CDKRD_HUNT_SNI_CERT_ARN" --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+import_cert() { # $1=CN → prints ARN
+  local cn="$1" key crt
+  key="$(mktemp)"; crt="$(mktemp)"
+  openssl req -x509 -newkey rsa:2048 -keyout "$key" -out "$crt" -days 7 -nodes -subj "/CN=$cn" 2>/dev/null || return 1
+  aws acm import-certificate --certificate "fileb://$crt" --private-key "fileb://$key" --region "$REGION" \
+    --tags Key=cdkrd:ephemeral,Value=1 --query CertificateArn --output text
+  rm -f "$key" "$crt"
+}
+
+echo "=== [$STACK] import two self-signed certs into ACM ==="
+CDKRD_HUNT_DEFAULT_CERT_ARN="$(import_cert cdkrd-hunt-default.internal)" || fail "acm import default"
+CDKRD_HUNT_SNI_CERT_ARN="$(import_cert cdkrd-hunt-sni.internal)" || fail "acm import sni"
+export CDKRD_HUNT_DEFAULT_CERT_ARN CDKRD_HUNT_SNI_CERT_ARN
+export CDK_DEFAULT_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+export CDK_DEFAULT_REGION="$REGION"
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/lambda-container-barest/Dockerfile
+++ b/tests/integration/lambda-container-barest/Dockerfile
@@ -1,0 +1,4 @@
+# Minimal Lambda container image (public base) for the container-Lambda FP-hunt fixture.
+FROM public.ecr.aws/lambda/nodejs:20
+COPY index.js ${LAMBDA_TASK_ROOT}/
+CMD ["index.handler"]

--- a/tests/integration/lambda-container-barest/app.ts
+++ b/tests/integration/lambda-container-barest/app.ts
@@ -1,0 +1,41 @@
+// Barest-config container-image Lambda fixture for the cdk-real-drift FP hunt.
+// Every existing Lambda fixture/corpus case is PackageType: Zip; a container-image
+// Lambda (PackageType: Image) has a DIFFERENT undeclared-default surface — no
+// Runtime/Handler, but AWS materializes Architectures, EphemeralStorage,
+// LoggingConfig, RuntimeManagementConfig, PackageType, and (crucially) an
+// ImageConfigResponse — none of which this barest template declares. This probes
+// whether those AWS-assigned defaults fold to atDefault on a first check (the
+// #1477 "one-variant-covered" class). The image is built + pushed to a dedicated
+// ECR repo out of band by verify.sh; its URI is passed via CDKRD_HUNT_IMAGE_URI.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+
+const imageUri = process.env.CDKRD_HUNT_IMAGE_URI;
+if (!imageUri) throw new Error("CDKRD_HUNT_IMAGE_URI must be set (see verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntLambdaImg0713");
+
+const role = new CfnRole(stack, "FnRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      { Effect: "Allow", Principal: { Service: "lambda.amazonaws.com" }, Action: "sts:AssumeRole" },
+    ],
+  },
+  managedPolicyArns: ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+});
+
+// Barest image function: only what CFn requires for a container package —
+// Code.ImageUri, PackageType, Role. No Architectures/EphemeralStorage/MemorySize/
+// Timeout/LoggingConfig/ImageConfig declared, so all of those are undeclared and
+// exercise the fold path for the Image variant.
+new CfnFunction(stack, "Fn", {
+  packageType: "Image",
+  code: { imageUri },
+  role: role.attrArn,
+});
+
+app.synth();

--- a/tests/integration/lambda-container-barest/cdk.json
+++ b/tests/integration/lambda-container-barest/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-container-barest/index.js
+++ b/tests/integration/lambda-container-barest/index.js
@@ -1,0 +1,1 @@
+export const handler = async () => ({ statusCode: 200, body: "ok" });

--- a/tests/integration/lambda-container-barest/package.json
+++ b/tests/integration/lambda-container-barest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-container-barest",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config container-image Lambda (PackageType: Image) fixture for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-container-barest/verify-detect.sh
+++ b/tests/integration/lambda-container-barest/verify-detect.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Detection (FN) + revert integration test for the container-image Lambda. MemorySize is
+# a declared MUTABLE property; mutate it out of band → check must DETECT (exit 1) →
+# revert restores it → check CLEAN. Assumes verify.sh already deployed the stack in this
+# run (reuses cdk.out + CDKRD_HUNT_IMAGE_URI).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntLambdaImg0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+fail() { echo "DETECT FAIL ($STACK): $*"; exit 1; }
+
+# The barest function declares no MemorySize, so it deploys at the AWS default (128) and
+# folds to atDefault on a first check. `record` snapshots that undeclared 128 into the
+# baseline; mutating it out of band then re-surfaces as a recorded-undeclared drift
+# (record KEEPS watching), which revert restores to the recorded 128.
+FN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN" ] || fail "could not resolve function name"
+
+echo "=== [$STACK] record clean baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "=== [$STACK] mutate MemorySize out of band (128 -> 512) ==="
+aws lambda update-function-configuration --function-name "$FN" --memory-size 512 --region "$REGION" >/dev/null || fail "update-function-configuration"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION" || true
+
+echo "=== [$STACK] check MUST DETECT the MemorySize change (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "check did NOT detect the MemorySize mutation (FN)"
+
+echo "=== [$STACK] revert MUST restore MemorySize ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK-revert.out" || fail "revert"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION" || true
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+LIVE_MEM="$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" --query MemorySize --output text)"
+[ "$LIVE_MEM" = "128" ] || fail "live MemorySize is $LIVE_MEM, expected 128 after revert"
+echo "DETECT PASS ($STACK)"

--- a/tests/integration/lambda-container-barest/verify.sh
+++ b/tests/integration/lambda-container-barest/verify.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS) for a container-image Lambda (PackageType:
+# Image). A tiny image is built from a public Lambda base and pushed to a dedicated ECR
+# repo out of band, then the barest CfnFunction (Code.ImageUri + Role only) is deployed.
+# A clean deploy must FIRST-check CLEAN — every AWS-assigned default the Image variant
+# materializes (Architectures, EphemeralStorage, PackageType, LoggingConfig,
+# RuntimeManagementConfig, ImageConfigResponse, MemorySize/Timeout) must fold, not FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntLambdaImg0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+REPO=cdkrd-hunt-lambdaimg0713
+REGISTRY="$ACCOUNT.dkr.ecr.$REGION.amazonaws.com"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  aws ecr delete-repository --repository-name "$REPO" --region "$REGION" --force >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] create ECR repo + build/push image ==="
+aws ecr create-repository --repository-name "$REPO" --region "$REGION" \
+  --tags Key=cdkrd:ephemeral,Value=1 >/dev/null 2>&1 || true
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$REGISTRY" || fail "ecr login"
+# Build linux/amd64: the barest function declares no Architectures, so Lambda defaults
+# to x86_64 and would reject an arm64 image. --provenance=false --sbom=false disable the
+# buildkit OCI attestation layers that Lambda rejects (InvalidImage:
+# UnsupportedImageLayerDetected) — required with Docker 24+ default buildkit.
+docker build --platform linux/amd64 --provenance=false --sbom=false -t "$REGISTRY/$REPO:latest" . || fail "docker build"
+docker push "$REGISTRY/$REPO:latest" || fail "docker push"
+# Resolve the immutable digest URI (Lambda pins by digest; use it so the template is stable).
+DIGEST="$(aws ecr describe-images --repository-name "$REPO" --region "$REGION" \
+  --query 'imageDetails[0].imageDigest' --output text)"
+export CDKRD_HUNT_IMAGE_URI="$REGISTRY/$REPO@$DIGEST"
+echo "image: $CDKRD_HUNT_IMAGE_URI"
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/revert-toggle-converge/app.ts
+++ b/tests/integration/revert-toggle-converge/app.ts
@@ -1,0 +1,34 @@
+// Revert-convergence fixture for the cdk-real-drift bug hunt: two undeclared defaults
+// that are folded by KNOWN_DEFAULTS but whose live values are toggled ONLY by a
+// DEDICATED provider API (not a settable scalar in the resource update), so a revert that
+// merely OMITS the property (a Cloud Control `remove`) is a SILENT NO-OP — Cloud Control
+// reports SUCCESS yet the live value persists. This is the #597 / #1541 class.
+//
+//   1. AWS::Events::Rule State (default ENABLED) — toggled by EnableRule/DisableRule.
+//   2. AWS::Kinesis::Stream RetentionPeriodHours (default 24) — changed only by
+//      Increase/DecreaseStreamRetentionPeriod.
+//
+// Both are barest (State / RetentionPeriodHours undeclared), so each folds to atDefault on
+// a first check. verify-detect.sh mutates each out of band, asserts detection, then reverts
+// and asserts the LIVE value actually returns to the default — the assertion that catches
+// the no-op. Without the REVERT_SET_DEFAULT_PATHS fix, revert claims CLEAN but the live
+// value stays mutated.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnRule } from "aws-cdk-lib/aws-events";
+import { CfnStream } from "aws-cdk-lib/aws-kinesis";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntRevertToggle0713");
+
+// Barest scheduled rule: only a schedule, no State, no targets.
+new CfnRule(stack, "Rule", {
+  scheduleExpression: "rate(1 day)",
+});
+
+// Barest provisioned stream: only a shard count, no RetentionPeriodHours.
+new CfnStream(stack, "Stream", {
+  shardCount: 1,
+});
+
+app.synth();

--- a/tests/integration/revert-toggle-converge/cdk.json
+++ b/tests/integration/revert-toggle-converge/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revert-toggle-converge/package.json
+++ b/tests/integration/revert-toggle-converge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revert-toggle-converge",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Revert-convergence fixture (Events::Rule State, Kinesis::Stream RetentionPeriodHours) for the cdk-real-drift bug hunt. Run via verify.sh + verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revert-toggle-converge/verify-detect.sh
+++ b/tests/integration/revert-toggle-converge/verify-detect.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Detection + REVERT-CONVERGENCE test. For each undeclared, KNOWN_DEFAULTS-folded property
+# that is toggled only by a dedicated provider API, mutate it out of band, assert check
+# DETECTS, revert, then assert the LIVE value actually returned to the default. The live
+# assertion is the point: a revert that merely OMITS the property is a silent no-op (Cloud
+# Control reports SUCCESS yet the value persists) unless REVERT_SET_DEFAULT_PATHS writes the
+# default explicitly.
+set -uo pipefail
+export AWS_PAGER=""
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevertToggle0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "DETECT FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never >/dev/null 2>&1 || fail "deploy"
+
+RULE="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Events::Rule'].PhysicalResourceId" --output text)"
+STREAM="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Kinesis::Stream'].PhysicalResourceId" --output text)"
+[ -n "$RULE" ] && [ -n "$STREAM" ] || fail "could not resolve physical ids"
+
+echo "=== record clean baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes >/dev/null 2>&1 || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail >/dev/null 2>&1 || fail "expected CLEAN after record"
+
+# --- Events::Rule State ---
+echo "=== Events::Rule: disable out of band, detect, revert, assert re-ENABLED ==="
+aws events disable-rule --name "$RULE" --region "$REGION" || fail "disable-rule"
+$CLI check "$STACK" --region "$REGION" --fail >/dev/null 2>&1 && fail "check did NOT detect DISABLED rule (FN)"
+$CLI revert "$STACK" --region "$REGION" --yes 2>&1 | grep -iE "State|revert|Rule" | head
+RULE_STATE="$(aws events describe-rule --name "$RULE" --region "$REGION" --query State --output text)"
+echo "live Rule State after revert: $RULE_STATE (want ENABLED)"
+[ "$RULE_STATE" = "ENABLED" ] || fail "revert did NOT restore Rule State (still $RULE_STATE) — silent no-op"
+
+# --- Kinesis::Stream RetentionPeriodHours ---
+echo "=== Kinesis::Stream: increase retention out of band, detect, revert, assert back to 24 ==="
+aws kinesis increase-stream-retention-period --stream-name "$STREAM" --retention-period-hours 48 --region "$REGION" || fail "increase-retention"
+# Kinesis retention update settles quickly but poll until ACTIVE.
+for _ in 1 2 3 4 5 6; do
+  st="$(aws kinesis describe-stream-summary --stream-name "$STREAM" --region "$REGION" --query StreamDescriptionSummary.StreamStatus --output text)"
+  [ "$st" = "ACTIVE" ] && break; sleep 5
+done
+$CLI check "$STACK" --region "$REGION" --fail >/dev/null 2>&1 && fail "check did NOT detect retention 48 (FN)"
+$CLI revert "$STACK" --region "$REGION" --yes 2>&1 | grep -iE "Retention|revert|Stream" | head
+for _ in 1 2 3 4 5 6; do
+  st="$(aws kinesis describe-stream-summary --stream-name "$STREAM" --region "$REGION" --query StreamDescriptionSummary.StreamStatus --output text)"
+  [ "$st" = "ACTIVE" ] && break; sleep 5
+done
+RET="$(aws kinesis describe-stream-summary --stream-name "$STREAM" --region "$REGION" --query StreamDescriptionSummary.RetentionPeriodHours --output text)"
+echo "live Stream RetentionPeriodHours after revert: $RET (want 24)"
+[ "$RET" = "24" ] || fail "revert did NOT restore RetentionPeriodHours (still $RET) — silent no-op"
+
+echo "=== post-revert check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail >/dev/null 2>&1 || fail "expected CLEAN after revert"
+echo "DETECT+CONVERGE PASS ($STACK)"

--- a/tests/integration/revert-toggle-converge/verify.sh
+++ b/tests/integration/revert-toggle-converge/verify.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# False-positive test: a barest Events::Rule + Kinesis::Stream must FIRST-check CLEAN
+# (State ENABLED and RetentionPeriodHours 24 fold to atDefault) and stay CLEAN after record.
+set -uo pipefail
+export AWS_PAGER=""
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevertToggle0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -576,6 +576,29 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('Kinesis Stream RetentionPeriodHours (SET-DEFAULT) -> add op writing the 24 default, not a no-op remove', () => {
+    // RetentionPeriodHours is changed only by the dedicated
+    // Increase/DecreaseStreamRetentionPeriod APIs — the Cloud Control Stream update handler
+    // ignores an OMITTED RetentionPeriodHours, so a bare `remove` of an out-of-band undeclared
+    // retention increase is a silent no-op (live-proven on CdkrdHuntRevertToggle0713: an
+    // increase to 48 was detected but the `remove` revert left the live value at 48). Revert
+    // must write the KNOWN_DEFAULTS `24` explicitly so the handler calls
+    // DecreaseStreamRetentionPeriod and converges.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Kinesis::Stream',
+      path: 'RetentionPeriodHours',
+      actual: 48,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/RetentionPeriodHours',
+      value: 24,
+      prior: 48,
+    });
+  });
+
   it('#1544: EC2 Instance MetadataOptions (SET-DEFAULT) -> add op writing the secure-defaults object, not a no-op remove', () => {
     // ModifyInstanceMetadataOptions is a one-shot API: a bare `remove` of an out-of-band
     // undeclared MetadataOptions change is a silent no-op (live-proven on


### PR DESCRIPTION
## What & why

`/hunt-bugs` session. One confirmed bug fixed, plus clean-round regression assets.

### Fix — Kinesis Stream RetentionPeriodHours revert was a silent no-op (Closes #1571)

`RetentionPeriodHours` is changed only by the dedicated `Increase`/`DecreaseStreamRetentionPeriod` APIs. The Cloud Control Stream update handler **ignores an OMITTED `RetentionPeriodHours`**, so cdkrd's default `remove`-op revert of an out-of-band retention increase was a **silent no-op** — Cloud Control reports SUCCESS yet the live value persists.

**Live-proven (us-east-1):** a barest provisioned stream (retention folds to `24`), record, `increase-stream-retention-period --retention-period-hours 48` → `check` correctly DETECTS → `revert` emits `RetentionPeriodHours -> remove` and the live value **stayed 48**.

**Fix:** add `AWS::Kinesis::Stream\0RetentionPeriodHours` to `REVERT_SET_DEFAULT_PATHS` so revert writes the `KNOWN_DEFAULTS` default (`24`) explicitly (an `add` op), which the CC handler translates to `DecreaseStreamRetentionPeriod`. **Post-fix live re-verified:** revert emits `RetentionPeriodHours -> AWS default` and the live value converges to `24`.

Unit test: `tests/revert-plan.test.ts` — asserts the plan produces `add /RetentionPeriodHours 24` (not a no-op remove), modelled on the #1541 RDS BackupRetentionPeriod case.

### Useful negatives (same class, live-proven to CONVERGE via `remove` — no fix needed)

The revert-no-op class is **non-uniform** — each sibling must be live-proven, not assumed:

| type / property | dedicated API | revert-via-remove |
| --- | --- | --- |
| `Events::Rule` State | Enable/DisableRule | **converges** (CC re-enables) |
| `SQS::Queue` VisibilityTimeout | SetQueueAttributes | **converges** |
| `EFS::FileSystem` BackupPolicy | PutBackupPolicy | **converges** |
| `Kinesis::Stream` RetentionPeriodHours | Increase/Decrease | **no-op → fixed here** |

(RDS::DBInstance twins MultiAZ / EnablePerformanceInsights / MonitoringInterval remain the in-source #1541 follow-up — awaiting their own live proof; not bundled here.)

### Clean-round regression assets (all first-`check` CLEAN, FN detect + revert verified live)

- **`tests/integration/elbv2-listenercert-barest`** — exercises the #1560
  `ListenerCertificate` SDK reader for the first time (was zero corpus / zero fixture).
  Confirmed: the reader's declared∩live projection folds cleanly (32 atDefault, resource
  is classified not skipped), and removing the attached SNI cert out of band surfaces as
  declared drift. New corpus type `ListenerCertificate.SniCert`.
- **`tests/integration/lambda-container-barest`** — the one uncovered Lambda variant axis,
  a container-image function (`PackageType: Image`); every prior Lambda fixture/corpus is
  Zip. Confirmed: Image-specific undeclared defaults (Architectures, EphemeralStorage,
  RecursiveLoop, LoggingConfig, …) fold to atDefault; MemorySize detect + revert converges.
  New corpus `Lambda Function ContainerImgFn`. (`verify.sh` builds with
  `--provenance=false --sbom=false` — required so Docker 24+ buildkit doesn't emit OCI
  attestation layers that Lambda rejects with `InvalidImage`.)
- **`tests/integration/revert-toggle-converge`** — the revert-convergence fixture: the
  fixed Kinesis case + the Events::Rule converge-via-remove control.

## Test

- `vp run typecheck` — pass
- `vp check --fix` — 0 errors
- `vp pack` — pass
- `vp test run` — 283 files, 5625 tests pass (incl. the new `revert-plan` case + 807 `corpus-replay`)
- Live: all four hunt stacks deployed, verified, and torn down; `sweep-orphans.sh` → SWEEP CLEAN.
