### PR TITLE
fix(noise): fold SageMaker MonitoringSchedule inline-definition defaults (MonitoringType + StoppingCondition)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1906,6 +1906,20 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'DataQualityJobInput.EndpointInput.S3DataDistributionType': 'FullyReplicated',
     'DataQualityJobInput.EndpointInput.S3InputMode': 'File',
   },
+  // A barest MonitoringSchedule with an INLINE MonitoringJobDefinition reads back two
+  // AWS-filled defaults (live-verified on a fresh BatchTransformInput schedule, us-east-1
+  // 2026-07-13, sagemaker-monitoring-min): `MonitoringType: "DataQuality"` — the type AWS
+  // assigns an inline definition (the named-definition style DECLARES MonitoringType, which
+  // then compares in the declared dimension) — and the job definition's
+  // `StoppingCondition: {MaxRuntimeInSeconds: 3600}`, the same schema-documented default the
+  // sibling AWS::SageMaker::DataQualityJobDefinition pins top-level in KNOWN_DEFAULTS.
+  // Equality-gated: an out-of-band type flip or a capped runtime still surfaces.
+  'AWS::SageMaker::MonitoringSchedule': {
+    'MonitoringScheduleConfig.MonitoringType': 'DataQuality',
+    'MonitoringScheduleConfig.MonitoringJobDefinition.StoppingCondition': {
+      MaxRuntimeInSeconds: 3600,
+    },
+  },
   // A SageMaker model whose container definition declares only the Image reads back the
   // AWS-filled `Mode: "SingleModel"` — the constant creation default for a container that
   // never declares it (the only other value, MultiModel, is an explicit opt-in). Both the

