### PR TITLE
fix(check,revert): fold Kinesis StreamModeDetails + EventBus LogConfig FPs and skip side-effectful Lambda Code re-include

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -310,7 +310,11 @@ BackupPolicy all CONVERGED via the bare `remove`** (the CC handler reset them). 
 cheap combined fixture (several folded toggles in one stack) that mutates each out of
 band and asserts the LIVE value after revert is the only reliable test — the API shape
 is not a predictor. The `revert-toggle-converge` fixture is the reference (one fixed
-case + converge-via-remove controls).
+case + converge-via-remove controls). Batch 2 (2026-07-14, `revconv-hunt` fixture):
+**`ECR::Repository` `ImageTagMutability` no-oped** (independently found+fixed the
+same day as #1580/#1581 — check upstream before pushing a same-table fix); Lambda
+`TracingConfig`, SQS `DelaySeconds`, KMS Key `Enabled` all converged via bare
+`remove` — again ~1-in-4, unpredictable from the API shape.
 
 ### 5. Harvest the live read into the golden corpus (EVERY round — bug or not)
 
@@ -588,7 +592,33 @@ Recorded]` breakdown with `--verbose`.
   the resource (a service update API call or a trivial template change) and re-check:
   every newly materialized undeclared field is a latent FP a real user hits on their
   second deploy. Fold it with the same decision order (the sizing pair joined the
-  existing value-independent MaxCapacity trio).
+  existing value-independent MaxCapacity trio). The CHEAP wide-sweep form (2026-07-14):
+  one combined barest stack of many common types whose app.ts threads a
+  `-c rev=2` context into a stack tag + per-resource descriptions — deploy, first
+  check, redeploy with `rev=2`, re-check; the `second-deploy-echo`/`-echo2` fixtures
+  swept 27 common types this way (no new echo found; Lambda materialized an empty
+  `VpcConfig` husk post-update — correctly dropped). Two lessons: (a) a barest
+  multi-type echo stack doubles as a first-run FP probe and that is where it actually
+  paid (the Kinesis `StreamModeDetails` FP below); (b) **`check --fail` exits 0 on
+  baseline-less potential drift, so a first-check assert MUST `grep "Potential
+Drift"` the output — trusting the exit code let a real FP print INTEG OK.**
+- **A barest PROVISIONED variant hides behind its richer/other-mode siblings.** The
+  2026-07-14 hunt's only first-run FP: a Kinesis stream declaring ONLY `ShardCount`
+  reads back `StreamModeDetails={"StreamMode":"PROVISIONED"}` undeclared — every
+  existing fixture either declared StreamModeDetails or was ON_DEMAND (#1487's fold
+  is the exact inverse: ON_DEMAND materializes ShardCount). When a type has a mode
+  axis, deploy the barest form of EACH mode and check which sibling props the OTHER
+  mode's fold assumed declared.
+- **A write-only re-include can be a side-effectful WRITE, not a keep-alive — watch
+  for revert-manufactured drift.** Reverting an unrelated prop (TracingConfig) on a
+  ZipFile Lambda re-included `Code.ZipFile` per the CC read-modify-write contract,
+  which the handler executed as UpdateFunctionCode: the zip re-packaged
+  (non-deterministically), live `CodeSha256` moved off the recorded baseline, and the
+  revert's own convergence check reported a drift the revert itself created
+  (permanent until re-record). Fix class: `WRITEONLY_REINCLUDE_SKIP` in
+  revert/plan.ts (live-proven 2026-07-14). When a revert leaves a synthetic read
+  signal (CodeSha256/ScriptSha256/bundle sha) "remaining", suspect the patch's own
+  re-include before calling it an AWS bug.
 - **Sibling-ATTACHMENT echo materialization is the post-update class's twin — deploy
   the ATTACHED shape, not just the barest parent.** A parent deployed ALONE can hide
   FPs that only materialize when a sibling attaches to it: a barest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,7 +136,12 @@ TransitGatewayAttachmentId]` composite is built from TWO declared props (its
    them (cdkd #812 — reverting any prop on an ECS Service with a managed EBS volume
    lost the write-only `VolumeConfigurations` and UpdateService hard-failed). The
    revert now re-includes every fully-resolved declared write-only top-level prop the
-   patch does not already touch (`writeOnlyReincludeOps` in plan.ts). A second
+   patch does not already touch (`writeOnlyReincludeOps` in plan.ts) — EXCEPT
+   side-effectful prefixes (`WRITEONLY_REINCLUDE_SKIP`: Lambda `Code`, whose
+   re-inclusion is itself an UpdateFunctionCode that re-packages the zip and moves
+   the live `CodeSha256` off the recorded baseline, so a revert of an unrelated
+   prop would manufacture its own post-revert drift; an omitted `Code` is
+   preserved by the handler — live-proven 2026-07-14). A second
    edge (#481): a service can REJECT its own read-back — the CC read of a
    VpcLattice Rule echoes `Match.HttpMatch.HeaderMatches: []`, and the update
    handler re-sends it to an UpdateRule that requires >= 1 members, so ANY

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1098,7 +1098,8 @@ export function augmentCcItemOps(
   const extra = writeOnlyReincludeOps(
     declaredByLogical(item.logicalId),
     schemas.get(item.resourceType),
-    tagged
+    tagged,
+    item.resourceType
   );
   // Drop service-echoed empty arrays the service itself rejects on update
   // (#481 — VpcLattice Rule HeaderMatches []). Live-gated + ancestor-aware.

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -397,6 +397,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // A rule that declares no State reads back ENABLED (the default for a new rule).
   // Equality-gated: a DISABLED rule reads a different value and surfaces.
   'AWS::Events::Rule': { EventBusName: 'default', State: 'ENABLED' },
+  // A custom event bus materializes the logging-disabled default LogConfig on its FIRST
+  // UPDATE (any harmless stack update — the #1569 post-update echo class): the fresh
+  // create reads back NO LogConfig, the post-update read echoes the OFF defaults.
+  // Equality-gated: enabling bus logging out of band (Level INFO/TRACE/ERROR) no longer
+  // matches and surfaces. Live, hunt 2026-07-14 (second-deploy-echo2, CdkrdHuntEcho2v0714).
+  'AWS::Events::EventBus': { LogConfig: { IncludeDetail: 'NONE', Level: 'OFF' } },
   'AWS::Athena::WorkGroup': {
     State: 'ENABLED',
     // A workgroup that declares ONLY Name/Description reads back AWS's whole default
@@ -735,6 +741,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // (24 hours). Equality-gated: a stream that sets a longer retention no longer matches
     // and surfaces (undeclared), and an out-of-band retention change still surfaces. #711.
     RetentionPeriodHours: 24,
+    // A PROVISIONED stream that declares only ShardCount reads back the materialized
+    // StreamModeDetails creation default (the inverse of #1487, where ON_DEMAND
+    // materializes ShardCount). Equality-gated: an out-of-band switch to ON_DEMAND
+    // reads {"StreamMode":"ON_DEMAND"}, no longer matches, and surfaces. Live,
+    // hunt 2026-07-14 (barest provisioned stream, stack CdkrdHuntEcho0714).
+    StreamModeDetails: { StreamMode: 'PROVISIONED' },
   },
   'AWS::SSM::Parameter': {
     DataType: 'text',

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -53,6 +53,22 @@ const SYNTHETIC_READ_SIGNAL_PATHS: Record<string, readonly string[]> = {
   'AWS::Glue::Job': ['ScriptSha256'],
 };
 
+// Write-only path PREFIXES that must NOT be re-included into a CC read-modify-write
+// patch that does not otherwise touch them: for these, re-sending the declared value is
+// not a harmless keep-alive but a SIDE-EFFECTFUL write. AWS::Lambda::Function `Code` is
+// the case: the update handler treats a patched-in Code value as an UpdateFunctionCode
+// call, re-packaging the deployment artifact (byte-nondeterministically for an inline
+// ZipFile), so a revert of an UNRELATED property (e.g. TracingConfig) silently redeploys
+// the function code and CHANGES the live CodeSha256 — invalidating the recorded baseline
+// (the #646 synthetic read signal) and leaving a permanent post-revert drift the revert
+// itself created. Omitting Code is safe by the create-only-skip argument above: function
+// code cannot silently vanish (the provider preserves an absent Code on update); it is
+// not a credential the handler would reset. Live-proven 2026-07-14 (revconv-hunt:
+// reverting TracingConfig re-included Code.ZipFile and CodeSha256 moved off baseline).
+const WRITEONLY_REINCLUDE_SKIP: Record<string, readonly string[]> = {
+  'AWS::Lambda::Function': ['Code'],
+};
+
 // SDK-override types that are nonetheless Cloud Control FULLY_MUTABLE — their override
 // exists only to work around a READ quirk, NOT because CC cannot UPDATE them, so a CC
 // UpdateResource revert is valid and they are EXEMPT from the "read-override => not
@@ -1543,10 +1559,12 @@ function valueAtDottedPath(model: Record<string, unknown>, path: string): unknow
 export function writeOnlyReincludeOps(
   declared: Record<string, unknown> | undefined,
   schema: SchemaInfo | undefined,
-  existingOps: PatchOp[]
+  existingOps: PatchOp[],
+  resourceType?: string
 ): PatchOp[] {
   if (!declared || !schema || schema.writeOnlyPaths.length === 0) return [];
   const touched = new Set(existingOps.map((o) => o.path));
+  const skipPrefixes = resourceType ? (WRITEONLY_REINCLUDE_SKIP[resourceType] ?? []) : [];
   const ops: PatchOp[] = [];
   // Iterate the FULL write-only paths, not just the top-level set: a NESTED write-only
   // property (AWS::IAM::User LoginProfile.Password, AWS::Amplify::App
@@ -1557,6 +1575,10 @@ export function writeOnlyReincludeOps(
   // present in the declared model from its template intent.
   for (const path of schema.writeOnlyPaths) {
     if (path.includes('*')) continue; // a wildcard (array-element) write-only — no single value to re-include
+    // A side-effectful write-only prefix (WRITEONLY_REINCLUDE_SKIP above): re-including
+    // it would WRITE (redeploy code), not merely preserve — skip unless the patch itself
+    // targets it (in which case the op is already in existingOps, not re-included here).
+    if (skipPrefixes.some((p) => path === p || path.startsWith(`${p}.`))) continue;
     // A property that is write-only AND create-only must NEVER enter an update patch:
     // Cloud Control hard-rejects any op on a create-only path ("createOnlyProperties
     // [...] cannot be updated"), failing the WHOLE revert at apply time — even though

--- a/tests/corpus/AWS__Events__EventBus.Echo2Bus0714.json
+++ b/tests/corpus/AWS__Events__EventBus.Echo2Bus0714.json
@@ -1,0 +1,87 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Echo2Bus0714",
+    "resourceType": "AWS::Events::EventBus",
+    "physicalId": "cdkrd-echo2-bus-0714",
+    "constructPath": "CdkrdHuntEcho2v0714/Echo2Bus0714",
+    "declared": {
+      "Description": "cdkrd echo probe rev 2",
+      "Name": "cdkrd-echo2-bus-0714",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd echo probe rev 2",
+    "Arn": "arn:aws:events:us-east-1:111111111111:event-bus/cdkrd-echo2-bus-0714",
+    "Tags": [
+      {
+        "Value": "CdkrdHuntEcho2v0714",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Echo2Bus0714",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntEcho2v0714/fafa2770-7f2d-11f1-a106-0e54c2561223",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-echo2-bus-0714",
+    "LogConfig": {
+      "IncludeDetail": "NONE",
+      "Level": "OFF"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["EventSourceName"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["EventSourceName"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Echo2Bus0714",
+      "resourceType": "AWS::Events::EventBus",
+      "path": "LogConfig",
+      "actual": {
+        "IncludeDetail": "NONE",
+        "Level": "OFF"
+      },
+      "physicalId": "cdkrd-echo2-bus-0714",
+      "constructPath": "CdkrdHuntEcho2v0714/Echo2Bus0714"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Kinesis__Stream.EchoStream0714.json
+++ b/tests/corpus/AWS__Kinesis__Stream.EchoStream0714.json
@@ -1,0 +1,104 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EchoStream0714",
+    "resourceType": "AWS::Kinesis::Stream",
+    "physicalId": "CdkrdHuntEcho0714-EchoStream0714-BidDYvkDHRA9",
+    "constructPath": "CdkrdHuntEcho0714/EchoStream0714",
+    "declared": {
+      "ShardCount": 1,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "StreamModeDetails": {
+      "StreamMode": "PROVISIONED"
+    },
+    "WarmThroughputObject": {
+      "CurrentMiBps": 0,
+      "TargetMiBps": 0
+    },
+    "Arn": "arn:aws:kinesis:ap-northeast-1:111111111111:stream/CdkrdHuntEcho0714-EchoStream0714-BidDYvkDHRA9",
+    "MaxRecordSizeInKiB": 1024,
+    "RetentionPeriodHours": 24,
+    "DesiredShardLevelMetrics": [],
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:rev"
+      }
+    ],
+    "Name": "CdkrdHuntEcho0714-EchoStream0714-BidDYvkDHRA9",
+    "ShardCount": 1
+  },
+  "schema": {
+    "readOnly": ["Arn", "WarmThroughputObject"],
+    "writeOnly": ["WarmThroughputMiBps"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "WarmThroughputObject"],
+    "writeOnlyPaths": ["WarmThroughputMiBps"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["DesiredShardLevelMetrics"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "ap-northeast-1",
+    "kmsAliasTargets": {
+      "alias/aws/backup": "8a6af96c-89fe-4ad4-b929-2534fb145917",
+      "alias/aws/kafka": "a2715ad0-2ae0-410e-8c6f-09e3de34ff91",
+      "alias/aws/lambda": "43bc8190-5c50-4bb1-8371-05e2cfbd695b",
+      "alias/aws/s3": "68b89604-663d-4bd6-9f88-b542040172db",
+      "alias/aws/secretsmanager": "e1a2f7df-c071-4f67-88b4-f987a02f90e1",
+      "alias/aws/sns": "fd051987-e227-4acf-9607-0bb8409b064f"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EchoStream0714",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "StreamModeDetails",
+      "actual": {
+        "StreamMode": "PROVISIONED"
+      },
+      "physicalId": "CdkrdHuntEcho0714-EchoStream0714-BidDYvkDHRA9",
+      "constructPath": "CdkrdHuntEcho0714/EchoStream0714"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EchoStream0714",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "MaxRecordSizeInKiB",
+      "actual": 1024,
+      "physicalId": "CdkrdHuntEcho0714-EchoStream0714-BidDYvkDHRA9",
+      "constructPath": "CdkrdHuntEcho0714/EchoStream0714"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EchoStream0714",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "RetentionPeriodHours",
+      "actual": 24,
+      "physicalId": "CdkrdHuntEcho0714-EchoStream0714-BidDYvkDHRA9",
+      "constructPath": "CdkrdHuntEcho0714/EchoStream0714"
+    }
+  ]
+}

--- a/tests/integration/revconv-hunt/app.ts
+++ b/tests/integration/revconv-hunt/app.ts
@@ -1,0 +1,56 @@
+// Revert-convergence probe (the #1571 class, next batch): four KNOWN_DEFAULTS-folded,
+// MUTABLE properties whose revert convergence has never been live-proven — Lambda
+// TracingConfig.Mode (PassThrough), SQS DelaySeconds (0), KMS Key Enabled (true),
+// ECR ImageTagMutability (MUTABLE). Each is mutated out of band, must be DETECTED,
+// then `revert` must actually restore the LIVE value to the default (some Cloud
+// Control handlers no-op an omitted property → REVERT_SET_DEFAULT_PATHS candidates;
+// the API shape is not a predictor, only a live test answers).
+import { App, Aws, Stack, Tags } from "aws-cdk-lib";
+import { CfnRepository } from "aws-cdk-lib/aws-ecr";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnKey } from "aws-cdk-lib/aws-kms";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntRevConv0714");
+
+new CfnQueue(stack, "ConvQueue0714", {});
+new CfnRepository(stack, "ConvRepo0714", {});
+
+new CfnKey(stack, "ConvKey0714", {
+  keyPolicy: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${Aws.ACCOUNT_ID}:root` },
+        Action: "kms:*",
+        Resource: "*",
+      },
+    ],
+  },
+});
+
+const role = new CfnRole(stack, "ConvFnRole0714", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+
+new CfnFunction(stack, "ConvFn0714", {
+  runtime: "nodejs20.x",
+  handler: "index.handler",
+  role: role.attrArn,
+  code: { zipFile: "exports.handler = async () => 'ok';" },
+});
+
+app.synth();

--- a/tests/integration/revconv-hunt/cdk.json
+++ b/tests/integration/revconv-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revconv-hunt/package.json
+++ b/tests/integration/revconv-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revconv-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Revert-convergence probe for KNOWN_DEFAULTS-folded mutable props never live-proven (Lambda TracingConfig, SQS DelaySeconds, KMS Enabled, ECR ImageTagMutability): mutate out of band -> detect -> revert -> assert the LIVE value returned to the default. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revconv-hunt/verify.sh
+++ b/tests/integration/revconv-hunt/verify.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Revert-convergence probe (real AWS): deploy barest Lambda/SQS/KMS/ECR, first
+# check MUST be CLEAN, record, mutate the four folded defaults out of band,
+# check MUST detect all four, revert, then assert each LIVE value actually
+# returned to its default (a silent revert no-op = REVERT_SET_DEFAULT_PATHS gap).
+set -uo pipefail
+export AWS_PAGER=""
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevConv0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN=$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id ConvFn0714 --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text)
+QURL=$(aws sqs get-queue-url --queue-name "$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id ConvQueue0714 --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text | awk -F/ '{print $NF}')" --region "$REGION" --query QueueUrl --output text)
+KEYID=$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id ConvKey0714 --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text)
+REPO=$(aws cloudformation describe-stack-resource --stack-name "$STACK" --logical-resource-id ConvRepo0714 --region "$REGION" --query 'StackResourceDetail.PhysicalResourceId' --output text)
+echo "FN=$FN QURL=$QURL KEYID=$KEYID REPO=$REPO"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-revconv $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-first.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] mutate all four folded defaults out of band ==="
+aws lambda update-function-configuration --function-name "$FN" --tracing-config Mode=Active --region "$REGION" >/dev/null || fail "lambda mutate"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION" || true
+aws sqs set-queue-attributes --queue-url "$QURL" --attributes DelaySeconds=30 --region "$REGION" || fail "sqs mutate"
+aws kms disable-key --key-id "$KEYID" --region "$REGION" || fail "kms mutate"
+aws ecr put-image-tag-mutability --repository-name "$REPO" --image-tag-mutability IMMUTABLE --region "$REGION" >/dev/null || fail "ecr mutate"
+sleep 5
+
+echo "=== [$STACK] check MUST detect all four ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1 after mutations"
+for want in TracingConfig DelaySeconds Enabled ImageTagMutability; do
+  grep -q "$want" "/tmp/cdkrd-$STACK-detect.out" || fail "mutation NOT detected: $want (FN)"
+done
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK-revert.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "revert"
+sleep 10
+
+echo "=== [$STACK] assert LIVE values converged back to defaults ==="
+TRC=$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" --query 'TracingConfig.Mode' --output text)
+[ "$TRC" = "PassThrough" ] || fail "Lambda TracingConfig did NOT converge (live=$TRC) — RSDP candidate"
+DLY=$(aws sqs get-queue-attributes --queue-url "$QURL" --attribute-names DelaySeconds --region "$REGION" --query 'Attributes.DelaySeconds' --output text)
+[ "$DLY" = "0" ] || fail "SQS DelaySeconds did NOT converge (live=$DLY) — RSDP candidate"
+KEN=$(aws kms describe-key --key-id "$KEYID" --region "$REGION" --query 'KeyMetadata.Enabled' --output text)
+[ "$KEN" = "True" ] || [ "$KEN" = "true" ] || fail "KMS Enabled did NOT converge (live=$KEN) — RSDP candidate"
+TAGMUT=$(aws ecr describe-repositories --repository-names "$REPO" --region "$REGION" --query 'repositories[0].imageTagMutability' --output text)
+[ "$TAGMUT" = "MUTABLE" ] || fail "ECR ImageTagMutability did NOT converge (live=$TAGMUT) — RSDP candidate"
+
+echo "=== [$STACK] final check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+echo "INTEG OK ($STACK)"

