### PR TITLE
fix(diff): surface wholesale out-of-band disables of all-boolean-object KNOWN_DEFAULTS pins (S3 PAB, SES options)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -361,7 +361,14 @@ or the fixture can never converge to zero (#1623). Batch 6 (2026-07-14, barest4/
 hunt): **RUM AppMonitor `CustomEvents`** no-oped (silent keep), and **ServiceCatalog
 TagOption `Active`** surfaced a FOURTH flavor — the handler REJECTS the bare remove
 outright (`InvalidRequest: Active and new value cannot both be null`), a hard error
-instead of a silent no-op; both fixed by RSDP entries. Piggyback the convergence
+instead of a silent no-op; both fixed by RSDP entries. Batch 7 (2026-07-14,
+`revconv5-hunt` fixture): Lambda `RecursiveLoop` + `RuntimeManagementConfig`, HTTP-API
+`DisableExecuteApiEndpoint`, SES ConfigurationSet `SendingOptions`/`ReputationOptions`,
+KinesisVideo `DataRetentionInHours`, CloudTrail `EventSelectors`, and S3
+`PublicAccessBlockConfiguration` ALL converged via the bare `remove` (0-in-8 no-op —
+the class has streaks; keep probing anyway, batches 4-5 were ~1-in-2). The batch's
+real payoff was the DETECTION side — see the all-boolean-object off-flip gotcha.
+Piggyback the convergence
 probe on every NEW KNOWN_DEFAULTS fold a hunt ships (mutate → revert → re-read) —
 it is ~1-in-3 to need an RSDP entry, and the probe is nearly free while the stack
 is still up.
@@ -598,14 +605,31 @@ Recorded]` breakdown with `--verbose`.
   Sanitize before committing: replace every occurrence with AWS's documented example
   id `AKIAIOSFODNN7EXAMPLE` (consistent replace keeps the case self-consistent;
   corpus-replay only needs internal equality) and re-run `corpus-replay` (#1526 PR).
-- **An off-flip FN candidate is real ONLY for a STANDALONE-boolean pin — object/array
-  pins are not swallowed.** `isTrivialEmpty` drops a bare `false`/`""`/`[]`/`{}`; a
-  `true` pinned INSIDE an object/array whose siblings are non-trivial (`ReadWriteType:
+- **An off-flip FN candidate is real for a STANDALONE-boolean pin OR an
+  ALL-BOOLEAN-object pin — mixed object/array pins are not swallowed.** `isTrivialEmpty`
+  drops a bare `false`/`""`/`[]`/`{}` AND an object whose every leaf is trivial; a
+  `true` pinned INSIDE an object whose siblings are non-trivial (`ReadWriteType:
 "All"`, `SSEAlgorithm:"AES256"`, `VersionNumber:1`) survives the flip — the flipped
   shape breaks the pin equality and surfaces normally. An offline audit of "unpaired
   true-pins" (the #1530 hunt) overcounted 9→4 for exactly this reason: before filing,
   check the pinned `true` stands ALONE at its path, and drop pins on immutable-revision
