### PR TITLE
fix(check,revert): fold Redshift/oracle/Multi-AZ-OpenSearch first-run FPs and fix write-only re-include false no-op

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -648,6 +648,15 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   service lowercase?"), but only a CFn DEPLOY proves reachability; a handler rejection
   is itself the determination (record it in the fixture comment). The inverse also
   held: Redshift's and Batch's handlers pass mixed case through, and both FP'd.
+  **Cheaper still: `aws cloudcontrol create-resource` exercises the SAME CFn/CC handler
+  with NO stack and NO fixture** — a rejection comes back as a FAILED progress event in
+  seconds, and an acceptance gives you the stored echo via `get-resource` before you
+  `delete-resource`. The 2026-07-14 hunt determined the whole remaining MemoryDB family
+  (SubnetGroup/User/ACL all reject: "must contain only lowercase") and Cassandra
+  Keyspace (accepts AND preserves case — no FP either way) for zero deploys; reserve
+  the paid CFn fixture for the types the handler lets THROUGH (Redshift::Cluster
+  ClusterIdentifier, #1589). Tag the probe resource `cdkrd:ephemeral=1` in its desired
+  state and delete it immediately.
 - **An undeclared-revert "proof" is void if the CDK L2 declares the leaf.** Before
   claiming a revert no-op / convergence proof for an UNDECLARED property, read the
   DEPLOYED template: mutating a value the L2 silently declared (RDS
@@ -675,6 +684,17 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   declared value out of band (e.g. `aws route53 change-resource-record-sets`) and
   asserting `check --fail` exits 1, then restore it manually; note the revert gap as a
   future `SDK_WRITERS` candidate rather than treating it as a regression.
+- **Read the revert's convergence REPORT text, not just the live value — the report
+  layer has its own bug class.** A revert whose target converges perfectly can still
+  print a false `NOT reverted: …MasterUserPassword — the default-value write was a
+no-op` for the write-only RE-INCLUDE op every password-declaring resource carries
+  (the CC read-modify-write contract): a write-only path re-reads as `readGap` with no
+  live value on either side, so a persistence check built on `deepEqual(pre, post)` is
+  vacuously true (#1594, live-hit on an aurora-pg Sv2 revert 2026-07-14). When a revert
+  probe passes on the live value, ALSO grep its output for `NOT reverted:` /
+  `could not be confirmed` on paths you never drifted — an unverifiable (readGap) path
+  must never drive a "value persists" verdict, and fixtures that only assert
+  `check --fail` exit codes ride right past this class.
 - **A clean result IS a result — but it must still leave an asset.** "6 common+rich
   stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do
   NOT manufacture a fix to have something to show. The deliverable of a bug-free

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1656,8 +1656,15 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       const key = `${item.logicalId}\0${dotted}`;
       if (!preActual.has(key)) continue;
       const pre = preActual.get(key);
+      // #1594: a readGap re-read carries NO live value (a write-only path — e.g. the
+      // MasterUserPassword re-include op every RDS revert adds for the CC
+      // read-modify-write contract — re-reads as readGap with `actual` undefined on both
+      // sides), so it can prove nothing about persistence; without this exclusion the
+      // vacuous deepEqual(undefined, undefined) flagged the re-include as a false
+      // "NOT reverted" no-op on every such revert.
       const post0 = post.find(
-        (f) => f.logicalId === item.logicalId && f.path === dotted && !isDrift(f)
+        (f) =>
+          f.logicalId === item.logicalId && f.path === dotted && !isDrift(f) && f.tier !== 'readGap'
       );
       // Same non-drift persisted-value proof for both op kinds: the pre-revert value is
       // still live after a SUCCESSFUL apply. For `add`, additionally require the live value

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1111,6 +1111,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     MaintenanceTrackName: 'current',
     KmsKeyId: 'AWS_OWNED_KMS_KEY',
     NumberOfNodes: 1,
+    // A cluster that declares no ClusterSubnetGroupName (default-VPC placement) reads back
+    // the literal subnet group name "default" (#1590, live-verified on a barest L1 cluster —
+    // every prior fixture/corpus case declared it, hiding the first-run FP). Equality-gated:
+    // an out-of-band move to a real subnet group no longer matches and surfaces.
+    ClusterSubnetGroupName: 'default',
   },
   // #1492: a Redshift ScheduledAction that declares no `Enable` reads back `true` — AWS enables a
   // new schedule by default. Stable constant → equality-gated fold; an out-of-band
@@ -1805,6 +1810,28 @@ export const KNOWN_DEFAULT_ONE_OF: Record<string, Record<string, readonly unknow
   'AWS::Glue::Job': {
     Timeout: [2880, 480],
   },
+  // #1593: a domain that declares no DomainEndpointOptions reads back the whole options
+  // object AWS materializes at creation, and its TLSSecurityPolicy member is ERA-dependent
+  // (the S3 TransitionDefaultMinimumObjectSize class): a fresh 2026 domain reads
+  // Policy-Min-TLS-1-2-2019-07 (live-proven, opensearch-multiaz-min 2026-07-14), domains
+  // created before the 2024 TLS-default bump read the documented prior default
+  // Policy-Min-TLS-1-0-2019-07. Both trios are AWS-assigned, never user intent when
+  // undeclared; equality-gating the SET preserves detection — an out-of-band EnforceHTTPS
+  // enable, a custom endpoint, or any third TLS policy breaks both pins and surfaces.
+  'AWS::OpenSearchService::Domain': {
+    DomainEndpointOptions: [
+      {
+        CustomEndpointEnabled: false,
+        EnforceHTTPS: false,
+        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
+      },
+      {
+        CustomEndpointEnabled: false,
+        EnforceHTTPS: false,
+        TLSSecurityPolicy: 'Policy-Min-TLS-1-0-2019-07',
+      },
+    ],
+  },
 };
 
 // The NESTED-path twin of KNOWN_DEFAULT_ONE_OF (#979): a nested undeclared value whose AWS
@@ -1851,6 +1878,15 @@ export const KNOWN_DEFAULT_ONE_OF_PATHS: Record<string, Record<string, readonly 
       [{ ImageType: 'ECS_AL2023' }],
       [{ ImageType: 'ECS_AL2' }],
     ],
+  },
+  // #1593: an EBS-backed domain that declares no VolumeType reads back the era default —
+  // "gp3" for domains created after OpenSearch's late-2023 gp3 default switch (live-proven
+  // on a fresh minimal Multi-AZ domain, opensearch-multiaz-min 2026-07-14), "gp2" for
+  // older-era domains (the documented prior default). A user who DECLARES a volume type is
+  // compared in the declared dimension; an out-of-band switch to io1/io2 or any third type
+  // still surfaces.
+  'AWS::OpenSearchService::Domain': {
+    'EBSOptions.VolumeType': ['gp3', 'gp2'],
   },
 };
 
@@ -2267,6 +2303,11 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // when the template leaves them unset — server defaults, not user intent.
     'EBSOptions.Iops': 3000,
     'EBSOptions.Throughput': 125,
+    // A zone-aware domain that declares ZoneAwarenessEnabled=true but no explicit
+    // ZoneAwarenessConfig reads back the materialized 2-AZ default (#1593, live-proven on
+    // opensearch-multiaz-min 2026-07-14 — the Multi-AZ variant axis was previously
+    // undeployed). Equality-gated: an out-of-band 3-AZ move breaks the pin and surfaces.
+    'ClusterConfig.ZoneAwarenessConfig': { AvailabilityZoneCount: 2 },
   },
   'AWS::KinesisFirehose::DeliveryStream': {
     // S3 backup is Disabled by default when a destination declares no backup mode.
@@ -2700,9 +2741,23 @@ export const ENGINE_DEFAULTS: Record<string, Record<string, (engine: string) => 
     LicenseModel: rdsDefaultLicense,
     // SQL Server materializes its default collation when none is declared — live-confirmed
     // "SQL_Latin1_General_CP1_CI_AS" on a fresh minimal sqlserver-ex (rds-sqlserver-min,
-    // 2026-07-12). CharacterSetName is create-only; a user-chosen collation is DECLARED and
-    // compared in the declared loop. Other engines expose no such echo → undefined.
-    CharacterSetName: (e) => (/sqlserver/.test(e) ? 'SQL_Latin1_General_CP1_CI_AS' : undefined),
+    // 2026-07-12). Oracle likewise materializes its default database character set
+    // "AL32UTF8" — live-confirmed on a fresh minimal oracle-se2 (rds-oracle-min,
+    // 2026-07-14, #1591). CharacterSetName is create-only; a user-chosen collation /
+    // charset is DECLARED and compared in the declared loop. Other engines expose no such
+    // echo → undefined.
+    CharacterSetName: (e) =>
+      /sqlserver/.test(e)
+        ? 'SQL_Latin1_General_CP1_CI_AS'
+        : /oracle/.test(e)
+          ? 'AL32UTF8'
+          : undefined,
+    // Oracle-only creation defaults, live-confirmed on the same minimal oracle-se2 (#1591):
+    // the national character set "AL16UTF16", and the default SID "ORCL" (DBName) — the
+    // other engine families create no default database, so neither key echoes there.
+    // Equality-gated: a non-default charset / SID still surfaces.
+    NcharCharacterSetName: (e) => (/oracle/.test(e) ? 'AL16UTF16' : undefined),
+    DBName: (e) => (/oracle/.test(e) ? 'ORCL' : undefined),
   },
   'AWS::RDS::DBCluster': {
     StorageType: (e) => (e.startsWith('aurora') ? 'aurora' : undefined),
@@ -3760,7 +3815,12 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'AvailabilityZone',
     'ClusterVersion',
   ]),