--- a/tests/integration/second-deploy-echo/app.ts
+++ b/tests/integration/second-deploy-echo/app.ts
@@ -1,0 +1,136 @@
+// Second-deploy echo probe (post-update echo materialization, the #1569 class):
+// a clean FIRST-run check proves nothing about the post-UPDATE echo surface —
+// some services normalize/materialize undeclared properties on EVERY update
+// (Glue re-sent sizing echoes on UpdateJob, #1569). This fixture deploys ~15
+// common, cheap, fast types in their barest form, asserts the first check is
+// CLEAN, then performs a harmless stack UPDATE (a tag / description bump via
+// `-c rev=2`) and asserts the check is STILL clean: any undeclared property
+// that materializes only after the update is a latent FP every real user hits
+// on their second `cdk deploy`.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnWorkGroup } from "aws-cdk-lib/aws-athena";
+import { CfnProject } from "aws-cdk-lib/aws-codebuild";
+import { CfnUserPool } from "aws-cdk-lib/aws-cognito";
+import { CfnTable } from "aws-cdk-lib/aws-dynamodb";
+import { CfnRepository } from "aws-cdk-lib/aws-ecr";
+import { CfnFileSystem } from "aws-cdk-lib/aws-efs";
+import { CfnRule } from "aws-cdk-lib/aws-events";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnStream } from "aws-cdk-lib/aws-kinesis";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+import { CfnStateMachine } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+const rev = String(app.node.tryGetContext("rev") ?? "1");
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+const stack = new Stack(app, "CdkrdHuntEcho0714");
+// The update trigger: bumping this tag revs every taggable resource in the
+// stack through its CFn/CC update handler — the realistic "second deploy".
+Tags.of(stack).add("cdkrd:rev", rev);
+
+new CfnBucket(stack, "EchoBucket0714", {});
+new CfnQueue(stack, "EchoQueue0714", {});
+new CfnTopic(stack, "EchoTopic0714", {});
+new CfnRepository(stack, "EchoRepo0714", {});
+new CfnLogGroup(stack, "EchoLogs0714", {});
+new CfnFileSystem(stack, "EchoEfs0714", {});
+new CfnUserPool(stack, "EchoPool0714", {});
+new CfnStream(stack, "EchoStream0714", { shardCount: 1 });
+
+new CfnTable(stack, "EchoTable0714", {
+  attributeDefinitions: [{ attributeName: "id", attributeType: "S" }],
+  keySchema: [{ attributeName: "id", keyType: "HASH" }],
+  billingMode: "PAY_PER_REQUEST",
+});
+
+// Events::Rule has no Tags property — the description carries the rev instead.
+new CfnRule(stack, "EchoRule0714", {
+  scheduleExpression: "rate(1 hour)",
+  state: "DISABLED",
+  description: `cdkrd echo probe rev ${rev}`,
+});
+
+new CfnWorkGroup(stack, "EchoWg0714", {
+  name: "cdkrd-echo-wg-0714",
+  description: `cdkrd echo probe rev ${rev}`,
+});
+
+const lambdaRole = new CfnRole(stack, "EchoLambdaRole0714", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  description: `cdkrd echo probe rev ${rev}`,
+});
+
+new CfnFunction(stack, "EchoFn0714", {
+  runtime: "nodejs20.x",
+  handler: "index.handler",
+  role: lambdaRole.attrArn,
+  code: { zipFile: "exports.handler = async () => 'ok';" },
+  description: `cdkrd echo probe rev ${rev}`,
+});
+
+const sfnRole = new CfnRole(stack, "EchoSfnRole0714", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+
+new CfnStateMachine(stack, "EchoSfn0714", {
+  roleArn: sfnRole.attrArn,
+  definitionString: JSON.stringify({
+    StartAt: "Done",
+    States: { Done: { Type: "Pass", End: true } },
+  }),
+});
+
+const cbRole = new CfnRole(stack, "EchoCbRole0714", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "codebuild.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+
+new CfnProject(stack, "EchoCb0714", {
+  serviceRole: cbRole.attrArn,
+  artifacts: { type: "NO_ARTIFACTS" },
+  environment: {
+    type: "LINUX_CONTAINER",
+    computeType: "BUILD_GENERAL1_SMALL",
+    image: "aws/codebuild/standard:7.0",
+  },
+  source: {
+    type: "NO_SOURCE",
+    buildSpec: JSON.stringify({
+      version: "0.2",
+      phases: { build: { commands: ["echo ok"] } },
+    }),
+  },
+});
+
+app.synth();

--- a/tests/integration/second-deploy-echo/cdk.json
+++ b/tests/integration/second-deploy-echo/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/second-deploy-echo/package.json
+++ b/tests/integration/second-deploy-echo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-second-deploy-echo",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Post-update echo materialization probe (the #1569 class, swept wide): barest common types, first check CLEAN, then a harmless tag/description stack UPDATE, then check MUST STILL be clean. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/second-deploy-echo/verify.sh
+++ b/tests/integration/second-deploy-echo/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Post-update echo materialization probe (real AWS): deploy ~15 barest common
+# types, assert the FIRST check (before record) is CLEAN, then run a harmless
+# stack UPDATE (tag/description bump via `-c rev=2`) and assert the check is
+# STILL clean. Any undeclared property materializing only after the update is
+# the #1569 (Glue sizing echo) FP class on a new type.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntEcho0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy v1 ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy v1"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-echo-v1 $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK-v1.out"
+V1=${PIPESTATUS[0]}
+# `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK-v1.out" && V1=10
+
+echo "=== [$STACK] deploy v2 (harmless tag/description bump) ==="
+npx cdk deploy -f "$STACK" -c rev=2 --require-approval never || fail "deploy v2"
+
+echo "=== [$STACK] check after UPDATE MUST STILL be clean ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-echo-v2 $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK-v2.out"
+V2=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK-v2.out" && V2=10
+
+[ "$V1" -eq 0 ] || fail "FIRST check reported potential drift on a clean deploy (fold gap)"
+[ "$V2" -eq 0 ] || fail "post-update check reported drift (post-update echo materialization)"
+echo "INTEG OK ($STACK)"

--- a/tests/integration/second-deploy-echo2/app.ts
+++ b/tests/integration/second-deploy-echo2/app.ts
@@ -1,0 +1,188 @@
+// Second-deploy echo probe, batch 2 (post-update echo materialization, the #1569
+// class): the types the first batch did not cover — the API Gateway REST chain
+// (RestApi/Resource/Method/Deployment/Stage), SSM Parameter, Secrets Manager
+// Secret, CloudWatch Alarm, EventBridge EventBus, an SNS->SQS Subscription,
+// Firehose DeliveryStream (S3 destination), Scheduler Schedule, IAM
+// ManagedPolicy, and a Logs MetricFilter. Deploy barest, first check MUST be
+// CLEAN, then a harmless `-c rev=2` tag/description update, then check MUST
+// STILL be clean.
+import { App, Aws, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnDeployment,
+  CfnMethod,
+  CfnResource,
+  CfnRestApi,
+  CfnStage,
+} from "aws-cdk-lib/aws-apigateway";
+import { CfnAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnEventBus } from "aws-cdk-lib/aws-events";
+import { CfnManagedPolicy, CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { CfnLogGroup, CfnMetricFilter } from "aws-cdk-lib/aws-logs";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+import { CfnSchedule } from "aws-cdk-lib/aws-scheduler";
+import { CfnSecret } from "aws-cdk-lib/aws-secretsmanager";
+import { CfnSubscription, CfnTopic } from "aws-cdk-lib/aws-sns";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+import { CfnParameter } from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+const rev = String(app.node.tryGetContext("rev") ?? "1");
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+const stack = new Stack(app, "CdkrdHuntEcho2v0714");
+Tags.of(stack).add("cdkrd:rev", rev);
+
+new CfnParameter(stack, "Echo2Param0714", {
+  type: "String",
+  value: `probe-rev-${rev}`,
+});
+
+new CfnSecret(stack, "Echo2Secret0714", {
+  description: `cdkrd echo probe rev ${rev}`,
+});
+
+new CfnAlarm(stack, "Echo2Alarm0714", {
+  namespace: "AWS/SQS",
+  metricName: "ApproximateNumberOfMessagesVisible",
+  statistic: "Average",
+  period: 300,
+  evaluationPeriods: 1,
+  threshold: 1000000,
+  comparisonOperator: "GreaterThanThreshold",
+  alarmDescription: `cdkrd echo probe rev ${rev}`,
+});
+
+new CfnEventBus(stack, "Echo2Bus0714", {
+  name: "cdkrd-echo2-bus-0714",
+  description: `cdkrd echo probe rev ${rev}`,
+});
+
+const topic = new CfnTopic(stack, "Echo2Topic0714", {});
+const queue = new CfnQueue(stack, "Echo2Queue0714", {});
+new CfnSubscription(stack, "Echo2Sub0714", {
+  topicArn: topic.ref,
+  protocol: "sqs",
+  endpoint: queue.attrArn,
+});
+
+// API Gateway REST chain — every layer updated via the description/variables.
+const api = new CfnRestApi(stack, "Echo2Api0714", {
+  name: "cdkrd-echo2-api-0714",
+  description: `cdkrd echo probe rev ${rev}`,
+});
+const res = new CfnResource(stack, "Echo2Res0714", {
+  restApiId: api.ref,
+  parentId: api.attrRootResourceId,
+  pathPart: "probe",
+});
+const method = new CfnMethod(stack, "Echo2Method0714", {
+  restApiId: api.ref,
+  resourceId: res.ref,
+  httpMethod: "GET",
+  authorizationType: "NONE",
+  integration: { type: "MOCK", requestTemplates: { "application/json": '{"statusCode": 200}' } },
+});
+const deployment = new CfnDeployment(stack, `Echo2Deploy0714R${rev}`, {
+  restApiId: api.ref,
+});
+deployment.addDependency(method);
+new CfnStage(stack, "Echo2Stage0714", {
+  restApiId: api.ref,
+  deploymentId: deployment.ref,
+  stageName: "probe",
+  variables: { rev },
+});
+
+const logGroup = new CfnLogGroup(stack, "Echo2Logs0714", {});
+new CfnMetricFilter(stack, "Echo2Mf0714", {
+  logGroupName: logGroup.ref,
+  filterPattern: "ERROR",
+  metricTransformations: [
+    {
+      metricName: `cdkrd-echo2-metric-rev${rev}`,
+      metricNamespace: "CdkrdEcho2",
+      metricValue: "1",
+    },
+  ],
+});
+
+new CfnManagedPolicy(stack, "Echo2Pol0714", {
+  description: "cdkrd echo probe",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: "s3:ListAllMyBuckets",
+        Resource: "*",
+        Sid: `Rev${rev}`,
+      },
+    ],
+  },
+});
+
+const schedRole = new CfnRole(stack, "Echo2SchedRole0714", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "scheduler.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+});
+new CfnSchedule(stack, "Echo2Sched0714", {
+  scheduleExpression: "rate(1 hour)",
+  state: "DISABLED",
+  description: `cdkrd echo probe rev ${rev}`,
+  flexibleTimeWindow: { mode: "OFF" },
+  target: {
+    arn: queue.attrArn,
+    roleArn: schedRole.attrArn,
+  },
+});
+
+const fhBucket = new CfnBucket(stack, "Echo2FhBucket0714", {});
+const fhRole = new CfnRole(stack, "Echo2FhRole0714", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "firehose.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  policies: [
+    {
+      policyName: "fh-s3",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: ["s3:PutObject", "s3:GetBucketLocation", "s3:ListBucket", "s3:AbortMultipartUpload"],
+            Resource: [fhBucket.attrArn, `${fhBucket.attrArn}/*`],
+          },
+        ],
+      },
+    },
+  ],
+});
+new CfnDeliveryStream(stack, "Echo2Fh0714", {
+  deliveryStreamType: "DirectPut",
+  s3DestinationConfiguration: {
+    bucketArn: fhBucket.attrArn,
+    roleArn: fhRole.attrArn,
+  },
+});
+
+// Aws.ACCOUNT_ID keeps the template account-agnostic (also exercises the
+// pseudo-parameter resolution path on the alarm's undeclared surface).
+void Aws.ACCOUNT_ID;
+
+app.synth();

