### PR TITLE
fix(revert): SQS MaximumMessageSize + Lambda Url InvokeMode revert converge (#1583)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -219,6 +219,19 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // keeps the current value instead of reconciling to the MUTABLE default. Write the
   // "MUTABLE" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
   'AWS::ECR::Repository\0ImageTagMutability',
+  // SQS: an omitted MaximumMessageSize is NOT reset to the default on a revert patch
+  // (live-proven on revert-noop-probe 2026-07-14, #1583: mutated 1048576->262144 out of
+  // band, then `revert` planned a `remove`, reported reverted, yet the queue stayed
+  // 262144). NON-UNIFORM within SQS: the other four folded scalars (VisibilityTimeout,
+  // MessageRetentionPeriod, DelaySeconds, ReceiveMessageWaitTimeSeconds) DO converge via
+  // the bare `remove` (live-verified same run), so ONLY MaximumMessageSize needs an
+  // explicit set-default write (the 1048576 default from KNOWN_DEFAULTS).
+  'AWS::SQS::Queue\0MaximumMessageSize',
+  // Lambda UpdateFunctionUrlConfig IGNORES an omitted InvokeMode (live-proven on
+  // revert-noop-probe 2026-07-14, #1583: a URL flipped BUFFERED->RESPONSE_STREAM out of
+  // band, then `revert` planned a `remove`, reported reverted, yet the URL stayed
+  // RESPONSE_STREAM). Write the "BUFFERED" default (from KNOWN_DEFAULTS) back explicitly.
+  'AWS::Lambda::Url\0InvokeMode',
   // RolesAnywhere UpdateProfile IGNORES an omitted DurationSeconds (live-proven follow-up to
   // the #619 fold: a profile's session duration changed out of band to 7200, then
   // `revert --remove-unrecorded` planned a `remove`, reported reverted, yet live `get-profile`

--- a/tests/integration/revert-noop-probe/app.ts
+++ b/tests/integration/revert-noop-probe/app.ts
@@ -1,0 +1,54 @@
+// Barest-config bundle to live-probe the revert-convergence (silent no-op) class:
+// each resource leaves KNOWN_DEFAULTS-folded MUTABLE scalars undeclared, so a
+// `revert` of an out-of-band change to one of them must CONVERGE (not silently
+// no-op). Probed here (2026-07-14 hunt, follow-up to #1580 ECR ImageTagMutability):
+//   - SQS Queue: VisibilityTimeout / MessageRetentionPeriod / DelaySeconds /
+//     ReceiveMessageWaitTimeSeconds / MaximumMessageSize (all via SetQueueAttributes)
+//   - Lambda Function: RecursiveLoop (PutFunctionRecursionConfig)
+//   - Lambda Url: InvokeMode (UpdateFunctionUrlConfig)
+//   - DynamoDB Table: DeletionProtectionEnabled (UpdateTable)
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+import { CfnFunction, CfnUrl } from "aws-cdk-lib/aws-lambda";
+import { CfnTable } from "aws-cdk-lib/aws-dynamodb";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntRevertNoop0714");
+
+// --- SQS: barest queue (every attribute folds atDefault) ---
+new CfnQueue(stack, "Queue", {});
+
+// --- Lambda: barest inline function + its Function URL ---
+const lambdaRole = new CfnRole(stack, "LambdaRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+const fn = new CfnFunction(stack, "Fn", {
+  code: { zipFile: "exports.handler = async () => 'ok';" },
+  handler: "index.handler",
+  runtime: "nodejs20.x",
+  role: lambdaRole.attrArn,
+});
+new CfnUrl(stack, "Url", {
+  targetFunctionArn: fn.attrArn,
+  authType: "NONE",
+});
+
+// --- DynamoDB: barest on-demand table (DeletionProtectionEnabled undeclared) ---
+new CfnTable(stack, "Table", {
+  billingMode: "PAY_PER_REQUEST",
+  attributeDefinitions: [{ attributeName: "pk", attributeType: "S" }],
+  keySchema: [{ attributeName: "pk", keyType: "HASH" }],
+});
+
+app.synth();

