### PR TITLE
fix(check,revert): fold ESM/CodePipeline/Fargate/GuardDuty first-run FPs, strip ESM husk, converge 4 no-op reverts

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -785,6 +785,15 @@ no-op` for the write-only RE-INCLUDE op every password-declaring resource carrie
   the FIRST (clean) check line only — or, if the mutated case is worth keeping as a
   detection pin, promote it under the existing `.drifted.json` naming so its intent
   is explicit.
+- **A sweep-orphans.sh fix made in a WORKTREE does not take effect for
+  `bughunt-track.sh verify` — the tracker resolves the script at the MAIN tree
+  root** (`--git-common-dir`), so a phantom-orphan fix (a new `resource_gone`
+  arm) authored in the hunt worktree still fails verify against the unpatched
+  main copy, deadlocking the gate the fix exists to release (hit 2026-07-14 on
+  the VPN-family arms). Resolution: temp-copy the patched script over the main
+  checkout's, run `verify` + `clear`, then `git -C <main> checkout --
+  tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
+  fix lands permanently at merge. Never force-clear instead.
 - **A clean result IS a result — but it must still leave an asset.** "6 common+rich
   stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do
   NOT manufacture a fix to have something to show. The deliverable of a bug-free

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -326,7 +326,14 @@ converge (both policies live-deleted), so the ECR gap is exactly the two
 scan/mutability scalars — prove per-property, not per-type. Also excluded from any
 in-run revert probe by AWS-side rate limits (not cdkrd bugs): DDB TTL (1 change/h),
 EFS ThroughputMode (1 change/24h); Kinesis stream-mode allows exactly 2 switches/24h
-— enough for one mutate + one revert, none left for a retry.
+— enough for one mutate + one revert, none left for a retry. Batch 4 (2026-07-14,
+`revconv3-hunt` fixture, #1613): **SQS `SqsManagedSseEnabled`** (its 4 scalar
+siblings converge — non-uniform WITHIN SQS again), **SFN `LoggingConfiguration`**,
+**ApiGateway RestApi `DisableExecuteApiEndpoint`**, **Cognito UserPoolClient
+`RefreshTokenValidity`** all no-oped; Athena WorkGroup `State`, DDB
+`DeletionProtectionEnabled`, Scheduler Schedule `State` converged via the bare
+`remove` — ~1-in-2 this round. Excluded as SERVER-SIDE IRREVERSIBLE (not a
+convergence probe): SSM Parameter `Tier` (AWS cannot downgrade Advanced→Standard).
 
 ### 5. Harvest the live read into the golden corpus (EVERY round — bug or not)
 
@@ -752,6 +759,32 @@ no-op` for the write-only RE-INCLUDE op every password-declaring resource carrie
   `could not be confirmed` on paths you never drifted — an unverifiable (readGap) path
   must never drive a "value persists" verdict, and fixtures that only assert
   `check --fail` exit codes ride right past this class.
+- **A declared+undeclared FP PAIR with the SAME value at sibling paths = a stored
+  KEY SYNONYM — canonicalize the declared side, after probing the echo via Cloud
+  Control.** GuardDuty stores a Filter's short condition keys as their long twins
+  (declared `Criterion.severity.Gte: 4` reads back `GreaterThanOrEqual: 4`), so one
+  declared short key produced BOTH a declared "removed" finding and an undeclared
+  "appeared" finding with equal values (#1612). The tell is that value-equal pair.
+  Probe the echo shape for free before fixing: `aws cloudcontrol create-resource`
+  with the short keys, `get-resource` back — the CC read echoed ONLY the long forms
+  (the raw `GetFilter` returns both, but cdkrd reads via CC). Fix = a declared-side
+  key canonicalization scoped to the criterion map (`canonicalizeGuardDutyCriterionKeys`).
+- **A curated per-name creation-status map re-breaks every time AWS launches an
+  OFF-by-default feature — that is its designed failure mode; the fix is one line.**
+  GuardDuty Detector `Features` folds via `GUARDDUTY_FEATURE_CREATION_STATUS`
+  (classify.ts), which errs toward VISIBILITY: a new opt-in protection AWS ships
+  DISABLED (AI_PROTECTION, 2026 — #1612, after #1485's AI_ANALYST) surfaces the whole
+  array as a first-run FP until its name is added. When a barest detector FPs on
+  `Features`, check that map FIRST — do not reach for value-independent (that was
+  reverted once already, #1092: it hid out-of-band disables forever).
+- **`CDKRD_CORPUS_DIR` exported around a whole verify-detect.sh records EVERY check
+  — the LAST (post-mutation) read wins.** A detect/revert script runs 3-4 checks;
+  the corpus case for a mutated resource then pins the MUTATED read, and a later
+  `measure-noise` sweep flags the mutated value as a bogus CANDIDATE default
+  (hit on Conv3PoolClient `RefreshTokenValidity: 60`, 2026-07-14). Scope the env to
+  the FIRST (clean) check line only — or, if the mutated case is worth keeping as a
+  detection pin, promote it under the existing `.drifted.json` naming so its intent
+  is explicit.
 - **A clean result IS a result — but it must still leave an asset.** "6 common+rich
   stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do
   NOT manufacture a fix to have something to show. The deliverable of a bug-free

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -792,7 +792,7 @@ no-op` for the write-only RE-INCLUDE op every password-declaring resource carrie
   main copy, deadlocking the gate the fix exists to release (hit 2026-07-14 on
   the VPN-family arms). Resolution: temp-copy the patched script over the main
   checkout's, run `verify` + `clear`, then `git -C <main> checkout --
