### PR TITLE
fix(revert): ApiGatewayV2 Api DisableExecuteApiEndpoint + Route AuthorizationType revert converge (#1585)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -387,6 +387,16 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // (the fields default to ABSENT, so KNOWN_DEFAULTS has no source).
   'AWS::ApiGatewayV2::IntegrationResponse\0TemplateSelectionExpression',
   'AWS::ApiGatewayV2::RouteResponse\0ModelSelectionExpression',
+  // #1585: the same ApiGatewayV2 omit-ignored update family, live-proven on
+  // revert-noop-probe2 2026-07-14. UpdateApi keeps an omitted DisableExecuteApiEndpoint
+  // (flipped false->true out of band, a `remove` revert reported reverted yet
+  // `get-api` stayed true) and UpdateRoute keeps an omitted AuthorizationType (flipped
+  // NONE->AWS_IAM, `remove` reverted yet `get-route` stayed AWS_IAM). Write their
+  // KNOWN_DEFAULTS defaults (false / "NONE") back explicitly so revert converges.
+  // (Contrast AWS::Lambda::EventSourceMapping Enabled, verified same run to CONVERGE via
+  // a bare `remove` — UpdateEventSourceMapping re-enables on omit — so it needs NO entry.)
+  'AWS::ApiGatewayV2::Api\0DisableExecuteApiEndpoint',
+  'AWS::ApiGatewayV2::Route\0AuthorizationType',
   // Kinesis RetentionPeriodHours is changed only by the dedicated
   // Increase/DecreaseStreamRetentionPeriod APIs — the Cloud Control Stream update handler
   // ignores an OMITTED RetentionPeriodHours, so a bare `remove` revert of an out-of-band

--- a/tests/integration/revert-noop-probe2/app.ts
+++ b/tests/integration/revert-noop-probe2/app.ts
@@ -1,0 +1,80 @@
+// Round-4 revert-convergence (silent no-op) probe (2026-07-14 hunt, follow-up to
+// #1580 / #1583): more common types with KNOWN_DEFAULTS-folded MUTABLE scalars
+// whose revert must CONVERGE (not silently no-op):
+//   - Lambda EventSourceMapping: Enabled / MaximumBatchingWindowInSeconds /
+//     MaximumRetryAttempts / MaximumRecordAgeInSeconds (UpdateEventSourceMapping)
+//   - ApiGatewayV2 Api: DisableExecuteApiEndpoint (UpdateApi)
+//   - ApiGatewayV2 Route: AuthorizationType (UpdateRoute)
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+import { CfnFunction, CfnEventSourceMapping } from "aws-cdk-lib/aws-lambda";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnApi, CfnIntegration, CfnRoute } from "aws-cdk-lib/aws-apigatewayv2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntRevertNoop2x0714");
+
+// --- SQS -> Lambda EventSourceMapping ---
+const queue = new CfnQueue(stack, "Queue", {});
+const lambdaRole = new CfnRole(stack, "LambdaRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  policies: [
+    {
+      policyName: "sqs",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: [
+              "sqs:ReceiveMessage",
+              "sqs:DeleteMessage",
+              "sqs:GetQueueAttributes",
+            ],
+            Resource: queue.attrArn,
+          },
+        ],
+      },
+    },
+  ],
+});
+const fn = new CfnFunction(stack, "Fn", {
+  code: { zipFile: "exports.handler = async () => 'ok';" },
+  handler: "index.handler",
+  runtime: "nodejs20.x",
+  role: lambdaRole.attrArn,
+});
+new CfnEventSourceMapping(stack, "Esm", {
+  eventSourceArn: queue.attrArn,
+  functionName: fn.ref,
+});
+
+// --- ApiGatewayV2 HTTP Api + Route (barest) ---
+const httpApi = new CfnApi(stack, "HttpApi", {
+  name: "cdkrd-noop2-api",
+  protocolType: "HTTP",
+});
+const integration = new CfnIntegration(stack, "Integration", {
+  apiId: httpApi.ref,
+  integrationType: "HTTP_PROXY",
+  integrationMethod: "GET",
+  integrationUri: "https://example.com",
+  payloadFormatVersion: "1.0",
+});
+new CfnRoute(stack, "Route", {
+  apiId: httpApi.ref,
+  routeKey: "GET /",
+  target: `integrations/${integration.ref}`,
+});
+
+app.synth();