--- a/tests/integration/revert-noop-probe/cdk.json
+++ b/tests/integration/revert-noop-probe/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revert-noop-probe/package.json
+++ b/tests/integration/revert-noop-probe/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revert-noop-probe",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest SQS/Lambda/Lambda-Url/DynamoDB fixture probing the revert-convergence (silent no-op) class. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revert-noop-probe/verify-detect.sh
+++ b/tests/integration/revert-noop-probe/verify-detect.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# #1583 revert-convergence regression (real AWS): SQS MaximumMessageSize + Lambda
+# Url InvokeMode both no-op on a bare `remove` revert (the provider ignores the
+# omitted property), so revert must write their KNOWN_DEFAULTS defaults explicitly.
+# We deliberately mutate/revert ONLY these two (never a Lambda Function property) so
+# the revert never re-uploads Code.ZipFile — that would change the generated
+# CodeSha256 and add unrelated noise to the convergence check.
+#
+# The four converging SQS scalars (VisibilityTimeout / MessageRetentionPeriod /
+# DelaySeconds / ReceiveMessageWaitTimeSeconds) are mutated too, as a CONTROL that
+# they converge via the bare `remove` (they are intentionally NOT in
+# REVERT_SET_DEFAULT_PATHS — the non-uniformity guard).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevertNoop0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+QURL="$(aws sqs get-queue-url --queue-name "$(aws cloudformation describe-stack-resource \
+  --stack-name "$STACK" --logical-resource-id Queue --region "$REGION" \
+  --query 'StackResourceDetail.PhysicalResourceId' --output text | sed 's#.*/##')" \
+  --region "$REGION" --query QueueUrl --output text)"
+FN="$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id Fn \
+  --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text)"
+[ -n "$QURL" ] && [ -n "$FN" ] || fail "could not resolve Queue/Fn physical ids"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band mutations (2 no-op targets + 4 converging controls) ==="
+aws sqs set-queue-attributes --queue-url "$QURL" --region "$REGION" --attributes \
+  MaximumMessageSize=262144,VisibilityTimeout=60,MessageRetentionPeriod=1209600,DelaySeconds=30,ReceiveMessageWaitTimeSeconds=20 \
+  || fail "sqs mutate"
+aws lambda update-function-url-config --function-name "$FN" --region "$REGION" \
+  --invoke-mode RESPONSE_STREAM >/dev/null || fail "url mutate"
+
+echo "=== check MUST DETECT (>=6 undeclared drifts) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-noop-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "MaximumMessageSize" /tmp/cdkrd-noop-detect.out || fail "MaximumMessageSize not reported"
+grep -q "InvokeMode" /tmp/cdkrd-noop-detect.out || fail "InvokeMode not reported"
+
+echo "=== revert (write defaults back for the no-op targets, remove for the controls) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert (convergence) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert — a revert did not converge"
+
+echo "=== live values MUST be restored to defaults ==="
+MMS="$(aws sqs get-queue-attributes --queue-url "$QURL" --region "$REGION" \
+  --attribute-names MaximumMessageSize --query 'Attributes.MaximumMessageSize' --output text)"
+IM="$(aws lambda get-function-url-config --function-name "$FN" --region "$REGION" \
+  --query 'InvokeMode' --output text)"
+[ "$MMS" = "1048576" ] || fail "MaximumMessageSize not restored (got: $MMS)"
+[ "$IM" = "BUFFERED" ] || fail "InvokeMode not restored (got: $IM)"
+
+echo "INTEG PASS ($STACK detect+revert, #1583)"

