### PR TITLE
fix(check,revert): fold EFS One Zone backup + Firehose HTTP-endpoint first-run FPs and converge ECR ImageScanningConfiguration revert

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -314,7 +314,19 @@ case + converge-via-remove controls). Batch 2 (2026-07-14, `revconv-hunt` fixtur
 **`ECR::Repository` `ImageTagMutability` no-oped** (independently found+fixed the
 same day as #1580/#1581 — check upstream before pushing a same-table fix); Lambda
 `TracingConfig`, SQS `DelaySeconds`, KMS Key `Enabled` all converged via bare
-`remove` — again ~1-in-4, unpredictable from the API shape.
+`remove` — again ~1-in-4, unpredictable from the API shape. Batch 3 (2026-07-14,
+`revconv2-hunt` fixture): **`ECR::Repository` `ImageScanningConfiguration` no-oped**
+(the ImageTagMutability sibling — same partial-update contract); DDB
+`PointInTimeRecoverySpecification`, S3 `VersioningConfiguration` (the handler
+actually SUSPENDS on omitted — S3 can never return to never-versioned), LogGroup
+`RetentionInDays`, EventBus `LogConfig`, Kinesis `StreamModeDetails`
+(ON_DEMAND→PROVISIONED via remove) all converged. The no-op contract is non-uniform
+even WITHIN a type: ECR's `RepositoryPolicyText` / `LifecyclePolicy` removes DO
+converge (both policies live-deleted), so the ECR gap is exactly the two
+scan/mutability scalars — prove per-property, not per-type. Also excluded from any
+in-run revert probe by AWS-side rate limits (not cdkrd bugs): DDB TTL (1 change/h),
+EFS ThroughputMode (1 change/24h); Kinesis stream-mode allows exactly 2 switches/24h
+— enough for one mutate + one revert, none left for a retry.
 
 ### 5. Harvest the live read into the golden corpus (EVERY round — bug or not)
 
@@ -609,6 +621,21 @@ Drift"` the output — trusting the exit code let a real FP print INTEG OK.**
   is the exact inverse: ON_DEMAND materializes ShardCount). When a type has a mode
   axis, deploy the barest form of EACH mode and check which sibling props the OTHER
   mode's fold assumed declared.
+- **The variant axis extends to UNION-TYPED config blocks and to defaults the variant
+  FLIPS on a sibling.** Two live instances (variants2-hunt, 2026-07-14): (a) Firehose's
+  destination union — every fixture was ExtendedS3, so a barest
+  `HttpEndpointDestinationConfiguration` first-ran 7 nested-echo FPs; each destination
+  variant carries its OWN default family (HTTP's `S3BackupMode` default is
+  `FailedDataOnly` while ExtendedS3's is `Disabled` — do NOT copy a sibling variant's
+  constants, read them from the live echo). (b) EFS One Zone (`AvailabilityZoneName`
+  declared) FLIPS the `BackupPolicy` default to ENABLED — the Regional constant
+  DISABLED pin missed it; the fix is a tier-2 derived fold gated on the declared
+  variant marker, with the Regional constant as the fall-through. When probing a
+  variant, expect it to change defaults on OTHER properties, not just add its own.
+  Fixture foot-gun: Firehose VALIDATES the endpoint URL shape at create — a
+  `.invalid`-TLD placeholder is REJECTED (`Invalid Url`), so use
+  `https://example.com/<path>` (reserved, resolvable, never actually called by a
+  DirectPut stream with no producers).
 - **A write-only re-include can be a side-effectful WRITE, not a keep-alive — watch
   for revert-manufactured drift.** Reverting an unrelated prop (TracingConfig) on a
   ZipFile Lambda re-included `Code.ZipFile` per the CC read-modify-write contract,

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -4959,6 +4959,28 @@ export function classifyResource(
         continue;
       }
     }
+    // A One Zone EFS file system (declared AvailabilityZoneName) defaults automatic backups
+    // to ENABLED — the OPPOSITE of the Regional default the KNOWN_DEFAULTS constant pins
+    // ({Status:'DISABLED'}), so a barest One Zone fs first-ran a [Potential Drift] on
+    // BackupPolicy (live, variants2-hunt 2026-07-14). The default is a deterministic
+    // function of the declared shape (#1477 variant-axis class), so derive it (tier 2):
+    // equality-gate against {Status:'ENABLED'} when AvailabilityZoneName is declared —
+    // an out-of-band backup DISABLE on a One Zone fs no longer matches and still surfaces
+    // as `undeclared`. Regional (no AvailabilityZoneName) falls through to the constant.
+    if (
+      resourceType === 'AWS::EFS::FileSystem' &&
+      k === 'BackupPolicy' &&
+      typeof declared['AvailabilityZoneName'] === 'string'
+    ) {
+      findings.push({
+        tier: matchesKnownDefault(v, { Status: 'ENABLED' }) ? 'atDefault' : 'undeclared',
+        logicalId,
+        resourceType,
+        path: k,
+        actual: v,
+      });
+      continue;
+    }
     // #1557: a DMS ReplicationInstance's undeclared AllocatedStorage is a DETERMINISTIC FUNCTION of
     // the declared ReplicationInstanceClass (dms.c6i.large → 100), NOT a fixed constant — the docs'
     // generic "50 GB" is not per-class truth. gather.ts prefetched the per-class

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -726,6 +726,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ECR::Repository': {
     EncryptionConfiguration: { EncryptionType: 'AES256' },
     ImageTagMutability: 'MUTABLE', // R-noise-sweep: default; switching to IMMUTABLE no longer matches and surfaces
+    // Scan-on-push is off by default; the pin (rather than the isTrivialEmpty drop) gives
+    // REVERT_SET_DEFAULT_PATHS a default value to write back explicitly — the ECR CC
+    // handler's partial update ignores an omitted ImageScanningConfiguration exactly like
+    // its ImageTagMutability sibling (#1580), live-proven on revconv2-hunt 2026-07-14.
+    ImageScanningConfiguration: { ScanOnPush: false },
   },
   // Same default family as AWS::ECR::Repository (above) — the template type was missed.
   // A creation template that declares only {Prefix, AppliedFor, Description} reads back