--- a/tests/integration/revert-noop-probe2/cdk.json
+++ b/tests/integration/revert-noop-probe2/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revert-noop-probe2/package.json
+++ b/tests/integration/revert-noop-probe2/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revert-noop-probe2",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest EventSourceMapping/ApiGatewayV2 fixture probing revert-convergence. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revert-noop-probe2/verify-detect.sh
+++ b/tests/integration/revert-noop-probe2/verify-detect.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# #1585 revert-convergence regression (real AWS): ApiGatewayV2 Api
+# DisableExecuteApiEndpoint + Route AuthorizationType both no-op on a bare `remove`
+# revert (UpdateApi / UpdateRoute ignore the omitted property), so revert must write
+# their KNOWN_DEFAULTS defaults (false / "NONE") explicitly.
+#
+# EventSourceMapping Enabled is mutated too, as a CONTROL that it converges via the
+# bare `remove` (UpdateEventSourceMapping re-enables on omit) — it is intentionally
+# NOT in REVERT_SET_DEFAULT_PATHS (the non-uniformity guard).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevertNoop2x0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ESM="$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id Esm \
+  --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text)"
+API="$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id HttpApi \
+  --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text)"
+ROUTE="$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id Route \
+  --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text)"
+[ -n "$API" ] && [ -n "$ROUTE" ] && [ -n "$ESM" ] || fail "could not resolve physical ids"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== wait ESM Enabled, then out-of-band mutations ==="
+for i in $(seq 1 15); do st=$(aws lambda get-event-source-mapping --uuid "$ESM" --region "$REGION" --query 'State' --output text 2>/dev/null); [ "$st" = "Enabled" ] && break; sleep 5; done
+aws lambda update-event-source-mapping --uuid "$ESM" --region "$REGION" --no-enabled >/dev/null || fail "esm mutate"
+aws apigatewayv2 update-api --api-id "$API" --region "$REGION" --disable-execute-api-endpoint >/dev/null || fail "api mutate"
+aws apigatewayv2 update-route --api-id "$API" --route-id "$ROUTE" --region "$REGION" --authorization-type AWS_IAM >/dev/null || fail "route mutate"
+for i in $(seq 1 15); do st=$(aws lambda get-event-source-mapping --uuid "$ESM" --region "$REGION" --query 'State' --output text 2>/dev/null); [ "$st" = "Disabled" ] && break; sleep 5; done
+
+echo "=== check MUST DETECT (>=3 undeclared drifts) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-noop2-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "DisableExecuteApiEndpoint" /tmp/cdkrd-noop2-detect.out || fail "DisableExecuteApiEndpoint not reported"
+grep -q "AuthorizationType" /tmp/cdkrd-noop2-detect.out || fail "AuthorizationType not reported"
+
+echo "=== revert (set-default for the two no-op targets, remove for the ESM control) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert (convergence) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert — a revert did not converge"
+
+echo "=== live values MUST be restored to defaults ==="
+DE="$(aws apigatewayv2 get-api --api-id "$API" --region "$REGION" --query 'DisableExecuteApiEndpoint' --output text)"
+AT="$(aws apigatewayv2 get-route --api-id "$API" --route-id "$ROUTE" --region "$REGION" --query 'AuthorizationType' --output text)"
+[ "$DE" = "False" ] || fail "DisableExecuteApiEndpoint not restored (got: $DE)"
+[ "$AT" = "NONE" ] || fail "AuthorizationType not restored (got: $AT)"
+
+echo "INTEG PASS ($STACK detect+revert, #1585)"

--- a/tests/integration/revert-noop-probe2/verify.sh
+++ b/tests/integration/revert-noop-probe2/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest SQS->Lambda EventSourceMapping
+# + ApiGatewayV2 HTTP Api/Route. Every KNOWN_DEFAULTS-folded scalar must fold to
+# atDefault. deploy -> check (pre-record) MUST be CLEAN -> record -> check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevertNoop2x0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.pre.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FIRST-RUN FALSE POSITIVE ---"; fail "expected CLEAN pre-record (exit 0), got $rc"; }
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1477,6 +1477,60 @@ describe('buildRevertPlan', () => {
     expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/VisibilityTimeout' });
   });
 
