### PR TITLE
fix(revert): ECR Repository ImageTagMutability revert converges via REVERT_SET_DEFAULT_PATHS (#1580)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -211,6 +211,14 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // planned a `remove`, reported CLEAN, yet live `get-monitor` stayed INACTIVE). Write the
   // "ACTIVE" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
   'AWS::InternetMonitor::Monitor\0Status',
+  // ECR Repository UpdateResource IGNORES an omitted ImageTagMutability (live-proven on
+  // echo-barest 2026-07-14, #1580: a barest repo flipped to IMMUTABLE out of band, then
+  // `revert` planned a `remove`, Cloud Control reported `reverted: Repo`, yet
+  // `describe-repositories` stayed IMMUTABLE — the convergence re-read reported "1 drift
+  // remain"). The ECR CC handler does a partial update, so an omitted ImageTagMutability
+  // keeps the current value instead of reconciling to the MUTABLE default. Write the
+  // "MUTABLE" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
+  'AWS::ECR::Repository\0ImageTagMutability',
   // RolesAnywhere UpdateProfile IGNORES an omitted DurationSeconds (live-proven follow-up to
   // the #619 fold: a profile's session duration changed out of band to 7200, then
   // `revert --remove-unrecorded` planned a `remove`, reported reverted, yet live `get-profile`

--- a/tests/integration/echo-barest/app.ts
+++ b/tests/integration/echo-barest/app.ts
@@ -1,0 +1,70 @@
+// Barest-config fixture bundling several CHEAP, common, instant-deploy types
+// whose service-materialized defaults are NOT in the fold tables (verified via
+// grep of src/normalize/noise.ts + src/diff/classify.ts, 2026-07-14 hunt):
+//   - Lambda Function  -> SnapStart {ApplyOn:"None"} (unfolded)
+//   - ECR Repository   -> ImageScanningConfiguration {ScanOnPush:false} (unfolded)
+//   - StepFunctions SM -> LoggingConfiguration / TracingConfiguration (unfolded)
+//   - Kinesis Stream   -> StreamEncryption (unfolded)
+// Each L1 declares only what CloudFormation REQUIRES, leaving the maximum
+// undeclared surface so a first `check` (before record) exercises the folds.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnRepository } from "aws-cdk-lib/aws-ecr";
+import { CfnStateMachine } from "aws-cdk-lib/aws-stepfunctions";
+import { CfnStream } from "aws-cdk-lib/aws-kinesis";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntEcho0714");
+
+// --- Lambda: barest inline zip function ---
+const lambdaRole = new CfnRole(stack, "LambdaRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+new CfnFunction(stack, "Fn", {
+  code: { zipFile: "exports.handler = async () => 'ok';" },
+  handler: "index.handler",
+  runtime: "nodejs20.x",
+  role: lambdaRole.attrArn,
+});
+
+// --- ECR: barest repository (nothing is required) ---
+new CfnRepository(stack, "Repo", {});
+
+// --- StepFunctions: barest STANDARD state machine ---
+const sfnRole = new CfnRole(stack, "SfnRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+new CfnStateMachine(stack, "Sm", {
+  roleArn: sfnRole.attrArn,
+  definitionString: JSON.stringify({
+    StartAt: "Done",
+    States: { Done: { Type: "Pass", End: true } },
+  }),
+});
+
+// --- Kinesis: barest on-demand stream (no shard cost) ---
+new CfnStream(stack, "Stream", {
+  streamModeDetails: { streamMode: "ON_DEMAND" },
+});
+
+app.synth();

--- a/tests/integration/echo-barest/cdk.json
+++ b/tests/integration/echo-barest/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/echo-barest/package.json
+++ b/tests/integration/echo-barest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-echo-barest",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-config Lambda/ECR/StepFunctions/Kinesis fixture for the cdk-real-drift first-run + post-update echo FP hunt. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/echo-barest/verify-detect.sh
+++ b/tests/integration/echo-barest/verify-detect.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# #1580 revert-convergence regression (real AWS): ECR Repository ImageTagMutability.
+# The barest repo leaves ImageTagMutability undeclared (folds atDefault=MUTABLE).
+# Flip it to IMMUTABLE out of band -> check MUST DETECT (exit 1) -> revert MUST
+# CONVERGE the live value back to MUTABLE (before the fix, revert planned a bare
+# `remove` that ECR's partial-update CC handler IGNORED, leaving IMMUTABLE and
+# never converging). Sequence needs a `record` between the clean check and the
+# out-of-band mutation, else the drift only surfaces as [Potential Drift] and
+# `check --fail` still exits 0.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntEcho0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+REPO="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::ECR::Repository'].PhysicalResourceId" --output text)"
+[ -n "$REPO" ] || fail "could not resolve ECR repository physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: ImageTagMutability MUTABLE->IMMUTABLE (console-edit) ==="
+aws ecr put-image-tag-mutability --repository-name "$REPO" --region "$REGION" \
+  --image-tag-mutability IMMUTABLE >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT undeclared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-echo-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "ImageTagMutability" /tmp/cdkrd-echo-detect.out || fail "ImageTagMutability not reported"
+
+echo "=== revert (write MUTABLE default back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert (convergence) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert — revert did not converge"
+
+echo "=== live ImageTagMutability MUST be restored to MUTABLE ==="
+GOT="$(aws ecr describe-repositories --repository-names "$REPO" --region "$REGION" \
+  --query 'repositories[0].imageTagMutability' --output text)"
+[ "$GOT" = "MUTABLE" ] || fail "live ImageTagMutability not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert, #1580)"

