### PR TITLE
fix(noise,revert): fold 5 barest-form first-run FPs and converge 2 undeclared reverts (barest4/ccpi hunt)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -200,7 +200,16 @@ short of a fix the user wanted.
    child segment → a likely declared-read gap worth a (cheap) deploy to confirm the
    exact composite order (the order is unreliable to guess — verify live, e.g. with
    `aws cloudcontrol get-resource`). Confirmed this way: Logs SubscriptionFilter
-   (`FilterName|LogGroupName`, PR #344).
+   (`FilterName|LogGroupName`, PR #344). **But weight by GENERATION: registry-era
+   types are overwhelmingly NATURAL composites** (their CFn physical id is already
+   the `seg1|seg2` join, so CC reads them as-is — no adapter needed). The 2026-07-14
+   ccpi-hunt deployed 7 uncovered composite-pi types in one cheap stack
+   (ServiceCatalog PortfolioPrincipalAssociation + TagOptionAssociation, AppRegistry
+   AttributeGroupAssociation, aoss AccessPolicy, EC2 SecurityGroupVpcAssociation,
+   Lex BotVersion + BotAlias) and ALL read clean — zero `skipped`. The gap class
+   lives in LEGACY types that kept a bare-segment physical id when registry-migrated
+   (the existing ~40 adapters are all that class); a one-stack association-pack probe
+   is still worth it for new suspects, but expect "no gap" as the common outcome.
 
 5. **Predict FP classes from the fold allowlists, then audit them OFFLINE before any
    paid deploy.** The per-type fold tables in `src/normalize/noise.ts` ARE the inventory
@@ -348,7 +357,14 @@ before writing the fix: `aws cloudcontrol update-resource --patch-document
 answers "does the explicit write converge?" with no stack.** Also found: CodeBuild
 Project + MediaConvert Queue detect fine but are read-only ("type not revertable
 yet") — when a probe target is such a type, restore it OUT OF BAND before `revert`
-or the fixture can never converge to zero (#1623).
+or the fixture can never converge to zero (#1623). Batch 6 (2026-07-14, barest4/ccpi
+hunt): **RUM AppMonitor `CustomEvents`** no-oped (silent keep), and **ServiceCatalog
+TagOption `Active`** surfaced a FOURTH flavor — the handler REJECTS the bare remove
+outright (`InvalidRequest: Active and new value cannot both be null`), a hard error
+instead of a silent no-op; both fixed by RSDP entries. Piggyback the convergence
+probe on every NEW KNOWN_DEFAULTS fold a hunt ships (mutate → revert → re-read) —
+it is ~1-in-3 to need an RSDP entry, and the probe is nearly free while the stack
+is still up.
 
 ### 5. Harvest the live read into the golden corpus (EVERY round — bug or not)
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -188,6 +188,10 @@ const notRestored =
 const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) => boolean>> = {
   // A KMS key is always created enabled; `disable-key` (Enabled=false) is always meaningful.
   'AWS::KMS::Key': { Enabled: () => true },
+  // A TagOption is always created active (the KNOWN_DEFAULTS true pin, barest4/ccpi hunt
+  // 2026-07-14); an undeclared `false` is an out-of-band deactivate that blocks the option
+  // from new provisioning — a bare false isTrivialEmpty would otherwise swallow.
+  'AWS::ServiceCatalog::TagOption': { Active: () => true },
   // SSE-SQS defaults ON, but is mutually exclusive with SSE-KMS: a queue that uses a KMS key
   // reads SqsManagedSseEnabled=false legitimately. Surface the OFF state only when the queue
   // uses no KMS key — i.e. encryption was genuinely disabled out of band.

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1214,6 +1214,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::EC2::FlowLog': {
     MaxAggregationInterval: 600,
+    // An S3-destination flow log that declares no DestinationOptions reads back the
+    // materialized default trio (plain-text, non-Hive, per-day partitions). Observed live
+    // on a barest S3-dest flow log (us-east-1, 2026-07-14 barest4 hunt). Equality-gated —
+    // Parquet / Hive / hourly partitioning no longer matches and surfaces (the options are
+    // create-only, so this mainly silences the first-run echo).
+    DestinationOptions: {
+      FileFormat: 'plain-text',
+      HiveCompatiblePartitions: false,
+      PerHourPartition: false,
+    },
     // A flow log that declares no LogFormat reads back AWS's documented default 14-field
     // format string. It is a STABLE, documented constant, so an equality-gated KNOWN_DEFAULTS
     // fold preserves detection: a user who sets a CUSTOM format out of band no longer matches
@@ -1475,9 +1485,22 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // source-map deobfuscation reads back the disabled-state object. Equality-gated:
   // an Android/iOS platform or an enabled deobfuscation config no longer matches and
   // surfaces as a real undeclared value.
+  // barest4 hunt (2026-07-14): a BAREST monitor (Name + Domain only — rum-appmonitor-rich
+  // declared the whole configuration, hiding the undeclared path) also materializes the
+  // disabled custom-events toggle and a default AppMonitorConfiguration (10% sampling,
+  // empty page lists, no telemetries). Equality-gated: enabling custom events or any
+  // configuration change out of band no longer matches and surfaces.
   'AWS::RUM::AppMonitor': {
     Platform: 'Web',
     DeobfuscationConfiguration: { JavaScriptSourceMaps: { Status: 'DISABLED' } },
+    CustomEvents: { Status: 'DISABLED' },
+    AppMonitorConfiguration: {
+      IncludedPages: [],
+      ExcludedPages: [],
+      FavoritePages: [],
+      SessionSampleRate: 0.1,
+      Telemetries: [],
+    },
   },
   // FIS experiment templates read back the documented option defaults (fail on
   // empty target resolution, single-account targeting) when the template declares
@@ -1564,6 +1587,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // per-artifact Type echo folds via KNOWN_DEFAULT_PATHS below.
   'AWS::ServiceCatalog::CloudFormationProduct': {
     ProductType: 'CLOUD_FORMATION_TEMPLATE',
+  },
+  // A TagOption is created active; the undeclared Active reads back true (observed live,
+  // barest4/ccpi hunt us-east-1 2026-07-14). Equality-gated, and the OFF flip (an
+  // out-of-band deactivate — which blocks the option from new provisioning) is a bare
+  // `false` that isTrivialEmpty would swallow, so it is paired with a MEANINGFUL_WHEN_OFF
+  // entry in classify.ts (the #1503 TLSEnabled lesson).
+  'AWS::ServiceCatalog::TagOption': {
+    Active: true,
   },
   // An Internet Monitor that declares no Status reads back "ACTIVE" (observed live, hunt
   // 2026-07-08 round F, #626). A user-settable knob (a user pausing a monitor sets INACTIVE)
@@ -2362,8 +2393,12 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'TopicPolicyConfig.TopicsTierConfig': { TierName: 'CLASSIC' },
   },
   // A canary that declares a Schedule but no RetryConfig reads back the default 0 retries.
+  // A Schedule that declares only Expression also reads back DurationInSeconds as the
+  // STRING "0" (run-forever; observed live on a barest canary, us-east-1 2026-07-14
+  // barest4 hunt). Equality-gated: an out-of-band duration limit surfaces.
   'AWS::Synthetics::Canary': {
     'Schedule.RetryConfig': { MaxRetries: 0 },
+    'Schedule.DurationInSeconds': '0',
   },
   'AWS::OpenSearchService::Domain': {
     // A gp3 EBS volume reads back the gp3 baseline 3000 IOPS / 125 MiB/s throughput

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -272,6 +272,16 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // (EnableTokenRevocation, AuthSessionValidity) ride the same call and are LIKELY the
   // same class but stay unlisted until individually live-proven (the per-property rule).
   'AWS::Cognito::UserPoolClient\0RefreshTokenValidity',
+  // barest4 hunt (live-proven 2026-07-14): RUM UpdateAppMonitor keeps an omitted
+  // CustomEvents (an out-of-band ENABLED persisted through a `remove` revert — the revert
+  // reported "reverted" yet convergence re-read ENABLED). Write the {Status:"DISABLED"}
+  // default (from KNOWN_DEFAULTS) back explicitly.
+  'AWS::RUM::AppMonitor\0CustomEvents',
+  // barest4/ccpi hunt (live-proven 2026-07-14): ServiceCatalog UpdateTagOption REJECTS the
+  // `remove` patch outright ("Active and new value cannot both be null") — the hard-reject
+  // flavor of the class (not a silent no-op, a hard error). Write the `true` default (from
+  // KNOWN_DEFAULTS) back explicitly.
+  'AWS::ServiceCatalog::TagOption\0Active',
   // Lambda UpdateFunctionUrlConfig IGNORES an omitted InvokeMode (live-proven on
   // revert-noop-probe 2026-07-14, #1583: a URL flipped BUFFERED->RESPONSE_STREAM out of
   // band, then `revert` planned a `remove`, reported reverted, yet the URL stayed

--- a/tests/corpus/AWS__APS__Workspace.Aps.json
+++ b/tests/corpus/AWS__APS__Workspace.Aps.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Aps",
+    "resourceType": "AWS::APS::Workspace",
+    "physicalId": "arn:aws:aps:us-east-1:111111111111:workspace/ws-6cdb1420-779f-4c03-8f20-f174f09a6f4f",
+    "constructPath": "CdkrdHunt0714Barest4B/Aps",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PrometheusEndpoint": "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-6cdb1420-779f-4c03-8f20-f174f09a6f4f/",
+    "WorkspaceId": "ws-6cdb1420-779f-4c03-8f20-f174f09a6f4f",
+    "WorkspaceConfiguration": {
+      "RuleQueryOffsetInSeconds": 60,
+      "RetentionPeriodInDays": 150,
+      "OutOfOrderTimeWindowInSeconds": 60,
+      "LimitsPerLabelSets": []
+    },
+    "Arn": "arn:aws:aps:us-east-1:111111111111:workspace/ws-6cdb1420-779f-4c03-8f20-f174f09a6f4f",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Barest4B",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Aps",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Barest4B/ddaaa560-7f77-11f1-b23e-0affeef325ef",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "PrometheusEndpoint", "WorkspaceId"],
+    "writeOnly": [],
+    "createOnly": ["KmsKeyArn"],
+    "readOnlyPaths": ["Arn", "PrometheusEndpoint", "WorkspaceId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KmsKeyArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["WorkspaceConfiguration.LimitsPerLabelSets"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Aps",
+      "resourceType": "AWS::APS::Workspace",
+      "path": "WorkspaceConfiguration",
+      "actual": {
+        "RuleQueryOffsetInSeconds": 60,
+        "RetentionPeriodInDays": 150,
+        "OutOfOrderTimeWindowInSeconds": 60,
+        "LimitsPerLabelSets": []
+      },
+      "physicalId": "arn:aws:aps:us-east-1:111111111111:workspace/ws-6cdb1420-779f-4c03-8f20-f174f09a6f4f",
+      "constructPath": "CdkrdHunt0714Barest4B/Aps"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Bedrock__Guardrail.GuardrailBarest.json
+++ b/tests/corpus/AWS__Bedrock__Guardrail.GuardrailBarest.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Guardrail",
+    "resourceType": "AWS::Bedrock::Guardrail",
+    "physicalId": "arn:aws:bedrock:us-east-1:111111111111:guardrail/093bfbms1etl",
+    "constructPath": "CdkrdHunt0714Barest4B/Guardrail",
+    "declared": {
+      "BlockedInputMessaging": "Blocked input.",
+      "BlockedOutputsMessaging": "Blocked output.",
+      "Name": "cdkrd-hunt-brst4",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ],
+      "WordPolicyConfig": {
+        "WordsConfig": [
+          {
+            "Text": "cdkrdblockedword"
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "FailureRecommendations": [],
+    "GuardrailId": "093bfbms1etl",
+    "Status": "READY",
+    "StatusReasons": [],
+    "CreatedAt": "2026-07-14T11:33:53.621143402Z",
+    "UpdatedAt": "2026-07-14T11:38:41.870150349Z",
+    "Name": "cdkrd-hunt-brst4",
+    "WordPolicyConfig": {
+      "ManagedWordListsConfig": [],
+      "WordsConfig": [
+        {
+          "Text": "cdkrdblockedword"
+        }
+      ]
+    },
+    "GuardrailArn": "arn:aws:bedrock:us-east-1:111111111111:guardrail/093bfbms1etl",
+    "Version": "DRAFT",
+    "BlockedInputMessaging": "Blocked input.",
+    "BlockedOutputsMessaging": "Blocked output.",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CreatedAt",
+      "FailureRecommendations",
+      "GuardrailArn",
+      "GuardrailId",
+      "Status",
+      "StatusReasons",
+      "UpdatedAt",
+      "Version"
+    ],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "CreatedAt",
+      "FailureRecommendations",
+      "GuardrailArn",
+      "GuardrailId",
+      "Status",
+      "StatusReasons",
+      "UpdatedAt",
+      "Version"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudTrail__Trail.Trail.json
+++ b/tests/corpus/AWS__CloudTrail__Trail.Trail.json
@@ -1,0 +1,95 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Trail",
+    "resourceType": "AWS::CloudTrail::Trail",
+    "physicalId": "CdkrdHunt0714Barest4A-Trail-kUG6FnhgRSJ2",
+    "constructPath": "CdkrdHunt0714Barest4A/Trail",
+    "declared": {
+      "IsLogging": true,
+      "S3BucketName": "cdkrdhunt0714barest4a-bucket-dhwv0z2i7mtc",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "IncludeGlobalServiceEvents": false,
+    "EventSelectors": [
+      {
+        "IncludeManagementEvents": true,
+        "ReadWriteType": "All",
+        "ExcludeManagementEventSources": [],
+        "DataResources": []
+      }
+    ],
+    "AggregationConfigurations": [],
+    "AdvancedEventSelectors": [],
+    "TrailName": "CdkrdHunt0714Barest4A-Trail-kUG6FnhgRSJ2",
+    "IsOrganizationTrail": false,
+    "InsightSelectors": [],
+    "IsMultiRegionTrail": false,
+    "S3BucketName": "cdkrdhunt0714barest4a-bucket-dhwv0z2i7mtc",
+    "EnableLogFileValidation": false,
+    "Arn": "arn:aws:cloudtrail:us-east-1:111111111111:trail/CdkrdHunt0714Barest4A-Trail-kUG6FnhgRSJ2",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      }
+    ],
+    "IsLogging": true
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnsTopicArn"],
+    "writeOnly": [],
+    "createOnly": ["TrailName"],
+    "readOnlyPaths": ["Arn", "SnsTopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TrailName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [
+      "AggregationConfigurations",
+      "EventSelectors",
+      "InsightSelectors"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Trail",
+      "resourceType": "AWS::CloudTrail::Trail",
+      "path": "EventSelectors",
+      "actual": [
+        {
+          "IncludeManagementEvents": true,
+          "ReadWriteType": "All",
+          "ExcludeManagementEventSources": [],
+          "DataResources": []
+        }
+      ],
+      "physicalId": "CdkrdHunt0714Barest4A-Trail-kUG6FnhgRSJ2",
+      "constructPath": "CdkrdHunt0714Barest4A/Trail"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeArtifact__Domain.CaDomain.json
+++ b/tests/corpus/AWS__CodeArtifact__Domain.CaDomain.json
@@ -1,0 +1,71 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CaDomain",
+    "resourceType": "AWS::CodeArtifact::Domain",
+    "physicalId": "arn:aws:codeartifact:us-east-1:111111111111:domain/cdkrd-hunt-brst4",
+    "constructPath": "CdkrdHunt0714Barest4B/CaDomain",
+    "declared": {
+      "DomainName": "cdkrd-hunt-brst4",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Owner": "111111111111",
+    "DomainName": "cdkrd-hunt-brst4",
+    "EncryptionKey": "arn:aws:kms:us-east-1:111111111111:key/f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+    "Arn": "arn:aws:codeartifact:us-east-1:111111111111:domain/cdkrd-hunt-brst4",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Barest4B",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CaDomain",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Barest4B/ddaaa560-7f77-11f1-b23e-0affeef325ef",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-brst4"
+  },
+  "schema": {
+    "readOnly": ["Arn", "EncryptionKey", "Name", "Owner"],
+    "writeOnly": [],
+    "createOnly": ["DomainName", "EncryptionKey"],
+    "readOnlyPaths": ["Arn", "EncryptionKey", "Name", "Owner"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DomainName", "EncryptionKey"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CodeArtifact__Repository.CaRepo.json
+++ b/tests/corpus/AWS__CodeArtifact__Repository.CaRepo.json
@@ -1,0 +1,72 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CaRepo",
+    "resourceType": "AWS::CodeArtifact::Repository",
+    "physicalId": "arn:aws:codeartifact:us-east-1:111111111111:repository/cdkrd-hunt-brst4/cdkrd-hunt-brst4",
+    "constructPath": "CdkrdHunt0714Barest4B/CaRepo",
+    "declared": {
+      "DomainName": "cdkrd-hunt-brst4",
+      "RepositoryName": "cdkrd-hunt-brst4",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkrd-hunt-brst4",
+    "RepositoryName": "cdkrd-hunt-brst4",
+    "Arn": "arn:aws:codeartifact:us-east-1:111111111111:repository/cdkrd-hunt-brst4/cdkrd-hunt-brst4",
+    "DomainOwner": "111111111111",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Barest4B",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CaRepo",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Barest4B/ddaaa560-7f77-11f1-b23e-0affeef325ef",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt-brst4"
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainOwner", "Name"],
+    "writeOnly": [],
+    "createOnly": ["DomainName", "DomainOwner", "RepositoryName"],
+    "readOnlyPaths": ["Arn", "DomainOwner", "Name"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DomainName", "DomainOwner", "RepositoryName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__FlowLog.FlowLog.json
+++ b/tests/corpus/AWS__EC2__FlowLog.FlowLog.json
@@ -1,0 +1,141 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FlowLog",
+    "resourceType": "AWS::EC2::FlowLog",
+    "physicalId": "fl-02e2f9eb4ca0c4938",
+    "constructPath": "CdkrdHunt0714Barest4A/FlowLog",
+    "declared": {
+      "LogDestination": "arn:aws:s3:::cdkrdhunt0714barest4a-bucket-dhwv0z2i7mtc",
+      "LogDestinationType": "s3",
+      "ResourceId": "vpc-00346b7ce53be4f32",
+      "ResourceType": "VPC",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ],
+      "TrafficType": "ALL"
+    }
+  },
+  "liveRaw": {
+    "LogFormat": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+    "ResourceId": "vpc-00346b7ce53be4f32",
+    "MaxAggregationInterval": 600,
+    "DestinationOptions": {
+      "PerHourPartition": false,
+      "HiveCompatiblePartitions": false,
+      "FileFormat": "plain-text"
+    },
+    "ResourceType": "VPC",
+    "Id": "fl-02e2f9eb4ca0c4938",
+    "LogDestination": "arn:aws:s3:::cdkrdhunt0714barest4a-bucket-dhwv0z2i7mtc",
+    "LogDestinationType": "s3",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Barest4A",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "FlowLog",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Barest4A/f1cbff30-7f77-11f1-b2c4-12e64a14fec7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "TrafficType": "ALL"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "DeliverCrossAccountRole",
+      "DeliverLogsPermissionArn",
+      "DestinationOptions",
+      "LogDestination",
+      "LogDestinationType",
+      "LogFormat",
+      "LogGroupName",
+      "MaxAggregationInterval",
+      "ResourceId",
+      "ResourceType",
+      "TagFieldSpecifications",
+      "TrafficType"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DeliverCrossAccountRole",
+      "DeliverLogsPermissionArn",
+      "DestinationOptions",
+      "LogDestination",
+      "LogDestinationType",
+      "LogFormat",
+      "LogGroupName",
+      "MaxAggregationInterval",
+      "ResourceId",
+      "ResourceType",
+      "TagFieldSpecifications",
+      "TrafficType"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "FlowLog",
+      "resourceType": "AWS::EC2::FlowLog",
+      "path": "LogFormat",
+      "actual": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "physicalId": "fl-02e2f9eb4ca0c4938",
+      "constructPath": "CdkrdHunt0714Barest4A/FlowLog"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FlowLog",
+      "resourceType": "AWS::EC2::FlowLog",
+      "path": "MaxAggregationInterval",
+      "actual": 600,
+      "physicalId": "fl-02e2f9eb4ca0c4938",
+      "constructPath": "CdkrdHunt0714Barest4A/FlowLog"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FlowLog",
+      "resourceType": "AWS::EC2::FlowLog",
+      "path": "DestinationOptions",
+      "actual": {
+        "PerHourPartition": false,
+        "HiveCompatiblePartitions": false,
+        "FileFormat": "plain-text"
+      },
+      "physicalId": "fl-02e2f9eb4ca0c4938",
+      "constructPath": "CdkrdHunt0714Barest4A/FlowLog"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SecurityGroupVpcAssociation.SgVpcAssoc.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupVpcAssociation.SgVpcAssoc.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SgVpcAssoc",
+    "resourceType": "AWS::EC2::SecurityGroupVpcAssociation",
+    "physicalId": "sg-0ae2c710f410e108b|vpc-041aad4f6fa0fea23",
+    "constructPath": "CdkrdHunt0714CcPi/SgVpcAssoc",
+    "declared": {
+      "GroupId": "sg-0ae2c710f410e108b",
+      "VpcId": "vpc-041aad4f6fa0fea23"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-041aad4f6fa0fea23",
+    "State": "associated",
+    "StateReason": "",
+    "VpcOwnerId": "111111111111",
+    "GroupId": "sg-0ae2c710f410e108b"
+  },
+  "schema": {
+    "readOnly": ["State", "StateReason", "VpcOwnerId"],
+    "writeOnly": [],
+    "createOnly": ["GroupId", "VpcId"],
+    "readOnlyPaths": ["State", "StateReason", "VpcOwnerId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GroupId", "VpcId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lex__BotAlias.BotAlias.json
+++ b/tests/corpus/AWS__Lex__BotAlias.BotAlias.json
@@ -1,0 +1,74 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BotAlias",
+    "resourceType": "AWS::Lex::BotAlias",
+    "physicalId": "WQLBVVPPEM|H4ZNLN2EXP",
+    "constructPath": "CdkrdHunt0714CcPi/BotAlias",
+    "declared": {
+      "BotAliasName": "hunt",
+      "BotAliasTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "BotId": "H4ZNLN2EXP",
+      "BotVersion": "1"
+    }
+  },
+  "liveRaw": {
+    "BotVersion": "1",
+    "BotId": "H4ZNLN2EXP",
+    "BotAliasStatus": "Available",
+    "BotAliasLocaleSettings": [],
+    "Arn": "arn:aws:lex:us-east-1:111111111111:bot-alias/H4ZNLN2EXP/WQLBVVPPEM",
+    "BotAliasId": "WQLBVVPPEM",
+    "SentimentAnalysisSettings": {
+      "DetectSentiment": false
+    },
+    "BotAliasName": "hunt",
+    "BotAliasTags": [
+      {
+        "Value": "BotAlias",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0714CcPi",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714CcPi/df0fb3a0-7f77-11f1-97e0-0affe5762c3f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "BotAliasId", "BotAliasStatus"],
+    "writeOnly": [],
+    "createOnly": ["BotId"],
+    "readOnlyPaths": ["Arn", "BotAliasId", "BotAliasStatus"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["BotId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [
+      "BotAliasLocaleSettings",
+      "ConversationLogSettings.AudioLogSettings",
+      "ConversationLogSettings.TextLogSettings"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lex__BotVersion.BotVersion.json
+++ b/tests/corpus/AWS__Lex__BotVersion.BotVersion.json
@@ -1,0 +1,55 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BotVersion",
+    "resourceType": "AWS::Lex::BotVersion",
+    "physicalId": "H4ZNLN2EXP|1",
+    "constructPath": "CdkrdHunt0714CcPi/BotVersion",
+    "declared": {
+      "BotId": "H4ZNLN2EXP",
+      "BotVersionLocaleSpecification": [
+        {
+          "BotVersionLocaleDetails": {
+            "SourceBotVersion": "DRAFT"
+          },
+          "LocaleId": "en_US"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "BotVersion": "1",
+    "BotId": "H4ZNLN2EXP"
+  },
+  "schema": {
+    "readOnly": ["BotVersion"],
+    "writeOnly": ["BotVersionLocaleSpecification"],
+    "createOnly": ["BotId"],
+    "readOnlyPaths": ["BotVersion"],
+    "writeOnlyPaths": ["BotVersionLocaleSpecification"],
+    "createOnlyPaths": ["BotId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["BotVersionLocaleSpecification"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "BotVersion",
+      "resourceType": "AWS::Lex::BotVersion",
+      "path": "BotVersionLocaleSpecification",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "H4ZNLN2EXP|1",
+      "constructPath": "CdkrdHunt0714CcPi/BotVersion"
+    }
+  ]
+}

--- a/tests/corpus/AWS__OpenSearchServerless__AccessPolicy.AossAccessPolicy.json
+++ b/tests/corpus/AWS__OpenSearchServerless__AccessPolicy.AossAccessPolicy.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AossAccessPolicy",
+    "resourceType": "AWS::OpenSearchServerless::AccessPolicy",
+    "physicalId": "data|cdkrd-hunt-ccpi",
+    "constructPath": "CdkrdHunt0714CcPi/AossAccessPolicy",
+    "declared": {
+      "Name": "cdkrd-hunt-ccpi",
+      "Policy": "[{\"Rules\":[{\"ResourceType\":\"collection\",\"Resource\":[\"collection/cdkrd-hunt-*\"],\"Permission\":[\"aoss:DescribeCollectionItems\"]}],\"Principal\":[\"arn:aws:iam::111111111111:root\"]}]",
+      "Type": "data"
+    }
+  },
+  "liveRaw": {
+    "Policy": "[{\"Rules\": [{\"Resource\": [\"collection/cdkrd-hunt-*\"],\"Permission\": [\"aoss:DescribeCollectionItems\"],\"ResourceType\": \"collection\"}],\"Principal\": [\"arn:aws:iam::111111111111:root\"]}]",
+    "Type": "data",
+    "Name": "cdkrd-hunt-ccpi"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name", "Type"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__RUM__AppMonitor.Rum.json
+++ b/tests/corpus/AWS__RUM__AppMonitor.Rum.json
@@ -1,0 +1,131 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rum",
+    "resourceType": "AWS::RUM::AppMonitor",
+    "physicalId": "cdkrd-hunt-brst4",
+    "constructPath": "CdkrdHunt0714Barest4B/Rum",
+    "declared": {
+      "Domain": "example.com",
+      "Name": "cdkrd-hunt-brst4",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "CustomEvents": {
+      "Status": "DISABLED"
+    },
+    "Platform": "Web",
+    "CwLogEnabled": false,
+    "Id": "fc4d3e9c-3c0b-44d2-8383-e0009a864bb5",
+    "DeobfuscationConfiguration": {
+      "JavaScriptSourceMaps": {
+        "Status": "DISABLED"
+      }
+    },
+    "Domain": "example.com",
+    "AppMonitorConfiguration": {
+      "IncludedPages": [],
+      "ExcludedPages": [],
+      "FavoritePages": [],
+      "SessionSampleRate": 0.1,
+      "Telemetries": []
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      }
+    ],
+    "Name": "cdkrd-hunt-brst4"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Platform"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Platform"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AppMonitorConfiguration.ExcludedPages",
+      "AppMonitorConfiguration.FavoritePages",
+      "AppMonitorConfiguration.IncludedPages",
+      "AppMonitorConfiguration.Telemetries"
+    ],
+    "unorderedObjectArrayPaths": ["AppMonitorConfiguration.MetricDestinations"],
+    "freeFormMapPaths": [
+      "AppMonitorConfiguration.MetricDestinations.*.MetricDefinitions.*.DimensionKeys"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Rum",
+      "resourceType": "AWS::RUM::AppMonitor",
+      "path": "CustomEvents",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4B/Rum"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Rum",
+      "resourceType": "AWS::RUM::AppMonitor",
+      "path": "Platform",
+      "actual": "Web",
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4B/Rum"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Rum",
+      "resourceType": "AWS::RUM::AppMonitor",
+      "path": "DeobfuscationConfiguration",
+      "actual": {
+        "JavaScriptSourceMaps": {
+          "Status": "DISABLED"
+        }
+      },
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4B/Rum"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Rum",
+      "resourceType": "AWS::RUM::AppMonitor",
+      "path": "AppMonitorConfiguration",
+      "actual": {
+        "IncludedPages": [],
+        "ExcludedPages": [],
+        "FavoritePages": [],
+        "SessionSampleRate": 0.1,
+        "Telemetries": []
+      },
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4B/Rum"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceCatalogAppRegistry__AttributeGroup.AttrGroup.json
+++ b/tests/corpus/AWS__ServiceCatalogAppRegistry__AttributeGroup.AttrGroup.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AttrGroup",
+    "resourceType": "AWS::ServiceCatalogAppRegistry::AttributeGroup",
+    "physicalId": "0a7vltldv7aiw2ng2pjb5mzols",
+    "constructPath": "CdkrdHunt0714CcPi/AttrGroup",
+    "declared": {
+      "Attributes": {
+        "env": "hunt"
+      },
+      "Name": "cdkrd-hunt-ccpi",
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "Attributes": {
+      "env": "hunt"
+    },
+    "Id": "0a7vltldv7aiw2ng2pjb5mzols",
+    "Arn": "arn:aws:servicecatalog:us-east-1:111111111111:/attribute-groups/0a7vltldv7aiw2ng2pjb5mzols",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdHunt0714CcPi",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714CcPi/df0fb3a0-7f77-11f1-97e0-0affe5762c3f",
+      "aws:servicecatalog:attributeGroupName": "cdkrd-hunt-ccpi",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "AttrGroup"
+    },
+    "Name": "cdkrd-hunt-ccpi"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ServiceCatalogAppRegistry__AttributeGroupAssociation.AttrGroupAssoc.json
+++ b/tests/corpus/AWS__ServiceCatalogAppRegistry__AttributeGroupAssociation.AttrGroupAssoc.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AttrGroupAssoc",
+    "resourceType": "AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation",
+    "physicalId": "arn:aws:servicecatalog:us-east-1:111111111111:/applications/05dyjdsk0i5ixb5zhbh2102w9z|arn:aws:servicecatalog:us-east-1:111111111111:/attribute-groups/0a7vltldv7aiw2ng2pjb5mzols",
+    "constructPath": "CdkrdHunt0714CcPi/AttrGroupAssoc",
+    "declared": {
+      "Application": "05dyjdsk0i5ixb5zhbh2102w9z",
+      "AttributeGroup": "0a7vltldv7aiw2ng2pjb5mzols"
+    }
+  },
+  "liveRaw": {
+    "ApplicationArn": "arn:aws:servicecatalog:us-east-1:111111111111:/applications/05dyjdsk0i5ixb5zhbh2102w9z",
+    "AttributeGroupArn": "arn:aws:servicecatalog:us-east-1:111111111111:/attribute-groups/0a7vltldv7aiw2ng2pjb5mzols",
+    "AttributeGroup": "0a7vltldv7aiw2ng2pjb5mzols",
+    "Application": "05dyjdsk0i5ixb5zhbh2102w9z"
+  },
+  "schema": {
+    "readOnly": ["ApplicationArn", "AttributeGroupArn"],
+    "writeOnly": [],
+    "createOnly": ["Application", "AttributeGroup"],
+    "readOnlyPaths": ["ApplicationArn", "AttributeGroupArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Application", "AttributeGroup"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ServiceCatalog__PortfolioPrincipalAssociation.PrincipalAssoc.json
+++ b/tests/corpus/AWS__ServiceCatalog__PortfolioPrincipalAssociation.PrincipalAssoc.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PrincipalAssoc",
+    "resourceType": "AWS::ServiceCatalog::PortfolioPrincipalAssociation",
+    "physicalId": "port-sne42owbwaygs|arn:aws:iam::111111111111:role/CdkrdHunt0714CcPi-PrincipalRole0B9742B6-JAc317Im0xrI",
+    "constructPath": "CdkrdHunt0714CcPi/PrincipalAssoc",
+    "declared": {
+      "PortfolioId": "port-sne42owbwaygs",
+      "PrincipalARN": "arn:aws:iam::111111111111:role/CdkrdHunt0714CcPi-PrincipalRole0B9742B6-JAc317Im0xrI",
+      "PrincipalType": "IAM"
+    }
+  },
+  "liveRaw": {
+    "PrincipalARN": "arn:aws:iam::111111111111:role/CdkrdHunt0714CcPi-PrincipalRole0B9742B6-JAc317Im0xrI",
+    "PortfolioId": "port-sne42owbwaygs",
+    "PrincipalType": "IAM"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["AcceptLanguage"],
+    "createOnly": ["AcceptLanguage", "PortfolioId", "PrincipalARN", "PrincipalType"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["AcceptLanguage"],
+    "createOnlyPaths": ["AcceptLanguage", "PortfolioId", "PrincipalARN", "PrincipalType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ServiceCatalog__TagOption.TagOption.json
+++ b/tests/corpus/AWS__ServiceCatalog__TagOption.TagOption.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TagOption",
+    "resourceType": "AWS::ServiceCatalog::TagOption",
+    "physicalId": "tag-ijpe32hv55kou",
+    "constructPath": "CdkrdHunt0714CcPi/TagOption",
+    "declared": {
+      "Key": "cdkrd-hunt",
+      "Value": "ccpi"
+    }
+  },
+  "liveRaw": {
+    "Active": true,
+    "Value": "ccpi",
+    "Id": "tag-ijpe32hv55kou",
+    "Key": "cdkrd-hunt"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Key", "Value"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Key", "Value"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TagOption",
+      "resourceType": "AWS::ServiceCatalog::TagOption",
+      "path": "Active",
+      "actual": true,
+      "physicalId": "tag-ijpe32hv55kou",
+      "constructPath": "CdkrdHunt0714CcPi/TagOption"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceCatalog__TagOptionAssociation.TagOptionAssoc.json
+++ b/tests/corpus/AWS__ServiceCatalog__TagOptionAssociation.TagOptionAssoc.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TagOptionAssoc",
+    "resourceType": "AWS::ServiceCatalog::TagOptionAssociation",
+    "physicalId": "tag-ijpe32hv55kou|port-sne42owbwaygs",
+    "constructPath": "CdkrdHunt0714CcPi/TagOptionAssoc",
+    "declared": {
+      "ResourceId": "port-sne42owbwaygs",
+      "TagOptionId": "tag-ijpe32hv55kou"
+    }
+  },
+  "liveRaw": {
+    "TagOptionId": "tag-ijpe32hv55kou",
+    "ResourceId": "port-sne42owbwaygs"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ResourceId", "TagOptionId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ResourceId", "TagOptionId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Synthetics__Canary.Canary.json
+++ b/tests/corpus/AWS__Synthetics__Canary.Canary.json
@@ -1,0 +1,172 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Canary",
+    "resourceType": "AWS::Synthetics::Canary",
+    "physicalId": "cdkrd-hunt-brst4",
+    "constructPath": "CdkrdHunt0714Barest4A/Canary",
+    "declared": {
+      "ArtifactS3Location": "s3://cdkrdhunt0714barest4a-bucket-dhwv0z2i7mtc/canary",
+      "Code": {
+        "Handler": "index.handler",
+        "Script": "exports.handler = async () => \"ok\";"
+      },
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Barest4A-CanaryRole4BD5F96A-fLRlxHEl3Pue",
+      "Name": "cdkrd-hunt-brst4",
+      "RuntimeVersion": "syn-nodejs-puppeteer-16.1",
+      "Schedule": {
+        "Expression": "rate(0 hour)"
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SuccessRetentionPeriod": 31,
+    "RuntimeVersion": "syn-nodejs-puppeteer-16.1",
+    "RunConfig": {
+      "TimeoutInSeconds": 840,
+      "MemoryInMB": 1500,
+      "EphemeralStorage": 1024,
+      "ActiveTracing": false
+    },
+    "FailureRetentionPeriod": 31,
+    "Code": {
+      "Handler": "index.handler"
+    },
+    "Name": "cdkrd-hunt-brst4",
+    "ProvisionedResourceCleanup": "AUTOMATIC",
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0714Barest4A-CanaryRole4BD5F96A-fLRlxHEl3Pue",
+    "State": "READY",
+    "Schedule": {
+      "DurationInSeconds": "0",
+      "RetryConfig": {
+        "MaxRetries": 0
+      },
+      "Expression": "rate(0 hour)"
+    },
+    "Id": "a69401a2-a70c-45eb-9f01-afc4d282aca9",
+    "ArtifactS3Location": "s3://cdkrdhunt0714barest4a-bucket-dhwv0z2i7mtc/canary",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id", "State"],
+    "writeOnly": [
+      "DeleteLambdaResourcesOnCanaryDeletion",
+      "DryRunAndUpdate",
+      "ResourcesToReplicateTags",
+      "StartCanaryAfterCreation",
+      "VisualReference",
+      "VisualReferences"
+    ],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Code.SourceLocationArn", "Id", "State"],
+    "writeOnlyPaths": [
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.Script",
+      "DeleteLambdaResourcesOnCanaryDeletion",
+      "DryRunAndUpdate",
+      "ResourcesToReplicateTags",
+      "RunConfig.EnvironmentVariables",
+      "StartCanaryAfterCreation",
+      "VisualReference",
+      "VisualReferences"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["RunConfig.EnvironmentVariables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Canary",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "SuccessRetentionPeriod",
+      "actual": 31,
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4A/Canary"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Canary",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "RunConfig",
+      "actual": {
+        "TimeoutInSeconds": 840,
+        "MemoryInMB": 1500,
+        "EphemeralStorage": 1024,
+        "ActiveTracing": false
+      },
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4A/Canary"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Canary",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "FailureRetentionPeriod",
+      "actual": 31,
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4A/Canary"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Canary",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "ProvisionedResourceCleanup",
+      "actual": "AUTOMATIC",
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4A/Canary"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Canary",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "Schedule.DurationInSeconds",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4A/Canary"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Canary",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "Schedule.RetryConfig",
+      "actual": {
+        "MaxRetries": 0
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-brst4",
+      "constructPath": "CdkrdHunt0714Barest4A/Canary"
+    }
+  ]
+}

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAclBarest.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAclBarest.json
@@ -1,0 +1,114 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WebAcl",
+    "resourceType": "AWS::WAFv2::WebACL",
+    "physicalId": "WebAcl-GTMYn46lDlqt|ffa3e574-a760-4b19-a934-d56e8e19c262|REGIONAL",
+    "constructPath": "CdkrdHunt0714Barest4B/WebAcl",
+    "declared": {
+      "DefaultAction": {
+        "Allow": {}
+      },
+      "Scope": "REGIONAL",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ],
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": false,
+        "MetricName": "cdkrdhuntbrst4",
+        "SampledRequestsEnabled": false
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "DefaultAction": {
+      "Allow": {}
+    },
+    "Scope": "REGIONAL",
+    "Capacity": 0,
+    "Id": "ffa3e574-a760-4b19-a934-d56e8e19c262",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/WebAcl-GTMYn46lDlqt/ffa3e574-a760-4b19-a934-d56e8e19c262",
+    "OnSourceDDoSProtectionConfig": {
+      "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+    },
+    "Rules": [],
+    "VisibilityConfig": {
+      "MetricName": "cdkrdhuntbrst4",
+      "SampledRequestsEnabled": false,
+      "CloudWatchMetricsEnabled": false
+    },
+    "LabelNamespace": "awswaf:111111111111:webacl:WebAcl-GTMYn46lDlqt:",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0714Barest4B",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "WebAcl",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0714Barest4B/ddaaa560-7f77-11f1-b23e-0affeef325ef",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "WebAcl-GTMYn46lDlqt"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["AssociationConfig.RequestBody", "CustomResponseBodies"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
+      "physicalId": "WebAcl-GTMYn46lDlqt|ffa3e574-a760-4b19-a934-d56e8e19c262|REGIONAL",
+      "constructPath": "CdkrdHunt0714Barest4B/WebAcl"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "Name",
+      "actual": "WebAcl-GTMYn46lDlqt",
+      "physicalId": "WebAcl-GTMYn46lDlqt|ffa3e574-a760-4b19-a934-d56e8e19c262|REGIONAL",
+      "constructPath": "CdkrdHunt0714Barest4B/WebAcl"
+    }
+  ]
+}

--- a/tests/integration/barest4-hunt/app.ts
+++ b/tests/integration/barest4-hunt/app.ts
@@ -1,0 +1,190 @@
+// Barest-form first-run FP probe batch 4 (real AWS): eight common types whose
+// corpus/fixture coverage is RICH-only — every existing case declares most
+// properties, so the undeclared-default fold surface was never exercised:
+// - Synthetics::Canary (synthetics-rich declares retention/timeout/start flags)
+// - CloudTrail::Trail (cloudtrail-rich = L2 Trail declares 6 props; barest = bucket + IsLogging)
+// - EC2::FlowLog (only corpus case declares TrafficType/LogGroup form; barest = S3 dest,
+//   TrafficType + MaxAggregationInterval undeclared)
+// - WAFv2::WebACL (every corpus case declares Rules; barest = no Rules, no Name)
+// - RUM::AppMonitor (rich case declares full AppMonitorConfiguration)
+// - APS::Workspace (zero required properties — fully naked)
+// - CodeArtifact::Domain + Repository (rich case declares policy/connections/description)
+// - Bedrock::Guardrail (rich case declares all policy families; barest = word policy only)
+// Stack A carries the plumbing-heavy trio (canary/trail/flowlog); stack B the rest,
+// so one create-time validation failure cannot roll back the whole probe.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnWorkspace } from "aws-cdk-lib/aws-aps";
+import { CfnGuardrail } from "aws-cdk-lib/aws-bedrock";
+import { CfnTrail } from "aws-cdk-lib/aws-cloudtrail";
+import { CfnDomain, CfnRepository } from "aws-cdk-lib/aws-codeartifact";
+import { CfnFlowLog, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import {
+  Effect,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { CfnAppMonitor } from "aws-cdk-lib/aws-rum";
+import { CfnBucket, CfnBucketPolicy } from "aws-cdk-lib/aws-s3";
+import { CfnCanary } from "aws-cdk-lib/aws-synthetics";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+// `-c rev=2` threads a neutral tag update through every resource — the
+// post-update echo probe (redeploy with rev=2, re-check; see hunt-bugs skill).
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+// ---------------------------------------------------------------- stack A
+const a = new Stack(app, "CdkrdHunt0714Barest4A");
+
+// One bucket serves the canary artifacts, the trail delivery, and the flow-log
+// delivery (policy statements for the latter two below).
+const bucket = new CfnBucket(a, "Bucket", {});
+
+new CfnBucketPolicy(a, "BucketPolicy", {
+  bucket: bucket.ref,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "AWSCloudTrailAclCheck",
+        Effect: "Allow",
+        Principal: { Service: "cloudtrail.amazonaws.com" },
+        Action: "s3:GetBucketAcl",
+        Resource: bucket.attrArn,
+      },
+      {
+        Sid: "AWSCloudTrailWrite",
+        Effect: "Allow",
+        Principal: { Service: "cloudtrail.amazonaws.com" },
+        Action: "s3:PutObject",
+        Resource: `${bucket.attrArn}/AWSLogs/${a.account}/*`,
+        Condition: {
+          StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
+        },
+      },
+      {
+        Sid: "AWSLogDeliveryAclCheck",
+        Effect: "Allow",
+        Principal: { Service: "delivery.logs.amazonaws.com" },
+        Action: "s3:GetBucketAcl",
+        Resource: bucket.attrArn,
+      },
+      {
+        Sid: "AWSLogDeliveryWrite",
+        Effect: "Allow",
+        Principal: { Service: "delivery.logs.amazonaws.com" },
+        Action: "s3:PutObject",
+        Resource: `${bucket.attrArn}/AWSLogs/${a.account}/*`,
+        Condition: {
+          StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" },
+        },
+      },
+    ],
+  },
+});
+
+// Barest trail: only the two schema-required props. TrailName undeclared →
+// CFn generates one (a generated-name fold probe on its own).
+const trail = new CfnTrail(a, "Trail", {
+  s3BucketName: bucket.ref,
+  isLogging: true,
+});
+trail.addDependency(a.node.findChild("BucketPolicy") as CfnBucketPolicy);
+
+const canaryRole = new Role(a, "CanaryRole", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+});
+canaryRole.addToPolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetBucketLocation",
+      "s3:ListAllMyBuckets",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "cloudwatch:PutMetricData",
+    ],
+    resources: ["*"],
+  }),
+);
+
+// Barest canary: the six schema-required props only. rate(0 hour) = run once
+// on start, and StartCanaryAfterCreation is undeclared — so it never runs.
+new CfnCanary(a, "Canary", {
+  name: "cdkrd-hunt-brst4",
+  code: {
+    handler: "index.handler",
+    script: 'exports.handler = async () => "ok";',
+  },
+  artifactS3Location: `s3://${bucket.ref}/canary`,
+  executionRoleArn: canaryRole.roleArn,
+  schedule: { expression: "rate(0 hour)" },
+  runtimeVersion: "syn-nodejs-puppeteer-16.1",
+});
+
+const vpc = new CfnVPC(a, "Vpc", { cidrBlock: "10.61.0.0/24" });
+
+// Barest flow log: S3 destination (no IAM role needed). TrafficType is NOT in
+// the schema's `required` list but the SERVICE demands it for a VPC target
+// ("traffic-type is required when the resource-type is VPC" — live-determined),
+// so it is declared; MaxAggregationInterval stays undeclared as the probe.
+const flowLog = new CfnFlowLog(a, "FlowLog", {
+  resourceId: vpc.ref,
+  resourceType: "VPC",
+  trafficType: "ALL",
+  logDestinationType: "s3",
+  logDestination: bucket.attrArn,
+});
+flowLog.addDependency(a.node.findChild("BucketPolicy") as CfnBucketPolicy);
+
+// ---------------------------------------------------------------- stack B
+const b = new Stack(app, "CdkrdHunt0714Barest4B");
+
+// Barest WebACL: no Rules, no Name (CFn generates one).
+new CfnWebACL(b, "WebAcl", {
+  defaultAction: { allow: {} },
+  scope: "REGIONAL",
+  visibilityConfig: {
+    cloudWatchMetricsEnabled: false,
+    metricName: "cdkrdhuntbrst4",
+    sampledRequestsEnabled: false,
+  },
+});
+
+// Schema requires only Name; Domain is declared because the service demands
+// one domain form at create — everything else (AppMonitorConfiguration,
+// CustomEvents, CwLogEnabled) stays undeclared.
+new CfnAppMonitor(b, "Rum", {
+  name: "cdkrd-hunt-brst4",
+  domain: "example.com",
+});
+
+// Fully naked Amazon Managed Prometheus workspace (zero required props).
+new CfnWorkspace(b, "Aps", {});
+
+const caDomain = new CfnDomain(b, "CaDomain", {
+  domainName: "cdkrd-hunt-brst4",
+});
+const caRepo = new CfnRepository(b, "CaRepo", {
+  domainName: "cdkrd-hunt-brst4",
+  repositoryName: "cdkrd-hunt-brst4",
+});
+caRepo.addDependency(caDomain);
+
+// Barest guardrail: the three schema-required props + one word policy (the
+// service rejects a guardrail with zero policies); every other policy family
+// and the cross-Region/KMS knobs stay undeclared.
+new CfnGuardrail(b, "Guardrail", {
+  name: "cdkrd-hunt-brst4",
+  blockedInputMessaging: "Blocked input.",
+  blockedOutputsMessaging: "Blocked output.",
+  wordPolicyConfig: { wordsConfig: [{ text: "cdkrdblockedword" }] },
+});
+
+app.synth();

--- a/tests/integration/barest4-hunt/cdk.json
+++ b/tests/integration/barest4-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/barest4-hunt/package.json
+++ b/tests/integration/barest4-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-barest4-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-form first-run FP probe batch 4: Synthetics Canary, CloudTrail Trail, EC2 FlowLog, WAFv2 WebACL, RUM AppMonitor, APS Workspace, CodeArtifact, Bedrock Guardrail. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/barest4-hunt/verify.sh
+++ b/tests/integration/barest4-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Barest-form first-run FP probe batch 4 (real AWS): deploy the barest form of
+# eight rich-only-covered types across two stacks, assert the FIRST check
+# (before record) is CLEAN, then record and assert check --fail is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0714Barest4A CdkrdHunt0714Barest4B)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (barest4-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-barest4}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "INTEG OK (barest4-hunt)"

--- a/tests/integration/ccpi-hunt/app.ts
+++ b/tests/integration/ccpi-hunt/app.ts
@@ -1,0 +1,146 @@
+// Composite-primaryIdentifier read-gap probe (real AWS): types whose registry
+// schema declares a MULTI-segment primaryIdentifier and that are NOT in
+// CC_IDENTIFIER_ADAPTERS / SDK_OVERRIDES. If a type's CFn physical id is only
+// the bare child segment, Cloud Control GetResource rejects it and the
+// resource is silently `skipped` (the #344 SubscriptionFilter class). One
+// cheap stack deploys them all; the first `check`'s footer tells which (if
+// any) need an adapter:
+// - ServiceCatalog::PortfolioPrincipalAssociation  [PortfolioId, PrincipalARN]
+// - ServiceCatalog::TagOptionAssociation           [TagOptionId, ResourceId]
+// - ServiceCatalogAppRegistry::AttributeGroupAssociation [ApplicationArn, AttributeGroupArn]
+// - OpenSearchServerless::AccessPolicy             [Type, Name]
+// - EC2::SecurityGroupVpcAssociation               [GroupId, VpcId]
+// - Lex::BotVersion [BotId, BotVersion] + Lex::BotAlias [BotAliasId, BotId]
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnSecurityGroup,
+  CfnSecurityGroupVpcAssociation,
+  CfnVPC,
+} from "aws-cdk-lib/aws-ec2";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnBot, CfnBotAlias, CfnBotVersion } from "aws-cdk-lib/aws-lex";
+import { CfnAccessPolicy } from "aws-cdk-lib/aws-opensearchserverless";
+import {
+  CfnPortfolio,
+  CfnPortfolioPrincipalAssociation,
+  CfnTagOption,
+  CfnTagOptionAssociation,
+} from "aws-cdk-lib/aws-servicecatalog";
+import {
+  CfnApplication,
+  CfnAttributeGroup,
+  CfnAttributeGroupAssociation,
+} from "aws-cdk-lib/aws-servicecatalogappregistry";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0714CcPi");
+
+// --- ServiceCatalog: portfolio + principal association + tag option assoc
+const portfolio = new CfnPortfolio(stack, "Portfolio", {
+  displayName: "cdkrd-hunt-ccpi",
+  providerName: "cdkrd",
+});
+const principalRole = new Role(stack, "PrincipalRole", {
+  assumedBy: new ServicePrincipal("servicecatalog.amazonaws.com"),
+});
+new CfnPortfolioPrincipalAssociation(stack, "PrincipalAssoc", {
+  portfolioId: portfolio.ref,
+  principalArn: principalRole.roleArn,
+  principalType: "IAM",
+});
+const tagOption = new CfnTagOption(stack, "TagOption", {
+  key: "cdkrd-hunt",
+  value: "ccpi",
+});
+new CfnTagOptionAssociation(stack, "TagOptionAssoc", {
+  tagOptionId: tagOption.ref,
+  resourceId: portfolio.ref,
+});
+
+// --- AppRegistry: application + attribute group + association
+const application = new CfnApplication(stack, "AppRegApp", {
+  name: "cdkrd-hunt-ccpi",
+});
+const attrGroup = new CfnAttributeGroup(stack, "AttrGroup", {
+  name: "cdkrd-hunt-ccpi",
+  attributes: { env: "hunt" },
+});
+// GetAtt references (not the name strings) so CFn orders the association
+// after both parents — the name form deployed first and 404ed on the race.
+new CfnAttributeGroupAssociation(stack, "AttrGroupAssoc", {
+  application: application.attrId,
+  attributeGroup: attrGroup.attrId,
+});
+
+// --- OpenSearch Serverless data access policy (no collection needed)
+new CfnAccessPolicy(stack, "AossAccessPolicy", {
+  name: "cdkrd-hunt-ccpi",
+  type: "data",
+  policy: JSON.stringify([
+    {
+      Rules: [
+        {
+          ResourceType: "collection",
+          Resource: ["collection/cdkrd-hunt-*"],
+          Permission: ["aoss:DescribeCollectionItems"],
+        },
+      ],
+      Principal: [`arn:aws:iam::${stack.account}:root`],
+    },
+  ]),
+});
+
+// --- EC2 SecurityGroupVpcAssociation (SG in VPC A associated into VPC B)
+const vpcA = new CfnVPC(stack, "VpcA", { cidrBlock: "10.62.0.0/24" });
+const vpcB = new CfnVPC(stack, "VpcB", { cidrBlock: "10.63.0.0/24" });
+const sg = new CfnSecurityGroup(stack, "Sg", {
+  groupDescription: "cdkrd hunt ccpi",
+  vpcId: vpcA.ref,
+});
+new CfnSecurityGroupVpcAssociation(stack, "SgVpcAssoc", {
+  groupId: sg.attrGroupId,
+  vpcId: vpcB.ref,
+});
+
+// --- Lex: minimal bot + a numbered version + an alias pinned to it
+const botRole = new Role(stack, "BotRole", {
+  assumedBy: new ServicePrincipal("lexv2.amazonaws.com"),
+});
+const bot = new CfnBot(stack, "Bot", {
+  name: "cdkrd-hunt-ccpi-bot",
+  roleArn: botRole.roleArn,
+  // CFn requires the raw `ChildDirected` casing (see lex-structural).
+  dataPrivacy: { ChildDirected: false } as unknown as CfnBot.DataPrivacyProperty,
+  idleSessionTtlInSeconds: 300,
+  autoBuildBotLocales: true,
+  botLocales: [
+    {
+      localeId: "en_US",
+      nluConfidenceThreshold: 0.4,
+      intents: [
+        {
+          name: "Greeting",
+          sampleUtterances: [{ utterance: "hello" }],
+        },
+        { name: "FallbackIntent", parentIntentSignature: "AMAZON.FallbackIntent" },
+      ],
+    },
+  ],
+});
+const botVersion = new CfnBotVersion(stack, "BotVersion", {
+  botId: bot.attrId,
+  botVersionLocaleSpecification: [
+    {
+      localeId: "en_US",
+      botVersionLocaleDetails: { sourceBotVersion: "DRAFT" },
+    },
+  ],
+});
+new CfnBotAlias(stack, "BotAlias", {
+  botAliasName: "hunt",
+  botId: bot.attrId,
+  botVersion: botVersion.attrBotVersion,
+});
+
+app.synth();

--- a/tests/integration/ccpi-hunt/cdk.json
+++ b/tests/integration/ccpi-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ccpi-hunt/package.json
+++ b/tests/integration/ccpi-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ccpi-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Composite-primaryIdentifier read-gap probe: ServiceCatalog associations, AppRegistry association, aoss AccessPolicy, EC2 SecurityGroupVpcAssociation, Lex BotVersion/BotAlias. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ccpi-hunt/verify.sh
+++ b/tests/integration/ccpi-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Composite-primaryIdentifier read-gap probe (real AWS): deploy the association
+# pack and assert (1) NO resource is silently skipped for a composite-id
+# ValidationException (the #344 class), (2) the first check is CLEAN, and
+# (3) record -> check --fail stays clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0714CcPi
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN + zero skipped ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-ccpi}" $CLI check "$STACK" --region "$REGION" --fail --verbose \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+# The probe's whole point: a skipped= footer here is a composite-id read gap.
+grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out" && RC=11
+[ "$RC" -eq 0 ] || fail "first check not clean (rc=$RC; 11 = skipped resources)"
+
+echo "=== [$STACK] record + check --fail ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "INTEG OK (ccpi-hunt)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -754,12 +754,22 @@ describe('noise suppressors', () => {
       AccountId: '',
       UseLakeFormationCredentials: false,
     });
-    // CloudWatch RUM AppMonitor (observed live on rum-appmonitor-rich): an undeclared
-    // Platform reads back "Web", and undeclared source-map deobfuscation reads back the
-    // disabled-state object. Equality-gated, so Android/iOS or an enabled config surfaces.
+    // CloudWatch RUM AppMonitor (observed live on rum-appmonitor-rich, extended by the
+    // barest4 hunt 2026-07-14): an undeclared Platform reads back "Web", undeclared
+    // source-map deobfuscation reads back the disabled-state object, and a BAREST monitor
+    // (Name + Domain only) also materializes the disabled custom-events toggle and the
+    // default AppMonitorConfiguration. Equality-gated, so any out-of-band change surfaces.
     expect(KNOWN_DEFAULTS['AWS::RUM::AppMonitor']).toEqual({
       Platform: 'Web',
       DeobfuscationConfiguration: { JavaScriptSourceMaps: { Status: 'DISABLED' } },
+      CustomEvents: { Status: 'DISABLED' },
+      AppMonitorConfiguration: {
+        IncludedPages: [],
+        ExcludedPages: [],
+        FavoritePages: [],
+        SessionSampleRate: 0.1,
+        Telemetries: [],
+      },
     });
   });
 

--- a/tests/noise-barest4-folds.test.ts
+++ b/tests/noise-barest4-folds.test.ts
@@ -1,0 +1,222 @@
+// barest4 hunt (2026-07-14): first-run FP folds mined from clean, un-mutated LIVE deploys
+// of the BAREST form of four rich-only-covered types (stacks CdkrdHunt0714Barest4A/B +
+// CdkrdHunt0714CcPi, us-east-1). Every existing fixture/corpus case for these types
+// DECLARED the suspect properties, so their undeclared-default path never ran:
+//   EC2::FlowLog DestinationOptions        -> tier-1 KNOWN_DEFAULTS object constant
+//   Synthetics::Canary Schedule.DurationInSeconds -> tier-1 KNOWN_DEFAULT_PATHS string "0"
+//   RUM::AppMonitor CustomEvents + AppMonitorConfiguration -> tier-1 KNOWN_DEFAULTS
+//   ServiceCatalog::TagOption Active       -> tier-1 KNOWN_DEFAULTS truthy-bool constant,
+//     paired with a MEANINGFUL_WHEN_OFF gate (the #1503 TLSEnabled lesson) so an
+//     out-of-band deactivate (undeclared false) still surfaces.
+// Live models are copied verbatim from the harvested corpus of those deploys.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('EC2::FlowLog undeclared DestinationOptions (barest S3-destination flow log)', () => {
+  const res: DesiredResource = {
+    logicalId: 'FlowLog',
+    resourceType: 'AWS::EC2::FlowLog',
+    physicalId: 'fl-02e2f9eb4ca0c4938',
+    declared: {
+      LogDestination: 'arn:aws:s3:::cdkrd-hunt-bucket',
+      LogDestinationType: 's3',
+      ResourceId: 'vpc-00346b7ce53be4f32',
+      ResourceType: 'VPC',
+      TrafficType: 'ALL',
+    },
+  };
+  const cleanLive = {
+    ResourceId: 'vpc-00346b7ce53be4f32',
+    ResourceType: 'VPC',
+    TrafficType: 'ALL',
+    LogDestination: 'arn:aws:s3:::cdkrd-hunt-bucket',
+    LogDestinationType: 's3',
+    LogFormat:
+      '${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}',
+    MaxAggregationInterval: 600,
+    DestinationOptions: {
+      PerHourPartition: false,
+      HiveCompatiblePartitions: false,
+      FileFormat: 'plain-text',
+    },
+  };
+
+  it('produces ZERO potential drift on a clean, un-mutated flow log', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('folds the default DestinationOptions trio to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('DestinationOptions');
+  });
+
+  it('surfaces a non-default file format (Parquet) — the equality gate holds', () => {
+    const changed = {
+      ...cleanLive,
+      DestinationOptions: {
+        PerHourPartition: false,
+        HiveCompatiblePartitions: false,
+        FileFormat: 'parquet',
+      },
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('DestinationOptions');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('DestinationOptions');
+  });
+});
+
+describe('Synthetics::Canary undeclared Schedule.DurationInSeconds (barest canary)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Canary',
+    resourceType: 'AWS::Synthetics::Canary',
+    physicalId: 'cdkrd-hunt-brst4',
+    declared: {
+      ArtifactS3Location: 's3://cdkrd-hunt-bucket/canary',
+      Code: { Handler: 'index.handler', Script: 'exports.handler = async () => "ok";' },
+      ExecutionRoleArn: 'arn:aws:iam::123456789012:role/canary-role',
+      Name: 'cdkrd-hunt-brst4',
+      RuntimeVersion: 'syn-nodejs-puppeteer-16.1',
+      Schedule: { Expression: 'rate(0 hour)' },
+    },
+  };
+  const cleanLive = {
+    Name: 'cdkrd-hunt-brst4',
+    ArtifactS3Location: 's3://cdkrd-hunt-bucket/canary',
+    Code: { Handler: 'index.handler' },
+    ExecutionRoleArn: 'arn:aws:iam::123456789012:role/canary-role',
+    RuntimeVersion: 'syn-nodejs-puppeteer-16.1',
+    // AWS materializes DurationInSeconds as the STRING "0" (run forever) on a schedule
+    // that declares only Expression.
+    Schedule: {
+      DurationInSeconds: '0',
+      RetryConfig: { MaxRetries: 0 },
+      Expression: 'rate(0 hour)',
+    },
+    SuccessRetentionPeriod: 31,
+    FailureRetentionPeriod: 31,
+    ProvisionedResourceCleanup: 'AUTOMATIC',
+    RunConfig: {
+      TimeoutInSeconds: 840,
+      MemoryInMB: 1500,
+      EphemeralStorage: 1024,
+      ActiveTracing: false,
+    },
+  };
+
+  it('produces ZERO potential drift on a clean, un-mutated canary', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band duration limit — the equality gate holds', () => {
+    const changed = {
+      ...cleanLive,
+      Schedule: { ...cleanLive.Schedule, DurationInSeconds: '600' },
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('Schedule.DurationInSeconds');
+  });
+});
+
+describe('RUM::AppMonitor undeclared defaults (barest monitor: Name + Domain only)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Rum',
+    resourceType: 'AWS::RUM::AppMonitor',
+    physicalId: 'cdkrd-hunt-brst4',
+    declared: { Domain: 'example.com', Name: 'cdkrd-hunt-brst4' },
+  };
+  const cleanLive = {
+    Name: 'cdkrd-hunt-brst4',
+    Domain: 'example.com',
+    Platform: 'Web',
+    CwLogEnabled: false,
+    CustomEvents: { Status: 'DISABLED' },
+    AppMonitorConfiguration: {
+      IncludedPages: [],
+      ExcludedPages: [],
+      FavoritePages: [],
+      SessionSampleRate: 0.1,
+      Telemetries: [],
+    },
+    DeobfuscationConfiguration: { JavaScriptSourceMaps: { Status: 'DISABLED' } },
+  };
+
+  it('produces ZERO potential drift on a clean, un-mutated monitor', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('folds CustomEvents and AppMonitorConfiguration to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    const atDefault = pathsByTier(f, 'atDefault');
+    expect(atDefault).toContain('CustomEvents');
+    expect(atDefault).toContain('AppMonitorConfiguration');
+  });
+
+  it('surfaces an out-of-band custom-events ENABLE (the live-proven mutation)', () => {
+    const changed = { ...cleanLive, CustomEvents: { Status: 'ENABLED' } };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('CustomEvents');
+  });
+
+  it('surfaces an out-of-band sampling-rate change', () => {
+    const changed = {
+      ...cleanLive,
+      AppMonitorConfiguration: { ...cleanLive.AppMonitorConfiguration, SessionSampleRate: 1 },
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('AppMonitorConfiguration');
+  });
+});
+
+describe('ServiceCatalog::TagOption undeclared Active (ccpi hunt)', () => {
+  const res: DesiredResource = {
+    logicalId: 'TagOption',
+    resourceType: 'AWS::ServiceCatalog::TagOption',
+    physicalId: 'tag-ijpe32hv55kou',
+    declared: { Key: 'cdkrd-hunt', Value: 'ccpi' },
+  };
+  const cleanLive = {
+    Key: 'cdkrd-hunt',
+    Value: 'ccpi',
+    Active: true,
+  };
+
+  it('produces ZERO potential drift on a clean, un-mutated tag option', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('folds the created-active default to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Active');
+  });
+
+  it('surfaces an out-of-band deactivate (undeclared false, via MEANINGFUL_WHEN_OFF)', () => {
+    // Without the MEANINGFUL_WHEN_OFF gate the live `false` is dropped by isTrivialEmpty
+    // before the pin gate, hiding the deactivation (live-proven detect on ccpi-hunt).
+    const changed = { ...cleanLive, Active: false };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('Active');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('Active');
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -694,6 +694,43 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  // barest4/ccpi hunt (live-proven 2026-07-14): two more members, each a distinct flavor —
+  // RUM UpdateAppMonitor silently KEEPS an omitted CustomEvents (an out-of-band ENABLED
+  // persisted through a `remove` that reported reverted), and ServiceCatalog
+  // UpdateTagOption REJECTS the remove outright ("Active and new value cannot both be
+  // null"). Both write the KNOWN_DEFAULTS default back explicitly.
+  it('RUM AppMonitor CustomEvents (SET-DEFAULT) -> add op writing the DISABLED default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RUM::AppMonitor',
+      path: 'CustomEvents',
+      actual: { Status: 'ENABLED' },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/CustomEvents',
+      value: { Status: 'DISABLED' },
+      prior: { Status: 'ENABLED' },
+    });
+  });
+
+  it('ServiceCatalog TagOption Active (SET-DEFAULT) -> add op writing the true default, not a rejected remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::ServiceCatalog::TagOption',
+      path: 'Active',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Active',
+      value: true,
+      prior: false,
+    });
+  });
+
   it('#1619: Glue Crawler SchemaChangePolicy (SET-DEFAULT) -> add op writing the whole-object default', () => {
     const f = F({
       tier: 'undeclared',


### PR DESCRIPTION
## Summary

Bug-hunt round (2026-07-14, live on us-east-1): deployed the BAREST form of eight rich-only-covered types (stacks `CdkrdHunt0714Barest4A/B`) plus a 7-type composite-primaryIdentifier association pack (`CdkrdHunt0714CcPi`), ran the first-check FP oracle, a neutral-redeploy echo probe, and mutate -> detect -> revert -> converge probes on every new fold. 7 bugs found and fixed; all stacks deleted and SWEEP CLEAN.

> Note: per-bug GitHub issues could not be filed from this session (issue creation requires per-instance approval in this environment), so this PR body carries the full evidence for each bug instead.

## First-run FP folds (5) — tier-1 equality-gated, live-proven clean + detect

| Type | Path | Materialized default | Fix |
| --- | --- | --- | --- |
| `AWS::EC2::FlowLog` | `DestinationOptions` | `{FileFormat:"plain-text", HiveCompatiblePartitions:false, PerHourPartition:false}` (S3 destination) | `KNOWN_DEFAULTS` |
| `AWS::Synthetics::Canary` | `Schedule.DurationInSeconds` | the STRING `"0"` | `KNOWN_DEFAULT_PATHS` |
| `AWS::RUM::AppMonitor` | `CustomEvents` | `{Status:"DISABLED"}` | `KNOWN_DEFAULTS` |
| `AWS::RUM::AppMonitor` | `AppMonitorConfiguration` | `{IncludedPages:[],ExcludedPages:[],FavoritePages:[],SessionSampleRate:0.1,Telemetries:[]}` | `KNOWN_DEFAULTS` |
| `AWS::ServiceCatalog::TagOption` | `Active` | `true` | `KNOWN_DEFAULTS` + `MEANINGFUL_WHEN_OFF` (a bare `false` would be swallowed by isTrivialEmpty — the #1503 TLSEnabled lesson; out-of-band deactivate live-proven to surface) |

Every fold was live-verified BOTH ways with the fixed binary: fresh first check -> CLEAN (5 FPs -> `atDefault`), then out-of-band mutation -> surfaces (equality gate holds).

## Revert convergence (2) — `REVERT_SET_DEFAULT_PATHS`, live-proven converged

- **RUM `UpdateAppMonitor` silently KEEPS an omitted `CustomEvents`**: an out-of-band ENABLED reverted as a bare `remove` reported "reverted" yet the convergence re-read stayed ENABLED. RSDP writes the `{Status:"DISABLED"}` default explicitly — live re-run converges, `get-app-monitor` confirms DISABLED.
- **ServiceCatalog `UpdateTagOption` REJECTS the bare remove outright** (`InvalidRequest: Active and new value cannot both be null`) — the hard-reject flavor of the class (not a silent no-op). RSDP writes `true` explicitly — live re-run converges, `describe-tag-option` confirms Active.

A declared-dimension FN probe also passed: CloudTrail `IsLogging` stop-logging out of band -> detected -> reverted -> live `get-trail-status` back to `true`.

## Determinations (no code change)

- **Composite-primaryIdentifier pack: zero gaps.** ServiceCatalog `PortfolioPrincipalAssociation` + `TagOptionAssociation`, AppRegistry `AttributeGroupAssociation`, aoss `AccessPolicy`, EC2 `SecurityGroupVpcAssociation`, Lex `BotVersion` + `BotAlias` all read via CC with zero `skipped` — registry-era types are natural composites (rule + evidence recorded in the hunt skill; the adapter gap class is legacy-generation only).
- **Post-update echo probe** (neutral `-c rev=2` redeploy) across all eight barest types: no new materialization.
- EC2::FlowLog service-requires `TrafficType` for VPC targets although the registry schema's `required` omits it (recorded in the fixture comment).

## Assets

- 18 promoted corpus cases, **9 genuinely new types** (SecurityGroupVpcAssociation, Lex BotAlias/BotVersion, aoss AccessPolicy, AppRegistry AttributeGroup/AttributeGroupAssociation, ServiceCatalog PortfolioPrincipalAssociation/TagOption/TagOptionAssociation) + barest variants of Canary/Trail/FlowLog/RUM/APS/CodeArtifact/Guardrail/WebACL.
- Regression fixtures `tests/integration/barest4-hunt/` + `tests/integration/ccpi-hunt/` (verify.sh asserts first-check CLEAN + zero skipped).
- Unit tests: `tests/noise-barest4-folds.test.ts` (12 tests: clean-zero, fold, and surface-on-change per type incl. the MEANINGFUL_WHEN_OFF off-flip) + 2 RSDP plan tests in `tests/revert-plan.test.ts`; the stale RUM assertion in `noise-and-strip.test.ts` updated.
- Hunt-skill lessons: registry-era natural-composite rule; hard-reject revert flavor + "piggyback the convergence probe on every new fold" cadence.

## Verification

- `vp run typecheck` / `vp check` / `vp pack` / `vp test run`: 304 files, 5911 tests, all green.
- measure-noise sweep over the new corpus: no new candidates (all reported candidates are pre-existing mutated-state pins).
- Live: all three stacks deleted via delstack; `sweep-orphans.sh` reports SWEEP CLEAN; bughunt gate released.
- Shared CORE integration suite deferred — the diff is fully covered by unit tests + corpus replay and was live-proven in this hunt (deferral logged per verify-pr section 7).
