### PR TITLE
fix(diff): fold ClientVpnEndpoint VpcId and SecurityGroupIds materialized by an in-stack target network association

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -572,6 +572,23 @@ Recorded]` breakdown with `--verbose`.
   every newly materialized undeclared field is a latent FP a real user hits on their
   second deploy. Fold it with the same decision order (the sizing pair joined the
   existing value-independent MaxCapacity trio).
+- **Sibling-ATTACHMENT echo materialization is the post-update class's twin — deploy
+  the ATTACHED shape, not just the barest parent.** A parent deployed ALONE can hide
+  FPs that only materialize when a sibling attaches to it: a barest
+  `ClientVpnEndpoint` (the existing `clientvpn-barest` fixture) reads back neither
+  `VpcId` nor `SecurityGroupIds`, but the moment an in-stack
+  `ClientVpnTargetNetworkAssociation` lands, BOTH materialize (the subnet's VPC + its
+  default SG) → 2 first-run FPs invisible under apparent coverage (#1574,
+  2026-07-13). When a type has attachment-style siblings (association / attachment /
+  registration / membership resources), deploy the parent WITH one attached and
+  first-check that shape too. Fold with the decision order — the association echo is
+  usually tier-2 derivable from the declared sibling (here: SubnetId → in-stack
+  Subnet.VpcId, plus the shared DEFAULT_SG_LIST gate). Related probe mechanics:
+  ClientVPN authorization-rule revoke is ASYNC (the rule lists as `revoking` for
+  ~30s+ — an FN probe that checks too early false-passes; poll until the rule is
+  GONE before asserting detection), and a rogue SG applied to an endpoint can't be
+  deleted until the swap-back propagates to the association ENIs
+  (`DependencyViolation` — retry with a wait loop).
 - **Immutable props can't drift.** Don't treat an `unresolved`/unverifiable
   create-only property (Subnet `AvailabilityZone` via `Fn::Select(Fn::GetAZs)`, NAT
   `AllocationId` via `Fn::GetAtt` EIP) as a bug — it's correctly classified. And

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -112,6 +112,11 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // subnet-group VPC's default SG — registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch
   // must fire when a replication instance is present or the OOB-swap gate loses its default-SG ids.
   'AWS::DMS::ReplicationInstance',
+  // A ClientVpnEndpoint that declares no SecurityGroupIds gains its associated VPC's default SG
+  // when the first target-network association lands (live-confirmed us-east-1 2026-07-13) —
+  // registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch must fire when an endpoint is
+  // present or the OOB-swap gate loses its default-SG ids.
+  'AWS::EC2::ClientVpnEndpoint',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —
@@ -1140,6 +1145,79 @@ export function buildSiblingEipAssociations(desired: Desired): Set<string> {
   return associated;
 }
 
+// Per ClientVpnEndpoint identity (logicalId + physicalId), the VPC id derived from a DECLARED
+// sibling AWS::EC2::ClientVpnTargetNetworkAssociation. The FIRST association materializes the
+// endpoint's undeclared `VpcId` (= the associated subnet's VPC) and default SG (live-confirmed
+// us-east-1 2026-07-13) — a deterministic echo of the stack's own association, so classify folds a
+// live VpcId equal to the derived value (an out-of-band `modify-client-vpn-endpoint --vpc-id` move
+// still surfaces). The derivation is PURELY in-stack (zero API calls): association.SubnetId →
+// the declared sibling Subnet's raw `VpcId` (a literal, or a Ref resolved via the VPC resource's
+// physical id). An association whose subnet/VPC is not derivable (imported subnet) maps to `null`
+// (fail open: classify folds any VpcId — best-effort, a clean deploy never gains a first-run FP);
+// conflicting derivations across associations also degrade to `null`. An endpoint with NO declared
+// association gets NO entry, so a live VpcId (an out-of-band association echo) keeps surfacing.
+export function buildClientVpnEndpointSiblingVpcs(desired: Desired): Record<string, string | null> {
+  const refLogicalId = (ref: unknown): string | undefined => {
+    if (ref && typeof ref === 'object') {
+      if ('Ref' in ref && typeof (ref as { Ref: unknown }).Ref === 'string')
+        return (ref as { Ref: string }).Ref;
+      if ('Fn::GetAtt' in ref) {
+        const g = (ref as { 'Fn::GetAtt': unknown })['Fn::GetAtt'];
+        if (Array.isArray(g) && typeof g[0] === 'string') return g[0];
+      }
+    }
+    return undefined;
+  };
+  const endpointIds = new Map<string, string[]>(); // endpoint logicalId -> identities
+  const subnetVpcRaw = new Map<string, unknown>(); // subnet logicalId AND physicalId -> raw VpcId
+  const vpcPhysical = new Map<string, string>(); // VPC logicalId -> physical id
+  for (const r of desired.resources) {
+    if (r.resourceType === 'AWS::EC2::ClientVpnEndpoint') {
+      const ids = [r.logicalId];
+      if (r.physicalId) ids.push(r.physicalId);
+      endpointIds.set(r.logicalId, ids);
+    } else if (r.resourceType === 'AWS::EC2::Subnet') {
+      const raw = (r.declared as Record<string, unknown> | undefined)?.VpcId;
+      subnetVpcRaw.set(r.logicalId, raw);
+      if (r.physicalId) subnetVpcRaw.set(r.physicalId, raw);
+    } else if (r.resourceType === 'AWS::EC2::VPC' && r.physicalId) {
+      vpcPhysical.set(r.logicalId, r.physicalId);
+    }
+  }
+  const out: Record<string, string | null> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::EC2::ClientVpnTargetNetworkAssociation') continue;
+    const d = (r.declared ?? {}) as Record<string, unknown>;
+    // Resolve the target endpoint's identities: a Ref/GetAtt to the sibling endpoint, or a
+    // resolved literal endpoint id (== the endpoint's physical id classify also looks up by).
+    const epLogical = refLogicalId(d.ClientVpnEndpointId);
+    const epKeys =
+      epLogical !== undefined
+        ? (endpointIds.get(epLogical) ?? [])
+        : typeof d.ClientVpnEndpointId === 'string' && d.ClientVpnEndpointId
+          ? [d.ClientVpnEndpointId]
+          : [];
+    if (epKeys.length === 0) continue;
+    // Derive the association's VPC from its subnet: in-stack subnet → its raw VpcId (literal or a
+    // Ref to the in-stack VPC's physical id). Anything not derivable → null (fail open).
+    const subnetKey =
+      refLogicalId(d.SubnetId) ?? (typeof d.SubnetId === 'string' ? d.SubnetId : '');
+    const rawVpc = subnetVpcRaw.get(subnetKey);
+    let derived: string | null = null;
+    if (typeof rawVpc === 'string' && rawVpc) derived = rawVpc;
+    else {
+      const vpcLogical = refLogicalId(rawVpc);
+      if (vpcLogical !== undefined) derived = vpcPhysical.get(vpcLogical) ?? null;
+    }
+    for (const key of epKeys) {
+      // Conflicting derivations across multiple associations degrade to fail-open null.
+      if (key in out && out[key] !== derived) derived = null;
+      out[key] = derived;
+    }
+  }
+  return out;
+}
+
 // #1498: the set of Subnet identities (logicalId + physicalId) whose IPv6 CIDR is assigned by a
 // sibling AWS::EC2::SubnetCidrBlock (the normal dual-stack CDK shape). The Subnet's own live model
 // echoes an undeclared Ipv6CidrBlock/Ipv6CidrBlocks that the SubnetCidrBlock sibling declares — so
@@ -1870,6 +1948,7 @@ export async function gatherFindings(
     bucketNotificationConfigs: buildBucketNotificationConfigs(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     scalableTargetBands: buildScalableTargetBands(desired),
+    siblingClientVpnEndpointVpcs: buildClientVpnEndpointSiblingVpcs(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 
@@ -1983,6 +2062,7 @@ export async function regatherTouched(
     bucketNotificationConfigs: buildBucketNotificationConfigs(desired),
     clusterEchoModel: buildClusterEchoModels(desired),
     scalableTargetBands: buildScalableTargetBands(desired),
+    siblingClientVpnEndpointVpcs: buildClientVpnEndpointSiblingVpcs(desired),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -116,6 +116,10 @@ export interface CorpusCase {
     // entry, so replay reproduces the derived AllocatedStorage fold. Without it a fresh-harvested RI
     // replays the undeclared default storage as false drift. Optional for back-compat.
     accountDefaults?: { dmsAllocatedStorageDefaults?: Record<string, number> };
+    // This ClientVpnEndpoint's own sibling-derived VPC entry (keyed by logicalId, else physicalId —
+    // classify's probe order), present only when a declared sibling target-network association
+    // derives it, so replay reproduces the association-echoed `VpcId` fold. Optional for back-compat.
+    siblingClientVpnEndpointVpcs?: Record<string, string | null>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -155,6 +159,7 @@ export function buildCorpusCase(
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
     siblingListenerPorts?: Record<string, number>;
     accountDefaults?: { dmsAllocatedStorageDefaults?: Record<string, number> };
+    siblingClientVpnEndpointVpcs?: Record<string, string | null>;
   },
   findings: Finding[]
 ): CorpusCase {
@@ -231,6 +236,19 @@ export function buildCorpusCase(
           },
         }
       : undefined;
+  // Carry ONLY this ClientVpnEndpoint's own sibling-derived VPC entry. classify probes the map by
+  // logicalId first, then physicalId — carry the key that is present (`null` is meaningful: an
+  // in-stack association whose VPC was not derivable → fail-open fold), so replay folds the
+  // association-echoed VpcId the same way the live check did.
+  const cvpnVpcMap = opts.siblingClientVpnEndpointVpcs;
+  const cvpnVpcKey =
+    resource.resourceType !== 'AWS::EC2::ClientVpnEndpoint' || cvpnVpcMap === undefined
+      ? undefined
+      : resource.logicalId in cvpnVpcMap
+        ? resource.logicalId
+        : resource.physicalId !== undefined && resource.physicalId in cvpnVpcMap
+          ? resource.physicalId
+          : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
     resource: {
@@ -277,6 +295,9 @@ export function buildCorpusCase(
         : {}),
       ...(gaListenerPort ? { siblingListenerPorts: gaListenerPort } : {}),
       ...(dmsStorageDefault ? { accountDefaults: dmsStorageDefault } : {}),
+      ...(cvpnVpcKey !== undefined && cvpnVpcMap !== undefined
+        ? { siblingClientVpnEndpointVpcs: { [cvpnVpcKey]: cvpnVpcMap[cvpnVpcKey] ?? null } }
+        : {}),
     },
     expected: findings,
   };

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -509,6 +509,15 @@ export const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // hide a rogue SG swap/append. Same derived VPC-default-SG gate: fold a single default SG,
   // surface an append/swap. Keep in sync with gather.ts DEFAULT_SG_LIST_TYPES.
   'AWS::DMS::ReplicationInstance': 'VpcSecurityGroupIds',
+  // A ClientVpnEndpoint that declares no SecurityGroupIds gains its associated VPC's default SG
+  // the moment the FIRST target-network association lands (live-confirmed on a fresh barest
+  // endpoint + in-stack association, us-east-1 2026-07-13; the unassociated `clientvpn-barest`
+  // shape never materializes the field, which is why this stayed latent). It is OOB-mutable
+  // (`ec2 apply-security-groups-to-client-vpn-target-network`), so the same derived
+  // VPC-default-SG gate applies: fold the single default SG, surface an append/swap. Keep in
+  // sync with gather.ts DEFAULT_SG_LIST_TYPES. The association-echoed `VpcId` sibling is folded
+  // via siblingClientVpnEndpointVpcs below.
+  'AWS::EC2::ClientVpnEndpoint': 'SecurityGroupIds',
 };
 /** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
  *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into
@@ -2822,6 +2831,14 @@ export function classifyResource(
     // over-set and SURFACES, marked autoscalerGoverned so revert refuses (a write-back the scaler
     // re-adjusts would never converge). Absent → no fold (fail-open, the finding stays visible).
     scalableTargetBands?: Record<string, { path: string; min: number; max: number }[]>;
+    // Per ClientVpnEndpoint identity (logicalId + physicalId), the VPC id DERIVED from a declared
+    // sibling AWS::EC2::ClientVpnTargetNetworkAssociation (its SubnetId's in-stack Subnet.VpcId; see
+    // gather.ts buildClientVpnEndpointSiblingVpcs). The FIRST association materializes the endpoint's
+    // undeclared `VpcId` (and default SG) — a deterministic echo of the stack's own association, not
+    // drift — so classify folds a `VpcId` equal to the derived VPC to atDefault. `null` = an in-stack
+    // association exists but its VPC is not derivable (imported subnet) → fail open (fold any VpcId).
+    // NO entry = no declared association → a live VpcId is an out-of-band association echo, SURFACES.
+    siblingClientVpnEndpointVpcs?: Record<string, string | null>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -4788,6 +4805,35 @@ export function classifyResource(
         actual: v,
       });
       continue;
+    }
+    // A ClientVpnEndpoint's undeclared `VpcId` is materialized by the FIRST target-network
+    // association (live-confirmed on a fresh barest endpoint + in-stack association, us-east-1
+    // 2026-07-13) — a deterministic echo of the stack's own declared association, so fold it when
+    // it equals the sibling-derived VPC (tier 2; an out-of-band `modify-client-vpn-endpoint
+    // --vpc-id` move no longer matches and surfaces). `null` = association present but VPC not
+    // derivable (imported subnet) → fail open. NO map entry = no declared association → a live
+    // VpcId is an out-of-band association echo and falls through (surfaces as undeclared).
+    if (resourceType === 'AWS::EC2::ClientVpnEndpoint' && k === 'VpcId' && typeof v === 'string') {
+      // `null` is meaningful (fail-open fold), so probe key presence — `??` would skip past it.
+      const vpcMap = opts.siblingClientVpnEndpointVpcs;
+      const derived =
+        vpcMap === undefined
+          ? undefined
+          : logicalId in vpcMap
+            ? vpcMap[logicalId]
+            : physicalId !== undefined && physicalId in vpcMap
+              ? vpcMap[physicalId]
+              : undefined;
+      if (derived !== undefined) {
+        findings.push({
+          tier: derived === null || derived === v ? 'atDefault' : 'undeclared',
+          logicalId,
+          resourceType,
+          path: k,
+          actual: v,
+        });
+        continue;
+      }
     }
     // #1269: an UNDECLARED default-subnet list (RedshiftServerless Workgroup SubnetIds) — replaces
     // the old value-independent fold, which hid an out-of-band subnet re-placement. Fold atDefault

