### PR TITLE
feat(baseline): detect out-of-band deletion of an atDefault-folded value via observed defaults (S3 PublicAccessBlockConfiguration)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -943,8 +943,24 @@ replace it — lives in [why-a-baseline-file.md](why-a-baseline-file.md).
   "completeResources": [ "<logicalIds the record snapshot fully covered>" ],
   "recordedPhysicalIds": { "<logicalId>": "<physical id at record>", ... },
   "recordedSourceFingerprints":
-    { "<logicalId>::<path>": "<declared-source hash>", ... } }
+    { "<logicalId>::<path>": "<declared-source hash>", ... },
+  "observedDefaults": [ { "logicalId", "resourceType", "path" }, ... ] }
 ```
+
+`observedDefaults` (additive, optional — #1637) records the CURATED top-level paths
+(`OBSERVED_DEFAULT_TRACKED_PATHS`, S3 `PublicAccessBlockConfiguration` first) that
+were observed AT their AWS default at record time — paths only, no value (the value
+IS the `KNOWN_DEFAULTS` pin). It exists because an atDefault-folded value DELETED
+out of band **vanishes from the Cloud Control read entirely** (live-proven:
+`aws s3api delete-public-access-block` opens the bucket to public ACLs/policies
+while every value-keyed mechanism — the pin gate, `MEANINGFUL_WHEN_OFF`, "appeared
+since record" — sees nothing). `applyBaseline` synthesizes an undeclared
+"observed default deleted since record" finding when an observed path yields NO
+undeclared-side finding on a positively-READ resource (unread / gone / replaced /
+re-typed / read-gapped / since-declared resources all stay silent, mirroring the
+removed-since-record guards), carrying the pin as `desired` so `revert` re-adds the
+default. Curated, NOT blanket: CC read shapes fluctuate across handler versions, so
+tracking every atDefault path would false-flag handler churn as deletion.
 
 `recordedPhysicalIds` (additive, optional — #674) records the PHYSICAL id each
 recorded-OR-snapshot-`complete` resource was captured against, so a later deploy

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -28,6 +28,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { deepEqual } from '../diff/drift-calculator.js';
 import { FREE_FORM_MAP_PARENTS, stripCcApiAwsManagedFields } from '../normalize/cc-api-strip.js';
+import { KNOWN_DEFAULTS } from '../normalize/noise.js';
 import { canonicalizeBaselineForCompare, canonicalizeForCompare } from '../normalize/pipeline.js';
 import {
   isRedactedHashSentinel,
@@ -44,6 +45,37 @@ export interface RecordedEntry {
   path: string;
   value: unknown;
 }
+
+// #1637: a top-level path OBSERVED at its AWS default at record time — a RecordedEntry
+// minus the value (the value IS the KNOWN_DEFAULTS pin, so storing it would only drift
+// from the table). Only paths in OBSERVED_DEFAULT_TRACKED_PATHS are captured.
+export interface ObservedDefaultEntry {
+  logicalId: string;
+  resourceType: string;
+  path: string;
+}
+
+// #1637: the CURATED (type -> top-level paths) set whose atDefault observation is
+// persisted into the baseline so a later out-of-band DELETION of the whole value (the
+// property VANISHES from the Cloud Control read — e.g. `aws s3api
+// delete-public-access-block`) surfaces as drift. Every other detection mechanism keys
+// on a live VALUE being present (the KNOWN_DEFAULTS equality gate, MEANINGFUL_WHEN_OFF
+// #1635, "appeared since record"), so a vanished unrecorded default is otherwise
+// invisible. Curated, NOT blanket: Cloud Control read shapes fluctuate across handler
+// versions (properties appear/disappear with no user action — the second-deploy-echo
+// hunts proved this), so tracking every atDefault path would false-flag handler churn
+// as "vanished". Add a path only when (a) its presence is stable on a clean resource
+// and (b) its deletion is a meaningful out-of-band act. Each entry's restore value for
+// revert is its KNOWN_DEFAULTS pin.
+export const OBSERVED_DEFAULT_TRACKED_PATHS: Record<string, readonly string[]> = {
+  // Live-proven (#1637, hunt 2026-07-14): `delete-public-access-block` removes the
+  // whole property from the CC read, silently opening the bucket to public
+  // ACLs/policies. A fresh bucket ALWAYS reads the all-true default (the KNOWN_DEFAULTS
+  // pin, S3's new-bucket default since 2023-04), so the observation is stable; a LEGACY
+  // bucket that never had a PAB config reads ABSENT at record time too — nothing is
+  // observed, so it can never false-flag.
+  'AWS::S3::Bucket': ['PublicAccessBlockConfiguration'],
+};
 
 export interface BaselineFile {
   schemaVersion: 1 | 2; // v1 files load fine; completeResources is absent (= nothing complete)
@@ -81,6 +113,13 @@ export interface BaselineFile {
   // matches and detection is fully preserved. Additive & OPTIONAL: old committed baselines
   // have none and keep today's behavior until the next `record` stamps it.
   recordedSourceFingerprints?: Record<string, string>;
+  // #1637: top-level paths observed AT their AWS default at record time (curated —
+  // OBSERVED_DEFAULT_TRACKED_PATHS only). An observed path with NO current
+  // undeclared-side finding on a positively-READ resource means the whole value was
+  // DELETED out of band (it vanished from the live read) — surfaced as drift with the
+  // KNOWN_DEFAULTS pin as the restore value. Additive & OPTIONAL: old committed
+  // baselines have none and keep today's behavior until the next `record` stamps it.
+  observedDefaults?: ObservedDefaultEntry[];
 }
 
 // #1048: the known top-level keys of a baseline file (the `BaselineFile` fields). Used to
@@ -97,6 +136,7 @@ const KNOWN_BASELINE_KEYS = new Set<string>([
   'completeResources',
   'recordedPhysicalIds',
   'recordedSourceFingerprints',
+  'observedDefaults',
 ]);
 // #1048: the known keys of a `recorded` array element. A typo'd key (`Value`, `vaule`) whose
 // intended `value` is then ABSENT reads as recorded `undefined` — a confirmed-drift false
@@ -255,6 +295,7 @@ export async function loadBaseline(
   validateCompleteResources(parsed.completeResources, path);
   validateRecordedPhysicalIds(parsed.recordedPhysicalIds, path);
   validateRecordedSourceFingerprints(parsed.recordedSourceFingerprints, path);
+  validateObservedDefaults(parsed.observedDefaults, path);
   return parsed;
 }
 
@@ -369,6 +410,35 @@ function validateRecordedSourceFingerprints(value: unknown, path: string): void 
     if (typeof v !== 'string') throw new Error(`${at}: "${key}" must map to a string`);
 }
 
