### PR TITLE
fix(baseline): void a legit TrustStore CA-bundle redeploy so the recorded hash does not false-surface (#1615)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1036,7 +1036,17 @@ all fold into a one-line stderr nudge (mirroring the promotion note), never drif
   missing/unresolvable current declared source never voids (fail-safe:
   surface). A re-record that CARRIES an entry forward unchanged (its resource
   was unread that run) keeps the PREVIOUS fingerprint, so the old hash stays
-  paired with the template that deployed it.
+  paired with the template that deployed it. The void also covers the ELBv2
+  TrustStore `CaCertificatesBundleSha256` (#1615) — the SAME class, with two
+  wrinkles: its source is a PROJECTION of three sibling writeOnly props
+  (`CaCertificatesBundleS3Bucket`/`Key`/`ObjectVersion`), so the fingerprint is
+  the deep-hash of the ORDERED tuple (an absent optional member is kept
+  positionally, so moving a resolvable sibling still voids; undefined only when
+  EVERY member is unresolvable); and because the TrustStore hash surfaces
+  first-run as a PLAIN `undeclared` entry (not a `generated` tier), a voided
+  entry cannot fold through a tier — it is SUPPRESSED instead, so it folds
+  silently with the same re-record nudge rather than resurfacing as "appeared
+  since record".
 
 **Stale-baseline warning.** `templateHash` (sha256 of the deployed template at
 capture) is verified on load (`warnTemplateHashDrift`): a mismatch prints a non-fatal

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -682,20 +682,50 @@ function isRecordableGenerated(f: Finding): boolean {
 // at record time lets `applyBaseline` tell the two apart: fingerprint unchanged = the
 // template never touched the code, so a moved hash IS an out-of-band swap (surface);
 // fingerprint changed = the code was redeployed through IaC (void + re-record nudge).
-const RECORDABLE_GENERATED_SOURCE_PATHS: Record<string, Record<string, string>> = {
+// The source is ONE declared path (the common case) or, for a hash derived from a PROJECTION
+// of sibling declared properties (#1615), an ORDERED TUPLE of paths fingerprinted together.
+const RECORDABLE_GENERATED_SOURCE_PATHS: Record<
+  string,
+  Record<string, string | readonly string[]>
+> = {
   // The hash covers whatever `Code` declares: S3Bucket/S3Key/S3ObjectVersion, an inline
   // ZipFile, or an ImageUri — fingerprint the whole object so any code-identity change voids.
   'AWS::Lambda::Function': { CodeSha256: 'Code' },
   // The synthetic script digest is fetched from the declared script location; a deploy that
   // re-points it (a new CDK asset key) changes the content the digest covers.
   'AWS::Glue::Job': { ScriptSha256: 'Command.ScriptLocation' },
+  // #1615: the TrustStore CA-bundle digest (#505) is a projection of THREE sibling writeOnly
+  // source props — the S3 location of the bundle. Fingerprint the ordered tuple so a legit
+  // deploy that re-points the bundle (a new asset key / PEM set) voids the stale recorded
+  // hash, while an out-of-band same-location swap (template untouched → tuple unchanged) still
+  // surfaces. S3ObjectVersion is optional; an absent member is positionally undefined in the
+  // tuple, not dropped, so moving a resolvable sibling still changes the fingerprint.
+  'AWS::ElasticLoadBalancingV2::TrustStore': {
+    CaCertificatesBundleSha256: [
+      'CaCertificatesBundleS3Bucket',
+      'CaCertificatesBundleS3Key',
+      'CaCertificatesBundleS3ObjectVersion',
+    ],
+  },
 };
+
+// Resolve a single declared source path to its node, or undefined when it does not resolve.
+function resolveDeclaredSourcePath(declared: Record<string, unknown>, sourcePath: string): unknown {
+  let node: unknown = declared;
+  for (const seg of pathSegments(sourcePath)) {
+    node = descendDeclared(node, seg);
+    if (node === undefined) return undefined;
+  }
+  return node;
+}
 
 /**
  * Fingerprint of a recordable-generated entry's DECLARED SOURCE value (deep key-sorted
  * content hash), or undefined when the (resourceType, path) has no source mapping, no
  * declared model is available, or the source path does not resolve in it — the undefined
- * cases all fall back to today's behavior (never void on unknown).
+ * cases all fall back to today's behavior (never void on unknown). For a TUPLE source
+ * (#1615) the ordered projection of each sibling path is fingerprinted; undefined only when
+ * EVERY member is unresolvable (an absent optional member is kept positionally, not dropped).
  */
 export function declaredSourceFingerprint(
   resourceType: string,
@@ -704,12 +734,13 @@ export function declaredSourceFingerprint(
 ): string | undefined {
   const sourcePath = RECORDABLE_GENERATED_SOURCE_PATHS[resourceType]?.[path];
   if (sourcePath === undefined || declared === undefined) return undefined;
-  let node: unknown = declared;
-  for (const seg of pathSegments(sourcePath)) {
-    node = descendDeclared(node, seg);
-    if (node === undefined) return undefined;
+  if (Array.isArray(sourcePath)) {
+    const parts = sourcePath.map((sp) => resolveDeclaredSourcePath(declared, sp));
+    if (parts.every((p) => p === undefined)) return undefined;
+    return stableValueHash(parts);
   }
-  return stableValueHash(node);
+  const node = resolveDeclaredSourcePath(declared, sourcePath as string);
+  return node === undefined ? undefined : stableValueHash(node);
 }
 
 /**
@@ -1471,8 +1502,16 @@ export function applyBaseline(
     const matched = replacedLogical.has(f.logicalId)
       ? undefined
       : recorded.find((a) => entryMatches(a, f));
-    const entry =
-      matched !== undefined && sourceRedeployedVoid.has(recordedKey(matched)) ? undefined : matched;
+    const sourceRedeployVoided =
+      matched !== undefined && sourceRedeployedVoid.has(recordedKey(matched));
+    // #1615: a `generated`-tier voided hash (Lambda CodeSha256, Glue ScriptSha256) folds
+    // through its own tier below once treated as absent. But a synthetic `undeclared` hash
+    // (ELBv2 TrustStore CaCertificatesBundleSha256 — not a `generated` tier) has no such fold:
+    // treated as absent it would resurface as "appeared since record" undeclared drift. Suppress
+    // it here so the stale hash folds silently; the one-line re-record nudge still fires from the
+    // recorded-entry loop below (`sourceRedeployedStale`), exactly as for the generated case.
+    if (sourceRedeployVoided && f.tier === 'undeclared') continue;
+    const entry = sourceRedeployVoided ? undefined : matched;
     // re-canonicalize the baseline value through the CURRENT pipeline before comparing
     // (f.actual is already canonical from classify): a baseline recorded under older
     // normalization rules still matches today's live, so a cdkrd version bump alone

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -523,6 +523,141 @@ describe('baseline', () => {
         await rm(dir, { recursive: true, force: true });
       }
     });
+
+    // #1615: the same class on ELBv2 TrustStore CaCertificatesBundleSha256 (#505) — a hash
+    // derived from a TUPLE of three sibling writeOnly source props, and a PLAIN undeclared
+    // entry (not a `generated` tier), so it must fold SILENTLY on a legit bundle redeploy.
+    describe('TrustStore CaCertificatesBundleSha256 (tuple source, undeclared tier)', () => {
+      const TS = 'AWS::ElasticLoadBalancingV2::TrustStore';
+      const tsHash = (path: string, value: unknown): Finding => ({
+        tier: 'undeclared',
+        logicalId: 'Ts',
+        resourceType: TS,
+        path,
+        actual: value,
+      });
+      const TS_SHA_A = `${'c'.repeat(43)}=`;
+      const TS_SHA_B = `${'d'.repeat(43)}=`;
+      const tsEntry = (value: unknown) => ({
+        logicalId: 'Ts',
+        resourceType: TS,
+        path: 'CaCertificatesBundleSha256',
+        value,
+      });
+      // The declared source is the S3 location tuple (bundle bucket/key/version).
+      const SRC_V1 = {
+        CaCertificatesBundleS3Bucket: 'bundles',
+        CaCertificatesBundleS3Key: 'ca-v1.pem',
+      };
+      const SRC_V2 = {
+        CaCertificatesBundleS3Bucket: 'bundles',
+        CaCertificatesBundleS3Key: 'ca-v2.pem',
+      };
+      const declaredTs = (src: Record<string, unknown>) =>
+        new Map<string, Record<string, unknown>>([['Ts', src]]);
+      const baselineWithTsFp = (value: unknown, src: Record<string, unknown>): BaselineFile => ({
+        ...baseline([tsEntry(value)]),
+        recordedSourceFingerprints: {
+          [recordedKey({ logicalId: 'Ts', path: 'CaCertificatesBundleSha256' })]:
+            declaredSourceFingerprint(TS, 'CaCertificatesBundleSha256', src)!,
+        },
+      });
+
+      it('fingerprints the ordered sibling tuple; a moved sibling (new bundle key) changes it', () => {
+        const a = declaredSourceFingerprint(TS, 'CaCertificatesBundleSha256', SRC_V1);
+        expect(a).toBeDefined();
+        expect(a).not.toBe(declaredSourceFingerprint(TS, 'CaCertificatesBundleSha256', SRC_V2));
+      });
+
+      it('tolerates an absent optional S3ObjectVersion (still fingerprints from the resolvable siblings)', () => {
+        const withoutVersion = declaredSourceFingerprint(TS, 'CaCertificatesBundleSha256', SRC_V1);
+        const withVersion = declaredSourceFingerprint(TS, 'CaCertificatesBundleSha256', {
+          ...SRC_V1,
+          CaCertificatesBundleS3ObjectVersion: 'v-abc',
+        });
+        expect(withoutVersion).toBeDefined();
+        expect(withVersion).toBeDefined();
+        // adding a version is a real source change → the fingerprint differs
+        expect(withoutVersion).not.toBe(withVersion);
+      });
+
+      it('returns undefined only when EVERY tuple member is unresolvable (fail-safe)', () => {
+        expect(
+          declaredSourceFingerprint(TS, 'CaCertificatesBundleSha256', { Unrelated: 'x' })
+        ).toBeUndefined();
+        expect(
+          declaredSourceFingerprint(TS, 'CaCertificatesBundleSha256', undefined)
+        ).toBeUndefined();
+      });
+
+      it('buildRecordedSourceFingerprints stamps the tuple fingerprint for the undeclared entry', () => {
+        const out = buildRecordedSourceFingerprints(
+          [tsEntry(TS_SHA_A)],
+          declaredTs(SRC_V1),
+          undefined
+        );
+        expect(out.recordedSourceFingerprints).toEqual({
+          'Ts::CaCertificatesBundleSha256': declaredSourceFingerprint(
+            TS,
+            'CaCertificatesBundleSha256',
+            SRC_V1
+          ),
+        });
+      });
+
+      it('fingerprint UNCHANGED + live hash moved = an out-of-band same-location bundle swap: still surfaces', () => {
+        const out = applyBaseline([tsHash('CaCertificatesBundleSha256', TS_SHA_B)], {
+          ...baselineWithTsFp(TS_SHA_A, SRC_V1),
+        });
+        const withDeclared = applyBaseline(
+          [tsHash('CaCertificatesBundleSha256', TS_SHA_B)],
+          baselineWithTsFp(TS_SHA_A, SRC_V1),
+          { declaredByLogical: declaredTs(SRC_V1) }
+        );
+        // both the fail-safe (no declared model) and the resolved-unchanged path surface
+        expect(out).toHaveLength(1);
+        expect(out[0]).toMatchObject({ tier: 'undeclared', desired: TS_SHA_A, actual: TS_SHA_B });
+        expect(withDeclared).toHaveLength(1);
+        expect(withDeclared[0]).toMatchObject({ tier: 'undeclared', desired: TS_SHA_A });
+      });
+
+      it('fingerprint CHANGED (legit bundle redeploy): the undeclared hash FOLDS SILENTLY with a re-record nudge', () => {
+        const warnings: string[] = [];
+        const out = applyBaseline(
+          [tsHash('CaCertificatesBundleSha256', TS_SHA_B)],
+          baselineWithTsFp(TS_SHA_A, SRC_V1),
+          { declaredByLogical: declaredTs(SRC_V2), warn: (s) => warnings.push(s) }
+        );
+        // unlike the generated case (which stays as folded `generated` inventory), a voided
+        // undeclared hash is suppressed entirely — never "changed since record", never surfaced.
+        expect(out).toEqual([]);
+        expect(warnings).toEqual([
+          formatSourceRedeployedStaleNote(['Ts.CaCertificatesBundleSha256']),
+        ]);
+      });
+
+      it('fingerprint CHANGED + hash finding ABSENT this run: no false "removed since record" either', () => {
+        const warnings: string[] = [];
+        const out = applyBaseline([], baselineWithTsFp(TS_SHA_A, SRC_V1), {
+          declaredByLogical: declaredTs(SRC_V2),
+          warn: (s) => warnings.push(s),
+        });
+        expect(out).toEqual([]);
+        expect(warnings).toEqual([
+          formatSourceRedeployedStaleNote(['Ts.CaCertificatesBundleSha256']),
+        ]);
+      });
+
+      it("old baseline WITHOUT fingerprints keeps today's behavior (surfaces changed since record)", () => {
+        const out = applyBaseline(
+          [tsHash('CaCertificatesBundleSha256', TS_SHA_B)],
+          baseline([tsEntry(TS_SHA_A)]),
+          { declaredByLogical: declaredTs(SRC_V2) }
+        );
+        expect(out).toHaveLength(1);
+        expect(out[0]).toMatchObject({ tier: 'undeclared', desired: TS_SHA_A });
+      });
+    });
   });
 
   describe('atDefault reconciliation (R86 — folded inventory, never drift, never a false removal)', () => {


### PR DESCRIPTION
Closes #1615.

Extends the #1606 stale-source void to `AWS::ElasticLoadBalancingV2::TrustStore` `CaCertificatesBundleSha256` (#505) — the same class as Lambda `CodeSha256` / Glue `ScriptSha256`, but with a TUPLE declared source and a plain `undeclared` tier.

## Problem
The TrustStore CA-bundle digest is a synthetic integrity signal derived from a DECLARED writeOnly source (the bundle S3 location). A legitimate `cdk deploy` that re-points the bundle moves the live hash with the template, so the recorded hash goes stale and re-surfaces as false "changed since record" drift until a re-record — the exact #1606 FP, on an IaC change.

## Fix
- `RECORDABLE_GENERATED_SOURCE_PATHS` now accepts a TUPLE of source paths; the TrustStore entry fingerprints the ordered projection of `CaCertificatesBundleS3Bucket`/`Key`/`ObjectVersion`. An absent optional member is kept positionally (a moved resolvable sibling still voids); undefined only when EVERY member is unresolvable (fail-safe — an out-of-band same-location swap keeps the fingerprint and still surfaces).
- The TrustStore hash surfaces first-run as a PLAIN `undeclared` entry (not a `generated` tier), so a voided entry has no tier to fold through — it would resurface as "appeared since record". Suppress it instead, so it folds silently with the same re-record nudge as the generated case.

## Tests
`tests/baseline.test.ts` gains a TrustStore block: tuple fingerprint (moved sibling / absent optional version / all-unresolvable fail-safe), the build-time stamp, and applyBaseline surface-on-swap / fold-on-redeploy / old-baseline behaviors. ARCHITECTURE §8 documents the extension.

## Verification
Unit-tested against the mechanism directly. A full live mTLS trust-store A/B (record → legit bundle re-point → check folds; out-of-band same-key `s3 cp` swap still surfaces) is noted in the issue as the deferred live check (needs an mTLS deploy).