--- a/tests/classify-clientvpn-assoc-echo.test.ts
+++ b/tests/classify-clientvpn-assoc-echo.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildClientVpnEndpointSiblingVpcs } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// First-run FP found by the 2026-07-13 hunt: an AWS::EC2::ClientVpnEndpoint that declares neither
+// `VpcId` nor `SecurityGroupIds` gains BOTH the moment the FIRST target-network association lands
+// (live-confirmed us-east-1: VpcId = the associated subnet's VPC, SecurityGroupIds = that VPC's
+// default SG). The unassociated `clientvpn-barest` shape never materializes the fields, which is
+// why this stayed latent. Folds (both tier 2, detection-preserving):
+//   - SecurityGroupIds → the shared derived VPC-default-SG gate (DEFAULT_SG_LIST_PATHS): a single
+//     default SG folds, an out-of-band swap/append surfaces.
+//   - VpcId → the sibling-derived VPC (gather.buildClientVpnEndpointSiblingVpcs: association
+//     SubnetId → in-stack Subnet.VpcId): a match folds, an out-of-band `modify-client-vpn-endpoint
+//     --vpc-id` move (or an association echo with NO declared sibling) surfaces.
+
+const schema: SchemaInfo = {
+  readOnly: new Set(['Id']),
+  writeOnly: new Set(),
+  createOnly: new Set(['AuthenticationOptions', 'ClientCidrBlock', 'TransportProtocol']),
+  readOnlyPaths: ['Id'],
+  writeOnlyPaths: [],
+  createOnlyPaths: ['AuthenticationOptions', 'ClientCidrBlock', 'TransportProtocol'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const CERT = 'arn:aws:acm:us-east-1:111111111111:certificate/a549a63e';
+const endpointResource: DesiredResource = {
+  logicalId: 'Endpoint',
+  resourceType: 'AWS::EC2::ClientVpnEndpoint',
+  physicalId: 'cvpn-endpoint-0eb61aeb3a584e71a',
+  declared: {
+    AuthenticationOptions: [
+      {
+        MutualAuthentication: { ClientRootCertificateChainArn: CERT },
+        Type: 'certificate-authentication',
+      },
+    ],
+    ClientCidrBlock: '10.100.0.0/22',
+    ConnectionLogOptions: { Enabled: false },
+    ServerCertificateArn: CERT,
+  },
+};
+
+// The live model mirrors the real DescribeClientVpnEndpoints projection of the associated
+// endpoint the hunt harvested (tests/corpus AWS__EC2__ClientVpnEndpoint.EndpointAssoc).
+const associatedLive = (): Record<string, unknown> => ({
+  ClientCidrBlock: '10.100.0.0/22',
+  SplitTunnel: false,
+  TransportProtocol: 'udp',
+  VpnPort: 443,
+  ServerCertificateArn: CERT,
+  SecurityGroupIds: ['sg-09b6d7fd7f1364328'],
+  VpcId: 'vpc-07c0e7826547bd2a7',
+  SessionTimeoutHours: 24,
+  DisconnectOnSessionTimeout: true,
+  ConnectionLogOptions: { Enabled: false },
+  AuthenticationOptions: [
+    {
+      Type: 'certificate-authentication',
+      MutualAuthentication: { ClientRootCertificateChainArn: CERT },
+    },
+  ],
+});
+
+const byPath = (findings: Finding[], path: string) => findings.filter((f) => f.path === path);
+
+const desiredWithAssociation = (subnetVpc: unknown, opts?: { vpcPhysical?: string }): Desired =>
+  ({
+    resources: [
+      endpointResource,
+      {
+        logicalId: 'Vpc',
+        resourceType: 'AWS::EC2::VPC',
+        physicalId: opts?.vpcPhysical ?? 'vpc-07c0e7826547bd2a7',
+        declared: { CidrBlock: '10.42.0.0/16' },
+      },
+      {
+        logicalId: 'Subnet',
+        resourceType: 'AWS::EC2::Subnet',
+        physicalId: 'subnet-0aaa1111bbb22222c',
+        declared: { VpcId: subnetVpc, CidrBlock: '10.42.0.0/24' },
+      },
+      {
+        logicalId: 'Assoc',
+        resourceType: 'AWS::EC2::ClientVpnTargetNetworkAssociation',
+        physicalId: 'cvpn-assoc-0123456789abcdef0',
+        declared: { ClientVpnEndpointId: { Ref: 'Endpoint' }, SubnetId: { Ref: 'Subnet' } },
+      },
+    ],
+  }) as unknown as Desired;
+
+describe('ClientVpnEndpoint association-echo folds (2026-07-13 hunt)', () => {
+  it('(map) derives the VPC from a Ref-form association + in-stack subnet with Ref VpcId', () => {
+    const map = buildClientVpnEndpointSiblingVpcs(desiredWithAssociation({ Ref: 'Vpc' }));
+    // Keyed by BOTH the endpoint's logicalId and physicalId; value = the VPC's physical id.
+    expect(map).toEqual({
+      Endpoint: 'vpc-07c0e7826547bd2a7',
+      'cvpn-endpoint-0eb61aeb3a584e71a': 'vpc-07c0e7826547bd2a7',
+    });
+  });
+
+  it('(map) derives from a fully RESOLVED association (literal endpoint + subnet ids)', () => {
+    const desired = {
+      resources: [
+        endpointResource,
+        {
+          logicalId: 'Subnet',
+          resourceType: 'AWS::EC2::Subnet',
+          physicalId: 'subnet-0aaa1111bbb22222c',
+          declared: { VpcId: 'vpc-07c0e7826547bd2a7', CidrBlock: '10.42.0.0/24' },
+        },
+        {
+          logicalId: 'Assoc',
+          resourceType: 'AWS::EC2::ClientVpnTargetNetworkAssociation',
+          declared: {
+            ClientVpnEndpointId: 'cvpn-endpoint-0eb61aeb3a584e71a',
+            SubnetId: 'subnet-0aaa1111bbb22222c',
+          },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildClientVpnEndpointSiblingVpcs(desired);
+    expect(map).toEqual({ 'cvpn-endpoint-0eb61aeb3a584e71a': 'vpc-07c0e7826547bd2a7' });
+  });
+
+  it('(map) an association onto an IMPORTED subnet (not in-stack) degrades to null (fail open)', () => {
+    const desired = {
+      resources: [
+        endpointResource,
+        {
+          logicalId: 'Assoc',
+          resourceType: 'AWS::EC2::ClientVpnTargetNetworkAssociation',
+          declared: {
+            ClientVpnEndpointId: { Ref: 'Endpoint' },
+            SubnetId: 'subnet-imported00000001',
+          },
+        },
+      ],
+    } as unknown as Desired;
+    const map = buildClientVpnEndpointSiblingVpcs(desired);
+    expect(map).toEqual({ Endpoint: null, 'cvpn-endpoint-0eb61aeb3a584e71a': null });
+  });
+
+  it('(map) no declared association → no entry (a live VpcId then surfaces)', () => {
+    const desired = { resources: [endpointResource] } as unknown as Desired;
+    expect(buildClientVpnEndpointSiblingVpcs(desired)).toEqual({});
+  });
+
+  it('(classify) the clean-deploy association echo folds: VpcId + default SG → atDefault', () => {
+    const findings = classifyResource(endpointResource, associatedLive(), schema, {
+      defaultSgIds: new Set(['sg-09b6d7fd7f1364328']),
+      siblingClientVpnEndpointVpcs: {
+        Endpoint: 'vpc-07c0e7826547bd2a7',
+        'cvpn-endpoint-0eb61aeb3a584e71a': 'vpc-07c0e7826547bd2a7',
+      },
+    });
+    expect(byPath(findings, 'VpcId')).toEqual([
+      expect.objectContaining({ tier: 'atDefault', actual: 'vpc-07c0e7826547bd2a7' }),
+    ]);
+    expect(byPath(findings, 'SecurityGroupIds')).toEqual([
+      expect.objectContaining({ tier: 'atDefault', actual: ['sg-09b6d7fd7f1364328'] }),
+    ]);
+    expect(findings.filter((f) => f.tier === 'undeclared')).toEqual([]);
+  });
+
+  it('(classify) an out-of-band VPC move (live VpcId ≠ derived) SURFACES', () => {
+    const live = { ...associatedLive(), VpcId: 'vpc-0feedfacefeedface0' };
+    const findings = classifyResource(endpointResource, live, schema, {
+      defaultSgIds: new Set(['sg-09b6d7fd7f1364328']),
+      siblingClientVpnEndpointVpcs: { Endpoint: 'vpc-07c0e7826547bd2a7' },
+    });
+    expect(byPath(findings, 'VpcId')).toEqual([
+      expect.objectContaining({ tier: 'undeclared', actual: 'vpc-0feedfacefeedface0' }),
+    ]);
+  });
+
+  it('(classify) a VpcId with NO declared association (out-of-band association echo) SURFACES', () => {
+    const findings = classifyResource(endpointResource, associatedLive(), schema, {
+      defaultSgIds: new Set(['sg-09b6d7fd7f1364328']),
+      siblingClientVpnEndpointVpcs: {},
+    });
+    expect(byPath(findings, 'VpcId')).toEqual([expect.objectContaining({ tier: 'undeclared' })]);
+  });
+
+  it('(classify) a null derivation (imported subnet) folds fail-open', () => {
+    const findings = classifyResource(endpointResource, associatedLive(), schema, {
+      defaultSgIds: new Set(['sg-09b6d7fd7f1364328']),
+      siblingClientVpnEndpointVpcs: { Endpoint: null },
+    });
+    expect(byPath(findings, 'VpcId')).toEqual([expect.objectContaining({ tier: 'atDefault' })]);
+  });
+
+  it('(classify) an out-of-band SG SWAP (single non-default SG) SURFACES', () => {
+    const live = { ...associatedLive(), SecurityGroupIds: ['sg-0rogue0000000000a'] };
+    const findings = classifyResource(endpointResource, live, schema, {
+      defaultSgIds: new Set(['sg-09b6d7fd7f1364328']),
+      siblingClientVpnEndpointVpcs: { Endpoint: 'vpc-07c0e7826547bd2a7' },
+    });
+    expect(byPath(findings, 'SecurityGroupIds')).toEqual([
+      expect.objectContaining({ tier: 'undeclared' }),
+    ]);
+  });
+
+  it('(classify) an out-of-band SG APPEND (default + extra) SURFACES', () => {
+    const live = {
+      ...associatedLive(),
+      SecurityGroupIds: ['sg-09b6d7fd7f1364328', 'sg-0rogue0000000000a'],
+    };
+    const findings = classifyResource(endpointResource, live, schema, {
+      defaultSgIds: new Set(['sg-09b6d7fd7f1364328']),
+      siblingClientVpnEndpointVpcs: { Endpoint: 'vpc-07c0e7826547bd2a7' },
+    });
+    expect(byPath(findings, 'SecurityGroupIds')).toEqual([
+      expect.objectContaining({ tier: 'undeclared' }),
+    ]);
+  });
+
+  it('(classify) the SG gate fails OPEN when the default-SG prefetch is unavailable', () => {
+    const findings = classifyResource(endpointResource, associatedLive(), schema, {
+      siblingClientVpnEndpointVpcs: { Endpoint: 'vpc-07c0e7826547bd2a7' },
+    });
+    expect(byPath(findings, 'SecurityGroupIds')).toEqual([
+      expect.objectContaining({ tier: 'atDefault' }),
+    ]);
+  });
+});

--- a/tests/corpus/AWS__EC2__ClientVpnAuthorizationRule.Rule.json
+++ b/tests/corpus/AWS__EC2__ClientVpnAuthorizationRule.Rule.json
@@ -1,0 +1,51 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rule",
+    "resourceType": "AWS::EC2::ClientVpnAuthorizationRule",
+    "physicalId": "Rule-5HQmcB8Cysby",
+    "constructPath": "CdkrdHuntCvpnKids0713/Rule",
+    "declared": {
+      "AuthorizeAllGroups": true,
+      "ClientVpnEndpointId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "TargetNetworkCidr": "10.42.0.0/16"
+    }
+  },
+  "liveRaw": {
+    "ClientVpnEndpointId": "cvpn-endpoint-0eb61aeb3a584e71a",
+    "TargetNetworkCidr": "10.42.0.0/16",
+    "AuthorizeAllGroups": true
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "AccessGroupId",
+      "AuthorizeAllGroups",
+      "ClientVpnEndpointId",
+      "Description",
+      "TargetNetworkCidr"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AccessGroupId",
+      "AuthorizeAllGroups",
+      "ClientVpnEndpointId",
+      "Description",
+      "TargetNetworkCidr"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__ClientVpnEndpoint.EndpointAssoc.json
+++ b/tests/corpus/AWS__EC2__ClientVpnEndpoint.EndpointAssoc.json
@@ -1,0 +1,140 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EndpointAssoc",
+    "resourceType": "AWS::EC2::ClientVpnEndpoint",
+    "physicalId": "cvpn-endpoint-0eb61aeb3a584e71a",
+    "constructPath": "CdkrdHuntCvpnKids0713/Endpoint",
+    "declared": {
+      "AuthenticationOptions": [
+        {
+          "MutualAuthentication": {
+            "ClientRootCertificateChainArn": "arn:aws:acm:us-east-1:111111111111:certificate/a549a63e-9ba1-4a00-ae93-cdf71b4e30bf"
+          },
+          "Type": "certificate-authentication"
+        }
+      ],
+      "ClientCidrBlock": "10.100.0.0/22",
+      "ConnectionLogOptions": {
+        "Enabled": false
+      },
+      "ServerCertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/a549a63e-9ba1-4a00-ae93-cdf71b4e30bf"
+    }
+  },
+  "liveRaw": {
+    "ClientCidrBlock": "10.100.0.0/22",
+    "SplitTunnel": false,
+    "TransportProtocol": "udp",
+    "VpnPort": 443,
+    "ServerCertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/a549a63e-9ba1-4a00-ae93-cdf71b4e30bf",
+    "SecurityGroupIds": ["sg-09b6d7fd7f1364328"],
+    "VpcId": "vpc-07c0e7826547bd2a7",
+    "SessionTimeoutHours": 24,
+    "DisconnectOnSessionTimeout": true,
+    "ConnectionLogOptions": {
+      "Enabled": false
+    },
+    "AuthenticationOptions": [
+      {
+        "Type": "certificate-authentication",
+        "MutualAuthentication": {
+          "ClientRootCertificateChainArn": "arn:aws:acm:us-east-1:111111111111:certificate/a549a63e-9ba1-4a00-ae93-cdf71b4e30bf"
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "AuthenticationOptions",
+      "ClientCidrBlock",
+      "EndpointIpAddressType",
+      "TagSpecifications",
+      "TrafficIpAddressType",
+      "TransitGatewayConfiguration",
+      "TransportProtocol"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AuthenticationOptions",
+      "ClientCidrBlock",
+      "EndpointIpAddressType",
+      "TagSpecifications",
+      "TrafficIpAddressType",
+      "TransitGatewayConfiguration",
+      "TransportProtocol"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "siblingClientVpnEndpointVpcs": {
+      "cvpn-endpoint-0eb61aeb3a584e71a": "vpc-07c0e7826547bd2a7"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EndpointAssoc",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "TransportProtocol",
+      "actual": "udp",
+      "physicalId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "constructPath": "CdkrdHuntCvpnKids0713/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EndpointAssoc",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "VpnPort",
+      "actual": 443,
+      "physicalId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "constructPath": "CdkrdHuntCvpnKids0713/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EndpointAssoc",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-09b6d7fd7f1364328"],
+      "physicalId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "constructPath": "CdkrdHuntCvpnKids0713/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EndpointAssoc",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "VpcId",
+      "actual": "vpc-07c0e7826547bd2a7",
+      "physicalId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "constructPath": "CdkrdHuntCvpnKids0713/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EndpointAssoc",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "SessionTimeoutHours",
+      "actual": 24,
+      "physicalId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "constructPath": "CdkrdHuntCvpnKids0713/Endpoint"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EndpointAssoc",
+      "resourceType": "AWS::EC2::ClientVpnEndpoint",
+      "path": "DisconnectOnSessionTimeout",
+      "actual": true,
+      "physicalId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "constructPath": "CdkrdHuntCvpnKids0713/Endpoint"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__ClientVpnTargetNetworkAssociation.Assoc.json
+++ b/tests/corpus/AWS__EC2__ClientVpnTargetNetworkAssociation.Assoc.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Assoc",
+    "resourceType": "AWS::EC2::ClientVpnTargetNetworkAssociation",
+    "physicalId": "cvpn-assoc-0a95ad8338e534ac2",
+    "constructPath": "CdkrdHuntCvpnKids0713/Assoc",
+    "declared": {
+      "ClientVpnEndpointId": "cvpn-endpoint-0eb61aeb3a584e71a",
+      "SubnetId": "subnet-0619cffd4994934f9"
+    }
+  },
+  "liveRaw": {
+    "ClientVpnEndpointId": "cvpn-endpoint-0eb61aeb3a584e71a",
+    "SubnetId": "subnet-0619cffd4994934f9"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["AvailabilityZone", "AvailabilityZoneId", "ClientVpnEndpointId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "ClientVpnEndpointId",
+      "SubnetId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ServiceDiscovery__PrivateDnsNamespace.Ns33A06F6E.json
+++ b/tests/corpus/AWS__ServiceDiscovery__PrivateDnsNamespace.Ns33A06F6E.json
@@ -1,0 +1,72 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Ns33A06F6E",
+    "resourceType": "AWS::ServiceDiscovery::PrivateDnsNamespace",
+    "physicalId": "ns-xd4yucfbkz52j6v2",
+    "constructPath": "CdkrdHuntCmapPriv0713/Ns",
+    "declared": {
+      "Name": "cdkrd-hunt-priv.internal",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Vpc": "vpc-0b1c00eff701aea24"
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt-priv.internal",
+    "Arn": "arn:aws:servicediscovery:us-east-1:111111111111:namespace/ns-xd4yucfbkz52j6v2",
+    "Id": "ns-xd4yucfbkz52j6v2",
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHuntCmapPriv0713"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "Ns33A06F6E"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntCmapPriv0713/2c546350-7ebe-11f1-8058-0e4f09930a2d"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "HostedZoneId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Vpc"],
+    "readOnlyPaths": ["Arn", "HostedZoneId", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Vpc"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Ns33A06F6E",
+      "resourceType": "AWS::ServiceDiscovery::PrivateDnsNamespace",
+      "path": "Vpc",
+      "note": "declared but not returned by live read",
+      "physicalId": "ns-xd4yucfbkz52j6v2",
+      "constructPath": "CdkrdHuntCmapPriv0713/Ns"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceDiscovery__Service.NsSvcFBBB2FA7.json
+++ b/tests/corpus/AWS__ServiceDiscovery__Service.NsSvcFBBB2FA7.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NsSvcFBBB2FA7",
+    "resourceType": "AWS::ServiceDiscovery::Service",
+    "physicalId": "srv-larvapfwzod2rbjj",
+    "constructPath": "CdkrdHuntCmapPriv0713/Ns/Svc",
+    "declared": {
+      "DnsConfig": {
+        "DnsRecords": [
+          {
+            "TTL": 60,
+            "Type": "A"
+          }
+        ],
+        "NamespaceId": "ns-xd4yucfbkz52j6v2",
+        "RoutingPolicy": "MULTIVALUE"
+      },
+      "Name": "hunt-svc",
+      "NamespaceId": "ns-xd4yucfbkz52j6v2",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Name": "hunt-svc",
+    "NamespaceId": "ns-xd4yucfbkz52j6v2",
+    "Type": "DNS_HTTP",
+    "DnsConfig": {
+      "NamespaceId": "ns-xd4yucfbkz52j6v2",
+      "RoutingPolicy": "MULTIVALUE",
+      "DnsRecords": [
+        {
+          "Type": "A",
+          "TTL": 60
+        }
+      ]
+    },
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHuntCmapPriv0713"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "NsSvcFBBB2FA7"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntCmapPriv0713/2c546350-7ebe-11f1-8058-0e4f09930a2d"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["HealthCheckCustomConfig", "Name", "NamespaceId", "Type"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HealthCheckCustomConfig", "Name", "NamespaceId", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "NsSvcFBBB2FA7",
+      "resourceType": "AWS::ServiceDiscovery::Service",
+      "path": "Type",
+      "actual": "DNS_HTTP",
+      "physicalId": "srv-larvapfwzod2rbjj",
+      "constructPath": "CdkrdHuntCmapPriv0713/Ns/Svc"
+    }
+  ]
+}

--- a/tests/integration/clientvpn-children/app.ts
+++ b/tests/integration/clientvpn-children/app.ts
@@ -1,0 +1,54 @@
+// Barest-config ClientVPN CHILD-resource fixture for the cdk-real-drift FP hunt.
+// AWS::EC2::ClientVpnAuthorizationRule and AWS::EC2::ClientVpnTargetNetworkAssociation
+// are NON_PROVISIONABLE CC gaps whose SDK_OVERRIDES readers (issue #534) had ZERO
+// corpus cases and ZERO fixtures — they were added without ever being exercised
+// live. This fixture deploys the smallest stack that materializes BOTH children:
+// a VPC + one subnet + a cert-auth endpoint (same self-signed ACM import trick as
+// clientvpn-barest, via CDKRD_HUNT_VPN_CERT_ARN) + one target-network association
+// + one authorize-all rule. First check (before record) MUST be CLEAN.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnClientVpnAuthorizationRule,
+  CfnClientVpnEndpoint,
+  CfnClientVpnTargetNetworkAssociation,
+  CfnSubnet,
+  CfnVPC,
+} from "aws-cdk-lib/aws-ec2";
+
+const certArn = process.env.CDKRD_HUNT_VPN_CERT_ARN;
+if (!certArn) throw new Error("CDKRD_HUNT_VPN_CERT_ARN must be set (see verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntCvpnKids0713");
+
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.42.0.0/16" });
+const subnet = new CfnSubnet(stack, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.42.0.0/24",
+});
+
+const endpoint = new CfnClientVpnEndpoint(stack, "Endpoint", {
+  clientCidrBlock: "10.100.0.0/22", // must not overlap the target VPC
+  serverCertificateArn: certArn,
+  authenticationOptions: [
+    {
+      type: "certificate-authentication",
+      mutualAuthentication: { clientRootCertificateChainArn: certArn },
+    },
+  ],
+  connectionLogOptions: { enabled: false },
+});
+
+new CfnClientVpnTargetNetworkAssociation(stack, "Assoc", {
+  clientVpnEndpointId: endpoint.ref,
+  subnetId: subnet.ref,
+});
+
+new CfnClientVpnAuthorizationRule(stack, "Rule", {
+  clientVpnEndpointId: endpoint.ref,
+  targetNetworkCidr: "10.42.0.0/16",
+  authorizeAllGroups: true,
+});
+
+app.synth();

--- a/tests/integration/clientvpn-children/cdk.json
+++ b/tests/integration/clientvpn-children/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/clientvpn-children/package.json
+++ b/tests/integration/clientvpn-children/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-clientvpn-children",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest ClientVPN authorization-rule + target-network-association fixture for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/clientvpn-children/verify.sh
+++ b/tests/integration/clientvpn-children/verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): the first live exercise of the
+# ClientVpnAuthorizationRule + ClientVpnTargetNetworkAssociation SDK_OVERRIDES
+# readers (#534). Imports a self-signed server cert into ACM out of band (same
+# trick as clientvpn-barest) and deploys a VPC + subnet + cert-auth endpoint +
+# one association + one authorize-all rule. First check (no baseline) MUST be
+# CLEAN; record + check MUST stay CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntCvpnKids0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  # The imported ACM cert is stack-external — delete it after the endpoint is gone.
+  [ -n "${CDKRD_HUNT_VPN_CERT_ARN:-}" ] &&
+    aws acm delete-certificate --certificate-arn "$CDKRD_HUNT_VPN_CERT_ARN" --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] import self-signed server cert into ACM ==="
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/cdkrd-cvpnkids-key.pem -out /tmp/cdkrd-cvpnkids-cert.pem \
+  -days 7 -nodes -subj "/CN=cdkrd-hunt-cvpn-children.internal" 2>/dev/null || fail "openssl"
+CDKRD_HUNT_VPN_CERT_ARN="$(aws acm import-certificate --certificate fileb:///tmp/cdkrd-cvpnkids-cert.pem \
+  --private-key fileb:///tmp/cdkrd-cvpnkids-key.pem --region "$REGION" \
+  --tags Key=cdkrd:ephemeral,Value=1 --query CertificateArn --output text)" || fail "acm import"
+export CDKRD_HUNT_VPN_CERT_ARN
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cloudmap-private-min/app.ts
+++ b/tests/integration/cloudmap-private-min/app.ts
@@ -1,0 +1,35 @@
+// Barest-config Cloud Map PRIVATE DNS namespace fixture for the cdk-real-drift FP
+// hunt. AWS::ServiceDiscovery::PrivateDnsNamespace shares readServiceDiscoveryNamespace
+// with the Http/Public variants, but the PRIVATE variant had ZERO corpus cases and
+// ZERO fixtures — its live shape (a DNS namespace carries a Vpc / hosted-zone side)
+// was never exercised. Uses the L2 constructs (the common user path): an L2
+// PrivateDnsNamespace over a minimal imported VPC + one L2-created DNS service
+// (exercises the #1537 DnsConfig.NamespaceId mirror on a PRIVATE namespace).
+// First check (before record) MUST be CLEAN.
+import { App, Duration, Stack, Tags } from "aws-cdk-lib";
+import { CfnVPC, Vpc } from "aws-cdk-lib/aws-ec2";
+import { DnsRecordType, PrivateDnsNamespace } from "aws-cdk-lib/aws-servicediscovery";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntCmapPriv0713");
+
+// Minimal VPC: the raw Cfn resource (no subnets/NAT), re-imported for the L2 API.
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.43.0.0/16" });
+const vpcRef = Vpc.fromVpcAttributes(stack, "VpcRef", {
+  vpcId: vpc.ref,
+  availabilityZones: ["dummy"], // unused by the namespace; required by the importer
+});
+
+const ns = new PrivateDnsNamespace(stack, "Ns", {
+  name: "cdkrd-hunt-priv.internal",
+  vpc: vpcRef,
+});
+
+ns.createService("Svc", {
+  name: "hunt-svc",
+  dnsRecordType: DnsRecordType.A,
+  dnsTtl: Duration.seconds(60),
+});
+
+app.synth();

--- a/tests/integration/cloudmap-private-min/cdk.json
+++ b/tests/integration/cloudmap-private-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudmap-private-min/package.json
+++ b/tests/integration/cloudmap-private-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudmap-private-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config Cloud Map PrivateDnsNamespace + private DNS service fixture for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudmap-private-min/verify.sh
+++ b/tests/integration/cloudmap-private-min/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): a barest PRIVATE Cloud Map namespace
+# + one L2 DNS service must FIRST-check CLEAN (no baseline) and stay CLEAN after
+# record. This is the first live exercise of readServiceDiscoveryNamespace on the
+# PrivateDnsNamespace variant.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntCmapPriv0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

/hunt-bugs round (2026-07-13): first live exercise of three zero-corpus SDK_OVERRIDES readers — `ClientVpnAuthorizationRule` + `ClientVpnTargetNetworkAssociation` (#534) and the `PrivateDnsNamespace` variant of the ServiceDiscovery reader. The readers themselves came back CLEAN (first check + out-of-band detection verified live), but the hunt confirmed one FP class on the PARENT endpoint:

**Closes #1574** — a `ClientVpnEndpoint` with an in-stack target-network association first-run FPs on the two undeclared properties the association materializes: `VpcId` (the associated subnet's VPC) and `SecurityGroupIds` (that VPC's default SG). Live-confirmed us-east-1 (`CdkrdHuntCvpnKids0713`).

## Fix (both tier-2 derived — detection preserved)

- `SecurityGroupIds` → joins the shared derived VPC-default-SG gate (`DEFAULT_SG_LIST_PATHS` + gather `DEFAULT_SG_LIST_TYPES`). Live-proven: an out-of-band `apply-security-groups-to-client-vpn-target-network` swap to a rogue SG re-surfaces; the restored default folds back CLEAN.
- `VpcId` → new `buildClientVpnEndpointSiblingVpcs` (gather): derives the expected VPC from the declared sibling association's `SubnetId` → in-stack `Subnet.VpcId` (zero API calls; fail-open `null` for an imported subnet; NO entry when no association is declared, so an out-of-band association echo still surfaces).
- Corpus recorder carries the endpoint's own sibling-derived VPC entry for exact replay.

## Live verification

| Step | Result |
| --- | --- |
| BASE first check (fresh assoc'd endpoint) | 2 × `[Potential Drift]` (the FPs) |
| FIX first check (same live stack) | CLEAN — atDefault 12 → 14 |
| OOB SG swap to rogue SG → check | surfaces (equality gate proven) |
| Restore default SG → check | CLEAN |
| OOB rule revoke → check (after record) | detected as `deleted`, exit 1 |
| Re-authorize → check | CLEAN |

Also `cloudmap-private-min` (PrivateDnsNamespace + L2 private DNS service): first check CLEAN; out-of-band `update-service` TTL change detected; revert gap (no SDK writer) filed as #1573.

## Assets

- `tests/integration/clientvpn-children/` + `tests/integration/cloudmap-private-min/` regression fixtures (first-check-CLEAN standard).
- 5 new golden-corpus cases: ClientVpnEndpoint (associated variant), ClientVpnAuthorizationRule, ClientVpnTargetNetworkAssociation, PrivateDnsNamespace, private DNS Service.
- 11 new unit tests (`tests/classify-clientvpn-assoc-echo.test.ts`); full suite 284 files / 5643 tests green.
- hunt-bugs SKILL.md gotcha: sibling-ATTACHMENT echo materialization is the post-update echo class's twin — deploy the attached shape, not just the barest parent.

## Notes

- Core shared-name integ suite deferred — the diff is fully covered by unit tests + corpus replay and was live-proven in this hunt (per /verify-pr step 7 deferral rule).
- Cleanup: both stacks + the out-of-band ACM cert deleted via delstack; `sweep-orphans.sh` reports SWEEP CLEAN; bughunt gate released.
