### PR TITLE
fix(check): shape-gated fold for barest VPN tunnel options + OpenSearch dedicated-master count default

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1570,6 +1570,46 @@ function clbDefaultSslPoliciesAtDefault(
   );
 }
 
+// #1604: a VPNConnection that declares no VpnTunnelOptionsSpecifications reads back both
+// tunnels' AWS-materialized options: a RANDOM link-local TunnelInsideCidr per tunnel (not
+// pinnable, not derivable), empty phase-1/2 algorithm + IKE-version restriction lists, and
+// logging off. NOT value-independent — tunnel options are OOB-mutable
+// (`modify-vpn-tunnel-options`) and security-relevant (weakened IKE/phase algorithms, a
+// logging disable), the #1266 class — so this is a SHAPE gate: fold only while every element
+// carries nothing but the pristine-creation members (restriction lists empty, both log flags
+// false, the AWS-assigned inside CIDRs). Any out-of-band restriction/enable adds or flips a
+// member, the shape no longer matches, and the whole path surfaces. A user who manages
+// tunnel options DECLARES them (the harvest12 shape) and is compared in the declared loop.
+const VPN_TUNNEL_EMPTY_LIST_KEYS = new Set([
+  'Phase1EncryptionAlgorithms',
+  'Phase1IntegrityAlgorithms',
+  'Phase1DHGroupNumbers',
+  'Phase2EncryptionAlgorithms',
+  'Phase2IntegrityAlgorithms',
+  'Phase2DHGroupNumbers',
+  'IKEVersions',
+]);
+const VPN_TUNNEL_INSIDE_CIDR = /^169\.254\.\d{1,3}\.\d{1,3}\/30$/;
+function vpnTunnelOptionsAtDefault(resourceType: string, key: string, value: unknown): boolean {
+  if (resourceType !== 'AWS::EC2::VPNConnection' || key !== 'VpnTunnelOptionsSpecifications')
+    return false;
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every((el) => {
+    if (!isNestedObject(el)) return false;
+    return Object.entries(el).every(([k, v]) => {
+      if (VPN_TUNNEL_EMPTY_LIST_KEYS.has(k)) return Array.isArray(v) && v.length === 0;
+      if (k === 'TunnelInsideCidr') return typeof v === 'string' && VPN_TUNNEL_INSIDE_CIDR.test(v);
+      // dual-stack/ipv6 VPNs carry an AWS-assigned inside IPv6 CIDR instead
+      if (k === 'TunnelInsideIpv6Cidr') return typeof v === 'string';
+      if (k === 'LogOptions')
+        return deepEqual(v, { CloudwatchLogOptions: { BgpLogEnabled: false, LogEnabled: false } });
+      // any other member (a lifetime knob, a DPD action, a PSK echo…) only appears when
+      // someone SET it — a real divergence, so the shape gate fails and the path surfaces
+      return false;
+    });
+  });
+}
+
 // A CloudFormation AUTO-GENERATED physical name. When a resource declares no explicit name,
 // CFn mints `<stackName>-<logicalId>-<random>` (the stack name is the FIRST segment of the
 // CDK construct path). DELIBERATELY strict — it must start with this stack's name AND end
@@ -5045,7 +5085,11 @@ export function classifyResource(
         !(k in knownDef)) ||
       // #705: a Classic ELB's undeclared Policies folds atDefault ONLY when it is exactly the
       // AWS default SSL negotiation policy (by PolicyName); a downgrade / added policy surfaces.
-      clbDefaultSslPoliciesAtDefault(resourceType, k, v)
+      clbDefaultSslPoliciesAtDefault(resourceType, k, v) ||
+      // #1604: a barest VPNConnection's materialized tunnel options fold ONLY in their
+      // pristine-creation shape (random inside CIDRs + empty restriction lists + logging
+      // off); an out-of-band tunnel-options change breaks the shape and surfaces.
+      vpnTunnelOptionsAtDefault(resourceType, k, v)
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2325,6 +2325,10 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // opensearch-multiaz-min 2026-07-14 — the Multi-AZ variant axis was previously
     // undeployed). Equality-gated: an out-of-band 3-AZ move breaks the pin and surfaces.
     'ClusterConfig.ZoneAwarenessConfig': { AvailabilityZoneCount: 2 },
