### PR TITLE
fix(baseline): declared write-only property no longer disables 'appeared since record' (#1582)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -521,6 +521,23 @@ Recorded]` breakdown with `--verbose`.
   exit-code assert even though detection worked (hit live on the MediaConvert Queue
   pause, #1526). Sequence: deploy → first check CLEAN → `record --yes` → mutate →
   `check --fail` MUST exit 1 (confirmed drift) → restore → CLEAN.
+- **An UNDECLARED-atDefault prop's OOB change is only caught via "appeared since record",
+  which needs the resource `complete` — and a DECLARED write-only prop (secret/password/key)
+  used to break that.** `record` snapshots only undeclared NON-default values; a prop at its
+  AWS default folds `atDefault` and is NOT recorded, so a later OOB change to it is caught
+  ONLY by the R62 "appeared since record" mechanism — which fires ONLY when the resource is
+  `complete`. A resource that DECLARES a write-only property (RDS `MasterUserPassword`, any
+  secret/token/key) surfaced a write-only `readGap` that (pre-#1582) marked it NOT complete,
+  silently disabling that detection — so mutating an undeclared-atDefault prop on it read
+  `[Not Recorded]`, `check --fail` exited 0, and it looked like a fold bug when it was a
+  completeness gap. When an undeclared-prop FN detect-test on a resource that declares a
+  secret/password unexpectedly MISSES: (1) don't assume a fold/classify bug — check whether
+  the pure `classify` surfaces it offline (it did here) and whether the resource is `complete`
+  (a `readGap=N` in the `info:` footer is the tell); (2) a MUTABLE prop that AWS applies as an
+  ONLINE modify (RDS CopyTagsToSnapshot/MonitoringInterval, no reboot) keeps the instance
+  `available`, so `aws … wait …-available` returns before the change propagates — poll
+  `describe` (AND `cloudcontrol get-resource`, a different surface) until the value flips
+  before asserting. The write-only-readGap→incomplete FN was live-found this way (#1582).
 - **A harvested corpus case can embed a credential-shaped physical id that
   git-secrets rightly blocks at commit.** An `AWS::IAM::AccessKey` case's physicalId
   IS a real `AKIA…` id (the corpus recorder strips account ids, not access-key ids).

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -444,7 +444,12 @@ export function computeCompleteResources(
   // deleting the ignore rule returns the value to `unrecorded`, never false "appeared".
   const blockedByIgnore = new Set<string>();
   for (const f of findings) {
-    if (f.tier === 'skipped' || f.tier === 'deleted' || f.tier === 'readGap')
+    // #1582: a WRITE-ONLY readGap (a declared, expectedly-unreadable secret/token/password —
+    // e.g. RDS MasterUserPassword) does NOT mean the readable undeclared model was unread, so it
+    // must NOT block completeness — otherwise "appeared since record" detection is silently
+    // disabled for every resource declaring a write-only prop (a false negative). A GENUINE
+    // readGap (Cloud Control could not read a declared prop back) still blocks.
+    if (f.tier === 'skipped' || f.tier === 'deleted' || (f.tier === 'readGap' && !f.writeOnly))
       blocked.add(f.logicalId);
     if (f.tier === 'undeclared' && !recordedKeys.has(recordedKey(f))) blocked.add(f.logicalId);
     // #1277: only DEMOTE for an ignored value that originated `undeclared`. `record`

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -3045,6 +3045,10 @@ export function classifyResource(
         resourceType,
         path: k,
         note: 'write-only — cannot be read back',
+        // #1582: an EXPECTEDLY-unreadable declared write-only key, not a coverage gap — so it
+        // must NOT disqualify the resource from `completeResources` (which would silently
+        // disable "appeared since record" detection for it). See Finding.writeOnly.
+        writeOnly: true,
       });
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,13 @@ export interface Finding {
   // "changed since record" off the degraded snippet (it suppresses a recorded one until
   // a clean read, like a transiently-skipped resource). Self-heals on the next check.
   modelReadFailed?: boolean;
+  // readGap tier only (#1582): the readGap is a DECLARED WRITE-ONLY property (expectedly
+  // unreadable), NOT a genuine coverage gap in the readable model. Unlike a real readGap it
+  // must NOT disqualify the resource from `completeResources` — the undeclared readable model
+  // is still fully snapshot, so "appeared since record" detection stays enabled. Without this,
+  // any resource declaring a write-only prop (RDS MasterUserPassword, secrets/tokens) can never
+  // detect an out-of-band appeared-since-record undeclared value (a false negative).
+  writeOnly?: boolean;
   // declared tier only (R111): set to 'unresolved' on an IAM Role `Policies` finding
   // when the role's sibling AWS::IAM::Policy names could NOT be resolved, so classify
   // left the sibling-managed (DefaultPolicy) entries in the live array. The revert plan

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -842,6 +842,30 @@ describe('baseline', () => {
       expect(computeCompleteResources(['Gap'], findings, [])).toEqual([]);
     });
 
+    it('#1582: a WRITE-ONLY readGap does NOT block completeness; a genuine one still does', () => {
+      // A declared write-only property (RDS MasterUserPassword, secrets/tokens/keys) surfaces
+      // as a readGap flagged `writeOnly` — it is EXPECTEDLY unreadable and does NOT mean the
+      // readable undeclared model was unread, so the resource stays complete and "appeared
+      // since record" detection remains enabled for it. Without this a resource declaring any
+      // write-only prop could never detect an out-of-band appeared-since-record undeclared
+      // value (a false negative). A GENUINE readGap (no `writeOnly`) still blocks.
+      const findings: Finding[] = [
+        {
+          tier: 'readGap',
+          logicalId: 'WriteOnly',
+          resourceType: 'AWS::RDS::DBInstance',
+          path: 'MasterUserPassword',
+          note: 'write-only — cannot be read back',
+          writeOnly: true,
+        },
+        { tier: 'readGap', logicalId: 'Genuine', resourceType: 'T', path: 'P' },
+      ];
+      // WriteOnly stays complete (its readable model was fully snapshot); Genuine is excluded.
+      expect(computeCompleteResources(['WriteOnly', 'Genuine'], findings, [])).toEqual([
+        'WriteOnly',
+      ]);
+    });
+
     it('a resource with one of two values recorded is NOT complete', () => {
       const findings = [undeclared('A', 'P', 1), undeclared('A', 'Q', 2)];
       const recorded = [{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: 1 }];

--- a/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
+++ b/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
@@ -158,7 +158,8 @@
       "path": "EngineVersion",
       "note": "write-only — cannot be read back",
       "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -167,7 +168,8 @@
       "path": "Users",
       "note": "write-only — cannot be read back",
       "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__AppConfig__ExtensionAssociation.HuntExtAssoc.json
+++ b/tests/corpus/AWS__AppConfig__ExtensionAssociation.HuntExtAssoc.json
@@ -64,7 +64,8 @@
       "path": "ExtensionIdentifier",
       "note": "write-only — cannot be read back",
       "physicalId": "qza1zzu",
-      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc"
+      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -73,7 +74,8 @@
       "path": "ResourceIdentifier",
       "note": "write-only — cannot be read back",
       "physicalId": "qza1zzu",
-      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc"
+      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.HuntScalableTarget.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.HuntScalableTarget.json
@@ -94,7 +94,8 @@
       "path": "RoleARN",
       "note": "write-only — cannot be read back",
       "physicalId": "table/CdkrdHunt0713FormatProbes-HuntTable71D348F5-1XKF7YYNYVE2I|dynamodb:table:ReadCapacityUnits|dynamodb",
-      "constructPath": "CdkrdHunt0713FormatProbes/HuntScalableTarget"
+      "constructPath": "CdkrdHunt0713FormatProbes/HuntScalableTarget",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.ReadTarget3B84E8CE.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.ReadTarget3B84E8CE.json
@@ -50,7 +50,8 @@
       "path": "RoleARN",
       "note": "write-only — cannot be read back",
       "physicalId": "table/CdkrdIntegHarvest4-Sessions8896A56D-1AME3ENAZ10B2|dynamodb:table:ReadCapacityUnits|dynamodb",
-      "constructPath": "CdkrdIntegHarvest4/ReadTarget"
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
@@ -73,7 +73,8 @@
       "path": "ScalingTargetId",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
-      "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil",
+      "writeOnly": true
     },
     {
       "tier": "generated",

--- a/tests/corpus/AWS__Athena__WorkGroup.Queries.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.Queries.json
@@ -71,7 +71,8 @@
       "path": "RecursiveDeleteOption",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-harvest",
-      "constructPath": "CdkrdIntegHarvest/Queries"
+      "constructPath": "CdkrdIntegHarvest/Queries",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Athena__WorkGroup.WgDescend.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.WgDescend.json
@@ -79,7 +79,8 @@
       "path": "RecursiveDeleteOption",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-integ-athena-descend",
-      "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend"
+      "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Batch__ComputeEnvironment.FargateCE1DBBBD09.json
+++ b/tests/corpus/AWS__Batch__ComputeEnvironment.FargateCE1DBBBD09.json
@@ -93,7 +93,8 @@
       "path": "ReplaceComputeEnvironment",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/FargateCE1DBBBD09-54Uxta4Aiy4unKOi",
-      "constructPath": "CdkRealDriftIntegBatchRich/FargateCE"
+      "constructPath": "CdkRealDriftIntegBatchRich/FargateCE",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -102,7 +103,8 @@
       "path": "UpdatePolicy",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/FargateCE1DBBBD09-54Uxta4Aiy4unKOi",
-      "constructPath": "CdkRealDriftIntegBatchRich/FargateCE"
+      "constructPath": "CdkRealDriftIntegBatchRich/FargateCE",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Bedrock__Agent.Agent.json
+++ b/tests/corpus/AWS__Bedrock__Agent.Agent.json
@@ -108,7 +108,8 @@
       "path": "AutoPrepare",
       "note": "write-only — cannot be read back",
       "physicalId": "9W8IFJ9ZK0",
-      "constructPath": "CdkRealDriftHunt0708Bedrock/Agent"
+      "constructPath": "CdkRealDriftHunt0708Bedrock/Agent",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Bedrock__ApplicationInferenceProfile.Aip.json
+++ b/tests/corpus/AWS__Bedrock__ApplicationInferenceProfile.Aip.json
@@ -88,7 +88,8 @@
       "path": "ModelSource",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:bedrock:us-east-1:111111111111:application-inference-profile/dgsnhongtx0l",
-      "constructPath": "CdkRealDriftHunt0708Bedrock/Aip"
+      "constructPath": "CdkRealDriftHunt0708Bedrock/Aip",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__CloudFront__Function.CfFunctionE996B776.json
+++ b/tests/corpus/AWS__CloudFront__Function.CfFunctionE996B776.json
@@ -68,7 +68,8 @@
       "path": "AutoPublish",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:cloudfront::111111111111:function/cdkrd-fn",
-      "constructPath": "CdkdriftIntegHarvest10/CfFunction"
+      "constructPath": "CdkdriftIntegHarvest10/CfFunction",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__CloudFront__Function.Fn9270CBC0.json
+++ b/tests/corpus/AWS__CloudFront__Function.Fn9270CBC0.json
@@ -65,7 +65,8 @@
       "path": "AutoPublish",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:cloudfront::111111111111:function/cdkrd-hunt-kvs-fn",
-      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/Fn"
+      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/Fn",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__CodePipeline__Pipeline.PipelineC660917D.json
+++ b/tests/corpus/AWS__CodePipeline__Pipeline.PipelineC660917D.json
@@ -185,7 +185,8 @@
       "path": "RestartExecutionOnUpdate",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-pipeline-rich",
-      "constructPath": "CdkRealDriftIntegCodepipelineRich/Pipeline"
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Pipeline",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
@@ -375,7 +375,8 @@
       "path": "EnabledMfas",
       "note": "write-only — cannot be read back",
       "physicalId": "us-east-1_DPFFObGj8",
-      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Cognito__UserPoolUser.User.json
+++ b/tests/corpus/AWS__Cognito__UserPoolUser.User.json
@@ -85,7 +85,8 @@
       "path": "MessageAction",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-readgap-user",
-      "constructPath": "CdkRealDriftIntegCognitoUserPoolUserRich/User"
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolUserRich/User",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__DataSync__LocationS3.SrcLoc.json
+++ b/tests/corpus/AWS__DataSync__LocationS3.SrcLoc.json
@@ -66,7 +66,8 @@
       "path": "S3BucketArn",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
-      "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc"
+      "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -75,7 +76,8 @@
       "path": "Subdirectory",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
-      "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc"
+      "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
+++ b/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
@@ -305,7 +305,8 @@
       "path": "LaunchTemplate",
       "note": "write-only — cannot be read back",
       "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host",
+      "writeOnly": true
     },
     {
       "tier": "unresolved",

--- a/tests/corpus/AWS__EC2__LaunchTemplate.LaunchTpl.json
+++ b/tests/corpus/AWS__EC2__LaunchTemplate.LaunchTpl.json
@@ -47,7 +47,8 @@
       "path": "LaunchTemplateData",
       "note": "write-only — cannot be read back",
       "physicalId": "lt-07d78df03ff0277ba",
-      "constructPath": "CdkrdIntegHarvest6/LaunchTpl"
+      "constructPath": "CdkrdIntegHarvest6/LaunchTpl",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
+++ b/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
@@ -78,7 +78,8 @@
       "path": "EmptyOnDelete",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
-      "constructPath": "CdkrdIntegHarvest/Images"
+      "constructPath": "CdkrdIntegHarvest/Images",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__EKS__Addon.AddonEksRich.json
+++ b/tests/corpus/AWS__EKS__Addon.AddonEksRich.json
@@ -63,7 +63,8 @@
       "path": "ResolveConflicts",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-eks|vpc-cni",
-      "constructPath": "CdkRealDriftIntegEksRich/Addon"
+      "constructPath": "CdkRealDriftIntegEksRich/Addon",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntCmeRg.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.HuntCmeRg.json
@@ -247,7 +247,8 @@
       "path": "NumNodeGroups",
       "note": "write-only — cannot be read back",
       "physicalId": "cdh1logc9nwhco4c",
-      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg"
+      "constructPath": "CdkRealDriftIntegElastiCacheCmeMin/HuntCmeRg",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
@@ -178,7 +178,8 @@
       "path": "CacheSubnetGroupName",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-ec-rich",
-      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -187,7 +188,8 @@
       "path": "SecurityGroupIds",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-ec-rich",
-      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__ElastiCache__User.HuntEcDefaultUser.json
+++ b/tests/corpus/AWS__ElastiCache__User.HuntEcDefaultUser.json
@@ -49,7 +49,8 @@
       "path": "NoPasswordRequired",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-hunt-default",
-      "constructPath": "CdkRealDriftIntegCacheUsers/HuntEcDefaultUser"
+      "constructPath": "CdkRealDriftIntegCacheUsers/HuntEcDefaultUser",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElastiCache__User.HuntEcReaderUser.json
+++ b/tests/corpus/AWS__ElastiCache__User.HuntEcReaderUser.json
@@ -49,7 +49,8 @@
       "path": "Passwords",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-hunt-reader",
-      "constructPath": "CdkRealDriftIntegCacheUsers/HuntEcReaderUser"
+      "constructPath": "CdkRealDriftIntegCacheUsers/HuntEcReaderUser",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnv.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnv.json
@@ -90,7 +90,8 @@
       "path": "OptionSettings",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-hunt-eb-env",
-      "constructPath": "CdkRealDriftIntegEbRich/EbEnv"
+      "constructPath": "CdkRealDriftIntegEbRich/EbEnv",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.json
@@ -105,7 +105,8 @@
       "path": "ListenerArn",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-ZOGq8SCU7OMY/ae1fe96c6ac55de6/7a6edcf8edb8f8b6/f7898cec75295d48",
-      "constructPath": "CdkRealDriftIntegElbv2ListenerRuleRich/Rule"
+      "constructPath": "CdkRealDriftIntegElbv2ListenerRuleRich/Rule",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.values.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.values.json
@@ -107,7 +107,8 @@
       "path": "ListenerArn",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-Gjv9j13vSOgr/5e8f46be04d0d5a6/160b3a942ed8a17a/90945430e6a97c3a",
-      "constructPath": "CdkRealDriftIntegElbv2RuleValues/Rule"
+      "constructPath": "CdkRealDriftIntegElbv2RuleValues/Rule",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleHttpHeader0B4061D9.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleHttpHeader0B4061D9.json
@@ -80,7 +80,8 @@
       "path": "ListenerArn",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/c8831c8e7557787f",
-      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleHttpHeader"
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleHttpHeader",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleMethodC8F28706.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleMethodC8F28706.json
@@ -78,7 +78,8 @@
       "path": "ListenerArn",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/83a565631c79e8a9",
-      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleMethod"
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleMethod",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleQueryString641E1B2B.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleQueryString641E1B2B.json
@@ -104,7 +104,8 @@
       "path": "ListenerArn",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/540f74d8bbd74bf2",
-      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleQueryString"
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleQueryString",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleSourceIpD7488250.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleSourceIpD7488250.json
@@ -78,7 +78,8 @@
       "path": "ListenerArn",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/e5d6031394001d04",
-      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleSourceIp"
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleSourceIp",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.TrustStore.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.TrustStore.json
@@ -77,7 +77,8 @@
       "path": "CaCertificatesBundleS3Bucket",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore-0712c/e8b86516bc8c9019",
-      "constructPath": "CdkrdHuntTrustStore0712c/TrustStore"
+      "constructPath": "CdkrdHuntTrustStore0712c/TrustStore",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -86,7 +87,8 @@
       "path": "CaCertificatesBundleS3Key",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt-truststore-0712c/e8b86516bc8c9019",
-      "constructPath": "CdkrdHuntTrustStore0712c/TrustStore"
+      "constructPath": "CdkrdHuntTrustStore0712c/TrustStore",
+      "writeOnly": true
     },
     {
       "tier": "undeclared",

--- a/tests/corpus/AWS__Glue__Schema.HuntGlueSchema.json
+++ b/tests/corpus/AWS__Glue__Schema.HuntGlueSchema.json
@@ -75,7 +75,8 @@
       "path": "SchemaDefinition",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:glue:us-east-1:111111111111:schema/cdkrd-hunt-registry/cdkrd-hunt-schema",
-      "constructPath": "CdkRealDriftIntegMisc0Cov3/HuntGlueSchema"
+      "constructPath": "CdkRealDriftIntegMisc0Cov3/HuntGlueSchema",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__ImageBuilder__Component.HuntComponent.json
+++ b/tests/corpus/AWS__ImageBuilder__Component.HuntComponent.json
@@ -89,7 +89,8 @@
       "path": "Data",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:imagebuilder:us-east-1:111111111111:component/cdkrd-hunt-component/1.0.0/1",
-      "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntComponent"
+      "constructPath": "CdkRealDriftIntegFreeMiscMin/HuntComponent",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
+++ b/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
@@ -84,7 +84,8 @@
       "path": "PendingWindowInDays",
       "note": "write-only — cannot be read back",
       "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
-      "constructPath": "CdkrdIntegHarvest3/DataKey"
+      "constructPath": "CdkrdIntegHarvest3/DataKey",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__KMS__Key.RotatedKey753373F0.json
+++ b/tests/corpus/AWS__KMS__Key.RotatedKey753373F0.json
@@ -112,7 +112,8 @@
       "path": "RotationPeriodInDays",
       "note": "write-only — cannot be read back",
       "physicalId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
-      "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey"
+      "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.HuntStream.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.HuntStream.json
@@ -146,7 +146,8 @@
       "path": "S3DestinationConfiguration",
       "note": "write-only — cannot be read back",
       "physicalId": "CdkrdHunt0713cFirehoseMin-HuntStream-abcDEFghiJKL",
-      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream"
+      "constructPath": "CdkrdHunt0713cFirehoseMin/HuntStream",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Tap.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Tap.json
@@ -124,7 +124,8 @@
       "path": "S3DestinationConfiguration",
       "note": "write-only — cannot be read back",
       "physicalId": "CdkrdIntegHarvest3-Tap-tX2SzyWziKT4",
-      "constructPath": "CdkrdIntegHarvest3/Tap"
+      "constructPath": "CdkrdIntegHarvest3/Tap",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Lambda__Function.Handler886CB40B_config_rich.json
+++ b/tests/corpus/AWS__Lambda__Function.Handler886CB40B_config_rich.json
@@ -139,7 +139,8 @@
       "path": "SnapStart",
       "note": "write-only — cannot be read back",
       "physicalId": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
-      "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler"
+      "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Lambda__LayerVersion.CaDeployAwsCliLayer58606CDE.json
+++ b/tests/corpus/AWS__Lambda__LayerVersion.CaDeployAwsCliLayer58606CDE.json
@@ -61,7 +61,8 @@
       "path": "Content",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:lambda:us-east-1:111111111111:layer:CaDeployAwsCliLayer58606CDE:1",
-      "constructPath": "CdkRealDriftIntegS3LensMiscRich/CaDeploy/AwsCliLayer"
+      "constructPath": "CdkRealDriftIntegS3LensMiscRich/CaDeploy/AwsCliLayer",
+      "writeOnly": true
     },
     {
       "tier": "generated",

--- a/tests/corpus/AWS__Lambda__LayerVersion.LayerB20D2F06.json
+++ b/tests/corpus/AWS__Lambda__LayerVersion.LayerB20D2F06.json
@@ -75,7 +75,8 @@
       "path": "Content",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:lambda:us-east-1:111111111111:layer:cdkrd-layer:1",
-      "constructPath": "CdkdriftIntegHarvest10/Layer"
+      "constructPath": "CdkdriftIntegHarvest10/Layer",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__Lex__Bot.Bot.json
+++ b/tests/corpus/AWS__Lex__Bot.Bot.json
@@ -199,7 +199,8 @@
       "path": "AutoBuildBotLocales",
       "note": "write-only — cannot be read back",
       "physicalId": "YVVVR3Y3FN",
-      "constructPath": "CdkRealDriftIntegLexStructural/Bot"
+      "constructPath": "CdkRealDriftIntegLexStructural/Bot",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__Logs__DeliverySource.DeliverySource.json
+++ b/tests/corpus/AWS__Logs__DeliverySource.DeliverySource.json
@@ -58,7 +58,8 @@
       "path": "ResourceArn",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-hunt-cf-access",
-      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliverySource"
+      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliverySource",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__MemoryDB__User.HuntMdbUser.json
+++ b/tests/corpus/AWS__MemoryDB__User.HuntMdbUser.json
@@ -47,7 +47,8 @@
       "path": "AuthenticationMode",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-hunt-mdb-user",
-      "constructPath": "CdkRealDriftIntegCacheUsers/HuntMdbUser"
+      "constructPath": "CdkRealDriftIntegCacheUsers/HuntMdbUser",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__Pipes__Pipe.Pipe.json
+++ b/tests/corpus/AWS__Pipes__Pipe.Pipe.json
@@ -69,7 +69,8 @@
       "path": "SourceParameters",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-harvest6",
-      "constructPath": "CdkrdIntegHarvest6/Pipe"
+      "constructPath": "CdkrdIntegHarvest6/Pipe",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Pipes__Pipe.Pipe_rich.json
+++ b/tests/corpus/AWS__Pipes__Pipe.Pipe_rich.json
@@ -104,7 +104,8 @@
       "path": "SourceParameters",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-pipe-rich",
-      "constructPath": "CdkRealDriftIntegPipesRich/Pipe"
+      "constructPath": "CdkRealDriftIntegPipesRich/Pipe",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
@@ -186,7 +186,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegaurorarich-clustereb0386a7-o3epflljsjiq",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster",
+      "writeOnly": true
     },
     {
       "tier": "unresolved",

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
@@ -193,7 +193,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster",
+      "writeOnly": true
     },
     {
       "tier": "unresolved",

--- a/tests/corpus/AWS__RDS__DBCluster.HuntAuroraPg.json
+++ b/tests/corpus/AWS__RDS__DBCluster.HuntAuroraPg.json
@@ -331,7 +331,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegaurorapgmin-huntaurorapg-yc0t1fhi8sxe",
-      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg"
+      "constructPath": "CdkRealDriftIntegAuroraPgMin/HuntAuroraPg",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
+++ b/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
@@ -264,7 +264,8 @@
       "path": "DeleteAutomatedBackups",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
-      "constructPath": "CdkdriftIntegHarvest13/Database"
+      "constructPath": "CdkdriftIntegHarvest13/Database",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -273,7 +274,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
-      "constructPath": "CdkdriftIntegHarvest13/Database"
+      "constructPath": "CdkdriftIntegHarvest13/Database",
+      "writeOnly": true
     },
     {
       "tier": "unresolved",

--- a/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.logexports.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.logexports.json
@@ -262,7 +262,8 @@
       "path": "DeleteAutomatedBackups",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegrdslogexportsreorder-db5d02a0a9-rivjok6hahv8",
-      "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
+      "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -271,7 +272,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegrdslogexportsreorder-db5d02a0a9-rivjok6hahv8",
-      "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
+      "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.sgreorder.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.sgreorder.json
@@ -228,7 +228,8 @@
       "path": "DeleteAutomatedBackups",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
-      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -237,7 +238,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
-      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db",
+      "writeOnly": true
     },
     {
       "tier": "unresolved",

--- a/tests/corpus/AWS__RDS__DBInstance.HuntMariaDbFC079FD5.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntMariaDbFC079FD5.json
@@ -236,7 +236,8 @@
       "path": "DeleteAutomatedBackups",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
-      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -245,7 +246,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrdhunt0713rdsmariadb-huntmariadbfc079fd5-bldhi0ooippa",
-      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb"
+      "constructPath": "CdkrdHunt0713RdsMariadb/HuntMariaDb",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__RDS__DBInstance.HuntPostgres.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntPostgres.json
@@ -474,7 +474,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegrdspostgresmin-huntpostgres-tfql7rya1joc",
-      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres"
+      "constructPath": "CdkRealDriftIntegRdsPostgresMin/HuntPostgres",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__RDS__DBInstance.HuntSqlServer.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntSqlServer.json
@@ -473,7 +473,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrealdriftintegrdssqlservermin-huntsqlserver-0gcv1zrepyqb",
-      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer"
+      "constructPath": "CdkRealDriftIntegRdsSqlServerMin/HuntSqlServer",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Redshift__Cluster.Cluster.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Cluster.json
@@ -121,7 +121,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cluster-v8dz6fiuvmd4",
-      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
@@ -122,7 +122,8 @@
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
       "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Redshift__Cluster.Warehouse.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Warehouse.json
@@ -35,7 +35,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
-      "physicalId": "corpus-warehouse"
+      "physicalId": "corpus-warehouse",
+      "writeOnly": true
     },
     {
       "tier": "readGap",

--- a/tests/corpus/AWS__Route53Resolver__FirewallDomainList.FwDomains.json
+++ b/tests/corpus/AWS__Route53Resolver__FirewallDomainList.FwDomains.json
@@ -78,7 +78,8 @@
       "path": "Domains",
       "note": "write-only — cannot be read back",
       "physicalId": "rslvr-fdl-fae10c927473462b",
-      "constructPath": "CdkdriftIntegHarvest8/FwDomains"
+      "constructPath": "CdkdriftIntegHarvest8/FwDomains",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__SSM__Parameter.GreetingParam.json
+++ b/tests/corpus/AWS__SSM__Parameter.GreetingParam.json
@@ -45,7 +45,8 @@
       "path": "Description",
       "note": "write-only — cannot be read back",
       "physicalId": "/app/greeting",
-      "constructPath": "Stack/GreetingParam"
+      "constructPath": "Stack/GreetingParam",
+      "writeOnly": true
     },
     {
       "tier": "readGap",

--- a/tests/corpus/AWS__SSM__Parameter.Param165332EC.json
+++ b/tests/corpus/AWS__SSM__Parameter.Param165332EC.json
@@ -46,7 +46,8 @@
       "path": "Description",
       "note": "write-only — cannot be read back",
       "physicalId": "/cdkrd/harvest5/config",
-      "constructPath": "CdkrdIntegHarvest5/Param"
+      "constructPath": "CdkrdIntegHarvest5/Param",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__SecretsManager__RotationSchedule.Rotation9515E0C5.json
+++ b/tests/corpus/AWS__SecretsManager__RotationSchedule.Rotation9515E0C5.json
@@ -61,7 +61,8 @@
       "path": "RotateImmediatelyOnUpdate",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:SecretA720EF05-me1CSgxlkGMO-hAz79g",
-      "constructPath": "CdkRealDriftIntegSecretRotationRich/Rotation"
+      "constructPath": "CdkRealDriftIntegSecretRotationRich/Rotation",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__SecretsManager__Secret.AppSecretFAB5164C.json
+++ b/tests/corpus/AWS__SecretsManager__Secret.AppSecretFAB5164C.json
@@ -44,7 +44,8 @@
       "path": "GenerateSecretString",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:AppSecretFAB5164C-dJ2LiOENJfDC-AwMLKc",
-      "constructPath": "CdkrdIntegHarvest3/AppSecret"
+      "constructPath": "CdkrdIntegHarvest3/AppSecret",
+      "writeOnly": true
     },
     {
       "tier": "generated",

--- a/tests/corpus/AWS__SecretsManager__Secret.ReplicaRegions.json
+++ b/tests/corpus/AWS__SecretsManager__Secret.ReplicaRegions.json
@@ -58,7 +58,8 @@
       "path": "GenerateSecretString",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-replica-regions-SOXFX4",
-      "constructPath": "CdkRealDriftIntegSecretReplicaRegions/Secret"
+      "constructPath": "CdkRealDriftIntegSecretReplicaRegions/Secret",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__StepFunctions__StateMachine.MachineDefObject.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.MachineDefObject.json
@@ -83,7 +83,8 @@
       "path": "Definition",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:states:ap-northeast-1:111111111111:stateMachine:cdkrd-fp-def-object",
-      "constructPath": "CdkRealDriftIntegSfnDefinitionObject/Machine"
+      "constructPath": "CdkRealDriftIntegSfnDefinitionObject/Machine",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
+++ b/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
@@ -92,7 +92,8 @@
       "path": "StartCanaryAfterCreation",
       "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-canary",
-      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
+      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary",
+      "writeOnly": true
     },
     {
       "tier": "atDefault",

--- a/tests/corpus/AWS__VpcLattice__Listener.HuntListener.json
+++ b/tests/corpus/AWS__VpcLattice__Listener.HuntListener.json
@@ -81,7 +81,8 @@
       "path": "ServiceIdentifier",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:service/svc-07215226a6b16ea1b/listener/listener-0881ae4b2367b2037",
-      "constructPath": "CdkRealDriftIntegLatticeListener/HuntListener"
+      "constructPath": "CdkRealDriftIntegLatticeListener/HuntListener",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__VpcLattice__Rule.HuntRule.json
+++ b/tests/corpus/AWS__VpcLattice__Rule.HuntRule.json
@@ -103,7 +103,8 @@
       "path": "ListenerIdentifier",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:service/svc-07215226a6b16ea1b/listener/listener-0881ae4b2367b2037/rule/rule-0262d24c9a9335dd9",
-      "constructPath": "CdkRealDriftIntegLatticeListener/HuntRule"
+      "constructPath": "CdkRealDriftIntegLatticeListener/HuntRule",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -112,7 +113,8 @@
       "path": "ServiceIdentifier",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:service/svc-07215226a6b16ea1b/listener/listener-0881ae4b2367b2037/rule/rule-0262d24c9a9335dd9",
-      "constructPath": "CdkRealDriftIntegLatticeListener/HuntRule"
+      "constructPath": "CdkRealDriftIntegLatticeListener/HuntRule",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/corpus/AWS__VpcLattice__ServiceNetworkServiceAssociation.HuntSnSvcAssoc.json
+++ b/tests/corpus/AWS__VpcLattice__ServiceNetworkServiceAssociation.HuntSnSvcAssoc.json
@@ -91,7 +91,8 @@
       "path": "ServiceIdentifier",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetworkserviceassociation/snsa-00731c74e0ef3793e",
-      "constructPath": "CdkRealDriftIntegLatticeListener/HuntSnSvcAssoc"
+      "constructPath": "CdkRealDriftIntegLatticeListener/HuntSnSvcAssoc",
+      "writeOnly": true
     },
     {
       "tier": "readGap",
@@ -100,7 +101,8 @@
       "path": "ServiceNetworkIdentifier",
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetworkserviceassociation/snsa-00731c74e0ef3793e",
-      "constructPath": "CdkRealDriftIntegLatticeListener/HuntSnSvcAssoc"
+      "constructPath": "CdkRealDriftIntegLatticeListener/HuntSnSvcAssoc",
+      "writeOnly": true
     }
   ]
 }

--- a/tests/integration/rds-appeared-writeonly/app.ts
+++ b/tests/integration/rds-appeared-writeonly/app.ts
@@ -1,0 +1,46 @@
+// #1582 regression fixture: an AWS::RDS::DBInstance DECLARES a write-only property
+// (MasterUserPassword), which surfaces as a write-only readGap. That readGap used to mark the
+// resource NOT `complete`, silently disabling "appeared since record" detection — so an
+// out-of-band change to an UNDECLARED property that was at its AWS default when recorded (here
+// CopyTagsToSnapshot false→true) surfaced only as [Not Recorded] and `check --fail` exited 0
+// (a false negative). verify-detect.sh enables CopyTagsToSnapshot out of band and asserts
+// `check` now DETECTS it. The undeclared CopyTagsToSnapshot / MonitoringInterval / MultiAZ are
+// left UNDECLARED (they fold atDefault on a first check) so they are appeared-since-record
+// candidates. A monitoring role is kept for reuse. (The ModifyDBInstance revert-no-op twins of
+// #1541 are a SEPARATE follow-up — detection had to be fixed first.)
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDBInstance } from "aws-cdk-lib/aws-rds";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntRdsRevertTwins0713");
+
+// Enhanced-monitoring role (used only when MonitoringInterval is enabled out of band).
+const monRole = new CfnRole(stack, "MonRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      { Effect: "Allow", Principal: { Service: "monitoring.rds.amazonaws.com" }, Action: "sts:AssumeRole" },
+    ],
+  },
+  managedPolicyArns: ["arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"],
+});
+
+// Barest provisioned instance: only the required props. Every twin below is UNDECLARED and
+// folds to its KNOWN_DEFAULTS default on a first check.
+new CfnDBInstance(stack, "Db", {
+  engine: "mariadb",
+  dbInstanceClass: "db.t3.micro",
+  allocatedStorage: "20",
+  masterUsername: "cdkrdadmin",
+  masterUserPassword: "CdkrdHunt0713Pass",
+  publiclyAccessible: false,
+  deletionProtection: false,
+});
+
+// Surface the monitoring role arn for verify-detect.sh (via a stack output is overkill; the
+// script resolves it from the stack resources instead). Keep a reference so it is not pruned.
+void monRole;
+
+app.synth();

--- a/tests/integration/rds-appeared-writeonly/cdk.json
+++ b/tests/integration/rds-appeared-writeonly/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rds-appeared-writeonly/package.json
+++ b/tests/integration/rds-appeared-writeonly/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-rds-appeared-writeonly",
+  "private": true,
+  "version": "0.0.0",
+  "description": "#1582 regression: a resource declaring a write-only property must still detect an appeared-since-record undeclared change. Run via verify.sh + verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/rds-appeared-writeonly/verify-detect.sh
+++ b/tests/integration/rds-appeared-writeonly/verify-detect.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# #1582 regression (real AWS): a resource that declares a WRITE-ONLY property (RDS
+# MasterUserPassword) must still detect an out-of-band, appeared-since-record change to an
+# UNDECLARED property. Before the fix the write-only readGap marked the resource NOT
+# `complete`, silently disabling "appeared since record" so the change surfaced only as
+# [Not Recorded] and `check --fail` exited 0 (a false negative). After the fix the write-only
+# readGap no longer blocks completeness, so the appeared value is [Potential Drift].
+# CopyTagsToSnapshot is an online modify (no reboot); poll describe until it propagates.
+set -uo pipefail
+export AWS_PAGER=""
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRdsRevertTwins0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "DETECT FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy (RDS ~8 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never >/dev/null 2>&1 || fail "deploy"
+DBID="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::RDS::DBInstance'].PhysicalResourceId" --output text)"
+[ -n "$DBID" ] || fail "could not resolve db id"
+
+echo "=== record clean baseline (CopyTagsToSnapshot folds atDefault=false, not recorded) ==="
+$CLI record "$STACK" --region "$REGION" --yes >/dev/null 2>&1 || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail >/dev/null 2>&1 || fail "expected CLEAN after record"
+
+echo "=== enable CopyTagsToSnapshot out of band ==="
+aws rds modify-db-instance --db-instance-identifier "$DBID" --apply-immediately --copy-tags-to-snapshot --region "$REGION" >/dev/null || fail "modify"
+v=""
+for _ in $(seq 1 24); do
+  v="$(aws rds describe-db-instances --db-instance-identifier "$DBID" --region "$REGION" --query 'DBInstances[0].CopyTagsToSnapshot' --output text)"
+  [ "$v" = "True" ] && break
+  sleep 5
+done
+[ "$v" = "True" ] || fail "modify did not propagate"
+
+echo "=== check MUST DETECT the appeared-since-record CopyTagsToSnapshot (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+RC="${PIPESTATUS[0]}"
+grep -qi "CopyTagsToSnapshot" "/tmp/cdkrd-$STACK-detect.out" || fail "CopyTagsToSnapshot not in the report"
+[ "$RC" -eq 1 ] || fail "check did NOT detect the appeared CopyTagsToSnapshot (#1582 FN)"
+echo "DETECT PASS ($STACK)"

