### PR TITLE
fix(check,revert): 2026-07-14 hunt — 4 revert no-ops + CompositeAlarm prop writer, ACM/DAX case FPs, Glue Iceberg / Lambda-compute CodeBuild / NLB-TG variant folds

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -334,6 +334,21 @@ siblings converge — non-uniform WITHIN SQS again), **SFN `LoggingConfiguration
 `DeletionProtectionEnabled`, Scheduler Schedule `State` converged via the bare
 `remove` — ~1-in-2 this round. Excluded as SERVER-SIDE IRREVERSIBLE (not a
 convergence probe): SSM Parameter `Tier` (AWS cannot downgrade Advanced→Standard).
+Batch 5 (2026-07-14, `revconv4-hunt` fixture, #1619): **ECS Cluster
+`ClusterSettings`**, **ApiGateway RestApi `ApiKeySourceType`**, **Glue Crawler
+`SchemaChangePolicy`** no-oped (RSDP entries converge them); CW Alarm
+`TreatMissingData`, AppSync `IntrospectionConfig`, Scheduler
+`ScheduleExpressionTimezone`, Pipes `DesiredState` converged — ~1-in-2 again. And a
+THIRD class appeared: **CloudWatch CompositeAlarm `ActionsEnabled`** no-ops even an
+EXPLICIT `add /ActionsEnabled true` CC patch (SUCCESS reported, value unchanged), so
+an RSDP set-default CANNOT converge it — the fix is an `SDK_PROP_WRITERS` entry
+driving the dedicated Enable/DisableAlarmActions API. **Probe that class for free
+before writing the fix: `aws cloudcontrol update-resource --patch-document
+'[{"op":"add","path":"/X","value":<default>}]'` against a CLI-created resource
+answers "does the explicit write converge?" with no stack.** Also found: CodeBuild
+Project + MediaConvert Queue detect fine but are read-only ("type not revertable
+yet") — when a probe target is such a type, restore it OUT OF BAND before `revert`
+or the fixture can never converge to zero (#1623).
 
 ### 5. Harvest the live read into the golden corpus (EVERY round — bug or not)
 
@@ -811,6 +826,20 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   fixture names FIRST — before any paid re-deploy — and abort if they already exist.
   A clean abort (remove the worktree; the AWS side was already swept) beats burning a
   deploy on a duplicate PR that will only conflict.
+- **Fixture buckets MUST set `removalPolicy: DESTROY` — the L2 `Bucket` default is
+  RETAIN, and a rollback/teardown then silently ORPHANS the bucket** (a failed
+  variants3-hunt deploy left `DELETE_SKIPPED` on its bucket, 2026-07-14; the sweep's
+  ephemeral-tag net catches it, but don't rely on that). Same for any L2 stateful
+  default-RETAIN construct in a hunt fixture.
+- **A service that VALIDATES a role's permissions at create races a `grant()`-style
+  attached policy — use `inlinePolicies` in hunt fixtures.** Firehose validated
+  glue/s3 access before the separate `AWS::IAM::Policy` resource attached (the
+  DeliveryStream only depended on the role) and failed create; inline policies are
+  part of the role create, so no dependency plumbing is needed (variants3-hunt,
+  2026-07-14). Related create-time determinations worth reusing: a table-less
+  Firehose Iceberg destination is REJECTED ("a single default destination table
+  configuration must be provided" — DestinationTableConfigurationList is part of the
+  barest form), and a CFn Glue Iceberg table requires `TableType: EXTERNAL_TABLE`.
 - **Working a filed issue → run `/work-issues` (don't re-implement its rules
   here).** The issues this hunt files get picked up by later parallel sessions that
   race for the same ones and collide on the same central tables (`noise.ts` /

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -857,7 +857,13 @@ only when non-zero — unrecorded values are named as such, never folded into
     string) reverts via `PutConfigRule`, writing a COMPACT JSON string with
     string-coerced param values: a CC `UpdateResource` re-serializes the JSON into
     Config's string field with spaces / a numeric value, which the provider rejects
-    ("Blank spaces are not acceptable for input parameter" — proven live). classify
+    ("Blank spaces are not acceptable for input parameter" — proven live). A
+    CloudWatch CompositeAlarm's `ActionsEnabled` reverts via the dedicated
+    `EnableAlarmActions`/`DisableAlarmActions` APIs: the CC update handler reports
+    SUCCESS yet applies NOTHING for this boolean — even an explicit
+    `add /ActionsEnabled true` patch leaves a disabled alarm disabled (proven live,
+    #1619), so neither a bare `remove` nor a `REVERT_SET_DEFAULT_PATHS` set-default
+    can converge it through Cloud Control. classify
     reports such a property WHOLE at its top-level path (never a fragile sub-path
     finding). Scoped to the EXACT top-level path: deeper
     `Policies.*` declared drift still patches via CC. A resource with both kinds

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1547,6 +1547,33 @@ function configRecordingStrategyAtDefault(
   return useOnly !== undefined && deepEqual(value, { UseOnly: useOnly });
 }
 
+// #1624: a Glue OpenTableFormat (Iceberg) table materializes SERVICE-MANAGED
+// TableInput.Parameters on create — `table_type: "ICEBERG"` (constant) plus
+// `metadata_location` (a per-commit S3 metadata pointer that MOVES on every table
+// commit; not pinnable, not derivable). Tier-2 shape-gated fold: keyed on the declared
+// `OpenTableFormatInput.IcebergInput` (the reliable in-template discriminator — a plain
+// table never reaches this), fold the appeared map ONLY when its keys are exactly the
+// managed pair (metadata_location optional) with table_type === "ICEBERG". Any extra or
+// changed key makes the whole map surface, so an out-of-band user parameter add on an
+// Iceberg table stays detected. Live-proven on a barest Iceberg table (variants3-hunt,
+// 2026-07-14).
+function glueIcebergManagedParamsAtDefault(
+  resourceType: string,
+  schemaPath: string,
+  value: unknown,
+  declared: Record<string, unknown>
+): boolean {
+  if (resourceType !== 'AWS::Glue::Table') return false;
+  if (schemaPath !== 'TableInput.Parameters') return false;
+  const otf = declared.OpenTableFormatInput;
+  if (!isNestedObject(otf) || !('IcebergInput' in (otf as Record<string, unknown>))) return false;
+  if (!isNestedObject(value)) return false;
+  const params = value as Record<string, unknown>;
+  const managed = new Set(['table_type', 'metadata_location']);
+  if (!Object.keys(params).every((k) => managed.has(k))) return false;
+  return params.table_type === 'ICEBERG';
+}
+
 // #705: a Classic ELB (ElasticLoadBalancing::LoadBalancer) with an HTTPS/SSL listener but no
 // declared SSL policy reads back an AWS-assigned SSL negotiation policy. The whole `Policies`
 // array was folded value-independently, which made an out-of-band SSL-policy DOWNGRADE (an older
@@ -3391,6 +3418,16 @@ export function classifyResource(
     if (typeof artifactName === 'string') {
       knownDefPaths = { ...knownDefPaths, 'Artifacts.Name': artifactName };
     }
+    // #1625: a Lambda-compute project (Environment.Type *_LAMBDA_CONTAINER) defaults
+    // TimeoutInMinutes to 15, not the standard-container 60 the KNOWN_DEFAULTS constant
+    // pins (the #1477 variant-axis class — live-proven on a barest LINUX_LAMBDA_CONTAINER
+    // project, variants3-hunt 2026-07-14). Derive from the declared environment type and
+    // equality-gate (fold tier 2): a changed timeout still surfaces, and a declared one
+    // is compared in the declared dimension.
+    const envType = (declared['Environment'] as Record<string, unknown> | undefined)?.['Type'];
+    if (typeof envType === 'string' && envType.endsWith('_LAMBDA_CONTAINER')) {
+      knownDef = { ...knownDef, TimeoutInMinutes: 15 };
+    }
   }
   // #845: a SecretsManager RotationSchedule declaring `RotationRules.ScheduleExpression`
   // "rate(N days)" reads back an undeclared `RotationRules.AutomaticallyAfterDays: N` — AWS
@@ -3449,6 +3486,24 @@ export function classifyResource(
           },
         }),
       };
+    }
+  }
+  // #1626: an NLB-family target group (create-only Protocol TCP/TLS/UDP/TCP_UDP) defaults
+  // its health check to TCP with a 10s timeout — the HTTP-family constants KNOWN_DEFAULTS
+  // pins (HTTP / 5) belong to the ALB variant (the #1477 variant-axis class; live-proven
+  // on a barest TCP/ip group, attach-echo-hunt 2026-07-14). Derive from the declared
+  // Protocol and equality-gate (fold tier 2): an out-of-band health-check change still
+  // surfaces, and a declared value is compared in the declared dimension.
+  if (resourceType === 'AWS::ElasticLoadBalancingV2::TargetGroup') {
+    const proto = declared['Protocol'];
+    if (
+      typeof proto === 'string' &&
+      (proto === 'TCP' || proto === 'TLS' || proto === 'UDP' || proto === 'TCP_UDP') &&
+      // an alb-TARGET group (ALB behind an NLB) has its OWN derived defaults
+      // (timeout 6 + Matcher, #1546) — do not clobber them with the TCP-family pair.
+      declared['TargetType'] !== 'alb'
+    ) {
+      knownDef = { ...knownDef, HealthCheckProtocol: 'TCP', HealthCheckTimeoutSeconds: 10 };
     }
   }
   // #975: an ElastiCache ReplicationGroup with in-transit encryption enabled at creation
@@ -3827,7 +3882,11 @@ export function classifyResource(
         value === declared['StatementId']) ||
       // #1553: a Config recorder's undeclared RecordingGroup.RecordingStrategy mirror, derived
       // from the live sibling RecordingGroup and equality-gated (helper above).
-      configRecordingStrategyAtDefault(resourceType, schemaPath, value, live);
+      configRecordingStrategyAtDefault(resourceType, schemaPath, value, live) ||
+      // #1624: a Glue Iceberg table's service-managed TableInput.Parameters pair
+      // (table_type + moving metadata_location), shape-gated on the declared
+      // OpenTableFormatInput.IcebergInput (helper above).
+      glueIcebergManagedParamsAtDefault(resourceType, schemaPath, value, declared);
     const tier = atDefault
       ? 'atDefault'
       : // R142: a GENERATED_PATHS value folds as `generated` ONLY when it echoes a

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -889,6 +889,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       MinimumHealthyPercent: 100,
     },
   },
+  // A ConfigurationProfile that declares no Type reads back the freeform default
+  // (the only other value, AWS.AppConfig.FeatureFlags, is always user-declared).
+  // Observed live on a barest hosted profile (second-deploy-echo3, 2026-07-14; #1622).
+  // Equality-gated: a feature-flags profile no longer matches and surfaces.
+  'AWS::AppConfig::ConfigurationProfile': {
+    Type: 'AWS.Freeform',
+  },
   'AWS::AppSync::GraphQLApi': {
     ApiType: 'GRAPHQL',
     Visibility: 'GLOBAL',
@@ -1152,6 +1159,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // `modify-scheduled-action --disable` (Enable=false) no longer matches and surfaces.
   'AWS::Redshift::ScheduledAction': {
     Enable: true,
+  },
+  // An endpoint service that declares no SupportedIpAddressTypes reads back the ipv4-only
+  // creation default (live, a barest NLB-backed service, attach-echo-hunt 2026-07-14;
+  // #1626). Equality-gated — a dualstack service reads ["ipv4","ipv6"] and still
+  // surfaces, as does an out-of-band modify-vpc-endpoint-service-configuration.
+  'AWS::EC2::VPCEndpointService': {
+    SupportedIpAddressTypes: ['ipv4'],
   },
   'AWS::EC2::VPCEndpoint': {
     IpAddressType: 'ipv4',
@@ -4623,25 +4637,37 @@ export const ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL: Record<string, Record<string
     'target_failover.on_deregistration': 'no_rebalance',
     'target_failover.on_unhealthy': 'no_rebalance',
   },
+  // #1626: the target_health_state.unhealthy.* pair are NLB-family attributes AWS returns
+  // at their defaults on a barest TCP group (live, attach-echo-hunt 2026-07-14); mirrored
+  // across the TCP-family siblings like the other entries (equality-gated — a non-matching
+  // variant value simply does not fold, and an out-of-band change still surfaces).
   TCP: {
     'stickiness.type': 'source_ip',
     'deregistration_delay.connection_termination.enabled': 'false',
     'proxy_protocol_v2.enabled': 'false',
+    'target_health_state.unhealthy.connection_termination.enabled': 'true',
+    'target_health_state.unhealthy.draining_interval_seconds': '0',
   },
   TLS: {
     'stickiness.type': 'source_ip',
     'deregistration_delay.connection_termination.enabled': 'false',
     'proxy_protocol_v2.enabled': 'false',
+    'target_health_state.unhealthy.connection_termination.enabled': 'true',
+    'target_health_state.unhealthy.draining_interval_seconds': '0',
   },
   UDP: {
     'stickiness.type': 'source_ip',
     'deregistration_delay.connection_termination.enabled': 'false',
     'proxy_protocol_v2.enabled': 'false',
+    'target_health_state.unhealthy.connection_termination.enabled': 'true',
+    'target_health_state.unhealthy.draining_interval_seconds': '0',
   },
   TCP_UDP: {
     'stickiness.type': 'source_ip',
     'deregistration_delay.connection_termination.enabled': 'false',
     'proxy_protocol_v2.enabled': 'false',
+    'target_health_state.unhealthy.connection_termination.enabled': 'true',
+    'target_health_state.unhealthy.draining_interval_seconds': '0',
   },
 };
 
@@ -4650,6 +4676,10 @@ export const ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL: Record<string, Record<string
 // overrides; live-verified on the same deploy.
 export const ELB_TG_ATTRIBUTE_DEFAULTS_BY_TARGET_TYPE: Record<string, Record<string, string>> = {
   alb: { 'preserve_client_ip.enabled': 'true' },
+  // #1626: an `ip`-target group defaults to NOT preserving client IPs — the inverse of
+  // the alb entry above (live, a barest TCP/ip group, attach-echo-hunt 2026-07-14).
+  // Equality-gated: an out-of-band preserve-client-ip ENABLE still surfaces.
+  ip: { 'preserve_client_ip.enabled': 'false' },
 };
 
 // (R95) The generic `projectLiveToDeclaredSubset` was REMOVED. It projected the live
@@ -4889,6 +4919,23 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // (the MemoryDB-family determination).
   'AWS::DMS::ReplicationInstance': new Set(['ReplicationInstanceIdentifier']),
   'AWS::DMS::ReplicationSubnetGroup': new Set(['ReplicationSubnetGroupIdentifier']),
+  // DAX stores parameter-group / subnet-group names lowercased (live-probed 2026-07-14:
+  // `create-parameter-group --parameter-group-name CdkrdHunt-Mixed-DaxPG` reads back
+  // `cdkrdhunt-mixed-daxpg`, subnet group likewise), and CFn reaches the raw API through
+  // the legacy provider with no client-side case rejection (the CC CREATE handler does not
+  // exist — UnsupportedActionException — so no MemoryDB-style server-side guard applies).
+  // Both names are create-only, so case-insensitive equality hides no revertable drift
+  // (#1621). Cluster.ClusterName is NOT listed — unprobed (cluster create is paid/slow).
+  'AWS::DAX::ParameterGroup': new Set(['ParameterGroupName']),
+  'AWS::DAX::SubnetGroup': new Set(['SubnetGroupName']),
+  // ACM lowercases certificate domain names on request (live-probed 2026-07-14:
+  // `request-certificate --domain-name CdkrdHunt-0714-Probe.Example.Com` describes back
+  // `cdkrdhunt-0714-probe.example.com`, SANs likewise), and the CFn path passes mixed case
+  // through — DNS names are case-insensitive, so users legitimately declare
+  // `MyApp.Example.Com` and hit a permanent declared FP. DomainName is create-only and two
+  // genuinely different names still differ after case-fold (#1620). SubjectAlternativeNames
+  // is an ARRAY compared wholesale, so it lives in CASE_INSENSITIVE_ARRAY_PATHS below.
+  'AWS::CertificateManager::Certificate': new Set(['DomainName']),
   // DMS Endpoint `EndpointType` — the CFn/CDK value is lowercase (`source` /
   // `target`) but the DMS API echoes it UPPERCASE (`SOURCE` / `TARGET`) on the
   // DescribeEndpoints read (the SDK_OVERRIDES reader), so a case-sensitive compare
@@ -5294,6 +5341,11 @@ export const CASE_INSENSITIVE_ARRAY_PATHS: Record<string, ReadonlySet<string>> =
     'CorsConfiguration.ExposeHeaders',
   ]),
   'AWS::Lambda::Url': new Set(['Cors.AllowHeaders', 'Cors.ExposeHeaders']),
+  // ACM stores SAN domain names lowercased (the array twin of the DomainName entry in
+  // CASE_INSENSITIVE_PATHS — see #1620): the same SAN set modulo case is not drift; a
+  // genuine SAN add/remove/rename still differs. DNS names are case-insensitive, so the
+  // fold hides no real change.
+  'AWS::CertificateManager::Certificate': new Set(['SubjectAlternativeNames']),
 };
 // True when both values are string arrays holding the same multiset of values
 // modulo ASCII case (order- and case-insensitive). Non-string-array inputs never
@@ -6104,6 +6156,14 @@ export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
   // every DNS-validated cert. It is a true readGap: AWS genuinely never returns the input
   // shape (#1090).
   'AWS::CertificateManager::Certificate': new Set(['DomainValidationOptions']),
+  // `OpenTableFormatInput` — the open-table-format (Iceberg) create-time INPUT
+  // ({IcebergInput: {MetadataOperation, Version}}). Glue GetTable never echoes it back
+  // (the format shows up as service-managed TableInput.Parameters instead — see the
+  // #1624 iceberg-params fold in classify), and the registry schema has no
+  // writeOnlyProperties, so schema-strip keeps it in the declared model → classify's
+  // removed-collection branch false-flagged `[CFn-Declared Drift] OpenTableFormatInput
+  // actual=undefined` on every Iceberg table (live, variants3-hunt 2026-07-14; #1624).
+  'AWS::Glue::Table': new Set(['OpenTableFormatInput']),
   // `TagSpecifications` — the EC2 create-time tag INPUT shape ([{ResourceType, Tags}]). The live
   // resource carries its tags under `Tags` (where the Cloud Control read returns them); the
   // `TagSpecifications` input wrapper is NEVER echoed back, so classify's removed-collection

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -3163,11 +3163,16 @@ const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region
   // removes ONLY the DomainName-matching element, so any OTHER extra/missing SAN still
   // surfaces (#1090). If the user DID declare the DomainName as a SAN, keep the live list
   // verbatim (they intend it, so it is a faithful compare).