--- a/tests/integration/second-deploy-echo2/cdk.json
+++ b/tests/integration/second-deploy-echo2/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/second-deploy-echo2/package.json
+++ b/tests/integration/second-deploy-echo2/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-second-deploy-echo2",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Post-update echo materialization probe, batch 2 (API GW REST chain, SSM Parameter, Secrets Manager Secret, CloudWatch Alarm, EventBridge bus, SNS->SQS subscription, Firehose, Scheduler, IAM ManagedPolicy, Logs MetricFilter): barest deploy, first check CLEAN, harmless -c rev=2 update, check MUST STILL be clean. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/second-deploy-echo2/verify.sh
+++ b/tests/integration/second-deploy-echo2/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Post-update echo materialization probe, batch 2 (real AWS): deploy the barest
+# API GW REST chain + SSM/Secrets/CW-Alarm/EventBus/SNS-sub/Firehose/Scheduler/
+# ManagedPolicy/MetricFilter set, assert the FIRST check (before record) is
+# CLEAN, then run a harmless stack UPDATE (`-c rev=2` tag/description bump) and
+# assert the check is STILL clean (any new undeclared materialization = the
+# #1569 post-update echo FP class).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntEcho2v0714
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy v1 ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy v1"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-echo2-v1 $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK-v1.out"
+V1=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK-v1.out" && V1=10
+
+echo "=== [$STACK] deploy v2 (harmless tag/description bump) ==="
+npx cdk deploy -f "$STACK" -c rev=2 --require-approval never || fail "deploy v2"
+
+echo "=== [$STACK] check after UPDATE MUST STILL be clean ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-echo2-v2 $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK-v2.out"
+V2=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK-v2.out" && V2=10
+
+[ "$V1" -eq 0 ] || fail "FIRST check surfaced potential drift on a clean deploy (fold gap)"
+[ "$V2" -eq 0 ] || fail "post-update check surfaced drift (post-update echo materialization)"
+echo "INTEG OK ($STACK)"