-  'AWS::OpenSearchService::Domain': new Set(['OffPeakWindowOptions']),
+  //   AWS::OpenSearchService::Domain.EngineVersion — a domain that pins no version reads back
+  //   the current GA engine version AWS assigns at creation (OpenSearch_3.5 on 2026-07-14,
+  //   #1593) and AWS moves that default over time — the same class as Redshift ClusterVersion /
+  //   ECS Service PlatformVersion above. A user who cares about the version DECLARES it (then
+  //   compared in the declared dimension); undeclared, the assigned version is AWS's choice.
+  'AWS::OpenSearchService::Domain': new Set(['OffPeakWindowOptions', 'EngineVersion']),
   //   AWS::AmazonMQ::Broker.MaintenanceWindowStartTime — a broker that declares no window reads
   //   back an AWS-assigned one as an OBJECT ({DayOfWeek, TimeOfDay, TimeZone}); value-independent
   //   folds the whole top-level property whatever its shape, so the assigned window is not first-
@@ -4716,9 +4776,15 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // "cdkrdhunt-rscpg" — the same stored-lowercased identifier family as the RDS
   // parameter/option groups (#1531). Two names differing beyond case are a genuine
   // replacement and still surface. Observed live (case-idents2-min, 2026-07-13; #1539).
-  // ClusterSubnetGroup has no declarable name; Cluster's ClusterIdentifier is CDK-lowered
-  // already and unprobed — add it here only with live proof.
+  // ClusterSubnetGroup has no declarable name.
   'AWS::Redshift::ClusterParameterGroup': new Set(['ParameterGroupName']),
+  // Redshift also lowercases the CLUSTER identifier itself, and the CFn handler passes a
+  // mixed-case ClusterIdentifier through (unlike the MemoryDB family, whose handlers reject
+  // mixed case server-side — probed 2026-07-14 via Cloud Control: SubnetGroup/User/ACL all
+  // "must contain only lowercase", unreachable, no entries needed). A template declaring
+  // "CdkrdHunt-Mixed-RsCluster" reads back "cdkrdhunt-mixed-rscluster" — declared-tier FP on
+  // every check. Observed live (case-idents3-min, 2026-07-14; #1589).
+  'AWS::Redshift::Cluster': new Set(['ClusterIdentifier']),
   'AWS::DMS::ReplicationInstance': new Set(['ReplicationInstanceIdentifier']),
   'AWS::DMS::ReplicationSubnetGroup': new Set(['ReplicationSubnetGroupIdentifier']),
   // DMS Endpoint `EndpointType` — the CFn/CDK value is lowercase (`source` /