-  const apex = str(cert.DomainName);
-  if (declaresSans && apex !== undefined && !declaredSans.includes(apex)) {
+  // Case-insensitively: ACM stores domain names lowercased while the template may
+  // declare mixed case (DNS names are case-insensitive), so a case-sensitive apex
+  // match would fail to subtract the implied SAN for a mixed-case declaration and
+  // false-surface it (#1620).
+  const apex = str(cert.DomainName)?.toLowerCase();
+  const declaredSansLower = declaredSans.map((s) => s.toLowerCase());
+  if (declaresSans && apex !== undefined && !declaredSansLower.includes(apex)) {
     let dropped = false;
     sans = sans.filter((s) => {
-      if (!dropped && s === apex) {
+      if (!dropped && s.toLowerCase() === apex) {
         dropped = true;
         return false;
       }

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -464,6 +464,27 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // handler DOES re-enable on an omitted State — proven in the same fixture — so it needs no
   // entry here.)
   'AWS::Kinesis::Stream\0RetentionPeriodHours',
+  // #1619 (batch 5, live-proven on revconv4-hunt 2026-07-14): four more omit-ignored
+  // update handlers — a bare `remove` revert of an out-of-band change reported SUCCESS
+  // yet the convergence re-read showed the live value unchanged. Write each
+  // KNOWN_DEFAULTS default back explicitly:
+  // - ECS UpdateCluster keeps an omitted Settings list (containerInsights enabled out of
+  //   band survived a `remove`); default [{containerInsights, disabled}].
+  // - CloudWatch CompositeAlarm ActionsEnabled: worse than omit-ignored — the CC handler
+  //   ignores even an EXPLICIT `add /ActionsEnabled true` patch (probed live), so this
+  //   set-default alone cannot converge it; the op routes to the SDK_PROP_WRITERS
+  //   Enable/DisableAlarmActions writer (writers.ts), which consumes the explicit value.
+  // - API Gateway's RestApi handler keeps an omitted ApiKeySourceType (an AUTHORIZER flip
+  //   survived); default 'HEADER'.
+  // - Glue UpdateCrawler keeps an omitted SchemaChangePolicy (a LOG/LOG flip survived);
+  //   default {UPDATE_IN_DATABASE, DEPRECATE_IN_DATABASE}.
+  // (Controls proven to CONVERGE via the bare `remove` in the same run — no entries needed:
+  // CloudWatch Alarm TreatMissingData, AppSync GraphQLApi IntrospectionConfig, Scheduler
+  // Schedule ScheduleExpressionTimezone, Pipes Pipe DesiredState.)
+  'AWS::ECS::Cluster\0ClusterSettings',
+  'AWS::CloudWatch::CompositeAlarm\0ActionsEnabled',
+  'AWS::ApiGateway::RestApi\0ApiKeySourceType',
+  'AWS::Glue::Crawler\0SchemaChangePolicy',
 ]);
 
 // Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -37,7 +37,12 @@ import {
   UpdateStageCommand as UpdateApiGatewayV2StageCommand,
 } from '@aws-sdk/client-apigatewayv2';
 import { AppSyncClient, DeleteApiKeyCommand } from '@aws-sdk/client-appsync';
-import { CloudWatchClient, PutAnomalyDetectorCommand } from '@aws-sdk/client-cloudwatch';
+import {
+  CloudWatchClient,
+  DisableAlarmActionsCommand,
+  EnableAlarmActionsCommand,
+  PutAnomalyDetectorCommand,
+} from '@aws-sdk/client-cloudwatch';
 import {
   DLMClient,
   GetLifecyclePolicyCommand,
@@ -1554,6 +1559,31 @@ const writeLogGroupBearerTokenAuth: SdkWriter = async (ctx, ops) => {
   }
 };
 
+// AWS::CloudWatch::CompositeAlarm.ActionsEnabled — the Cloud Control update handler
+// reports SUCCESS yet applies NOTHING for this boolean: both a bare `remove` AND an
+// explicit `add /ActionsEnabled true` patch leave a disable-alarm-actions'd composite
+// at False (probed live via cloudcontrol update-resource, 2026-07-14; #1619), so even a
+// REVERT_SET_DEFAULT_PATHS set-default cannot converge. CloudWatch exposes the dedicated
+// Enable/DisableAlarmActions APIs for exactly this toggle (live-proven to converge), so
+// route the revert through them. The composite alarm's physical id IS its name. A
+// `remove` (undeclared, not in baseline) reverts to the schema default of enabled; an
+// `add` carries the desired boolean (declared drift / recorded baseline value).
+const writeCompositeAlarmActionsEnabled: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['AlarmName']);
+  if (!name) throw new Error('cannot resolve composite alarm name for ActionsEnabled revert');
+  const c = new CloudWatchClient({ region: ctx.region, ...CLIENT_TIMEOUTS });
+  for (const op of ops) {
+    // plan.ts groups this prop-scoped item to the single ActionsEnabled path, so there is
+    // one op; a `remove` means "back to default (actions enabled)".
+    const enabled = op.op === 'remove' ? true : op.value === true;
+    await c.send(
+      enabled
+        ? new EnableAlarmActionsCommand({ AlarmNames: [name] })
+        : new DisableAlarmActionsCommand({ AlarmNames: [name] })
+    );
+  }
+};
+
 // AWS::Cognito::IdentityPool `CognitoEvents` (the writeOnly "Cognito Events" Sync
 // trigger) cannot be patched through Cloud Control — it is set via the cognito-sync
 // SetCognitoEvents API. Reconstruct the DESIRED event map (current live + revert ops)
@@ -2975,6 +3005,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
 // resource type -> EXACT top-level finding path. Deeper paths (e.g. a declared
 // drift at Policies.0...) still go through Cloud Control as before.
 export const SDK_PROP_WRITERS: Record<string, Record<string, SdkWriter>> = {
+  'AWS::CloudWatch::CompositeAlarm': { ActionsEnabled: writeCompositeAlarmActionsEnabled },
   'AWS::Cognito::IdentityPool': { CognitoEvents: writeCognitoIdentityPoolEvents },
   'AWS::Config::ConfigRule': { InputParameters: writeConfigRuleInputParameters },
   'AWS::KinesisVideo::Stream': { DataRetentionInHours: writeKinesisVideoStreamRetention },

--- a/tests/classify-elbv2-variants-1546.test.ts
+++ b/tests/classify-elbv2-variants-1546.test.ts
@@ -165,3 +165,113 @@ describe('#1546 TCP-family listener tcp.idle_timeout.seconds default', () => {
     expect(pathsByTier(f, 'undeclared')).toEqual(['ListenerAttributes[tcp.idle_timeout.seconds]']);
   });
 });