--- a/tests/corpus/AWS__SageMaker__MonitoringSchedule.HuntSchedule.json
+++ b/tests/corpus/AWS__SageMaker__MonitoringSchedule.HuntSchedule.json
@@ -1,0 +1,159 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntSchedule",
+    "resourceType": "AWS::SageMaker::MonitoringSchedule",
+    "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:monitoring-schedule/cdkrd-hunt-monsched-0713",
+    "constructPath": "CdkrdHuntSmMonSched0713/Schedule",
+    "declared": {
+      "MonitoringScheduleConfig": {
+        "MonitoringJobDefinition": {
+          "MonitoringAppSpecification": {
+            "ImageUri": "156813124566.dkr.ecr.us-east-1.amazonaws.com/sagemaker-model-monitor-analyzer"
+          },
+          "MonitoringInputs": [
+            {
+              "BatchTransformInput": {
+                "DataCapturedDestinationS3Uri": "s3://cdkrdhuntsmmonsched0713-data666c94c7-cfeuxltvufjg/capture",
+                "DatasetFormat": {
+                  "Csv": {
+                    "Header": false
+                  }
+                },
+                "LocalPath": "/opt/ml/processing/input"
+              }
+            }
+          ],
+          "MonitoringOutputConfig": {
+            "MonitoringOutputs": [
+              {
+                "S3Output": {
+                  "LocalPath": "/opt/ml/processing/output",
+                  "S3Uri": "s3://cdkrdhuntsmmonsched0713-data666c94c7-cfeuxltvufjg/out"
+                }
+              }
+            ]
+          },
+          "MonitoringResources": {
+            "ClusterConfig": {
+              "InstanceCount": 1,
+              "InstanceType": "ml.m5.large",
+              "VolumeSizeInGB": 20
+            }
+          },
+          "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHuntSmMonSched0713-MonitorRole437F0C3A-Kd8B3RQqKpJa"
+        },
+        "ScheduleConfig": {
+          "ScheduleExpression": "cron(0 23 ? * * *)"
+        }
+      },
+      "MonitoringScheduleName": "cdkrd-hunt-monsched-0713",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MonitoringScheduleName": "cdkrd-hunt-monsched-0713",
+    "MonitoringScheduleConfig": {
+      "ScheduleConfig": {
+        "ScheduleExpression": "cron(0 23 ? * * *)"
+      },
+      "MonitoringJobDefinition": {
+        "MonitoringInputs": [
+          {
+            "BatchTransformInput": {
+              "DataCapturedDestinationS3Uri": "s3://cdkrdhuntsmmonsched0713-data666c94c7-cfeuxltvufjg/capture",
+              "DatasetFormat": {
+                "Csv": {
+                  "Header": false
+                }
+              },
+              "LocalPath": "/opt/ml/processing/input",
+              "S3InputMode": "File",
+              "S3DataDistributionType": "FullyReplicated"
+            }
+          }
+        ],
+        "MonitoringOutputConfig": {
+          "MonitoringOutputs": [
+            {
+              "S3Output": {
+                "S3Uri": "s3://cdkrdhuntsmmonsched0713-data666c94c7-cfeuxltvufjg/out",
+                "LocalPath": "/opt/ml/processing/output",
+                "S3UploadMode": "EndOfJob"
+              }
+            }
+          ]
+        },
+        "MonitoringResources": {
+          "ClusterConfig": {
+            "InstanceCount": 1,
+            "InstanceType": "ml.m5.large",
+            "VolumeSizeInGB": 20
+          }
+        },
+        "MonitoringAppSpecification": {
+          "ImageUri": "156813124566.dkr.ecr.us-east-1.amazonaws.com/sagemaker-model-monitor-analyzer"
+        },
+        "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHuntSmMonSched0713-MonitorRole437F0C3A-Kd8B3RQqKpJa",
+        "StoppingCondition": {
+          "MaxRuntimeInSeconds": 3600
+        }
+      },
+      "MonitoringType": "DataQuality"
+    },
+    "Tags": [
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreationTime", "LastModifiedTime", "MonitoringScheduleArn"],
+    "writeOnly": [],
+    "createOnly": ["MonitoringScheduleName"],
+    "readOnlyPaths": ["CreationTime", "LastModifiedTime", "MonitoringScheduleArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["MonitoringScheduleName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["MonitoringScheduleConfig.MonitoringJobDefinition.Environment"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSchedule",
+      "resourceType": "AWS::SageMaker::MonitoringSchedule",
+      "path": "MonitoringScheduleConfig.MonitoringJobDefinition.StoppingCondition",
+      "actual": {
+        "MaxRuntimeInSeconds": 3600
+      },
+      "nested": true,
+      "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:monitoring-schedule/cdkrd-hunt-monsched-0713",
+      "constructPath": "CdkrdHuntSmMonSched0713/Schedule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSchedule",
+      "resourceType": "AWS::SageMaker::MonitoringSchedule",
+      "path": "MonitoringScheduleConfig.MonitoringType",
+      "actual": "DataQuality",
+      "nested": true,
+      "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:monitoring-schedule/cdkrd-hunt-monsched-0713",
+      "constructPath": "CdkrdHuntSmMonSched0713/Schedule"
+    }
+  ]
+}

--- a/tests/integration/sagemaker-monitoring-min/app.ts
+++ b/tests/integration/sagemaker-monitoring-min/app.ts
@@ -1,0 +1,67 @@
+// Barest-config SageMaker MonitoringSchedule fixture for the cdk-real-drift FP hunt.
+// AWS::SageMaker::MonitoringSchedule is read via readSageMakerMonitoringSchedule
+// (the #1523 ARN-vs-name fix) but had ZERO corpus cases and ZERO fixtures — the
+// reader was never exercised live, and it projects the SDK-shaped
+// MonitoringScheduleConfig WHOLESALE, a prime echo-FP surface. Uses a
+// BatchTransformInput (NOT EndpointInput) so no SageMaker endpoint is needed —
+// the schedule deploys against a plain S3 prefix. The cron fires daily at 23:00
+// UTC so no processing job ever launches inside a hunt window (near-zero cost).
+// First check (before record) MUST be CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnMonitoringSchedule } from "aws-cdk-lib/aws-sagemaker";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntSmMonSched0713");
+
+const bucket = new Bucket(stack, "Data", { removalPolicy: RemovalPolicy.DESTROY });
+const role = new Role(stack, "MonitorRole", {
+  assumedBy: new ServicePrincipal("sagemaker.amazonaws.com"),
+});
+role.addToPolicy(
+  new PolicyStatement({
+    actions: ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+    resources: [bucket.bucketArn, bucket.arnForObjects("*")],
+  })
+);
+
+// us-east-1 account for the AWS-provided model-monitor analyzer image.
+const analyzerImage =
+  "156813124566.dkr.ecr.us-east-1.amazonaws.com/sagemaker-model-monitor-analyzer";
+
+new CfnMonitoringSchedule(stack, "Schedule", {
+  monitoringScheduleName: "cdkrd-hunt-monsched-0713",
+  monitoringScheduleConfig: {
+    scheduleConfig: { scheduleExpression: "cron(0 23 ? * * *)" },
+    monitoringJobDefinition: {
+      monitoringInputs: [
+        {
+          batchTransformInput: {
+            dataCapturedDestinationS3Uri: `s3://${bucket.bucketName}/capture`,
+            datasetFormat: { csv: { header: false } },
+            localPath: "/opt/ml/processing/input",
+          },
+        },
+      ],
+      monitoringOutputConfig: {
+        monitoringOutputs: [
+          {
+            s3Output: {
+              s3Uri: `s3://${bucket.bucketName}/out`,
+              localPath: "/opt/ml/processing/output",
+            },
+          },
+        ],
+      },
+      monitoringResources: {
+        clusterConfig: { instanceCount: 1, instanceType: "ml.m5.large", volumeSizeInGb: 20 },
+      },
+      monitoringAppSpecification: { imageUri: analyzerImage },
+      roleArn: role.roleArn,
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/sagemaker-monitoring-min/cdk.json
+++ b/tests/integration/sagemaker-monitoring-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sagemaker-monitoring-min/package.json
+++ b/tests/integration/sagemaker-monitoring-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sagemaker-monitoring-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest SageMaker MonitoringSchedule (BatchTransformInput, no endpoint) fixture for the cdk-real-drift first-run FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sagemaker-monitoring-min/verify.sh
+++ b/tests/integration/sagemaker-monitoring-min/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): the first live exercise of the
+# readSageMakerMonitoringSchedule SDK_OVERRIDES reader (#1523 lineage). A barest
+# BatchTransformInput monitoring schedule (no endpoint) must FIRST-check CLEAN
+# (no baseline) and stay CLEAN after record.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntSmMonSched0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-sagemaker-monsched-folds.test.ts
+++ b/tests/noise-sagemaker-monsched-folds.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// First-run FPs found by the 2026-07-13 hunt (sagemaker-monitoring-min, live us-east-1):
+// a barest MonitoringSchedule with an INLINE MonitoringJobDefinition reads back two
+// AWS-filled defaults the template never declares —
+//   MonitoringScheduleConfig.MonitoringType = "DataQuality"
+//   MonitoringScheduleConfig.MonitoringJobDefinition.StoppingCondition = {MaxRuntimeInSeconds:3600}
+// Both are stable constants (the StoppingCondition default is the same one the sibling
+// AWS::SageMaker::DataQualityJobDefinition pins top-level), so they fold via
+// KNOWN_DEFAULT_PATHS — equality-gated, so a flip away still surfaces. The declared/live
+// models mirror the harvested corpus case AWS__SageMaker__MonitoringSchedule.Schedule.
+
+const schema: SchemaInfo = {
+  readOnly: new Set(['MonitoringScheduleArn', 'CreationTime', 'LastModifiedTime']),
+  writeOnly: new Set(),
+  createOnly: new Set(['MonitoringScheduleName']),
+  readOnlyPaths: ['MonitoringScheduleArn', 'CreationTime', 'LastModifiedTime'],
+  writeOnlyPaths: [],
+  createOnlyPaths: ['MonitoringScheduleName'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const jobDefinition = (stopping?: Record<string, unknown>) => ({
+  MonitoringInputs: [
+    {
+      BatchTransformInput: {
+        DataCapturedDestinationS3Uri: 's3://hunt-bucket/capture',
+        DatasetFormat: { Csv: { Header: false } },
+        LocalPath: '/opt/ml/processing/input',
+      },
+    },
+  ],
+  MonitoringOutputConfig: {
+    MonitoringOutputs: [
+      { S3Output: { S3Uri: 's3://hunt-bucket/out', LocalPath: '/opt/ml/processing/output' } },
+    ],
+  },
+  MonitoringResources: {
+    ClusterConfig: { InstanceCount: 1, InstanceType: 'ml.m5.large', VolumeSizeInGB: 20 },
+  },
+  MonitoringAppSpecification: {
+    ImageUri: '156813124566.dkr.ecr.us-east-1.amazonaws.com/sagemaker-model-monitor-analyzer',
+  },
+  RoleArn: 'arn:aws:iam::111111111111:role/hunt-monitor-role',
+  ...(stopping !== undefined && { StoppingCondition: stopping }),
+});
+
+const resource: DesiredResource = {
+  logicalId: 'Schedule',
+  resourceType: 'AWS::SageMaker::MonitoringSchedule',
+  physicalId:
+    'arn:aws:sagemaker:us-east-1:111111111111:monitoring-schedule/cdkrd-hunt-monsched-0713',
+  declared: {
+    MonitoringScheduleName: 'cdkrd-hunt-monsched-0713',
+    MonitoringScheduleConfig: {
+      ScheduleConfig: { ScheduleExpression: 'cron(0 23 ? * * *)' },
+      MonitoringJobDefinition: jobDefinition(),
+    },
+  },
+};
+
+const live = (over: { type?: string; stopping?: Record<string, unknown> } = {}) => ({
+  MonitoringScheduleName: 'cdkrd-hunt-monsched-0713',
+  MonitoringScheduleConfig: {
+    ScheduleConfig: { ScheduleExpression: 'cron(0 23 ? * * *)' },
+    MonitoringJobDefinition: jobDefinition(over.stopping ?? { MaxRuntimeInSeconds: 3600 }),
+    MonitoringType: over.type ?? 'DataQuality',
+  },
+});
+
+const byPath = (findings: Finding[], path: string) => findings.filter((f) => f.path === path);
+const TYPE_PATH = 'MonitoringScheduleConfig.MonitoringType';
+const STOP_PATH = 'MonitoringScheduleConfig.MonitoringJobDefinition.StoppingCondition';
+
+describe('SageMaker MonitoringSchedule inline-definition default folds (2026-07-13 hunt)', () => {
+  it('folds the AWS-filled MonitoringType=DataQuality + StoppingCondition default to atDefault', () => {
+    const findings = classifyResource(resource, live(), schema, {});
+    expect(byPath(findings, TYPE_PATH)).toEqual([expect.objectContaining({ tier: 'atDefault' })]);
+    expect(byPath(findings, STOP_PATH)).toEqual([expect.objectContaining({ tier: 'atDefault' })]);
+    expect(findings.filter((f) => f.tier === 'undeclared')).toEqual([]);
+  });
+
+  it('a non-default MonitoringType (out-of-band flip) SURFACES', () => {
+    const findings = classifyResource(resource, live({ type: 'ModelQuality' }), schema, {});
+    expect(byPath(findings, TYPE_PATH)).toEqual([
+      expect.objectContaining({ tier: 'undeclared', actual: 'ModelQuality' }),
+    ]);
+  });
+
+  it('a capped MaxRuntimeInSeconds (non-default StoppingCondition) SURFACES', () => {
+    const findings = classifyResource(
+      resource,
+      live({ stopping: { MaxRuntimeInSeconds: 1800 } }),
+      schema,
+      {}
+    );
+    expect(byPath(findings, STOP_PATH)).toEqual([expect.objectContaining({ tier: 'undeclared' })]);
+  });
+});


### PR DESCRIPTION
## Summary

/hunt-bugs round 2 (2026-07-13): first live exercise of the zero-corpus `readSageMakerMonitoringSchedule` reader (#1523 lineage). Found + fixed 2 first-run FPs on a barest inline-definition schedule; the reader itself works (incl. the #1523 ARN→name extraction) and out-of-band detection is live-verified.

## The FPs (live us-east-1, `CdkrdHuntSmMonSched0713`)

```
[Potential Drift: 2]
  Schedule.MonitoringScheduleConfig.MonitoringJobDefinition.StoppingCondition
      actual ={"MaxRuntimeInSeconds":3600}
  Schedule.MonitoringScheduleConfig.MonitoringType
      actual ="DataQuality"
```

Both are AWS-filled constants on an INLINE MonitoringJobDefinition: `MonitoringType` is what AWS assigns an inline definition (the named-definition style declares it → declared dimension), and `StoppingCondition` is the same schema-documented default the sibling `AWS::SageMaker::DataQualityJobDefinition` already pins top-level in `KNOWN_DEFAULTS`.

## Fix

Two `KNOWN_DEFAULT_PATHS` entries (fold-strategy tier 1 — equality-gated constants; a type flip or capped runtime still surfaces). 3 new unit tests mirror the harvested live model.

## Live verification

| Step | Result |
| --- | --- |
| BASE first check | 2 × `[Potential Drift]` |
| FIX first check (same live stack) | CLEAN — atDefault 7 → 9 |
| record → OOB `update-monitoring-schedule` cron 23:00→22:00 → check | detects, exit 1 |
| restore → check | CLEAN |
| revert | not revertable (no writer) → filed **#1577** (`UpdateMonitoringSchedule` SDK_WRITERS candidate, same pattern as #1573/#1576) |

## Assets

- `tests/integration/sagemaker-monitoring-min/` — barest BatchTransformInput schedule fixture (NO endpoint needed — the EndpointInput style requires an InService endpoint; BatchTransformInput deploys against a plain S3 prefix. Daily 23:00 UTC cron so no processing job launches inside a hunt window).
- Golden-corpus case `AWS__SageMaker__MonitoringSchedule.HuntSchedule` — first MonitoringSchedule corpus coverage (813 replay cases green; full suite 285 files / 5655 tests).

Cleanup: stack deleted via delstack, `sweep-orphans.sh` SWEEP CLEAN, gate released.

Also from this follow-up session's offline audits (no code): the sibling-attachment-echo class (#1574) was swept across other attachment types — all already guarded or non-echoing (ListenerCertificate SNI certs don't echo into the parent Listener, corpus-proven; GA HealthCheckPort already classify-integrated) — and `ACM::Certificate` was ruled un-huntable live (CFn create hangs on DNS validation without an owned, delegated domain).