--- a/tests/corpus/AWS__EFS__FileSystem.HuntEfsProvisioned.json
+++ b/tests/corpus/AWS__EFS__FileSystem.HuntEfsProvisioned.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEfsProvisioned",
+    "resourceType": "AWS::EFS::FileSystem",
+    "physicalId": "fs-0ff39274912a28930",
+    "constructPath": "CdkrdHunt0714VariantPack/HuntEfsProvisioned",
+    "declared": {
+      "FileSystemTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "ProvisionedThroughputInMibps": 1,
+      "ThroughputMode": "provisioned"
+    }
+  },
+  "liveRaw": {
+    "PerformanceMode": "generalPurpose",
+    "Encrypted": false,
+    "FileSystemTags": [
+      {
+        "Value": "HuntEfsProvisioned",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714VariantPack/e5723b90-7ee7-11f1-860c-0ed95510442f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdHunt0714VariantPack",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "ProvisionedThroughputInMibps": 1,
+    "FileSystemId": "fs-0ff39274912a28930",
+    "FileSystemProtection": {
+      "ReplicationOverwriteProtection": "ENABLED"
+    },
+    "LifecyclePolicies": [],
+    "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:file-system/fs-0ff39274912a28930",
+    "ThroughputMode": "provisioned",
+    "BackupPolicy": {
+      "Status": "DISABLED"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "FileSystemId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck"],
+    "createOnly": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "readOnlyPaths": [
+      "Arn",
+      "FileSystemId",
+      "ReplicationConfiguration.Destinations.*.Status",
+      "ReplicationConfiguration.Destinations.*.StatusMessage"
+    ],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "ReplicationConfiguration.Destinations.*.AvailabilityZoneName",
+      "ReplicationConfiguration.Destinations.*.KmsKeyId"
+    ],
+    "createOnlyPaths": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEfsProvisioned",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "PerformanceMode",
+      "actual": "generalPurpose",
+      "physicalId": "fs-0ff39274912a28930",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntEfsProvisioned"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEfsProvisioned",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "FileSystemProtection",
+      "actual": {
+        "ReplicationOverwriteProtection": "ENABLED"
+      },
+      "physicalId": "fs-0ff39274912a28930",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntEfsProvisioned"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEfsProvisioned",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "fs-0ff39274912a28930",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntEfsProvisioned"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.HuntJavaSnapStartFnAAF8FCFE.json
+++ b/tests/corpus/AWS__Lambda__Function.HuntJavaSnapStartFnAAF8FCFE.json
@@ -1,0 +1,226 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+    "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn",
+    "declared": {
+      "Code": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "ac6e6b9b6b63b7135a3a51cd6fb9a4f29815e6aceb41e48d65ee9391886f7629.zip"
+      },
+      "Handler": "example.Handler::handleRequest",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0714VariantPack-HuntJavaSnapStartFnService-wVitpyT9Dm9V",
+      "Runtime": "java21",
+      "SnapStart": {
+        "ApplyOn": "PublishedVersions"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "example.Handler::handleRequest",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "PublishedVersions"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdHunt0714VariantPack-HuntJavaSnapStartFnService-wVitpyT9Dm9V",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+    "Runtime": "java21",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714VariantPack",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "HuntJavaSnapStartFnAAF8FCFE",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714VariantPack/e5723b90-7ee7-11f1-860c-0ed95510442f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["x86_64"],
+    "CodeSha256": "sFSjQhQ7zsKdyAGuo2dyz2U13OWqcy1WIE4wRKtUIg8="
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectStorageMode",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "SnapStart",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X"
+      },
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntJavaSnapStartFnAAF8FCFE",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "CodeSha256",
+      "actual": "sFSjQhQ7zsKdyAGuo2dyz2U13OWqcy1WIE4wRKtUIg8=",
+      "physicalId": "CdkrdHunt0714VariantPack-HuntJavaSnapStartFnAAF8FC-qydsJ0ohod0X",
+      "constructPath": "CdkrdHunt0714VariantPack/HuntJavaSnapStartFn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__OpenSearchService__Domain.HuntOsMultiAz.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.HuntOsMultiAz.json
@@ -1,0 +1,317 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOsMultiAz",
+    "resourceType": "AWS::OpenSearchService::Domain",
+    "physicalId": "huntosmultiaz-fr6can7z6wpw",
+    "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz",
+    "declared": {
+      "ClusterConfig": {
+        "InstanceCount": 2,
+        "InstanceType": "t3.small.search",
+        "ZoneAwarenessEnabled": true
+      },
+      "EBSOptions": {
+        "EBSEnabled": true,
+        "VolumeSize": 10
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SnapshotOptions": {
+      "AutomatedSnapshotStartHour": 0
+    },
+    "NodeToNodeEncryptionOptions": {
+      "Enabled": false
+    },
+    "DomainEndpoints": {},
+    "DomainEndpointOptions": {
+      "CustomEndpointEnabled": false,
+      "EnforceHTTPS": false,
+      "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+    },
+    "DomainArn": "arn:aws:es:us-east-1:111111111111:domain/huntosmultiaz-fr6can7z6wpw",
+    "CognitoOptions": {
+      "Enabled": false
+    },
+    "AdvancedOptions": {
+      "override_main_response_version": "false",
+      "rest.action.multi.allow_explicit_index": "true"
+    },
+    "IPAddressType": "ipv4",
+    "EBSOptions": {
+      "EBSEnabled": true,
+      "VolumeType": "gp3",
+      "Throughput": 125,
+      "Iops": 3000,
+      "VolumeSize": 10
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "EngineVersion": "OpenSearch_3.5",
+    "SoftwareUpdateOptions": {
+      "AutoSoftwareUpdateEnabled": false
+    },
+    "DomainName": "huntosmultiaz-fr6can7z6wpw",
+    "LogPublishingOptions": {},
+    "AIMLOptions": {
+      "S3VectorsEngine": {
+        "Enabled": false
+      },
+      "ServerlessVectorAcceleration": {
+        "Enabled": false
+      }
+    },
+    "AutomatedSnapshotPauseOptions": {
+      "Enabled": false
+    },
+    "DeploymentStrategyOptions": {
+      "DeploymentStrategy": "CapacityOptimized"
+    },
+    "AdvancedSecurityOptions": {
+      "AnonymousAuthEnabled": false,
+      "InternalUserDatabaseEnabled": false,
+      "Enabled": false,
+      "AnonymousAuthDisableDate": "null"
+    },
+    "DomainEndpoint": "search-huntosmultiaz-fr6can7z6wpw-u2vslfntkyeke7txsy2rl4d33i.us-east-1.es.amazonaws.com",
+    "ServiceSoftwareOptions": {
+      "NewVersion": "",
+      "UpdateStatus": "COMPLETED",
+      "Description": "There is no software update available for this domain.",
+      "Cancellable": false,
+      "CurrentVersion": "OpenSearch_3_5_R20260428-P3",
+      "AutomatedUpdateDate": "1970-01-01T00:00:00Z",
+      "UpdateAvailable": false,
+      "OptionalDeployment": true
+    },
+    "IdentityCenterOptions": {},
+    "Id": "111111111111/huntosmultiaz-fr6can7z6wpw",
+    "Arn": "arn:aws:es:us-east-1:111111111111:domain/huntosmultiaz-fr6can7z6wpw",
+    "EncryptionAtRestOptions": {
+      "Enabled": false
+    },
+    "OffPeakWindowOptions": {
+      "OffPeakWindow": {
+        "WindowStartTime": {
+          "Hours": 2,
+          "Minutes": 0
+        }
+      },
+      "Enabled": true
+    },
+    "ClusterConfig": {
+      "InstanceCount": 2,
+      "MultiAZWithStandbyEnabled": false,
+      "WarmEnabled": false,
+      "DedicatedMasterEnabled": false,
+      "ZoneAwarenessConfig": {
+        "AvailabilityZoneCount": 2
+      },
+      "ColdStorageOptions": {
+        "Enabled": false
+      },
+      "InstanceType": "t3.small.search",
+      "ZoneAwarenessEnabled": true
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnly": [],
+    "createOnly": ["DomainName"],
+    "readOnlyPaths": [
+      "AdvancedSecurityOptions.AnonymousAuthDisableDate",
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "IdentityCenterOptions.IdentityCenterApplicationARN",
+      "IdentityCenterOptions.IdentityStoreId",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnlyPaths": [
+      "AdvancedSecurityOptions.JWTOptions.PublicKey",
+      "AdvancedSecurityOptions.MasterUserOptions",
+      "AdvancedSecurityOptions.SAMLOptions.MasterBackendRole",
+      "AdvancedSecurityOptions.SAMLOptions.MasterUserName"
+    ],
+    "createOnlyPaths": ["DomainName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["AdvancedOptions", "DomainEndpoints", "LogPublishingOptions"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "SnapshotOptions",
+      "actual": {
+        "AutomatedSnapshotStartHour": 0
+      },
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "DomainEndpointOptions",
+      "actual": {
+        "CustomEndpointEnabled": false,
+        "EnforceHTTPS": false,
+        "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+      },
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "AdvancedOptions",
+      "actual": {
+        "override_main_response_version": "false",
+        "rest.action.multi.allow_explicit_index": "true"
+      },
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "IPAddressType",
+      "actual": "ipv4",
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EngineVersion",
+      "actual": "OpenSearch_3.5",
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "DeploymentStrategyOptions",
+      "actual": {
+        "DeploymentStrategy": "CapacityOptimized"
+      },
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "OffPeakWindowOptions",
+      "actual": {
+        "OffPeakWindow": {
+          "WindowStartTime": {
+            "Hours": 2,
+            "Minutes": 0
+          }
+        },
+        "Enabled": true
+      },
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "ClusterConfig.ZoneAwarenessConfig",
+      "actual": {
+        "AvailabilityZoneCount": 2
+      },
+      "nested": true,
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.VolumeType",
+      "actual": "gp3",
+      "nested": true,
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Throughput",
+      "actual": 125,
+      "nested": true,
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsMultiAz",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Iops",
+      "actual": 3000,
+      "nested": true,
+      "physicalId": "huntosmultiaz-fr6can7z6wpw",
+      "constructPath": "CdkrdHunt0714OsMultiAz/HuntOsMultiAz"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBCluster.HuntAuroraPgSv2E3DC79F1.json
+++ b/tests/corpus/AWS__RDS__DBCluster.HuntAuroraPgSv2E3DC79F1.json
@@ -1,0 +1,307 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntAuroraPgSv2E3DC79F1",
+    "resourceType": "AWS::RDS::DBCluster",
+    "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+    "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2",
+    "declared": {
+      "CopyTagsToSnapshot": true,
+      "DBClusterParameterGroupName": "default.aurora-postgresql16",
+      "DBSubnetGroupName": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2subnetscf8b1bcb-zegmpfqfjd7r",
+      "Engine": "aurora-postgresql",
+      "EngineVersion": "16.4",
+      "MasterUserPassword": "CdkrdHuntPassw0rd1",
+      "MasterUsername": "huntadmin",
+      "Port": 5432,
+      "ServerlessV2ScalingConfiguration": {
+        "MaxCapacity": 1,
+        "MinCapacity": 0.5
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcSecurityGroupIds": ["sg-094b13a73404cd86d"]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "AssociatedRoles": [],
+    "EnableHttpEndpoint": false,
+    "EngineMode": "provisioned",
+    "Port": 5432,
+    "DBClusterIdentifier": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+    "PreferredBackupWindow": "08:37-09:07",
+    "Endpoint": {
+      "Address": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "5432"
+    },
+    "NetworkType": "IPV4",
+    "VpcSecurityGroupIds": ["sg-094b13a73404cd86d"],
+    "CopyTagsToSnapshot": true,
+    "Engine": "aurora-postgresql",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0714AuroraPgSv2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntAuroraPgSv2E3DC79F1",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714AuroraPgSv2/76fe67e0-7ee9-11f1-a272-0afff7023071",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "EngineVersion": "16.4",
+    "StorageType": "aurora",
+    "AvailabilityZones": ["us-east-1c", "us-east-1a", "us-east-1b"],
+    "ServerlessV2ScalingConfiguration": {
+      "MinCapacity": 0.5,
+      "MaxCapacity": 1
+    },
+    "StorageEncryptionType": "sse-rds",
+    "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+    "EnableLocalWriteForwarding": false,
+    "PreferredMaintenanceWindow": "sat:07:48-sat:08:18",
+    "DBClusterResourceId": "cluster-KTO22VDHRMCQ6HINY7PH5K22YQ",
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2subnetscf8b1bcb-zegmpfqfjd7r",
+    "DeletionProtection": false,
+    "AllocatedStorage": 1,
+    "ManageMasterUserPassword": false,
+    "MasterUserSecret": {},
+    "MasterUsername": "huntadmin",
+    "ReadEndpoint": {
+      "Address": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+    },
+    "EnableIAMDatabaseAuthentication": false,
+    "DBClusterParameterGroupName": "default.aurora-postgresql16",
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "DBClusterArn",
+      "DBClusterResourceId",
+      "Endpoint",
+      "ReadEndpoint",
+      "StorageEncryptionType",
+      "StorageThroughput"
+    ],
+    "writeOnly": [
+      "ClusterScalabilityType",
+      "DBInstanceParameterGroupName",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "AvailabilityZones",
+      "ClusterScalabilityType",
+      "DBClusterIdentifier",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "DatabaseName",
+      "EngineMode",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "StorageEncrypted",
+      "UseLatestRestorableTime"
+    ],
+    "readOnlyPaths": [
+      "DBClusterArn",
+      "DBClusterResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "ReadEndpoint",
+      "ReadEndpoint.Address",
+      "StorageEncryptionType",
+      "StorageThroughput"
+    ],
+    "writeOnlyPaths": [
+      "ClusterScalabilityType",
+      "DBInstanceParameterGroupName",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZones",
+      "ClusterScalabilityType",
+      "DBClusterIdentifier",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "DatabaseName",
+      "EngineMode",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "StorageEncrypted",
+      "UseLatestRestorableTime"
+    ],
+    "defaults": {
+      "BackupRetentionPeriod": 1
+    },
+    "defaultPaths": {
+      "BackupRetentionPeriod": 1
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "EngineMode",
+      "actual": "provisioned",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "PreferredBackupWindow",
+      "actual": "08:37-09:07",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "StorageType",
+      "actual": "aurora",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1b", "us-east-1c"],
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "sat:07:48-sat:08:18",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AllocatedStorage",
+      "actual": 1,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2E3DC79F1",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.HuntAuroraPgSv2writerCC5B6A4E.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntAuroraPgSv2writerCC5B6A4E.json
@@ -1,0 +1,410 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+    "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer",
+    "declared": {
+      "DBClusterIdentifier": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+      "DBInstanceClass": "db.serverless",
+      "Engine": "aurora-postgresql",
+      "PromotionTier": 0,
+      "PubliclyAccessible": false,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-07-13T18:39:53Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "5432",
+    "DBClusterIdentifier": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-HXGLCUDH7P7O5G2GWQTVHC3EBA",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.aurora-postgresql16",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+    "Endpoint": {
+      "Address": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "5432",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "MultiAZ": false,
+    "Engine": "aurora-postgresql",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714AuroraPgSv2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntAuroraPgSv2writerCC5B6A4E",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714AuroraPgSv2/76fe67e0-7ee9-11f1-a272-0afff7023071",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "EngineVersion": "16.4",
+    "StorageType": "aurora",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.serverless",
+    "AvailabilityZone": "us-east-1a",
+    "OptionGroupName": "default:aurora-postgresql-16",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2subnetscf8b1bcb-zegmpfqfjd7r",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+    "AllocatedStorage": "1",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "huntadmin",
+    "PromotionTier": 0,
+    "PubliclyAccessible": false,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-07-13T18:41:41.617Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "08:37-09:07",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "LicenseModel": "postgresql-license",
+    "PreferredMaintenanceWindow": "wed:05:40-wed:06:10",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-094b13a73404cd86d"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "clusterEchoModel": {
+      "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs": {
+        "DatabaseInsightsMode": "standard",
+        "StorageEncrypted": false,
+        "AssociatedRoles": [],
+        "EnableHttpEndpoint": false,
+        "EngineMode": "provisioned",
+        "Port": 5432,
+        "DBClusterIdentifier": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+        "PreferredBackupWindow": "08:37-09:07",
+        "Endpoint": {
+          "Address": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+          "Port": "5432"
+        },
+        "NetworkType": "IPV4",
+        "VpcSecurityGroupIds": ["sg-094b13a73404cd86d"],
+        "CopyTagsToSnapshot": true,
+        "Engine": "aurora-postgresql",
+        "Tags": [
+          {
+            "Value": "1",
+            "Key": "cdkrd:ephemeral"
+          },
+          {
+            "Value": "CdkrdHunt0714AuroraPgSv2",
+            "Key": "aws:cloudformation:stack-name"
+          },
+          {
+            "Value": "HuntAuroraPgSv2E3DC79F1",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714AuroraPgSv2/76fe67e0-7ee9-11f1-a272-0afff7023071",
+            "Key": "aws:cloudformation:stack-id"
+          }
+        ],
+        "EngineLifecycleSupport": "open-source-rds-extended-support",
+        "EngineVersion": "16.4",
+        "StorageType": "aurora",
+        "AvailabilityZones": ["us-east-1c", "us-east-1a", "us-east-1b"],
+        "ServerlessV2ScalingConfiguration": {
+          "MinCapacity": 0.5,
+          "MaxCapacity": 1
+        },
+        "StorageEncryptionType": "sse-rds",
+        "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs",
+        "EnableLocalWriteForwarding": false,
+        "PreferredMaintenanceWindow": "sat:07:48-sat:08:18",
+        "DBClusterResourceId": "cluster-KTO22VDHRMCQ6HINY7PH5K22YQ",
+        "AutoMinorVersionUpgrade": true,
+        "DBSubnetGroupName": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2subnetscf8b1bcb-zegmpfqfjd7r",
+        "DeletionProtection": false,
+        "AllocatedStorage": 1,
+        "ManageMasterUserPassword": false,
+        "MasterUserSecret": {},
+        "MasterUsername": "huntadmin",
+        "ReadEndpoint": {
+          "Address": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2e3dc79f1-pv7mq4jgtwzs.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+        },
+        "EnableIAMDatabaseAuthentication": false,
+        "DBClusterParameterGroupName": "default.aurora-postgresql16",
+        "BackupRetentionPeriod": 1,
+        "EnableCloudwatchLogsExports": []
+      }
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.aurora-postgresql16",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:aurora-postgresql-16",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "postgresql-license",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "wed:05:40-wed:06:10",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntAuroraPgSv2writerCC5B6A4E",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrdhunt0714aurorapgsv2-huntaurorapgsv2writercc5b-asemoz1dogbs",
+      "constructPath": "CdkrdHunt0714AuroraPgSv2/HuntAuroraPgSv2/writer"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.HuntOracle.json
+++ b/tests/corpus/AWS__RDS__DBInstance.HuntOracle.json
@@ -1,0 +1,502 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOracle",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+    "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle",
+    "declared": {
+      "AllocatedStorage": "20",
+      "DBInstanceClass": "db.t3.small",
+      "Engine": "oracle-se2",
+      "LicenseModel": "license-included",
+      "MasterUserPassword": "CdkrdHuntPassw0rd1",
+      "MasterUsername": "huntadmin",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2029-07-13T18:25:31Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "1521",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-C7QUZK2T5AI3SGHLHCHKWCOA3M",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.oracle-se2-19",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+    "Endpoint": {
+      "Address": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "1521",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "LatestRestorableTime": "2026-07-13T18:33:40Z",
+    "MultiAZ": false,
+    "Engine": "oracle-se2",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714RdsOracle",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntOracle",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714RdsOracle/e15e8810-7ee7-11f1-b098-0e2903357f0d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "IsStorageConfigUpgradeAvailable": false,
+    "EngineVersion": "19.0.0.0.ru-2026-04.rur-2026-04.r1",
+    "StorageType": "gp2",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.t3.small",
+    "AvailabilityZone": "us-east-1f",
+    "OptionGroupName": "default:oracle-se2-19",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "default",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+    "AllocatedStorage": "20",
+    "MasterUserSecret": {},
+    "NcharCharacterSetName": "AL16UTF16",
+    "DBSecurityGroups": [],
+    "MasterUsername": "huntadmin",
+    "PubliclyAccessible": true,
+    "CharacterSetName": "AL32UTF8",
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-07-13T18:33:34.439Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "09:19-09:49",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "LicenseModel": "license-included",
+    "PreferredMaintenanceWindow": "tue:04:26-tue:04:56",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-0a26e23e2310ee0c9"],
+    "DBName": "ORCL",
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "1521",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.oracle-se2-19",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineVersion",
+      "actual": "19.0.0.0.ru-2026-04.rur-2026-04.r1",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageType",
+      "actual": "gp2",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1f",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:oracle-se2-19",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBSubnetGroupName",
+      "actual": "default",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NcharCharacterSetName",
+      "actual": "AL16UTF16",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PubliclyAccessible",
+      "actual": true,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CharacterSetName",
+      "actual": "AL32UTF8",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "09:19-09:49",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "tue:04:26-tue:04:56",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "VPCSecurityGroups",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBName",
+      "actual": "ORCL",
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOracle",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrdhunt0714rdsoracle-huntoracle-gjuzhvg0yfrc",
+      "constructPath": "CdkrdHunt0714RdsOracle/HuntOracle"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Redshift__Cluster.HuntRsCluster.json
+++ b/tests/corpus/AWS__Redshift__Cluster.HuntRsCluster.json
@@ -1,0 +1,281 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRsCluster",
+    "resourceType": "AWS::Redshift::Cluster",
+    "physicalId": "cdkrdhunt-mixed-rscluster",
+    "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster",
+    "declared": {
+      "ClusterIdentifier": "CdkrdHunt-Mixed-RsCluster",
+      "ClusterType": "single-node",
+      "DBName": "huntdb",
+      "MasterUserPassword": "CdkrdHuntPassw0rd1",
+      "MasterUsername": "huntadmin",
+      "NodeType": "ra3.large",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AutomatedSnapshotRetentionPeriod": 1,
+    "AvailabilityZoneRelocationStatus": "enabled",
+    "AquaConfigurationStatus": "auto",
+    "Encrypted": true,
+    "Port": 5439,
+    "NumberOfNodes": 1,
+    "EnhancedVpcRouting": false,
+    "ClusterParameterGroupName": "default.redshift-2.0",
+    "AllowVersionUpgrade": true,
+    "Endpoint": {
+      "Address": "cdkrdhunt-mixed-rscluster.c5qzh3zoxdm2.us-east-1.redshift.amazonaws.com",
+      "Port": "5439"
+    },
+    "VpcSecurityGroupIds": ["sg-0a26e23e2310ee0c9"],
+    "MaintenanceTrackName": "current",
+    "ClusterNamespaceArn": "arn:aws:redshift:us-east-1:111111111111:namespace:2f212b0e-506f-4270-879b-fbaf1c05302c",
+    "MultiAZ": false,
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "IamRoles": [],
+    "ClusterVersion": "1.0",
+    "KmsKeyId": "AWS_OWNED_KMS_KEY",
+    "AvailabilityZone": "us-east-1d",
+    "PreferredMaintenanceWindow": "wed:04:00-wed:04:30",
+    "ClusterType": "single-node",
+    "ClusterSecurityGroups": [],
+    "ClusterIdentifier": "cdkrdhunt-mixed-rscluster",
+    "ClusterSubnetGroupName": "default",
+    "LoggingProperties": {
+      "LogExports": []
+    },
+    "NodeType": "ra3.large",
+    "MasterUsername": "huntadmin",
+    "DBName": "huntdb",
+    "PubliclyAccessible": false,
+    "ManualSnapshotRetentionPeriod": -1
+  },
+  "schema": {
+    "readOnly": ["ClusterNamespaceArn", "DeferMaintenanceIdentifier", "MasterPasswordSecretArn"],
+    "writeOnly": [
+      "Classic",
+      "DeferMaintenance",
+      "DeferMaintenanceDuration",
+      "ManageMasterPassword",
+      "MasterUserPassword",
+      "SnapshotIdentifier"
+    ],
+    "createOnly": [
+      "ClusterIdentifier",
+      "ClusterSubnetGroupName",
+      "DBName",
+      "MasterUsername",
+      "OwnerAccount",
+      "SnapshotClusterIdentifier",
+      "SnapshotIdentifier"
+    ],
+    "readOnlyPaths": [
+      "ClusterNamespaceArn",
+      "DeferMaintenanceIdentifier",
+      "Endpoint.Address",
+      "Endpoint.Port",
+      "MasterPasswordSecretArn"
+    ],
+    "writeOnlyPaths": [
+      "Classic",
+      "DeferMaintenance",
+      "DeferMaintenanceDuration",
+      "ManageMasterPassword",
+      "MasterUserPassword",
+      "SnapshotIdentifier"
+    ],
+    "createOnlyPaths": [
+      "ClusterIdentifier",
+      "ClusterSubnetGroupName",
+      "DBName",
+      "MasterUsername",
+      "OwnerAccount",
+      "SnapshotClusterIdentifier",
+      "SnapshotIdentifier"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "ClusterSecurityGroups",
+      "IamRoles",
+      "LoggingProperties.LogExports",
+      "VpcSecurityGroupIds"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AutomatedSnapshotRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AvailabilityZoneRelocationStatus",
+      "actual": "enabled",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AquaConfigurationStatus",
+      "actual": "auto",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "Encrypted",
+      "actual": true,
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "Port",
+      "actual": 5439,
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "NumberOfNodes",
+      "actual": 1,
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "ClusterParameterGroupName",
+      "actual": "default.redshift-2.0",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AllowVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "VpcSecurityGroupIds",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "MaintenanceTrackName",
+      "actual": "current",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "ClusterVersion",
+      "actual": "1.0",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "KmsKeyId",
+      "actual": "AWS_OWNED_KMS_KEY",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1d",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "wed:04:00-wed:04:30",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "ClusterSubnetGroupName",
+      "actual": "default",
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRsCluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "ManualSnapshotRetentionPeriod",
+      "actual": -1,
+      "physicalId": "cdkrdhunt-mixed-rscluster",
+      "constructPath": "CdkrdHunt0714CaseIdents3/HuntRsCluster"
+    }
+  ]
+}

--- a/tests/integration/aurora-pg-sv2-min/app.ts
+++ b/tests/integration/aurora-pg-sv2-min/app.ts
@@ -1,0 +1,37 @@
+// CDK app for the cdk-real-drift aurora-pg-sv2-min false-positive integration
+// test. Aurora POSTGRESQL + ServerlessV2 — the corpus covers Sv2 scaling only on
+// aurora-mysql and aurora-postgresql only as provisioned, so the combination
+// (pg-specific default parameter/option groups + Sv2 capacity echoes on the
+// cluster, plus a db.serverless instance) is unexercised. Minimal: engine +
+// Sv2 scaling + one serverless instance; version / groups / storage stay
+// undeclared to probe the folds.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, SecretValue, Stack, Tags } from "aws-cdk-lib";
+import { InstanceType, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  AuroraPostgresEngineVersion,
+  ClusterInstance,
+  Credentials,
+  DatabaseCluster,
+  DatabaseClusterEngine,
+} from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714AuroraPgSv2");
+
+const vpc = new Vpc(stack, "HuntVpc", {
+  maxAzs: 2,
+  natGateways: 0,
+});
+
+new DatabaseCluster(stack, "HuntAuroraPgSv2", {
+  engine: DatabaseClusterEngine.auroraPostgres({ version: AuroraPostgresEngineVersion.VER_16_4 }),
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  credentials: Credentials.fromPassword("huntadmin", SecretValue.unsafePlainText("CdkrdHuntPassw0rd1")),
+  serverlessV2MinCapacity: 0.5,
+  serverlessV2MaxCapacity: 1,
+  writer: ClusterInstance.serverlessV2("writer"),
+  removalPolicy: RemovalPolicy.DESTROY,
+});

--- a/tests/integration/aurora-pg-sv2-min/cdk.json
+++ b/tests/integration/aurora-pg-sv2-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/aurora-pg-sv2-min/package.json
+++ b/tests/integration/aurora-pg-sv2-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-aurora-pg-sv2-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift aurora-pg-sv2-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/aurora-pg-sv2-min/verify.sh
+++ b/tests/integration/aurora-pg-sv2-min/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): Aurora POSTGRESQL + ServerlessV2
+# (corpus covers Sv2 only on aurora-mysql, and aurora-postgresql only
+# provisioned) -> FIRST check (pre-record) must show ZERO drift -> record ->
+# check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714AuroraPgSv2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~15 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (aurora-pg Sv2 fold gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/case-idents3-min/app.ts
+++ b/tests/integration/case-idents3-min/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift case-idents3-min false-positive integration test.
+// Mixed-case identifier echo probe #3 — AWS::Redshift::Cluster ClusterIdentifier,
+// the sibling CASE_INSENSITIVE_PATHS explicitly defers in noise.ts ("CDK-lowered
+// already and unprobed — add it here only with live proof"). Redshift stores
+// cluster identifiers lowercase; its ClusterParameterGroup handler passed mixed
+// case through and FP'd (#1531). If the Cluster handler also passes it through,
+// the declared value echoes back lowercased -> declared-tier FP. A handler-side
+// rejection is itself the determination (no allowlist entry needed).
+// Live determinations (2026-07-14, Cloud Control create-resource probes — the
+// CC handler IS the CFn handler): AWS::MemoryDB::SubnetGroup / User / ACL all
+// REJECT a mixed-case name server-side ("must contain only lowercase ASCII
+// letters...") — unreachable via CloudFormation, so no FP risk and no
+// CASE_INSENSITIVE_PATHS entries needed (completes the MemoryDB family begun
+// by the ParameterGroup determination in case-idents2-min).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnCluster } from "aws-cdk-lib/aws-redshift";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714CaseIdents3");
+
+new CfnCluster(stack, "HuntRsCluster", {
+  clusterIdentifier: "CdkrdHunt-Mixed-RsCluster",
+  clusterType: "single-node",
+  nodeType: "ra3.large",
+  dbName: "huntdb",
+  masterUsername: "huntadmin",
+  masterUserPassword: "CdkrdHuntPassw0rd1",
+});

--- a/tests/integration/case-idents3-min/cdk.json
+++ b/tests/integration/case-idents3-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/case-idents3-min/package.json
+++ b/tests/integration/case-idents3-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-case-idents3-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift case-idents3-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/case-idents3-min/verify.sh
+++ b/tests/integration/case-idents3-min/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): Redshift Cluster with a
+# MIXED-CASE ClusterIdentifier (the deferred CASE_INSENSITIVE_PATHS sibling of
+# the #1531 ClusterParameterGroup lowercase-echo FP) -> FIRST check (pre-record)
+# must show ZERO drift -> record -> check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714CaseIdents3
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~5 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (mixed-case ClusterIdentifier echo)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/opensearch-multiaz-min/app.ts
+++ b/tests/integration/opensearch-multiaz-min/app.ts
@@ -1,0 +1,28 @@
+// CDK app for the cdk-real-drift opensearch-multiaz-min false-positive
+// integration test. A MINIMAL zone-aware (Multi-AZ) OpenSearch domain — both
+// existing corpus domains are single-AZ (ZoneAwareness=false, no dedicated
+// master), so the ClusterConfig default cascade that Multi-AZ materializes
+// (ZoneAwarenessConfig.AvailabilityZoneCount, per-AZ distribution echoes) is
+// unexercised. Declares only the zone-awareness axis + the minimal capacity it
+// requires (2 data nodes); everything else (EngineVersion, EBS defaults,
+// software update options, ...) stays undeclared to probe the folds.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnDomain } from "aws-cdk-lib/aws-opensearchservice";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714OsMultiAz");
+
+const domain = new CfnDomain(stack, "HuntOsMultiAz", {
+  clusterConfig: {
+    instanceType: "t3.small.search",
+    instanceCount: 2,
+    zoneAwarenessEnabled: true,
+  },
+  ebsOptions: {
+    ebsEnabled: true,
+    volumeSize: 10,
+  },
+});
+domain.applyRemovalPolicy(RemovalPolicy.DESTROY);

--- a/tests/integration/opensearch-multiaz-min/cdk.json
+++ b/tests/integration/opensearch-multiaz-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/opensearch-multiaz-min/package.json
+++ b/tests/integration/opensearch-multiaz-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-opensearch-multiaz-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift opensearch-multiaz-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/opensearch-multiaz-min/verify.sh
+++ b/tests/integration/opensearch-multiaz-min/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): minimal ZONE-AWARE (Multi-AZ)
+# OpenSearch domain (single-AZ is corpus-covered; the Multi-AZ ClusterConfig
+# default cascade is not) -> FIRST check (pre-record) must show ZERO drift ->
+# record -> check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714OsMultiAz
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~25 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (Multi-AZ ClusterConfig fold gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/rds-oracle-min/app.ts
+++ b/tests/integration/rds-oracle-min/app.ts
@@ -1,0 +1,28 @@
+// CDK app for the cdk-real-drift rds-oracle-min false-positive integration test.
+// BAREST-possible provisioned DBInstance on the ONE engine family with zero
+// corpus/fixture coverage: oracle (oracle-se2). The ENGINE_DEFAULTS folds in
+// noise.ts were live-confirmed on mysql/mariadb/postgres/sqlserver only —
+// oracle-specific defaults (CharacterSetName AL32UTF8 + NcharCharacterSetName,
+// Port 1521, StorageType, default:oracle-se2-19 option/parameter groups,
+// undeclared EngineVersion) ride unverified branches (#1477 proved a variant
+// you did not deploy is an unguarded gap). L1 CfnDBInstance so EngineVersion /
+// StorageType / CharacterSetName / group names all stay UNDECLARED (the L2
+// forces a version). LicenseModel IS declared: the Oracle API default is
+// bring-your-own-license, which this account neither holds nor wants to probe.
+// Uses the default VPC (no DBSubnetGroup) — the barest possible shape.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDBInstance } from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714RdsOracle");
+
+new CfnDBInstance(stack, "HuntOracle", {
+  engine: "oracle-se2",
+  dbInstanceClass: "db.t3.small",
+  allocatedStorage: "20",
+  licenseModel: "license-included",
+  masterUsername: "huntadmin",
+  masterUserPassword: "CdkrdHuntPassw0rd1",
+});

--- a/tests/integration/rds-oracle-min/cdk.json
+++ b/tests/integration/rds-oracle-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rds-oracle-min/package.json
+++ b/tests/integration/rds-oracle-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-rds-oracle-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift rds-oracle-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/rds-oracle-min/verify.sh
+++ b/tests/integration/rds-oracle-min/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest oracle-se2 DBInstance (the
+# one engine family with zero prior corpus/fixture coverage) -> FIRST check
+# (pre-record) must show ZERO drift (every line is an oracle engine-default
+# fold gap) -> record -> check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714RdsOracle
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~15 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (oracle engine-default fold gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/variantpack-min/app.ts
+++ b/tests/integration/variantpack-min/app.ts
@@ -1,0 +1,32 @@
+// CDK app for the cdk-real-drift variantpack-min false-positive integration test.
+// Two cheap un-exercised variants in one stack:
+//   - AWS::EFS::FileSystem ThroughputMode=provisioned (+ the required
+//     ProvisionedThroughputInMibps) — corpus covers bursting (undeclared) and
+//     elastic only; provisioned may materialize different throughput defaults.
+//     L1 CfnFileSystem so no VPC / mount targets / SG are dragged along.
+//   - AWS::Lambda::Function java21 + SnapStart DECLARED (PublishedVersions) —
+//     lambda-java-min covers java-undeclared-SnapStart ({ApplyOn:"None"}) and
+//     lambda-config-rich covers SnapStart-on-python; the declared-on-java echo
+//     (SnapStartResponse / RuntimeVersionConfig) is unexercised. The handler
+//     asset is a placeholder (never invoked; no version is ever published).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnFileSystem } from "aws-cdk-lib/aws-efs";
+import { Code, Function as LambdaFunction, Runtime, SnapStartConf } from "aws-cdk-lib/aws-lambda";
+import * as path from "node:path";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714VariantPack");
+
+new CfnFileSystem(stack, "HuntEfsProvisioned", {
+  throughputMode: "provisioned",
+  provisionedThroughputInMibps: 1,
+});
+
+new LambdaFunction(stack, "HuntJavaSnapStartFn", {
+  runtime: Runtime.JAVA_21,
+  handler: "example.Handler::handleRequest",
+  code: Code.fromAsset(path.join(import.meta.dirname, "handler")),
+  snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
+});

--- a/tests/integration/variantpack-min/cdk.json
+++ b/tests/integration/variantpack-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/variantpack-min/handler/placeholder.txt
+++ b/tests/integration/variantpack-min/handler/placeholder.txt
@@ -1,0 +1,1 @@
+cdkrd hunt placeholder (never invoked)

--- a/tests/integration/variantpack-min/package.json
+++ b/tests/integration/variantpack-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-variantpack-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift variantpack-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/variantpack-min/verify.sh
+++ b/tests/integration/variantpack-min/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): EFS provisioned-throughput +
+# Lambda java21 SnapStart-declared (two un-exercised variants) -> FIRST check
+# (pre-record) must show ZERO drift -> record -> check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714VariantPack
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~3 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (variant fold gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -589,6 +589,8 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULT_PATHS['AWS::OpenSearchService::Domain']).toEqual({
       'EBSOptions.Iops': 3000,
       'EBSOptions.Throughput': 125,
+      // #1593: the 2-AZ config a zone-aware domain materializes when undeclared
+      'ClusterConfig.ZoneAwarenessConfig': { AvailabilityZoneCount: 2 },
     });
     expect(KNOWN_DEFAULT_PATHS['AWS::KinesisFirehose::DeliveryStream']).toEqual({
       'ExtendedS3DestinationConfiguration.S3BackupMode': 'Disabled',

--- a/tests/noise-opensearch-multiaz-1593.test.ts
+++ b/tests/noise-opensearch-multiaz-1593.test.ts
@@ -1,0 +1,118 @@
+// #1593 — minimal Multi-AZ OpenSearch domain first-run FPs, live-proven on
+// opensearch-multiaz-min (us-east-1, 2026-07-14). Four creation defaults fold:
+//   * DomainEndpointOptions — whole-object era ONE_OF (TLS policy default moved
+//     from Policy-Min-TLS-1-0-2019-07 to -1-2-; both trios fold, any leaf flip
+//     — an EnforceHTTPS enable, a custom endpoint — surfaces).
+//   * ClusterConfig.ZoneAwarenessConfig {AvailabilityZoneCount:2} — the value a
+//     zone-aware domain materializes when no explicit config is declared.
+//   * EBSOptions.VolumeType — era ONE_OF gp3 (current) / gp2 (legacy).
+//   * EngineVersion — value-independent (AWS assigns the moving GA version).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tier = (findings: Finding[], t: string) =>
+  findings
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const declared = {
+  ClusterConfig: {
+    InstanceType: 't3.small.search',
+    InstanceCount: 2,
+    ZoneAwarenessEnabled: true,
+  },
+  EBSOptions: { EBSEnabled: true, VolumeSize: 10 },
+};
+
+const mk = (live: Record<string, unknown>) =>
+  classifyResource(
+    {
+      logicalId: 'HuntOsMultiAz',
+      resourceType: 'AWS::OpenSearchService::Domain',
+      physicalId: 'huntos',
+      declared,
+    },
+    {
+      ClusterConfig: {
+        InstanceType: 't3.small.search',
+        InstanceCount: 2,
+        ZoneAwarenessEnabled: true,
+        ...(live.ZoneAwarenessConfig ? { ZoneAwarenessConfig: live.ZoneAwarenessConfig } : {}),
+      },
+      EBSOptions: {
+        EBSEnabled: true,
+        VolumeSize: 10,
+        ...(live.VolumeType ? { VolumeType: live.VolumeType } : {}),
+      },
+      ...(live.DomainEndpointOptions !== undefined
+        ? { DomainEndpointOptions: live.DomainEndpointOptions }
+        : {}),
+      ...(live.EngineVersion !== undefined ? { EngineVersion: live.EngineVersion } : {}),
+    },
+    emptySchema
+  );
+
+describe('#1593 Multi-AZ OpenSearch first-run folds', () => {
+  it('the live-proven creation-default quartet folds with zero potential drift', () => {
+    const f = mk({
+      DomainEndpointOptions: {
+        CustomEndpointEnabled: false,
+        EnforceHTTPS: false,
+        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
+      },
+      EngineVersion: 'OpenSearch_3.5',
+      ZoneAwarenessConfig: { AvailabilityZoneCount: 2 },
+      VolumeType: 'gp3',
+    });
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'declared')).toEqual([]);
+  });
+
+  it('the legacy-era variants (TLS-1-0 policy, gp2 volume) also fold', () => {
+    const f = mk({
+      DomainEndpointOptions: {
+        CustomEndpointEnabled: false,
+        EnforceHTTPS: false,
+        TLSSecurityPolicy: 'Policy-Min-TLS-1-0-2019-07',
+      },
+      VolumeType: 'gp2',
+    });
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('detection kept: an endpoint-options leaf flip / 3-AZ move / third volume type surface', () => {
+    expect(
+      tier(
+        mk({
+          DomainEndpointOptions: {
+            CustomEndpointEnabled: false,
+            EnforceHTTPS: true,
+            TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07',
+          },
+        }),
+        'undeclared'
+      )
+    ).toEqual(['DomainEndpointOptions']);
+    expect(tier(mk({ ZoneAwarenessConfig: { AvailabilityZoneCount: 3 } }), 'undeclared')).toEqual([
+      'ClusterConfig.ZoneAwarenessConfig',
+    ]);
+    expect(tier(mk({ VolumeType: 'io1' }), 'undeclared')).toEqual(['EBSOptions.VolumeType']);
+  });
+
+  it('EngineVersion folds value-independent whatever GA version AWS assigns', () => {
+    expect(tier(mk({ EngineVersion: 'OpenSearch_9.9' }), 'undeclared')).toEqual([]);
+  });
+});

--- a/tests/noise-rds-oracle-1591.test.ts
+++ b/tests/noise-rds-oracle-1591.test.ts
@@ -1,0 +1,65 @@
+// #1591 — barest oracle-se2 DBInstance first-run FPs, live-proven on rds-oracle-min
+// (us-east-1, 2026-07-14): Oracle materializes CharacterSetName "AL32UTF8",
+// NcharCharacterSetName "AL16UTF16", and the default SID DBName "ORCL" when
+// undeclared. All three fold via ENGINE_DEFAULTS oracle arms (engine-derived,
+// equality-gated) — a non-default charset / SID still surfaces, and the
+// non-oracle engines are unaffected (they create no default database).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+const rdsSchema: SchemaInfo = {
+  readOnly: new Set(['Endpoint']),
+  writeOnly: new Set(['MasterUserPassword']),
+  createOnly: new Set(['Engine']),
+  readOnlyPaths: ['Endpoint'],
+  writeOnlyPaths: ['MasterUserPassword'],
+  createOnlyPaths: ['Engine'],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tier = (findings: Finding[], t: string) =>
+  findings
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (engine: string, live: Record<string, unknown>) =>
+  classifyResource(
+    {
+      logicalId: 'HuntOracle',
+      resourceType: 'AWS::RDS::DBInstance',
+      physicalId: 'huntoracle',
+      declared: { Engine: engine, DBInstanceClass: 'db.t3.small' },
+    },
+    { Engine: engine, DBInstanceClass: 'db.t3.small', ...live },
+    rdsSchema
+  );
+
+describe('#1591 DBInstance oracle arms: CharacterSetName + NcharCharacterSetName + DBName fold', () => {
+  it('the three oracle creation defaults fold atDefault', () => {
+    const f = mk('oracle-se2', {
+      CharacterSetName: 'AL32UTF8',
+      NcharCharacterSetName: 'AL16UTF16',
+      DBName: 'ORCL',
+    });
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toEqual(['CharacterSetName', 'DBName', 'NcharCharacterSetName']);
+  });
+
+  it('a non-default charset / SID still surfaces (equality gate kept)', () => {
+    expect(tier(mk('oracle-se2', { CharacterSetName: 'WE8ISO8859P1' }), 'undeclared')).toEqual([
+      'CharacterSetName',
+    ]);
+    expect(tier(mk('oracle-ee', { DBName: 'PRODDB' }), 'undeclared')).toEqual(['DBName']);
+  });
+
+  it('the sqlserver collation arm is unchanged and non-oracle engines do not fold ORCL', () => {
+    expect(
+      tier(mk('sqlserver-ex', { CharacterSetName: 'SQL_Latin1_General_CP1_CI_AS' }), 'atDefault')
+    ).toEqual(['CharacterSetName']);
+    // a hypothetical DBName echo on mysql is NOT folded by the oracle arm
+    expect(tier(mk('mysql', { DBName: 'ORCL' }), 'undeclared')).toEqual(['DBName']);
+  });
+});

--- a/tests/noise-redshift-cluster-1589.test.ts
+++ b/tests/noise-redshift-cluster-1589.test.ts
@@ -1,0 +1,93 @@
+// #1589 / #1590 — two first-run FPs on a barest Redshift Cluster, live-proven on
+// case-idents3-min (us-east-1, 2026-07-14):
+//   * ClusterIdentifier: the CFn handler accepts a mixed-case identifier and the
+//     service stores/echoes it lowercased ("CdkrdHunt-Mixed-RsCluster" ->
+//     "cdkrdhunt-mixed-rscluster") — the #1531 lowercase-echo family, on the
+//     cluster itself (CASE_INSENSITIVE_PATHS).
+//   * ClusterSubnetGroupName: a cluster declaring no subnet group (default-VPC
+//     placement) reads back the literal "default" — an AWS creation-time constant
+//     (KNOWN_DEFAULTS, equality-gated so an out-of-band move still surfaces).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'HuntRsCluster',
+  resourceType: 'AWS::Redshift::Cluster',
+  physicalId: 'cdkrdhunt-mixed-rscluster',
+  declared,
+});
+
+const declared = {
+  ClusterIdentifier: 'CdkrdHunt-Mixed-RsCluster',
+  ClusterType: 'single-node',
+  NodeType: 'ra3.large',
+  DBName: 'huntdb',
+  MasterUsername: 'huntadmin',
+};
+
+describe('#1589 Redshift Cluster lowercase-stored ClusterIdentifier', () => {
+  it('a pure case-fold echo is not declared drift', () => {
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, ClusterIdentifier: 'cdkrdhunt-mixed-rscluster' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toEqual([]);
+  });
+
+  it('an identifier differing beyond case still surfaces as declared drift', () => {
+    const f = classifyResource(
+      mk(declared),
+      { ...declared, ClusterIdentifier: 'cdkrdhunt-other' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toEqual(['ClusterIdentifier']);
+  });
+});
+
+describe('#1590 Redshift Cluster default-VPC ClusterSubnetGroupName="default"', () => {
+  it('the undeclared "default" subnet group folds to atDefault', () => {
+    const f = classifyResource(
+      mk(declared),
+      {
+        ...declared,
+        ClusterIdentifier: 'cdkrdhunt-mixed-rscluster',
+        ClusterSubnetGroupName: 'default',
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'atDefault')).toContain('ClusterSubnetGroupName');
+  });
+
+  it('an out-of-band move to a real subnet group still surfaces', () => {
+    const f = classifyResource(
+      mk(declared),
+      {
+        ...declared,
+        ClusterIdentifier: 'cdkrdhunt-mixed-rscluster',
+        ClusterSubnetGroupName: 'my-own-sng',
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ClusterSubnetGroupName']);
+  });
+});

--- a/tests/revert-writeonly-reinclude-1594.test.ts
+++ b/tests/revert-writeonly-reinclude-1594.test.ts
@@ -1,0 +1,140 @@
+import {
+  CloudControlClient,
+  GetResourceCommand,
+  UpdateResourceCommand,
+} from '@aws-sdk/client-cloudcontrol';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { GatherResult } from '../src/commands/gather.js';
+import { revertStack } from '../src/commands/stack-actions.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+// #1594: the #763 silent-no-op-`add` detector flagged the WRITE-ONLY RE-INCLUDE op
+// (the `add /MasterUserPassword` every revert of a password-declaring resource carries
+// for the Cloud Control read-modify-write contract) as a false "NOT reverted ... no-op":
+// a write-only path re-reads as a readGap finding whose `actual` is undefined on BOTH
+// sides, so deepEqual(pre, post) was vacuously true and `post.actual !== op.value`
+// trivially held. A readGap re-read carries no live value and must never drive a
+// "the value persists" verdict — live-hit on every RDS revert (aurora-pg-sv2-min,
+// 2026-07-14).
+
+const schema: SchemaInfo = {
+  readOnly: new Set<string>(),
+  writeOnly: new Set<string>(['MasterUserPassword']),
+  createOnly: new Set<string>(),
+  readOnlyPaths: [],
+  writeOnlyPaths: ['MasterUserPassword'],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const declared = { Description: 'intended', MasterUserPassword: 'pw' };
+
+// A REAL declared drift (Description changed out of band) + the readGap finding the
+// declared write-only password always produces.
+const findings = (): Finding[] => [
+  {
+    tier: 'declared',
+    logicalId: 'R',
+    resourceType: 'AWS::IAM::Role',
+    path: 'Description',
+    physicalId: 'r-phys',
+    desired: 'intended',
+    actual: 'oob-changed',
+  },
+  {
+    tier: 'readGap',
+    logicalId: 'R',
+    resourceType: 'AWS::IAM::Role',
+    path: 'MasterUserPassword',
+    physicalId: 'r-phys',
+    actual: undefined,
+  },
+];
+
+const gathered = (): GatherResult =>
+  ({
+    desired: {
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources: [
+        { logicalId: 'R', resourceType: 'AWS::IAM::Role', physicalId: 'r-phys', declared },
+      ],
+      rawTemplate: '{}',
+      ctx: {
+        params: {},
+        pseudo: {},
+        conditions: {},
+        physIds: {},
+        liveAttrs: {},
+        mappings: {},
+        exports: {},
+        condCache: new Map(),
+      },
+    },
+    findings: findings(),
+    schemas: new Map([['AWS::IAM::Role', schema]]),
+    liveByLogical: new Map(),
+  }) as GatherResult;
+
+const params = () => ({
+  stackName: 's',
+  region: 'r',
+  gathered: gathered(),
+  baseline: undefined,
+  config: { ignore: [] },
+  dryRun: false,
+  yes: true,
+  removeUnrecorded: false,
+  verbose: false,
+  interactive: false,
+  convergeRetryDelayMs: 0,
+});
+
+const run = async () => {
+  const logs: string[] = [];
+  const orig = console.log;
+  console.log = (s: unknown) => logs.push(String(s));
+  try {
+    const outcome = await revertStack(params());
+    return { outcome, logs: logs.join('\n') };
+  } finally {
+    console.log = orig;
+  }
+};
+
+describe('revertStack #1594 — a write-only re-include op is not a false no-op', () => {
+  let cfnMock: ReturnType<typeof mockClient>;
+  beforeEach(() => {
+    cfnMock = mockClient(CloudFormationClient);
+    cfnMock
+      .on(DescribeStacksCommand)
+      .resolves({ Stacks: [{ StackStatus: 'CREATE_COMPLETE' } as never] });
+  });
+  afterEach(() => cfnMock.restore());
+
+  it('a converged revert carrying the password re-include is CLEAN, exit 0', async () => {
+    const cc = mockClient(CloudControlClient);
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' },
+    });
+    // The re-read never returns the write-only password (readGap on both sides); the
+    // real drift (Description) converged to the declared value.
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Identifier: 'r-phys',
+        Properties: JSON.stringify({ Description: 'intended' }),
+      },
+    });
+
+    const { outcome, logs } = await run();
+    expect(logs).toContain('re-include write-only');
+    expect(logs).not.toContain('NOT reverted:');
+    expect(logs).not.toContain('could not be confirmed converged');
+    expect(logs).toContain('s: CLEAN after revert.');
+    expect(outcome.exit).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

2026-07-14 bug hunt (5 rounds, multi-angle). Five confirmed bugs, all live-verified on fresh minimal deploys with an A/B (old binary surfaces / new binary folds), plus the assets a hunt leaves behind.

Closes #1589, closes #1590, closes #1591, closes #1593, closes #1594.

### Fixes

| Issue | Bug | Fix |
|---|---|---|
| #1589 | Mixed-case Redshift Cluster `ClusterIdentifier` lowercase echo → declared-tier FP on every check (the deferred `CASE_INSENSITIVE_PATHS` sibling of #1531) | `CASE_INSENSITIVE_PATHS['AWS::Redshift::Cluster']` |
| #1590 | Barest Redshift Cluster in the default VPC first-run FPs on `ClusterSubnetGroupName="default"` | `KNOWN_DEFAULTS` equality-gated constant |
| #1591 | Barest oracle-se2 DBInstance first-run FPs: `CharacterSetName=AL32UTF8`, `NcharCharacterSetName=AL16UTF16`, `DBName=ORCL` (folds were built from mysql/mariadb/postgres/sqlserver only) | `ENGINE_DEFAULTS` oracle arms (tier-2 derived, equality-gated) |
| #1593 | Minimal Multi-AZ OpenSearch domain first-run FPs ×4: `DomainEndpointOptions`, `EngineVersion`, `ClusterConfig.ZoneAwarenessConfig`, `EBSOptions.VolumeType` | era `ONE_OF` (endpoint options trio, gp3/gp2), nested `KNOWN_DEFAULT_PATHS` pin (2-AZ config), value-independent (GA `EngineVersion`) |
| #1594 | Every revert of a resource declaring a write-only prop (any RDS `MasterUserPassword`) falsely printed `NOT reverted … no-op` for the re-include op — a `readGap` re-read (no live value on either side) was used as persistence proof | no-op detector excludes `readGap`-tier re-reads (`src/commands/stack-actions.ts`) |

### Live verification

- Every FP fix: fresh deploy → first `check` surfaces the FP → fix → re-`check` CLEAN → `record` → `check --fail` CLEAN → teardown.
- #1594: OOB `ServerlessV2ScalingConfiguration.MaxCapacity` 1→2 on a live aurora-postgresql Sv2 cluster → detected (exit 1) → revert → live value converged 2.0→1.0 → post-fix output `CLEAN after revert.` with no false `NOT reverted` (pre-fix output attached in the issue).

### Assets

- **5 regression fixtures**: `rds-oracle-min`, `case-idents3-min`, `variantpack-min` (EFS provisioned + java21 SnapStart — clean first run, FN detect proven), `opensearch-multiaz-min`, `aurora-pg-sv2-min` (clean first run, Sv2 detect+revert proven).
- **7 corpus cases** promoted (Redshift mixed-case cluster, oracle DBInstance, Multi-AZ OpenSearch, aurora-pg Sv2 cluster + db.serverless writer, EFS provisioned, java21+SnapStart Lambda) — replay green (820 cases).
- **Zero-cost determinations** recorded in fixture comments: MemoryDB SubnetGroup/User/ACL reject mixed case server-side (unreachable via CFn — completes the family after #1539's ParameterGroup); Cassandra Keyspace preserves case; Lambda neutral update materializes no echo.
- **Hunt-skill gotchas**: `cloudcontrol create-resource` as the no-stack handler-reachability probe; read the revert convergence REPORT text, not just the live value.

### Verification

- `/check`: typecheck / lint+format / `vp pack` / 5703 unit tests across 290 files — all green (re-run after rebasing onto `origin/main` @ 0.18.7).
- `/check-docs`: no docs-visible surface touched (fold tables + an internal report guard).
- `/verify-pr`: live-test evidence per issue above; **core shared suite deferred — offline+corpus+hunt-verified** (diff is fold-table entries + a report-layer guard, all pinned by unit tests + corpus replay).
- Cleanup: all 5 hunt stacks deleted (`delstack`), `sweep-orphans.sh` → `SWEEP CLEAN`, bughunt gate released.