-  resources (ECS TaskDefinition) that cannot drift out of band.
+  resources (ECS TaskDefinition) that cannot drift out of band. But the INVERSE trap
+  (hunt 2026-07-14): a whole-object pin with ONLY boolean leaves (`SendingOptions:
+{SendingEnabled: true}`, the 4-flag S3 `PublicAccessBlockConfiguration`) flips
+  ALL-FALSE when every toggle is disabled, and the all-false object IS trivially empty —
+  swallowed before the pin gate exactly like a standalone bool (the GuardDuty
+  `DataSources` shape, #1092). The class is mechanically enumerable: scan
+  `KNOWN_DEFAULTS` for object pins whose leaves are all booleans, then live-probe each
+  for (a) OOB mutability (AmazonMQ `EncryptionOptions` = create-only, S3 AccessPoint
+  PABC = no mutate API, VpcLattice `SharingConfig` = update API can't flip it,
+  EMRServerless monitoring = service rejects the all-false state — all EXCLUDED) and
+  (b) the off-state READ shape (all-false object = fixable via `MEANINGFUL_WHEN_OFF`;
+  ABSENT-from-read like a deleted S3 PAB config = the separate vanished-undeclared-
+  default limitation, not fixable by a pin gate). The 2026-07-14 sweep confirmed +
+  fixed S3 Bucket PABC (check stayed CLEAN while a bucket was opened to public
+  access — the most security-critical FN found to date), SES ConfigurationSet
+  SendingOptions/ReputationOptions (live end-to-end), and SES EmailIdentity
+  DkimAttributes/FeedbackAttributes (CC-read-shape proven).
 - **A corpus promotion can PIN a live FP as `expected` — eyeball declared-tier findings
   before promoting.** The #1507 hunt promoted three RDS cases whose `expected` carried
   the mixed-case-name declared FP (`CdkrdHunt-Mixed-CPG` vs `cdkrdhunt-mixed-cpg`), so

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -676,7 +676,12 @@ curated `MEANINGFUL_WHEN_OFF` allowlist in `classify.ts` names the exact
 pin and surfaces them even on a first run; it is predicate-gated (NOT a blanket
 "any diverging `false` surfaces") because most "default true" booleans are
 CONDITIONAL — an SSE-KMS queue reads `SqsManagedSseEnabled:false` legitimately,
-so the predicate surfaces the OFF state only when the queue uses no KMS key. A
+so the predicate surfaces the OFF state only when the queue uses no KMS key. The
+same swallow applies to a pin whose value is an OBJECT with only boolean leaves
+— disabling every toggle flips it ALL-FALSE, which is equally trivially-empty
+(GuardDuty `DataSources` #1092; S3 `PublicAccessBlockConfiguration` + the SES
+ConfigurationSet / EmailIdentity option objects, hunt 2026-07-14) — so those
+whole-object pins carry entries too. A
 NESTED twin (`MEANINGFUL_WHEN_OFF_NESTED`) applies the same predicate-gated carve-out
 to `KNOWN_DEFAULT_PATHS`-pinned nested booleans that `emitNested` would otherwise
 swallow (e.g. CloudFront `DistributionConfig.IPV6Enabled` disabled out of band, #660);

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -312,6 +312,37 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // TerminateInstanceOnFailure=false silently starts leaking build instances on failure.
   'AWS::ImageBuilder::ImagePipeline': { EnhancedImageMetadataEnabled: () => true },
   'AWS::ImageBuilder::InfrastructureConfiguration': { TerminateInstanceOnFailure: () => true },
+  // A fresh SES configuration set always reads back BOTH toggles enabled (the KNOWN_DEFAULTS
+  // whole-object pins `SendingOptions: {SendingEnabled: true}` / `ReputationOptions:
+  // {ReputationMetricsEnabled: true}`; live-confirmed on a barest set, hunt 2026-07-14) and
+  // there is no restore/import path to an untouched `false`. An out-of-band
+  // `put-configuration-set-sending-options --no-sending-enabled` (or the reputation twin)
+  // flips the pin's object ALL-FALSE, which isTrivialEmpty would swallow before the pin gate
+  // — silently hiding a disable that stops ALL mail from the set (the GuardDuty
+  // `DataSources` shape, #1092). Both are unconditionally meaningful when off.
+  'AWS::SES::ConfigurationSet': {
+    SendingOptions: () => true,
+    ReputationOptions: () => true,
+  },
+  // The identity-level twins (same hunt, CC-read-shape live-proven on a CLI-created
+  // identity): a fresh identity always reads DkimAttributes {SigningEnabled: true} and
+  // FeedbackAttributes {EmailForwardingEnabled: true} (the KNOWN_DEFAULTS pins);
+  // `put-email-identity-dkim-attributes --no-signing-enabled` / the feedback twin flip each
+  // ALL-FALSE in the read. No restore/import path. Both unconditionally meaningful when off.
+  'AWS::SES::EmailIdentity': {
+    DkimAttributes: () => true,
+    FeedbackAttributes: () => true,
+  },
+  // The most security-critical member of the all-boolean-object class (hunt 2026-07-14,
+  // live-proven end-to-end on a fresh CFn bucket): an out-of-band `put-public-access-block`
+  // disabling ALL FOUR flags — opening the bucket to public ACLs/policies — reads back an
+  // all-false object that isTrivialEmpty swallowed, so `check` stayed CLEAN. A fresh bucket
+  // always reads the pin's all-true shape (S3's new-bucket default since 2023-04); a LEGACY
+  // or fully-deleted PAB config is ABSENT from the Cloud Control read (live-proven via
+  // `delete-public-access-block`), never all-false — so an all-false read is always an
+  // explicit out-of-band act. A PARTIAL disable keeps a `true` leaf (not trivially empty)
+  // and already surfaced; only the wholesale disable was invisible.
+  'AWS::S3::Bucket': { PublicAccessBlockConfiguration: () => true },
 };
 
 // #660 item 3: the NESTED twin of MEANINGFUL_WHEN_OFF. The table above gates TOP-LEVEL

--- a/tests/classify-allbool-offflip-hunt.test.ts
+++ b/tests/classify-allbool-offflip-hunt.test.ts
@@ -1,0 +1,102 @@
+// Hunt 2026-07-14 (all-boolean-object off-flip class closure): a KNOWN_DEFAULTS pin whose
+// value is an object with ONLY boolean leaves flips ALL-FALSE when every toggle is disabled
+// out of band, and isTrivialEmpty swallowed the all-false object BEFORE the pin gate — the
+// GuardDuty DataSources shape (#1092), re-found live on SES ConfigurationSet and then closed
+// for the whole class by a mechanical scan of KNOWN_DEFAULTS. Members fixed here:
+//   - AWS::S3::Bucket PublicAccessBlockConfiguration — live-proven END-TO-END on a fresh CFn
+//     bucket (us-east-1, CdkrdHuntRevconv5): `put-public-access-block` all-false left `check
+//     --fail` at exit 0 while the CC read carried the all-false object. The most
+//     security-critical member (the bucket is opened to public ACLs/policies).
+//   - AWS::SES::EmailIdentity DkimAttributes / FeedbackAttributes — CC-read-shape live-proven
+//     on a CLI-created identity (`--no-signing-enabled` / `--no-email-forwarding-enabled`
+//     each read back {SigningEnabled: false} / {EmailForwardingEnabled: false}).
+// Scanned and EXCLUDED with live/schema determinations: GuardDuty DataSources (already
+// guarded), ECR ImageScanningConfiguration (pin is false), AmazonMQ EncryptionOptions
+// (create-only), S3 AccessPoint PABC (no out-of-band mutate API), VpcLattice SharingConfig
+// (UpdateServiceNetwork cannot flip it), EMRServerless MonitoringConfiguration (the service
+// rejects the all-false state: "Either S3 Logging or Managed Debugging must be enabled").
+// A DELETED bucket PAB config is ABSENT from the read (not all-false) — the vanished-
+// undeclared-default limitation is a separate class, out of scope here.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('S3 Bucket PublicAccessBlockConfiguration wholesale off-flip (hunt 2026-07-14)', () => {
+  const res: DesiredResource = {
+    logicalId: 'TrailBucketA831CE63',
+    resourceType: 'AWS::S3::Bucket',
+    physicalId: 'cdkrdhuntrevconv5-trailbucketa831ce63-yfd2qczd2djh',
+    declared: {},
+  };
+  const pab = (v: boolean) => ({
+    RestrictPublicBuckets: v,
+    BlockPublicPolicy: v,
+    BlockPublicAcls: v,
+    IgnorePublicAcls: v,
+  });
+
+  it('folds the fresh-bucket all-true shape to atDefault (first-run stays CLEAN)', () => {
+    const f = classifyResource(res, { PublicAccessBlockConfiguration: pab(true) }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('PublicAccessBlockConfiguration');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band all-four disable (the live-proven FN)', () => {
+    const f = classifyResource(res, { PublicAccessBlockConfiguration: pab(false) }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['PublicAccessBlockConfiguration']);
+  });
+
+  it('a deleted PAB config (absent from the read) stays silent — no FP on legacy buckets', () => {
+    const f = classifyResource(res, {}, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});
+
+describe('SES EmailIdentity dkim/feedback off-flips (hunt 2026-07-14)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Identity',
+    resourceType: 'AWS::SES::EmailIdentity',
+    physicalId: 'cdkrd-hunt-offflip.example.com',
+    declared: { EmailIdentity: 'cdkrd-hunt-offflip.example.com' },
+  };
+  const live = (signing: boolean, forwarding: boolean) => ({
+    EmailIdentity: 'cdkrd-hunt-offflip.example.com',
+    DkimAttributes: { SigningEnabled: signing },
+    FeedbackAttributes: { EmailForwardingEnabled: forwarding },
+  });
+
+  it('folds the fresh-identity true shapes to atDefault', () => {
+    const f = classifyResource(res, live(true, true), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['DkimAttributes', 'FeedbackAttributes'])
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band --no-signing-enabled (DKIM disable)', () => {
+    const f = classifyResource(res, live(false, true), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['DkimAttributes']);
+  });
+
+  it('surfaces an out-of-band --no-email-forwarding-enabled', () => {
+    const f = classifyResource(res, live(true, false), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['FeedbackAttributes']);
+  });
+});

--- a/tests/classify-ses-configurationset-offflip.test.ts
+++ b/tests/classify-ses-configurationset-offflip.test.ts
@@ -1,0 +1,68 @@
+// Hunt 2026-07-14 (revconv5 batch): an out-of-band DISABLE of an SES ConfigurationSet's
+// SendingOptions.SendingEnabled or ReputationOptions.ReputationMetricsEnabled was invisible —
+// both KNOWN_DEFAULTS whole-object pins flip ALL-FALSE, which isTrivialEmpty swallowed before
+// the pin gate (the GuardDuty DataSources shape, #1092). Live-proven on a fresh barest set
+// (us-east-1, stack CdkrdHuntRevconv5): `put-configuration-set-sending-options
+// --no-sending-enabled` + the reputation twin left `check --fail` at exit 0 while the Cloud
+// Control read carried both `false` leaves. The paired MEANINGFUL_WHEN_OFF entries surface
+// them; the clean-deploy `true` shapes must still fold atDefault (no new first-run FP).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('SES ConfigurationSet sending/reputation off-flips (hunt 2026-07-14)', () => {
+  const res: DesiredResource = {
+    logicalId: 'SesCs',
+    resourceType: 'AWS::SES::ConfigurationSet',
+    physicalId: 'cdkrd-hunt-revconv5-cs',
+    declared: { Name: 'cdkrd-hunt-revconv5-cs' },
+  };
+  // The live Cloud Control read shape (copied from the 2026-07-14 live probe).
+  const live = (sending: boolean, reputation: boolean) => ({
+    Name: 'cdkrd-hunt-revconv5-cs',
+    SendingOptions: { SendingEnabled: sending },
+    ReputationOptions: { ReputationMetricsEnabled: reputation },
+  });
+
+  it('folds the clean-deploy true shapes to atDefault (first-run stays CLEAN)', () => {
+    const f = classifyResource(res, live(true, true), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['ReputationOptions', 'SendingOptions'])
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band --no-sending-enabled (the live-proven FN)', () => {
+    const f = classifyResource(res, live(false, true), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['SendingOptions']);
+    expect(pathsByTier(f, 'atDefault')).toContain('ReputationOptions');
+  });
+
+  it('surfaces an out-of-band --no-reputation-metrics-enabled', () => {
+    const f = classifyResource(res, live(true, false), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ReputationOptions']);
+    expect(pathsByTier(f, 'atDefault')).toContain('SendingOptions');
+  });
+
+  it('surfaces both when both are disabled out of band', () => {
+    const f = classifyResource(res, live(false, false), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ReputationOptions', 'SendingOptions']);
+  });
+});

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.Revconv5TwoActions.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.Revconv5TwoActions.json
@@ -1,0 +1,117 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ScaleTarget",
+    "resourceType": "AWS::ApplicationAutoScaling::ScalableTarget",
+    "physicalId": "table/CdkrdHuntRevconv5-ScaleTable58932DE6-13KQP326M3WH4|dynamodb:table:ReadCapacityUnits|dynamodb",
+    "constructPath": "CdkrdHuntRevconv5/ScaleTarget",
+    "declared": {
+      "MaxCapacity": 5,
+      "MinCapacity": 1,
+      "ResourceId": "table/CdkrdHuntRevconv5-ScaleTable58932DE6-13KQP326M3WH4",
+      "RoleARN": "arn:aws:iam::111111111111:role/CdkrdHuntRevconv5-ScalingRoleFEB16CD6-vqNIXTKUbxD0",
+      "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+      "ScheduledActions": [
+        {
+          "ScalableTargetAction": {
+            "MaxCapacity": 5,
+            "MinCapacity": 1
+          },
+          "Schedule": "at(2033-01-01T00:00:00)",
+          "ScheduledActionName": "zebra-cdkrd-hunt"
+        },
+        {
+          "ScalableTargetAction": {
+            "MaxCapacity": 4,
+            "MinCapacity": 2
+          },
+          "Schedule": "at(2033-06-01T00:00:00)",
+          "ScheduledActionName": "alpha-cdkrd-hunt"
+        }
+      ],
+      "ServiceNamespace": "dynamodb"
+    }
+  },
+  "liveRaw": {
+    "ScheduledActions": [
+      {
+        "ScheduledActionName": "alpha-cdkrd-hunt",
+        "Schedule": "at(2033-06-01T00:00:00)",
+        "ScalableTargetAction": {
+          "MinCapacity": 2,
+          "MaxCapacity": 4
+        }
+      },
+      {
+        "ScheduledActionName": "zebra-cdkrd-hunt",
+        "Schedule": "at(2033-01-01T00:00:00)",
+        "ScalableTargetAction": {
+          "MinCapacity": 1,
+          "MaxCapacity": 5
+        }
+      }
+    ],
+    "ResourceId": "table/CdkrdHuntRevconv5-ScaleTable58932DE6-13KQP326M3WH4",
+    "ServiceNamespace": "dynamodb",
+    "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+    "SuspendedState": {
+      "DynamicScalingOutSuspended": false,
+      "ScheduledScalingSuspended": false,
+      "DynamicScalingInSuspended": false
+    },
+    "Id": "table/CdkrdHuntRevconv5-ScaleTable58932DE6-13KQP326M3WH4|dynamodb:table:ReadCapacityUnits|dynamodb",
+    "MinCapacity": 1,
+    "MaxCapacity": 5
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["RoleARN"],
+    "createOnly": ["ResourceId", "ScalableDimension", "ServiceNamespace"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["RoleARN"],
+    "createOnlyPaths": ["ResourceId", "ScalableDimension", "ServiceNamespace"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["ScheduledActions"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "ScaleTarget",
+      "resourceType": "AWS::ApplicationAutoScaling::ScalableTarget",
+      "path": "RoleARN",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "table/CdkrdHuntRevconv5-ScaleTable58932DE6-13KQP326M3WH4|dynamodb:table:ReadCapacityUnits|dynamodb",
+      "constructPath": "CdkrdHuntRevconv5/ScaleTarget"
+    }
+  ]
+}