--- a/tests/integration/revert-noop-probe/verify.sh
+++ b/tests/integration/revert-noop-probe/verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest SQS/Lambda/Lambda-Url/DynamoDB.
+# Every KNOWN_DEFAULTS-folded scalar must fold to atDefault. deploy -> check
+# (pre-record) MUST be CLEAN -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevertNoop0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  # DynamoDB DeletionProtection may be enabled by verify-detect.sh; disable so delstack can delete.
+  TBL="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?ResourceType=='AWS::DynamoDB::Table'].PhysicalResourceId" --output text 2>/dev/null)"
+  [ -n "$TBL" ] && aws dynamodb update-table --table-name "$TBL" --region "$REGION" --no-deletion-protection-enabled >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.pre.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FIRST-RUN FALSE POSITIVE ---"; fail "expected CLEAN pre-record (exit 0), got $rc"; }
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1422,6 +1422,61 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#1583: SQS Queue MaximumMessageSize (SET-DEFAULT) -> add op writing 1048576, not a no-op remove', () => {
+    // #1583 (live-proven on revert-noop-probe 2026-07-14): mutated 1048576->262144 out of
+    // band, then `revert` planned a `remove`, reported reverted, yet the queue stayed 262144.
+    // NON-UNIFORM within SQS: the other four folded scalars converge via a bare `remove`, so
+    // ONLY MaximumMessageSize needs the explicit set-default write (1048576 from KNOWN_DEFAULTS).
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::SQS::Queue',
+      path: 'MaximumMessageSize',
+      actual: 262144,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/MaximumMessageSize',
+      value: 1048576,
+      prior: 262144,
+    });
+  });
+
+  it('#1583: Lambda Url InvokeMode (SET-DEFAULT) -> add op writing BUFFERED, not a no-op remove', () => {
+    // #1583 (live-proven on revert-noop-probe 2026-07-14): a URL flipped BUFFERED->RESPONSE_STREAM
+    // out of band, then `revert` planned a `remove`, reported reverted, yet the URL stayed
+    // RESPONSE_STREAM. UpdateFunctionUrlConfig ignores an omitted InvokeMode — write the
+    // "BUFFERED" default (from KNOWN_DEFAULTS) explicitly so revert converges.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Lambda::Url',
+      path: 'InvokeMode',
+      actual: 'RESPONSE_STREAM',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/InvokeMode',
+      value: 'BUFFERED',
+      prior: 'RESPONSE_STREAM',
+    });
+  });
+
+  it('#1583 control: SQS VisibilityTimeout is NOT a set-default path (converges via bare remove) -> remove op', () => {
+    // The NON-UNIFORMITY guard: the other four SQS folded scalars were live-verified to
+    // converge via a bare `remove` (the CC handler resets them on omit), so they must stay
+    // OFF REVERT_SET_DEFAULT_PATHS — a future entry here would be wrong. VisibilityTimeout
+    // stands for the four.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::SQS::Queue',
+      path: 'VisibilityTimeout',
+      actual: 60,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/VisibilityTimeout' });
+  });
+
   it('RolesAnywhere Profile DurationSeconds (SET-DEFAULT) -> add op writing 3600, not a no-op remove', () => {
     // Follow-up to #619: UpdateProfile IGNORES an omitted DurationSeconds (live-proven — a
     // profile duration changed to 7200, then `revert --remove-unrecorded` reported reverted,


### PR DESCRIPTION
## What

Two more `revert` silent no-ops of the `REVERT_SET_DEFAULT_PATHS` class (follow-up to #1580), found + fixed together in the 2026-07-14 hunt:

1. **`AWS::SQS::Queue` `MaximumMessageSize`** — an out-of-band decrease (1048576 → 262144) is detected, but `revert`'s bare `remove` was a no-op (the queue stayed 262144).
2. **`AWS::Lambda::Url` `InvokeMode`** — a `BUFFERED` → `RESPONSE_STREAM` flip is detected, but `revert`'s bare `remove` was a no-op (the URL stayed `RESPONSE_STREAM`).

## The SQS non-uniformity

The other four `KNOWN_DEFAULTS`-folded SQS scalars (`VisibilityTimeout`, `MessageRetentionPeriod`, `DelaySeconds`, `ReceiveMessageWaitTimeSeconds`) **DO converge** via the bare `remove` — live-verified in the same revert (all four returned to defaults). Only `MaximumMessageSize` no-ops, even though all five ride the same `SetQueueAttributes` path. This is the "revert-noop class is NON-UNIFORM — live-prove EACH, don't predict from the API shape" rule holding **within a single type's single API**. So the fix is scoped to `MaximumMessageSize` alone.

## Fix

Add to `REVERT_SET_DEFAULT_PATHS` (`src/revert/plan.ts`):
- `AWS::SQS::Queue\0MaximumMessageSize` (default `1048576` from `KNOWN_DEFAULTS`)
- `AWS::Lambda::Url\0InvokeMode` (default `"BUFFERED"` from `KNOWN_DEFAULTS`)

Both defaults are stable constants → no `MOVING_REVERT_PINS` entries.

## Verification

- **Unit tests** (`tests/revert-plan.test.ts`): two set-default assertions (`add /MaximumMessageSize = 1048576`, `add /InvokeMode = BUFFERED`) — both confirmed to FAIL without the fix (`{op:'remove'}`), pass with it — plus a **control** asserting `SQS VisibilityTimeout` stays a bare `remove` (the non-uniformity guard: the four converging scalars must stay OFF the set).
- **Live-proven** (real AWS, us-east-1) on the new `revert-noop-probe` fixture: mutate out of band → `check` detects 6 drifts (exit 1) → `revert` plans `MaximumMessageSize`/`InvokeMode → AWS default` and the four controls → `remove` → **"CLEAN after revert"** → live `MaximumMessageSize=1048576`, `InvokeMode=BUFFERED`.
- **Regression fixture** (`tests/integration/revert-noop-probe`): barest SQS/Lambda/Lambda-Url/DynamoDB. `verify.sh` = first-run FP-clean; `verify-detect.sh` = the #1583 detect→revert→converge cycle with the four converging SQS scalars kept as converge-via-remove controls.

Full local gates green (typecheck / lint+format / build / 5666 unit tests).

Closes #1583