+
+// #1626 — the NLB-family extension of the same variant axis, live-proven on a barest
+// TCP / ip-target group behind an internal NLB (attach-echo-hunt, us-east-1,
+// 2026-07-14): the health check defaults to TCP with a 10s timeout (the KNOWN_DEFAULTS
+// constants HTTP / 5 are the ALB-family values), the target_health_state.unhealthy.*
+// bag pair returns at its defaults, and an ip-target group does NOT preserve client
+// IPs (the inverse of the #1546 alb entry).
+describe('#1626 TCP/ip-target NLB target group defaults', () => {
+  const declared = {
+    Protocol: 'TCP',
+    Port: 80,
+    VpcId: 'vpc-0123456789abcdef0',
+    TargetType: 'ip',
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'AttachTg',
+    resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+    physicalId: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/tcp/abc',
+    declared,
+  });
+  const nlbDefaults = {
+    HealthCheckProtocol: 'TCP',
+    HealthCheckTimeoutSeconds: 10,
+    TargetGroupAttributes: attrs({
+      'preserve_client_ip.enabled': 'false',
+      'target_health_state.unhealthy.connection_termination.enabled': 'true',
+      'target_health_state.unhealthy.draining_interval_seconds': '0',
+    }),
+  };
+
+  it('folds the TCP-family health-check + bag defaults to atDefault (ZERO first-run drift)', () => {
+    const f = classifyResource(mk(), { ...declared, ...nlbDefaults }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'atDefault')).toContain('HealthCheckProtocol');
+    expect(pathsByTier(f, 'atDefault')).toContain('HealthCheckTimeoutSeconds');
+  });
+
+  it('an out-of-band health-check timeout change still surfaces (equality gate)', () => {
+    const f = classifyResource(
+      mk(),
+      { ...declared, ...nlbDefaults, HealthCheckTimeoutSeconds: 30 },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['HealthCheckTimeoutSeconds']);
+  });
+
+  it('an out-of-band preserve-client-ip ENABLE still surfaces (equality gate)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        ...nlbDefaults,
+        TargetGroupAttributes: attrs({
+          'preserve_client_ip.enabled': 'true',
+          'target_health_state.unhealthy.connection_termination.enabled': 'true',
+          'target_health_state.unhealthy.draining_interval_seconds': '0',
+        }),
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([
+      'TargetGroupAttributes[preserve_client_ip.enabled]',
+    ]);
+  });
+
+  it('an HTTP (ALB) group keeps the HTTP/5 constants — TCP/10 there is a real divergence', () => {
+    const httpDeclared = { ...declared, Protocol: 'HTTP', TargetType: 'instance' };
+    const f = classifyResource(
+      { ...mk(), declared: httpDeclared },
+      { ...httpDeclared, HealthCheckProtocol: 'HTTP', HealthCheckTimeoutSeconds: 5 },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});
+
+// #1626 — a barest VPCEndpointService reads back the ipv4-only creation default.
+describe('#1626 VPCEndpointService SupportedIpAddressTypes default', () => {
+  const declared = {
+    NetworkLoadBalancerArns: [
+      'arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/nlb/abc',
+    ],
+    AcceptanceRequired: true,
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'AttachEpService',
+    resourceType: 'AWS::EC2::VPCEndpointService',
+    physicalId: 'vpce-svc-0123456789abcdef0',
+    declared,
+  });
+
+  it('folds the undeclared ["ipv4"] to atDefault (ZERO first-run drift)', () => {
+    const f = classifyResource(
+      mk(),
+      { ...declared, SupportedIpAddressTypes: ['ipv4'] },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('SupportedIpAddressTypes');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a dualstack service still surfaces — detection preserved', () => {
+    const f = classifyResource(
+      mk(),
+      { ...declared, SupportedIpAddressTypes: ['ipv4', 'ipv6'] },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['SupportedIpAddressTypes']);
+  });
+});

--- a/tests/corpus/AWS__AppConfig__ConfigurationProfile.Echo3AcProfile.json
+++ b/tests/corpus/AWS__AppConfig__ConfigurationProfile.Echo3AcProfile.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Echo3AcProfile",
+    "resourceType": "AWS::AppConfig::ConfigurationProfile",
+    "physicalId": "y9b3uxn",
+    "constructPath": "CdkrdHuntEcho3/Echo3AcProfile",
+    "declared": {
+      "ApplicationId": "o9fy8c3",
+      "Description": "cdkrd echo3 probe rev 1",
+      "LocationUri": "hosted",
+      "Name": "cdkrd-echo3-profile",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ConfigurationProfileId": "y9b3uxn",
+    "LocationUri": "hosted",
+    "Type": "AWS.Freeform",
+    "Description": "cdkrd echo3 probe rev 1",
+    "ApplicationId": "o9fy8c3",
+    "Tags": [
+      {
+        "Value": "Echo3AcProfile",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHuntEcho3/12d04e40-7f62-11f1-8d5f-0afff0323aef",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdHuntEcho3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:rev"
+      }
+    ],
+    "Name": "cdkrd-echo3-profile"
+  },
+  "schema": {
+    "readOnly": ["ConfigurationProfileId", "KmsKeyArn"],
+    "writeOnly": ["DeletionProtectionCheck"],
+    "createOnly": ["ApplicationId", "LocationUri", "Type"],
+    "readOnlyPaths": ["ConfigurationProfileId", "KmsKeyArn"],
+    "writeOnlyPaths": ["DeletionProtectionCheck"],
+    "createOnlyPaths": ["ApplicationId", "LocationUri", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["Validators"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Echo3AcProfile",
+      "resourceType": "AWS::AppConfig::ConfigurationProfile",
+      "path": "Type",
+      "actual": "AWS.Freeform",
+      "physicalId": "y9b3uxn",
+      "constructPath": "CdkrdHuntEcho3/Echo3AcProfile"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Batch__ComputeEnvironment.Var3SpotCe.json
+++ b/tests/corpus/AWS__Batch__ComputeEnvironment.Var3SpotCe.json
@@ -1,0 +1,116 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Var3SpotCe",
+    "resourceType": "AWS::Batch::ComputeEnvironment",
+    "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/Var3SpotCe-d6kzcbCD7oUgwvYX",
+    "constructPath": "CdkrdHunt0714Variants3/Var3SpotCe",
+    "declared": {
+      "ComputeResources": {
+        "MaxvCpus": 1,
+        "SecurityGroupIds": ["sg-04c22d544f676a7bb"],
+        "Subnets": ["subnet-01e0fd51da4daf84e"],
+        "Type": "FARGATE_SPOT"
+      },
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Type": "MANAGED"
+    }
+  },
+  "liveRaw": {
+    "Type": "MANAGED",
+    "ServiceRole": "arn:aws:iam::111111111111:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch",
+    "ComputeEnvironmentName": "Var3SpotCe-d6kzcbCD7oUgwvYX",
+    "ComputeResources": {
+      "Subnets": ["subnet-01e0fd51da4daf84e"],
+      "Type": "FARGATE_SPOT",
+      "MaxvCpus": 1,
+      "InstanceTypes": [],
+      "Ec2Configuration": [],
+      "SecurityGroupIds": ["sg-04c22d544f676a7bb"]
+    },
+    "State": "ENABLED",
+    "ComputeEnvironmentArn": "arn:aws:batch:us-east-1:111111111111:compute-environment/Var3SpotCe-d6kzcbCD7oUgwvYX",
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["ComputeEnvironmentArn"],
+    "writeOnly": ["ReplaceComputeEnvironment", "UpdatePolicy"],
+    "createOnly": ["ComputeEnvironmentName", "EksConfiguration", "Tags", "Type"],
+    "readOnlyPaths": [
+      "ComputeEnvironmentArn",
+      "ComputeResources.Ec2Configuration.*.BatchImageStatus"
+    ],
+    "writeOnlyPaths": [
+      "ComputeResources.UpdateToLatestImageVersion",
+      "ReplaceComputeEnvironment",
+      "UpdatePolicy"
+    ],
+    "createOnlyPaths": [
+      "ComputeEnvironmentName",
+      "ComputeResources.SpotIamFleetRole",
+      "EksConfiguration",
+      "Tags",
+      "Type"
+    ],
+    "defaults": {
+      "ReplaceComputeEnvironment": true
+    },
+    "defaultPaths": {
+      "ComputeResources.UpdateToLatestImageVersion": false,
+      "ReplaceComputeEnvironment": true,
+      "UpdatePolicy.TerminateJobsOnUpdate": false,
+      "UpdatePolicy.JobExecutionTimeoutMinutes": 30,
+      "EksConfiguration.EksClusterArn": false,
+      "EksConfiguration.KubernetesNamespace": false
+    },
+    "unorderedScalarPaths": [
+      "ComputeResources.InstanceTypes",
+      "ComputeResources.SecurityGroupIds",
+      "ComputeResources.Subnets"
+    ],
+    "unorderedObjectArrayPaths": [
+      "ComputeResources.Ec2Configuration",
+      "ComputeResources.LaunchTemplate.Overrides"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3SpotCe",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ServiceRole",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/Var3SpotCe-d6kzcbCD7oUgwvYX",
+      "constructPath": "CdkrdHunt0714Variants3/Var3SpotCe"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Var3SpotCe",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ComputeEnvironmentName",
+      "actual": "Var3SpotCe-d6kzcbCD7oUgwvYX",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/Var3SpotCe-d6kzcbCD7oUgwvYX",
+      "constructPath": "CdkrdHunt0714Variants3/Var3SpotCe"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3SpotCe",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/Var3SpotCe-d6kzcbCD7oUgwvYX",
+      "constructPath": "CdkrdHunt0714Variants3/Var3SpotCe"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeBuild__Project.Var3ArmCb.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Var3ArmCb.json
@@ -1,0 +1,155 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Var3ArmCb",
+    "resourceType": "AWS::CodeBuild::Project",
+    "physicalId": "cdkrd-hunt0714-var3-cb-arm",
+    "constructPath": "CdkrdHunt0714Variants3/Var3ArmCb",
+    "declared": {
+      "Artifacts": {
+        "Type": "NO_ARTIFACTS"
+      },
+      "Environment": {
+        "ComputeType": "BUILD_GENERAL1_SMALL",
+        "Image": "aws/codebuild/amazonlinux2-aarch64-standard:3.0",
+        "Type": "ARM_CONTAINER"
+      },
+      "Name": "cdkrd-hunt0714-var3-cb-arm",
+      "ServiceRole": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3CbRole3C45F627-i6bK6L1U80La",
+      "Source": {
+        "BuildSpec": "{\"version\":\"0.2\",\"phases\":{}}",
+        "Type": "NO_SOURCE"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt0714-var3-cb-arm",
+    "ServiceRole": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3CbRole3C45F627-i6bK6L1U80La",
+    "TimeoutInMinutes": 60,
+    "QueuedTimeoutInMinutes": 480,
+    "EncryptionKey": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+    "Source": {
+      "Type": "NO_SOURCE",
+      "BuildSpec": "{\"version\":\"0.2\",\"phases\":{}}",
+      "InsecureSsl": false
+    },
+    "Artifacts": {
+      "Type": "NO_ARTIFACTS"
+    },
+    "Environment": {
+      "Type": "ARM_CONTAINER",
+      "ComputeType": "BUILD_GENERAL1_SMALL",
+      "Image": "aws/codebuild/amazonlinux2-aarch64-standard:3.0",
+      "PrivilegedMode": false,
+      "ImagePullCredentialsType": "CODEBUILD",
+      "EnvironmentVariables": []
+    },
+    "Visibility": "PRIVATE",
+    "BadgeEnabled": false,
+    "Cache": {
+      "Type": "NO_CACHE"
+    },
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0714Variants3"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "Var3ArmCb"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Variants3/ede9fa20-7f63-11f1-b1a2-123a84cbb8d5"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3ArmCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "TimeoutInMinutes",
+      "actual": 60,
+      "physicalId": "cdkrd-hunt0714-var3-cb-arm",
+      "constructPath": "CdkrdHunt0714Variants3/Var3ArmCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3ArmCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "QueuedTimeoutInMinutes",
+      "actual": 480,
+      "physicalId": "cdkrd-hunt0714-var3-cb-arm",
+      "constructPath": "CdkrdHunt0714Variants3/Var3ArmCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3ArmCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "EncryptionKey",
+      "actual": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+      "physicalId": "cdkrd-hunt0714-var3-cb-arm",
+      "constructPath": "CdkrdHunt0714Variants3/Var3ArmCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3ArmCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Visibility",
+      "actual": "PRIVATE",
+      "physicalId": "cdkrd-hunt0714-var3-cb-arm",
+      "constructPath": "CdkrdHunt0714Variants3/Var3ArmCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3ArmCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Cache",
+      "actual": {
+        "Type": "NO_CACHE"
+      },
+      "physicalId": "cdkrd-hunt0714-var3-cb-arm",
+      "constructPath": "CdkrdHunt0714Variants3/Var3ArmCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3ArmCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Environment.ImagePullCredentialsType",
+      "actual": "CODEBUILD",
+      "nested": true,
+      "physicalId": "cdkrd-hunt0714-var3-cb-arm",
+      "constructPath": "CdkrdHunt0714Variants3/Var3ArmCb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeBuild__Project.Var3LambdaCb.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Var3LambdaCb.json
@@ -1,0 +1,145 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Var3LambdaCb",
+    "resourceType": "AWS::CodeBuild::Project",
+    "physicalId": "cdkrd-hunt0714-var3-cb-lambda",
+    "constructPath": "CdkrdHunt0714Variants3/Var3LambdaCb",
+    "declared": {
+      "Artifacts": {
+        "Type": "NO_ARTIFACTS"
+      },
+      "Environment": {
+        "ComputeType": "BUILD_LAMBDA_1GB",
+        "Image": "aws/codebuild/amazonlinux-x86_64-lambda-standard:nodejs20",
+        "Type": "LINUX_LAMBDA_CONTAINER"
+      },
+      "Name": "cdkrd-hunt0714-var3-cb-lambda",
+      "ServiceRole": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3CbRole3C45F627-i6bK6L1U80La",
+      "Source": {
+        "BuildSpec": "{\"version\":\"0.2\",\"phases\":{}}",
+        "Type": "NO_SOURCE"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt0714-var3-cb-lambda",
+    "ServiceRole": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3CbRole3C45F627-i6bK6L1U80La",
+    "TimeoutInMinutes": 15,
+    "EncryptionKey": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+    "Source": {
+      "Type": "NO_SOURCE",
+      "BuildSpec": "{\"version\":\"0.2\",\"phases\":{}}",
+      "InsecureSsl": false
+    },
+    "Artifacts": {
+      "Type": "NO_ARTIFACTS"
+    },
+    "Environment": {
+      "Type": "LINUX_LAMBDA_CONTAINER",
+      "ComputeType": "BUILD_LAMBDA_1GB",
+      "Image": "aws/codebuild/amazonlinux-x86_64-lambda-standard:nodejs20",
+      "PrivilegedMode": false,
+      "ImagePullCredentialsType": "CODEBUILD",
+      "EnvironmentVariables": []
+    },
+    "Visibility": "PRIVATE",
+    "BadgeEnabled": false,
+    "Cache": {
+      "Type": "NO_CACHE"
+    },
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0714Variants3"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "Var3LambdaCb"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Variants3/ede9fa20-7f63-11f1-b1a2-123a84cbb8d5"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3LambdaCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "TimeoutInMinutes",
+      "actual": 15,
+      "physicalId": "cdkrd-hunt0714-var3-cb-lambda",
+      "constructPath": "CdkrdHunt0714Variants3/Var3LambdaCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3LambdaCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "EncryptionKey",
+      "actual": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+      "physicalId": "cdkrd-hunt0714-var3-cb-lambda",
+      "constructPath": "CdkrdHunt0714Variants3/Var3LambdaCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3LambdaCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Visibility",
+      "actual": "PRIVATE",
+      "physicalId": "cdkrd-hunt0714-var3-cb-lambda",
+      "constructPath": "CdkrdHunt0714Variants3/Var3LambdaCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3LambdaCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Cache",
+      "actual": {
+        "Type": "NO_CACHE"
+      },
+      "physicalId": "cdkrd-hunt0714-var3-cb-lambda",
+      "constructPath": "CdkrdHunt0714Variants3/Var3LambdaCb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3LambdaCb",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Environment.ImagePullCredentialsType",
+      "actual": "CODEBUILD",
+      "nested": true,
+      "physicalId": "cdkrd-hunt0714-var3-cb-lambda",
+      "constructPath": "CdkrdHunt0714Variants3/Var3LambdaCb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VPCEndpointService.AttachEpService.json
+++ b/tests/corpus/AWS__EC2__VPCEndpointService.AttachEpService.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AttachEpService",
+    "resourceType": "AWS::EC2::VPCEndpointService",
+    "physicalId": "vpce-svc-03982c2ca53eb5b7b",
+    "constructPath": "CdkrdHunt0714AttachEcho/AttachEpService",
+    "declared": {
+      "AcceptanceRequired": true,
+      "NetworkLoadBalancerArns": [
+        "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-Attac-rurZLpodmvYZ/d2c747579badb68f"
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "NetworkLoadBalancerArns": [
+      "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-Attac-rurZLpodmvYZ/d2c747579badb68f"
+    ],
+    "AcceptanceRequired": true,
+    "SupportedIpAddressTypes": ["ipv4"],
+    "GatewayLoadBalancerArns": [],
+    "SupportedRegions": ["us-east-1"],
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "ServiceId": "vpce-svc-03982c2ca53eb5b7b"
+  },
+  "schema": {
+    "readOnly": ["ServiceId"],
+    "writeOnly": ["ContributorInsightsEnabled"],
+    "createOnly": [],
+    "readOnlyPaths": ["ServiceId"],
+    "writeOnlyPaths": ["ContributorInsightsEnabled"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SupportedIpAddressTypes", "SupportedRegions"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachEpService",
+      "resourceType": "AWS::EC2::VPCEndpointService",
+      "path": "SupportedIpAddressTypes",
+      "actual": ["ipv4"],
+      "physicalId": "vpce-svc-03982c2ca53eb5b7b",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachEpService"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachEpService",
+      "resourceType": "AWS::EC2::VPCEndpointService",
+      "path": "SupportedRegions",
+      "actual": ["us-east-1"],
+      "physicalId": "vpce-svc-03982c2ca53eb5b7b",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachEpService"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VPCEndpointServicePermissions.AttachEpPerms.json
+++ b/tests/corpus/AWS__EC2__VPCEndpointServicePermissions.AttachEpPerms.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AttachEpPerms",
+    "resourceType": "AWS::EC2::VPCEndpointServicePermissions",
+    "physicalId": "vpce-svc-03982c2ca53eb5b7b",
+    "constructPath": "CdkrdHunt0714AttachEcho/AttachEpPerms",
+    "declared": {
+      "AllowedPrincipals": ["arn:aws:iam::111111111111:root"],
+      "ServiceId": "vpce-svc-03982c2ca53eb5b7b"
+    }
+  },
+  "liveRaw": {
+    "AllowedPrincipals": ["arn:aws:iam::111111111111:root"],
+    "ServiceId": "vpce-svc-03982c2ca53eb5b7b"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ServiceId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ServiceId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.Var3RedirectListener.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.Var3RedirectListener.json
@@ -1,0 +1,122 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Var3RedirectListener",
+    "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-Var3A-2U9apPGL3QQv/e1d73be1c32091e7/8dd0897fa0c49ac1",
+    "constructPath": "CdkrdHunt0714Variants3/Var3RedirectListener",
+    "declared": {
+      "DefaultActions": [
+        {
+          "RedirectConfig": {
+            "Protocol": "HTTPS",
+            "StatusCode": "HTTP_301"
+          },
+          "Type": "redirect"
+        }
+      ],
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-Var3A-2U9apPGL3QQv/e1d73be1c32091e7",
+      "Port": 80,
+      "Protocol": "HTTP"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-Var3A-2U9apPGL3QQv/e1d73be1c32091e7/8dd0897fa0c49ac1",
+    "ListenerAttributes": [
+      {
+        "Value": "true",
+        "Key": "routing.http.response.server.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_frame_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_methods.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_origin.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_credentials.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_content_type_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.content_security_policy.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_expose_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.strict_transport_security.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_max_age.header_value"
+      }
+    ],
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-Var3A-2U9apPGL3QQv/e1d73be1c32091e7",
+    "DefaultActions": [
+      {
+        "Type": "redirect",
+        "RedirectConfig": {
+          "Path": "/#{path}",
+          "Query": "#{query}",
+          "Port": "#{port}",
+          "Host": "#{host}",
+          "Protocol": "HTTPS",
+          "StatusCode": "HTTP_301"
+        }
+      }
+    ],
+    "Port": 80,
+    "Protocol": "HTTP"
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": ["DefaultActions.*.AuthenticateOidcConfig.ClientSecret"],
+    "createOnlyPaths": ["LoadBalancerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "DefaultActions.*.AuthenticateCognitoConfig.AuthenticationRequestExtraParams",
+      "DefaultActions.*.AuthenticateOidcConfig.AuthenticationRequestExtraParams"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3RedirectListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "ListenerAttributes[routing.http.response.server.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-Var3A-2U9apPGL3QQv/e1d73be1c32091e7/8dd0897fa0c49ac1",
+      "constructPath": "CdkrdHunt0714Variants3/Var3RedirectListener"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.AttachTg.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.AttachTg.json
@@ -1,0 +1,368 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AttachTg",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+    "constructPath": "CdkrdHunt0714AttachEcho/AttachTg",
+    "declared": {
+      "Port": 80,
+      "Protocol": "TCP",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TargetType": "ip",
+      "VpcId": "vpc-0b5a0a4d981d3f1d1"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [
+      "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-Attac-rurZLpodmvYZ/d2c747579badb68f"
+    ],
+    "Port": 80,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 10,
+    "Name": "CdkrdH-Attac-1TPDZADDDYBK",
+    "VpcId": "vpc-0b5a0a4d981d3f1d1",
+    "TargetGroupFullName": "targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "source_ip",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "target_health_state.unhealthy.draining_interval_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "false",
+        "Key": "proxy_protocol_v2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "deregistration_delay.connection_termination.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "preserve_client_ip.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "target_health_state.unhealthy.connection_termination.enabled"
+      }
+    ],
+    "TargetType": "ip",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "TCP",
+    "TargetGroupName": "CdkrdH-Attac-1TPDZADDDYBK",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714AttachEcho",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "AttachTg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714AttachEcho/17538fa0-7f66-11f1-9b0f-0e0bb0e82511",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-Attac-1TPDZADDDYBK",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "TCP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.connection_termination.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[preserve_client_ip.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[proxy_protocol_v2.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.draining_interval_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AttachTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Attac-1TPDZADDDYBK/ea9c9f2f9f24863e",
+      "constructPath": "CdkrdHunt0714AttachEcho/AttachTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Table.Var3IcebergTable.json
+++ b/tests/corpus/AWS__Glue__Table.Var3IcebergTable.json
@@ -1,0 +1,121 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Var3IcebergTable",
+    "resourceType": "AWS::Glue::Table",
+    "physicalId": "cdkrd_hunt0714_var3_tbl",
+    "constructPath": "CdkrdHunt0714Variants3/Var3IcebergTable",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseName": "cdkrd_hunt0714_var3_db",
+      "OpenTableFormatInput": {
+        "IcebergInput": {
+          "MetadataOperation": "CREATE",
+          "Version": "2"
+        }
+      },
+      "TableInput": {
+        "Name": "cdkrd_hunt0714_var3_tbl",
+        "StorageDescriptor": {
+          "Columns": [
+            {
+              "Name": "id",
+              "Type": "string"
+            }
+          ],
+          "Location": "s3://cdkrdhunt0714variants3-var3icebergbucketa4990b9c-jwkbf443egea/table/"
+        },
+        "TableType": "EXTERNAL_TABLE"
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_hunt0714_var3_db",
+    "TableInput": {
+      "Name": "cdkrd_hunt0714_var3_tbl",
+      "Retention": 0,
+      "TableType": "EXTERNAL_TABLE",
+      "Parameters": {
+        "metadata_location": "s3://cdkrdhunt0714variants3-var3icebergbucketa4990b9c-jwkbf443egea/table/metadata/00000-8517df65-f2ae-4049-8069-123e27b72d63.metadata.json",
+        "table_type": "ICEBERG"
+      },
+      "StorageDescriptor": {
+        "Columns": [
+          {
+            "Name": "id",
+            "Type": "string"
+          }
+        ],
+        "Location": "s3://cdkrdhunt0714variants3-var3icebergbucketa4990b9c-jwkbf443egea/table/",
+        "Compressed": false,
+        "NumberOfBuckets": 0,
+        "SortColumns": [],
+        "StoredAsSubDirectories": false
+      }
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["CatalogId", "DatabaseName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["CatalogId", "DatabaseName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Var3IcebergTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "OpenTableFormatInput",
+      "note": "declared but not returned by live read",
+      "physicalId": "cdkrd_hunt0714_var3_tbl",
+      "constructPath": "CdkrdHunt0714Variants3/Var3IcebergTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3IcebergTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.Retention",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_hunt0714_var3_tbl",
+      "constructPath": "CdkrdHunt0714Variants3/Var3IcebergTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3IcebergTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.Parameters",
+      "actual": {
+        "metadata_location": "s3://cdkrdhunt0714variants3-var3icebergbucketa4990b9c-jwkbf443egea/table/metadata/00000-8517df65-f2ae-4049-8069-123e27b72d63.metadata.json",
+        "table_type": "ICEBERG"
+      },
+      "nested": true,
+      "physicalId": "cdkrd_hunt0714_var3_tbl",
+      "constructPath": "CdkrdHunt0714Variants3/Var3IcebergTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3IcebergTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.StorageDescriptor.NumberOfBuckets",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_hunt0714_var3_tbl",
+      "constructPath": "CdkrdHunt0714Variants3/Var3IcebergTable"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Var3IcebergFirehose.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Var3IcebergFirehose.json
@@ -1,0 +1,141 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Var3IcebergFirehose",
+    "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+    "physicalId": "cdkrd-hunt0714-var3-iceberg",
+    "constructPath": "CdkrdHunt0714Variants3/Var3IcebergFirehose",
+    "declared": {
+      "DeliveryStreamName": "cdkrd-hunt0714-var3-iceberg",
+      "DeliveryStreamType": "DirectPut",
+      "IcebergDestinationConfiguration": {
+        "CatalogConfiguration": {
+          "CatalogArn": "arn:aws:glue:us-east-1:111111111111:catalog"
+        },
+        "DestinationTableConfigurationList": [
+          {
+            "DestinationDatabaseName": "cdkrd_hunt0714_var3_db",
+            "DestinationTableName": "cdkrd_hunt0714_var3_tbl"
+          }
+        ],
+        "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3FhRoleB1C718B3-dxcdzFMkYG06",
+        "S3Configuration": {
+          "BucketARN": "arn:aws:s3:::cdkrdhunt0714variants3-var3icebergbucketa4990b9c-jwkbf443egea",
+          "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3FhRoleB1C718B3-dxcdzFMkYG06"
+        }
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DeliveryStreamType": "DirectPut",
+    "DeliveryStreamName": "cdkrd-hunt0714-var3-iceberg",
+    "Arn": "arn:aws:firehose:us-east-1:111111111111:deliverystream/cdkrd-hunt0714-var3-iceberg",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "ElasticsearchDestinationConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration"
+    ],
+    "createOnly": [
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration"
+    ],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "DirectPutSourceConfiguration.ThroughputHintInMBs",
+      "ElasticsearchDestinationConfiguration",
+      "ElasticsearchDestinationConfiguration.CloudWatchLoggingOptions.Enabled",
+      "ExtendedS3DestinationConfiguration.CustomTimeZone",
+      "ExtendedS3DestinationConfiguration.FileExtension",
+      "HttpEndpointDestinationConfiguration.EndpointConfiguration.AccessKey",
+      "HttpEndpointDestinationConfiguration.ProcessingConfiguration",
+      "HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "HttpEndpointDestinationConfiguration.SecretsManagerConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "RedshiftDestinationConfiguration.Password",
+      "RedshiftDestinationConfiguration.ProcessingConfiguration",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3Configuration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.Enabled",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.RoleARN",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.SecretARN",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration",
+      "SplunkDestinationConfiguration.BufferingHints",
+      "SplunkDestinationConfiguration.CloudWatchLoggingOptions",
+      "SplunkDestinationConfiguration.ProcessingConfiguration",
+      "SplunkDestinationConfiguration.S3Configuration.EncryptionConfiguration.NoEncryptionConfig",
+      "SplunkDestinationConfiguration.SecretsManagerConfiguration"
+    ],
+    "createOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration.VpcConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration.VpcConfiguration",
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "ElasticsearchDestinationConfiguration.VpcConfiguration",
+      "IcebergDestinationConfiguration.CatalogConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "ExtendedS3DestinationConfiguration.DataFormatConversionConfiguration.InputFormatConfiguration.Deserializer.OpenXJsonSerDe.ColumnToJsonKeyMappings"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Var3IcebergFirehose",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "IcebergDestinationConfiguration",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "cdkrd-hunt0714-var3-iceberg",
+      "constructPath": "CdkrdHunt0714Variants3/Var3IcebergFirehose"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Scheduler__Schedule.Var3FlexSchedule.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.Var3FlexSchedule.json
@@ -1,0 +1,121 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Var3FlexSchedule",
+    "resourceType": "AWS::Scheduler::Schedule",
+    "physicalId": "cdkrd-hunt0714-var3-flex",
+    "constructPath": "CdkrdHunt0714Variants3/Var3FlexSchedule",
+    "declared": {
+      "FlexibleTimeWindow": {
+        "MaximumWindowInMinutes": 15,
+        "Mode": "FLEXIBLE"
+      },
+      "Name": "cdkrd-hunt0714-var3-flex",
+      "ScheduleExpression": "rate(12 hours)",
+      "Target": {
+        "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0714Variants3-Var3SchedQueue-06f7Tw4ucZUz",
+        "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3SchedRoleBB058680-huQo3yI4KgUM"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-hunt0714-var3-flex",
+    "GroupName": "default",
+    "ScheduleExpression": "rate(12 hours)",
+    "ScheduleExpressionTimezone": "UTC",
+    "FlexibleTimeWindow": {
+      "Mode": "FLEXIBLE",
+      "MaximumWindowInMinutes": 15
+    },
+    "State": "ENABLED",
+    "ActionAfterCompletion": "NONE",
+    "Target": {
+      "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0714Variants3-Var3SchedQueue-06f7Tw4ucZUz",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Variants3-Var3SchedRoleBB058680-huQo3yI4KgUM",
+      "RetryPolicy": {
+        "MaximumEventAgeInSeconds": 86400,
+        "MaximumRetryAttempts": 185
+      }
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {
+      "Target.EcsParameters.CapacityProviderStrategy.*.Weight": 0,
+      "Target.EcsParameters.CapacityProviderStrategy.*.Base": 0
+    },
+    "unorderedScalarPaths": [
+      "Target.EcsParameters.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups",
+      "Target.EcsParameters.NetworkConfiguration.AwsvpcConfiguration.Subnets"
+    ],
+    "unorderedObjectArrayPaths": [
+      "Target.EcsParameters.CapacityProviderStrategy",
+      "Target.EcsParameters.PlacementConstraints",
+      "Target.EcsParameters.PlacementStrategy"
+    ],
+    "freeFormMapPaths": ["Target.EcsParameters.Tags.*"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3FlexSchedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "GroupName",
+      "actual": "default",
+      "physicalId": "cdkrd-hunt0714-var3-flex",
+      "constructPath": "CdkrdHunt0714Variants3/Var3FlexSchedule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3FlexSchedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "ScheduleExpressionTimezone",
+      "actual": "UTC",
+      "physicalId": "cdkrd-hunt0714-var3-flex",
+      "constructPath": "CdkrdHunt0714Variants3/Var3FlexSchedule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3FlexSchedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "cdkrd-hunt0714-var3-flex",
+      "constructPath": "CdkrdHunt0714Variants3/Var3FlexSchedule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3FlexSchedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "ActionAfterCompletion",
+      "actual": "NONE",
+      "physicalId": "cdkrd-hunt0714-var3-flex",
+      "constructPath": "CdkrdHunt0714Variants3/Var3FlexSchedule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Var3FlexSchedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "Target.RetryPolicy",
+      "actual": {
+        "MaximumEventAgeInSeconds": 86400,
+        "MaximumRetryAttempts": 185
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0714-var3-flex",
+      "constructPath": "CdkrdHunt0714Variants3/Var3FlexSchedule"
+    }
+  ]
+}

--- a/tests/hunt-case-folds-1620-1622.test.ts
+++ b/tests/hunt-case-folds-1620-1622.test.ts
@@ -1,0 +1,178 @@
+// 2026-07-14 hunt — three first-run/declared FP fixes, each live-probed:
+//   #1620 ACM lowercases certificate domain names (request-certificate with
+//     "CdkrdHunt-0714-Probe.Example.Com" describes back all-lowercase, SANs too)
+//     -> CASE_INSENSITIVE_PATHS DomainName + SubjectAlternativeNames.*, and the
+//     reader's implied-apex SAN subtraction goes case-insensitive.
+//   #1621 DAX lowercases parameter-group / subnet-group names (raw create echoes
+//     "cdkrdhunt-mixed-daxpg"), reachable via CFn's legacy provider (no CC CREATE
+//     handler to reject) -> CASE_INSENSITIVE_PATHS entries.
+//   #1622 a barest AppConfig ConfigurationProfile reads back the undeclared
+//     Type "AWS.Freeform" -> KNOWN_DEFAULTS tier-1 pin.
+import {
+  ACMClient,
+  DescribeCertificateCommand,
+  ListTagsForCertificateCommand,
+} from '@aws-sdk/client-acm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({ logicalId: 'Res', resourceType, declared, physicalId });
+
+describe('#1620 ACM Certificate lowercase-stored domain names', () => {
+  const declared = {
+    DomainName: 'MyApp.Example.Com',
+    SubjectAlternativeNames: ['Www.Example.Com'],
+  };
+
+  it('a pure case-fold echo of DomainName + SANs is not declared drift', () => {
+    const f = classifyResource(
+      mk('AWS::CertificateManager::Certificate', declared),
+      { DomainName: 'myapp.example.com', SubjectAlternativeNames: ['www.example.com'] },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toEqual([]);
+  });
+
+  it('a domain differing beyond case still surfaces as declared drift', () => {
+    const f = classifyResource(
+      mk('AWS::CertificateManager::Certificate', declared),
+      { DomainName: 'other.example.com', SubjectAlternativeNames: ['www.example.com'] },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toEqual(['DomainName']);
+  });
+});
+
+describe('#1620 ACM reader apex-SAN subtraction is case-insensitive', () => {
+  const acm = mockClient(ACMClient);
+  const ARN = 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012';
+  const read = (declared: Record<string, unknown>) =>
+    SDK_OVERRIDES['AWS::CertificateManager::Certificate']({
+      physicalId: ARN,
+      declared,
+      region: 'us-east-1',
+      accountId: '123456789012',
+    });
+
+  beforeEach(() => acm.reset());
+
+  it('subtracts the lowercased implied apex for a mixed-case declared DomainName', async () => {
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        // ACM stores everything lowercased regardless of the declared case.
+        DomainName: 'myapp.example.com',
+        SubjectAlternativeNames: ['myapp.example.com', 'www.example.com'],
+        KeyAlgorithm: 'RSA_2048',
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+
+    const out = await read({
+      DomainName: 'MyApp.Example.Com',
+      SubjectAlternativeNames: ['Www.Example.Com'],
+    });
+    // the implied apex is subtracted despite the case difference; only the real SAN stays.
+    expect(out).toMatchObject({ SubjectAlternativeNames: ['www.example.com'] });
+  });
+
+  it('keeps the live list verbatim when the declared SANs contain the apex in ANY case', async () => {
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        DomainName: 'myapp.example.com',
+        SubjectAlternativeNames: ['myapp.example.com', 'www.example.com'],
+        KeyAlgorithm: 'RSA_2048',
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+
+    const out = await read({
+      DomainName: 'MyApp.Example.Com',
+      SubjectAlternativeNames: ['MyApp.Example.Com', 'Www.Example.Com'],
+    });
+    // the user intends the apex as a SAN → no subtraction, faithful compare.
+    expect(out).toMatchObject({
+      SubjectAlternativeNames: ['myapp.example.com', 'www.example.com'],
+    });
+  });
+});
+
+describe('#1621 DAX lowercase-stored group names', () => {
+  it('a pure case-fold echo of ParameterGroupName is not declared drift', () => {
+    const f = classifyResource(
+      mk('AWS::DAX::ParameterGroup', { ParameterGroupName: 'CdkrdHunt-Mixed-DaxPG' }),
+      { ParameterGroupName: 'cdkrdhunt-mixed-daxpg' },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toEqual([]);
+  });
+
+  it('a pure case-fold echo of SubnetGroupName is not declared drift', () => {
+    const f = classifyResource(
+      mk('AWS::DAX::SubnetGroup', {
+        SubnetGroupName: 'CdkrdHunt-Mixed-DaxSG',
+        SubnetIds: ['subnet-1'],
+      }),
+      { SubnetGroupName: 'cdkrdhunt-mixed-daxsg', SubnetIds: ['subnet-1'] },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toEqual([]);
+  });
+
+  it('a name differing beyond case still surfaces as declared drift', () => {
+    const f = classifyResource(
+      mk('AWS::DAX::ParameterGroup', { ParameterGroupName: 'CdkrdHunt-Mixed-DaxPG' }),
+      { ParameterGroupName: 'cdkrdhunt-other' },
+      emptySchema
+    );
+    expect(tier(f, 'declared')).toEqual(['ParameterGroupName']);
+  });
+});
+
+describe('#1622 AppConfig ConfigurationProfile undeclared Type default', () => {
+  const declared = { ApplicationId: 'app-1', Name: 'profile', LocationUri: 'hosted' };
+
+  it('folds the undeclared Type "AWS.Freeform" to atDefault (ZERO first-run drift)', () => {
+    const f = classifyResource(
+      mk('AWS::AppConfig::ConfigurationProfile', declared),
+      { ...declared, Type: 'AWS.Freeform' },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('Type');
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces a Type that diverges from the freeform default — detection preserved', () => {
+    const f = classifyResource(
+      mk('AWS::AppConfig::ConfigurationProfile', declared),
+      { ...declared, Type: 'AWS.AppConfig.FeatureFlags' },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toEqual(['Type']);
+  });
+});

--- a/tests/hunt-variants3-folds-1624-1625.test.ts
+++ b/tests/hunt-variants3-folds-1624-1625.test.ts
@@ -1,0 +1,163 @@
+// 2026-07-14 hunt (variants3-hunt live findings):
+//   #1624 a barest Glue Iceberg table first-runs 2 FPs — the create-time
+//     OpenTableFormatInput is never echoed by GetTable (readGap denylist), and the
+//     service materializes managed TableInput.Parameters (table_type ICEBERG + a
+//     per-commit metadata_location pointer; shape-gated derived fold).
+//   #1625 a Lambda-compute CodeBuild project defaults TimeoutInMinutes to 15, not
+//     the standard-container 60 (derived from the declared Environment.Type).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1624 Glue Iceberg table first-run folds', () => {
+  const tableInput = {
+    Name: 'iceberg_tbl',
+    TableType: 'EXTERNAL_TABLE',
+    StorageDescriptor: { Columns: [{ Name: 'id', Type: 'string' }], Location: 's3://b/table/' },
+  };
+  const mkTable = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'IcebergTable',
+    resourceType: 'AWS::Glue::Table',
+    physicalId: 'iceberg_tbl',
+    declared,
+  });
+  const icebergDeclared = {
+    CatalogId: '123456789012',
+    DatabaseName: 'db',
+    OpenTableFormatInput: { IcebergInput: { MetadataOperation: 'CREATE', Version: '2' } },
+    TableInput: tableInput,
+  };
+  const managedParams = {
+    metadata_location: 's3://b/table/metadata/00000-abc.metadata.json',
+    table_type: 'ICEBERG',
+  };
+
+  it('declared OpenTableFormatInput absent from live stays readGap, not declared drift', () => {
+    const f = classifyResource(
+      mkTable(icebergDeclared),
+      { CatalogId: '123456789012', DatabaseName: 'db', TableInput: tableInput },
+      emptySchema
+    );
+    expect(f.some((x) => x.tier === 'declared' && x.path === 'OpenTableFormatInput')).toBe(false);
+    expect(f.some((x) => x.tier === 'readGap' && x.path === 'OpenTableFormatInput')).toBe(true);
+  });
+
+  it('the service-managed iceberg Parameters pair folds to atDefault (ZERO first-run drift)', () => {
+    const f = classifyResource(
+      mkTable(icebergDeclared),
+      {
+        CatalogId: '123456789012',
+        DatabaseName: 'db',
+        TableInput: { ...tableInput, Parameters: managedParams },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toEqual([]);
+    expect(tier(f, 'atDefault')).toContain('TableInput.Parameters');
+  });
+
+  it('an extra out-of-band parameter makes the map surface — detection preserved', () => {
+    const f = classifyResource(
+      mkTable(icebergDeclared),
+      {
+        CatalogId: '123456789012',
+        DatabaseName: 'db',
+        TableInput: {
+          ...tableInput,
+          Parameters: { ...managedParams, classification: 'json' },
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toEqual(['TableInput.Parameters']);
+  });
+
+  it('the fold is gated on the declared IcebergInput — a plain table never folds it', () => {
+    const f = classifyResource(
+      mkTable({ CatalogId: '123456789012', DatabaseName: 'db', TableInput: tableInput }),
+      {
+        CatalogId: '123456789012',
+        DatabaseName: 'db',
+        TableInput: { ...tableInput, Parameters: managedParams },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toEqual(['TableInput.Parameters']);
+  });
+});
+
+describe('#1625 CodeBuild Lambda-compute TimeoutInMinutes derived default', () => {
+  const mkProject = (envType: string): DesiredResource => ({
+    logicalId: 'LambdaCb',
+    resourceType: 'AWS::CodeBuild::Project',
+    physicalId: 'cdkrd-cb-lambda',
+    declared: {
+      Name: 'cdkrd-cb-lambda',
+      ServiceRole: 'arn:aws:iam::123456789012:role/cb',
+      Source: { Type: 'NO_SOURCE' },
+      Artifacts: { Type: 'NO_ARTIFACTS' },
+      Environment: {
+        Type: envType,
+        ComputeType: 'BUILD_LAMBDA_1GB',
+        Image: 'aws/codebuild/amazonlinux-x86_64-lambda-standard:nodejs20',
+      },
+    },
+  });
+  const liveBase = {
+    Name: 'cdkrd-cb-lambda',
+    ServiceRole: 'arn:aws:iam::123456789012:role/cb',
+    Source: { Type: 'NO_SOURCE' },
+    Artifacts: { Type: 'NO_ARTIFACTS' },
+  };
+
+  it('folds the Lambda-compute 15-minute default to atDefault (ZERO first-run drift)', () => {
+    const f = classifyResource(
+      mkProject('LINUX_LAMBDA_CONTAINER'),
+      { ...liveBase, TimeoutInMinutes: 15 },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('TimeoutInMinutes');
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a Lambda-compute timeout changed away from 15 still surfaces', () => {
+    const f = classifyResource(
+      mkProject('ARM_LAMBDA_CONTAINER'),
+      { ...liveBase, TimeoutInMinutes: 30 },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toEqual(['TimeoutInMinutes']);
+  });
+
+  it('a standard container keeps the 60 constant fold — 15 there is a real divergence', () => {
+    const std = classifyResource(
+      mkProject('LINUX_CONTAINER'),
+      { ...liveBase, TimeoutInMinutes: 60 },
+      emptySchema
+    );
+    expect(tier(std, 'atDefault')).toContain('TimeoutInMinutes');
+    const drifted = classifyResource(
+      mkProject('LINUX_CONTAINER'),
+      { ...liveBase, TimeoutInMinutes: 15 },
+      emptySchema
+    );
+    expect(tier(drifted, 'undeclared')).toEqual(['TimeoutInMinutes']);
+  });
+});

--- a/tests/integration/attach-echo-hunt/app.ts
+++ b/tests/integration/attach-echo-hunt/app.ts
@@ -1,0 +1,122 @@
+// Sibling-attachment echo probe (the ClientVPN #1574 class): a parent deployed
+// ALONE can hide first-run FPs that only materialize when an attachment-style
+// sibling lands in-stack (the association echoes back onto the PARENT's live
+// read). Four common parent+attachment pairs whose ATTACHED-shape parent has
+// never been pre-record first-checked (existing fixtures record first, which
+// folds any materialized echo into the baseline silently):
+// - SecretsManager Secret + RotationSchedule (does RotationRules/RotationEnabled
+//   materialize on the Secret read?)
+// - EC2 VPCEndpointService + VPCEndpointServicePermissions (AllowedPrincipals?)
+// - ECS Cluster + ClusterCapacityProviderAssociations (CapacityProviders echo —
+//   classify has hasSiblingCapacityProviders, this proves it live)
+// - EFS FileSystem + MountTarget
+import { App, Duration, Fn, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnSecurityGroup,
+  CfnSubnet,
+  CfnVPC,
+  CfnVPCEndpointService,
+  CfnVPCEndpointServicePermissions,
+} from "aws-cdk-lib/aws-ec2";
+import {
+  CfnCluster,
+  CfnClusterCapacityProviderAssociations,
+} from "aws-cdk-lib/aws-ecs";
+import { CfnFileSystem, CfnMountTarget } from "aws-cdk-lib/aws-efs";
+import {
+  CfnListener,
+  CfnLoadBalancer,
+  CfnTargetGroup,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { CfnRotationSchedule, CfnSecret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714AttachEcho");
+
+// --- Secret + RotationSchedule (rotation NEVER runs: no rotate-immediately,
+// far-future schedule; the dummy function is never invoked) ---
+const secret = new CfnSecret(stack, "AttachSecret", {
+  generateSecretString: {},
+});
+const rotFn = new LambdaFunction(stack, "AttachRotFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => {};"),
+  timeout: Duration.seconds(30),
+});
+rotFn.addPermission("SecretsManagerInvoke", {
+  principal: new ServicePrincipal("secretsmanager.amazonaws.com"),
+});
+const rotation = new CfnRotationSchedule(stack, "AttachRotation", {
+  secretId: secret.ref,
+  rotationLambdaArn: rotFn.functionArn,
+  rotationRules: { scheduleExpression: "rate(365 days)" },
+  rotateImmediatelyOnUpdate: false,
+});
+// Secrets Manager validates the function policy at create — wait for the permission.
+rotation.node.addDependency(rotFn.permissionsNode.findChild("SecretsManagerInvoke"));
+
+// --- minimal VPC (internal NLB for the endpoint service + EFS mount target) ---
+const vpc = new CfnVPC(stack, "AttachVpc", { cidrBlock: "10.1.0.0/16" });
+const subnet1 = new CfnSubnet(stack, "AttachSubnet1", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.1.0.0/24",
+  availabilityZone: Fn.select(0, Fn.getAzs()),
+});
+
+// --- VPCEndpointService + Permissions ---
+const nlb = new CfnLoadBalancer(stack, "AttachNlb", {
+  scheme: "internal",
+  type: "network",
+  subnets: [subnet1.ref],
+});
+const tg = new CfnTargetGroup(stack, "AttachTg", {
+  protocol: "TCP",
+  port: 80,
+  targetType: "ip",
+  vpcId: vpc.ref,
+});
+new CfnListener(stack, "AttachNlbListener", {
+  loadBalancerArn: nlb.ref,
+  port: 80,
+  protocol: "TCP",
+  defaultActions: [{ type: "forward", targetGroupArn: tg.ref }],
+});
+const epSvc = new CfnVPCEndpointService(stack, "AttachEpService", {
+  networkLoadBalancerArns: [nlb.ref],
+  acceptanceRequired: true,
+});
+new CfnVPCEndpointServicePermissions(stack, "AttachEpPerms", {
+  serviceId: epSvc.ref,
+  allowedPrincipals: [`arn:aws:iam::${stack.account}:root`],
+});
+
+// --- ECS Cluster + ClusterCapacityProviderAssociations ---
+const ecsCluster = new CfnCluster(stack, "AttachEcsCluster", {
+  clusterName: "cdkrd-hunt0714-attach-ecs",
+});
+new CfnClusterCapacityProviderAssociations(stack, "AttachEcsCpa", {
+  cluster: ecsCluster.ref,
+  capacityProviders: ["FARGATE", "FARGATE_SPOT"],
+  defaultCapacityProviderStrategy: [
+    { capacityProvider: "FARGATE", weight: 1 },
+  ],
+});
+
+// --- EFS FileSystem + MountTarget ---
+const efsSg = new CfnSecurityGroup(stack, "AttachEfsSg", {
+  groupDescription: "cdkrd hunt0714 attach efs",
+  vpcId: vpc.ref,
+});
+const efs = new CfnFileSystem(stack, "AttachEfs", {});
+efs.applyRemovalPolicy(RemovalPolicy.DESTROY);
+new CfnMountTarget(stack, "AttachEfsMt", {
+  fileSystemId: efs.ref,
+  subnetId: subnet1.ref,
+  securityGroups: [efsSg.attrGroupId],
+});
+
+app.synth();

--- a/tests/integration/attach-echo-hunt/cdk.json
+++ b/tests/integration/attach-echo-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/attach-echo-hunt/package.json
+++ b/tests/integration/attach-echo-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-attach-echo-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Sibling-attachment echo probe: Secret+RotationSchedule, VPCEndpointService+Permissions, ECS Cluster+CapacityProviderAssociations, EFS+MountTarget — the ATTACHED-shape parents must first-check CLEAN. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/attach-echo-hunt/verify.sh
+++ b/tests/integration/attach-echo-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Sibling-attachment echo probe (real AWS): deploy four common parents WITH an
+# attachment-style sibling in-stack, and assert the FIRST check (before record)
+# is CLEAN — an association echo materializing on the parent read is the
+# ClientVPN #1574 FP class.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714AttachEcho
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-attach-echo}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+# `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+[ "$RC" -eq 0 ] || fail "FIRST check reported potential drift on an attached-shape clean deploy (sibling echo fold gap)"
+
+echo "=== [$STACK] record, then check --fail MUST exit 0 ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.post.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "post-record check not clean"
+
+echo "INTEG OK ($STACK)"

--- a/tests/integration/revconv4-hunt/app.ts
+++ b/tests/integration/revconv4-hunt/app.ts
@@ -1,0 +1,137 @@
+// Revert-convergence probe batch 5 (real AWS): ten cheap common types whose
+// folded MUTABLE default has never been convergence-proven — does the CC
+// handler reconcile a bare `remove` back to the default, or silently no-op
+// (the #1571 class)? The API shape is not a predictor; only the live test
+// answers, per-property. Candidates mined offline from KNOWN_DEFAULTS minus
+// REVERT_SET_DEFAULT_PATHS coverage (none routes through an SDK writer):
+// - ECS Cluster ClusterSettings (containerInsights disabled)
+// - CloudWatch Alarm TreatMissingData ('missing')
+// - CloudWatch CompositeAlarm ActionsEnabled (true)
+// - CodeBuild Project TimeoutInMinutes (60) / QueuedTimeoutInMinutes (480)
+// - AppSync GraphQLApi IntrospectionConfig ('ENABLED')
+// - ApiGateway RestApi ApiKeySourceType ('HEADER')
+// - MediaConvert Queue Status ('ACTIVE')
+// - Scheduler Schedule ScheduleExpressionTimezone ('UTC')
+// - Glue Crawler SchemaChangePolicy (UPDATE_IN_DATABASE/DEPRECATE_IN_DATABASE)
+// - Pipes Pipe DesiredState ('RUNNING')
+// The barest ECS Cluster / AppSync API / Glue Crawler / Pipe here also double
+// as first-run FP probes.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnRestApi } from "aws-cdk-lib/aws-apigateway";
+import { CfnGraphQLApi } from "aws-cdk-lib/aws-appsync";
+import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnProject } from "aws-cdk-lib/aws-codebuild";
+import { CfnCluster } from "aws-cdk-lib/aws-ecs";
+import { CfnCrawler, CfnDatabase } from "aws-cdk-lib/aws-glue";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnQueue as CfnMcQueue } from "aws-cdk-lib/aws-mediaconvert";
+import { CfnPipe } from "aws-cdk-lib/aws-pipes";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnSchedule } from "aws-cdk-lib/aws-scheduler";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714RevConv4");
+
+new CfnCluster(stack, "Conv4EcsCluster", {});
+
+const alarm = new CfnAlarm(stack, "Conv4Alarm", {
+  alarmName: "cdkrd-hunt0714-conv4-alarm",
+  namespace: "cdkrd/hunt",
+  metricName: "Conv4Metric",
+  statistic: "Sum",
+  period: 300,
+  evaluationPeriods: 1,
+  threshold: 1,
+  comparisonOperator: "GreaterThanThreshold",
+});
+
+new CfnCompositeAlarm(stack, "Conv4Composite", {
+  alarmName: "cdkrd-hunt0714-conv4-composite",
+  alarmRule: `ALARM("${alarm.alarmName}")`,
+}).addDependency(alarm);
+
+const cbRole = new Role(stack, "Conv4CbRole", {
+  assumedBy: new ServicePrincipal("codebuild.amazonaws.com"),
+});
+new CfnProject(stack, "Conv4CbProject", {
+  name: "cdkrd-hunt0714-conv4-cb",
+  serviceRole: cbRole.roleArn,
+  source: { type: "NO_SOURCE", buildSpec: '{"version":"0.2","phases":{}}' },
+  artifacts: { type: "NO_ARTIFACTS" },
+  environment: {
+    type: "LINUX_CONTAINER",
+    computeType: "BUILD_GENERAL1_SMALL",
+    image: "aws/codebuild/standard:7.0",
+  },
+});
+
+new CfnGraphQLApi(stack, "Conv4AppSync", {
+  name: "cdkrd-hunt0714-conv4-appsync",
+  authenticationType: "API_KEY",
+});
+
+new CfnRestApi(stack, "Conv4RestApi", { name: "cdkrd-hunt0714-conv4-rest" });
+
+new CfnMcQueue(stack, "Conv4McQueue", { name: "cdkrd-hunt0714-conv4-mcq" });
+
+// Scheduler: barest schedule targeting an SQS queue (never fires anything useful).
+const schedQueue = new CfnQueue(stack, "Conv4SchedQueue", {});
+const schedRole = new Role(stack, "Conv4SchedRole", {
+  assumedBy: new ServicePrincipal("scheduler.amazonaws.com"),
+});
+schedRole.addToPolicy(
+  new PolicyStatement({ actions: ["sqs:SendMessage"], resources: [schedQueue.attrArn] }),
+);
+const schedule = new CfnSchedule(stack, "Conv4Schedule", {
+  name: "cdkrd-hunt0714-conv4-sched",
+  flexibleTimeWindow: { mode: "OFF" },
+  scheduleExpression: "rate(12 hours)",
+  target: { arn: schedQueue.attrArn, roleArn: schedRole.roleArn },
+});
+schedule.node.addDependency(schedRole);
+
+// Glue crawler: barest S3-target crawler (never runs).
+const crawlBucket = new Bucket(stack, "Conv4CrawlBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const glueRole = new Role(stack, "Conv4GlueRole", {
+  assumedBy: new ServicePrincipal("glue.amazonaws.com"),
+});
+crawlBucket.grantRead(glueRole);
+new CfnDatabase(stack, "Conv4GlueDb", {
+  catalogId: stack.account,
+  databaseInput: { name: "cdkrd_hunt0714_conv4_db" },
+});
+new CfnCrawler(stack, "Conv4Crawler", {
+  name: "cdkrd-hunt0714-conv4-crawler",
+  role: glueRole.roleArn,
+  databaseName: "cdkrd_hunt0714_conv4_db",
+  targets: { s3Targets: [{ path: `s3://${crawlBucket.bucketName}/data/` }] },
+});
+
+// Pipes: barest SQS -> SQS pipe.
+const pipeSrc = new CfnQueue(stack, "Conv4PipeSrc", {});
+const pipeDst = new CfnQueue(stack, "Conv4PipeDst", {});
+const pipeRole = new Role(stack, "Conv4PipeRole", {
+  assumedBy: new ServicePrincipal("pipes.amazonaws.com"),
+});
+pipeRole.addToPolicy(
+  new PolicyStatement({
+    actions: ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+    resources: [pipeSrc.attrArn],
+  }),
+);
+pipeRole.addToPolicy(
+  new PolicyStatement({ actions: ["sqs:SendMessage"], resources: [pipeDst.attrArn] }),
+);
+const pipe = new CfnPipe(stack, "Conv4Pipe", {
+  name: "cdkrd-hunt0714-conv4-pipe",
+  roleArn: pipeRole.roleArn,
+  source: pipeSrc.attrArn,
+  target: pipeDst.attrArn,
+});
+pipe.node.addDependency(pipeRole);
+
+app.synth();

--- a/tests/integration/revconv4-hunt/cdk.json
+++ b/tests/integration/revconv4-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revconv4-hunt/package.json
+++ b/tests/integration/revconv4-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revconv4-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Revert-convergence probe batch 5: ten folded mutable surfaces, mutate -> detect -> revert -> live-value converge. Run via verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revconv4-hunt/verify-detect.sh
+++ b/tests/integration/revconv4-hunt/verify-detect.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Revert-convergence probe batch 5 (real AWS): mutate ten folded MUTABLE
+# surfaces out of band -> check MUST DETECT -> revert -> check MUST be CLEAN ->
+# the LIVE values MUST be back at their defaults (a silent no-op revert is the
+# #1571 class; the API shape is not a predictor, only this live test answers).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714RevConv4
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ALARM=cdkrd-hunt0714-conv4-alarm
+COMPOSITE=cdkrd-hunt0714-conv4-composite
+CB=cdkrd-hunt0714-conv4-cb
+APPSYNC_NAME=cdkrd-hunt0714-conv4-appsync
+MCQ=cdkrd-hunt0714-conv4-mcq
+SCHED=cdkrd-hunt0714-conv4-sched
+CRAWLER=cdkrd-hunt0714-conv4-crawler
+PIPE=cdkrd-hunt0714-conv4-pipe
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?LogicalResourceId=='$1'].PhysicalResourceId" --output text
+}
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN (barest ECS cluster / AppSync / crawler / pipe FP probe), then record ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP (see pre.out)"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+ECS="$(phys Conv4EcsCluster)"
+API="$(phys Conv4RestApi)"
+APPSYNC_ID="$(phys Conv4AppSync | awk -F/ '{print $NF}')"
+
+echo "=== [$STACK] mutate out of band (10 surfaces) ==="
+aws ecs update-cluster-settings --cluster "$ECS" --region "$REGION" \
+  --settings name=containerInsights,value=enabled >/dev/null || fail "mutate ecs insights"
+aws cloudwatch put-metric-alarm --alarm-name "$ALARM" --region "$REGION" \
+  --namespace cdkrd/hunt --metric-name Conv4Metric --statistic Sum --period 300 \
+  --evaluation-periods 1 --threshold 1 --comparison-operator GreaterThanThreshold \
+  --treat-missing-data notBreaching || fail "mutate alarm treatmissing"
+aws cloudwatch disable-alarm-actions --alarm-names "$COMPOSITE" --region "$REGION" \
+  || fail "mutate composite actions"
+aws codebuild update-project --name "$CB" --region "$REGION" \
+  --timeout-in-minutes 30 --queued-timeout-in-minutes 240 >/dev/null || fail "mutate codebuild timeouts"
+aws appsync update-graphql-api --api-id "$APPSYNC_ID" --region "$REGION" \
+  --name "$APPSYNC_NAME" --authentication-type API_KEY \
+  --introspection-config DISABLED >/dev/null || fail "mutate appsync introspection"
+aws apigateway update-rest-api --rest-api-id "$API" --region "$REGION" \
+  --patch-operations op=replace,path=/apiKeySource,value=AUTHORIZER >/dev/null || fail "mutate apigw keysource"
+aws mediaconvert update-queue --name "$MCQ" --region "$REGION" --status PAUSED >/dev/null \
+  || fail "mutate mediaconvert status"
+TGT="$(aws scheduler get-schedule --name "$SCHED" --region "$REGION" --query 'Target' --output json)"
+aws scheduler update-schedule --name "$SCHED" --region "$REGION" \
+  --schedule-expression 'rate(12 hours)' --flexible-time-window Mode=OFF \
+  --schedule-expression-timezone 'Asia/Tokyo' --target "$TGT" >/dev/null || fail "mutate scheduler tz"
+aws glue update-crawler --name "$CRAWLER" --region "$REGION" \
+  --schema-change-policy UpdateBehavior=LOG,DeleteBehavior=LOG || fail "mutate crawler policy"
+aws pipes stop-pipe --name "$PIPE" --region "$REGION" >/dev/null || fail "mutate pipe state"
+sleep 25
+
+echo "=== [$STACK] check MUST DETECT all 10 ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc"
+for needle in ClusterSettings TreatMissingData ActionsEnabled TimeoutInMinutes QueuedTimeoutInMinutes \
+  IntrospectionConfig ApiKeySourceType Status ScheduleExpressionTimezone SchemaChangePolicy DesiredState; do
+  grep -q "$needle" "/tmp/cdkrd-$STACK.detect.out" || fail "missed detection: $needle"
+done
+
+echo "=== [$STACK] restore the not-yet-revertable surfaces out of band ==="
+# CodeBuild::Project and MediaConvert::Queue are SDK_OVERRIDES read-only types
+# ("type not revertable yet", #1623) — their mutations are detect-only in this
+# fixture, so restore them manually before revert to let it converge to zero.
+aws codebuild update-project --name "$CB" --region "$REGION" \
+  --timeout-in-minutes 60 --queued-timeout-in-minutes 480 >/dev/null || fail "restore codebuild timeouts"
+aws mediaconvert update-queue --name "$MCQ" --region "$REGION" --status ACTIVE >/dev/null \
+  || fail "restore mediaconvert status"
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+grep -Eq "NOT reverted|could not be confirmed" "/tmp/cdkrd-$STACK.revert.out" \
+  && fail "revert reported a non-converged path (see output)"
+sleep 25
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.post.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after revert — a revert did not converge"
+
+echo "=== [$STACK] live values MUST be back at their defaults ==="
+CI="$(aws ecs describe-clusters --clusters "$ECS" --region "$REGION" --include SETTINGS \
+  --query "clusters[0].settings[?name=='containerInsights'].value | [0]" --output text)"
+{ [ "$CI" = "disabled" ] || [ "$CI" = "None" ]; } || fail "containerInsights still $CI (revert no-op)"
+TMD="$(aws cloudwatch describe-alarms --alarm-names "$ALARM" --region "$REGION" \
+  --query 'MetricAlarms[0].TreatMissingData' --output text)"
+{ [ "$TMD" = "missing" ] || [ "$TMD" = "None" ]; } || fail "TreatMissingData still $TMD (revert no-op)"
+AE="$(aws cloudwatch describe-alarms --alarm-names "$COMPOSITE" --alarm-types CompositeAlarm --region "$REGION" \
+  --query 'CompositeAlarms[0].ActionsEnabled' --output text)"
+[ "$AE" = "True" ] || fail "composite ActionsEnabled still $AE (revert no-op)"
+CBT="$(aws codebuild batch-get-projects --names "$CB" --region "$REGION" \
+  --query 'projects[0].timeoutInMinutes' --output text)"
+[ "$CBT" = "60" ] || fail "CodeBuild timeoutInMinutes still $CBT (revert no-op)"
+CBQ="$(aws codebuild batch-get-projects --names "$CB" --region "$REGION" \
+  --query 'projects[0].queuedTimeoutInMinutes' --output text)"
+[ "$CBQ" = "480" ] || fail "CodeBuild queuedTimeoutInMinutes still $CBQ (revert no-op)"
+INTRO="$(aws appsync get-graphql-api --api-id "$APPSYNC_ID" --region "$REGION" \
+  --query 'graphqlApi.introspectionConfig' --output text)"
+{ [ "$INTRO" = "ENABLED" ] || [ "$INTRO" = "None" ]; } || fail "IntrospectionConfig still $INTRO (revert no-op)"
+AKS="$(aws apigateway get-rest-api --rest-api-id "$API" --region "$REGION" \
+  --query 'apiKeySource' --output text)"
+[ "$AKS" = "HEADER" ] || fail "ApiKeySourceType still $AKS (revert no-op)"
+MCS="$(aws mediaconvert get-queue --name "$MCQ" --region "$REGION" --query 'Queue.Status' --output text)"
+[ "$MCS" = "ACTIVE" ] || fail "MediaConvert Queue Status still $MCS (revert no-op)"
+STZ="$(aws scheduler get-schedule --name "$SCHED" --region "$REGION" \
+  --query 'ScheduleExpressionTimezone' --output text)"
+{ [ "$STZ" = "UTC" ] || [ "$STZ" = "None" ]; } || fail "ScheduleExpressionTimezone still $STZ (revert no-op)"
+SCP="$(aws glue get-crawler --name "$CRAWLER" --region "$REGION" \
+  --query '[Crawler.SchemaChangePolicy.UpdateBehavior,Crawler.SchemaChangePolicy.DeleteBehavior]' --output text)"
+[ "$SCP" = "UPDATE_IN_DATABASE	DEPRECATE_IN_DATABASE" ] || fail "Crawler SchemaChangePolicy still $SCP (revert no-op)"
+PDS="$(aws pipes describe-pipe --name "$PIPE" --region "$REGION" --query 'DesiredState' --output text)"
+[ "$PDS" = "RUNNING" ] || fail "Pipe DesiredState still $PDS (revert no-op)"
+
+echo "INTEG PASS ($STACK detect+revert batch 5)"

--- a/tests/integration/second-deploy-echo3/app.ts
+++ b/tests/integration/second-deploy-echo3/app.ts
@@ -1,0 +1,160 @@
+// Second-deploy echo probe batch 3 (post-update echo materialization, the
+// #1569 class): ~10 more common, cheap, fast, no-VPC types in their barest
+// form — first check MUST be CLEAN, then a harmless stack UPDATE (tag /
+// description bump via `-c rev=2`) and the check MUST STILL be clean. Any
+// undeclared property materializing only after the update is a latent FP every
+// real user hits on their second `cdk deploy`. Covers (echo1+echo2 swept 27
+// types; these are the next-most-common uncovered ones): Cognito
+// UserPoolClient, KMS Key, WAFv2 WebACL, CloudWatch Dashboard, AppConfig
+// Application/Environment/ConfigurationProfile, Glue Database/Crawler/Trigger,
+// SSM Document, AppSync GraphQLApi, SES ConfigurationSet, Backup Vault/Plan.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnConfigurationProfile,
+  CfnEnvironment,
+} from "aws-cdk-lib/aws-appconfig";
+import { CfnGraphQLApi } from "aws-cdk-lib/aws-appsync";
+import { CfnBackupPlan, CfnBackupVault } from "aws-cdk-lib/aws-backup";
+import { CfnDashboard } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnUserPool, CfnUserPoolClient } from "aws-cdk-lib/aws-cognito";
+import { CfnCrawler, CfnDatabase, CfnTrigger } from "aws-cdk-lib/aws-glue";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnKey } from "aws-cdk-lib/aws-kms";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnConfigurationSet } from "aws-cdk-lib/aws-ses";
+import { CfnDocument } from "aws-cdk-lib/aws-ssm";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const rev = String(app.node.tryGetContext("rev") ?? "1");
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+const stack = new Stack(app, "CdkrdHuntEcho3");
+// The update trigger: bumping this tag revs every taggable resource in the
+// stack through its CFn/CC update handler — the realistic "second deploy".
+Tags.of(stack).add("cdkrd:rev", rev);
+
+const pool = new CfnUserPool(stack, "Echo3Pool", {});
+new CfnUserPoolClient(stack, "Echo3PoolClient", { userPoolId: pool.ref });
+
+new CfnKey(stack, "Echo3Key", {
+  description: `cdkrd echo3 probe rev ${rev}`,
+  pendingWindowInDays: 7,
+});
+
+new CfnWebACL(stack, "Echo3WebAcl", {
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    cloudWatchMetricsEnabled: false,
+    sampledRequestsEnabled: false,
+    metricName: "cdkrdEcho3",
+  },
+  description: `cdkrd echo3 probe rev ${rev}`,
+});
+
+// Dashboard has no Tags — the body itself carries the rev (a body update IS
+// the realistic second-deploy shape for dashboards).
+new CfnDashboard(stack, "Echo3Dashboard", {
+  dashboardName: "cdkrd-echo3-dashboard",
+  dashboardBody: JSON.stringify({
+    widgets: [
+      {
+        type: "text",
+        x: 0,
+        y: 0,
+        width: 6,
+        height: 3,
+        properties: { markdown: `cdkrd echo3 probe rev ${rev}` },
+      },
+    ],
+  }),
+});
+
+const acApp = new CfnApplication(stack, "Echo3AcApp", {
+  name: "cdkrd-echo3-app",
+  description: `cdkrd echo3 probe rev ${rev}`,
+});
+new CfnEnvironment(stack, "Echo3AcEnv", {
+  applicationId: acApp.ref,
+  name: "cdkrd-echo3-env",
+  description: `cdkrd echo3 probe rev ${rev}`,
+});
+new CfnConfigurationProfile(stack, "Echo3AcProfile", {
+  applicationId: acApp.ref,
+  name: "cdkrd-echo3-profile",
+  locationUri: "hosted",
+  description: `cdkrd echo3 probe rev ${rev}`,
+});
+
+const crawlBucket = new Bucket(stack, "Echo3CrawlBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const glueRole = new Role(stack, "Echo3GlueRole", {
+  assumedBy: new ServicePrincipal("glue.amazonaws.com"),
+});
+crawlBucket.grantRead(glueRole);
+new CfnDatabase(stack, "Echo3GlueDb", {
+  catalogId: stack.account,
+  databaseInput: {
+    name: "cdkrd_echo3_db",
+    description: `cdkrd echo3 probe rev ${rev}`,
+  },
+});
+const crawler = new CfnCrawler(stack, "Echo3Crawler", {
+  name: "cdkrd-echo3-crawler",
+  role: glueRole.roleArn,
+  databaseName: "cdkrd_echo3_db",
+  targets: { s3Targets: [{ path: `s3://${crawlBucket.bucketName}/data/` }] },
+  description: `cdkrd echo3 probe rev ${rev}`,
+});
+new CfnTrigger(stack, "Echo3Trigger", {
+  name: "cdkrd-echo3-trigger",
+  type: "ON_DEMAND",
+  actions: [{ crawlerName: crawler.name }],
+  description: `cdkrd echo3 probe rev ${rev}`,
+}).addDependency(crawler);
+
+new CfnDocument(stack, "Echo3Doc", {
+  content: {
+    schemaVersion: "2.2",
+    description: "cdkrd echo3 probe",
+    mainSteps: [
+      {
+        action: "aws:runShellScript",
+        name: "noop",
+        inputs: { runCommand: ["true"] },
+      },
+    ],
+  },
+  documentType: "Command",
+  updateMethod: "NewVersion",
+});
+
+new CfnGraphQLApi(stack, "Echo3AppSync", {
+  name: "cdkrd-echo3-appsync",
+  authenticationType: "API_KEY",
+});
+
+new CfnConfigurationSet(stack, "Echo3SesConfigSet", {
+  name: "cdkrd-echo3-configset",
+});
+
+const vault = new CfnBackupVault(stack, "Echo3BackupVault", {
+  backupVaultName: "cdkrd-echo3-vault",
+});
+new CfnBackupPlan(stack, "Echo3BackupPlan", {
+  backupPlan: {
+    backupPlanName: "cdkrd-echo3-plan",
+    backupPlanRule: [
+      {
+        ruleName: `cdkrd-echo3-rule-rev${rev}`,
+        targetBackupVault: "cdkrd-echo3-vault",
+        scheduleExpression: "cron(0 5 ? * 7 *)",
+      },
+    ],
+  },
+}).addDependency(vault);
+
+app.synth();

--- a/tests/integration/second-deploy-echo3/cdk.json
+++ b/tests/integration/second-deploy-echo3/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/second-deploy-echo3/package.json
+++ b/tests/integration/second-deploy-echo3/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-second-deploy-echo3",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Post-update echo materialization probe batch 3: ~10 more barest common no-VPC types, first check clean, tag-bump update, still clean. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/second-deploy-echo3/verify.sh
+++ b/tests/integration/second-deploy-echo3/verify.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Post-update echo materialization probe batch 3 (real AWS): deploy ~10 barest
+# common types, assert the FIRST check (before record) is CLEAN, then run a
+# harmless stack UPDATE (tag/description bump via `-c rev=2`) and assert the
+# check is STILL clean. Any undeclared property materializing only after the
+# update is the #1569 (Glue sizing echo) FP class on a new type.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntEcho3
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy v1 ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy v1"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-echo3-v1}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK-v1.out"
+V1=${PIPESTATUS[0]}
+# `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK-v1.out" && V1=10
+
+echo "=== [$STACK] deploy v2 (harmless tag/description bump) ==="
+npx cdk deploy -f "$STACK" -c rev=2 --require-approval never || fail "deploy v2"
+
+echo "=== [$STACK] check after UPDATE MUST STILL be clean ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-v2.out"
+V2=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK-v2.out" && V2=10
+
+[ "$V1" -eq 0 ] || fail "FIRST check reported potential drift on a clean deploy (fold gap)"
+[ "$V2" -eq 0 ] || fail "post-update check reported drift (post-update echo materialization)"
+echo "INTEG OK ($STACK)"

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -211,6 +211,18 @@ resource_gone() {
           { [ -z "$state" ] || [ "$state" = "terminated" ]; } && return 0
           return 1
           ;;
+        *:vpc-endpoint-service/vpce-svc-*)
+          # arn:aws:ec2:<region>:<acct>:vpc-endpoint-service/vpce-svc-<id> — the seventh
+          # RGT-lag subtype (2026-07-14 hunt, attach-echo fixture): an endpoint service
+          # deleted with its stack lingered in the tag index while
+          # DescribeVpcEndpointServiceConfigurations answered
+          # InvalidVpcEndpointServiceId.NotFound. Only NotFound counts as gone
+          # (fail-safe, mirrors the vpc-endpoint arm).
+          id="${arn##*/}"
+          err="$(aws ec2 describe-vpc-endpoint-service-configurations --service-ids "$id" --region "$REGION" 2>&1 >/dev/null)" && return 1
+          printf '%s' "$err" | grep -q 'InvalidVpcEndpointServiceId.NotFound' && return 0
+          return 1
+          ;;
         *:volume/vol-*)
           # arn:aws:ec2:<region>:<acct>:volume/vol-<id> — the fourth RGT-lag subtype
           # (2026-07-11, #1463): a just-deleted EBS volume lingers in the tag index for

--- a/tests/integration/variants3-hunt/app.ts
+++ b/tests/integration/variants3-hunt/app.ts
@@ -1,0 +1,205 @@
+// Variant-axis first-run FP probe batch 3 (real AWS): barest forms of variant
+// branches whose sibling variants are covered but whose OWN default family has
+// never been read live (the #1477/#1487/Firehose-HTTP class — folds built from
+// one variant miss the others):
+// - Firehose IcebergDestinationConfiguration (ExtendedS3 + HttpEndpoint covered;
+//   Iceberg carries its own nested S3/buffering/retry echo family)
+// - Batch ComputeEnvironment FARGATE_SPOT (EC2 + FARGATE covered)
+// - CodeBuild LINUX_LAMBDA_CONTAINER + ARM_CONTAINER (LINUX_CONTAINER only so far)
+// - ELBv2 Listener default action `redirect` (forward + fixed-response covered;
+//   RedirectConfig materializes "#{host}"/"#{path}"/"#{port}"/"#{query}" defaults)
+// - Scheduler FlexibleTimeWindow FLEXIBLE mode (both corpus schedules are OFF)
+import { App, Fn, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnComputeEnvironment } from "aws-cdk-lib/aws-batch";
+import { CfnProject } from "aws-cdk-lib/aws-codebuild";
+import { CfnSecurityGroup, CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import {
+  CfnListener,
+  CfnLoadBalancer,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import {
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { CfnDatabase, CfnTable } from "aws-cdk-lib/aws-glue";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnSchedule } from "aws-cdk-lib/aws-scheduler";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714Variants3");
+
+// --- minimal VPC (2 subnets for the ALB; no IGW/NAT — the ALB is internal) ---
+const vpc = new CfnVPC(stack, "Var3Vpc", { cidrBlock: "10.0.0.0/16" });
+const subnet1 = new CfnSubnet(stack, "Var3Subnet1", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.0.0/24",
+  availabilityZone: Fn.select(0, Fn.getAzs()),
+});
+const subnet2 = new CfnSubnet(stack, "Var3Subnet2", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.1.0/24",
+  availabilityZone: Fn.select(1, Fn.getAzs()),
+});
+
+// --- ELBv2 Listener with a barest `redirect` default action ---
+const alb = new CfnLoadBalancer(stack, "Var3Alb", {
+  scheme: "internal",
+  type: "application",
+  subnets: [subnet1.ref, subnet2.ref],
+});
+new CfnListener(stack, "Var3RedirectListener", {
+  loadBalancerArn: alb.ref,
+  port: 80,
+  protocol: "HTTP",
+  defaultActions: [
+    {
+      type: "redirect",
+      // Only the required modification (Protocol) + StatusCode are declared;
+      // Host/Path/Port/Query stay undeclared to probe their "#{...}" echoes.
+      redirectConfig: { statusCode: "HTTP_301", protocol: "HTTPS" },
+    },
+  ],
+});
+
+// --- Batch FARGATE_SPOT compute environment (barest) ---
+const batchSg = new CfnSecurityGroup(stack, "Var3BatchSg", {
+  groupDescription: "cdkrd hunt0714 var3 batch",
+  vpcId: vpc.ref,
+});
+new CfnComputeEnvironment(stack, "Var3SpotCe", {
+  type: "MANAGED",
+  computeResources: {
+    type: "FARGATE_SPOT",
+    maxvCpus: 1,
+    subnets: [subnet1.ref],
+    securityGroupIds: [batchSg.attrGroupId],
+  },
+});
+
+// --- CodeBuild Lambda-compute + ARM projects (barest) ---
+const cbRole = new Role(stack, "Var3CbRole", {
+  assumedBy: new ServicePrincipal("codebuild.amazonaws.com"),
+});
+new CfnProject(stack, "Var3LambdaCb", {
+  name: "cdkrd-hunt0714-var3-cb-lambda",
+  serviceRole: cbRole.roleArn,
+  source: { type: "NO_SOURCE", buildSpec: '{"version":"0.2","phases":{}}' },
+  artifacts: { type: "NO_ARTIFACTS" },
+  environment: {
+    type: "LINUX_LAMBDA_CONTAINER",
+    computeType: "BUILD_LAMBDA_1GB",
+    image: "aws/codebuild/amazonlinux-x86_64-lambda-standard:nodejs20",
+  },
+});
+new CfnProject(stack, "Var3ArmCb", {
+  name: "cdkrd-hunt0714-var3-cb-arm",
+  serviceRole: cbRole.roleArn,
+  source: { type: "NO_SOURCE", buildSpec: '{"version":"0.2","phases":{}}' },
+  artifacts: { type: "NO_ARTIFACTS" },
+  environment: {
+    type: "ARM_CONTAINER",
+    computeType: "BUILD_GENERAL1_SMALL",
+    image: "aws/codebuild/amazonlinux2-aarch64-standard:3.0",
+  },
+});
+
+// --- Firehose Iceberg destination (barest REACHABLE form; DirectPut, no
+// producers). Deploy-time determination: a table-less Iceberg destination is
+// REJECTED at create ("A single default destination table configuration must
+// be provided when both Lambda and MetadataExtraction processors are not
+// provided"), so DestinationTableConfigurationList is part of the barest
+// form; everything else (buffering / retry / backup mode / logging) stays
+// undeclared to probe the per-variant echo family. ---
+const icebergBucket = new Bucket(stack, "Var3IcebergBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+// Inline policies (not grant()-style attached policies): Firehose VALIDATES the
+// role's glue/s3 access at create, and a separate AWS::IAM::Policy resource can
+// land after that validation — inline policies are part of the role create.
+const fhRole = new Role(stack, "Var3FhRole", {
+  assumedBy: new ServicePrincipal("firehose.amazonaws.com"),
+  inlinePolicies: {
+    iceberg: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          actions: [
+            "glue:GetDatabase",
+            "glue:GetTable",
+            "glue:GetTableVersion",
+            "glue:GetTableVersions",
+            "glue:UpdateTable",
+          ],
+          resources: ["*"],
+        }),
+        new PolicyStatement({
+          actions: ["s3:*"],
+          resources: [icebergBucket.bucketArn, `${icebergBucket.bucketArn}/*`],
+        }),
+      ],
+    }),
+  },
+});
+const icebergDb = new CfnDatabase(stack, "Var3IcebergDb", {
+  catalogId: stack.account,
+  databaseInput: { name: "cdkrd_hunt0714_var3_db" },
+});
+const icebergTable = new CfnTable(stack, "Var3IcebergTable", {
+  catalogId: stack.account,
+  databaseName: "cdkrd_hunt0714_var3_db",
+  openTableFormatInput: {
+    icebergInput: { metadataOperation: "CREATE", version: "2" },
+  },
+  tableInput: {
+    name: "cdkrd_hunt0714_var3_tbl",
+    tableType: "EXTERNAL_TABLE",
+    storageDescriptor: {
+      columns: [{ name: "id", type: "string" }],
+      location: `s3://${icebergBucket.bucketName}/table/`,
+    },
+  },
+});
+icebergTable.addDependency(icebergDb);
+const firehose = new CfnDeliveryStream(stack, "Var3IcebergFirehose", {
+  deliveryStreamName: "cdkrd-hunt0714-var3-iceberg",
+  deliveryStreamType: "DirectPut",
+  icebergDestinationConfiguration: {
+    roleArn: fhRole.roleArn,
+    catalogConfiguration: {
+      catalogArn: `arn:aws:glue:${stack.region}:${stack.account}:catalog`,
+    },
+    destinationTableConfigurationList: [
+      {
+        destinationDatabaseName: "cdkrd_hunt0714_var3_db",
+        destinationTableName: "cdkrd_hunt0714_var3_tbl",
+      },
+    ],
+    s3Configuration: {
+      bucketArn: icebergBucket.bucketArn,
+      roleArn: fhRole.roleArn,
+    },
+  },
+});
+firehose.addDependency(icebergTable);
+
+// --- Scheduler FLEXIBLE time window (barest) ---
+const schedQueue = new CfnQueue(stack, "Var3SchedQueue", {});
+const schedRole = new Role(stack, "Var3SchedRole", {
+  assumedBy: new ServicePrincipal("scheduler.amazonaws.com"),
+});
+schedRole.addToPolicy(
+  new PolicyStatement({ actions: ["sqs:SendMessage"], resources: [schedQueue.attrArn] }),
+);
+const schedule = new CfnSchedule(stack, "Var3FlexSchedule", {
+  name: "cdkrd-hunt0714-var3-flex",
+  flexibleTimeWindow: { mode: "FLEXIBLE", maximumWindowInMinutes: 15 },
+  scheduleExpression: "rate(12 hours)",
+  target: { arn: schedQueue.attrArn, roleArn: schedRole.roleArn },
+});
+schedule.node.addDependency(schedRole);
+
+app.synth();

--- a/tests/integration/variants3-hunt/cdk.json
+++ b/tests/integration/variants3-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/variants3-hunt/package.json
+++ b/tests/integration/variants3-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-variants3-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Variant-axis first-run FP probe batch 3: Firehose Iceberg, Batch FARGATE_SPOT, CodeBuild Lambda/ARM, ELBv2 redirect action, Scheduler FLEXIBLE window. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/variants3-hunt/verify.sh
+++ b/tests/integration/variants3-hunt/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Variant-axis first-run FP probe batch 3 (real AWS): deploy the barest form of
+# five uncovered variant branches, assert the FIRST check (before record) is
+# CLEAN, then record and assert check --fail is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714Variants3
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-var3}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+# `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+[ "$RC" -eq 0 ] || fail "FIRST check reported potential drift on a clean deploy (fold gap)"
+
+echo "=== [$STACK] record, then check --fail MUST exit 0 ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.post.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "post-record check not clean"
+
+echo "INTEG OK ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -643,6 +643,72 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  // #1619 (revconv4 batch-5, live-proven 2026-07-14): four more omit-keeps-value handlers —
+  // each mutated out of band, reverted via a bare `remove` that reported success, and the
+  // convergence re-read caught the live value persisting. Each is now in
+  // REVERT_SET_DEFAULT_PATHS so revert writes the KNOWN_DEFAULTS default back explicitly.
+  it('#1619: ECS Cluster ClusterSettings (SET-DEFAULT) -> add op writing the containerInsights-disabled default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ECS::Cluster',
+      path: 'ClusterSettings',
+      actual: [{ Name: 'containerInsights', Value: 'enabled' }],
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ClusterSettings',
+      value: [{ Name: 'containerInsights', Value: 'disabled' }],
+    });
+  });
+
+  it('#1619: CloudWatch CompositeAlarm ActionsEnabled (SET-DEFAULT) -> add op writing the true default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::CloudWatch::CompositeAlarm',
+      path: 'ActionsEnabled',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ActionsEnabled',
+      value: true,
+      prior: false,
+    });
+  });
+
+  it('#1619: ApiGateway RestApi ApiKeySourceType (SET-DEFAULT) -> add op writing the HEADER default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ApiGateway::RestApi',
+      path: 'ApiKeySourceType',
+      actual: 'AUTHORIZER',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ApiKeySourceType',
+      value: 'HEADER',
+      prior: 'AUTHORIZER',
+    });
+  });
+
+  it('#1619: Glue Crawler SchemaChangePolicy (SET-DEFAULT) -> add op writing the whole-object default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Glue::Crawler',
+      path: 'SchemaChangePolicy',
+      actual: { UpdateBehavior: 'LOG', DeleteBehavior: 'LOG' },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SchemaChangePolicy',
+      value: { UpdateBehavior: 'UPDATE_IN_DATABASE', DeleteBehavior: 'DEPRECATE_IN_DATABASE' },
+    });
+  });
+
   // #1588: the remaining ModifyDBInstance revert-no-op twins of #1541 — same selective-modify
   // semantics (an omitted property keeps its existing value), so a bare `remove` revert of an
   // out-of-band, undeclared, KNOWN_DEFAULTS-folded change is a silent no-op. Each is now in

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -14,6 +14,8 @@ import {
 import {
   CloudWatchClient,
   DescribeAnomalyDetectorsCommand,
+  DisableAlarmActionsCommand,
+  EnableAlarmActionsCommand,
   PutAnomalyDetectorCommand,
 } from '@aws-sdk/client-cloudwatch';
 import {
@@ -3097,6 +3099,56 @@ describe('Logs LogGroup BearerTokenAuthenticationEnabled prop-scoped writer (CC 
     expect(
       logs.commandCalls(PutBearerTokenAuthenticationCommand)[0].args[0].input.logGroupIdentifier
     ).toBe(LG);
+  });
+});
+
+describe('CloudWatch CompositeAlarm ActionsEnabled prop-scoped writer (#1619 — the CC handler ignores even an explicit write)', () => {
+  const NAME = 'cdkrd-composite';
+  const actionsRemoveOp: PatchOp = {
+    op: 'remove',
+    path: '/ActionsEnabled',
+    prior: false,
+    human: 'ActionsEnabled -> AWS default (undeclared, not in baseline)',
+  };
+  const actionsAddOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/ActionsEnabled',
+    value,
+    human: 'ActionsEnabled -> deployed-template value',
+  });
+
+  it('resolveSdkWriter routes ActionsEnabled to the prop-scoped writer, other paths stay CC', () => {
+    expect(resolveSdkWriter('AWS::CloudWatch::CompositeAlarm', [actionsRemoveOp])).toBeDefined();
+    expect(
+      resolveSdkWriter('AWS::CloudWatch::CompositeAlarm', [
+        { op: 'remove', path: '/AlarmDescription', human: '' },
+      ])
+    ).toBeUndefined();
+  });
+
+  it('a remove (undeclared, not in baseline) re-ENABLES actions via EnableAlarmActions', async () => {
+    cloudwatch.on(EnableAlarmActionsCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::CloudWatch::CompositeAlarm', [actionsRemoveOp])!;
+    await writer(ctx({ physicalId: NAME }), [actionsRemoveOp]);
+    const calls = cloudwatch.commandCalls(EnableAlarmActionsCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toEqual({ AlarmNames: [NAME] });
+  });
+
+  it('an add true (the REVERT_SET_DEFAULT_PATHS set-default) also routes to EnableAlarmActions', async () => {
+    cloudwatch.on(EnableAlarmActionsCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::CloudWatch::CompositeAlarm', [actionsAddOp(true)])!;
+    await writer(ctx({ physicalId: NAME }), [actionsAddOp(true)]);
+    expect(cloudwatch.commandCalls(EnableAlarmActionsCommand)).toHaveLength(1);
+  });
+
+  it('an add false (declared / baseline restore of a disable) routes to DisableAlarmActions', async () => {
+    cloudwatch.on(DisableAlarmActionsCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::CloudWatch::CompositeAlarm', [actionsAddOp(false)])!;
+    await writer(ctx({ physicalId: NAME }), [actionsAddOp(false)]);
+    expect(cloudwatch.commandCalls(DisableAlarmActionsCommand)[0].args[0].input).toEqual({
+      AlarmNames: [NAME],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

2026-07-14 bug-hunt sweep (5 rounds, 4 deployed fixture stacks + free CC/raw-API probes). 8 issues filed; 7 fixed here (#1623 — CodeBuild Project / MediaConvert Queue SDK writers — stays open as a tracked feature gap).

### Revert (batch 5 — `revconv4-hunt`, all live-proven: mutate -> detect -> revert -> live value back at default)

- **#1619**: 4 more omit-ignored update handlers → `REVERT_SET_DEFAULT_PATHS`: ECS Cluster `ClusterSettings`, ApiGateway RestApi `ApiKeySourceType`, Glue Crawler `SchemaChangePolicy`, CloudWatch CompositeAlarm `ActionsEnabled`. Controls that converged via the bare `remove` (no entries): CW Alarm `TreatMissingData`, AppSync `IntrospectionConfig`, Scheduler `ScheduleExpressionTimezone`, Pipes `DesiredState`.
- **#1619 (third class)**: CompositeAlarm `ActionsEnabled` no-ops even an **explicit** `add true` CC patch (probed live via `cloudcontrol update-resource`) → new `SDK_PROP_WRITERS` entry driving `EnableAlarmActions`/`DisableAlarmActions` (live-proven to converge).

### Check — first-run FP folds (each live-proven in its originating fixture / probe)

- **#1620** ACM Certificate: mixed-case `DomainName`/`SubjectAlternativeNames` read back lowercased → `CASE_INSENSITIVE_PATHS` + `CASE_INSENSITIVE_ARRAY_PATHS`; the reader's apex-SAN subtraction goes case-insensitive. (Probe determinations: SES EmailIdentity echoes requested case — no entry; Athena WorkGroup case-preserving — no entry.)
- **#1621** DAX ParameterGroup/SubnetGroup names stored lowercased (raw API accepts+lowercases; no CC CREATE handler to reject) → `CASE_INSENSITIVE_PATHS`.
- **#1622** AppConfig ConfigurationProfile undeclared `Type` reads back `AWS.Freeform` → `KNOWN_DEFAULTS`.
- **#1624** Glue **Iceberg** table: `OpenTableFormatInput` never echoed by GetTable → `READGAP_COLLECTION_PATHS`; service-managed `TableInput.Parameters` (`table_type: ICEBERG` + per-commit `metadata_location`) → shape-gated derived fold keyed on the declared `IcebergInput` (an extra out-of-band parameter still surfaces).
- **#1625** Lambda-compute CodeBuild project defaults `TimeoutInMinutes` to **15** (not the standard 60) → derived from declared `Environment.Type` (`*_LAMBDA_CONTAINER`).
- **#1626** NLB-family TargetGroup: health check defaults TCP/10 (derived from declared `Protocol`, excluding the `alb`-target #1546 derivation), `target_health_state.unhealthy.*` bag pair, `ip`-target `preserve_client_ip.enabled: false`; VPCEndpointService `SupportedIpAddressTypes: ["ipv4"]` → `KNOWN_DEFAULTS`.

### Fixtures (committed regressions; every one ends INTEG PASS/OK on the fixed binary)

- `revconv4-hunt` — 10-surface detect+revert batch 5 (CodeBuild/MediaConvert restored out of band pre-revert: read-only types, #1623).
- `variants3-hunt` — Firehose **Iceberg** destination (barest reachable form: destination-table config is required), Batch **FARGATE_SPOT**, CodeBuild **LINUX_LAMBDA_CONTAINER + ARM_CONTAINER**, ELBv2 **redirect** default action, Scheduler **FLEXIBLE** window.
- `second-deploy-echo3` — 10 more common no-VPC types through the tag-bump update echo probe (no new post-update echo found).
- `attach-echo-hunt` — 4 parent+attachment pairs (Secret+RotationSchedule, VPCEndpointService+Permissions, ECS Cluster+CPA, EFS+MountTarget): **no association echo materialized** (clean determination); the 6 FPs it caught were the #1626 variant-axis gaps.

### Also

- 11 new golden-corpus cases (incl. first `AWS::EC2::VPCEndpointServicePermissions` case) — `corpus-replay` green.
- `sweep-orphans.sh`: `vpc-endpoint-service` RGT-lag `resource_gone` arm (deleted endpoint services lingered in the tag index and false-flagged ORPHAN).
- hunt-bugs SKILL.md: batch-5 results, the explicit-write-ignored third revert class + its free CC probe, L2-Bucket-RETAIN and grant()-race fixture gotchas.

### Verification

- `/check`: typecheck / lint+format / build / **303 files, 5864 tests** pass.
- `/check-docs`: ARCHITECTURE.md SDK_PROP_WRITERS section updated for the CompositeAlarm writer.
- `/verify-pr`: live evidence = the four fixtures' INTEG PASS/OK on the fixed binary + the ACM/DAX raw-API probes recorded in the issues. **Shared CORE suite deferred** — diff fully covered by unit tests + corpus replay + hunt-origin live proof (per the R50 deferral rule); it runs at the next clean-window release verification.
- AWS cleanup: all stacks deleted, `SWEEP CLEAN`, bughunt gate released.

Closes #1619. Closes #1620. Closes #1621. Closes #1622. Closes #1624. Closes #1625. Closes #1626.