--- a/tests/integration/revconv5-hunt/app.ts
+++ b/tests/integration/revconv5-hunt/app.ts
@@ -1,0 +1,118 @@
+// CDK app for the cdk-real-drift revconv5 hunt: revert-convergence batch 7 over
+// KNOWN_DEFAULTS-folded MUTABLE props never probed for the silent-no-op revert class
+// (see hunt-bugs SKILL.md "revert non-convergence" — ~1-in-3 needs an RSDP entry):
+//   - Lambda::Function  RecursiveLoop ('Terminate') + RuntimeManagementConfig ({Auto})
+//   - ApiGatewayV2::Api (HTTP) DisableExecuteApiEndpoint (false)
+//   - SES::ConfigurationSet SendingOptions.SendingEnabled + ReputationOptions.
+//     ReputationMetricsEnabled (both true — off-flip candidates)
+//   - KinesisVideo::Stream DataRetentionInHours (0)
+//   - CloudTrail::Trail EventSelectors (management/All default array)
+// Plus two free ride-along probes:
+//   - AAS ScalableTarget with TWO ScheduledActions declared in non-alphabetical order
+//     (echo-reorder probe — the existing corpus/fixture only ever had one action)
+//   - every resource in its BAREST form → the first (pre-record) check doubles as a
+//     first-run FP probe, and a `-c rev=2` redeploy probes post-update echo.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnApi } from "aws-cdk-lib/aws-apigatewayv2";
+import { CfnScalableTarget } from "aws-cdk-lib/aws-applicationautoscaling";
+import { CfnTrail } from "aws-cdk-lib/aws-cloudtrail";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Effect, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnStream } from "aws-cdk-lib/aws-kinesisvideo";
+import { Code, Function as LambdaFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnConfigurationSet } from "aws-cdk-lib/aws-ses";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHuntRevconv5");
+// A neutral `-c rev=2` redeploy flips this tag on every taggable resource — a real
+// UpdateResource against each, probing post-update echo materialization for free.
+Tags.of(stack).add("cdkrd:rev", String(app.node.tryGetContext("rev") ?? "1"));
+
+// -- Lambda: RecursiveLoop + RuntimeManagementConfig probes (both undeclared) --
+const fn = new LambdaFunction(stack, "Fn", {
+  runtime: Runtime.NODEJS_22_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => 'ok';"),
+});
+
+// -- HTTP API: DisableExecuteApiEndpoint probe (undeclared, default false) --
+new CfnApi(stack, "HttpApi", {
+  name: "cdkrd-hunt-revconv5-http",
+  protocolType: "HTTP",
+});
+
+// -- SES ConfigurationSet: sending/reputation toggle probes (both undeclared true) --
+new CfnConfigurationSet(stack, "SesCs", { name: "cdkrd-hunt-revconv5-cs" });
+
+// -- Kinesis Video Stream: DataRetentionInHours probe (undeclared, default 0) --
+new CfnStream(stack, "Kvs", { name: "cdkrd-hunt-revconv5-kvs" });
+
+// -- CloudTrail: EventSelectors probe. Raw L1 so EventSelectors stays UNDECLARED
+//    (the L2 Trail declares management-event selectors, which would void the probe). --
+const trailBucket = new Bucket(stack, "TrailBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+trailBucket.addToResourcePolicy(
+  new PolicyStatement({
+    sid: "AWSCloudTrailAclCheck",
+    effect: Effect.ALLOW,
+    principals: [new ServicePrincipal("cloudtrail.amazonaws.com")],
+    actions: ["s3:GetBucketAcl"],
+    resources: [trailBucket.bucketArn],
+  }),
+);
+trailBucket.addToResourcePolicy(
+  new PolicyStatement({
+    sid: "AWSCloudTrailWrite",
+    effect: Effect.ALLOW,
+    principals: [new ServicePrincipal("cloudtrail.amazonaws.com")],
+    actions: ["s3:PutObject"],
+    resources: [trailBucket.arnForObjects("AWSLogs/*")],
+    conditions: { StringEquals: { "s3:x-amz-acl": "bucket-owner-full-control" } },
+  }),
+);
+const trail = new CfnTrail(stack, "Trail", {
+  trailName: "cdkrd-hunt-revconv5-trail",
+  s3BucketName: trailBucket.bucketName,
+  isLogging: true,
+});
+trail.node.addDependency(trailBucket.policy!);
+
+// -- AAS ScalableTarget: TWO ScheduledActions in non-alphabetical declared order --
+const table = new Table(stack, "ScaleTable", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  billingMode: BillingMode.PROVISIONED,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const scalingRole = new Role(stack, "ScalingRole", {
+  assumedBy: new ServicePrincipal("application-autoscaling.amazonaws.com"),
+});
+new CfnScalableTarget(stack, "ScaleTarget", {
+  serviceNamespace: "dynamodb",
+  resourceId: `table/${table.tableName}`,
+  scalableDimension: "dynamodb:table:ReadCapacityUnits",
+  minCapacity: 1,
+  maxCapacity: 5,
+  roleArn: scalingRole.roleArn,
+  scheduledActions: [
+    // one-shot schedules far in the future so neither ever fires; declared order
+    // (zebra before alpha) is deliberately NOT the alphabetical echo order
+    {
+      scheduledActionName: "zebra-cdkrd-hunt",
+      schedule: "at(2033-01-01T00:00:00)",
+      scalableTargetAction: { minCapacity: 1, maxCapacity: 5 },
+    },
+    {
+      scheduledActionName: "alpha-cdkrd-hunt",
+      schedule: "at(2033-06-01T00:00:00)",
+      scalableTargetAction: { minCapacity: 2, maxCapacity: 4 },
+    },
+  ],
+});
+
+// keep the linter quiet about the unused function handle (it is mutated out of band
+// by verify.sh via its physical name, resolved from the stack)
+void fn;

--- a/tests/integration/revconv5-hunt/cdk.json
+++ b/tests/integration/revconv5-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revconv5-hunt/package.json
+++ b/tests/integration/revconv5-hunt/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdk-real-drift-integ-revconv5-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift revconv5-hunt false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "npm@12.0.1"
+}

