### PR TITLE
fix(revert): SDK writer for AWS::SageMaker::MonitoringSchedule via UpdateMonitoringSchedule (#1577)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,10 @@ Control cannot sub-path patch it),
 `servicediscovery:UpdateService` (reverts an `AWS::ServiceDiscovery::Service`'s
 `Description` / `DnsConfig.DnsRecords` / `HealthCheckConfig` — a DNS-namespace
 service; an API-only (HTTP) namespace service cannot be updated),
+`sagemaker:UpdateMonitoringSchedule` (reverts an
+`AWS::SageMaker::MonitoringSchedule`'s `MonitoringScheduleConfig` — e.g. an
+out-of-band `ScheduleExpression` cron change; the API re-PUTs the whole config,
+which cdkrd reconstructs from the live read),
 `cognito-sync:SetCognitoEvents` (reverts an `AWS::Cognito::IdentityPool`'s
 writeOnly `CognitoEvents`),
 `kinesisvideo:UpdateDataRetention` / `kinesisvideo:UpdateSignalingChannel` /

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -206,6 +206,11 @@ import {
 import { ChangeResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { DeleteBucketPolicyCommand, PutBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
 import {
+  type MonitoringScheduleConfig,
+  SageMakerClient,
+  UpdateMonitoringScheduleCommand,
+} from '@aws-sdk/client-sagemaker';
+import {
   DeleteResourcePolicyCommand as SecretsDeleteResourcePolicyCommand,
   SecretsManagerClient,
 } from '@aws-sdk/client-secrets-manager';
@@ -707,6 +712,34 @@ const writeServiceDiscoveryService: SdkWriter = async (ctx, ops) => {
     throw new Error(
       `ServiceDiscovery Service ${id}: UpdateService cannot express ${[...unExpressible].join(', ')} (create-only / immutable)${anyExpressible ? ' — the other drifted values were reverted' : ''}`
     );
+};
+
+// AWS::SageMaker::MonitoringSchedule — read via the readSageMakerMonitoringSchedule SDK
+// override (#1523/#1577; CC read omits Tags so it is SDK-override-read), which parks it behind
+// the plan.ts CC-gap bar ("type not revertable yet") until a whole-resource SDK writer exists.
+// sagemaker:UpdateMonitoringSchedule is the only mutating API and it takes the FULL
+// MonitoringScheduleConfig (MonitoringScheduleName is create-only) — so reconstruct the desired
+// model (current read + revert ops applied) and re-PUT its whole MonitoringScheduleConfig, the
+// same full-desired-shape pattern as writeServiceDiscoveryHttpNamespace / writeConfigConfigurationRecorder.
+// Live-verified 2026-07-13 (us-east-1): an out-of-band ScheduleExpression cron change reverts back.
+const writeSageMakerMonitoringSchedule: SdkWriter = async (ctx, ops) => {
+  // The CFn physical id is the schedule ARN (arn:…:monitoring-schedule/<name>) but
+  // UpdateMonitoringSchedule wants the BARE name — mirror the reader's ARN-tail extraction (#1523).
+  const raw = str(ctx.physicalId) ?? str(ctx.declared['MonitoringScheduleName']);
+  if (!raw) throw new Error('cannot resolve MonitoringSchedule name for revert');
+  const name = raw.startsWith('arn:') ? (raw.split('/').pop() ?? raw) : raw;
+  const desired = await desiredModel('AWS::SageMaker::MonitoringSchedule', ctx, ops);
+  const config = desired.MonitoringScheduleConfig;
+  if (config === undefined || config === null)
+    throw new Error(
+      'SageMaker MonitoringSchedule revert requires the full MonitoringScheduleConfig, which the live read did not return; update it manually'
+    );
+  await new SageMakerClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+    new UpdateMonitoringScheduleCommand({
+      MonitoringScheduleName: name,
+      MonitoringScheduleConfig: config as MonitoringScheduleConfig,
+    })
+  );
 };
 
 // AWS::DocDB::DBCluster — Cloud Control cannot read OR write this type
@@ -2927,6 +2960,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::DocDB::DBInstance': writeDocDbInstance,
   'AWS::ServiceDiscovery::HttpNamespace': writeServiceDiscoveryHttpNamespace,
   'AWS::ServiceDiscovery::Service': writeServiceDiscoveryService,
+  'AWS::SageMaker::MonitoringSchedule': writeSageMakerMonitoringSchedule,
   'AWS::S3::BucketPolicy': writeS3BucketPolicy,
   'AWS::SNS::TopicPolicy': writeSnsTopicPolicy,
   'AWS::SQS::QueuePolicy': writeSqsQueuePolicy,

--- a/tests/revert-sagemaker-monsched-writer-1577.test.ts
+++ b/tests/revert-sagemaker-monsched-writer-1577.test.ts
@@ -1,0 +1,114 @@
+// #1577: AWS::SageMaker::MonitoringSchedule drift DETECTION works (read via the
+// readSageMakerMonitoringSchedule SDK override — CC read omits Tags), but before this fix
+// `revert` reported "type not revertable yet" because an SDK-override-read type with no
+// SDK_WRITERS entry is parked behind the plan.ts CC-gap bar. Registering a whole-resource
+// writer that re-PUTs the full MonitoringScheduleConfig via sagemaker:UpdateMonitoringSchedule
+// (MonitoringScheduleName is create-only) makes a declared ScheduleExpression drift route to a
+// kind='sdk' item and converge. Live-verified 2026-07-13 (us-east-1).
+import {
+  DescribeMonitoringScheduleCommand,
+  ListTagsCommand,
+  type MonitoringScheduleConfig,
+  SageMakerClient,
+  UpdateMonitoringScheduleCommand,
+} from '@aws-sdk/client-sagemaker';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { OverrideCtx } from '../src/read/overrides.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import { SDK_WRITERS } from '../src/revert/writers.js';
+import type { Finding } from '../src/types.js';
+
+const sagemaker = mockClient(SageMakerClient);
+
+const NAME = 'CdkrdMonSched';
+const ARN = `arn:aws:sagemaker:us-east-1:123456789012:monitoring-schedule/${NAME}`;
+
+// The full live config the reader returns, carrying the OUT-OF-BAND cron (cron(0 22 ? * * *)).
+const liveConfig = (): MonitoringScheduleConfig => ({
+  ScheduleConfig: { ScheduleExpression: 'cron(0 22 ? * * *)' },
+  MonitoringJobDefinitionName: 'jobdef-abc',
+  MonitoringType: 'DataQuality',
+});
+
+beforeEach(() => {
+  sagemaker.reset();
+  sagemaker.on(DescribeMonitoringScheduleCommand).resolves({
+    MonitoringScheduleName: NAME,
+    MonitoringScheduleArn: ARN,
+    MonitoringScheduleConfig: liveConfig(),
+  });
+  sagemaker.on(ListTagsCommand).resolves({ Tags: [] });
+  sagemaker.on(UpdateMonitoringScheduleCommand).resolves({ MonitoringScheduleArn: ARN });
+});
+
+describe('#1577 SageMaker MonitoringSchedule is SDK-revertable', () => {
+  it('a declared ScheduleExpression drift builds a kind=sdk item (not "not revertable")', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Schedule',
+      physicalId: ARN,
+      resourceType: 'AWS::SageMaker::MonitoringSchedule',
+      path: 'MonitoringScheduleConfig.ScheduleConfig.ScheduleExpression',
+      desired: 'cron(0 23 ? * * *)',
+      actual: 'cron(0 22 ? * * *)',
+    };
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.resourceType).toBe('AWS::SageMaker::MonitoringSchedule');
+  });
+
+  it('the writer PUTs the FULL config with the reverted cron, keyed by the bare name from the ARN', async () => {
+    const ctx: OverrideCtx = {
+      physicalId: ARN,
+      declared: {},
+      region: 'us-east-1',
+      accountId: '123456789012',
+      resourceType: 'AWS::SageMaker::MonitoringSchedule',
+    };
+    // Revert op: restore the declared cron (cron 23) over the live cron (cron 22).
+    await SDK_WRITERS['AWS::SageMaker::MonitoringSchedule']!(ctx, [
+      {
+        op: 'add',
+        path: '/MonitoringScheduleConfig/ScheduleConfig/ScheduleExpression',
+        value: 'cron(0 23 ? * * *)',
+        prior: 'cron(0 22 ? * * *)',
+        human: 'ScheduleExpression -> deployed-template value',
+      },
+    ]);
+    const calls = sagemaker.commandCalls(UpdateMonitoringScheduleCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input;
+    // Create-only name extracted from the ARN tail (not the raw ARN).
+    expect(input.MonitoringScheduleName).toBe(NAME);
+    // The WHOLE config is re-sent, not just the leaf — with the reverted cron and the
+    // untouched sibling fields intact.
+    expect(input.MonitoringScheduleConfig).toEqual({
+      ScheduleConfig: { ScheduleExpression: 'cron(0 23 ? * * *)' },
+      MonitoringJobDefinitionName: 'jobdef-abc',
+      MonitoringType: 'DataQuality',
+    });
+  });
+
+  it('throws (honest not-reverted) when the reconstructed model carries no MonitoringScheduleConfig', async () => {
+    // Live read returns no config and the revert op does not touch it either — the writer
+    // cannot re-PUT a full config, so it fails honestly rather than silently no-op.
+    sagemaker.reset();
+    sagemaker.on(DescribeMonitoringScheduleCommand).resolves({ MonitoringScheduleName: NAME });
+    sagemaker.on(ListTagsCommand).resolves({ Tags: [] });
+    const ctx: OverrideCtx = {
+      physicalId: ARN,
+      declared: {},
+      region: 'us-east-1',
+      accountId: '123456789012',
+      resourceType: 'AWS::SageMaker::MonitoringSchedule',
+    };
+    await expect(
+      SDK_WRITERS['AWS::SageMaker::MonitoringSchedule']!(ctx, [
+        { op: 'add', path: '/Tags', value: [{ Key: 'a', Value: 'b' }], human: 'x' },
+      ])
+    ).rejects.toThrow(/MonitoringScheduleConfig/);
+  });
+});


### PR DESCRIPTION
Closes #1577.

## Problem

`AWS::SageMaker::MonitoringSchedule` drift **detection** works (live-verified
us-east-1, 2026-07-13: an out-of-band `ScheduleExpression` cron change surfaced as
declared drift), but `revert` reported **"NOT revertable: 1 (type not revertable
yet)"**. The type is read via the `readSageMakerMonitoringSchedule` SDK override
(#1523 lineage; the CC read omits `Tags`), and an SDK-override-read type with no
`SDK_WRITERS` entry is parked behind the `plan.ts` CC-gap bar
([plan.ts:1080-1092](src/revert/plan.ts#L1080-L1092)).

## Fix

Add `SDK_WRITERS['AWS::SageMaker::MonitoringSchedule']` — a whole-resource writer
that re-PUTs the full `MonitoringScheduleConfig` via
`sagemaker:UpdateMonitoringSchedule` (`MonitoringScheduleName` is create-only). It
reconstructs the desired model (current read + revert ops applied) — the same
full-desired-shape pattern as `writeServiceDiscoveryHttpNamespace` /
`writeConfigConfigurationRecorder` — and mirrors the reader's ARN→bare-name tail
extraction. Registering the writer makes a declared `ScheduleExpression` drift route
to a `kind='sdk'` item that converges instead of "not revertable".

## Tests

`tests/revert-sagemaker-monsched-writer-1577.test.ts`:
- plan routing: a declared `MonitoringScheduleConfig.ScheduleConfig.ScheduleExpression`
  drift builds a `kind='sdk'` item (`notRevertable` empty).
- writer (mocked SDK): PUTs the FULL config with the reverted cron, keyed by the bare
  name extracted from the ARN, siblings intact.
- guard: throws honestly (not a silent no-op) when the reconstructed model carries no
  `MonitoringScheduleConfig`.

## Docs

README "Additional write permissions (revert)" now lists
`sagemaker:UpdateMonitoringSchedule`.
