### PR TITLE
fix(revert): RDS DBInstance MultiAZ/PerformanceInsights/MonitoringInterval/CopyTagsToSnapshot/CACertificateIdentifier revert converge (#1588)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -359,12 +359,24 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // on CdkrdHunt0713RdsMariadb (us-east-1, 2026-07-13): an out-of-band undeclared
   // BackupRetentionPeriod 1->3 survived a bare-`remove` revert that reported success (the
   // convergence re-read flagged it NOT reverted); with this entry the set-default `add 1`
-  // (from KNOWN_DEFAULTS) converges — live re-verified to 1. The remaining folded siblings
-  // on the same API (MultiAZ, CopyTagsToSnapshot, EnablePerformanceInsights,
-  // CACertificateIdentifier, MonitoringInterval) are expected twins — add each ONLY with
-  // its own live proof (note the CDK L2 declares CopyTagsToSnapshot, so proving it needs a
-  // raw-CFn/L1 fixture that leaves it undeclared).
+  // (from KNOWN_DEFAULTS) converges — live re-verified to 1.
   'AWS::RDS::DBInstance\0BackupRetentionPeriod',
+  // #1588: the remaining folded ModifyDBInstance siblings flagged as expected twins by the
+  // #1541 note — each now live-proven on Cdkrd1588Verify (us-east-1, 2026-07-14, a barest
+  // db.t3.medium mariadb with every twin left UNDECLARED). For each: an out-of-band enable
+  // (MultiAZ false->true, EnablePerformanceInsights false->true, MonitoringInterval 0->60,
+  // CopyTagsToSnapshot false->true) or CA swap (CACertificateIdentifier
+  // rds-ca-rsa2048-g1 -> rds-ca-rsa4096-g1) was DETECTED (appeared-since-record, post-#1586)
+  // yet survived a bare-`remove` revert (the live value persisted unchanged) — the
+  // ModifyDBInstance selective-modify keeps the existing value for an omitted property (the
+  // pre-fix binary's convergence re-read flagged it NOT reverted). With these entries the
+  // set-default `add <default>` (all sourced from KNOWN_DEFAULTS: false / false / 0 / false /
+  // rds-ca-rsa2048-g1) converges — each live re-verified back to its default.
+  'AWS::RDS::DBInstance\0MultiAZ',
+  'AWS::RDS::DBInstance\0EnablePerformanceInsights',
+  'AWS::RDS::DBInstance\0MonitoringInterval',
+  'AWS::RDS::DBInstance\0CopyTagsToSnapshot',
+  'AWS::RDS::DBInstance\0CACertificateIdentifier',
   'AWS::RDS::DBCluster\0AutoMinorVersionUpgrade',
   'AWS::Neptune::DBInstance\0AutoMinorVersionUpgrade',
   'AWS::ElastiCache::CacheCluster\0AutoMinorVersionUpgrade',
@@ -474,6 +486,16 @@ export const MOVING_REVERT_PINS: Record<string, MovingRevertPin> = {
     lastVerified: '2026-07-10',
     moveAxis:
       'RDS/DocDB rotate the default server CA on a published schedule; a bump makes revert write a superseded CA identifier (reboots the instance onto an old cert).',
+  },
+  // #1588: RDS::DBInstance CACertificateIdentifier is now a revert-write pin (added to
+  // REVERT_SET_DEFAULT_PATHS). Same moving default as the DocDB twin above — AWS advanced the
+  // default RDS server CA before (rds-ca-2019 -> rds-ca-rsa2048-g1) and will again, so track
+  // its staleness here (a revert-write pin's rot is not self-surfacing).
+  'AWS::RDS::DBInstance\0CACertificateIdentifier': {
+    value: 'rds-ca-rsa2048-g1',
+    lastVerified: '2026-07-14',
+    moveAxis:
+      'RDS rotates the default server CA on a published schedule; a bump makes revert write a superseded CA identifier (reboots the instance onto an old cert). Live-confirmed rds-ca-rsa2048-g1 is the fresh-instance default (us-east-1, 2026-07-14).',
   },
 };
 

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -576,6 +576,91 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  // #1588: the remaining ModifyDBInstance revert-no-op twins of #1541 — same selective-modify
+  // semantics (an omitted property keeps its existing value), so a bare `remove` revert of an
+  // out-of-band, undeclared, KNOWN_DEFAULTS-folded change is a silent no-op. Each is now in
+  // REVERT_SET_DEFAULT_PATHS, so revert writes the KNOWN_DEFAULTS default back explicitly.
+  // Live-proven on Cdkrd1588Verify (us-east-1, 2026-07-14).
+  it('#1588: RDS DBInstance MultiAZ (SET-DEFAULT) -> add op writing the false default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RDS::DBInstance',
+      path: 'MultiAZ',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/MultiAZ',
+      value: false,
+      prior: true,
+    });
+  });
+
+  it('#1588: RDS DBInstance EnablePerformanceInsights (SET-DEFAULT) -> add op writing the false default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RDS::DBInstance',
+      path: 'EnablePerformanceInsights',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/EnablePerformanceInsights',
+      value: false,
+      prior: true,
+    });
+  });
+
+  it('#1588: RDS DBInstance MonitoringInterval (SET-DEFAULT) -> add op writing the 0 default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RDS::DBInstance',
+      path: 'MonitoringInterval',
+      actual: 60,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/MonitoringInterval',
+      value: 0,
+      prior: 60,
+    });
+  });
+
+  it('#1588: RDS DBInstance CopyTagsToSnapshot (SET-DEFAULT) -> add op writing the false default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RDS::DBInstance',
+      path: 'CopyTagsToSnapshot',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/CopyTagsToSnapshot',
+      value: false,
+      prior: true,
+    });
+  });
+
+  it('#1588: RDS DBInstance CACertificateIdentifier (SET-DEFAULT) -> add op writing the rds-ca-rsa2048-g1 default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RDS::DBInstance',
+      path: 'CACertificateIdentifier',
+      actual: 'rds-ca-rsa4096-g1',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/CACertificateIdentifier',
+      value: 'rds-ca-rsa2048-g1',
+      prior: 'rds-ca-rsa4096-g1',
+    });
+  });
+
   it('Kinesis Stream RetentionPeriodHours (SET-DEFAULT) -> add op writing the 24 default, not a no-op remove', () => {
     // RetentionPeriodHours is changed only by the dedicated
     // Increase/DecreaseStreamRetentionPeriod APIs — the Cloud Control Stream update handler


### PR DESCRIPTION
## Summary

Closes #1588. Follow-up to #1541 (unblocked by #1586). `ModifyDBInstance` keeps the
existing value for **any** omitted property, so a bare `remove` revert of an
out-of-band, undeclared, `KNOWN_DEFAULTS`-folded `AWS::RDS::DBInstance` property is a
silent no-op. #1541 fixed this for `BackupRetentionPeriod`; the in-source note flagged
the remaining same-API siblings as expected twins to add **only with their own live
proof**. This adds all five to `REVERT_SET_DEFAULT_PATHS` so revert writes the
`KNOWN_DEFAULTS` default explicitly and converges:

| Twin | Default (from `KNOWN_DEFAULTS`) |
| --- | --- |
| `MultiAZ` | `false` |
| `EnablePerformanceInsights` | `false` |
| `MonitoringInterval` | `0` |
| `CopyTagsToSnapshot` | `false` |
| `CACertificateIdentifier` | `rds-ca-rsa2048-g1` |

Each set-default value resolves from the existing `KNOWN_DEFAULTS` entry (same as
`BackupRetentionPeriod`) — no `REVERT_SET_DEFAULT_VALUES` entry needed.

## Live proof

Deployed `Cdkrd1588Verify` (us-east-1) — a barest `db.t3.medium` mariadb `DBInstance`
with every twin left UNDECLARED (folds `atDefault` on a clean `check`, verified). For
each twin: `record` a clean baseline → mutate out of band → `check` DETECTS
(appeared-since-record, post-#1586) → revert.

A/B against the pre-fix binary (main HEAD, has detection, lacks these entries) vs the
fixed binary:

| Twin | pre-fix bare `remove` | fixed set-default |
| --- | --- | --- |
| CopyTagsToSnapshot | no-op (stayed `true`) | converged → `false` ✅ |
| MonitoringInterval | no-op (stayed `60`) | converged → `0` ✅ |
| EnablePerformanceInsights | no-op (stayed `true`) | converged → `false` ✅ |
| CACertificateIdentifier | no-op (`remove` op, stayed `rds-ca-rsa4096-g1`) | wrote `rds-ca-rsa2048-g1` → converged ✅ |
| MultiAZ | no-op (stayed `true`) | converged → `false` ✅ |

Post-revert `check` is CLEAN for each (the CA/PI/CopyTags/MultiAZ cases); enabling
enhanced monitoring attaches an inert `MonitoringRoleArn` that legitimately persists
after `MonitoringInterval → 0`, which is a separate real undeclared value (recorded),
not a twin-revert failure.

## Tests

Five regression tests in `tests/revert-plan.test.ts` (modeled on the `#1541`
`BackupRetentionPeriod` case) asserting each twin produces an `add` op writing the
default rather than a no-op `remove`. Full suite green (286 files, 5679 tests).