--- a/tests/integration/revconv5-hunt/verify.sh
+++ b/tests/integration/revconv5-hunt/verify.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# revconv5 hunt regression (real AWS): barest first-run FP probe + post-update echo probe
+# + the batch-7 revert-convergence / off-flip detection cycle over KNOWN_DEFAULTS-folded
+# mutable props (Lambda RecursiveLoop + RuntimeManagementConfig, HTTP API
+# DisableExecuteApiEndpoint, SES ConfigurationSet sending/reputation toggles, KinesisVideo
+# DataRetentionInHours, CloudTrail EventSelectors, S3 PublicAccessBlockConfiguration).
+# Hunt 2026-07-14 findings this pins live:
+#   - the SES ConfigurationSet + S3 Bucket PAB off-flips were INVISIBLE (all-boolean-object
+#     pins swallowed by isTrivialEmpty) — fixed via MEANINGFUL_WHEN_OFF entries
+#   - every probed prop converges via the bare `remove` revert (no RSDP entry needed)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntRevconv5
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record) MUST show zero Potential Drift ==="
+$CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-revconv5-first.out
+grep -q "Potential Drift" /tmp/cdkrd-revconv5-first.out && fail "first-run FP on a fresh barest deploy"
+
+echo "=== [$STACK] record ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] neutral rev=2 redeploy (post-update echo probe) ==="
+npx cdk deploy -f "$STACK" --require-approval never -c rev=2 || fail "rev=2 redeploy"
+$CLI check "$STACK" --region "$REGION" --fail
+[ "${PIPESTATUS[0]:-$?}" -eq 0 ] || fail "post-update echo materialized undeclared drift"
+
+echo "=== [$STACK] out-of-band mutations (all probes) ==="
+FN_NAME=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?LogicalResourceId=='Fn9270CBC0'].PhysicalResourceId" --output text)
+BUCKET=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?LogicalResourceId=='TrailBucketA831CE63'].PhysicalResourceId" --output text)
+API_ID=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?LogicalResourceId=='HttpApi'].PhysicalResourceId" --output text)
+aws lambda put-function-recursion-config --function-name "$FN_NAME" --recursive-loop Allow --region "$REGION" >/dev/null || fail "mutate recursion"
+aws lambda put-runtime-management-config --function-name "$FN_NAME" --update-runtime-on FunctionUpdate --region "$REGION" >/dev/null || fail "mutate rmc"
+aws apigatewayv2 update-api --api-id "$API_ID" --disable-execute-api-endpoint --region "$REGION" >/dev/null || fail "mutate api"
+aws sesv2 put-configuration-set-sending-options --configuration-set-name cdkrd-hunt-revconv5-cs --no-sending-enabled --region "$REGION" || fail "mutate ses send"
+aws sesv2 put-configuration-set-reputation-options --configuration-set-name cdkrd-hunt-revconv5-cs --no-reputation-metrics-enabled --region "$REGION" || fail "mutate ses rep"
+KVS_V=$(aws kinesisvideo describe-stream --stream-name cdkrd-hunt-revconv5-kvs --region "$REGION" --query StreamInfo.Version --output text)
+aws kinesisvideo update-data-retention --stream-name cdkrd-hunt-revconv5-kvs --current-version "$KVS_V" \
+  --operation INCREASE_DATA_RETENTION --data-retention-change-in-hours 24 --region "$REGION" || fail "mutate kvs"
+aws cloudtrail put-event-selectors --trail-name cdkrd-hunt-revconv5-trail \
+  --event-selectors '[{"ReadWriteType":"WriteOnly","IncludeManagementEvents":true}]' --region "$REGION" >/dev/null || fail "mutate trail"
+aws s3api put-public-access-block --bucket "$BUCKET" --region "$REGION" \
+  --public-access-block-configuration BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false || fail "mutate pab"
+
+echo "=== [$STACK] check MUST detect all 8 mutations (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-revconv5-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc"
+for p in RecursiveLoop RuntimeManagementConfig DisableExecuteApiEndpoint SendingOptions ReputationOptions DataRetentionInHours EventSelectors PublicAccessBlockConfiguration; do
+  grep -q "$p" /tmp/cdkrd-revconv5-detect.out || fail "mutation NOT detected: $p"
+done
+
+echo "=== [$STACK] revert MUST converge every probe (batch-7 result: all via bare remove) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+[ "$(aws lambda get-function-recursion-config --function-name "$FN_NAME" --region "$REGION" --query RecursiveLoop --output text)" = "Terminate" ] || fail "RecursiveLoop did not converge"
+[ "$(aws lambda get-runtime-management-config --function-name "$FN_NAME" --region "$REGION" --query UpdateRuntimeOn --output text)" = "Auto" ] || fail "RuntimeManagementConfig did not converge"
+[ "$(aws apigatewayv2 get-api --api-id "$API_ID" --region "$REGION" --query DisableExecuteApiEndpoint --output text)" = "False" ] || fail "DisableExecuteApiEndpoint did not converge"
+[ "$(aws sesv2 get-configuration-set --configuration-set-name cdkrd-hunt-revconv5-cs --region "$REGION" --query SendingOptions.SendingEnabled --output text)" = "True" ] || fail "SendingEnabled did not converge"
+[ "$(aws sesv2 get-configuration-set --configuration-set-name cdkrd-hunt-revconv5-cs --region "$REGION" --query ReputationOptions.ReputationMetricsEnabled --output text)" = "True" ] || fail "ReputationMetricsEnabled did not converge"
+[ "$(aws kinesisvideo describe-stream --stream-name cdkrd-hunt-revconv5-kvs --region "$REGION" --query StreamInfo.DataRetentionInHours --output text)" = "0" ] || fail "DataRetentionInHours did not converge"
+[ "$(aws cloudtrail get-event-selectors --trail-name cdkrd-hunt-revconv5-trail --region "$REGION" --query 'EventSelectors[0].ReadWriteType' --output text)" = "All" ] || fail "EventSelectors did not converge"
+[ "$(aws s3api get-public-access-block --bucket "$BUCKET" --region "$REGION" --query PublicAccessBlockConfiguration.BlockPublicAcls --output text)" = "True" ] || fail "PublicAccessBlockConfiguration did not converge"
+
+echo "=== [$STACK] final check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -179,6 +179,25 @@ resource_gone() {
       printf '%s' "$err" | grep -q 'ResourceNotFoundException' && return 0
       return 1
       ;;