@@ -2336,6 +2341,35 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'ExtendedS3DestinationConfiguration.BufferingHints': {
       IntervalInSeconds: 300,
       SizeInMBs: 5,
+    },
+    // The HTTP-endpoint destination variant (Datadog/Splunk-style) materializes its own
+    // echo family — every existing fixture was ExtendedS3, so a barest
+    // HttpEndpointDestinationConfiguration (url + name + the required S3 backup config)
+    // first-ran 7 FPs. All are documented stable constants, equality-gated (an
+    // out-of-band buffering/retry/backup-mode/compression change still surfaces).
+    // Observed live on a fresh variants2-hunt deploy (2026-07-14). Note the S3BackupMode
+    // default differs from ExtendedS3's ('FailedDataOnly' vs 'Disabled' — the HTTP enum
+    // is FailedDataOnly|AllData). The other destination variants (Splunk / Redshift /
+    // OpenSearch / Snowflake …) each carry their OWN per-variant defaults and stay
+    // unpinned until live-proven — an equality-gated pin added blind cannot false-fold,
+    // but an unverified constant is just dead weight.
+    'HttpEndpointDestinationConfiguration.RequestConfiguration': {
+      CommonAttributes: [],
+      ContentEncoding: 'NONE',
+    },
+    'HttpEndpointDestinationConfiguration.BufferingHints': {
+      IntervalInSeconds: 300,
+      SizeInMBs: 5,
+    },
+    'HttpEndpointDestinationConfiguration.RetryOptions': { DurationInSeconds: 300 },
+    'HttpEndpointDestinationConfiguration.S3BackupMode': 'FailedDataOnly',
+    'HttpEndpointDestinationConfiguration.S3Configuration.BufferingHints': {
+      IntervalInSeconds: 300,
+      SizeInMBs: 5,
+    },
+    'HttpEndpointDestinationConfiguration.S3Configuration.CompressionFormat': 'UNCOMPRESSED',
+    'HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration': {
+      NoEncryptionConfig: 'NoEncryption',
     },
   },
   'AWS::Athena::WorkGroup': {
@@ -4753,7 +4787,10 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // that survives `record` and never converges (a revert just re-writes the mixed case, which
   // the service lowercases again). Every identifier here is create-only, so case-insensitive
   // equality hides no revertable drift (a genuine rename is a replacement). ElastiCache
-  // SubnetGroup live-verified; the rest docs-verified from the AWS CLI help. NOTE:
+  // SubnetGroup live-verified; the Neptune trio live-verified 2026-07-14 (Cloud Control
+  // create-resource passes a mixed-case DBClusterIdentifier / DBSubnetGroupName through and
+  // the stored echo reads back lowercased; DBInstanceIdentifier lowercased in the raw
+  // create-db-instance echo); the rest docs-verified from the AWS CLI help. NOTE:
   // AWS::Route53::HostedZone.Name was live-ruled-out (Route53 PRESERVES case on read) so it
   // is deliberately NOT added. (An earlier note also ruled out RDS DBSubnetGroupName, but a
   // 2026-07-12 live probe disproved that: `create-db-subnet-group

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -235,6 +235,14 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // keeps the current value instead of reconciling to the MUTABLE default. Write the
   // "MUTABLE" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
   'AWS::ECR::Repository\0ImageTagMutability',
+  // The same ECR partial-update contract swallows an omitted ImageScanningConfiguration
+  // (live-proven on revconv2-hunt 2026-07-14: scan-on-push enabled out of band, `revert`
+  // planned a `remove`, Cloud Control reported `reverted: Conv2Repo`, yet
+  // `describe-repositories` stayed scanOnPush=true — the ONLY non-converging remove of
+  // that six-surface batch; DDB PITR / S3 Versioning / LogGroup RetentionInDays /
+  // EventBus LogConfig / Kinesis StreamModeDetails all reconciled via the bare remove).
+  // Write the {ScanOnPush:false} default (from KNOWN_DEFAULTS) back explicitly.
+  'AWS::ECR::Repository\0ImageScanningConfiguration',
   // SQS: an omitted MaximumMessageSize is NOT reset to the default on a revert patch
   // (live-proven on revert-noop-probe 2026-07-14, #1583: mutated 1048576->262144 out of
   // band, then `revert` planned a `remove`, reported reverted, yet the queue stayed

--- a/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
+++ b/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ECR::Repository model; surviving raw-classify findings locked as-is (EmptyOnDelete, EncryptionConfiguration, ImageTagMutability). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ECR::Repository model; surviving raw-classify findings locked as-is (EmptyOnDelete, EncryptionConfiguration, ImageTagMutability). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
   "resource": {
     "logicalId": "Images2D38C313",
     "resourceType": "AWS::ECR::Repository",
@@ -76,7 +76,7 @@
       "logicalId": "Images2D38C313",
       "resourceType": "AWS::ECR::Repository",
       "path": "EmptyOnDelete",
-      "note": "write-only — cannot be read back",
+      "note": "write-only \u2014 cannot be read back",
       "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
       "constructPath": "CdkrdIntegHarvest/Images",
       "writeOnly": true
@@ -88,6 +88,17 @@
       "path": "EncryptionConfiguration",
       "actual": {
         "EncryptionType": "AES256"
+      },
+      "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+      "constructPath": "CdkrdIntegHarvest/Images"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Images2D38C313",
+      "resourceType": "AWS::ECR::Repository",
+      "path": "ImageScanningConfiguration",
+      "actual": {
+        "ScanOnPush": false
       },
       "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
       "constructPath": "CdkrdIntegHarvest/Images"

--- a/tests/corpus/AWS__EFS__FileSystem.HuntOneZoneFs.json
+++ b/tests/corpus/AWS__EFS__FileSystem.HuntOneZoneFs.json
@@ -1,0 +1,125 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOneZoneFs",
+    "resourceType": "AWS::EFS::FileSystem",
+    "physicalId": "fs-0211b6a049cdb7e7f",
+    "constructPath": "CdkrdHunt0714Var2/HuntOneZoneFs",
+    "declared": {
+      "AvailabilityZoneName": "us-east-1a",
+      "FileSystemTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PerformanceMode": "generalPurpose",
+    "Encrypted": false,
+    "FileSystemTags": [
+      {
+        "Value": "HuntOneZoneFs",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Var2/071791b0-7f37-11f1-9753-0affd2ec42e1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdHunt0714Var2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "enabled",
+        "Key": "aws:elasticfilesystem:default-backup"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "AvailabilityZoneName": "us-east-1a",
+    "FileSystemId": "fs-0211b6a049cdb7e7f",
+    "FileSystemProtection": {
+      "ReplicationOverwriteProtection": "ENABLED"
+    },
+    "LifecyclePolicies": [],
+    "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:file-system/fs-0211b6a049cdb7e7f",
+    "ThroughputMode": "bursting",
+    "BackupPolicy": {
+      "Status": "ENABLED"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "FileSystemId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck"],
+    "createOnly": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "readOnlyPaths": [
+      "Arn",
+      "FileSystemId",
+      "ReplicationConfiguration.Destinations.*.Status",
+      "ReplicationConfiguration.Destinations.*.StatusMessage"
+    ],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "ReplicationConfiguration.Destinations.*.AvailabilityZoneName",
+      "ReplicationConfiguration.Destinations.*.KmsKeyId"
+    ],
+    "createOnlyPaths": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOneZoneFs",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "PerformanceMode",
+      "actual": "generalPurpose",
+      "physicalId": "fs-0211b6a049cdb7e7f",
+      "constructPath": "CdkrdHunt0714Var2/HuntOneZoneFs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOneZoneFs",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "FileSystemProtection",
+      "actual": {
+        "ReplicationOverwriteProtection": "ENABLED"
+      },
+      "physicalId": "fs-0211b6a049cdb7e7f",
+      "constructPath": "CdkrdHunt0714Var2/HuntOneZoneFs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOneZoneFs",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "ThroughputMode",
+      "actual": "bursting",
+      "physicalId": "fs-0211b6a049cdb7e7f",
+      "constructPath": "CdkrdHunt0714Var2/HuntOneZoneFs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOneZoneFs",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "ENABLED"
+      },
+      "physicalId": "fs-0211b6a049cdb7e7f",
+      "constructPath": "CdkrdHunt0714Var2/HuntOneZoneFs"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.HuntHttpFirehose.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.HuntHttpFirehose.json
@@ -1,0 +1,251 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntHttpFirehose",
+    "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+    "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+    "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose",
+    "declared": {
+      "HttpEndpointDestinationConfiguration": {
+        "EndpointConfiguration": {
+          "Name": "hunt-endpoint",
+          "Url": "https://example.com/cdkrd-hunt"
+        },
+        "S3Configuration": {
+          "BucketARN": "arn:aws:s3:::cdkrdhunt0714var2-huntfirehosebackupccf91131-kvmemnbemccs",
+          "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHunt0714Var2-HuntFirehoseRoleE863A135-gMm9UBZyxL2g"
+        }
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "HttpEndpointDestinationConfiguration": {
+      "RequestConfiguration": {
+        "CommonAttributes": [],
+        "ContentEncoding": "NONE"
+      },
+      "S3Configuration": {
+        "BucketARN": "arn:aws:s3:::cdkrdhunt0714var2-huntfirehosebackupccf91131-kvmemnbemccs",
+        "BufferingHints": {
+          "IntervalInSeconds": 300,
+          "SizeInMBs": 5
+        },
+        "CompressionFormat": "UNCOMPRESSED",
+        "EncryptionConfiguration": {
+          "NoEncryptionConfig": "NoEncryption"
+        },
+        "CloudWatchLoggingOptions": {
+          "Enabled": false
+        },
+        "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHunt0714Var2-HuntFirehoseRoleE863A135-gMm9UBZyxL2g"
+      },
+      "BufferingHints": {
+        "IntervalInSeconds": 300,
+        "SizeInMBs": 5
+      },
+      "RetryOptions": {
+        "DurationInSeconds": 300
+      },
+      "EndpointConfiguration": {
+        "Url": "https://example.com/cdkrd-hunt",
+        "Name": "hunt-endpoint"
+      },
+      "CloudWatchLoggingOptions": {
+        "Enabled": false
+      },
+      "S3BackupMode": "FailedDataOnly"
+    },
+    "DeliveryStreamType": "DirectPut",
+    "DeliveryStreamName": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+    "Arn": "arn:aws:firehose:us-east-1:111111111111:deliverystream/CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "ElasticsearchDestinationConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration"
+    ],
+    "createOnly": [
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration"
+    ],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "DirectPutSourceConfiguration.ThroughputHintInMBs",
+      "ElasticsearchDestinationConfiguration",
+      "ElasticsearchDestinationConfiguration.CloudWatchLoggingOptions.Enabled",
+      "ExtendedS3DestinationConfiguration.CustomTimeZone",
+      "ExtendedS3DestinationConfiguration.FileExtension",
+      "HttpEndpointDestinationConfiguration.EndpointConfiguration.AccessKey",
+      "HttpEndpointDestinationConfiguration.ProcessingConfiguration",
+      "HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "HttpEndpointDestinationConfiguration.SecretsManagerConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "RedshiftDestinationConfiguration.Password",
+      "RedshiftDestinationConfiguration.ProcessingConfiguration",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3Configuration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.Enabled",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.RoleARN",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.SecretARN",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration",
+      "SplunkDestinationConfiguration.BufferingHints",
+      "SplunkDestinationConfiguration.CloudWatchLoggingOptions",
+      "SplunkDestinationConfiguration.ProcessingConfiguration",
+      "SplunkDestinationConfiguration.S3Configuration.EncryptionConfiguration.NoEncryptionConfig",
+      "SplunkDestinationConfiguration.SecretsManagerConfiguration"
+    ],
+    "createOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration.VpcConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration.VpcConfiguration",
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "ElasticsearchDestinationConfiguration.VpcConfiguration",
+      "IcebergDestinationConfiguration.CatalogConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "ExtendedS3DestinationConfiguration.DataFormatConversionConfiguration.InputFormatConfiguration.Deserializer.OpenXJsonSerDe.ColumnToJsonKeyMappings"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "DeliveryStreamType",
+      "actual": "DirectPut",
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "HttpEndpointDestinationConfiguration.RequestConfiguration",
+      "actual": {
+        "CommonAttributes": [],
+        "ContentEncoding": "NONE"
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "HttpEndpointDestinationConfiguration.S3Configuration.BufferingHints",
+      "actual": {
+        "IntervalInSeconds": 300,
+        "SizeInMBs": 5
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "HttpEndpointDestinationConfiguration.S3Configuration.CompressionFormat",
+      "actual": "UNCOMPRESSED",
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration",
+      "actual": {
+        "NoEncryptionConfig": "NoEncryption"
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "HttpEndpointDestinationConfiguration.BufferingHints",
+      "actual": {
+        "IntervalInSeconds": 300,
+        "SizeInMBs": 5
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "HttpEndpointDestinationConfiguration.RetryOptions",
+      "actual": {
+        "DurationInSeconds": 300
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntHttpFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "HttpEndpointDestinationConfiguration.S3BackupMode",
+      "actual": "FailedDataOnly",
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Var2-HuntHttpFirehose-aRUkRQmqH3dT",
+      "constructPath": "CdkrdHunt0714Var2/HuntHttpFirehose"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SageMaker__EndpointConfig.HuntServerlessEpc.json
+++ b/tests/corpus/AWS__SageMaker__EndpointConfig.HuntServerlessEpc.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntServerlessEpc",
+    "resourceType": "AWS::SageMaker::EndpointConfig",
+    "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:endpoint-config/HuntServerlessEpc-eJF2maNSeqzn",
+    "constructPath": "CdkrdHunt0714Var2/HuntServerlessEpc",
+    "declared": {
+      "ProductionVariants": [
+        {
+          "ModelName": "HuntSmModel-vBVDS98KOxXo",
+          "ServerlessConfig": {
+            "MaxConcurrency": 5,
+            "MemorySizeInMB": 2048
+          },
+          "VariantName": "AllTraffic"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EndpointConfigName": "HuntServerlessEpc-eJF2maNSeqzn",
+    "ProductionVariants": [
+      {
+        "VariantName": "AllTraffic",
+        "ModelName": "HuntSmModel-vBVDS98KOxXo",
+        "InitialVariantWeight": 1,
+        "ServerlessConfig": {
+          "MemorySizeInMB": 2048,
+          "MaxConcurrency": 5
+        },
+        "VolumeSizeInGB": 5
+      }
+    ],
+    "EnableNetworkIsolation": false,
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0714Var2"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "HuntServerlessEpc"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Var2/071791b0-7f37-11f1-9753-0affd2ec42e1"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "AsyncInferenceConfig",
+      "DataCaptureConfig",
+      "EnableNetworkIsolation",
+      "EndpointConfigName",
+      "ExecutionRoleArn",
+      "ExplainerConfig",
+      "KmsKeyId",
+      "ProductionVariants",
+      "ShadowProductionVariants",
+      "VpcConfig"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AsyncInferenceConfig",
+      "DataCaptureConfig",
+      "EnableNetworkIsolation",
+      "EndpointConfigName",
+      "ExecutionRoleArn",
+      "ExplainerConfig",
+      "KmsKeyId",
+      "ProductionVariants",
+      "ShadowProductionVariants",
+      "VpcConfig"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "HuntServerlessEpc",
+      "resourceType": "AWS::SageMaker::EndpointConfig",
+      "path": "EndpointConfigName",
+      "actual": "HuntServerlessEpc-eJF2maNSeqzn",
+      "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:endpoint-config/HuntServerlessEpc-eJF2maNSeqzn",
+      "constructPath": "CdkrdHunt0714Var2/HuntServerlessEpc"
+    }
+  ]
+}

--- a/tests/integration/revconv2-hunt/app.ts
+++ b/tests/integration/revconv2-hunt/app.ts
@@ -1,0 +1,40 @@
+// Revert-convergence probe (the #1571 class, batch 3): six KNOWN_DEFAULTS/atDefault-
+// folded, MUTABLE surfaces whose revert convergence has never been live-proven —
+// DynamoDB PointInTimeRecoverySpecification, S3 VersioningConfiguration, Logs
+// LogGroup RetentionInDays, ECR ImageScanningConfiguration.ScanOnPush, Events
+// EventBus LogConfig (fold added in #1596, detection+revert never live-proven),
+// Kinesis StreamModeDetails PROVISIONED->ON_DEMAND (the #1596 fold's mode-switch
+// detection + revert). Each is mutated out of band, must be DETECTED, then
+// `revert` must actually restore the LIVE value (some Cloud Control handlers
+// no-op an omitted property -> REVERT_SET_DEFAULT_PATHS candidates; the API
+// shape is not a predictor, only a live test answers).
+// Deliberately EXCLUDED (AWS-side rate limits make an in-run revert impossible,
+// not a cdkrd bug): DDB TimeToLiveSpecification (1 change/hour), EFS
+// ThroughputMode (1 change/24h).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnTable } from "aws-cdk-lib/aws-dynamodb";
+import { CfnRepository } from "aws-cdk-lib/aws-ecr";
+import { CfnEventBus } from "aws-cdk-lib/aws-events";
+import { CfnStream } from "aws-cdk-lib/aws-kinesis";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714RevConv2");
+
+const table = new CfnTable(stack, "Conv2Table", {
+  keySchema: [{ attributeName: "pk", keyType: "HASH" }],
+  attributeDefinitions: [{ attributeName: "pk", attributeType: "S" }],
+  billingMode: "PAY_PER_REQUEST",
+});
+table.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+new CfnBucket(stack, "Conv2Bucket", {});
+new CfnLogGroup(stack, "Conv2LogGroup", {});
+new CfnRepository(stack, "Conv2Repo", {});
+new CfnEventBus(stack, "Conv2Bus", { name: "cdkrd-hunt0714-conv2-bus" });
+new CfnStream(stack, "Conv2Stream", { shardCount: 1 });
+
+app.synth();

--- a/tests/integration/revconv2-hunt/cdk.json
+++ b/tests/integration/revconv2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revconv2-hunt/package.json
+++ b/tests/integration/revconv2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revconv2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Revert-convergence probe batch 3 for folded mutable props never live-proven (DDB PITR, S3 Versioning, LogGroup Retention, ECR ScanOnPush, EventBus LogConfig, Kinesis stream-mode switch): mutate out of band -> detect -> revert -> assert the LIVE value returned to the default. Run via verify.sh + verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revconv2-hunt/verify-detect.sh
+++ b/tests/integration/revconv2-hunt/verify-detect.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Revert-convergence probe batch 3 (real AWS): mutate six folded MUTABLE surfaces
+# out of band -> check MUST DETECT -> revert -> check MUST be CLEAN -> the LIVE
+# values MUST be back at their defaults (a silent no-op revert is the #1571 bug
+# class; the API shape is not a predictor, only this live test answers).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714RevConv2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+BUS_NAME=cdkrd-hunt0714-conv2-bus
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?LogicalResourceId=='$1'].PhysicalResourceId" --output text
+}
+
+wait_stream_active() {
+  for _ in $(seq 1 60); do
+    st="$(aws kinesis describe-stream-summary --stream-name "$1" --region "$REGION" \
+      --query 'StreamDescriptionSummary.StreamStatus' --output text 2>/dev/null)"
+    [ "$st" = "ACTIVE" ] && return 0
+    sleep 5
+  done
+  return 1
+}
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN, then record ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP before the probe even starts"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+TBL="$(phys Conv2Table)"
+BKT="$(phys Conv2Bucket)"
+LG="$(phys Conv2LogGroup)"
+REPO="$(phys Conv2Repo)"
+STREAM="$(phys Conv2Stream)"
+STREAM_ARN="$(aws kinesis describe-stream-summary --stream-name "$STREAM" --region "$REGION" \
+  --query 'StreamDescriptionSummary.StreamARN' --output text)"
+
+echo "=== [$STACK] mutate out of band (6 surfaces) ==="
+aws dynamodb update-continuous-backups --table-name "$TBL" --region "$REGION" \
+  --point-in-time-recovery-specification PointInTimeRecoveryEnabled=true >/dev/null || fail "mutate PITR"
+aws s3api put-bucket-versioning --bucket "$BKT" --region "$REGION" \
+  --versioning-configuration Status=Enabled || fail "mutate versioning"
+aws logs put-retention-policy --log-group-name "$LG" --region "$REGION" \
+  --retention-in-days 7 || fail "mutate retention"
+aws ecr put-image-scanning-configuration --repository-name "$REPO" --region "$REGION" \
+  --image-scanning-configuration scanOnPush=true >/dev/null || fail "mutate scanOnPush"
+aws events update-event-bus --name "$BUS_NAME" --region "$REGION" \
+  --log-config '{"IncludeDetail":"FULL","Level":"INFO"}' >/dev/null || fail "mutate bus log-config"
+aws kinesis update-stream-mode --stream-arn "$STREAM_ARN" --region "$REGION" \
+  --stream-mode-details StreamMode=ON_DEMAND || fail "mutate stream mode"
+wait_stream_active "$STREAM" || fail "stream not ACTIVE after mode switch"
+
+echo "=== [$STACK] check MUST DETECT all 6 ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc"
+for needle in PointInTimeRecovery Versioning RetentionInDays ImageScanningConfiguration LogConfig StreamModeDetails; do
+  grep -q "$needle" "/tmp/cdkrd-$STACK.detect.out" || fail "missed detection: $needle"
+done
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+grep -Eq "NOT reverted|could not be confirmed" "/tmp/cdkrd-$STACK.revert.out" \
+  && fail "revert reported a non-converged path (see output)"
+wait_stream_active "$STREAM" || fail "stream not ACTIVE after revert"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.post.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after revert — a revert did not converge"
+
+echo "=== [$STACK] live values MUST be back at their defaults ==="
+PITR="$(aws dynamodb describe-continuous-backups --table-name "$TBL" --region "$REGION" \
+  --query 'ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus' --output text)"
+[ "$PITR" = "DISABLED" ] || fail "PITR still $PITR (revert no-op)"
+VER="$(aws s3api get-bucket-versioning --bucket "$BKT" --region "$REGION" --query 'Status' --output text)"
+[ "$VER" = "Suspended" ] || fail "bucket versioning still $VER (revert no-op)"
+RET="$(aws logs describe-log-groups --log-group-name-prefix "$LG" --region "$REGION" \
+  --query 'logGroups[0].retentionInDays' --output text)"
+[ "$RET" = "None" ] || fail "log retention still $RET (revert no-op)"
+SCAN="$(aws ecr describe-repositories --repository-names "$REPO" --region "$REGION" \
+  --query 'repositories[0].imageScanningConfiguration.scanOnPush' --output text)"
+[ "$SCAN" = "False" ] || fail "scanOnPush still $SCAN (revert no-op)"
+LVL="$(aws events describe-event-bus --name "$BUS_NAME" --region "$REGION" \
+  --query 'LogConfig.Level' --output text 2>/dev/null)"
+{ [ "$LVL" = "OFF" ] || [ "$LVL" = "None" ] || [ -z "$LVL" ]; } || fail "bus log level still $LVL (revert no-op)"
+MODE="$(aws kinesis describe-stream-summary --stream-name "$STREAM" --region "$REGION" \
+  --query 'StreamDescriptionSummary.StreamModeDetails.StreamMode' --output text)"
+[ "$MODE" = "PROVISIONED" ] || fail "stream mode still $MODE (revert no-op)"
+
+echo "INTEG PASS ($STACK detect+revert batch 3)"

--- a/tests/integration/revconv2-hunt/verify.sh
+++ b/tests/integration/revconv2-hunt/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest DDB/S3/LogGroup/ECR/EventBus/
+# Kinesis-provisioned. deploy -> first check (pre-record) MUST be CLEAN (zero
+# [Potential Drift] — grep the output, the exit code is 0 on baseline-less
+# potential drift) -> record -> check MUST be CLEAN.
+# The detect/revert half (batch-3 convergence probe) is verify-detect.sh.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714RevConv2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/variants2-hunt/app.ts
+++ b/tests/integration/variants2-hunt/app.ts
@@ -1,0 +1,85 @@
+// False-positive probe (real AWS): three common VARIANT axes with zero fixture
+// coverage in their barest form — a default is frequently a function of the
+// variant, so a variant never deployed is an unguarded fold gap (#1477 class):
+// - AWS::EFS::FileSystem One Zone (AvailabilityZoneName) — every existing EFS
+//   fixture is Regional; One Zone materializes AvailabilityZoneId and may
+//   default differently.
+// - AWS::SageMaker::EndpointConfig SERVERLESS variant (ServerlessConfig, no
+//   instanceType/count) — sagemaker-epc-min covers only the instance variant.
+// - AWS::KinesisFirehose::DeliveryStream HttpEndpointDestinationConfiguration
+//   (Datadog/Splunk-style) — every existing Firehose fixture is ExtendedS3.
+// Nothing here bills while idle (EPC/Model are metadata; Firehose DirectPut
+// with no producers; empty EFS). Pinned to us-east-1 (DLC image + AZ name).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnFileSystem } from "aws-cdk-lib/aws-efs";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnEndpointConfig, CfnModel } from "aws-cdk-lib/aws-sagemaker";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714Var2");
+
+// --- EFS One Zone, barest (no VPC needed; mount targets are what need one) ---
+new CfnFileSystem(stack, "HuntOneZoneFs", {
+  availabilityZoneName: "us-east-1a",
+});
+
+// --- SageMaker serverless EndpointConfig, barest serverless variant ---
+const smRole = new Role(stack, "HuntSmRole", {
+  assumedBy: new ServicePrincipal("sagemaker.amazonaws.com"),
+});
+const model = new CfnModel(stack, "HuntSmModel", {
+  executionRoleArn: smRole.roleArn,
+  primaryContainer: {
+    image: "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-scikit-learn:1.2-1-cpu-py3",
+  },
+});
+new CfnEndpointConfig(stack, "HuntServerlessEpc", {
+  productionVariants: [
+    {
+      modelName: model.attrModelName,
+      variantName: "AllTraffic",
+      serverlessConfig: {
+        maxConcurrency: 5,
+        memorySizeInMb: 2048,
+      },
+    },
+  ],
+});
+
+// --- Firehose HTTP-endpoint destination, barest (S3 backup config is required) ---
+// No autoDeleteObjects: DirectPut with no producers never writes a byte, and
+// skipping it avoids the custom-resource Lambda + its orphan log group.
+const backupBucket = new Bucket(stack, "HuntFirehoseBackup", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const fhRole = new Role(stack, "HuntFirehoseRole", {
+  assumedBy: new ServicePrincipal("firehose.amazonaws.com"),
+});
+fhRole.addToPolicy(
+  new PolicyStatement({
+    actions: ["s3:AbortMultipartUpload", "s3:GetBucketLocation", "s3:GetObject", "s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:PutObject"],
+    resources: [backupBucket.bucketArn, `${backupBucket.bucketArn}/*`],
+  }),
+);
+new CfnDeliveryStream(stack, "HuntHttpFirehose", {
+  httpEndpointDestinationConfiguration: {
+    endpointConfiguration: {
+      // Firehose validates the URL shape at create (https, port 443/unspecified,
+      // real-looking domain — a `.invalid` TLD is REJECTED with "Invalid Url").
+      // example.com is reserved + resolvable; nothing is ever delivered (DirectPut,
+      // no producers), so no traffic reaches it.
+      url: "https://example.com/cdkrd-hunt",
+      name: "hunt-endpoint",
+    },
+    s3Configuration: {
+      bucketArn: backupBucket.bucketArn,
+      roleArn: fhRole.roleArn,
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/variants2-hunt/cdk.json
+++ b/tests/integration/variants2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/variants2-hunt/package.json
+++ b/tests/integration/variants2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-variants2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "First-run FP probe for three uncovered common variants in their barest form: EFS One Zone, SageMaker serverless EndpointConfig, Firehose HTTP-endpoint destination. deploy -> first check (pre-record) MUST be CLEAN. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/variants2-hunt/verify.sh
+++ b/tests/integration/variants2-hunt/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest EFS One Zone + SageMaker
+# serverless EndpointConfig + Firehose HTTP-endpoint destination.
+# deploy -> first check (pre-record) MUST be CLEAN (zero [Potential Drift] —
+# grep the output, the exit code is 0 on baseline-less potential drift) ->
+# record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Var2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -602,6 +602,26 @@ describe('noise suppressors', () => {
         IntervalInSeconds: 300,
         SizeInMBs: 5,
       },
+      // The HTTP-endpoint destination's echo twins (live-proven, variants2-hunt
+      // 2026-07-14). Note S3BackupMode's per-variant default differs from ExtendedS3.
+      'HttpEndpointDestinationConfiguration.RequestConfiguration': {
+        CommonAttributes: [],
+        ContentEncoding: 'NONE',
+      },
+      'HttpEndpointDestinationConfiguration.BufferingHints': {
+        IntervalInSeconds: 300,
+        SizeInMBs: 5,
+      },
+      'HttpEndpointDestinationConfiguration.RetryOptions': { DurationInSeconds: 300 },
+      'HttpEndpointDestinationConfiguration.S3BackupMode': 'FailedDataOnly',
+      'HttpEndpointDestinationConfiguration.S3Configuration.BufferingHints': {
+        IntervalInSeconds: 300,
+        SizeInMBs: 5,
+      },
+      'HttpEndpointDestinationConfiguration.S3Configuration.CompressionFormat': 'UNCOMPRESSED',
+      'HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration': {
+        NoEncryptionConfig: 'NoEncryption',
+      },
     });
   });
 

--- a/tests/noise-firstrun-folds.test.ts
+++ b/tests/noise-firstrun-folds.test.ts
@@ -309,3 +309,127 @@ describe('#847 AutoScaling ScheduledAction StartTime / EndTime (undeclared, time
     expect(pathsByTier(f, 'atDefault')).not.toContain('EndTime');
   });
 });
+
+describe('ECR Repository ImageScanningConfiguration default (revconv2-hunt 2026-07-14)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Repo',
+    resourceType: 'AWS::ECR::Repository',
+    physicalId: 'repo',
+    declared: {},
+  };
+  it('folds {ScanOnPush:false} to atDefault (via the KNOWN_DEFAULTS pin, not the trivial-empty drop)', () => {
+    const f = classifyResource(
+      res,
+      { ImageScanningConfiguration: { ScanOnPush: false } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('ImageScanningConfiguration');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('ImageScanningConfiguration');
+  });
+  it('surfaces an out-of-band scan-on-push enable as undeclared (detection preserved)', () => {
+    const f = classifyResource(
+      res,
+      { ImageScanningConfiguration: { ScanOnPush: true } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('ImageScanningConfiguration');
+  });
+});
+
+describe('EFS FileSystem BackupPolicy — One Zone derived default (variants2-hunt 2026-07-14)', () => {
+  const oneZone: DesiredResource = {
+    logicalId: 'OneZoneFs',
+    resourceType: 'AWS::EFS::FileSystem',
+    physicalId: 'fs-1',
+    declared: { AvailabilityZoneName: 'us-east-1a' },
+  };
+  const regional: DesiredResource = {
+    logicalId: 'RegionalFs',
+    resourceType: 'AWS::EFS::FileSystem',
+    physicalId: 'fs-2',
+    declared: {},
+  };
+  it('One Zone: folds the ENABLED backup default to atDefault (derived from AvailabilityZoneName)', () => {
+    const f = classifyResource(oneZone, { BackupPolicy: { Status: 'ENABLED' } }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('BackupPolicy');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('BackupPolicy');
+  });
+  it('One Zone: an out-of-band backup DISABLE still surfaces as undeclared (detection preserved)', () => {
+    const f = classifyResource(oneZone, { BackupPolicy: { Status: 'DISABLED' } }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('BackupPolicy');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('BackupPolicy');
+  });
+  it('Regional: still folds the DISABLED constant (falls through to KNOWN_DEFAULTS)', () => {
+    const f = classifyResource(regional, { BackupPolicy: { Status: 'DISABLED' } }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('BackupPolicy');
+  });
+  it('Regional: an out-of-band backup ENABLE still surfaces as undeclared', () => {
+    const f = classifyResource(regional, { BackupPolicy: { Status: 'ENABLED' } }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('BackupPolicy');
+  });
+});
+
+describe('Firehose HTTP-endpoint destination first-run echo family (variants2-hunt 2026-07-14)', () => {
+  // A barest HttpEndpointDestinationConfiguration (url + name + required S3 backup config)
+  // reads back 7 materialized constants — the HTTP-variant twins of the ExtendedS3 family.
+  const declared = {
+    HttpEndpointDestinationConfiguration: {
+      EndpointConfiguration: { Url: 'https://example.com/cdkrd-hunt', Name: 'hunt-endpoint' },
+      S3Configuration: { BucketARN: 'arn:aws:s3:::backup', RoleARN: 'arn:aws:iam::1:role/fh' },
+    },
+  };
+  const res: DesiredResource = {
+    logicalId: 'HttpFirehose',
+    resourceType: 'AWS::KinesisFirehose::DeliveryStream',
+    physicalId: 'stream',
+    declared,
+  };
+  const live = {
+    HttpEndpointDestinationConfiguration: {
+      EndpointConfiguration: { Url: 'https://example.com/cdkrd-hunt', Name: 'hunt-endpoint' },
+      S3Configuration: {
+        BucketARN: 'arn:aws:s3:::backup',
+        RoleARN: 'arn:aws:iam::1:role/fh',
+        BufferingHints: { IntervalInSeconds: 300, SizeInMBs: 5 },
+        CompressionFormat: 'UNCOMPRESSED',
+        EncryptionConfiguration: { NoEncryptionConfig: 'NoEncryption' },
+      },
+      RequestConfiguration: { CommonAttributes: [], ContentEncoding: 'NONE' },
+      BufferingHints: { IntervalInSeconds: 300, SizeInMBs: 5 },
+      RetryOptions: { DurationInSeconds: 300 },
+      S3BackupMode: 'FailedDataOnly',
+    },
+  };
+  it('folds all 7 materialized HTTP-endpoint echo constants to atDefault (zero undeclared)', () => {
+    const f = classifyResource(res, live, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'declared')).toEqual([]);
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining([
+        'HttpEndpointDestinationConfiguration.RequestConfiguration',
+        'HttpEndpointDestinationConfiguration.BufferingHints',
+        'HttpEndpointDestinationConfiguration.RetryOptions',
+        'HttpEndpointDestinationConfiguration.S3BackupMode',
+        'HttpEndpointDestinationConfiguration.S3Configuration.BufferingHints',
+        'HttpEndpointDestinationConfiguration.S3Configuration.CompressionFormat',
+        'HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration',
+      ])
+    );
+  });
+  it('an out-of-band buffering / backup-mode change still surfaces (equality-gated)', () => {
+    const mutated = structuredClone(live);
+    mutated.HttpEndpointDestinationConfiguration.BufferingHints = {
+      IntervalInSeconds: 900,
+      SizeInMBs: 5,
+    };
+    (mutated.HttpEndpointDestinationConfiguration as Record<string, unknown>)['S3BackupMode'] =
+      'AllData';
+    const f = classifyResource(res, mutated, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(
+      expect.arrayContaining([
+        'HttpEndpointDestinationConfiguration.BufferingHints',
+        'HttpEndpointDestinationConfiguration.S3BackupMode',
+      ])
+    );
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1507,6 +1507,27 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('ECR Repository ImageScanningConfiguration (SET-DEFAULT) -> add op writing {ScanOnPush:false}, not a no-op remove', () => {
+    // Live-proven on revconv2-hunt 2026-07-14: scan-on-push enabled out of band, `revert`
+    // planned a `remove`, Cloud Control reported reverted, yet `describe-repositories`
+    // stayed scanOnPush=true — the same ECR partial-update contract as ImageTagMutability
+    // (#1580). Revert must write the {ScanOnPush:false} default (from KNOWN_DEFAULTS)
+    // explicitly so it converges.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ECR::Repository',
+      path: 'ImageScanningConfiguration',
+      actual: { ScanOnPush: true },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ImageScanningConfiguration',
+      value: { ScanOnPush: false },
+      prior: { ScanOnPush: true },
+    });
+  });
+
   it('#1583: SQS Queue MaximumMessageSize (SET-DEFAULT) -> add op writing 1048576, not a no-op remove', () => {
     // #1583 (live-proven on revert-noop-probe 2026-07-14): mutated 1048576->262144 out of
     // band, then `revert` planned a `remove`, reported reverted, yet the queue stayed 262144.


### PR DESCRIPTION
## Summary

Three live-found bug classes from a /hunt-bugs sweep (2026-07-14), all live-verified A/B with the fixed binary. Issue filing was denied by the session's permission mode, so the full repro evidence lives in this PR body.

### 1. EFS One Zone `BackupPolicy` first-run FP (`src/diff/classify.ts`)

A barest One Zone file system (`AvailabilityZoneName` declared, nothing else) first-ran:

```
HuntOneZoneFs.BackupPolicy (AWS::EFS::FileSystem)  actual={"Status":"ENABLED"}
```

AWS enables automatic backups **by default for One Zone** file systems — the opposite of the Regional default the `KNOWN_DEFAULTS` constant pins (`{Status:'DISABLED'}`). Tier-2 derived fold gated on the declared `AvailabilityZoneName`; Regional falls through to the constant; an out-of-band backup disable on a One Zone fs still surfaces (unit-tested both ways).

### 2. Firehose HTTP-endpoint destination first-run echo family (`src/normalize/noise.ts`)

Every existing Firehose fixture/corpus case was ExtendedS3; a barest `HttpEndpointDestinationConfiguration` (url + name + required S3 backup config) first-ran **7 FPs**: `RequestConfiguration`, `BufferingHints`, `RetryOptions`, `S3BackupMode`, `S3Configuration.{BufferingHints,CompressionFormat,EncryptionConfiguration}`. All documented stable constants, equality-gated. Per-variant caveat baked into the comment: HTTP's `S3BackupMode` default is `FailedDataOnly`, NOT ExtendedS3's `Disabled` — destination-union variants carry their own default families.

### 3. ECR `ImageScanningConfiguration` revert no-op (`noise.ts` + `revert/plan.ts`)

Revert-convergence batch 3 (six folded mutable surfaces mutated out of band on `revconv2-hunt`): detection fired 6/6, and the bare `remove` converged on **5/6** live — DDB `PointInTimeRecoverySpecification` (PITR back to DISABLED), S3 `VersioningConfiguration` (handler actually SUSPENDS), LogGroup `RetentionInDays`, EventBus `LogConfig`, Kinesis `StreamModeDetails` (ON_DEMAND→PROVISIONED). The one silent no-op: **ECR scan-on-push stayed `true` while revert reported reverted** — the same ECR partial-update contract as `ImageTagMutability` (#1580). Fix: `KNOWN_DEFAULTS` pin `{ScanOnPush:false}` + `REVERT_SET_DEFAULT_PATHS` entry; re-run with the fixed binary plans `-> AWS default`, live reads `scanOnPush=False`, CLEAN after revert.

**ECR class closed live**: `RepositoryPolicyText` / `LifecyclePolicy` removes DO converge (both policies live-deleted after revert), so the partial-update gap is exactly the two scalars — per-property non-uniformity, per the batch-1/2 lesson.

### Bonus determinations (no code change needed)

- Neptune mixed-case identifier family upgraded docs-verified → **live-verified** (CC `create-resource` passes mixed-case `DBClusterIdentifier`/`DBSubnetGroupName` through, stored echo lowercased; instance raw echo lowercased) — comment updated.
- DDB TTL (1 change/h) and EFS ThroughputMode (1 change/24h) are excluded from in-run revert probes by AWS rate limits — recorded in the fixture + skill.

## Verification

- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` — 293 files, 5730 tests green (includes new fold/derive/set-default tests + 3 promoted corpus cases + updated ECR corpus expected).
- Live A/B: `CdkrdHunt0714Var2` BASE 8 FP → FIX first-check CLEAN → record → check CLEAN; `CdkrdHunt0714RevConv2` first-check CLEAN → 6 OOB mutations detected → revert → 5 converge + ECR no-op → FIX revert converges (live values asserted for all six).
- Shared CORE suite deferred — diff fully covered by unit + corpus replay and live-proven in this hunt (per verify-pr §7 deferral rule).
- Cleanup: both stacks delstack-deleted, Neptune probe resources gone, `sweep-orphans.sh` SWEEP CLEAN, bughunt gate released.

New regression fixtures: `tests/integration/variants2-hunt` (first-run FP probe: EFS One Zone / SageMaker serverless EPC / Firehose HTTP), `tests/integration/revconv2-hunt` (six-surface detect/revert convergence probe).