+  it('#1585: ApiGatewayV2 Api DisableExecuteApiEndpoint (SET-DEFAULT) -> add op writing false, not a no-op remove', () => {
+    // #1585 (live-proven on revert-noop-probe2 2026-07-14): flipped false->true out of band,
+    // `revert` planned a `remove`, reported reverted, yet `get-api` stayed true. Same
+    // ApiGatewayV2 omit-ignored update family as #1567. Write the false default (from
+    // KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ApiGatewayV2::Api',
+      path: 'DisableExecuteApiEndpoint',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DisableExecuteApiEndpoint',
+      value: false,
+      prior: true,
+    });
+  });
+
+  it('#1585: ApiGatewayV2 Route AuthorizationType (SET-DEFAULT) -> add op writing NONE, not a no-op remove', () => {
+    // #1585 (live-proven on revert-noop-probe2 2026-07-14): flipped NONE->AWS_IAM out of band,
+    // `revert` planned a `remove`, reported reverted, yet `get-route` stayed AWS_IAM.
+    // UpdateRoute ignores an omitted AuthorizationType — write the "NONE" default (from
+    // KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ApiGatewayV2::Route',
+      path: 'AuthorizationType',
+      actual: 'AWS_IAM',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/AuthorizationType',
+      value: 'NONE',
+      prior: 'AWS_IAM',
+    });
+  });
+
+  it('#1585 control: Lambda EventSourceMapping Enabled is NOT a set-default path (converges via bare remove) -> remove op', () => {
+    // The non-uniformity guard: EventSourceMapping Enabled was live-verified to converge via a
+    // bare `remove` (UpdateEventSourceMapping re-enables on omit), so it must stay OFF
+    // REVERT_SET_DEFAULT_PATHS — a future entry here would be wrong.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Lambda::EventSourceMapping',
+      path: 'Enabled',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/Enabled' });
+  });
+
   it('RolesAnywhere Profile DurationSeconds (SET-DEFAULT) -> add op writing 3600, not a no-op remove', () => {
     // Follow-up to #619: UpdateProfile IGNORES an omitted DurationSeconds (live-proven — a
     // profile duration changed to 7200, then `revert --remove-unrecorded` reported reverted,


### PR DESCRIPTION
## What

Two more `revert` silent no-ops of the `REVERT_SET_DEFAULT_PATHS` class (follow-up to #1580 / #1583), on **ApiGatewayV2 HTTP APIs** — a daily-driver type, and the same omit-ignored update family as the already-fixed #1567 (`*SelectionExpression`).

1. **`AWS::ApiGatewayV2::Api` `DisableExecuteApiEndpoint`** — `false` → `true` flip detected, but `revert`'s bare `remove` no-oped (stayed `true`). Default `false`.
2. **`AWS::ApiGatewayV2::Route` `AuthorizationType`** — `NONE` → `AWS_IAM` flip detected, but `revert`'s bare `remove` no-oped (stayed `AWS_IAM`). Default `"NONE"`.

Verified in the same run that **`AWS::Lambda::EventSourceMapping` `Enabled` DOES converge** via the bare `remove` (`UpdateEventSourceMapping` re-enables on omit), so it correctly needs no entry — kept as a converge-via-remove control (the non-uniformity guard).

## Fix

Add to `REVERT_SET_DEFAULT_PATHS` (`src/revert/plan.ts`):
- `AWS::ApiGatewayV2::Api\0DisableExecuteApiEndpoint` (default `false` from `KNOWN_DEFAULTS`)
- `AWS::ApiGatewayV2::Route\0AuthorizationType` (default `"NONE"` from `KNOWN_DEFAULTS`)

Both stable constants → no `MOVING_REVERT_PINS` entries.

## Verification

- **Unit tests** (`tests/revert-plan.test.ts`): two set-default assertions (confirmed to FAIL without the fix) + a control asserting `EventSourceMapping Enabled` stays a bare `remove`.
- **Live-proven** (real AWS, us-east-1) on the new `revert-noop-probe2` fixture: mutate out of band → `check` detects (exit 1) → `revert` plans the two as `AWS default` and the ESM control as `remove` → **"CLEAN after revert"** → live `DisableExecuteApiEndpoint=false`, `AuthorizationType=NONE`.
- **Regression fixture** (`tests/integration/revert-noop-probe2`): barest SQS→Lambda ESM + ApiGatewayV2 HTTP Api/Route. `verify.sh` = first-run FP-clean; `verify-detect.sh` = the #1585 detect→revert→converge cycle.

Full local gates green (typecheck / lint+format / build / 5671 unit tests).

Closes #1585