+    // A domain with DedicatedMasterEnabled=true but no DedicatedMasterCount reads back the
+    // documented default of 3 masters (#1605, live-proven on os-variants2-min 2026-07-14).
+    // Equality-gated: an out-of-band scale to 5 masters surfaces.
+    'ClusterConfig.DedicatedMasterCount': 3,
   },
   'AWS::KinesisFirehose::DeliveryStream': {
     // S3 backup is Disabled by default when a destination declares no backup mode.

--- a/tests/corpus/AWS__EC2__VPNConnection.HuntVpn.json
+++ b/tests/corpus/AWS__EC2__VPNConnection.HuntVpn.json
@@ -1,0 +1,224 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntVpn",
+    "resourceType": "AWS::EC2::VPNConnection",
+    "physicalId": "vpn-09228c44c422987ac",
+    "constructPath": "CdkrdHunt0714VpnRoute/HuntVpn",
+    "declared": {
+      "CustomerGatewayId": "cgw-078237bf5e8489d90",
+      "StaticRoutesOnly": true,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Type": "ipsec.1",
+      "VpnGatewayId": "vgw-03685926b9436e67e"
+    }
+  },
+  "liveRaw": {
+    "RemoteIpv4NetworkCidr": "0.0.0.0/0",
+    "VpnTunnelOptionsSpecifications": [
+      {
+        "Phase2EncryptionAlgorithms": [],
+        "Phase2DHGroupNumbers": [],
+        "Phase2IntegrityAlgorithms": [],
+        "Phase1IntegrityAlgorithms": [],
+        "TunnelInsideCidr": "169.254.61.176/30",
+        "IKEVersions": [],
+        "LogOptions": {
+          "CloudwatchLogOptions": {
+            "BgpLogEnabled": false,
+            "LogEnabled": false
+          }
+        },
+        "Phase1EncryptionAlgorithms": [],
+        "Phase1DHGroupNumbers": []
+      },
+      {
+        "Phase2EncryptionAlgorithms": [],
+        "Phase2DHGroupNumbers": [],
+        "Phase2IntegrityAlgorithms": [],
+        "Phase1IntegrityAlgorithms": [],
+        "TunnelInsideCidr": "169.254.61.164/30",
+        "IKEVersions": [],
+        "LogOptions": {
+          "CloudwatchLogOptions": {
+            "BgpLogEnabled": false,
+            "LogEnabled": false
+          }
+        },
+        "Phase1EncryptionAlgorithms": [],
+        "Phase1DHGroupNumbers": []
+      }
+    ],
+    "CustomerGatewayId": "cgw-078237bf5e8489d90",
+    "OutsideIpAddressType": "PublicIpv4",
+    "StaticRoutesOnly": true,
+    "EnableAcceleration": false,
+    "Type": "ipsec.1",
+    "TunnelBandwidth": "standard",
+    "LocalIpv4NetworkCidr": "0.0.0.0/0",
+    "VpnGatewayId": "vgw-03685926b9436e67e",
+    "VpnConnectionId": "vpn-09228c44c422987ac",
+    "TunnelInsideIpVersion": "ipv4",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714VpnRoute",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntVpn",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714VpnRoute/630435c0-7f44-11f1-b193-0affee47f7cd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["VpnConnectionId"],
+    "writeOnly": ["PreSharedKeyStorage"],
+    "createOnly": [
+      "EnableAcceleration",
+      "LocalIpv4NetworkCidr",
+      "LocalIpv6NetworkCidr",
+      "OutsideIpAddressType",
+      "PreSharedKeyStorage",
+      "RemoteIpv4NetworkCidr",
+      "RemoteIpv6NetworkCidr",
+      "StaticRoutesOnly",
+      "TransportTransitGatewayAttachmentId",
+      "TunnelInsideIpVersion",
+      "Type",
+      "VpnConcentratorId"
+    ],
+    "readOnlyPaths": ["VpnConnectionId"],
+    "writeOnlyPaths": ["PreSharedKeyStorage", "VpnTunnelOptionsSpecifications.*.PreSharedKey"],
+    "createOnlyPaths": [
+      "EnableAcceleration",
+      "LocalIpv4NetworkCidr",
+      "LocalIpv6NetworkCidr",
+      "OutsideIpAddressType",
+      "PreSharedKeyStorage",
+      "RemoteIpv4NetworkCidr",
+      "RemoteIpv6NetworkCidr",
+      "StaticRoutesOnly",
+      "TransportTransitGatewayAttachmentId",
+      "TunnelInsideIpVersion",
+      "Type",
+      "VpnConcentratorId"
+    ],
+    "defaults": {
+      "TunnelBandwidth": "standard"
+    },
+    "defaultPaths": {
+      "TunnelBandwidth": "standard"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["VpnTunnelOptionsSpecifications"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntVpn",
+      "resourceType": "AWS::EC2::VPNConnection",
+      "path": "RemoteIpv4NetworkCidr",
+      "actual": "0.0.0.0/0",
+      "physicalId": "vpn-09228c44c422987ac",
+      "constructPath": "CdkrdHunt0714VpnRoute/HuntVpn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntVpn",
+      "resourceType": "AWS::EC2::VPNConnection",
+      "path": "VpnTunnelOptionsSpecifications",
+      "actual": [
+        {
+          "Phase2EncryptionAlgorithms": [],
+          "Phase2DHGroupNumbers": [],
+          "Phase2IntegrityAlgorithms": [],
+          "Phase1IntegrityAlgorithms": [],
+          "TunnelInsideCidr": "169.254.61.164/30",
+          "IKEVersions": [],
+          "LogOptions": {
+            "CloudwatchLogOptions": {
+              "BgpLogEnabled": false,
+              "LogEnabled": false
+            }
+          },
+          "Phase1EncryptionAlgorithms": [],
+          "Phase1DHGroupNumbers": []
+        },
+        {
+          "Phase2EncryptionAlgorithms": [],
+          "Phase2DHGroupNumbers": [],
+          "Phase2IntegrityAlgorithms": [],
+          "Phase1IntegrityAlgorithms": [],
+          "TunnelInsideCidr": "169.254.61.176/30",
+          "IKEVersions": [],
+          "LogOptions": {
+            "CloudwatchLogOptions": {
+              "BgpLogEnabled": false,
+              "LogEnabled": false
+            }
+          },
+          "Phase1EncryptionAlgorithms": [],
+          "Phase1DHGroupNumbers": []
+        }
+      ],
+      "physicalId": "vpn-09228c44c422987ac",
+      "constructPath": "CdkrdHunt0714VpnRoute/HuntVpn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntVpn",
+      "resourceType": "AWS::EC2::VPNConnection",
+      "path": "OutsideIpAddressType",
+      "actual": "PublicIpv4",
+      "physicalId": "vpn-09228c44c422987ac",
+      "constructPath": "CdkrdHunt0714VpnRoute/HuntVpn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntVpn",
+      "resourceType": "AWS::EC2::VPNConnection",
+      "path": "TunnelBandwidth",
+      "actual": "standard",
+      "physicalId": "vpn-09228c44c422987ac",
+      "constructPath": "CdkrdHunt0714VpnRoute/HuntVpn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntVpn",
+      "resourceType": "AWS::EC2::VPNConnection",
+      "path": "LocalIpv4NetworkCidr",
+      "actual": "0.0.0.0/0",
+      "physicalId": "vpn-09228c44c422987ac",
+      "constructPath": "CdkrdHunt0714VpnRoute/HuntVpn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntVpn",
+      "resourceType": "AWS::EC2::VPNConnection",
+      "path": "TunnelInsideIpVersion",
+      "actual": "ipv4",
+      "physicalId": "vpn-09228c44c422987ac",
+      "constructPath": "CdkrdHunt0714VpnRoute/HuntVpn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VPNConnectionRoute.HuntVpnRoute.json
+++ b/tests/corpus/AWS__EC2__VPNConnectionRoute.HuntVpnRoute.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntVpnRoute",
+    "resourceType": "AWS::EC2::VPNConnectionRoute",
+    "physicalId": "203.0.113.0/24|vpn-09228c44c422987ac",
+    "constructPath": "CdkrdHunt0714VpnRoute/HuntVpnRoute",
+    "declared": {
+      "DestinationCidrBlock": "203.0.113.0/24",
+      "VpnConnectionId": "vpn-09228c44c422987ac"
+    }
+  },
+  "liveRaw": {
+    "DestinationCidrBlock": "203.0.113.0/24",
+    "VpnConnectionId": "vpn-09228c44c422987ac"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DestinationCidrBlock", "VpnConnectionId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DestinationCidrBlock", "VpnConnectionId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__OpenSearchService__Domain.HuntEsLegacy.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.HuntEsLegacy.json
@@ -1,0 +1,293 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEsLegacy",
+    "resourceType": "AWS::OpenSearchService::Domain",
+    "physicalId": "hunteslegacy-pihhhwnpxkn6",
+    "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy",
+    "declared": {
+      "ClusterConfig": {
+        "InstanceCount": 1,
+        "InstanceType": "t3.small.search"
+      },
+      "EBSOptions": {
+        "EBSEnabled": true,
+        "VolumeSize": 10
+      },
+      "EngineVersion": "Elasticsearch_7.10",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SnapshotOptions": {
+      "AutomatedSnapshotStartHour": 0
+    },
+    "NodeToNodeEncryptionOptions": {
+      "Enabled": false
+    },
+    "DomainEndpoints": {},
+    "DomainEndpointOptions": {
+      "CustomEndpointEnabled": false,
+      "EnforceHTTPS": false,
+      "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+    },
+    "DomainArn": "arn:aws:es:us-east-1:111111111111:domain/hunteslegacy-pihhhwnpxkn6",
+    "CognitoOptions": {
+      "Enabled": false
+    },
+    "AdvancedOptions": {
+      "override_main_response_version": "false",
+      "rest.action.multi.allow_explicit_index": "true"
+    },
+    "IPAddressType": "ipv4",
+    "EBSOptions": {
+      "EBSEnabled": true,
+      "VolumeType": "gp3",
+      "Throughput": 125,
+      "Iops": 3000,
+      "VolumeSize": 10
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "EngineVersion": "Elasticsearch_7.10",
+    "SoftwareUpdateOptions": {
+      "AutoSoftwareUpdateEnabled": false
+    },
+    "DomainName": "hunteslegacy-pihhhwnpxkn6",
+    "LogPublishingOptions": {},
+    "AIMLOptions": {
+      "S3VectorsEngine": {
+        "Enabled": false
+      },
+      "ServerlessVectorAcceleration": {
+        "Enabled": false
+      }
+    },
+    "AutomatedSnapshotPauseOptions": {
+      "Enabled": false
+    },
+    "DeploymentStrategyOptions": {
+      "DeploymentStrategy": "CapacityOptimized"
+    },
+    "AdvancedSecurityOptions": {
+      "AnonymousAuthEnabled": false,
+      "InternalUserDatabaseEnabled": false,
+      "Enabled": false,
+      "AnonymousAuthDisableDate": "null"
+    },
+    "DomainEndpoint": "search-hunteslegacy-pihhhwnpxkn6-t7cevfl7i42hjzmlccu5etfria.us-east-1.es.amazonaws.com",
+    "ServiceSoftwareOptions": {
+      "NewVersion": "",
+      "UpdateStatus": "COMPLETED",
+      "Description": "There is no software update available for this domain.",
+      "Cancellable": false,
+      "CurrentVersion": "Elasticsearch_7_10_R20260626",
+      "AutomatedUpdateDate": "1970-01-01T00:00:00Z",
+      "UpdateAvailable": false,
+      "OptionalDeployment": true
+    },
+    "IdentityCenterOptions": {},
+    "Id": "111111111111/hunteslegacy-pihhhwnpxkn6",
+    "Arn": "arn:aws:es:us-east-1:111111111111:domain/hunteslegacy-pihhhwnpxkn6",
+    "EncryptionAtRestOptions": {
+      "Enabled": false
+    },
+    "OffPeakWindowOptions": {
+      "OffPeakWindow": {
+        "WindowStartTime": {
+          "Hours": 2,
+          "Minutes": 0
+        }
+      },
+      "Enabled": true
+    },
+    "ClusterConfig": {
+      "InstanceCount": 1,
+      "MultiAZWithStandbyEnabled": false,
+      "WarmEnabled": false,
+      "DedicatedMasterEnabled": false,
+      "ColdStorageOptions": {
+        "Enabled": false
+      },
+      "InstanceType": "t3.small.search",
+      "ZoneAwarenessEnabled": false
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnly": [],
+    "createOnly": ["DomainName"],
+    "readOnlyPaths": [
+      "AdvancedSecurityOptions.AnonymousAuthDisableDate",
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "IdentityCenterOptions.IdentityCenterApplicationARN",
+      "IdentityCenterOptions.IdentityStoreId",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnlyPaths": [
+      "AdvancedSecurityOptions.JWTOptions.PublicKey",
+      "AdvancedSecurityOptions.MasterUserOptions",
+      "AdvancedSecurityOptions.SAMLOptions.MasterBackendRole",
+      "AdvancedSecurityOptions.SAMLOptions.MasterUserName"
+    ],
+    "createOnlyPaths": ["DomainName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["AdvancedOptions", "DomainEndpoints", "LogPublishingOptions"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "SnapshotOptions",
+      "actual": {
+        "AutomatedSnapshotStartHour": 0
+      },
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "DomainEndpointOptions",
+      "actual": {
+        "CustomEndpointEnabled": false,
+        "EnforceHTTPS": false,
+        "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+      },
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "AdvancedOptions",
+      "actual": {
+        "override_main_response_version": "false",
+        "rest.action.multi.allow_explicit_index": "true"
+      },
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "IPAddressType",
+      "actual": "ipv4",
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "DeploymentStrategyOptions",
+      "actual": {
+        "DeploymentStrategy": "CapacityOptimized"
+      },
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "OffPeakWindowOptions",
+      "actual": {
+        "OffPeakWindow": {
+          "WindowStartTime": {
+            "Hours": 2,
+            "Minutes": 0
+          }
+        },
+        "Enabled": true
+      },
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.VolumeType",
+      "actual": "gp3",
+      "nested": true,
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Throughput",
+      "actual": 125,
+      "nested": true,
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEsLegacy",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Iops",
+      "actual": 3000,
+      "nested": true,
+      "physicalId": "hunteslegacy-pihhhwnpxkn6",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntEsLegacy"
+    }
+  ]
+}

--- a/tests/corpus/AWS__OpenSearchService__Domain.HuntOsDedMaster.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.HuntOsDedMaster.json
@@ -1,0 +1,331 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOsDedMaster",
+    "resourceType": "AWS::OpenSearchService::Domain",
+    "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+    "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster",
+    "declared": {
+      "ClusterConfig": {
+        "DedicatedMasterEnabled": true,
+        "DedicatedMasterType": "t3.small.search",
+        "InstanceCount": 2,
+        "InstanceType": "t3.small.search",
+        "ZoneAwarenessEnabled": true
+      },
+      "EBSOptions": {
+        "EBSEnabled": true,
+        "VolumeSize": 10
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SnapshotOptions": {
+      "AutomatedSnapshotStartHour": 0
+    },
+    "NodeToNodeEncryptionOptions": {
+      "Enabled": false
+    },
+    "DomainEndpoints": {},
+    "DomainEndpointOptions": {
+      "CustomEndpointEnabled": false,
+      "EnforceHTTPS": false,
+      "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+    },
+    "DomainArn": "arn:aws:es:us-east-1:111111111111:domain/huntosdedmaster-qi8cuff4lgjq",
+    "CognitoOptions": {
+      "Enabled": false
+    },
+    "AdvancedOptions": {
+      "override_main_response_version": "false",
+      "rest.action.multi.allow_explicit_index": "true"
+    },
+    "IPAddressType": "ipv4",
+    "EBSOptions": {
+      "EBSEnabled": true,
+      "VolumeType": "gp3",
+      "Throughput": 125,
+      "Iops": 3000,
+      "VolumeSize": 10
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "EngineVersion": "OpenSearch_3.5",
+    "SoftwareUpdateOptions": {
+      "AutoSoftwareUpdateEnabled": false
+    },
+    "DomainName": "huntosdedmaster-qi8cuff4lgjq",
+    "LogPublishingOptions": {},
+    "AIMLOptions": {
+      "S3VectorsEngine": {
+        "Enabled": false
+      },
+      "ServerlessVectorAcceleration": {
+        "Enabled": false
+      }
+    },
+    "AutomatedSnapshotPauseOptions": {
+      "Enabled": false
+    },
+    "DeploymentStrategyOptions": {
+      "DeploymentStrategy": "CapacityOptimized"
+    },
+    "AdvancedSecurityOptions": {
+      "AnonymousAuthEnabled": false,
+      "InternalUserDatabaseEnabled": false,
+      "Enabled": false,
+      "AnonymousAuthDisableDate": "null"
+    },
+    "DomainEndpoint": "search-huntosdedmaster-qi8cuff4lgjq-kvpetebylmzp6jd46jukeddjga.us-east-1.es.amazonaws.com",
+    "ServiceSoftwareOptions": {
+      "NewVersion": "",
+      "UpdateStatus": "COMPLETED",
+      "Description": "There is no software update available for this domain.",
+      "Cancellable": false,
+      "CurrentVersion": "OpenSearch_3_5_R20260428-P3",
+      "AutomatedUpdateDate": "1970-01-01T00:00:00Z",
+      "UpdateAvailable": false,
+      "OptionalDeployment": true
+    },
+    "IdentityCenterOptions": {},
+    "Id": "111111111111/huntosdedmaster-qi8cuff4lgjq",
+    "Arn": "arn:aws:es:us-east-1:111111111111:domain/huntosdedmaster-qi8cuff4lgjq",
+    "EncryptionAtRestOptions": {
+      "Enabled": false
+    },
+    "OffPeakWindowOptions": {
+      "OffPeakWindow": {
+        "WindowStartTime": {
+          "Hours": 2,
+          "Minutes": 0
+        }
+      },
+      "Enabled": true
+    },
+    "ClusterConfig": {
+      "InstanceCount": 2,
+      "MultiAZWithStandbyEnabled": false,
+      "WarmEnabled": false,
+      "DedicatedMasterEnabled": true,
+      "ZoneAwarenessConfig": {
+        "AvailabilityZoneCount": 2
+      },
+      "DedicatedMasterCount": 3,
+      "ColdStorageOptions": {
+        "Enabled": false
+      },
+      "InstanceType": "t3.small.search",
+      "ZoneAwarenessEnabled": true,
+      "DedicatedMasterType": "t3.small.search"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnly": [],
+    "createOnly": ["DomainName"],
+    "readOnlyPaths": [
+      "AdvancedSecurityOptions.AnonymousAuthDisableDate",
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "IdentityCenterOptions.IdentityCenterApplicationARN",
+      "IdentityCenterOptions.IdentityStoreId",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnlyPaths": [
+      "AdvancedSecurityOptions.JWTOptions.PublicKey",
+      "AdvancedSecurityOptions.MasterUserOptions",
+      "AdvancedSecurityOptions.SAMLOptions.MasterBackendRole",
+      "AdvancedSecurityOptions.SAMLOptions.MasterUserName"
+    ],
+    "createOnlyPaths": ["DomainName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["AdvancedOptions", "DomainEndpoints", "LogPublishingOptions"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "SnapshotOptions",
+      "actual": {
+        "AutomatedSnapshotStartHour": 0
+      },
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "DomainEndpointOptions",
+      "actual": {
+        "CustomEndpointEnabled": false,
+        "EnforceHTTPS": false,
+        "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+      },
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "AdvancedOptions",
+      "actual": {
+        "override_main_response_version": "false",
+        "rest.action.multi.allow_explicit_index": "true"
+      },
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "IPAddressType",
+      "actual": "ipv4",
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EngineVersion",
+      "actual": "OpenSearch_3.5",
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "DeploymentStrategyOptions",
+      "actual": {
+        "DeploymentStrategy": "CapacityOptimized"
+      },
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "OffPeakWindowOptions",
+      "actual": {
+        "OffPeakWindow": {
+          "WindowStartTime": {
+            "Hours": 2,
+            "Minutes": 0
+          }
+        },
+        "Enabled": true
+      },
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "ClusterConfig.ZoneAwarenessConfig",
+      "actual": {
+        "AvailabilityZoneCount": 2
+      },
+      "nested": true,
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "ClusterConfig.DedicatedMasterCount",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.VolumeType",
+      "actual": "gp3",
+      "nested": true,
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Throughput",
+      "actual": 125,
+      "nested": true,
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntOsDedMaster",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Iops",
+      "actual": 3000,
+      "nested": true,
+      "physicalId": "huntosdedmaster-qi8cuff4lgjq",
+      "constructPath": "CdkrdHunt0714OsVariants2/HuntOsDedMaster"
+    }
+  ]
+}

--- a/tests/integration/os-variants2-min/app.ts
+++ b/tests/integration/os-variants2-min/app.ts
@@ -1,0 +1,45 @@
+// CDK app for the cdk-real-drift os-variants2-min false-positive integration test.
+// The two OpenSearchService Domain variant axes still un-deployed after
+// opensearch-multiaz-min (#1593):
+//   - DEDICATED MASTER: DedicatedMasterEnabled=true with count/type UNDECLARED —
+//     probes the materialized master defaults (documented count default 3; the
+//     type echo is the open question).
+//   - LEGACY ELASTICSEARCH ENGINE: EngineVersion=Elasticsearch_7.10 (declared to
+//     select the axis; still creatable) — probes ES-era default echoes
+//     (AdvancedOptions, endpoint options) against folds live-proven on
+//     OpenSearch_* engines only.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnDomain } from "aws-cdk-lib/aws-opensearchservice";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714OsVariants2");
+
+const dedMaster = new CfnDomain(stack, "HuntOsDedMaster", {
+  clusterConfig: {
+    instanceType: "t3.small.search",
+    instanceCount: 2,
+    zoneAwarenessEnabled: true,
+    dedicatedMasterEnabled: true,
+    dedicatedMasterType: "t3.small.search",
+  },
+  ebsOptions: {
+    ebsEnabled: true,
+    volumeSize: 10,
+  },
+});
+dedMaster.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+const esLegacy = new CfnDomain(stack, "HuntEsLegacy", {
+  engineVersion: "Elasticsearch_7.10",
+  clusterConfig: {
+    instanceType: "t3.small.search",
+    instanceCount: 1,
+  },
+  ebsOptions: {
+    ebsEnabled: true,
+    volumeSize: 10,
+  },
+});
+esLegacy.applyRemovalPolicy(RemovalPolicy.DESTROY);

--- a/tests/integration/os-variants2-min/cdk.json
+++ b/tests/integration/os-variants2-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/os-variants2-min/package.json
+++ b/tests/integration/os-variants2-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-os-variants2-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift os-variants2-min false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/os-variants2-min/verify.sh
+++ b/tests/integration/os-variants2-min/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): dedicated-master + legacy
+# Elasticsearch-engine OpenSearch domains (the two variant axes left after
+# opensearch-multiaz-min) -> FIRST check (pre-record) must show ZERO drift ->
+# record -> check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714OsVariants2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~30 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every drift line is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (dedicated-master / legacy-ES fold gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/vpnroute-min/app.ts
+++ b/tests/integration/vpnroute-min/app.ts
@@ -1,0 +1,46 @@
+// CDK app for the cdk-real-drift vpnroute-min integration test. Two probes:
+//   - AWS::EC2::VPNConnectionRoute — the top remaining composite-primaryIdentifier
+//     candidate ([DestinationCidrBlock, VpnConnectionId]) with zero corpus coverage:
+//     if the CFn physical id is only one segment, the CC read ValidationException-
+//     skips it (a silent read-gap; check the `info:` footer for `skipped=`), which
+//     would need a CC_IDENTIFIER_ADAPTERS entry. A clean read is the inverse
+//     determination (Ref is already the full composite).
+//   - the BAREST static VPNConnection: harvest12 DECLARES VpnTunnelOptionsSpecifications,
+//     so the undeclared tunnel-options echo (AWS materializes both tunnels' inside
+//     CIDRs / PSKs at creation) is unexercised — a first-run FP probe.
+// The customer gateway IP is TEST-NET-2 documentation space (no real peer needed;
+// the VPN never connects, which costs nothing extra and detects nothing less).
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnCustomerGateway,
+  CfnVPNConnection,
+  CfnVPNConnectionRoute,
+  CfnVPNGateway,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714VpnRoute");
+
+const cgw = new CfnCustomerGateway(stack, "HuntCgw", {
+  type: "ipsec.1",
+  ipAddress: "198.51.100.7",
+  bgpAsn: 65000,
+});
+
+const vgw = new CfnVPNGateway(stack, "HuntVgw", {
+  type: "ipsec.1",
+});
+
+const vpn = new CfnVPNConnection(stack, "HuntVpn", {
+  type: "ipsec.1",
+  customerGatewayId: cgw.ref,
+  vpnGatewayId: vgw.ref,
+  staticRoutesOnly: true,
+});
+
+new CfnVPNConnectionRoute(stack, "HuntVpnRoute", {
+  destinationCidrBlock: "203.0.113.0/24",
+  vpnConnectionId: vpn.ref,
+});

--- a/tests/integration/vpnroute-min/cdk.json
+++ b/tests/integration/vpnroute-min/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/vpnroute-min/package.json
+++ b/tests/integration/vpnroute-min/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-vpnroute-min",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift vpnroute-min integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/vpnroute-min/verify.sh
+++ b/tests/integration/vpnroute-min/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Integration test (real AWS): static VPNConnection + VPNConnectionRoute ->
+# FIRST check (pre-record) must show ZERO drift AND ZERO skipped (a skipped=
+# on the route = the composite-primaryIdentifier read-gap) -> record -> CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714VpnRoute
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (~10 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): drift-free AND no skipped route ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Drift:" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "first check must be drift-free (VPN fold gap)"
+fi
+if grep -q "skipped=" "/tmp/cdkrd-$STACK.first.out"; then
+  fail "no resource may be skipped (VPNConnectionRoute composite-id read-gap)"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -591,6 +591,8 @@ describe('noise suppressors', () => {
       'EBSOptions.Throughput': 125,
       // #1593: the 2-AZ config a zone-aware domain materializes when undeclared
       'ClusterConfig.ZoneAwarenessConfig': { AvailabilityZoneCount: 2 },
+      // #1605: the documented 3-master default when DedicatedMasterEnabled with no count
+      'ClusterConfig.DedicatedMasterCount': 3,
     });
     expect(KNOWN_DEFAULT_PATHS['AWS::KinesisFirehose::DeliveryStream']).toEqual({
       'ExtendedS3DestinationConfiguration.S3BackupMode': 'Disabled',

--- a/tests/noise-opensearch-dedmaster-1605.test.ts
+++ b/tests/noise-opensearch-dedmaster-1605.test.ts
@@ -1,0 +1,60 @@
+// #1605 — a dedicated-master OpenSearch domain (DedicatedMasterEnabled=true, count
+// undeclared) reads back the documented default DedicatedMasterCount=3 and first-run
+// FP'd, live-proven on os-variants2-min (us-east-1, 2026-07-14). Tier-1 nested pin,
+// equality-gated: an out-of-band master scale to 5 still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tier = (findings: Finding[], t: string) =>
+  findings
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const declared = {
+  ClusterConfig: {
+    InstanceType: 't3.small.search',
+    InstanceCount: 2,
+    ZoneAwarenessEnabled: true,
+    DedicatedMasterEnabled: true,
+    DedicatedMasterType: 't3.small.search',
+  },
+};
+
+const mk = (count: number) =>
+  classifyResource(
+    {
+      logicalId: 'HuntOsDedMaster',
+      resourceType: 'AWS::OpenSearchService::Domain',
+      physicalId: 'huntosded',
+      declared,
+    },
+    {
+      ClusterConfig: { ...declared.ClusterConfig, DedicatedMasterCount: count },
+    },
+    emptySchema
+  );
+
+describe('#1605 dedicated-master count default fold', () => {
+  it('the undeclared 3-master default folds to atDefault', () => {
+    const f = mk(3);
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain('ClusterConfig.DedicatedMasterCount');
+  });
+
+  it('an out-of-band master scale to 5 still surfaces', () => {
+    expect(tier(mk(5), 'undeclared')).toEqual(['ClusterConfig.DedicatedMasterCount']);
+  });
+});

--- a/tests/noise-vpn-tunnel-options-1604.test.ts
+++ b/tests/noise-vpn-tunnel-options-1604.test.ts
@@ -1,0 +1,101 @@
+// #1604 — a BAREST static VPNConnection (no VpnTunnelOptionsSpecifications declared)
+// reads back both tunnels' AWS-materialized options and first-run FP'd, live-proven on
+// vpnroute-min (us-east-1, 2026-07-14). The fold is a SHAPE gate, not value-independent:
+// tunnel options are OOB-mutable (`modify-vpn-tunnel-options`) and security-relevant, so
+// only the pristine-creation shape (random link-local inside CIDRs, empty phase/IKE
+// restriction lists, logging off) folds — a logging enable, an algorithm restriction, or
+// any extra member (lifetime knob, DPD action) breaks the gate and surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tier = (findings: Finding[], t: string) =>
+  findings
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const declared = {
+  Type: 'ipsec.1',
+  CustomerGatewayId: 'cgw-0123456789abcdef0',
+  VpnGatewayId: 'vgw-0123456789abcdef0',
+  StaticRoutesOnly: true,
+};
+
+const pristineTunnel = (cidr: string) => ({
+  Phase1EncryptionAlgorithms: [],
+  Phase1IntegrityAlgorithms: [],
+  Phase1DHGroupNumbers: [],
+  Phase2EncryptionAlgorithms: [],
+  Phase2IntegrityAlgorithms: [],
+  Phase2DHGroupNumbers: [],
+  IKEVersions: [],
+  TunnelInsideCidr: cidr,
+  LogOptions: { CloudwatchLogOptions: { BgpLogEnabled: false, LogEnabled: false } },
+});
+
+const mk = (tunnels: unknown) =>
+  classifyResource(
+    {
+      logicalId: 'HuntVpn',
+      resourceType: 'AWS::EC2::VPNConnection',
+      physicalId: 'vpn-0123456789abcdef0',
+      declared,
+    },
+    { ...declared, VpnTunnelOptionsSpecifications: tunnels },
+    emptySchema
+  );
+
+describe('#1604 barest VPNConnection tunnel-options shape gate', () => {
+  it('the pristine creation echo (both tunnels) folds to atDefault', () => {
+    const f = mk([pristineTunnel('169.254.61.176/30'), pristineTunnel('169.254.61.164/30')]);
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain('VpnTunnelOptionsSpecifications');
+  });
+
+  it('an out-of-band tunnel-logging enable breaks the gate and surfaces', () => {
+    const logging = {
+      ...pristineTunnel('169.254.61.176/30'),
+      LogOptions: {
+        CloudwatchLogOptions: {
+          BgpLogEnabled: false,
+          LogEnabled: true,
+          LogGroupArn: 'arn:aws:logs:us-east-1:111122223333:log-group:vpn',
+        },
+      },
+    };
+    const f = mk([logging, pristineTunnel('169.254.61.164/30')]);
+    expect(tier(f, 'undeclared')).toEqual(['VpnTunnelOptionsSpecifications']);
+  });
+
+  it('an out-of-band algorithm restriction / extra knob surfaces', () => {
+    const restricted = {
+      ...pristineTunnel('169.254.61.176/30'),
+      Phase1EncryptionAlgorithms: [{ Value: 'AES256' }],
+    };
+    expect(tier(mk([restricted, pristineTunnel('169.254.61.164/30')]), 'undeclared')).toEqual([
+      'VpnTunnelOptionsSpecifications',
+    ]);
+    const knob = { ...pristineTunnel('169.254.61.176/30'), Phase1LifetimeSeconds: 14400 };
+    expect(tier(mk([knob, pristineTunnel('169.254.61.164/30')]), 'undeclared')).toEqual([
+      'VpnTunnelOptionsSpecifications',
+    ]);
+  });
+
+  it('a non-link-local inside CIDR (user-shaped value) surfaces', () => {
+    expect(tier(mk([pristineTunnel('10.0.0.0/30')]), 'undeclared')).toEqual([
+      'VpnTunnelOptionsSpecifications',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

2026-07-14 hunt, round 4 (the follow-up round after #1595). Two confirmed first-run FPs fixed — one via a new detection-preserving SHAPE gate — plus two zero-cost determinations.

Closes #1604, closes #1605.

### Fixes

| Issue | Bug | Fix |
|---|---|---|
| #1604 | A barest static `AWS::EC2::VPNConnection` first-run FPs on undeclared `VpnTunnelOptionsSpecifications` (AWS materializes both tunnels: random link-local inside CIDRs, empty phase/IKE restriction lists, logging off). Latent because the only prior coverage (harvest12) DECLARES tunnel options. | **Shape-gated fold** in `classify.ts` — NOT value-independent, because tunnel options are OOB-mutable (`modify-vpn-tunnel-options`) and security-relevant (the #1266 class). Only the pristine-creation shape folds; a logging enable, algorithm restriction, or any extra knob breaks the gate and surfaces. |
| #1605 | An OpenSearch domain with `DedicatedMasterEnabled: true` and no count first-run FPs on the documented `DedicatedMasterCount=3` default (the dedicated-master variant axis was never deployed). | Nested `KNOWN_DEFAULT_PATHS` pin, equality-gated (an out-of-band scale to 5 masters surfaces). |

### Live verification

- #1604 FP direction: fresh deploy → FP surfaced → fix → re-check CLEAN → record → CLEAN.
- #1604 **FN direction (the shape gate's point)**: out-of-band `modify-vpn-tunnel-options` phase1-algorithm restriction → the gate breaks → `appeared since record`, `check --fail` exit 1.
- #1605: same FP A/B cycle, CLEAN end-to-end.

### Determinations (recorded in fixture comments)

- `AWS::EC2::VPNConnectionRoute` — the suspected composite-primaryIdentifier read-gap does NOT exist: the CFn physical id is already the full `cidr|vpn-id` composite; the route reads with zero `skipped=`. Closes out the top remaining candidate from the offline composite-id audit.
- A legacy `Elasticsearch_7.10` domain first-runs fully CLEAN — the #1593 folds hold across the engine axis.

### Assets

- Fixtures: `vpnroute-min` (also asserts zero `skipped=`), `os-variants2-min` (dedicated-master + legacy-ES).
- 4 corpus cases promoted (barest VPNConnection, VPNConnectionRoute — a new type, dedicated-master + legacy-ES domains); replay 829 green.

### Verification

- typecheck / lint+format / `vp pack` / full suite 5742 tests across 295 files — all green; branch is on latest `origin/main` (0 behind).
- `/check-docs`: no docs-visible surface touched (classify shape gate + a noise-table pin).
- `/verify-pr`: per-issue live evidence above; **core shared suite deferred — offline+corpus+hunt-verified**.
- Cleanup: both stacks deleted (`delstack`), `sweep-orphans.sh` → `SWEEP CLEAN`, bughunt gate released.