+/**
+ * #1637: validate `observedDefaults` (optional). When present it must be an array of
+ * { logicalId, resourceType, path } string triples with no unknown keys — the same
+ * loud-vs-silent principle as validateRecordedEntry (a typo'd key silently disables the
+ * vanish detection this field exists to drive). No `value` field by design: the restore
+ * value is the KNOWN_DEFAULTS pin.
+ */
+function validateObservedDefaults(value: unknown, path: string): void {
+  if (value === undefined) return;
+  const at = `baseline file ${path}: \`observedDefaults\``;
+  if (!Array.isArray(value))
+    throw new Error(`${at} must be an array of { logicalId, resourceType, path }`);
+  value.forEach((entry, i) => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry))
+      throw new Error(`${at}[${i}] must be an object { logicalId, resourceType, path }`);
+    const obj = entry as Record<string, unknown>;
+    for (const k of ['logicalId', 'resourceType', 'path'] as const)
+      if (typeof obj[k] !== 'string')
+        throw new Error(`${at}[${i}]: "${k}" is required and must be a string`);
+    const unknown = Object.keys(obj).filter(
+      (k) => k !== 'logicalId' && k !== 'resourceType' && k !== 'path'
+    );
+    if (unknown.length > 0)
+      throw new Error(
+        `${at}[${i}]: unknown key(s) ${unknown.map((k) => `"${k}"`).join(', ')} — known keys: "logicalId", "resourceType", "path"`
+      );
+  });
+}
+
 /** Deterministic order for `recorded` entries: lexicographic by (logicalId, path).
  *  The single point where order is imposed — read/compare logic is order-independent,
  *  so this only affects the bytes on disk. Without it the entries inherit findings
@@ -447,6 +517,16 @@ export async function writeBaselineFile(b: BaselineFile): Promise<string> {
           recordedSourceFingerprints: sortedSourceFingerprints(
             b.recordedSourceFingerprints,
             b.recorded
+          ),
+        }
+      : {}),
+    // #1637: same byte-stability for the observed-default paths (sorted like `recorded`).
+    ...(b.observedDefaults && b.observedDefaults.length > 0
+      ? {
+          observedDefaults: [...b.observedDefaults].sort(
+            (a, c) =>
+              (a.logicalId < c.logicalId ? -1 : a.logicalId > c.logicalId ? 1 : 0) ||
+              (a.path < c.path ? -1 : a.path > c.path ? 1 : 0)
           ),
         }
       : {}),
@@ -590,8 +670,45 @@ export async function writeBaseline(
     // BaselineFile type). Carries the previous fingerprint for entries carried forward
     // unchanged, symmetric with buildRecordedPhysicalIds' prior-id fallback.
     ...buildRecordedSourceFingerprints(recorded, opts.declaredByLogical, opts.previous),
+    // #1637: persist the curated paths observed AT their AWS default this run, so a later
+    // out-of-band DELETION of the whole value (it vanishes from the live read) surfaces.
+    ...buildObservedDefaults(findings, opts.previous),
   });
   return { path, count: recorded.length };
+}
+
+/**
+ * #1637: build the `observedDefaults` entries for this record run. Seeds from THIS run's
+ * `atDefault` findings on the curated OBSERVED_DEFAULT_TRACKED_PATHS, then carries forward
+ * the previous baseline's entries for resources this run could NOT observe (a `skipped`
+ * finding — unread, symmetric with carryForwardUnreadable), so a transient read failure
+ * never silently drops the watch. A resource READ this run whose tracked value is ABSENT
+ * (already vanished, or a legacy resource that never had it) is deliberately NOT observed —
+ * re-recording ACCEPTS the current state, exactly like the recorded-value flow. Returns
+ * `{}` (spread to nothing) when empty so old-shaped baselines stay byte-identical.
+ */
+export function buildObservedDefaults(
+  findings: Finding[],
+  previous: BaselineFile | undefined
+): { observedDefaults?: ObservedDefaultEntry[] } {
+  const out: ObservedDefaultEntry[] = [];
+  const seen = new Set<string>();
+  for (const f of findings) {
+    if (f.tier !== 'atDefault') continue;
+    if (!OBSERVED_DEFAULT_TRACKED_PATHS[f.resourceType]?.includes(f.path)) continue;
+    const key = `${f.logicalId}\0${f.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ logicalId: f.logicalId, resourceType: f.resourceType, path: f.path });
+  }
+  const skipped = new Set(findings.filter((f) => f.tier === 'skipped').map((f) => f.logicalId));
+  for (const o of previous?.observedDefaults ?? []) {
+    const key = `${o.logicalId}\0${o.path}`;
+    if (seen.has(key) || !skipped.has(o.logicalId)) continue;
+    seen.add(key);
+    out.push(o);
+  }
+  return out.length > 0 ? { observedDefaults: out } : {};
 }
 
 /**
@@ -1778,6 +1895,54 @@ export function applyBaseline(
       desired: a.value,
       actual: undefined,
       note: 'baseline value removed since record',
+    });
+  }
+  // #1637: observed-default VANISH pass — the third synthesis family (after "removed since
+  // record" for recorded values and "recorded added resource removed"). An observedDefaults
+  // entry records that a curated top-level path READ AT ITS AWS DEFAULT at record time; if
+  // this run the resource was positively READ yet the path yields NO undeclared-side finding
+  // at all, the whole value was DELETED out of band (it vanished from the live read — e.g.
+  // `aws s3api delete-public-access-block`). Every guard mirrors the recorded-entry loop
+  // above, fail-safe toward silence: an unread / gone / replaced / re-typed / declared /
+  // read-gapped resource never fires. The restore value is the KNOWN_DEFAULTS pin (what was
+  // observed, by construction), so `revert` re-adds it via the existing
+  // actual-undefined + desired branch in revert/plan.ts.
+  const readGapLogical = new Set(
+    findings.filter((f) => f.tier === 'readGap').map((f) => f.logicalId)
+  );
+  for (const o of baseline.observedDefaults ?? []) {
+    if (currentPaths.has(`${o.logicalId}.${o.path}`)) continue; // value still present -> classify owns it
+    if (
+      recorded.some(
+        (a) => a.logicalId === o.logicalId && a.path === o.path && a.resourceType === o.resourceType
+      )
+    )
+      continue; // a recorded entry owns the path (its own removed-since-record loop covers it)
+    if (skippedLogical.has(o.logicalId)) continue; // unread this run -> not "vanished"
+    if (deletedLogical.has(o.logicalId)) continue; // whole resource gone -> `deleted` subsumes
+    if (!readParentLogical.has(o.logicalId)) continue; // no POSITIVE read proof -> fail-safe silence
+    if (readGapLogical.has(o.logicalId)) continue; // part of the live model unread -> may be behind the gap
+    if (isTypeVoid(o)) continue; // logicalId reused for a different type -> stale observation
+    if (replacedLogical.has(o.logicalId)) continue; // replaced -> fresh defaults; next record re-observes
+    if (currentLogicalIds !== undefined && !currentLogicalIds.has(o.logicalId)) continue; // removed from template
+    if (underDeclaredDrift(o.logicalId, o.path)) continue; // subsumed by parent declared drift
+    if (declaredPathIsPromoted(opts.declaredByLogical?.get(o.logicalId), o.path)) continue; // declared now -> declared tier owns it
+    kept.push({
+      tier: 'undeclared',
+      logicalId: o.logicalId,
+      resourceType: o.resourceType,
+      ...(opts.constructPathByLogical?.get(o.logicalId) !== undefined && {
+        constructPath: opts.constructPathByLogical.get(o.logicalId),
+      }),
+      ...(opts.physicalIdByLogical?.get(o.logicalId) !== undefined && {
+        physicalId: opts.physicalIdByLogical.get(o.logicalId),
+      }),
+      path: o.path,
+      // the restore value for revert: the default that was observed at record time. A pin
+      // missing from today's KNOWN_DEFAULTS (table refactor) degrades to detect-only.
+      desired: KNOWN_DEFAULTS[o.resourceType]?.[o.path],
+      actual: undefined,
+      note: 'observed default deleted since record (the whole value vanished from the live read)',
     });
   }
   if (promotedStale.length > 0) opts.warn?.(formatPromotedStaleNote(promotedStale));

--- a/tests/baseline-observed-defaults-1637.test.ts
+++ b/tests/baseline-observed-defaults-1637.test.ts
@@ -1,0 +1,185 @@
+// #1637: an atDefault-folded undeclared value DELETED out of band (the whole property
+// VANISHES from the Cloud Control read — live-proven: `aws s3api delete-public-access-block`
+// on a fresh bucket left `check --fail` at exit 0) was structurally invisible: every
+// detection mechanism keys on a live VALUE being present. The fix persists the curated
+// OBSERVED_DEFAULT_TRACKED_PATHS observations into the baseline (`observedDefaults`) at
+// record time, and applyBaseline synthesizes an undeclared "observed default deleted since
+// record" finding when an observed path yields NO finding on a positively-READ resource.
+// The restore value is the KNOWN_DEFAULTS pin, riding revert's existing
+// actual-undefined + desired branch.
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyBaseline,
+  buildObservedDefaults,
+  type BaselineFile,
+} from '../src/baseline/baseline-file.js';
+import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
+import type { Finding } from '../src/types.js';
+
+const S3 = 'AWS::S3::Bucket';
+const PAB = 'PublicAccessBlockConfiguration';
+const PAB_DEFAULT = KNOWN_DEFAULTS[S3]![PAB];
+
+function baseline(overrides: Partial<BaselineFile> = {}): BaselineFile {
+  return {
+    schemaVersion: 2,
+    stackName: 's',
+    region: 'r',
+    accountId: '111122223333',
+    capturedAt: '',
+    templateHash: '',
+    recorded: [],
+    completeResources: ['Bucket'],
+    observedDefaults: [{ logicalId: 'Bucket', resourceType: S3, path: PAB }],
+    ...overrides,
+  };
+}
+
+const finding = (tier: Finding['tier'], path: string, actual?: unknown): Finding => ({
+  tier,
+  logicalId: 'Bucket',
+  resourceType: S3,
+  path,
+  actual,
+});
+
+describe('#1637 buildObservedDefaults (record-time capture)', () => {
+  it('captures an atDefault finding on a tracked path', () => {
+    const out = buildObservedDefaults([finding('atDefault', PAB, PAB_DEFAULT)], undefined);
+    expect(out.observedDefaults).toEqual([{ logicalId: 'Bucket', resourceType: S3, path: PAB }]);
+  });
+
+  it('ignores untracked paths and non-atDefault tiers', () => {
+    const out = buildObservedDefaults(
+      [
+        finding('atDefault', 'VersioningConfiguration', { Status: 'Suspended' }),
+        finding('undeclared', PAB, { BlockPublicAcls: false }),
+      ],
+      undefined
+    );
+    expect(out).toEqual({});
+  });
+
+  it('carries a prior observation forward for a resource SKIPPED this run', () => {
+    const prev = baseline();
+    const out = buildObservedDefaults([finding('skipped', '')], prev);
+    expect(out.observedDefaults).toEqual([{ logicalId: 'Bucket', resourceType: S3, path: PAB }]);
+  });
+
+  it('drops a prior observation for a resource READ this run with the value ABSENT (re-record accepts)', () => {
+    const prev = baseline();
+    const out = buildObservedDefaults([finding('atDefault', 'OwnershipControls', {})], prev);
+    expect(out).toEqual({});
+  });
+});
+
+describe('#1637 applyBaseline vanish pass', () => {
+  it('surfaces an observed default whose value vanished from the read (the live-proven FN)', () => {
+    // The resource was positively read (an unrelated atDefault finding) but the tracked
+    // path yields NO finding at all — the delete-public-access-block shape.
+    const out = applyBaseline([finding('atDefault', 'OwnershipControls', {})], baseline(), {
+      physicalIdByLogical: new Map([['Bucket', 'my-bucket']]),
+    });
+    const vanished = out.find((f) => f.path === PAB);
+    expect(vanished).toBeDefined();
+    expect(vanished!.tier).toBe('undeclared');
+    expect(vanished!.actual).toBeUndefined();
+    expect(vanished!.desired).toEqual(PAB_DEFAULT); // the restore value for revert
+    expect(vanished!.physicalId).toBe('my-bucket');
+    expect(vanished!.note).toContain('deleted since record');
+  });
+
+  it('stays silent while the value is still present (any undeclared-side tier)', () => {
+    for (const tier of ['atDefault', 'undeclared'] as const) {
+      const out = applyBaseline([finding(tier, PAB, { BlockPublicAcls: true })], baseline(), {});
+      expect(out.filter((f) => f.path === PAB && f.actual === undefined)).toEqual([]);
+    }
+  });
+
+  it('stays silent on an unread (skipped) resource', () => {
+    const out = applyBaseline([finding('skipped', '')], baseline(), {});
+    expect(out.filter((f) => f.path === PAB)).toEqual([]);
+  });
+
+  it('stays silent on a deleted resource (the deleted finding subsumes it)', () => {
+    const out = applyBaseline([finding('deleted', '')], baseline(), {});
+    expect(out.filter((f) => f.path === PAB)).toEqual([]);
+  });
+
+  it('stays silent with no positive read proof at all (empty findings)', () => {
+    const out = applyBaseline([], baseline(), {});
+    expect(out.filter((f) => f.path === PAB)).toEqual([]);
+  });
+
+  it('stays silent when part of the live model was unreadable (readGap)', () => {
+    const out = applyBaseline(
+      [finding('atDefault', 'OwnershipControls', {}), finding('readGap', 'SomeProp')],
+      baseline(),
+      {}
+    );
+    expect(out.filter((f) => f.path === PAB && f.actual === undefined)).toEqual([]);
+  });
+
+  it('stays silent when the user has since DECLARED the path (declared tier owns it)', () => {
+    const out = applyBaseline([finding('atDefault', 'OwnershipControls', {})], baseline(), {
+      declaredByLogical: new Map([
+        ['Bucket', { [PAB]: { BlockPublicAcls: true } } as Record<string, unknown>],
+      ]),
+    });
+    expect(out.filter((f) => f.path === PAB)).toEqual([]);
+  });
+
+  it('stays silent on a REPLACED resource (fresh physical id, fresh defaults)', () => {
+    const out = applyBaseline(
+      [finding('atDefault', 'OwnershipControls', {})],
+      {
+        ...baseline(),
+        recordedPhysicalIds: { Bucket: 'old-bucket' },
+      },
+      {
+        physicalIdByLogical: new Map([['Bucket', 'new-bucket']]),
+      }
+    );
+    expect(out.filter((f) => f.path === PAB)).toEqual([]);
+  });
+
+  it('stays silent when the logicalId now hosts a DIFFERENT type', () => {
+    const out = applyBaseline(
+      [
+        {
+          tier: 'atDefault',
+          logicalId: 'Bucket',
+          resourceType: 'AWS::SNS::Topic',
+          path: 'FifoTopic',
+          actual: false,
+        },
+      ],
+      baseline(),
+      {}
+    );
+    expect(out.filter((f) => f.path === PAB)).toEqual([]);
+  });
+
+  it('defers to a recorded entry for the same path (removed-since-record owns it)', () => {
+    const out = applyBaseline(
+      [finding('atDefault', 'OwnershipControls', {})],
+      baseline({
+        recorded: [
+          { logicalId: 'Bucket', resourceType: S3, path: PAB, value: { BlockPublicAcls: false } },
+        ],
+      }),
+      {}
+    );
+    // exactly ONE synthetic for the path — the recorded-entry removal, not a duplicate vanish
+    const synthetic = out.filter((f) => f.path === PAB && f.actual === undefined);
+    expect(synthetic).toHaveLength(1);
+    expect(synthetic[0]!.note).toBe('baseline value removed since record');
+  });
+
+  it('stays silent when the resource was removed from the template', () => {
+    const out = applyBaseline([finding('atDefault', 'OwnershipControls', {})], baseline(), {
+      allLogicalIds: ['SomethingElse'],
+    });
+    expect(out.filter((f) => f.path === PAB)).toEqual([]);
+  });
+});

--- a/tests/integration/s3-pab-vanish/app.ts
+++ b/tests/integration/s3-pab-vanish/app.ts
@@ -1,0 +1,16 @@
+// CDK app for the cdk-real-drift #1637 vanished-observed-default integration test.
+// A barest bucket (no declared PublicAccessBlockConfiguration) reads the all-true
+// AWS default at deploy; `record` persists the observation (baseline
+// `observedDefaults`), and an out-of-band `aws s3api delete-public-access-block`
+// — which removes the WHOLE property from the Cloud Control read, silently opening
+// the bucket to public ACLs/policies — must surface as drift and revert back to
+// the all-true default. Pre-#1637 this deletion was structurally invisible (no
+// live value for any pin gate to see).
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdVerify1637PabVanish");
+
+new Bucket(stack, "Bucket", { removalPolicy: RemovalPolicy.DESTROY });

--- a/tests/integration/s3-pab-vanish/cdk.json
+++ b/tests/integration/s3-pab-vanish/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-pab-vanish/package.json
+++ b/tests/integration/s3-pab-vanish/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3-pab-vanish",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-pab-vanish false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3-pab-vanish/verify.sh
+++ b/tests/integration/s3-pab-vanish/verify.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# #1637 vanished-observed-default integration test (real AWS): deploy a barest bucket ->
+# record (persists the PublicAccessBlockConfiguration observation) -> out-of-band
+# `delete-public-access-block` (the whole value VANISHES from the Cloud Control read —
+# pre-#1637 this was structurally invisible) -> check MUST detect (exit 1) -> revert
+# MUST restore the all-true default -> final check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdVerify1637PabVanish
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN, then record ==="
+$CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-1637-first.out
+grep -q "Potential Drift" /tmp/cdkrd-1637-first.out && fail "first-run FP on a fresh bucket"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+grep -q '"observedDefaults"' .cdkrd/baselines/"$STACK".*.json || fail "record did not persist the PAB observation"
+
+echo "=== [$STACK] out-of-band delete-public-access-block ==="
+BUCKET=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)
+aws s3api delete-public-access-block --bucket "$BUCKET" --region "$REGION" || fail "delete-public-access-block"
+
+echo "=== [$STACK] check MUST detect the vanished default (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-1637-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc — the deletion is invisible"
+grep -q "observed default deleted since record" /tmp/cdkrd-1637-detect.out || fail "vanish note missing"
+
+echo "=== [$STACK] revert MUST restore the all-true default ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+[ "$(aws s3api get-public-access-block --bucket "$BUCKET" --region "$REGION" \
+  --query PublicAccessBlockConfiguration.BlockPublicAcls --output text)" = "True" ] || fail "PAB not restored"
+
+echo "=== [$STACK] final check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

Closes #1637 — the vanished-undeclared-default class filed as the follow-up to #1636/#1635: an atDefault-folded value DELETED out of band **vanishes from the Cloud Control read entirely**, so every value-keyed mechanism (KNOWN_DEFAULTS pin gate, MEANINGFUL_WHEN_OFF, "appeared since record") sees nothing. Live-proven: `aws s3api delete-public-access-block` opened a bucket to public ACLs/policies while `check --fail` stayed at exit 0.

## Mechanism

- **record**: persists the curated `OBSERVED_DEFAULT_TRACKED_PATHS` observations (S3 `PublicAccessBlockConfiguration` first) as baseline `observedDefaults` entries — `{logicalId, resourceType, path}` only, no value (the value IS the `KNOWN_DEFAULTS` pin). Carry-forward for skipped resources; a READ resource with the value absent drops the observation (re-record accepts current state).
- **applyBaseline**: the third synthesis family (after "removed since record" and "recorded added removed") — an observed path yielding NO undeclared-side finding on a positively-READ resource surfaces as undeclared "observed default deleted since record", with the pin as `desired`.
- **revert**: no plan change — the finding rides the existing actual-undefined + `desired` branch and re-adds the default.
- **Fail-safe guards** mirror the removed-since-record loop: skipped / deleted / replaced (#674) / re-typed (#793) / read-gapped / removed-from-template (#675) / since-declared (#1079) resources stay silent; a recorded entry for the same path defers to its own synthesis. Curated, NOT blanket (CC read-shape churn across handler versions must not false-flag).

## Compat

Additive optional baseline key, `schemaVersion` stays 2. An older cdkrd rejects the new key LOUDLY at load (#1048 guard — verified live against v0.19.2), the same accepted pre-release tradeoff as `recordedSourceFingerprints` (#1606).

## Verification

- 15 new unit tests (capture / carry-forward / vanish surfacing / every silence guard); `vp test run` 5940 passed.
- Live end-to-end (us-east-1, `CdkrdVerify1637PabVanish`): deploy barest bucket → record persists the observation → `delete-public-access-block` → check exits 1 with the vanish finding → revert restores all-true (service-API confirmed) → final check CLEAN. Committed as the `s3-pab-vanish` integ fixture.
- Stack delstack-deleted, sweep SWEEP CLEAN, gate released.
- Core suite deferred — additive baseline synthesis fully covered by units + the dedicated live fixture (explicit, not silent).