+    emr-serverless)
+      # arn:aws:emr-serverless:<region>:<acct>:/applications/<appId> — an EMR Serverless
+      # application DELETED via DeleteApplication moves to the terminal TERMINATED state
+      # and STAYS both in GetApplication and the tag index for a retention period
+      # (observed live 2026-07-14: two CLI-probe apps deleted minutes earlier still
+      # listed, keeping the sweep RED). TERMINATED means deleted — nothing deletable
+      # remains — so it counts as gone, as does a definitive ResourceNotFoundException.
+      # Any other state (CREATED/STARTED/STOPPED/…) keeps the ORPHAN RED (fail-safe).
+      id="${arn##*/}"
+      [ -n "$id" ] || return 1
+      local emrstate
+      if ! emrstate="$(aws emr-serverless get-application --application-id "$id" --region "$REGION" \
+        --query 'application.state' --output text 2>&1)"; then
+        printf '%s' "$emrstate" | grep -q 'ResourceNotFoundException' && return 0
+        return 1
+      fi
+      [ "$(printf '%s' "$emrstate" | tr -d '[:space:]')" = "TERMINATED" ] && return 0
+      return 1
+      ;;
     ec2)
       # arn:aws:ec2:<region>:<acct>:vpc-endpoint/vpce-<id> — the second type observed
       # lingering in the RGT index after deletion (2026-07-10): DescribeVpcEndpoints