--- a/tests/integration/echo-barest/verify.sh
+++ b/tests/integration/echo-barest/verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): the barest Lambda/ECR/StepFunctions/
+# Kinesis bundle. Every service-materialized default (SnapStart, ImageScanning,
+# LoggingConfiguration, TracingConfiguration, StreamEncryption, …) must fold to
+# atDefault. deploy -> check (pre-record) MUST be CLEAN -> record -> check MUST be
+# CLEAN. Any [Potential Drift] on this un-mutated stack is a fold gap (a bug).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntEcho0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.pre.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FIRST-RUN FALSE POSITIVE ---"; fail "expected CLEAN pre-record (exit 0), got $rc"; }
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1401,6 +1401,27 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#1580: ECR Repository ImageTagMutability (SET-DEFAULT) -> add op writing MUTABLE, not a no-op remove', () => {
+    // #1580 (live-proven on echo-barest 2026-07-14): a barest ECR repo flipped to IMMUTABLE
+    // out of band, then `revert` planned a `remove`, Cloud Control reported `reverted: Repo`,
+    // yet `describe-repositories` stayed IMMUTABLE ("1 drift remain"). The ECR CC handler does
+    // a partial update, so an omitted ImageTagMutability keeps the current value. Revert must
+    // write the "MUTABLE" default (from KNOWN_DEFAULTS) explicitly so it converges.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ECR::Repository',
+      path: 'ImageTagMutability',
+      actual: 'IMMUTABLE',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ImageTagMutability',
+      value: 'MUTABLE',
+      prior: 'IMMUTABLE',
+    });
+  });
+
   it('RolesAnywhere Profile DurationSeconds (SET-DEFAULT) -> add op writing 3600, not a no-op remove', () => {
     // Follow-up to #619: UpdateProfile IGNORES an omitted DurationSeconds (live-proven — a
     // profile duration changed to 7200, then `revert --remove-unrecorded` reported reverted,


### PR DESCRIPTION
## What

`revert` of an out-of-band **`AWS::ECR::Repository` `ImageTagMutability`** change was a **silent no-op**. ECR's Cloud Control `UpdateResource` handler does a partial update — an omitted `ImageTagMutability` keeps the current value instead of reconciling to the `MUTABLE` default — so a bare `remove` revert reported success yet left the repo `IMMUTABLE`, and the convergence re-read reported "1 drift remain". This is the `REVERT_SET_DEFAULT_PATHS` "provider ignores an omitted property on update" class (Transfer `SecurityPolicyName` #597, Cognito UserPool `DeletionProtection` #630, Events ApiDestination `InvocationRateLimitPerSecond`, …).

ECR is a daily-driver type and flipping a repo to `IMMUTABLE` in the console is a common out-of-band change, so a `revert` that claims success but leaves it `IMMUTABLE` is user-damaging.

## Fix

Add `AWS::ECR::Repository\0ImageTagMutability` to `REVERT_SET_DEFAULT_PATHS` (`src/revert/plan.ts`). The `MUTABLE` default is already pinned in `KNOWN_DEFAULTS`, so revert now writes it explicitly and converges. `MUTABLE` is a stable constant → no `MOVING_REVERT_PINS` entry.

## Verification

- **Unit test** (`tests/revert-plan.test.ts`): asserts the plan is `add /ImageTagMutability = MUTABLE`, not a `remove`. Confirmed to FAIL without the fix (`{op:'remove'}` vs `{op:'add'}`) and pass with it.
- **Live-proven** (real AWS, us-east-1, 2026-07-14 hunt) on the new `echo-barest` fixture: barest repo flipped to `IMMUTABLE` out of band → `check` detects (exit 1) → `revert` plans `ImageTagMutability -> AWS default` → **"CLEAN after revert"** → live `imageTagMutability` = `MUTABLE`. Before the fix the same revert reported `reverted: Repo` yet left `IMMUTABLE` ("1 drift remain").
- **Regression fixture** (`tests/integration/echo-barest`): a barest Lambda/ECR/StepFunctions/Kinesis bundle. `verify.sh` asserts a first-run FP-clean deploy (all service-materialized defaults fold `atDefault`); `verify-detect.sh` is the #1580 detect→revert→converge cycle.

Scope: within ECR, `ImageTagMutability` is the only mutable scalar `KNOWN_DEFAULTS` folds (`EncryptionConfiguration` is create-only; `ImageScanningConfiguration` is schema-stripped). The revert-noop class is non-uniform (per prior hunts), so this is scoped to the one live-proven property.

Full local gates green (typecheck / lint+format / build / 5661 unit tests).

Closes #1580