-  tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
+tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   fix lands permanently at merge. Never force-clear instead.
 - **A clean result IS a result — but it must still leave an asset.** "6 common+rich
   stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -23,6 +23,7 @@ import {
   isAllAwsTags,
   identityField,
   isCaseInsensitiveEqualScalarSet,
+  canonicalizeGuardDutyCriterionKeys,
   isCaseInsensitiveKeyMapEqual,
   isCaseInsensitiveScalarEqual,
   BOOLEAN_PARAM_MAP_PATHS,
@@ -401,6 +402,9 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
 // agent-management members (a modern-era-only construct materialized OFF) stay single-status
 // DISABLED, so an out-of-band ENABLE — a billable protection turned on later — still surfaces.
 const GUARDDUTY_FEATURE_CREATION_STATUS: Record<string, readonly string[]> = {
+  // #1612: AI_PROTECTION (2026-new, ships OFF) joined AI_ANALYST — a fresh barest detector
+  // read it DISABLED and the whole Features array first-run-FP'd again (guardduty-hunt).
+  AI_PROTECTION: ['DISABLED'],
   AI_ANALYST: ['DISABLED'],
   RUNTIME_MONITORING: ['DISABLED', 'ENABLED'],
   EKS_RUNTIME_MONITORING: ['DISABLED', 'ENABLED'],
@@ -2911,10 +2915,17 @@ export function classifyResource(
     opts.stackTags ?? {},
     declaredTagKeys(declaredForCompare)
   );
-  const declared = canonicalizeForCompare(
+  let declared = canonicalizeForCompare(
     rewriteOaiPrincipalsDeep(declaredForCompare, oaiMap),
     resourceType
   ) as Record<string, unknown>;
+  // #1612: GuardDuty stores a filter's short condition keys (Gte/Eq/...) as their long
+  // synonyms (GreaterThanOrEqual/Equals/...), value unchanged — canonicalize the declared
+  // side to the long forms the Cloud Control read echoes so a short-key template does not
+  // double-FP (declared "removed" + long twin "appeared").
+  if (resourceType === 'AWS::GuardDuty::Filter') {
+    declared = canonicalizeGuardDutyCriterionKeys(declared);
+  }
   // Drop a parent's reflected child-aggregate property (e.g. SNS Topic.Subscription)
   // UNLESS the template declares it inline — cdkrd tracks those children as their own
   // resources (+ the `added` enumerator), so comparing the reflection would double-report

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -80,6 +80,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   //     surface AWS EXTENDS over time, is folded value-independently — see
   //     VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS.) Live-confirmed on a fresh
   //     `Enable: true`-only detector (CdkrdHuntUGd, 2026-07-09; #879).
+  // A filter that declares no Action reads back NOOP — the documented constant default
+  // (the only other value, ARCHIVE, is a real behavior change). Equality-gated: an
+  // out-of-band switch to ARCHIVE re-surfaces. Observed live on a barest filter
+  // (guardduty-hunt, 2026-07-14; #1612).
+  'AWS::GuardDuty::Filter': { Action: 'NOOP' },
   'AWS::GuardDuty::Detector': {
     FindingPublishingFrequency: 'SIX_HOURS',
     DataSources: {
@@ -379,6 +384,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // Equality-gated: a mapping that pins a real window no longer matches and surfaces.
     // Observed live on a dev SQS-triggered function.
     MaximumBatchingWindowInSeconds: 0,
+    // A STREAM-source mapping (DynamoDB Streams / Kinesis) additionally materializes the
+    // stream-only concurrency + windowing defaults: 1 concurrent batch per shard and no
+    // tumbling window (the documented defaults). SQS sources never carry either prop, so
+    // the entries can't mis-fold there. Equality-gated — raise the parallelization or set
+    // a real window out of band and it no longer matches, so it re-surfaces. Observed live
+    // on barest DDB + Kinesis mappings (esm-hunt, 2026-07-14, #1608).
+    ParallelizationFactor: 1,
+    TumblingWindowInSeconds: 0,
   },
   // An alias created without a Description reads back the empty string. Folded as
   // atDefault so a never-declared alias does not report `Description=""` as drift; it
@@ -1827,6 +1840,16 @@ export const KNOWN_DEFAULT_ONE_OF: Record<string, Record<string, readonly unknow
   'AWS::Glue::Job': {
     Timeout: [2880, 480],
   },
+  // #1609: a pipeline that declares no PipelineType reads back the create-time default, and
+  // AWS MOVED that default when V2 launched (2023-10): a fresh barest pipeline now reads "V2"
+  // (live-proven, codepipeline-hunt 2026-07-14), pipelines created undeclared before the flip
+  // read "V1". Both are stable constants but the discriminator — when the pipeline was created
+  // — is off the resource's model (the #1249 era class). A user who DECLARES the type is
+  // compared in the declared dimension; the enum has only these two values, so the ONE_OF
+  // detection loss is confined to an out-of-band V1<->V2 flip on a never-declared type.
+  'AWS::CodePipeline::Pipeline': {
+    PipelineType: ['V1', 'V2'],
+  },
   // #1593: a domain that declares no DomainEndpointOptions reads back the whole options
   // object AWS materializes at creation, and its TLSSecurityPolicy member is ERA-dependent
   // (the S3 TransitionDefaultMinimumObjectSize class): a fresh 2026 domain reads
@@ -2278,7 +2301,20 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   'AWS::Scheduler::Schedule': {
     'Target.RetryPolicy': { MaximumEventAgeInSeconds: 86400, MaximumRetryAttempts: 185 },
   },
+  // #1609: every pipeline action the template declares without a RunOrder reads back the
+  // documented default 1 (actions in a stage run in parallel unless ordered), so a barest
+  // pipeline reports one FP per action on first run (live, codepipeline-hunt 2026-07-14).
+  // Equality-gated: an out-of-band re-ordering (RunOrder 2+) no longer matches and surfaces.
+  'AWS::CodePipeline::Pipeline': {
+    'Stages.*.Actions.*.RunOrder': 1,
+  },
   'AWS::ECS::Service': {
+    // A service that declares NetworkConfiguration (required for awsvpc mode) but omits
+    // AssignPublicIp reads back the DISABLED default — every existing Fargate fixture
+    // declared it, so the barest form leaked this on first run (live, fargate-hunt
+    // 2026-07-14, #1610). Equality-gated: an out-of-band ENABLED flip (a real exposure
+    // change) no longer matches and surfaces.
+    'NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp': 'DISABLED',
     // A service declaring no deployment configuration reads back AWS's defaults — the
     // ROLLING strategy with a 0-minute bake time. Observed unanimous across the corpus.
     'DeploymentConfiguration.Strategy': 'ROLLING',
@@ -3585,6 +3621,14 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   without enumerating each. Both observed live first-run (one real app's cognito
   //   authorizer, another's TOKEN "custom" one) with no out-of-band edit.
   'AWS::ApiGateway::Authorizer': new Set(['AuthType']),
+  //   AWS::GuardDuty::Filter.Rank — an undeclared rank is AWS-assigned ordering, and it is
+  //   VOLATILE: creating another filter on the detector assigns the NEW filter rank 1 and
+  //   pushes every existing filter down (live-probed 2026-07-14, #1612 — two undeclared-rank
+  //   filters read Rank 2 and 1 in creation order). A sibling's create would flip an
+  //   equality-gated pin into a false out-of-band drift, so no constant or derivation can
+  //   hold. A user who cares about evaluation order DECLARES Rank (compared in the declared
+  //   loop, detected).
+  'AWS::GuardDuty::Filter': new Set(['Rank']),
   //   AWS::GuardDuty::Detector.Features is NO LONGER value-independent (#1092): folding any
   //   Status hid an out-of-band disable of a Features-only protection (RUNTIME_MONITORING,
   //   RDS_LOGIN_EVENTS, LAMBDA_NETWORK_LOGS — none have a legacy DataSources mirror) FOREVER,
@@ -4838,6 +4882,11 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // "CdkrdHunt-Mixed-RsCluster" reads back "cdkrdhunt-mixed-rscluster" — declared-tier FP on
   // every check. Observed live (case-idents3-min, 2026-07-14; #1589).
   'AWS::Redshift::Cluster': new Set(['ClusterIdentifier']),
+  // Glue Database/Table names are stored lowercased by the raw Glue API, but BOTH CFn
+  // handlers reject mixed-case input client-side ("must not contain uppercase characters"
+  // — Database probed via Cloud Control create-resource, Table via a raw CFn stack, both
+  // 2026-07-14), so the divergence is unreachable via CloudFormation: no entries needed
+  // (the MemoryDB-family determination).
   'AWS::DMS::ReplicationInstance': new Set(['ReplicationInstanceIdentifier']),
   'AWS::DMS::ReplicationSubnetGroup': new Set(['ReplicationSubnetGroupIdentifier']),
   // DMS Endpoint `EndpointType` — the CFn/CDK value is lowercase (`source` /
@@ -4943,6 +4992,52 @@ export function isBooleanTokenEquivalent(a: unknown, b: unknown): boolean {
 export const CASE_INSENSITIVE_KEY_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::DataBrew::Recipe': new Set(['Steps[].Action.Parameters']),
 };
+// #1612: GuardDuty stores a filter's SHORT condition keys as their LONG synonyms — a
+// template declaring `Criterion: {severity: {Gte: 4}, type: {Eq: [...]}}` reads back (via
+// Cloud Control) `{severity: {GreaterThanOrEqual: 4}, type: {Equals: [...]}}`, the value
+// unchanged — so a declared short key double-FPs on every check (declared "removed" + the
+// long twin "appeared"). Live-probed 2026-07-14: the CC read echoes ONLY the long forms
+// (the raw GetFilter response carries both, but cdkrd reads via CC). The fix is a
+// declared-side key canonicalization scoped to `FindingCriteria.Criterion.<field>`.
+const GUARDDUTY_CONDITION_KEY_ALIASES: Record<string, string> = {
+  Eq: 'Equals',
+  Neq: 'NotEquals',
+  Gt: 'GreaterThan',
+  Gte: 'GreaterThanOrEqual',
+  Lt: 'LessThan',
+  Lte: 'LessThanOrEqual',
+};
+// Rewrite the short condition keys of a declared GuardDuty Filter model to the long forms
+// the live read echoes. Pure (returns a rewritten clone; the input is not mutated).
+// Fail-safe: a short key is renamed ONLY when its long twin is absent from the same
+// condition (a template declaring both is left as-is and compared normally), and anything
+// that is not the expected object shape is passed through untouched.
+export function canonicalizeGuardDutyCriterionKeys(
+  declared: Record<string, unknown>
+): Record<string, unknown> {
+  const fc = declared['FindingCriteria'];
+  if (fc === null || typeof fc !== 'object' || Array.isArray(fc)) return declared;
+  const criterion = (fc as Record<string, unknown>)['Criterion'];
+  if (criterion === null || typeof criterion !== 'object' || Array.isArray(criterion))
+    return declared;
+  const outCriterion: Record<string, unknown> = {};
+  for (const [field, cond] of Object.entries(criterion as Record<string, unknown>)) {
+    if (cond === null || typeof cond !== 'object' || Array.isArray(cond)) {
+      outCriterion[field] = cond;
+      continue;
+    }
+    const outCond: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(cond as Record<string, unknown>)) {
+      const long = GUARDDUTY_CONDITION_KEY_ALIASES[k];
+      outCond[long !== undefined && !(long in (cond as Record<string, unknown>)) ? long : k] = v;
+    }
+    outCriterion[field] = outCond;
+  }
+  return {
+    ...declared,
+    FindingCriteria: { ...(fc as Record<string, unknown>), Criterion: outCriterion },
+  };
+}
 // True when two objects are equal modulo the ASCII CASE of their keys — the same key set
 // case-folded, with EQUAL values per matched key-pair. Equality-gated per key-pair: a real
 // key change (an added/removed parameter) or a value change on a matched key still differs,

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -251,6 +251,27 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // the bare `remove` (live-verified same run), so ONLY MaximumMessageSize needs an
   // explicit set-default write (the 1048576 default from KNOWN_DEFAULTS).
   'AWS::SQS::Queue\0MaximumMessageSize',
+  // #1613 (revconv3, live-proven 2026-07-14): SQS also keeps an omitted
+  // SqsManagedSseEnabled — an out-of-band SSE DISABLE (a real security downgrade) reverted
+  // as a `remove` reports success yet the queue stays unencrypted. Write the `true` default
+  // (from KNOWN_DEFAULTS) back explicitly. Still NON-UNIFORM within SQS: the four scalar
+  // controls above converge via the bare `remove`.
+  'AWS::SQS::Queue\0SqsManagedSseEnabled',
+  // #1613: StepFunctions UpdateStateMachine keeps an omitted LoggingConfiguration (an
+  // out-of-band Level=ALL enable persisted through a `remove` revert). Write the whole-object
+  // OFF default (from KNOWN_DEFAULTS) back explicitly — the Transfer ProtocolDetails
+  // whole-object precedent.
+  'AWS::StepFunctions::StateMachine\0LoggingConfiguration',
+  // #1613: API Gateway keeps an omitted DisableExecuteApiEndpoint on the CC patch (an
+  // out-of-band `true` — the default endpoint cut off — persisted through a `remove`
+  // revert). Write the `false` default back explicitly.
+  'AWS::ApiGateway::RestApi\0DisableExecuteApiEndpoint',
+  // #1613: Cognito UpdateUserPoolClient is a full-replace API that nevertheless kept an
+  // omitted RefreshTokenValidity (an out-of-band 60-day validity persisted through a
+  // `remove` revert). Write the 30 default back explicitly. Its siblings
+  // (EnableTokenRevocation, AuthSessionValidity) ride the same call and are LIKELY the
+  // same class but stay unlisted until individually live-proven (the per-property rule).
+  'AWS::Cognito::UserPoolClient\0RefreshTokenValidity',
   // Lambda UpdateFunctionUrlConfig IGNORES an omitted InvokeMode (live-proven on
   // revert-noop-probe 2026-07-14, #1583: a URL flipped BUFFERED->RESPONSE_STREAM out of
   // band, then `revert` planned a `remove`, reported reverted, yet the URL stayed
@@ -1783,6 +1804,13 @@ export const CC_UPDATE_REJECTED_EMPTY_PATHS: Record<string, readonly string[]> =
     '/DestinationConfig/OnSuccess',
     '/DestinationConfig/OnFailure',
   ],
+  // #1611: the SAME husk class on the EventSourceMapping itself — every stream-source
+  // (DDB/Kinesis) mapping with no failure destination echoes `DestinationConfig:
+  // {OnFailure: {}}` on read, and the CC update handler folds that read-back into ANY
+  // patch (even a ParallelizationFactor-only revert), which Lambda rejects with "The
+  // Destination field is required for an OnFailure configuration" (live-proven on the
+  // #1608 revert-convergence probe, 2026-07-14).
+  'AWS::Lambda::EventSourceMapping': ['/DestinationConfig/OnFailure'],
 };
 // Expand a JSON pointer that MAY contain `*` array-wildcard segments into a {pointer, value}
 // pair for every matching live node. A `*` matches each index of an array node; a normal

--- a/tests/corpus/AWS__ApiGatewayV2__Deployment.HuntWsDeployment.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Deployment.HuntWsDeployment.json
@@ -1,0 +1,36 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntWsDeployment",
+    "resourceType": "AWS::ApiGatewayV2::Deployment",
+    "physicalId": "e60xod",
+    "constructPath": "CdkrdHunt0714WsExt/HuntWsDeployment",
+    "declared": {
+      "ApiId": "kb3d1jkoqf"
+    }
+  },
+  "liveRaw": {
+    "DeploymentId": "e60xod",
+    "ApiId": "kb3d1jkoqf"
+  },
+  "schema": {
+    "readOnly": ["DeploymentId"],
+    "writeOnly": ["StageName"],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["DeploymentId"],
+    "writeOnlyPaths": ["StageName"],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Model.HuntWsModel.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Model.HuntWsModel.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntWsModel",
+    "resourceType": "AWS::ApiGatewayV2::Model",
+    "physicalId": "7hpyny",
+    "constructPath": "CdkrdHunt0714WsExt/HuntWsModel",
+    "declared": {
+      "ApiId": "kb3d1jkoqf",
+      "ContentType": "application/json",
+      "Name": "HuntModel",
+      "Schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": "HuntModel",
+        "type": "object"
+      }
+    }
+  },
+  "liveRaw": {
+    "ContentType": "application/json",
+    "Schema": {
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "title": "HuntModel",
+      "type": "object"
+    },
+    "ApiId": "kb3d1jkoqf",
+    "ModelId": "7hpyny",
+    "Name": "HuntModel"
+  },
+  "schema": {
+    "readOnly": ["ModelId"],
+    "writeOnly": [],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["ModelId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CodePipeline__Pipeline.HuntPipeline.json
+++ b/tests/corpus/AWS__CodePipeline__Pipeline.HuntPipeline.json
@@ -1,0 +1,197 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPipeline",
+    "resourceType": "AWS::CodePipeline::Pipeline",
+    "physicalId": "CdkrdHunt0714Pipe-HuntPipeline-9IkuBuDKn9hg",
+    "constructPath": "CdkrdHunt0714Pipe/HuntPipeline",
+    "declared": {
+      "ArtifactStore": {
+        "Location": "cdkrdhunt0714pipe-huntartifacts-xm3nndqspxtg",
+        "Type": "S3"
+      },
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Pipe-HuntPipeRole1A5D3DA7-g5M0oQ5WMQd1",
+      "Stages": [
+        {
+          "Actions": [
+            {
+              "ActionTypeId": {
+                "Category": "Source",
+                "Owner": "AWS",
+                "Provider": "S3",
+                "Version": "1"
+              },
+              "Configuration": {
+                "S3Bucket": "cdkrdhunt0714pipe-huntartifacts-xm3nndqspxtg",
+                "S3ObjectKey": "src.zip"
+              },
+              "Name": "Src",
+              "OutputArtifacts": [
+                {
+                  "Name": "SrcOut"
+                }
+              ]
+            }
+          ],
+          "Name": "Source"
+        },
+        {
+          "Actions": [
+            {
+              "ActionTypeId": {
+                "Category": "Approval",
+                "Owner": "AWS",
+                "Provider": "Manual",
+                "Version": "1"
+              },
+              "Name": "Gate"
+            }
+          ],
+          "Name": "Approve"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Variables": [],
+    "ArtifactStores": [],
+    "Version": "1",
+    "ArtifactStore": {
+      "Type": "S3",
+      "Location": "cdkrdhunt0714pipe-huntartifacts-xm3nndqspxtg"
+    },
+    "DisableInboundStageTransitions": [],
+    "Stages": [
+      {
+        "Blockers": [],
+        "Actions": [
+          {
+            "ActionTypeId": {
+              "Owner": "AWS",
+              "Category": "Source",
+              "Version": "1",
+              "Provider": "S3"
+            },
+            "Configuration": {
+              "S3Bucket": "cdkrdhunt0714pipe-huntartifacts-xm3nndqspxtg",
+              "S3ObjectKey": "src.zip"
+            },
+            "InputArtifacts": [],
+            "OutputArtifacts": [
+              {
+                "Files": [],
+                "Name": "SrcOut"
+              }
+            ],
+            "Commands": [],
+            "OutputVariables": [],
+            "RunOrder": 1,
+            "Name": "Src"
+          }
+        ],
+        "Name": "Source"
+      },
+      {
+        "Blockers": [],
+        "Actions": [
+          {
+            "ActionTypeId": {
+              "Owner": "AWS",
+              "Category": "Approval",
+              "Version": "1",
+              "Provider": "Manual"
+            },
+            "Configuration": {},
+            "InputArtifacts": [],
+            "OutputArtifacts": [],
+            "Commands": [],
+            "OutputVariables": [],
+            "RunOrder": 1,
+            "Name": "Gate"
+          }
+        ],
+        "Name": "Approve"
+      }
+    ],
+    "PipelineType": "V2",
+    "ExecutionMode": "SUPERSEDED",
+    "Arn": "arn:aws:codepipeline:us-east-1:111111111111:CdkrdHunt0714Pipe-HuntPipeline-9IkuBuDKn9hg",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Pipe-HuntPipeRole1A5D3DA7-g5M0oQ5WMQd1",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "CdkrdHunt0714Pipe-HuntPipeline-9IkuBuDKn9hg"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Version"],
+    "writeOnly": ["RestartExecutionOnUpdate"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Version"],
+    "writeOnlyPaths": ["RestartExecutionOnUpdate"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {
+      "ExecutionMode": "SUPERSEDED"
+    },
+    "defaultPaths": {
+      "ExecutionMode": "SUPERSEDED"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPipeline",
+      "resourceType": "AWS::CodePipeline::Pipeline",
+      "path": "PipelineType",
+      "actual": "V2",
+      "physicalId": "CdkrdHunt0714Pipe-HuntPipeline-9IkuBuDKn9hg",
+      "constructPath": "CdkrdHunt0714Pipe/HuntPipeline"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPipeline",
+      "resourceType": "AWS::CodePipeline::Pipeline",
+      "path": "ExecutionMode",
+      "actual": "SUPERSEDED",
+      "physicalId": "CdkrdHunt0714Pipe-HuntPipeline-9IkuBuDKn9hg",
+      "constructPath": "CdkrdHunt0714Pipe/HuntPipeline"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPipeline",
+      "resourceType": "AWS::CodePipeline::Pipeline",
+      "path": "Stages[Source].Actions[Src].RunOrder",
+      "actual": 1,
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Pipe-HuntPipeline-9IkuBuDKn9hg",
+      "constructPath": "CdkrdHunt0714Pipe/HuntPipeline"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPipeline",
+      "resourceType": "AWS::CodePipeline::Pipeline",
+      "path": "Stages[Approve].Actions[Gate].RunOrder",
+      "actual": 1,
+      "nested": true,
+      "physicalId": "CdkrdHunt0714Pipe-HuntPipeline-9IkuBuDKn9hg",
+      "constructPath": "CdkrdHunt0714Pipe/HuntPipeline"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Conv3PoolClient.drifted.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Conv3PoolClient.drifted.json
@@ -1,0 +1,119 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Conv3PoolClient",
+    "resourceType": "AWS::Cognito::UserPoolClient",
+    "physicalId": "1msoaare5gbgou3cp53skc7mmc",
+    "constructPath": "CdkrdHunt0714RevConv3/Conv3PoolClient",
+    "declared": {
+      "UserPoolId": "us-east-1_03xvQbZFA"
+    }
+  },
+  "liveRaw": {
+    "GenerateSecret": false,
+    "CallbackURLs": [],
+    "EnablePropagateAdditionalUserContextData": false,
+    "AuthSessionValidity": 3,
+    "AllowedOAuthScopes": [],
+    "TokenValidityUnits": {},
+    "ReadAttributes": [],
+    "AllowedOAuthFlowsUserPoolClient": false,
+    "SupportedIdentityProviders": [],
+    "Name": "Conv3PoolClient-POeBYmBiaOxl",
+    "ClientName": "Conv3PoolClient-POeBYmBiaOxl",
+    "UserPoolId": "us-east-1_03xvQbZFA",
+    "AllowedOAuthFlows": [],
+    "ExplicitAuthFlows": [],
+    "LogoutURLs": [],
+    "ClientId": "1msoaare5gbgou3cp53skc7mmc",
+    "RefreshTokenValidity": 60,
+    "WriteAttributes": [],
+    "EnableTokenRevocation": true
+  },
+  "schema": {
+    "readOnly": ["ClientId", "ClientSecret", "Name"],
+    "writeOnly": [],
+    "createOnly": ["GenerateSecret", "UserPoolId"],
+    "readOnlyPaths": ["ClientId", "ClientSecret", "Name"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GenerateSecret", "UserPoolId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Conv3PoolClient",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "EnablePropagateAdditionalUserContextData",
+      "actual": false,
+      "physicalId": "1msoaare5gbgou3cp53skc7mmc",
+      "constructPath": "CdkrdHunt0714RevConv3/Conv3PoolClient"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Conv3PoolClient",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "AuthSessionValidity",
+      "actual": 3,
+      "physicalId": "1msoaare5gbgou3cp53skc7mmc",
+      "constructPath": "CdkrdHunt0714RevConv3/Conv3PoolClient"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Conv3PoolClient",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "ClientName",
+      "actual": "Conv3PoolClient-POeBYmBiaOxl",
+      "physicalId": "1msoaare5gbgou3cp53skc7mmc",
+      "constructPath": "CdkrdHunt0714RevConv3/Conv3PoolClient"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Conv3PoolClient",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "RefreshTokenValidity",
+      "actual": 60,
+      "physicalId": "1msoaare5gbgou3cp53skc7mmc",
+      "constructPath": "CdkrdHunt0714RevConv3/Conv3PoolClient"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Conv3PoolClient",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "EnableTokenRevocation",
+      "actual": true,
+      "physicalId": "1msoaare5gbgou3cp53skc7mmc",
+      "constructPath": "CdkrdHunt0714RevConv3/Conv3PoolClient"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__Service.HuntFargateSvc.json
+++ b/tests/corpus/AWS__ECS__Service.HuntFargateSvc.json
@@ -1,0 +1,212 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntFargateSvc",
+    "resourceType": "AWS::ECS::Service",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+    "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc",
+    "declared": {
+      "Cluster": "CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20",
+      "DesiredCount": 0,
+      "LaunchType": "FARGATE",
+      "NetworkConfiguration": {
+        "AwsvpcConfiguration": {
+          "Subnets": ["subnet-04f1d945e9981f02a"]
+        }
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv:1"
+    }
+  },
+  "liveRaw": {
+    "PlatformVersion": "LATEST",
+    "HealthCheckGracePeriodSeconds": 0,
+    "EnableECSManagedTags": false,
+    "EnableExecuteCommand": false,
+    "PlacementConstraints": [],
+    "Cluster": "CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20",
+    "ServiceArn": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+    "DesiredCount": 0,
+    "PlacementStrategies": [],
+    "DeploymentController": {
+      "Type": "ECS"
+    },
+    "LaunchType": "FARGATE",
+    "Name": "CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+    "AvailabilityZoneRebalancing": "ENABLED",
+    "Role": "arn:aws:iam::111111111111:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+    "SchedulingStrategy": "REPLICA",
+    "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv:1",
+    "ServiceName": "CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+    "NetworkConfiguration": {
+      "AwsvpcConfiguration": {
+        "SecurityGroups": [],
+        "Subnets": ["subnet-04f1d945e9981f02a"],
+        "AssignPublicIp": "DISABLED"
+      }
+    },
+    "DeploymentConfiguration": {
+      "BakeTimeInMinutes": 0,
+      "Strategy": "ROLLING",
+      "DeploymentCircuitBreaker": {
+        "ThresholdConfiguration": {
+          "Type": "BOUNDED_PERCENT",
+          "Value": 50
+        },
+        "Enable": false,
+        "ResetOnHealthyTask": true,
+        "Rollback": false
+      },
+      "MaximumPercent": 200,
+      "MinimumHealthyPercent": 100
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Name", "ServiceArn"],
+    "writeOnly": ["ForceNewDeployment", "Monitoring"],
+    "createOnly": ["Cluster", "Role", "SchedulingStrategy", "ServiceName"],
+    "readOnlyPaths": ["Name", "ServiceArn"],
+    "writeOnlyPaths": ["ForceNewDeployment", "Monitoring"],
+    "createOnlyPaths": ["Cluster", "Role", "SchedulingStrategy", "ServiceName"],
+    "defaults": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "defaultPaths": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "unorderedScalarPaths": [
+      "NetworkConfiguration.AwsvpcConfiguration.SecurityGroups",
+      "NetworkConfiguration.AwsvpcConfiguration.Subnets"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["ServiceConnectConfiguration.LogConfiguration.Options"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "PlatformVersion",
+      "actual": "LATEST",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "HealthCheckGracePeriodSeconds",
+      "actual": 0,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "EnableExecuteCommand",
+      "actual": false,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentController",
+      "actual": {
+        "Type": "ECS"
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "AvailabilityZoneRebalancing",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "Role",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "SchedulingStrategy",
+      "actual": "REPLICA",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "ServiceName",
+      "actual": "CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentConfiguration",
+      "actual": {
+        "BakeTimeInMinutes": 0,
+        "Strategy": "ROLLING",
+        "DeploymentCircuitBreaker": {
+          "ThresholdConfiguration": {
+            "Type": "BOUNDED_PERCENT",
+            "Value": 50
+          },
+          "Enable": false,
+          "ResetOnHealthyTask": true,
+          "Rollback": false
+        },
+        "MaximumPercent": 200,
+        "MinimumHealthyPercent": 100
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFargateSvc",
+      "resourceType": "AWS::ECS::Service",
+      "path": "NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp",
+      "actual": "DISABLED",
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkrdHunt0714Fargate-HuntCluster-RClkksghkn20/CdkrdHunt0714Fargate-HuntFargateSvc-F5lAiEmDPYxT",
+      "constructPath": "CdkrdHunt0714Fargate/HuntFargateSvc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__TaskDefinition.HuntTaskDef.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.HuntTaskDef.json
@@ -1,0 +1,165 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTaskDef",
+    "resourceType": "AWS::ECS::TaskDefinition",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv:1",
+    "constructPath": "CdkrdHunt0714Fargate/HuntTaskDef",
+    "declared": {
+      "ContainerDefinitions": [
+        {
+          "Image": "public.ecr.aws/docker/library/busybox:stable",
+          "Name": "app"
+        }
+      ],
+      "Cpu": "256",
+      "Memory": "512",
+      "NetworkMode": "awsvpc",
+      "RequiresCompatibilities": ["FARGATE"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Volumes": [],
+    "InferenceAccelerators": [],
+    "Memory": "512",
+    "PlacementConstraints": [],
+    "ContainerDefinitions": [
+      {
+        "ExtraHosts": [],
+        "Secrets": [],
+        "VolumesFrom": [],
+        "Cpu": 0,
+        "EntryPoint": [],
+        "DnsServers": [],
+        "Image": "public.ecr.aws/docker/library/busybox:stable",
+        "Essential": true,
+        "ResourceRequirements": [],
+        "EnvironmentFiles": [],
+        "Name": "app",
+        "MountPoints": [],
+        "DependsOn": [],
+        "DockerLabels": {},
+        "PortMappings": [],
+        "DockerSecurityOptions": [],
+        "SystemControls": [],
+        "Command": [],
+        "DnsSearchDomains": [],
+        "Environment": [],
+        "Links": [],
+        "CredentialSpecs": [],
+        "Ulimits": []
+      }
+    ],
+    "Family": "CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv",
+    "Cpu": "256",
+    "RequiresCompatibilities": ["FARGATE"],
+    "NetworkMode": "awsvpc",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "TaskDefinitionArn": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv:1"
+  },
+  "schema": {
+    "readOnly": ["TaskDefinitionArn"],
+    "writeOnly": [],
+    "createOnly": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "readOnlyPaths": ["TaskDefinitionArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "ContainerDefinitions.*.VersionConsistency": "enabled"
+    },
+    "unorderedScalarPaths": ["RequiresCompatibilities"],
+    "unorderedObjectArrayPaths": ["InferenceAccelerators", "PlacementConstraints"],
+    "freeFormMapPaths": [
+      "ContainerDefinitions.*.DockerLabels",
+      "ContainerDefinitions.*.FirelensConfiguration.Options",
+      "ContainerDefinitions.*.LogConfiguration.Options",
+      "Volumes.*.DockerVolumeConfiguration.DriverOpts",
+      "Volumes.*.DockerVolumeConfiguration.Labels"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "HuntTaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "Family",
+      "actual": "CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv:1",
+      "constructPath": "CdkrdHunt0714Fargate/HuntTaskDef"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[app].Cpu",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv:1",
+      "constructPath": "CdkrdHunt0714Fargate/HuntTaskDef"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[app].Essential",
+      "actual": true,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkrdHunt0714Fargate-HuntTaskDef-g0RYq9G3lZTv:1",
+      "constructPath": "CdkrdHunt0714Fargate/HuntTaskDef"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GuardDuty__Detector.HuntDetector0714.json
+++ b/tests/corpus/AWS__GuardDuty__Detector.HuntDetector0714.json
@@ -1,0 +1,257 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDetector",
+    "resourceType": "AWS::GuardDuty::Detector",
+    "physicalId": "7d934291dde5406887fffdf094922448",
+    "constructPath": "CdkrdHunt0714Gd/HuntDetector",
+    "declared": {
+      "Enable": true,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "FindingPublishingFrequency": "SIX_HOURS",
+    "DataSources": {
+      "MalwareProtection": {
+        "ScanEc2InstanceWithFindings": {
+          "EbsVolumes": true
+        }
+      },
+      "S3Logs": {
+        "Enable": true
+      },
+      "Kubernetes": {
+        "AuditLogs": {
+          "Enable": true
+        }
+      }
+    },
+    "Enable": true,
+    "Features": [
+      {
+        "Status": "ENABLED",
+        "Name": "CLOUD_TRAIL"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "DNS_LOGS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "FLOW_LOGS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "S3_DATA_EVENTS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "EKS_AUDIT_LOGS"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "EBS_MALWARE_PROTECTION"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "RDS_LOGIN_EVENTS"
+      },
+      {
+        "Status": "DISABLED",
+        "Name": "AI_PROTECTION"
+      },
+      {
+        "Status": "DISABLED",
+        "Name": "AI_ANALYST"
+      },
+      {
+        "Status": "DISABLED",
+        "AdditionalConfiguration": [
+          {
+            "Status": "DISABLED",
+            "Name": "EKS_ADDON_MANAGEMENT"
+          }
+        ],
+        "Name": "EKS_RUNTIME_MONITORING"
+      },
+      {
+        "Status": "ENABLED",
+        "Name": "LAMBDA_NETWORK_LOGS"
+      },
+      {
+        "Status": "DISABLED",
+        "AdditionalConfiguration": [
+          {
+            "Status": "DISABLED",
+            "Name": "EKS_ADDON_MANAGEMENT"
+          },
+          {
+            "Status": "DISABLED",
+            "Name": "ECS_FARGATE_AGENT_MANAGEMENT"
+          },
+          {
+            "Status": "DISABLED",
+            "Name": "EC2_AGENT_MANAGEMENT"
+          }
+        ],
+        "Name": "RUNTIME_MONITORING"
+      }
+    ],
+    "Id": "7d934291dde5406887fffdf094922448",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Gd",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntDetector",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Gd/a36563a0-7f53-11f1-b807-0e8c900acc83",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDetector",
+      "resourceType": "AWS::GuardDuty::Detector",
+      "path": "FindingPublishingFrequency",
+      "actual": "SIX_HOURS",
+      "physicalId": "7d934291dde5406887fffdf094922448",
+      "constructPath": "CdkrdHunt0714Gd/HuntDetector"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDetector",
+      "resourceType": "AWS::GuardDuty::Detector",
+      "path": "DataSources",
+      "actual": {
+        "MalwareProtection": {
+          "ScanEc2InstanceWithFindings": {
+            "EbsVolumes": true
+          }
+        },
+        "S3Logs": {
+          "Enable": true
+        },
+        "Kubernetes": {
+          "AuditLogs": {
+            "Enable": true
+          }
+        }
+      },
+      "physicalId": "7d934291dde5406887fffdf094922448",
+      "constructPath": "CdkrdHunt0714Gd/HuntDetector"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDetector",
+      "resourceType": "AWS::GuardDuty::Detector",
+      "path": "Features",
+      "actual": [
+        {
+          "Status": "DISABLED",
+          "Name": "AI_ANALYST"
+        },
+        {
+          "Status": "DISABLED",
+          "Name": "AI_PROTECTION"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "CLOUD_TRAIL"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "DNS_LOGS"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "EBS_MALWARE_PROTECTION"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "EKS_AUDIT_LOGS"
+        },
+        {
+          "Status": "DISABLED",
+          "AdditionalConfiguration": [
+            {
+              "Status": "DISABLED",
+              "Name": "EKS_ADDON_MANAGEMENT"
+            }
+          ],
+          "Name": "EKS_RUNTIME_MONITORING"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "FLOW_LOGS"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "LAMBDA_NETWORK_LOGS"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "RDS_LOGIN_EVENTS"
+        },
+        {
+          "Status": "DISABLED",
+          "AdditionalConfiguration": [
+            {
+              "Status": "DISABLED",
+              "Name": "EC2_AGENT_MANAGEMENT"
+            },
+            {
+              "Status": "DISABLED",
+              "Name": "ECS_FARGATE_AGENT_MANAGEMENT"
+            },
+            {
+              "Status": "DISABLED",
+              "Name": "EKS_ADDON_MANAGEMENT"
+            }
+          ],
+          "Name": "RUNTIME_MONITORING"
+        },
+        {
+          "Status": "ENABLED",
+          "Name": "S3_DATA_EVENTS"
+        }
+      ],
+      "physicalId": "7d934291dde5406887fffdf094922448",
+      "constructPath": "CdkrdHunt0714Gd/HuntDetector"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GuardDuty__Filter.HuntFilter.json
+++ b/tests/corpus/AWS__GuardDuty__Filter.HuntFilter.json
@@ -1,0 +1,96 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntFilter",
+    "resourceType": "AWS::GuardDuty::Filter",
+    "physicalId": "cdkrd-hunt0714-filter",
+    "constructPath": "CdkrdHunt0714Gd/HuntFilter",
+    "declared": {
+      "DetectorId": "7d934291dde5406887fffdf094922448",
+      "FindingCriteria": {
+        "Criterion": {
+          "severity": {
+            "Gte": 4
+          }
+        }
+      },
+      "Name": "cdkrd-hunt0714-filter",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Action": "NOOP",
+    "DetectorId": "7d934291dde5406887fffdf094922448",
+    "FindingCriteria": {
+      "Criterion": {
+        "severity": {
+          "GreaterThanOrEqual": 4
+        }
+      }
+    },
+    "Rank": 1,
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Gd",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntFilter",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Gd/a36563a0-7f53-11f1-b807-0e8c900acc83",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0714-filter"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DetectorId", "Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DetectorId", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["FindingCriteria.Criterion"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFilter",
+      "resourceType": "AWS::GuardDuty::Filter",
+      "path": "Action",
+      "actual": "NOOP",
+      "physicalId": "cdkrd-hunt0714-filter",
+      "constructPath": "CdkrdHunt0714Gd/HuntFilter"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntFilter",
+      "resourceType": "AWS::GuardDuty::Filter",
+      "path": "Rank",
+      "actual": 1,
+      "physicalId": "cdkrd-hunt0714-filter",
+      "constructPath": "CdkrdHunt0714Gd/HuntFilter"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GuardDuty__IPSet.HuntIpSet.json
+++ b/tests/corpus/AWS__GuardDuty__IPSet.HuntIpSet.json
@@ -1,0 +1,78 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntIpSet",
+    "resourceType": "AWS::GuardDuty::IPSet",
+    "physicalId": "4a0623158c2b4d35afae9e77fbeafe07",
+    "constructPath": "CdkrdHunt0714Gd/HuntIpSet",
+    "declared": {
+      "Activate": true,
+      "DetectorId": "7d934291dde5406887fffdf094922448",
+      "Format": "TXT",
+      "Location": "https://s3.amazonaws.com/cdkrd-hunt0714-gd-111111111111/iplist.txt",
+      "Name": "cdkrd-hunt0714-ipset",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Format": "TXT",
+    "DetectorId": "7d934291dde5406887fffdf094922448",
+    "Id": "4a0623158c2b4d35afae9e77fbeafe07",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Gd",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntIpSet",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Gd/a36563a0-7f53-11f1-b807-0e8c900acc83",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0714-ipset",
+    "Location": "https://s3.amazonaws.com/cdkrd-hunt0714-gd-111111111111/iplist.txt"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["Activate"],
+    "createOnly": ["DetectorId", "Format"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["Activate"],
+    "createOnlyPaths": ["DetectorId", "Format"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntIpSet",
+      "resourceType": "AWS::GuardDuty::IPSet",
+      "path": "Activate",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "4a0623158c2b4d35afae9e77fbeafe07",
+      "constructPath": "CdkrdHunt0714Gd/HuntIpSet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GuardDuty__ThreatIntelSet.HuntThreatSet.json
+++ b/tests/corpus/AWS__GuardDuty__ThreatIntelSet.HuntThreatSet.json
@@ -1,0 +1,78 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntThreatSet",
+    "resourceType": "AWS::GuardDuty::ThreatIntelSet",
+    "physicalId": "616df09218fa455dbba71777d409a05f",
+    "constructPath": "CdkrdHunt0714Gd/HuntThreatSet",
+    "declared": {
+      "Activate": true,
+      "DetectorId": "7d934291dde5406887fffdf094922448",
+      "Format": "TXT",
+      "Location": "https://s3.amazonaws.com/cdkrd-hunt0714-gd-111111111111/threatlist.txt",
+      "Name": "cdkrd-hunt0714-threatset",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Format": "TXT",
+    "DetectorId": "7d934291dde5406887fffdf094922448",
+    "Id": "616df09218fa455dbba71777d409a05f",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Gd",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntThreatSet",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Gd/a36563a0-7f53-11f1-b807-0e8c900acc83",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0714-threatset",
+    "Location": "https://s3.amazonaws.com/cdkrd-hunt0714-gd-111111111111/threatlist.txt"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["Activate"],
+    "createOnly": ["DetectorId", "Format"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["Activate"],
+    "createOnlyPaths": ["DetectorId", "Format"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntThreatSet",
+      "resourceType": "AWS::GuardDuty::ThreatIntelSet",
+      "path": "Activate",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "616df09218fa455dbba71777d409a05f",
+      "constructPath": "CdkrdHunt0714Gd/HuntThreatSet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.HuntDdbEsm.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.HuntDdbEsm.json
@@ -1,0 +1,170 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntDdbEsm",
+    "resourceType": "AWS::Lambda::EventSourceMapping",
+    "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+    "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm",
+    "declared": {
+      "EventSourceArn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkrdHunt0714Esm-HuntEsmTable-1RSCQP4LX3B6Q/stream/2026-07-14T06:39:17.645",
+      "FunctionName": "CdkrdHunt0714Esm-HuntEsmFn-cGyRi7EveaXl",
+      "StartingPosition": "LATEST",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "StartingPosition": "LATEST",
+    "BatchSize": 100,
+    "MaximumRetryAttempts": -1,
+    "ParallelizationFactor": 1,
+    "Enabled": true,
+    "EventSourceArn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkrdHunt0714Esm-HuntEsmTable-1RSCQP4LX3B6Q/stream/2026-07-14T06:39:17.645",
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0714Esm-HuntEsmFn-cGyRi7EveaXl",
+    "TumblingWindowInSeconds": 0,
+    "BisectBatchOnFunctionError": false,
+    "DestinationConfig": {
+      "OnFailure": {}
+    },
+    "EventSourceMappingArn": "arn:aws:lambda:us-east-1:111111111111:event-source-mapping:631f0458-b1f1-4442-95da-32499d25aa63",
+    "MaximumRecordAgeInSeconds": -1,
+    "Id": "631f0458-b1f1-4442-95da-32499d25aa63",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Esm/b4cfcd10-7f4e-11f1-b820-0e9d46a73fdd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "HuntDdbEsm",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0714Esm",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "MaximumBatchingWindowInSeconds": 0
+  },
+  "schema": {
+    "readOnly": ["EventSourceMappingArn", "Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "readOnlyPaths": ["EventSourceMappingArn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDdbEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "BatchSize",
+      "actual": 100,
+      "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+      "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDdbEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumRetryAttempts",
+      "actual": -1,
+      "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+      "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDdbEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "ParallelizationFactor",
+      "actual": 1,
+      "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+      "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDdbEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+      "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDdbEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "TumblingWindowInSeconds",
+      "actual": 0,
+      "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+      "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDdbEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumRecordAgeInSeconds",
+      "actual": -1,
+      "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+      "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntDdbEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumBatchingWindowInSeconds",
+      "actual": 0,
+      "physicalId": "631f0458-b1f1-4442-95da-32499d25aa63",
+      "constructPath": "CdkrdHunt0714Esm/HuntDdbEsm"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.HuntKinesisEsm.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.HuntKinesisEsm.json
@@ -1,0 +1,170 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntKinesisEsm",
+    "resourceType": "AWS::Lambda::EventSourceMapping",
+    "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+    "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm",
+    "declared": {
+      "EventSourceArn": "arn:aws:kinesis:us-east-1:111111111111:stream/CdkrdHunt0714Esm-HuntEsmStream-leajwCLLOnrg",
+      "FunctionName": "CdkrdHunt0714Esm-HuntEsmFn-cGyRi7EveaXl",
+      "StartingPosition": "LATEST",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "StartingPosition": "LATEST",
+    "BatchSize": 100,
+    "MaximumRetryAttempts": -1,
+    "ParallelizationFactor": 1,
+    "Enabled": true,
+    "EventSourceArn": "arn:aws:kinesis:us-east-1:111111111111:stream/CdkrdHunt0714Esm-HuntEsmStream-leajwCLLOnrg",
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0714Esm-HuntEsmFn-cGyRi7EveaXl",
+    "TumblingWindowInSeconds": 0,
+    "BisectBatchOnFunctionError": false,
+    "DestinationConfig": {
+      "OnFailure": {}
+    },
+    "EventSourceMappingArn": "arn:aws:lambda:us-east-1:111111111111:event-source-mapping:9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+    "MaximumRecordAgeInSeconds": -1,
+    "Id": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "HuntKinesisEsm",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Esm/b4cfcd10-7f4e-11f1-b820-0e9d46a73fdd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdHunt0714Esm",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "MaximumBatchingWindowInSeconds": 0
+  },
+  "schema": {
+    "readOnly": ["EventSourceMappingArn", "Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "readOnlyPaths": ["EventSourceMappingArn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKinesisEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "BatchSize",
+      "actual": 100,
+      "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+      "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKinesisEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumRetryAttempts",
+      "actual": -1,
+      "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+      "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKinesisEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "ParallelizationFactor",
+      "actual": 1,
+      "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+      "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKinesisEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+      "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKinesisEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "TumblingWindowInSeconds",
+      "actual": 0,
+      "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+      "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKinesisEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumRecordAgeInSeconds",
+      "actual": -1,
+      "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+      "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKinesisEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumBatchingWindowInSeconds",
+      "actual": 0,
+      "physicalId": "9aed2c55-b60f-4994-945d-beebd6d5d2a8",
+      "constructPath": "CdkrdHunt0714Esm/HuntKinesisEsm"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Pipes__Pipe.HuntPipe.json
+++ b/tests/corpus/AWS__Pipes__Pipe.HuntPipe.json
@@ -1,0 +1,94 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPipe",
+    "resourceType": "AWS::Pipes::Pipe",
+    "physicalId": "HuntPipe-aep0qV9ADOo3",
+    "constructPath": "CdkrdHunt0714Pack/HuntPipe",
+    "declared": {
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Pack-HuntPipeRole1A5D3DA7-UUSuH2J05MHJ",
+      "Source": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0714Pack-HuntPipeSrc-8CwXfPxydRRA",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Target": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0714Pack-HuntPipeDst-xdP5EVuR2TlS"
+    }
+  },
+  "liveRaw": {
+    "Target": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0714Pack-HuntPipeDst-xdP5EVuR2TlS",
+    "DesiredState": "RUNNING",
+    "StateReason": "USER_INITIATED",
+    "CurrentState": "RUNNING",
+    "CreationTime": "2026-07-14T06:40:27Z",
+    "LastModifiedTime": "2026-07-14T06:40:36Z",
+    "Arn": "arn:aws:pipes:us-east-1:111111111111:pipe/HuntPipe-aep0qV9ADOo3",
+    "EnrichmentParameters": {},
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Pack-HuntPipeRole1A5D3DA7-UUSuH2J05MHJ",
+    "Source": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0714Pack-HuntPipeSrc-8CwXfPxydRRA",
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "Name": "HuntPipe-aep0qV9ADOo3"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreationTime", "CurrentState", "LastModifiedTime", "StateReason"],
+    "writeOnly": ["SourceParameters", "TargetParameters"],
+    "createOnly": ["Name", "Source"],
+    "readOnlyPaths": ["Arn", "CreationTime", "CurrentState", "LastModifiedTime", "StateReason"],
+    "writeOnlyPaths": ["SourceParameters", "TargetParameters"],
+    "createOnlyPaths": [
+      "Name",
+      "Source",
+      "SourceParameters.ActiveMQBrokerParameters.QueueName",
+      "SourceParameters.DynamoDBStreamParameters.StartingPosition",
+      "SourceParameters.KinesisStreamParameters.StartingPosition",
+      "SourceParameters.KinesisStreamParameters.StartingPositionTimestamp",
+      "SourceParameters.ManagedStreamingKafkaParameters.ConsumerGroupID",
+      "SourceParameters.ManagedStreamingKafkaParameters.StartingPosition",
+      "SourceParameters.ManagedStreamingKafkaParameters.TopicName",
+      "SourceParameters.RabbitMQBrokerParameters.QueueName",
+      "SourceParameters.RabbitMQBrokerParameters.VirtualHost",
+      "SourceParameters.SelfManagedKafkaParameters.AdditionalBootstrapServers",
+      "SourceParameters.SelfManagedKafkaParameters.ConsumerGroupID",
+      "SourceParameters.SelfManagedKafkaParameters.StartingPosition",
+      "SourceParameters.SelfManagedKafkaParameters.TopicName"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "TargetParameters.EcsTaskParameters.CapacityProviderStrategy.*.Weight": 0,
+      "TargetParameters.EcsTaskParameters.CapacityProviderStrategy.*.Base": 0,
+      "TargetParameters.EcsTaskParameters.EnableECSManagedTags": false,
+      "TargetParameters.EcsTaskParameters.EnableExecuteCommand": false,
+      "TargetParameters.EcsTaskParameters.Overrides.EphemeralStorage.SizeInGiB": 0,
+      "TargetParameters.BatchJobParameters.ArrayProperties.Size": 0,
+      "TargetParameters.BatchJobParameters.RetryStrategy.Attempts": 0,
+      "TargetParameters.RedshiftDataParameters.WithEvent": false
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "EnrichmentParameters.HttpParameters.HeaderParameters",
+      "EnrichmentParameters.HttpParameters.QueryStringParameters",
+      "TargetParameters.BatchJobParameters.Parameters",
+      "TargetParameters.HttpParameters.HeaderParameters",
+      "TargetParameters.HttpParameters.QueryStringParameters"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPipe",
+      "resourceType": "AWS::Pipes::Pipe",
+      "path": "DesiredState",
+      "actual": "RUNNING",
+      "physicalId": "HuntPipe-aep0qV9ADOo3",
+      "constructPath": "CdkrdHunt0714Pack/HuntPipe"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.HuntFifoTopic.json
+++ b/tests/corpus/AWS__SNS__Topic.HuntFifoTopic.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntFifoTopic",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0714Pack.fifo",
+    "constructPath": "CdkrdHunt0714Pack/HuntFifoTopic",
+    "declared": {
+      "FifoTopic": true,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TopicName": "CdkrdHunt0714Pack.fifo"
+    }
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0714Pack.fifo",
+    "FifoTopic": true,
+    "ContentBasedDeduplication": false,
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Pack",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntFifoTopic",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Pack/b9c52e00-7f4e-11f1-bc0a-0e7efe71f17d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "CdkrdHunt0714Pack.fifo"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["DeliveryStatusLogging", "Subscription"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/codepipeline-hunt/app.ts
+++ b/tests/integration/codepipeline-hunt/app.ts
@@ -1,0 +1,61 @@
+// False-positive probe (real AWS): barest CodePipeline — only a rich fixture
+// existed. Declares ONLY RoleArn + ArtifactStore + the minimum two stages
+// (S3 source + manual approval, so no build infrastructure is needed).
+// High-value undeclared surface: PipelineType (AWS's console default flipped
+// V1 -> V2), ExecutionMode, RestartExecutionOnUpdate, per-action defaults
+// (PollForSourceChanges echo in the S3 source Configuration map), Triggers.
+// The pipeline auto-starts once on create and the source action fails
+// harmlessly (no object at the key); nothing bills while idle.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnPipeline } from "aws-cdk-lib/aws-codepipeline";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714Pipe");
+
+const bucket = new CfnBucket(stack, "HuntArtifacts", {
+  versioningConfiguration: { status: "Enabled" },
+});
+
+const role = new Role(stack, "HuntPipeRole", {
+  assumedBy: new ServicePrincipal("codepipeline.amazonaws.com"),
+});
+role.addToPolicy(
+  new PolicyStatement({
+    actions: ["s3:GetObject", "s3:GetObjectVersion", "s3:GetBucketVersioning", "s3:PutObject"],
+    resources: [bucket.attrArn, `${bucket.attrArn}/*`],
+  }),
+);
+
+const pipeline = new CfnPipeline(stack, "HuntPipeline", {
+  roleArn: role.roleArn,
+  artifactStore: { type: "S3", location: bucket.ref },
+  stages: [
+    {
+      name: "Source",
+      actions: [
+        {
+          name: "Src",
+          actionTypeId: { category: "Source", owner: "AWS", provider: "S3", version: "1" },
+          configuration: { S3Bucket: bucket.ref, S3ObjectKey: "src.zip" },
+          outputArtifacts: [{ name: "SrcOut" }],
+        },
+      ],
+    },
+    {
+      name: "Approve",
+      actions: [
+        {
+          name: "Gate",
+          actionTypeId: { category: "Approval", owner: "AWS", provider: "Manual", version: "1" },
+        },
+      ],
+    },
+  ],
+});
+pipeline.node.addDependency(role);
+
+app.synth();

--- a/tests/integration/codepipeline-hunt/cdk.json
+++ b/tests/integration/codepipeline-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/codepipeline-hunt/package.json
+++ b/tests/integration/codepipeline-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-codepipeline-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "First-run FP probe fixture. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/codepipeline-hunt/verify.sh
+++ b/tests/integration/codepipeline-hunt/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest CodePipeline (PipelineType default flip probe)
+# 
+# deploy -> first check (pre-record) MUST be CLEAN (zero [Potential Drift] —
+# grep the output, the exit code is 0 on baseline-less potential drift) ->
+# record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Pipe
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/esm-hunt/app.ts
+++ b/tests/integration/esm-hunt/app.ts
@@ -1,0 +1,79 @@
+// False-positive probe (real AWS): Lambda EventSourceMapping with the two
+// STREAM sources that have zero fixture coverage — every existing ESM fixture
+// is SQS or self-managed Kafka:
+// - DynamoDB Streams source (barest: FunctionName + EventSourceArn +
+//   StartingPosition) — surfaces the stream-source default family
+//   (BatchSize=100, MaximumBatchingWindowInSeconds, BisectBatchOnFunctionError,
+//   ParallelizationFactor, MaximumRecordAgeInSeconds, MaximumRetryAttempts,
+//   TumblingWindowInSeconds, DestinationConfig, FilterCriteria).
+// - Kinesis source (same barest required set, its own default surface).
+// Nothing bills while idle beyond one provisioned Kinesis shard (~$0.015/h);
+// the streams have no producers so the function never invokes.
+// A first `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { AttributeType, CfnTable, StreamViewType } from "aws-cdk-lib/aws-dynamodb";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnStream } from "aws-cdk-lib/aws-kinesis";
+import { CfnEventSourceMapping, CfnFunction } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714Esm");
+
+// --- stream sources, barest ---
+const table = new CfnTable(stack, "HuntEsmTable", {
+  keySchema: [{ attributeName: "pk", keyType: "HASH" }],
+  attributeDefinitions: [{ attributeName: "pk", attributeType: AttributeType.STRING }],
+  billingMode: "PAY_PER_REQUEST",
+  streamSpecification: { streamViewType: StreamViewType.NEW_IMAGE },
+});
+const kstream = new CfnStream(stack, "HuntEsmStream", {
+  shardCount: 1,
+});
+
+// --- consumer function (barest zip) ---
+const role = new Role(stack, "HuntEsmRole", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+});
+// ESM creation validates the role can read the source stream.
+role.addToPolicy(
+  new PolicyStatement({
+    actions: [
+      "dynamodb:GetRecords",
+      "dynamodb:GetShardIterator",
+      "dynamodb:DescribeStream",
+      "dynamodb:ListStreams",
+      "kinesis:GetRecords",
+      "kinesis:GetShardIterator",
+      "kinesis:DescribeStream",
+      "kinesis:DescribeStreamSummary",
+      "kinesis:ListShards",
+      "kinesis:ListStreams",
+      "kinesis:SubscribeToShard",
+    ],
+    resources: ["*"],
+  }),
+);
+const fn = new CfnFunction(stack, "HuntEsmFn", {
+  code: { zipFile: "exports.handler = async () => {};" },
+  handler: "index.handler",
+  runtime: "nodejs20.x",
+  role: role.roleArn,
+});
+fn.node.addDependency(role.node.defaultChild!);
+
+// --- the two uncovered ESM variants, barest ---
+const ddbEsm = new CfnEventSourceMapping(stack, "HuntDdbEsm", {
+  functionName: fn.ref,
+  eventSourceArn: table.attrStreamArn,
+  startingPosition: "LATEST",
+});
+ddbEsm.node.addDependency(role);
+const kinesisEsm = new CfnEventSourceMapping(stack, "HuntKinesisEsm", {
+  functionName: fn.ref,
+  eventSourceArn: kstream.attrArn,
+  startingPosition: "LATEST",
+});
+kinesisEsm.node.addDependency(role);
+
+app.synth();

--- a/tests/integration/esm-hunt/cdk.json
+++ b/tests/integration/esm-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/esm-hunt/package.json
+++ b/tests/integration/esm-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-esm-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "First-run FP probe: barest Lambda EventSourceMapping over the two uncovered STREAM sources (DynamoDB Streams + Kinesis). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/esm-hunt/verify-detect.sh
+++ b/tests/integration/esm-hunt/verify-detect.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Detect + revert-convergence probe for the #1608 folds (real AWS): mutate the
+# two newly folded MUTABLE stream-ESM surfaces out of band -> check MUST DETECT
+# -> revert -> check MUST be CLEAN -> the LIVE values MUST be back at their
+# defaults (a silent no-op revert is the #1571 class; only this live test
+# answers whether the Lambda CC handler converges a bare `remove`).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Esm
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?LogicalResourceId=='$1'].PhysicalResourceId" --output text
+}
+
+# ESM updates transition through State=Updating; poll until the field reflects
+# the expected value (async-update convergence, the #1519 lesson).
+wait_esm_field() { # uuid jmespath expected
+  for _ in $(seq 1 36); do
+    v="$(aws lambda get-event-source-mapping --uuid "$1" --region "$REGION" \
+      --query "$2" --output text 2>/dev/null)"
+    [ "$v" = "$3" ] && return 0
+    sleep 5
+  done
+  echo "last value: $v"
+  return 1
+}
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN (the #1608 fix, live), then record ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP still present after the fold fix"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+DDB_ESM="$(phys HuntDdbEsm)"
+KIN_ESM="$(phys HuntKinesisEsm)"
+
+echo "=== [$STACK] mutate out of band (2 surfaces) ==="
+aws lambda update-event-source-mapping --uuid "$DDB_ESM" --region "$REGION" \
+  --parallelization-factor 5 >/dev/null || fail "mutate parallelization"
+aws lambda update-event-source-mapping --uuid "$KIN_ESM" --region "$REGION" \
+  --tumbling-window-in-seconds 30 >/dev/null || fail "mutate tumbling window"
+wait_esm_field "$DDB_ESM" 'ParallelizationFactor' 5 || fail "parallelization mutation not settled"
+wait_esm_field "$KIN_ESM" 'TumblingWindowInSeconds' 30 || fail "tumbling mutation not settled"
+
+echo "=== [$STACK] check MUST DETECT both ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc"
+grep -q "ParallelizationFactor" "/tmp/cdkrd-$STACK.detect.out" || fail "missed detection: ParallelizationFactor"
+grep -q "TumblingWindowInSeconds" "/tmp/cdkrd-$STACK.detect.out" || fail "missed detection: TumblingWindowInSeconds"
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+grep -Eq "NOT reverted|could not be confirmed" "/tmp/cdkrd-$STACK.revert.out" \
+  && fail "revert reported a non-converged path (see output)"
+wait_esm_field "$DDB_ESM" 'State' Enabled || fail "DDB ESM not settled after revert"
+wait_esm_field "$KIN_ESM" 'State' Enabled || fail "Kinesis ESM not settled after revert"
+
+echo "=== [$STACK] live values MUST be back at their defaults ==="
+wait_esm_field "$DDB_ESM" 'ParallelizationFactor' 1 || fail "ParallelizationFactor did not converge (revert no-op)"
+wait_esm_field "$KIN_ESM" 'TumblingWindowInSeconds' 0 || fail "TumblingWindowInSeconds did not converge (revert no-op)"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.post.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after revert"
+
+echo "INTEG PASS ($STACK detect+revert, #1608)"

--- a/tests/integration/esm-hunt/verify.sh
+++ b/tests/integration/esm-hunt/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest Lambda EventSourceMapping
+# over DynamoDB Streams + Kinesis stream sources.
+# deploy -> first check (pre-record) MUST be CLEAN (zero [Potential Drift] —
+# grep the output, the exit code is 0 on baseline-less potential drift) ->
+# record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Esm
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/fargate-hunt/app.ts
+++ b/tests/integration/fargate-hunt/app.ts
@@ -1,0 +1,53 @@
+// False-positive probe (real AWS): barest L1 FARGATE service — the default
+// ECS mode, yet only the EC2 launch type has a barest fixture
+// (ecs-ec2-service-min); every Fargate fixture is a rich L2. A barest Fargate
+// service surfaces the Fargate-side default family: PlatformVersion,
+// DeploymentConfiguration (MaximumPercent/MinimumHealthyPercent + circuit
+// breaker), DeploymentController, AssignPublicIp=DISABLED, default
+// SecurityGroups echo, SchedulingStrategy, EnableECSManagedTags,
+// AvailabilityZoneRebalancing. DesiredCount is pinned to 0 so no task ever
+// starts (no image pull, no NAT/IGW needed, nothing bills) and CFn's
+// service-stability wait cannot hang.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnService, CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714Fargate");
+
+const vpc = new CfnVPC(stack, "HuntVpc", { cidrBlock: "10.61.0.0/16" });
+const subnet = new CfnSubnet(stack, "HuntSubnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.61.0.0/24",
+  availabilityZone: "us-east-1a",
+});
+
+const cluster = new CfnCluster(stack, "HuntCluster", {});
+
+const taskDef = new CfnTaskDefinition(stack, "HuntTaskDef", {
+  requiresCompatibilities: ["FARGATE"],
+  networkMode: "awsvpc",
+  cpu: "256",
+  memory: "512",
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "public.ecr.aws/docker/library/busybox:stable",
+    },
+  ],
+});
+
+new CfnService(stack, "HuntFargateSvc", {
+  cluster: cluster.ref,
+  taskDefinition: taskDef.ref,
+  launchType: "FARGATE",
+  desiredCount: 0,
+  networkConfiguration: {
+    awsvpcConfiguration: {
+      subnets: [subnet.ref],
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/fargate-hunt/cdk.json
+++ b/tests/integration/fargate-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/fargate-hunt/package.json
+++ b/tests/integration/fargate-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-fargate-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "First-run FP probe fixture. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/fargate-hunt/verify.sh
+++ b/tests/integration/fargate-hunt/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest L1 FARGATE service
+# (DesiredCount 0, no task ever starts).
+# deploy -> first check (pre-record) MUST be CLEAN (zero [Potential Drift] —
+# grep the output, the exit code is 0 on baseline-less potential drift) ->
+# record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Fargate
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/guardduty-hunt/app.ts
+++ b/tests/integration/guardduty-hunt/app.ts
@@ -1,0 +1,48 @@
+// Adapter-family probe (real AWS): the GuardDuty sub-resource
+// CC_IDENTIFIER_ADAPTERS entries (Filter / IPSet / ThreatIntelSet) have zero
+// corpus and zero fixture coverage — only the Detector itself was ever read.
+// Their primaryIdentifier is composite (DetectorId + child id) while the CFn
+// physical id is only the child segment, so a wrong adapter order silently
+// skips every read (the #1523 class: a throwing reader looks CLEAN). This
+// deploys the barest detector + the three children and asserts the first
+// check is CLEAN (reads resolve + defaults fold).
+// The IP/threat list files are pre-uploaded out of band by verify.sh (bucket
+// via GD_BUCKET env) — GuardDuty validates the S3 location at create.
+// PublishingDestination (bucket-policy + KMS plumbing) is deferred.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDetector, CfnFilter, CfnIPSet, CfnThreatIntelSet } from "aws-cdk-lib/aws-guardduty";
+
+const bucket = process.env.GD_BUCKET;
+if (!bucket) throw new Error("GD_BUCKET env is required (set by verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714Gd");
+
+const detector = new CfnDetector(stack, "HuntDetector", { enable: true });
+
+new CfnFilter(stack, "HuntFilter", {
+  detectorId: detector.ref,
+  name: "cdkrd-hunt0714-filter",
+  findingCriteria: {
+    criterion: { severity: { Gte: 4 } },
+  },
+});
+
+new CfnIPSet(stack, "HuntIpSet", {
+  detectorId: detector.ref,
+  name: "cdkrd-hunt0714-ipset",
+  format: "TXT",
+  location: `https://s3.amazonaws.com/${bucket}/iplist.txt`,
+  activate: true,
+});
+
+new CfnThreatIntelSet(stack, "HuntThreatSet", {
+  detectorId: detector.ref,
+  name: "cdkrd-hunt0714-threatset",
+  format: "TXT",
+  location: `https://s3.amazonaws.com/${bucket}/threatlist.txt`,
+  activate: true,
+});
+
+app.synth();

--- a/tests/integration/guardduty-hunt/cdk.json
+++ b/tests/integration/guardduty-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/guardduty-hunt/package.json
+++ b/tests/integration/guardduty-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-guardduty-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Adapter-family probe: barest GuardDuty Detector + Filter/IPSet/ThreatIntelSet children. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/guardduty-hunt/verify.sh
+++ b/tests/integration/guardduty-hunt/verify.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Adapter-family integration test (real AWS): barest GuardDuty Detector +
+# Filter/IPSet/ThreatIntelSet children (composite-identifier adapter probe).
+# Pre-uploads the list files to an out-of-band bucket (GuardDuty validates the
+# S3 location at create), grants guardduty.amazonaws.com read via bucket
+# policy, then: deploy -> first check (pre-record) MUST be CLEAN and MUST NOT
+# skip the children -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Gd
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+export GD_BUCKET="cdkrd-hunt0714-gd-${ACCOUNT}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  aws s3 rb "s3://$GD_BUCKET" --force >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] out-of-band prep: list bucket + files + guardduty read policy ==="
+aws s3 mb "s3://$GD_BUCKET" --region "$REGION" >/dev/null || fail "mb"
+printf '198.51.100.1\n' > /tmp/cdkrd-gd-list.txt
+aws s3 cp /tmp/cdkrd-gd-list.txt "s3://$GD_BUCKET/iplist.txt" >/dev/null || fail "cp iplist"
+aws s3 cp /tmp/cdkrd-gd-list.txt "s3://$GD_BUCKET/threatlist.txt" >/dev/null || fail "cp threatlist"
+aws s3api put-bucket-policy --bucket "$GD_BUCKET" --policy "{
+  \"Version\": \"2012-10-17\",
+  \"Statement\": [{
+    \"Effect\": \"Allow\",
+    \"Principal\": { \"Service\": \"guardduty.amazonaws.com\" },
+    \"Action\": \"s3:GetObject\",
+    \"Resource\": \"arn:aws:s3:::$GD_BUCKET/*\"
+  }]
+}" || fail "bucket policy"
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN + children READ ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+# A composite-id adapter gap surfaces as skipped= in the info footer — that is
+# the bug this fixture exists to catch, so fail loudly on it.
+if grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out"; then
+  fail "children were skipped (composite-identifier read gap)"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/pack-hunt/app.ts
+++ b/tests/integration/pack-hunt/app.ts
@@ -1,0 +1,110 @@
+// False-positive probe (real AWS): barest forms of six common types that have
+// only rich (or zero) fixture coverage — each declares ONLY what CFn requires,
+// so the undeclared default surface is maximal:
+// - Lambda LayerVersion (asset Content only; CompatibleRuntimes/Architectures
+//   undeclared) — rich-only until now.
+// - Lambda function on arm64 (the arm path's defaults were only ever deployed
+//   inside rich fixtures).
+// - CloudWatch Dashboard (DashboardBody only — also a JSON-string echo probe).
+// - CloudWatch CompositeAlarm (AlarmName+AlarmRule; ActionsEnabled undeclared).
+// - SNS FIFO topic (TopicName+FifoTopic; ContentBasedDeduplication /
+//   FifoThroughputScope / ArchivePolicy undeclared) — only a rich KMS+dedup
+//   FIFO fixture existed.
+// - EventBridge Pipes (Source+Target+RoleArn; DesiredState + batch parameter
+//   defaults undeclared) — rich-only until now.
+// Nothing bills while idle. A first `check` (pre-record) must show ZERO
+// [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnAlarm, CfnCompositeAlarm, CfnDashboard } from "aws-cdk-lib/aws-cloudwatch";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { Code, LayerVersion } from "aws-cdk-lib/aws-lambda";
+import { CfnPipe } from "aws-cdk-lib/aws-pipes";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714Pack");
+
+// --- Lambda LayerVersion, barest (Content only via asset) ---
+new LayerVersion(stack, "HuntLayer", {
+  code: Code.fromAsset("layer-src"),
+});
+
+// --- Lambda on arm64, barest ---
+const fnRole = new Role(stack, "HuntArmRole", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+});
+new CfnFunction(stack, "HuntArmFn", {
+  code: { zipFile: "exports.handler = async () => {};" },
+  handler: "index.handler",
+  runtime: "nodejs20.x",
+  architectures: ["arm64"],
+  role: fnRole.roleArn,
+});
+
+// --- CloudWatch Dashboard, barest (JSON-string body echo probe) ---
+new CfnDashboard(stack, "HuntDashboard", {
+  dashboardBody: JSON.stringify({
+    widgets: [
+      {
+        type: "text",
+        x: 0,
+        y: 0,
+        width: 6,
+        height: 3,
+        properties: { markdown: "cdkrd hunt" },
+      },
+    ],
+  }),
+});
+
+// --- CloudWatch metric alarm (named, for the composite rule) + composite ---
+const alarm = new CfnAlarm(stack, "HuntAlarm", {
+  alarmName: "CdkrdHunt0714PackChild",
+  comparisonOperator: "GreaterThanThreshold",
+  evaluationPeriods: 1,
+  metricName: "NumberOfObjects",
+  namespace: "AWS/S3",
+  period: 86400,
+  statistic: "Average",
+  threshold: 100000,
+});
+const composite = new CfnCompositeAlarm(stack, "HuntComposite", {
+  alarmName: "CdkrdHunt0714PackComposite",
+  alarmRule: `ALARM("${alarm.alarmName}")`,
+});
+composite.addDependency(alarm);
+
+// --- SNS FIFO topic, barest ---
+new CfnTopic(stack, "HuntFifoTopic", {
+  topicName: "CdkrdHunt0714Pack.fifo",
+  fifoTopic: true,
+});
+
+// --- EventBridge Pipe, barest (SQS -> SQS) ---
+const srcQueue = new CfnQueue(stack, "HuntPipeSrc", {});
+const dstQueue = new CfnQueue(stack, "HuntPipeDst", {});
+const pipeRole = new Role(stack, "HuntPipeRole", {
+  assumedBy: new ServicePrincipal("pipes.amazonaws.com"),
+});
+pipeRole.addToPolicy(
+  new PolicyStatement({
+    actions: [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:SendMessage",
+    ],
+    resources: [srcQueue.attrArn, dstQueue.attrArn],
+  }),
+);
+const pipe = new CfnPipe(stack, "HuntPipe", {
+  roleArn: pipeRole.roleArn,
+  source: srcQueue.attrArn,
+  target: dstQueue.attrArn,
+});
+pipe.node.addDependency(pipeRole);
+
+app.synth();

--- a/tests/integration/pack-hunt/cdk.json
+++ b/tests/integration/pack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/pack-hunt/layer-src/index.js
+++ b/tests/integration/pack-hunt/layer-src/index.js
@@ -1,0 +1,2 @@
+// Placeholder layer content for the barest LayerVersion probe.
+module.exports = {};

--- a/tests/integration/pack-hunt/package.json
+++ b/tests/integration/pack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-pack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "First-run FP probe fixture. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/pack-hunt/verify.sh
+++ b/tests/integration/pack-hunt/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest common-type pack (LayerVersion, arm64 fn,
+# Dashboard, CompositeAlarm, SNS FIFO, Pipes).
+# deploy -> first check (pre-record) MUST be CLEAN (zero [Potential Drift] —
+# grep the output, the exit code is 0 on baseline-less potential drift) ->
+# record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Pack
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/revconv3-hunt/app.ts
+++ b/tests/integration/revconv3-hunt/app.ts
@@ -1,0 +1,93 @@
+// Revert-convergence probe batch 4 (real AWS): seven cheap common types whose
+// folded MUTABLE default has never been convergence-proven — does the CC
+// handler reconcile a bare `remove` back to the default, or silently no-op
+// (the #1571 class)? The API shape is not a predictor; only the live test
+// answers, per-property. Candidates mined offline from KNOWN_DEFAULTS minus
+// REVERT_SET_DEFAULT_PATHS coverage:
+// - SQS Queue SqsManagedSseEnabled (true)
+// - Athena WorkGroup State (ENABLED)
+// - DynamoDB Table DeletionProtectionEnabled (false)
+// - StepFunctions StateMachine LoggingConfiguration (whole-object OFF)
+// - ApiGateway RestApi DisableExecuteApiEndpoint (false)
+// - Cognito UserPoolClient RefreshTokenValidity (30; full-PUT update API)
+// - Scheduler Schedule State (ENABLED; full-PUT update API)
+// (SSM Parameter Tier was excluded: AWS cannot downgrade Advanced->Standard,
+// so the revert is server-side irreversible — not a convergence probe.)
+// The barest Athena WorkGroup + Cognito UserPoolClient here also double as
+// first-run FP probes (rich-only coverage until now).
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnRestApi } from "aws-cdk-lib/aws-apigateway";
+import { CfnWorkGroup } from "aws-cdk-lib/aws-athena";
+import { CfnUserPool, CfnUserPoolClient } from "aws-cdk-lib/aws-cognito";
+import { AttributeType, CfnTable } from "aws-cdk-lib/aws-dynamodb";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+import { CfnSchedule } from "aws-cdk-lib/aws-scheduler";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+import { CfnStateMachine } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714RevConv3");
+
+new CfnQueue(stack, "Conv3Queue", {});
+
+new CfnWorkGroup(stack, "Conv3WorkGroup", { name: "cdkrd-hunt0714-wg" });
+
+new CfnTable(stack, "Conv3Table", {
+  keySchema: [{ attributeName: "pk", keyType: "HASH" }],
+  attributeDefinitions: [{ attributeName: "pk", attributeType: AttributeType.STRING }],
+  billingMode: "PAY_PER_REQUEST",
+});
+
+// StepFunctions: the role needs log-delivery perms so the out-of-band
+// "enable logging" mutation is accepted by UpdateStateMachine.
+const sfnRole = new Role(stack, "Conv3SfnRole", {
+  assumedBy: new ServicePrincipal("states.amazonaws.com"),
+});
+sfnRole.addToPolicy(
+  new PolicyStatement({
+    actions: [
+      "logs:CreateLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:UpdateLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:ListLogDeliveries",
+      "logs:PutResourcePolicy",
+      "logs:DescribeResourcePolicies",
+      "logs:DescribeLogGroups",
+    ],
+    resources: ["*"],
+  }),
+);
+new CfnLogGroup(stack, "Conv3SfnLogs", {});
+const sm = new CfnStateMachine(stack, "Conv3Sfn", {
+  roleArn: sfnRole.roleArn,
+  definitionString: JSON.stringify({
+    StartAt: "Done",
+    States: { Done: { Type: "Pass", End: true } },
+  }),
+});
+sm.node.addDependency(sfnRole.node.defaultChild!);
+
+new CfnRestApi(stack, "Conv3RestApi", { name: "cdkrd-hunt0714-rest" });
+
+const pool = new CfnUserPool(stack, "Conv3Pool", {});
+new CfnUserPoolClient(stack, "Conv3PoolClient", { userPoolId: pool.ref });
+
+// Scheduler: barest schedule targeting the queue (never fires anything useful).
+const schedQueue = new CfnQueue(stack, "Conv3SchedQueue", {});
+const schedRole = new Role(stack, "Conv3SchedRole", {
+  assumedBy: new ServicePrincipal("scheduler.amazonaws.com"),
+});
+schedRole.addToPolicy(
+  new PolicyStatement({ actions: ["sqs:SendMessage"], resources: [schedQueue.attrArn] }),
+);
+const schedule = new CfnSchedule(stack, "Conv3Schedule", {
+  flexibleTimeWindow: { mode: "OFF" },
+  scheduleExpression: "rate(12 hours)",
+  target: { arn: schedQueue.attrArn, roleArn: schedRole.roleArn },
+});
+schedule.node.addDependency(schedRole);
+
+app.synth();

--- a/tests/integration/revconv3-hunt/cdk.json
+++ b/tests/integration/revconv3-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revconv3-hunt/package.json
+++ b/tests/integration/revconv3-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revconv3-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Revert-convergence probe batch 4: seven folded mutable surfaces, mutate -> detect -> revert -> live-value converge. Run via verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revconv3-hunt/verify-detect.sh
+++ b/tests/integration/revconv3-hunt/verify-detect.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Revert-convergence probe batch 4 (real AWS): mutate seven folded MUTABLE
+# surfaces out of band -> check MUST DETECT -> revert -> check MUST be CLEAN ->
+# the LIVE values MUST be back at their defaults (a silent no-op revert is the
+# #1571 class; the API shape is not a predictor, only this live test answers).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714RevConv3
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+WG=cdkrd-hunt0714-wg
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?LogicalResourceId=='$1'].PhysicalResourceId" --output text
+}
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN (barest Athena WG + UserPoolClient FP probe), then record ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP (see pre.out)"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+QURL="$(aws sqs get-queue-url --queue-name "$(phys Conv3Queue | awk -F/ '{print $NF}')" --region "$REGION" --query QueueUrl --output text)"
+TBL="$(phys Conv3Table)"
+SM_ARN="$(phys Conv3Sfn)"
+SFN_LG="$(phys Conv3SfnLogs)"
+API="$(phys Conv3RestApi)"
+POOL="$(phys Conv3Pool)"
+CLIENT="$(phys Conv3PoolClient)"
+SCHED="$(phys Conv3Schedule | awk -F/ '{print $NF}')"
+
+echo "=== [$STACK] mutate out of band (7 surfaces) ==="
+aws sqs set-queue-attributes --queue-url "$QURL" --region "$REGION" \
+  --attributes SqsManagedSseEnabled=false || fail "mutate sqs sse"
+aws athena update-work-group --work-group "$WG" --region "$REGION" --state DISABLED || fail "mutate athena state"
+aws dynamodb update-table --table-name "$TBL" --region "$REGION" \
+  --deletion-protection-enabled >/dev/null || fail "mutate ddb delprot"
+LG_ARN="$(aws logs describe-log-groups --log-group-name-prefix "$SFN_LG" --region "$REGION" \
+  --query 'logGroups[0].arn' --output text)"
+aws stepfunctions update-state-machine --state-machine-arn "$SM_ARN" --region "$REGION" \
+  --logging-configuration "level=ALL,includeExecutionData=true,destinations=[{cloudWatchLogsLogGroup={logGroupArn=$LG_ARN}}]" \
+  >/dev/null || fail "mutate sfn logging"
+aws apigateway update-rest-api --rest-api-id "$API" --region "$REGION" \
+  --patch-operations op=replace,path=/disableExecuteApiEndpoint,value=true >/dev/null || fail "mutate apigw"
+aws cognito-idp update-user-pool-client --user-pool-id "$POOL" --client-id "$CLIENT" --region "$REGION" \
+  --refresh-token-validity 60 >/dev/null || fail "mutate cognito client"
+TGT="$(aws scheduler get-schedule --name "$SCHED" --region "$REGION" --query 'Target' --output json)"
+aws scheduler update-schedule --name "$SCHED" --region "$REGION" --state DISABLED \
+  --schedule-expression 'rate(12 hours)' --flexible-time-window Mode=OFF \
+  --target "$TGT" >/dev/null || fail "mutate scheduler state"
+sleep 20
+
+echo "=== [$STACK] check MUST DETECT all 7 ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc"
+for needle in SqsManagedSseEnabled State DeletionProtectionEnabled LoggingConfiguration DisableExecuteApiEndpoint RefreshTokenValidity; do
+  grep -q "$needle" "/tmp/cdkrd-$STACK.detect.out" || fail "missed detection: $needle"
+done
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+grep -Eq "NOT reverted|could not be confirmed" "/tmp/cdkrd-$STACK.revert.out" \
+  && fail "revert reported a non-converged path (see output)"
+sleep 20
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.post.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after revert — a revert did not converge"
+
+echo "=== [$STACK] live values MUST be back at their defaults ==="
+SSE="$(aws sqs get-queue-attributes --queue-url "$QURL" --region "$REGION" \
+  --attribute-names SqsManagedSseEnabled --query 'Attributes.SqsManagedSseEnabled' --output text)"
+[ "$SSE" = "true" ] || fail "SqsManagedSseEnabled still $SSE (revert no-op)"
+WGS="$(aws athena get-work-group --work-group "$WG" --region "$REGION" \
+  --query 'WorkGroup.State' --output text)"
+[ "$WGS" = "ENABLED" ] || fail "Athena WorkGroup State still $WGS (revert no-op)"
+DP="$(aws dynamodb describe-table --table-name "$TBL" --region "$REGION" \
+  --query 'Table.DeletionProtectionEnabled' --output text)"
+[ "$DP" = "False" ] || fail "DDB DeletionProtectionEnabled still $DP (revert no-op)"
+LVL="$(aws stepfunctions describe-state-machine --state-machine-arn "$SM_ARN" --region "$REGION" \
+  --query 'loggingConfiguration.level' --output text)"
+[ "$LVL" = "OFF" ] || fail "SFN logging level still $LVL (revert no-op)"
+DEE="$(aws apigateway get-rest-api --rest-api-id "$API" --region "$REGION" \
+  --query 'disableExecuteApiEndpoint' --output text)"
+{ [ "$DEE" = "False" ] || [ "$DEE" = "None" ]; } || fail "DisableExecuteApiEndpoint still $DEE (revert no-op)"
+RTV="$(aws cognito-idp describe-user-pool-client --user-pool-id "$POOL" --client-id "$CLIENT" --region "$REGION" \
+  --query 'UserPoolClient.RefreshTokenValidity' --output text)"
+[ "$RTV" = "30" ] || fail "RefreshTokenValidity still $RTV (revert no-op)"
+SST="$(aws scheduler get-schedule --name "$SCHED" --region "$REGION" --query 'State' --output text)"
+[ "$SST" = "ENABLED" ] || fail "Schedule State still $SST (revert no-op)"
+
+echo "INTEG PASS ($STACK detect+revert batch 4)"

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -245,6 +245,37 @@ resource_gone() {
           { [ "$nst" = "deleted" ] || [ "$nst" = "deleting" ] || [ "$nst" = "None" ]; } && return 0
           return 1
           ;;
+        *:vpn-gateway/vgw-*)
+          # Same terminal-state lag for the VPN family (2026-07-14 hunt cleanup, after a
+          # peer's #1607 VPN fixture): a deleted VPN gateway / connection / customer
+          # gateway stays visible in its describe with State "deleted" for a while AND in
+          # the tag index, false-flagging as ORPHAN and blocking an unrelated gate.
+          # deleted/deleting counts as gone; NotFound too. Any other state stays RED.
+          id="${arn##*/}"
+          local vgst
+          vgst="$(aws ec2 describe-vpn-gateways --vpn-gateway-ids "$id" --region "$REGION" \
+            --query 'VpnGateways[0].State' --output text 2>/dev/null)" || return 0
+          { [ "$vgst" = "deleted" ] || [ "$vgst" = "deleting" ] || [ "$vgst" = "None" ]; } && return 0
+          return 1
+          ;;
+        *:vpn-connection/vpn-*)
+          # VPN connection twin of the vpn-gateway arm above (2026-07-14).
+          id="${arn##*/}"
+          local vcst
+          vcst="$(aws ec2 describe-vpn-connections --vpn-connection-ids "$id" --region "$REGION" \
+            --query 'VpnConnections[0].State' --output text 2>/dev/null)" || return 0
+          { [ "$vcst" = "deleted" ] || [ "$vcst" = "deleting" ] || [ "$vcst" = "None" ]; } && return 0
+          return 1
+          ;;
+        *:customer-gateway/cgw-*)
+          # Customer gateway twin of the vpn-gateway arm above (2026-07-14).
+          id="${arn##*/}"
+          local cgst
+          cgst="$(aws ec2 describe-customer-gateways --customer-gateway-ids "$id" --region "$REGION" \
+            --query 'CustomerGateways[0].State' --output text 2>/dev/null)" || return 0
+          { [ "$cgst" = "deleted" ] || [ "$cgst" = "deleting" ] || [ "$cgst" = "None" ]; } && return 0
+          return 1
+          ;;
         *:transit-gateway/tgw-*)
           # Same terminal-state lag for a deleted TRANSIT GATEWAY itself (2026-07-13
           # follow-up: a TGW orphaned by an attachment-race delstack, then deleted, stayed

--- a/tests/integration/wsapi-model-hunt/app.ts
+++ b/tests/integration/wsapi-model-hunt/app.ts
@@ -1,0 +1,79 @@
+// Adapter probe (real AWS): AWS::ApiGatewayV2::Model and ::Deployment have
+// CC_IDENTIFIER_ADAPTERS entries (composite ApiId|child id) but ZERO corpus and
+// ZERO fixture coverage — a wrong adapter order silently skips every read (the
+// #1523 class). Deploys a barest WebSocket API with a Model + an explicit
+// Deployment (+ the Lambda integration a deployable route requires) and asserts
+// the first check is CLEAN with nothing skipped.
+// (ApiMapping / v1 BasePathMapping need an ACM cert + custom domain — deferred.)
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnApi,
+  CfnDeployment,
+  CfnIntegration,
+  CfnModel,
+  CfnRoute,
+  CfnStage,
+} from "aws-cdk-lib/aws-apigatewayv2";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnFunction, CfnPermission } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714WsExt");
+
+const api = new CfnApi(stack, "HuntWsApi", {
+  name: "cdkrd-hunt0714-ws",
+  protocolType: "WEBSOCKET",
+  routeSelectionExpression: "$request.body.action",
+});
+
+const fnRole = new Role(stack, "HuntWsFnRole", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+});
+const fn = new CfnFunction(stack, "HuntWsFn", {
+  code: { zipFile: "exports.handler = async () => ({ statusCode: 200 });" },
+  handler: "index.handler",
+  runtime: "nodejs20.x",
+  role: fnRole.roleArn,
+});
+new CfnPermission(stack, "HuntWsPerm", {
+  action: "lambda:InvokeFunction",
+  functionName: fn.ref,
+  principal: "apigateway.amazonaws.com",
+});
+
+const integration = new CfnIntegration(stack, "HuntWsIntegration", {
+  apiId: api.ref,
+  integrationType: "AWS_PROXY",
+  integrationUri: `arn:aws:apigateway:${stack.region}:lambda:path/2015-03-31/functions/${fn.attrArn}/invocations`,
+});
+
+const route = new CfnRoute(stack, "HuntWsRoute", {
+  apiId: api.ref,
+  routeKey: "$connect",
+  target: `integrations/${integration.ref}`,
+});
+
+new CfnModel(stack, "HuntWsModel", {
+  apiId: api.ref,
+  name: "HuntModel",
+  contentType: "application/json",
+  schema: {
+    $schema: "http://json-schema.org/draft-04/schema#",
+    title: "HuntModel",
+    type: "object",
+  },
+});
+
+const deployment = new CfnDeployment(stack, "HuntWsDeployment", {
+  apiId: api.ref,
+});
+deployment.addDependency(route);
+
+new CfnStage(stack, "HuntWsStage", {
+  apiId: api.ref,
+  stageName: "hunt",
+  deploymentId: deployment.ref,
+});
+
+app.synth();

--- a/tests/integration/wsapi-model-hunt/cdk.json
+++ b/tests/integration/wsapi-model-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wsapi-model-hunt/package.json
+++ b/tests/integration/wsapi-model-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wsapi-model-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Adapter probe: barest ApiGatewayV2 Model + Deployment on a WebSocket API. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wsapi-model-hunt/verify.sh
+++ b/tests/integration/wsapi-model-hunt/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): barest ApiGatewayV2 Model + Deployment (composite-adapter probe)
+# 
+# deploy -> first check (pre-record) MUST be CLEAN (zero [Potential Drift] —
+# grep the output, the exit code is 0 on baseline-less potential drift) ->
+# record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714WsExt
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out"; then
+  echo "--- FIRST-RUN FALSE POSITIVE ---"
+  fail "expected zero [Potential Drift] on first check"
+fi
+
+# A composite-id adapter gap surfaces as skipped= in the info footer — that is
+# the read gap this fixture exists to catch.
+if grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out"; then
+  fail "resources were skipped (composite-identifier read gap)"
+fi
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE on clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -572,6 +572,8 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULTS['AWS::Cognito::UserPoolClient'].RefreshTokenValidity).toBe(30);
     expect(KNOWN_DEFAULTS['AWS::ECS::Service'].HealthCheckGracePeriodSeconds).toBe(0);
     expect(KNOWN_DEFAULT_PATHS['AWS::ECS::Service']).toEqual({
+      // #1610: the awsvpc-mode public-IP default a barest Fargate service reads back.
+      'NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp': 'DISABLED',
       'DeploymentConfiguration.Strategy': 'ROLLING',
       'DeploymentConfiguration.BakeTimeInMinutes': 0,
       'DeploymentConfiguration.DeploymentCircuitBreaker.ResetOnHealthyTask': true,
@@ -671,6 +673,9 @@ describe('noise suppressors', () => {
       MaximumRecordAgeInSeconds: -1,
       Enabled: true,
       MaximumBatchingWindowInSeconds: 0,
+      // #1608: stream-source (DDB/Kinesis) concurrency + windowing defaults.
+      ParallelizationFactor: 1,
+      TumblingWindowInSeconds: 0,
     });
   });
 

--- a/tests/noise-codepipeline-defaults.test.ts
+++ b/tests/noise-codepipeline-defaults.test.ts
@@ -1,0 +1,83 @@
+// #1609: a barest CodePipeline (RoleArn + ArtifactStore + minimal stages)
+// materializes PipelineType (era-dependent: fresh pipelines read "V2", pre-2023-10
+// pipelines read "V1" -> KNOWN_DEFAULT_ONE_OF) and RunOrder=1 on every action
+// (constant -> nested KNOWN_DEFAULT_PATHS). Both must fold to atDefault on a
+// clean deploy. Live-found on the 2026-07-14 hunt (codepipeline-hunt,
+// CdkrdHunt0714Pipe).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const stages = (runOrder?: number) => [
+  {
+    Name: 'Source',
+    Actions: [
+      {
+        Name: 'Src',
+        ActionTypeId: { Category: 'Source', Owner: 'AWS', Provider: 'S3', Version: '1' },
+        Configuration: { S3Bucket: 'b', S3ObjectKey: 'src.zip' },
+        OutputArtifacts: [{ Name: 'SrcOut' }],
+        ...(runOrder === undefined ? {} : { RunOrder: runOrder }),
+      },
+    ],
+  },
+];
+
+const res: DesiredResource = {
+  logicalId: 'HuntPipeline',
+  resourceType: 'AWS::CodePipeline::Pipeline',
+  physicalId: 'HuntPipeline-ABC',
+  declared: {
+    RoleArn: 'arn:aws:iam::111122223333:role/pipe',
+    ArtifactStore: { Type: 'S3', Location: 'b' },
+    Stages: stages(),
+  },
+};
+const cleanLive = (pipelineType: string, runOrder = 1) => ({
+  RoleArn: 'arn:aws:iam::111122223333:role/pipe',
+  ArtifactStore: { Type: 'S3', Location: 'b' },
+  Stages: stages(runOrder),
+  PipelineType: pipelineType,
+});
+
+describe('CodePipeline PipelineType (era ONE_OF) + Actions RunOrder (nested constant)', () => {
+  it('folds the V2-era creation default + RunOrder=1 on a clean deploy', () => {
+    const f = classifyResource(res, cleanLive('V2'), emptySchema);
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain('PipelineType');
+    expect(tier(f, 'atDefault').filter((p) => p.endsWith('RunOrder'))).toHaveLength(1);
+  });
+  it('folds the V1 era default too (same-template asymmetry)', () => {
+    const f = classifyResource(res, cleanLive('V1'), emptySchema);
+    expect(tier(f, 'atDefault')).toContain('PipelineType');
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+  it('surfaces an out-of-band RunOrder re-ordering — detection preserved', () => {
+    const f = classifyResource(res, cleanLive('V2', 3), emptySchema);
+    expect(tier(f, 'undeclared').filter((p) => p.endsWith('RunOrder'))).toHaveLength(1);
+  });
+  it('compares a DECLARED PipelineType in the declared dimension (unaffected)', () => {
+    const declaredRes: DesiredResource = {
+      ...res,
+      declared: { ...res.declared, PipelineType: 'V1' },
+    };
+    const f = classifyResource(declaredRes, cleanLive('V2'), emptySchema);
+    expect(tier(f, 'declared')).toContain('PipelineType');
+  });
+});

--- a/tests/noise-ecs-assignpublicip.test.ts
+++ b/tests/noise-ecs-assignpublicip.test.ts
@@ -1,0 +1,77 @@
+// #1610: a barest awsvpc-mode ECS service (NetworkConfiguration declared with
+// Subnets only) materializes AssignPublicIp=DISABLED, which must fold to
+// atDefault on a clean deploy while an out-of-band ENABLED flip (a real
+// exposure change) still surfaces. Live-found on the 2026-07-14 hunt
+// (fargate-hunt, CdkrdHunt0714Fargate).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const res: DesiredResource = {
+  logicalId: 'HuntFargateSvc',
+  resourceType: 'AWS::ECS::Service',
+  physicalId: 'arn:aws:ecs:us-east-1:111122223333:service/c/svc',
+  declared: {
+    Cluster: 'c',
+    TaskDefinition: 'td',
+    LaunchType: 'FARGATE',
+    DesiredCount: 0,
+    NetworkConfiguration: { AwsvpcConfiguration: { Subnets: ['subnet-1'] } },
+  },
+};
+const live = (assign: string) => ({
+  Cluster: 'c',
+  TaskDefinition: 'td',
+  LaunchType: 'FARGATE',
+  DesiredCount: 0,
+  NetworkConfiguration: {
+    AwsvpcConfiguration: { Subnets: ['subnet-1'], AssignPublicIp: assign },
+  },
+});
+
+describe('ECS::Service AwsvpcConfiguration.AssignPublicIp (equality-gated constant)', () => {
+  it('folds the DISABLED creation default on a clean deploy', () => {
+    const f = classifyResource(res, live('DISABLED'), emptySchema);
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain(
+      'NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp'
+    );
+  });
+  it('surfaces an out-of-band ENABLED flip — detection preserved', () => {
+    const f = classifyResource(res, live('ENABLED'), emptySchema);
+    expect(tier(f, 'undeclared')).toEqual([
+      'NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp',
+    ]);
+  });
+  it('compares a DECLARED AssignPublicIp in the declared dimension (unaffected)', () => {
+    const declaredRes: DesiredResource = {
+      ...res,
+      declared: {
+        ...res.declared,
+        NetworkConfiguration: {
+          AwsvpcConfiguration: { Subnets: ['subnet-1'], AssignPublicIp: 'DISABLED' },
+        },
+      },
+    };
+    const f = classifyResource(declaredRes, live('ENABLED'), emptySchema);
+    expect(tier(f, 'declared')).toContain(
+      'NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp'
+    );
+  });
+});

--- a/tests/noise-esm-stream-defaults.test.ts
+++ b/tests/noise-esm-stream-defaults.test.ts
@@ -1,0 +1,68 @@
+// #1608: a barest STREAM-source EventSourceMapping (DynamoDB Streams / Kinesis —
+// FunctionName + EventSourceArn + StartingPosition only) materializes the
+// stream-only defaults ParallelizationFactor=1 and TumblingWindowInSeconds=0,
+// which must fold to atDefault on a clean deploy (they are AWS-assigned
+// defaults, not divergences). SQS sources never carry either prop.
+// Live-found on the 2026-07-14 hunt (esm-hunt, CdkrdHunt0714Esm).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const res: DesiredResource = {
+  logicalId: 'HuntDdbEsm',
+  resourceType: 'AWS::Lambda::EventSourceMapping',
+  physicalId: 'esm-uuid',
+  declared: {
+    FunctionName: 'huntfn',
+    EventSourceArn: 'arn:aws:dynamodb:us-east-1:111122223333:table/t/stream/2026',
+    StartingPosition: 'LATEST',
+  },
+};
+const cleanLive = {
+  FunctionName: 'huntfn',
+  EventSourceArn: 'arn:aws:dynamodb:us-east-1:111122223333:table/t/stream/2026',
+  StartingPosition: 'LATEST',
+  ParallelizationFactor: 1,
+  TumblingWindowInSeconds: 0,
+};
+
+describe('Lambda::EventSourceMapping stream-source defaults (equality-gated constants)', () => {
+  it('folds ParallelizationFactor=1 and TumblingWindowInSeconds=0 on a clean deploy', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain('ParallelizationFactor');
+    expect(tier(f, 'atDefault')).toContain('TumblingWindowInSeconds');
+  });
+  it('surfaces an out-of-band parallelization raise — detection preserved', () => {
+    const f = classifyResource(res, { ...cleanLive, ParallelizationFactor: 5 }, emptySchema);
+    expect(tier(f, 'undeclared')).toEqual(['ParallelizationFactor']);
+  });
+  it('surfaces an out-of-band tumbling window — detection preserved', () => {
+    const f = classifyResource(res, { ...cleanLive, TumblingWindowInSeconds: 30 }, emptySchema);
+    expect(tier(f, 'undeclared')).toEqual(['TumblingWindowInSeconds']);
+  });
+  it('compares a DECLARED ParallelizationFactor in the declared dimension (unaffected)', () => {
+    const declaredRes: DesiredResource = {
+      ...res,
+      declared: { ...res.declared, ParallelizationFactor: 4 },
+    };
+    const f = classifyResource(declaredRes, cleanLive, emptySchema);
+    expect(tier(f, 'declared')).toContain('ParallelizationFactor');
+  });
+});

--- a/tests/noise-guardduty-filter.test.ts
+++ b/tests/noise-guardduty-filter.test.ts
@@ -1,0 +1,118 @@
+// #1612: barest GuardDuty Filter/Detector first-run FPs, live-found 2026-07-14
+// (guardduty-hunt):
+// - GuardDuty stores short condition keys as their long synonyms (Gte ->
+//   GreaterThanOrEqual, Eq -> Equals) -> declared-side canonicalization.
+// - Filter Action defaults to NOOP (constant), Rank is AWS-assigned volatile
+//   ordering (a sibling filter's create re-ranks every filter -> value-independent).
+// - Detector Features: AI_PROTECTION ships DISABLED (joined the
+//   GUARDDUTY_FEATURE_CREATION_STATUS map).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const filterRes: DesiredResource = {
+  logicalId: 'HuntFilter',
+  resourceType: 'AWS::GuardDuty::Filter',
+  physicalId: 'cdkrd-hunt0714-filter',
+  declared: {
+    DetectorId: 'd1',
+    Name: 'cdkrd-hunt0714-filter',
+    FindingCriteria: { Criterion: { severity: { Gte: 4 }, type: { Eq: ['Recon:EC2/Foo'] } } },
+  },
+};
+const filterLive = (sev: number) => ({
+  DetectorId: 'd1',
+  Name: 'cdkrd-hunt0714-filter',
+  FindingCriteria: {
+    Criterion: { severity: { GreaterThanOrEqual: sev }, type: { Equals: ['Recon:EC2/Foo'] } },
+  },
+  Action: 'NOOP',
+  Rank: 1,
+});
+
+describe('GuardDuty::Filter criterion key aliases + Action/Rank defaults (#1612)', () => {
+  it('folds the long-form echo of declared short keys + Action/Rank on a clean deploy', () => {
+    const f = classifyResource(filterRes, filterLive(4), emptySchema);
+    expect(tier(f, 'declared')).toEqual([]);
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain('Action');
+  });
+  it('still detects a REAL out-of-band criterion change through the alias', () => {
+    const f = classifyResource(filterRes, filterLive(8), emptySchema);
+    expect(tier(f, 'declared').some((p) => p.includes('severity'))).toBe(true);
+  });
+  it('surfaces an out-of-band Action switch to ARCHIVE — detection preserved', () => {
+    const f = classifyResource(filterRes, { ...filterLive(4), Action: 'ARCHIVE' }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('Action');
+  });
+  it('leaves a template that already declares the long form untouched', () => {
+    const longRes: DesiredResource = {
+      ...filterRes,
+      declared: {
+        DetectorId: 'd1',
+        Name: 'cdkrd-hunt0714-filter',
+        FindingCriteria: { Criterion: { severity: { GreaterThanOrEqual: 4 } } },
+      },
+    };
+    const f = classifyResource(
+      longRes,
+      {
+        DetectorId: 'd1',
+        Name: 'cdkrd-hunt0714-filter',
+        FindingCriteria: { Criterion: { severity: { GreaterThanOrEqual: 4 } } },
+        Action: 'NOOP',
+        Rank: 1,
+      },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toEqual([]);
+  });
+});
+
+describe('GuardDuty::Detector Features — AI_PROTECTION ships DISABLED (#1612)', () => {
+  const detRes: DesiredResource = {
+    logicalId: 'HuntDetector',
+    resourceType: 'AWS::GuardDuty::Detector',
+    physicalId: 'd1',
+    declared: { Enable: true },
+  };
+  const features = (aiProtStatus: string, s3Status = 'ENABLED') => [
+    { Status: 'ENABLED', Name: 'CLOUD_TRAIL' },
+    { Status: s3Status, Name: 'S3_DATA_EVENTS' },
+    { Status: aiProtStatus, Name: 'AI_PROTECTION' },
+    { Status: 'DISABLED', Name: 'AI_ANALYST' },
+  ];
+  it('folds a fresh detector whose AI_PROTECTION is DISABLED at creation', () => {
+    const f = classifyResource(
+      detRes,
+      { Enable: true, Features: features('DISABLED') },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain('Features');
+  });
+  it('still surfaces an out-of-band disable of a default-ENABLED protection', () => {
+    const f = classifyResource(
+      detRes,
+      { Enable: true, Features: features('DISABLED', 'DISABLED') },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('Features');
+  });
+});

--- a/tests/revert-esm-husk.test.ts
+++ b/tests/revert-esm-husk.test.ts
@@ -1,0 +1,32 @@
+// #1611: every stream-source EventSourceMapping with no failure destination echoes the
+// empty husk `DestinationConfig: {OnFailure: {}}` on read, and the CC update handler
+// folds that read-back into ANY patch — Lambda rejects it ("The Destination field is
+// required for an OnFailure configuration"), so every revert on the type failed.
+// The husk must be stripped from the patch (the #650 EventInvokeConfig class).
+import { describe, expect, it } from 'vite-plus/test';
+import { type PatchOp, rejectedEmptyStripOps } from '../src/revert/plan.js';
+
+const T = 'AWS::Lambda::EventSourceMapping';
+const revertOp: PatchOp = { op: 'remove', path: '/ParallelizationFactor', human: 'x' };
+
+describe('EventSourceMapping DestinationConfig.OnFailure husk strip (#1611)', () => {
+  it('strips the empty OnFailure husk the live read echoes', () => {
+    const live = {
+      ParallelizationFactor: 5,
+      DestinationConfig: { OnFailure: {} },
+    };
+    const strip = rejectedEmptyStripOps(T, [revertOp], live);
+    expect(strip).toHaveLength(1);
+    expect(strip[0]).toMatchObject({ op: 'remove', path: '/DestinationConfig/OnFailure' });
+  });
+  it('never strips a REAL failure destination', () => {
+    const live = {
+      ParallelizationFactor: 5,
+      DestinationConfig: { OnFailure: { Destination: 'arn:aws:sqs:us-east-1:1:dlq' } },
+    };
+    expect(rejectedEmptyStripOps(T, [revertOp], live)).toEqual([]);
+  });
+  it('no-op when the husk is absent (an SQS-source mapping)', () => {
+    expect(rejectedEmptyStripOps(T, [revertOp], { BatchSize: 10 })).toEqual([]);
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -576,6 +576,73 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  // #1613 (revconv3 batch-4, live-proven 2026-07-14): four more omit-keeps-value handlers —
+  // each mutated out of band, reverted via a bare `remove` that reported success, and the
+  // convergence re-read caught the live value persisting. Each is now in
+  // REVERT_SET_DEFAULT_PATHS so revert writes the KNOWN_DEFAULTS default back explicitly.
+  it('#1613: SQS SqsManagedSseEnabled (SET-DEFAULT) -> add op writing the true default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::SQS::Queue',
+      path: 'SqsManagedSseEnabled',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SqsManagedSseEnabled',
+      value: true,
+      prior: false,
+    });
+  });
+
+  it('#1613: SFN LoggingConfiguration (SET-DEFAULT) -> add op writing the whole-object OFF default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::StepFunctions::StateMachine',
+      path: 'LoggingConfiguration',
+      actual: { Level: 'ALL', IncludeExecutionData: true },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/LoggingConfiguration',
+      value: { IncludeExecutionData: false, Level: 'OFF' },
+    });
+  });
+
+  it('#1613: ApiGateway RestApi DisableExecuteApiEndpoint (SET-DEFAULT) -> add op writing the false default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ApiGateway::RestApi',
+      path: 'DisableExecuteApiEndpoint',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DisableExecuteApiEndpoint',
+      value: false,
+      prior: true,
+    });
+  });
+
+  it('#1613: Cognito UserPoolClient RefreshTokenValidity (SET-DEFAULT) -> add op writing the 30 default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Cognito::UserPoolClient',
+      path: 'RefreshTokenValidity',
+      actual: 60,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/RefreshTokenValidity',
+      value: 30,
+      prior: 60,
+    });
+  });
+
   // #1588: the remaining ModifyDBInstance revert-no-op twins of #1541 — same selective-modify
   // semantics (an omitted property keeps its existing value), so a bare `remove` revert of an
   // out-of-band, undeclared, KNOWN_DEFAULTS-folded change is a silent no-op. Each is now in


### PR DESCRIPTION
## Summary

2026-07-14 bug hunt (5 rounds: offline audit → barest first-run FP wave → GuardDuty adapter family → revert-convergence batch 4 → corpus/noise sweep). Six issues found, fixed, and live-re-verified in one pass:

- **#1608 — stream-ESM first-run FPs.** A barest DDB-Streams / Kinesis `EventSourceMapping` surfaced `ParallelizationFactor=1` + `TumblingWindowInSeconds=0` (every existing ESM fixture was SQS/Kafka). Folded as equality-gated `KNOWN_DEFAULTS` constants.
- **#1609 — barest CodePipeline FPs.** Undeclared `PipelineType` materializes `V2` today but `V1` for pipelines created before 2023-10 (era default → `KNOWN_DEFAULT_ONE_OF`), and every action echoes `RunOrder=1` (nested `KNOWN_DEFAULT_PATHS`, wildcard over both array levels).
- **#1610 — barest Fargate service FP.** `NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp="DISABLED"` (every Fargate fixture declared it; only EC2 had a barest form). Nested `KNOWN_DEFAULT_PATHS` constant.
- **#1611 — every stream-ESM revert failed.** The live read echoes the empty husk `DestinationConfig:{OnFailure:{}}` and the CC handler folds it into any patch → Lambda rejects ("The Destination field is required"). Added to `CC_UPDATE_REJECTED_EMPTY_PATHS` (the #650 EventInvokeConfig class).
- **#1612 — GuardDuty Filter/Detector FPs.** (a) GuardDuty stores short condition keys as long synonyms (`Gte`→`GreaterThanOrEqual`, `Eq`→`Equals` — CC-probed: the CC read echoes ONLY the long forms) → declared-side key canonicalization; (b) `Filter.Action=NOOP` → `KNOWN_DEFAULTS`; (c) `Filter.Rank` is volatile AWS ordering (a sibling filter's create re-ranks every filter — live-probed) → value-independent; (d) `Detector.Features` FP'd again because `AI_PROTECTION` (2026-new) ships DISABLED → one-line `GUARDDUTY_FEATURE_CREATION_STATUS` addition (NOT value-independent — #1092's designed failure mode).
- **#1613 — 4 silent no-op reverts** (revert-convergence batch 4, 7 surfaces probed): SQS `SqsManagedSseEnabled`, SFN `LoggingConfiguration`, RestApi `DisableExecuteApiEndpoint`, Cognito UserPoolClient `RefreshTokenValidity` all kept the mutated value through a bare `remove` → `REVERT_SET_DEFAULT_PATHS` entries. Controls that converged fine: Athena WorkGroup `State`, DDB `DeletionProtectionEnabled`, Scheduler `State`.

Determinations (no code change needed, recorded as rule-out notes): Glue Database/Table mixed-case names are CFn-unreachable (both handlers reject uppercase — CC-probed + raw-CFn-probed); SSM Parameter `Tier` is server-side irreversible (Advanced→Standard downgrade impossible), excluded from convergence probes.

## Live verification (all INTEG PASS with the fixed binary)

- `esm-hunt` verify + verify-detect: first check CLEAN → record → OOB mutate both props → detect → revert → **live values converged** (husk strip proven).
- `fargate-hunt`, `codepipeline-hunt`, `pack-hunt` (6-type barest pack, clean), `guardduty-hunt` (adapter family reads resolve, zero FP), `revconv3-hunt` verify-detect (7 mutations detected, all 7 reverts converge on live re-read), `wsapi-model-hunt` (ApiGatewayV2 Model + Deployment composite adapters).

## Tests / assets

- 6 new unit-test files + `revert-plan` / `noise-and-strip` pin updates (5773 → all green).
- 12 promoted golden-corpus cases (stream ESMs, barest Fargate Service/TaskDef, barest CodePipeline, SNS FIFO, barest Pipe, GuardDuty Detector/Filter/IPSet/ThreatIntelSet, UserPoolClient `.drifted` detection pin).
- 7 new committed integ fixtures.
- `measure-noise` sweep run post-promotion: no new genuine constant candidates (remaining CANDIDATEs are probe-drift artifacts / per-resource values).
- hunt-bugs skill updated: batch-4 convergence results, key-synonym FP-pair lesson, `GUARDDUTY_FEATURE_CREATION_STATUS` growth mode, corpus-recorder env-scope gotcha.

Closes #1608, closes #1609, closes #1610, closes #1611, closes #1612, closes #1613.

All hunt stacks deleted (`delstack`) and swept (SWEEP CLEAN).