--- a/tests/integration/xstack-importvalue/app.ts
+++ b/tests/integration/xstack-importvalue/app.ts
@@ -1,0 +1,58 @@
+// CDK app for the cdk-real-drift CROSS-STACK (Fn::ImportValue) false-positive test.
+// No existing fixture is a multi-stack app: every one deploys a single stack, so the
+// cross-stack reference path — CDK auto-generating Outputs/Exports on the producer and
+// `Fn::ImportValue` in the consumer's DECLARED properties — has never been exercised
+// live end-to-end (only unit-tested via the intrinsic resolver's prefetched exports).
+// This is one of the most common real-world CDK shapes (any multi-stack app).
+//
+// The consumer embeds the imported values in several distinct declared positions:
+//   - SNS::Subscription.TopicArn        — a bare top-level Fn::ImportValue
+//   - SQS::QueuePolicy policy document  — Fn::ImportValue nested inside a policy Condition
+//     (created automatically by SqsSubscription for a cross-stack topic)
+//   - CloudWatch::Alarm Dimensions[].Value — Fn::ImportValue inside an object array
+//   - SSM::Parameter.Value              — a bare string-typed import
+// A freshly deployed + recorded app MUST report CLEAN on every stack, and the first
+// (pre-record) check must show ZERO [Potential Drift] and ZERO unresolved on these.
+import { App, Duration, Stack, Tags } from "aws-cdk-lib";
+import { Alarm, ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+const producer = new Stack(app, "CdkrdHuntXstkProd");
+const topic = new Topic(producer, "Topic");
+const producerQueue = new Queue(producer, "ProdQueue", {
+  visibilityTimeout: Duration.seconds(45),
+});
+
+const consumer = new Stack(app, "CdkrdHuntXstkCons");
+const consumerQueue = new Queue(consumer, "ConsQueue", {
+  visibilityTimeout: Duration.seconds(45),
+});
+
+// Cross-stack subscription: CDK places the Subscription (and the QueuePolicy granting
+// the topic) in the QUEUE's stack, importing the topic ARN from the producer.
+topic.addSubscription(new SqsSubscription(consumerQueue));
+
+// The producer queue's NAME crosses stacks into an alarm dimension value.
+new Alarm(consumer, "ProdQueueDepthAlarm", {
+  metric: new Metric({
+    namespace: "AWS/SQS",
+    metricName: "ApproximateNumberOfMessagesVisible",
+    dimensionsMap: { QueueName: producerQueue.queueName },
+    period: Duration.minutes(5),
+  }),
+  threshold: 100,
+  evaluationPeriods: 3,
+  comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+});
+
+// The topic ARN crosses stacks into a bare string-typed parameter value.
+new StringParameter(consumer, "TopicArnParam", {
+  parameterName: "/cdkrd-hunt/xstack/topic-arn",
+  stringValue: topic.topicArn,
+});

--- a/tests/integration/xstack-importvalue/cdk.json
+++ b/tests/integration/xstack-importvalue/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/xstack-importvalue/package.json
+++ b/tests/integration/xstack-importvalue/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-xstack-importvalue",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cross-stack Fn::ImportValue false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/xstack-importvalue/verify.sh
+++ b/tests/integration/xstack-importvalue/verify.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Cross-stack Fn::ImportValue false-positive integration test (real AWS):
+# deploy BOTH stacks -> first check (pre-record, all stacks) MUST show zero
+# [Potential Drift] and zero unresolved -> record -> check MUST be CLEAN.
+# Any drift/unresolved on the consumer's ImportValue-consuming declared props is a
+# cross-stack resolution bug (exports prefetch / intrinsic resolver).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+PROD=CdkrdHuntXstkProd
+CONS=CdkrdHuntXstkCons
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($PROD + $CONS) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f --all >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (xstack-importvalue): $*"; exit 1; }
+
+echo "=== [xstack] deploy both stacks ==="
+npx cdk deploy --all -f --require-approval never || fail "deploy"
+
+echo "=== [xstack] FIRST check (pre-record, all stacks) MUST show zero Potential Drift / unresolved ==="
+FIRST_OUT="/tmp/cdkrd-xstack-first.out"
+$CLI check --region "$REGION" | tee "$FIRST_OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -le 1 ] || fail "first check errored (exit $rc)"
+grep -q "Potential Drift" "$FIRST_OUT" && { echo "--- FIRST-RUN FP: undeclared value surfaced on a fresh cross-stack deploy ---"; fail "expected zero [Potential Drift] pre-record"; }
+grep -q "unresolved=" "$FIRST_OUT" && { echo "--- UNRESOLVED: an ImportValue-consuming declared prop did not resolve ---"; fail "expected zero unresolved"; }
+
+echo "=== [xstack] record (write baselines for both stacks) ==="
+$CLI record --region "$REGION" --yes || fail "record"
+
+echo "=== [xstack] check MUST be CLEAN ==="
+$CLI check --region "$REGION" --fail | tee "/tmp/cdkrd-xstack.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: cross-stack app reported drift on a clean recorded deploy ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS (xstack-importvalue)"


### PR DESCRIPTION
## Summary

/hunt-bugs round (2026-07-14d): 5 angles — free rate()-normalization probes, a first-ever CROSS-STACK (Fn::ImportValue) live fixture, a post-update echo + ScheduledActions-reorder probe, revert-convergence batch 7, and an all-boolean-object off-flip class-closure sweep. One FN bug CLASS found and fixed (5 table entries), everything live-verified, all stacks deleted + SWEEP CLEAN.

## The bug class (fixed): all-boolean-object KNOWN_DEFAULTS pins swallow the wholesale out-of-band disable

A `KNOWN_DEFAULTS` pin whose value is an object with ONLY boolean leaves flips ALL-FALSE when every toggle is disabled out of band; `isTrivialEmpty` swallowed the all-false object BEFORE the pin gate (the GuardDuty `DataSources` shape, #1092). Live-found on SES ConfigurationSet, then closed for the whole class by a mechanical scan of `KNOWN_DEFAULTS` + per-member live probes. New top-level `MEANINGFUL_WHEN_OFF` entries:

- **`AWS::S3::Bucket` `PublicAccessBlockConfiguration`** — the most security-critical FN found to date: `put-public-access-block` disabling all four flags (opening the bucket to public ACLs/policies) left `check --fail` at exit 0. Live-proven end-to-end on a fresh CFn bucket (detect → revert → live all-true restored → CLEAN). Partial disables already surfaced; a DELETED PAB config is ABSENT from the read (the separate vanished-undeclared-default limitation, out of scope).
- **`AWS::SES::ConfigurationSet` `SendingOptions` / `ReputationOptions`** — `--no-sending-enabled` (stops ALL mail from the set) + reputation twin, both invisible; live-proven end-to-end incl. revert convergence (bare `remove` restores both true).
- **`AWS::SES::EmailIdentity` `DkimAttributes` / `FeedbackAttributes`** — CC-read-shape proven on a CLI-created identity.

Scanned + EXCLUDED with determinations: GuardDuty DataSources (guarded), ECR ImageScanningConfiguration (false pin), AmazonMQ EncryptionOptions (create-only), S3 AccessPoint PABC (no mutate API), VpcLattice SharingConfig (update API can't flip it), EMRServerless MonitoringConfiguration (service rejects the all-false state).

## Clean determinations (the non-bug results)

- **Cross-stack Fn::ImportValue** (`xstack-importvalue`, first multi-stack fixture): producer/consumer app with imports in 4 declared positions (bare TopicArn, policy Condition, alarm Dimensions value, SSM Parameter value) — first check CLEAN, zero unresolved; SNS `RawMessageDelivery` OOB enable detected + revert converged.
- **Revert-convergence batch 7** (`revconv5-hunt`): Lambda `RecursiveLoop` + `RuntimeManagementConfig`, HTTP-API `DisableExecuteApiEndpoint`, SES CS toggles, KinesisVideo `DataRetentionInHours`, CloudTrail `EventSelectors`, S3 PABC — ALL converge via the bare `remove` (0-in-8 no-op; no new RSDP entries needed).
- **rate() normalization**: Events::Rule + SSM MaintenanceWindow store `rate(60 minutes)` / `rate(168 hours)` verbatim — no allowlist entry needed.
- **Post-update echo** (`-c rev=2` tag-flip redeploy over 13 resources) + **AAS ScheduledActions ×2 reorder**: CLEAN.

## Changes

- `src/diff/classify.ts` — 5 `MEANINGFUL_WHEN_OFF` entries (SES CS ×2, SES EmailIdentity ×2, S3 Bucket PABC), each with provenance comments.
- `tests/classify-ses-configurationset-offflip.test.ts` + `tests/classify-allbool-offflip-hunt.test.ts` — 10 unit tests (fail without the fix: 3+4 of them), live read shapes copied from the probes.
- `tests/integration/xstack-importvalue/` + `tests/integration/revconv5-hunt/` — the two hunt fixtures as committed regression integs (full FP/FN/revert pipelines in verify.sh).
- `tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.Revconv5TwoActions.json` — first multi-ScheduledActions corpus case.
- `.claude/skills/hunt-bugs/SKILL.md` — batch-7 results + the amended off-flip gotcha (all-boolean-object pins ARE swallowed; scan + probe recipe).

## Verification

- `vp run test` 5924 passed; new tests fail without the fix.
- Live A/B on `CdkrdHuntRevconv5` / `CdkrdHuntXstk{Prod,Cons}` (us-east-1): base binary missed the SES/S3 off-flips (exit 0), fixed binary surfaces them (exit 1) → revert → service-API-verified convergence → final CLEAN.
- All 3 stacks delstack-deleted; sweep-orphans SWEEP CLEAN; bughunt gate released.
