### PR TITLE
fix(record): label a CloudFormation-redeployed content hash as a refresh, not "CHANGED out of band" (#1616)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -16,6 +16,7 @@ import {
   checkBaselineAccount,
   constructPathsByLogical,
   declaredKeysByLogical,
+  declaredSourceFingerprint,
   loadBaseline,
   physicalIdsByLogical,
   type RecordedEntry,
@@ -250,7 +251,8 @@ export function previewValue(resourceType: string, path: string, v: unknown, max
  */
 export function changedRecordLabel(
   entry: { logicalId: string; path: string; value: unknown; resourceType: string },
-  recordedValue: { hasRecorded: boolean; recordedValue: unknown }
+  recordedValue: { hasRecorded: boolean; recordedValue: unknown },
+  sourceRedeployed = false
 ): string {
   const id = entry.path
     ? `${entry.logicalId}.${entry.path}`
@@ -260,7 +262,39 @@ export function changedRecordLabel(
   // path and sanitize control chars — both the recorded and live sides.
   const recorded = previewValue(entry.resourceType, entry.path, recordedValue.recordedValue);
   const live = previewValue(entry.resourceType, entry.path, entry.value);
+  // #1616: a recorded content hash (Lambda CodeSha256, Glue ScriptSha256, …) whose DECLARED
+  // source was redeployed through CloudFormation since record did NOT change out of band — the
+  // IaC deploy moved the live hash WITH the template (the #1606 stale-source void proves it on
+  // the check side). Say that plainly instead of "changed since record" — the latter is the
+  // phrase that makes a user stop and audit a possibly attacker-set value, so crying wolf on
+  // every legit code redeploy dulls the real warning. Refreshing the watch is still correct.
+  if (sourceRedeployed)
+    return `${id} (declared source redeployed via CloudFormation — refreshing watch: ${recorded} → ${live})`;
   return `${id} (changed since record: ${recorded} → ${live})`;
+}
+
+/**
+ * #1616: true when a `changed` recorded entry is a content hash whose DECLARED SOURCE was
+ * redeployed through CloudFormation since record — the SAME predicate `applyBaseline`'s
+ * stale-source void (#1606) uses to fold the check-side false positive. Such an entry did NOT
+ * change out of band (the IaC deploy moved the live hash with the template), so record must
+ * label and summarize it as a legit refresh, not "CHANGED out of band". Fail-safe: false when
+ * no source fingerprint was stored (an old baseline, or a path with no source mapping) or the
+ * current declared source does not resolve — exactly the void's own gates. Pure + exported.
+ */
+export function isRecordedSourceRedeployed(
+  entry: { logicalId: string; path: string; resourceType: string },
+  existing: BaselineFile | undefined,
+  declaredByLogical: Map<string, Record<string, unknown>>
+): boolean {
+  const storedFp = existing?.recordedSourceFingerprints?.[recordedKey(entry)];
+  if (storedFp === undefined) return false;
+  const currentFp = declaredSourceFingerprint(
+    entry.resourceType,
+    entry.path,
+    declaredByLogical.get(entry.logicalId)
+  );
+  return currentFp !== undefined && currentFp !== storedFp;
 }
 
 /**
@@ -532,12 +566,27 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
   // summary of what it BLESSED — recorded values CHANGED out of band (a possibly attacker-
   // changed value) and baseline-only entries PRESERVED — so the acceptance is not silent.
   if (yes && existing) {
+    const declaredModel = declaredKeysByLogical(desired.resources);
     const { changed } = splitRecordedByBaseline(recorded, existing);
     const changedExisting = changed.filter((e) => recordedValueForChanged(e, existing).hasRecorded);
-    if (changedExisting.length > 0)
+    // #1616: split off the content hashes whose DECLARED source was redeployed through
+    // CloudFormation since record — those did NOT change out of band (the #1606 void's own
+    // predicate), so labelling them "CHANGED out of band" cries wolf on every legit code
+    // redeploy and dulls the real warning. Report them as a legit refresh instead.
+    const redeployedViaCfn = changedExisting.filter((e) =>
+      isRecordedSourceRedeployed(e, existing, declaredModel)
+    );
+    const redeployedKeys = new Set(redeployedViaCfn.map((e) => recordedKey(e)));
+    const changedOob = changedExisting.filter((e) => !redeployedKeys.has(recordedKey(e)));
+    if (changedOob.length > 0)
       console.error(
-        `note: ${stackName}: --yes accepted ${changedExisting.length} recorded value(s) CHANGED out of band since record (review the baseline diff): ` +
-          changedExisting.map((e) => `${e.logicalId}.${e.path}`).join(', ')
+        `note: ${stackName}: --yes accepted ${changedOob.length} recorded value(s) CHANGED out of band since record (review the baseline diff): ` +
+          changedOob.map((e) => `${e.logicalId}.${e.path}`).join(', ')
+      );
+    if (redeployedViaCfn.length > 0)
+      console.error(
+        `note: ${stackName}: --yes refreshed ${redeployedViaCfn.length} recorded content hash(es) whose declared source was redeployed via CloudFormation since record (not an out-of-band change): ` +
+          redeployedViaCfn.map((e) => `${e.logicalId}.${e.path}`).join(', ')
       );
     if (dropCandidates.length > 0)
       console.error(
@@ -600,6 +649,7 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
           }
           picked = changed.map((e) => recordedKey(e));
         } else {
+          const declaredModel = declaredKeysByLogical(desired.resources);
           const fromPrompt = await bulkMultiselect(
             recordSelectMessage(stackName, region, folded.length),
             standout.map((e) => {
@@ -608,9 +658,13 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
               // so the (possibly attacker-changed) value is not blessed by one Enter. A
               // genuinely NEW path stays default-selected (today's behavior).
               const rec = recordedValueForChanged(e, existing);
+              // #1616: a content hash whose declared source was redeployed via CloudFormation
+              // gets the "refreshing watch" label, not "changed since record" (labelling only —
+              // the UNSELECTED default is unchanged so the refresh stays an explicit choice).
+              const redeployed = isRecordedSourceRedeployed(e, existing, declaredModel);
               return {
                 value: recordedKey(e),
-                label: changedRecordLabel(e, rec),
+                label: changedRecordLabel(e, rec, redeployed),
                 selected: !rec.hasRecorded,
               };
             })

--- a/tests/record-source-redeploy-label-1616.test.ts
+++ b/tests/record-source-redeploy-label-1616.test.ts
@@ -1,0 +1,107 @@
+// #1616 (follow-up to #1606): after the stale-source void folds a recorded content hash
+// (Lambda CodeSha256 / Glue ScriptSha256) because the declared code was redeployed through
+// CloudFormation, the nudged re-`record` must NOT label the refreshed hash "CHANGED out of
+// band" — that phrase is what makes a user stop and audit a possibly attacker-set value, so
+// crying wolf on every legit code redeploy dulls the real warning. It is a legit refresh.
+import { describe, expect, it } from 'vite-plus/test';
+import { type BaselineFile, declaredSourceFingerprint } from '../src/baseline/baseline-file.js';
+import { changedRecordLabel, isRecordedSourceRedeployed } from '../src/commands/stack-actions.js';
+
+const SHA_A = `${'a'.repeat(43)}=`;
+const SHA_B = `${'b'.repeat(43)}=`;
+const CODE_V1 = { S3Bucket: 'assets', S3Key: 'aaaa1111.zip' };
+const CODE_V2 = { S3Bucket: 'assets', S3Key: 'bbbb2222.zip' };
+const fnEntry = {
+  logicalId: 'Fn',
+  path: 'CodeSha256',
+  resourceType: 'AWS::Lambda::Function',
+};
+const declaredWith = (code: Record<string, unknown>) =>
+  new Map<string, Record<string, unknown>>([['Fn', { Code: code, Handler: 'index.handler' }]]);
+const baselineWithFp = (code: Record<string, unknown>): BaselineFile => ({
+  schemaVersion: 2,
+  stackName: 's',
+  region: 'r',
+  accountId: '111122223333',
+  capturedAt: '',
+  templateHash: '',
+  recorded: [{ ...fnEntry, value: SHA_A }],
+  recordedSourceFingerprints: {
+    'Fn::CodeSha256': declaredSourceFingerprint('AWS::Lambda::Function', 'CodeSha256', {
+      Code: code,
+    })!,
+  },
+});
+
+describe('#1616 record label for a content hash redeployed via CloudFormation', () => {
+  describe('changedRecordLabel', () => {
+    it('reads "changed since record" when NOT source-redeployed (today\'s wording, default arg)', () => {
+      const label = changedRecordLabel(
+        {
+          logicalId: 'Fn',
+          path: 'CodeSha256',
+          value: SHA_B,
+          resourceType: 'AWS::Lambda::Function',
+        },
+        { hasRecorded: true, recordedValue: SHA_A }
+      );
+      expect(label).toContain('changed since record');
+      expect(label).not.toContain('redeployed via CloudFormation');
+    });
+
+    it('reads "redeployed via CloudFormation — refreshing watch" when source-redeployed', () => {
+      const label = changedRecordLabel(
+        {
+          logicalId: 'Fn',
+          path: 'CodeSha256',
+          value: SHA_B,
+          resourceType: 'AWS::Lambda::Function',
+        },
+        { hasRecorded: true, recordedValue: SHA_A },
+        true
+      );
+      expect(label).toContain('declared source redeployed via CloudFormation');
+      expect(label).toContain('refreshing watch');
+      expect(label).not.toContain('changed since record');
+      // still shows recorded → live so the user sees the hashes moved
+      expect(label).toContain('→');
+    });
+  });
+
+  describe('isRecordedSourceRedeployed (the #1606 void predicate, reused for the label)', () => {
+    it('true when the stored fingerprint differs from the CURRENT declared source (legit redeploy)', () => {
+      expect(
+        isRecordedSourceRedeployed(fnEntry, baselineWithFp(CODE_V1), declaredWith(CODE_V2))
+      ).toBe(true);
+    });
+
+    it('false when the declared source is UNCHANGED (an out-of-band same-source swap still surfaces)', () => {
+      expect(
+        isRecordedSourceRedeployed(fnEntry, baselineWithFp(CODE_V1), declaredWith(CODE_V1))
+      ).toBe(false);
+    });
+
+    it("false for an OLD baseline with no stored fingerprint (fail-safe: keeps today's wording)", () => {
+      const noFp: BaselineFile = { ...baselineWithFp(CODE_V1), recordedSourceFingerprints: {} };
+      expect(isRecordedSourceRedeployed(fnEntry, noFp, declaredWith(CODE_V2))).toBe(false);
+      expect(isRecordedSourceRedeployed(fnEntry, undefined, declaredWith(CODE_V2))).toBe(false);
+    });
+
+    it('false when the current declared source does not resolve (fail-safe: never mislabels on unknown)', () => {
+      // Code absent from the declared model → current fingerprint undefined → not redeployed.
+      const declaredNoCode = new Map<string, Record<string, unknown>>([['Fn', { Handler: 'h' }]]);
+      expect(isRecordedSourceRedeployed(fnEntry, baselineWithFp(CODE_V1), declaredNoCode)).toBe(
+        false
+      );
+    });
+
+    it('false for a path with no source mapping (a plain undeclared recorded value)', () => {
+      const plain = { logicalId: 'B', path: 'SomeProp', resourceType: 'AWS::S3::Bucket' };
+      const b: BaselineFile = {
+        ...baselineWithFp(CODE_V1),
+        recordedSourceFingerprints: { 'B::SomeProp': 'sha256:whatever' },
+      };
+      expect(isRecordedSourceRedeployed(plain, b, new Map([['B', { SomeProp: 'x' }]]))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1616.

Cosmetic mislabel, follow-up to #1606 (labelling only, no behavior change).

## Problem
After the check-side stale-source void folds a recorded content hash (Lambda `CodeSha256` / Glue `ScriptSha256`) because the declared code was redeployed through CloudFormation, the nudged re-`record` printed under `--yes`:

> note: <stack>: --yes accepted N recorded value(s) CHANGED out of band since record ...

The value did NOT change out of band — the void just proved the change went through IaC. `CHANGED out of band` is exactly the phrase that makes a user stop and audit a possibly attacker-set value, so crying wolf on every legit code redeploy dulls the real warning.

## Fix
`isRecordedSourceRedeployed` reuses the voids own predicate (stored `recordedSourceFingerprints` value differs from the current declared source fingerprint) to classify such an entry:
- the `record --yes` summary splits them into a `declared source was redeployed via CloudFormation ... (not an out-of-band change)` note;
- the interactive picker row reads `declared source redeployed via CloudFormation — refreshing watch` instead of `changed since record`.

Labelling only — the UNSELECTED default is unchanged (the refresh stays an explicit choice); entries without a stored fingerprint keep todays wording (fail-safe).

## Tests
`tests/record-source-redeploy-label-1616.test.ts` covers both label branches and the predicate (redeployed / unchanged-source / no-fingerprint / unresolvable-source / no-mapping). Pure + exported functions, no live deploy needed (labelling-only).