--- a/tests/noise-eventbus-logconfig.test.ts
+++ b/tests/noise-eventbus-logconfig.test.ts
@@ -1,0 +1,52 @@
+// Post-update echo FP (the #1569 class) on AWS::Events::EventBus: a custom bus
+// reads back NO LogConfig on a fresh create, but the first stack UPDATE (any
+// harmless change) materializes the logging-disabled default
+// {"IncludeDetail":"NONE","Level":"OFF"} undeclared — an AWS-assigned default,
+// not a divergence, so it must fold to atDefault. Live-found on the 2026-07-14
+// hunt (second-deploy-echo2 fixture, stack CdkrdHuntEcho2v0714).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const res: DesiredResource = {
+  logicalId: 'Echo2Bus0714',
+  resourceType: 'AWS::Events::EventBus',
+  physicalId: 'cdkrd-echo2-bus-0714',
+  declared: { Name: 'cdkrd-echo2-bus-0714' },
+};
+
+describe('Events::EventBus LogConfig (post-update echo, equality-gated constant)', () => {
+  it('folds the logging-disabled default materialized by the first update', () => {
+    const f = classifyResource(
+      res,
+      { Name: 'cdkrd-echo2-bus-0714', LogConfig: { IncludeDetail: 'NONE', Level: 'OFF' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('LogConfig');
+    expect(tier(f, 'undeclared')).not.toContain('LogConfig');
+  });
+  it('surfaces out-of-band-enabled bus logging — detection preserved', () => {
+    const f = classifyResource(
+      res,
+      { Name: 'cdkrd-echo2-bus-0714', LogConfig: { IncludeDetail: 'FULL', Level: 'INFO' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('LogConfig');
+  });
+});

--- a/tests/noise-kinesis-streammode.test.ts
+++ b/tests/noise-kinesis-streammode.test.ts
@@ -1,0 +1,63 @@
+// Barest PROVISIONED Kinesis stream first-run FP: a stream that declares only
+// ShardCount reads back the materialized StreamModeDetails creation default
+// ({"StreamMode":"PROVISIONED"}) — an AWS-assigned default, not a divergence, so
+// it must fold to atDefault (the inverse of #1487, where ON_DEMAND materializes
+// ShardCount). Live-found on the 2026-07-14 hunt (stack CdkrdHuntEcho0714).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const res: DesiredResource = {
+  logicalId: 'EchoStream0714',
+  resourceType: 'AWS::Kinesis::Stream',
+  physicalId: 'phys',
+  declared: { ShardCount: 1 },
+};
+
+describe('Kinesis::Stream StreamModeDetails (equality-gated constant)', () => {
+  it('folds the PROVISIONED creation default on a clean deploy', () => {
+    const f = classifyResource(
+      res,
+      { ShardCount: 1, StreamModeDetails: { StreamMode: 'PROVISIONED' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('StreamModeDetails');
+    expect(tier(f, 'undeclared')).not.toContain('StreamModeDetails');
+  });
+  it('surfaces an out-of-band switch to ON_DEMAND — detection preserved', () => {
+    const f = classifyResource(
+      res,
+      { ShardCount: 1, StreamModeDetails: { StreamMode: 'ON_DEMAND' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('StreamModeDetails');
+  });
+  it('compares a DECLARED StreamModeDetails in the declared dimension (unaffected)', () => {
+    const declaredRes: DesiredResource = {
+      ...res,
+      declared: { ShardCount: 1, StreamModeDetails: { StreamMode: 'PROVISIONED' } },
+    };
+    const f = classifyResource(
+      declaredRes,
+      { ShardCount: 1, StreamModeDetails: { StreamMode: 'ON_DEMAND' } },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toContain('StreamModeDetails.StreamMode');
+  });
+});

--- a/tests/revert-convergence-0714.test.ts
+++ b/tests/revert-convergence-0714.test.ts
@@ -1,0 +1,43 @@
+// 2026-07-14 revert-convergence hunt (revconv-hunt fixture, live-proven):
+// writeOnlyReincludeOps re-included Lambda `Code.ZipFile` into a patch that
+// only reverted TracingConfig — the update handler treated it as an
+// UpdateFunctionCode, re-packaging the zip and CHANGING the live CodeSha256
+// (the #646 synthetic read signal) off the recorded baseline: the revert
+// itself manufactured a permanent post-revert drift. Code must not be
+// re-included when the patch does not target it. (The same run live-proved the
+// #1571 batch: ECR ImageTagMutability no-oped — fixed upstream as #1580/#1581 —
+// while Lambda TracingConfig / SQS DelaySeconds / KMS Enabled converged via
+// bare `remove`.)
+import { describe, expect, it } from 'vite-plus/test';
+import { writeOnlyReincludeOps } from '../src/revert/plan.js';
+import type { SchemaInfo } from '../src/types.js';
+
+const lambdaSchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: ['Code.S3Bucket', 'Code.S3Key', 'Code.ZipFile'],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+describe('Lambda Code is never re-included into an unrelated CC revert patch', () => {
+  const declared = { Code: { ZipFile: "exports.handler = async () => 'ok';" }, Handler: 'h' };
+  it('a TracingConfig-only patch does NOT re-include Code.ZipFile (side-effectful write)', () => {
+    const ops = writeOnlyReincludeOps(
+      declared,
+      lambdaSchema,
+      [{ op: 'remove', path: '/TracingConfig', human: 'TracingConfig -> remove' }],
+      'AWS::Lambda::Function'
+    );
+    expect(ops).toEqual([]);
+  });
+  it('without the type-specific skip, the same shape IS re-included (contract preserved for other types)', () => {
+    const ops = writeOnlyReincludeOps(declared, lambdaSchema, [
+      { op: 'remove', path: '/TracingConfig', human: 'TracingConfig -> remove' },
+    ]);
+    expect(ops).toMatchObject([{ op: 'add', path: '/Code/ZipFile' }]);
+  });
+});


### PR DESCRIPTION
## Summary

2026-07-14 bug hunt (`/hunt-bugs`, 5 rounds): swept the **post-update echo** axis (the #1569 class) wide for the first time — no fixture had ever re-checked after a second `cdk deploy` — plus a cross-region echo pass and a revert-convergence batch (#1571 class, batch 2). 4 live-proven bugs found; 3 fixed here (the 4th had already been fixed upstream mid-hunt):

### 1. `fix(noise)`: Kinesis Stream first-run FP on undeclared `StreamModeDetails` (R1)

A barest **provisioned** stream (only `ShardCount` declared) reads back `StreamModeDetails={"StreamMode":"PROVISIONED"}` undeclared → `[Potential Drift]` on a fresh deploy. The exact inverse of #1487 (ON_DEMAND materializes `ShardCount`); latent because every existing fixture declared `StreamModeDetails` or was ON_DEMAND (the #615 declared-hides-undeclared class). Fold: tier-1 equality-gated constant — an out-of-band switch to ON_DEMAND still surfaces.

**Live:** base binary FP'd in us-east-1 AND ap-northeast-1; fixed binary folds it (`CdkrdHuntEcho0714`, both regions).

### 2. `fix(noise)`: EventBridge EventBus post-update echo FP on `LogConfig` (the #1569 class on a new type)

A custom bus reads back NO `LogConfig` on a fresh create — but the FIRST stack update (any harmless change; here a description bump) materializes `LogConfig={"IncludeDetail":"NONE","Level":"OFF"}` undeclared → every user hits it on their second deploy. Fold: tier-1 equality-gated constant — out-of-band-enabled bus logging (Level INFO/TRACE/ERROR) still surfaces.

**Live:** `CdkrdHuntEcho2v0714` v1 check CLEAN → `-c rev=2` update → base binary surfaced the FP; fixed binary CLEAN end-to-end.

### 3. ECR `ImageTagMutability` revert no-op — independently confirmed (already fixed upstream as #1580/#1581)

This run found the same no-op live; #1580/#1581 had already merged the identical RSDP fix mid-hunt, so this PR carries NO change for it — the revconv-hunt fixture is a second, independent live confirmation. Controls live-proven converging via bare `remove` in the same batch: Lambda `TracingConfig`, SQS `DelaySeconds`, KMS Key `Enabled` — again ~1-in-4 needing RSDP, unpredictable from the API shape.

### 4. `fix(revert)`: Lambda `Code.ZipFile` re-include manufactured post-revert drift

Reverting an UNRELATED prop (`TracingConfig`) re-included `Code.ZipFile` per the CC read-modify-write contract (`writeOnlyReincludeOps`) — the handler executed it as an UpdateFunctionCode, re-packaging the zip (byte-nondeterministically) and moving the live `CodeSha256` (the #646 synthetic read signal) off the recorded baseline: the revert **created its own permanent drift**. New `WRITEONLY_REINCLUDE_SKIP` table excludes side-effectful prefixes (Lambda `Code`); an omitted `Code` is preserved by the handler.

**Live (revert batch):** `CdkrdHuntRevConv0714` — mutate 4 folded defaults → detect 4/4 → revert → convergence CLEAN, all 4 LIVE values asserted back at defaults via the service APIs → final check CLEAN.

## Probe results that found no bug (still shipped as regression assets)

- **Post-update echo sweep, 27 common types** (`second-deploy-echo` + `second-deploy-echo2` fixtures): tag/description-bump second deploy, re-check must stay clean. Only EventBus misbehaved (fixed above). Lambda materialized an empty `VpcConfig` husk post-update — correctly dropped by the existing folds.
- **Cross-region pass (ap-northeast-1)**: no region-dependent fold gaps on the batch-1 types.
- **Composite `primaryIdentifier` audit (offline)**: `CC_IDENTIFIER_ADAPTERS`' 53 types already cover the common composite-id surface; no new candidate.

## Changes

- `src/normalize/noise.ts` — `KNOWN_DEFAULTS`: Kinesis `StreamModeDetails`, EventBus `LogConfig`
- `src/revert/plan.ts` — new `WRITEONLY_REINCLUDE_SKIP` + `writeOnlyReincludeOps(resourceType?)` param
- `src/commands/stack-actions.ts` — pass `item.resourceType` to `writeOnlyReincludeOps`
- `tests/` — 3 new unit test files (each fails without its fix), 2 promoted golden-corpus cases, 3 committed integ fixtures (`second-deploy-echo`, `second-deploy-echo2`, `revconv-hunt`)
- `docs/ARCHITECTURE.md` — re-include exception documented
- `.claude/skills/hunt-bugs/SKILL.md` — durable lessons (echo wide-sweep recipe; `check --fail` exits 0 on baseline-less potential drift → grep the output; mode-axis barest variants; side-effectful write-only re-includes)

## Verification

- `vp run test`: 293 files / 5715 tests (post-rebase onto 0.18.8) pass (incl. corpus replay over the 2 new cases)
- Live A/B on all 4 fixes as described above; all hunt stacks deleted + `sweep-orphans.sh` SWEEP CLEAN