--- a/tests/integration/rds-appeared-writeonly/verify.sh
+++ b/tests/integration/rds-appeared-writeonly/verify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# False-positive test: a barest mariadb DBInstance must FIRST-check CLEAN (MonitoringInterval,
+# EnablePerformanceInsights, MultiAZ, CopyTagsToSnapshot, BackupRetentionPeriod all fold to
+# atDefault) and stay CLEAN after record.
+set -uo pipefail
+export AWS_PAGER=""
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRdsRevertTwins0713
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy (RDS ~8 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What & why (Closes #1582)

A false-negative found while chasing the #1541 RDS revert-twins follow-up.

A resource that **declares a write-only property** (`AWS::RDS::DBInstance` `MasterUserPassword`, and any secret/token/password/key the schema marks write-only) surfaces that property as a **write-only `readGap`**. `computeCompleteResources` excluded ANY resource carrying a `readGap` from `completeResources`, which **silently disabled the "appeared since record" mechanism** for it. So an out-of-band change to an **undeclared** property that was at its AWS default when recorded (folded `atDefault`, never written to the baseline) surfaced only as `[Not Recorded]` — not `[Potential Drift]` — and `check --fail` exited 0. The out-of-band change was missed.

A write-only readGap is **expectedly** unreadable; it does not mean any part of the readable undeclared model was unread, so it must not disqualify completeness.

## Fix

- Mark the write-only readGap finding `writeOnly: true` (`src/diff/classify.ts`, `Finding.writeOnly` in `src/types.ts`).
- In `computeCompleteResources` (`src/baseline/baseline-file.ts`) skip only **genuine** readGaps: `f.tier === 'readGap' && !f.writeOnly`. A real readGap (a declared prop Cloud Control could not read back) still blocks completeness.

## Live proof (us-east-1)

Barest `AWS::RDS::DBInstance` declaring `masterUserPassword`, `CopyTagsToSnapshot` undeclared:

```
cdkrd record <stack> --yes
aws rds modify-db-instance --db-instance-identifier <id> --apply-immediately --copy-tags-to-snapshot
# describe + cloudcontrol get-resource both confirm CopyTagsToSnapshot=True
cdkrd check --fail
```

- **Pre-fix:** exit 0 — the enable was `[Not Recorded]`, missed.
- **Post-fix:** `Db.CopyTagsToSnapshot (AWS::RDS::DBInstance) — appeared since record  actual=true`, `result: 1 drift(s)`, exit 1. The write-only prop still shows `readGap=1 (1 write-only)` but no longer blocks completeness.

Contrast: the container-image Lambda from #1572 (no declared write-only prop → `complete`) already detected an appeared-since-record `MemorySize` — confirming the mechanism works once the resource is `complete`; this PR makes write-only-declaring resources `complete` again.

## Blast radius

Every resource type with a **declared write-only property** — RDS DB instances/clusters (`MasterUserPassword`), and any resource where the user declares a secret/token/password/key. On all of them, an out-of-band NEW undeclared value is now detected.

## Test

- Unit: `tests/baseline.test.ts` — `#1582` case asserts a write-only readGap stays `complete` while a genuine readGap still blocks.
- Corpus: the additive `writeOnly: true` field is regenerated onto the write-only readGap findings of **69** golden cases (classification is otherwise unchanged — a reviewable, mechanical diff).
- Full suite: 283 files, 5628 tests pass.
- Regression fixture: `tests/integration/rds-appeared-writeonly` (`verify.sh` + `verify-detect.sh`).
- Live: deployed, verified, torn down; all RDS final snapshots swept; `sweep-orphans.sh` → SWEEP CLEAN.
