### PR TITLE
fix(noise): fold 17 live-found first-run defaults + 4 revert set-default no-ops (2026-07-15 hunt)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -368,6 +368,13 @@ KinesisVideo `DataRetentionInHours`, CloudTrail `EventSelectors`, and S3
 `PublicAccessBlockConfiguration` ALL converged via the bare `remove` (0-in-8 no-op —
 the class has streaks; keep probing anyway, batches 4-5 were ~1-in-2). The batch's
 real payoff was the DETECTION side — see the all-boolean-object off-flip gotcha.
+Batch 8 (2026-07-15, misspack/lattice2/attach2 hunt, probed as piggybacks on that
+hunt's NEW folds rather than a dedicated fixture): **VpcLattice ResourceConfiguration
+`AllowAssociationToSharableServiceNetwork`**, **Backup RestoreTestingPlan
+`StartWindowHours` AND `ScheduleExpressionTimezone`** (same handler, both proven
+individually), and **EC2 TransitGatewayAttachment `Options`** ALL no-oped — 4-in-4
+for this batch's new folds (streaks run hot too); every one converged via an explicit
+CC `add` patch → plain RSDP entries (#1639/#1640/#1642).
 Piggyback the convergence
 probe on every NEW KNOWN_DEFAULTS fold a hunt ships (mutate → revert → re-read) —
 it is ~1-in-3 to need an RSDP entry, and the probe is nearly free while the stack
@@ -849,6 +856,25 @@ no-op` for the write-only RE-INCLUDE op every password-declaring resource carrie
   checkout's, run `verify` + `clear`, then `git -C <main> checkout --
 tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   fix lands permanently at merge. Never force-clear instead.
+- **The uncovered-type well is nearly dry — most remaining corpus-missing types are
+  dead, closed, or expensive, so audit ALIVENESS before building a fixture.** The
+  2026-07-15 sweep enumerated every corpus-missing type: the bulk are EOL/closed to
+  new customers (QLDB, CodeCommit, MediaStore, Evidently, Pinpoint, Timestream
+  LiveAnalytics, **S3 Object Lambda** — live create rejects with "available only to
+  existing customers", determined the hard way via a rolled-back deploy), account
+  singletons unsafe to touch (Macie/Inspector/Detective/SecurityLake), or
+  cost-prohibitive (ACMPCA $400/mo, FSx, EKS nodegroups, MWAA). The surviving cheap
+  tail (EMR SecurityConfiguration, SageMaker Pipeline/ModelPackageGroup, Transfer
+  Workflow, Location APIKey, SES DedicatedIpPool, XRay ResourcePolicy, Backup
+  RestoreTestingPlan, VpcLattice AuthPolicy/ALS/ResourceGateway/ResourceConfiguration/
+  SNVpcAssociation, TGW Attachment, SES CSED) was deployed by `misspack-hunt` /
+  `lattice2-hunt` / `attach2-hunt` — future hunts should pivot to variant/echo/
+  attachment/notation angles rather than re-mining the missing-type list. Also
+  determined there: same-account Oam::Link is REJECTED ("Cannot create a link to a
+  sink in the same account" — cross-account only, unprobeable solo), and a
+  lowercase-only-name service (VPC Lattice) mints its CFn generated name LOWERCASED
+  (`cdkrdhunt0715lattice-sn-<random>`), which the exact-case isCfnGeneratedName
+  branches missed until #1639.
 - **A clean result IS a result — but it must still leave an asset.** "6 common+rich
   stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do
   NOT manufacture a fix to have something to show. The deliverable of a bug-free

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -117,6 +117,11 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // registered in classify DEFAULT_SG_LIST_PATHS, so the prefetch must fire when an endpoint is
   // present or the OOB-swap gate loses its default-SG ids.
   'AWS::EC2::ClientVpnEndpoint',
+  // A VPC Lattice resource gateway that declares no SecurityGroupIds reads back its VPC's
+  // default SG (live, lattice2-hunt 2026-07-15) — registered in classify
+  // DEFAULT_SG_LIST_PATHS, so the prefetch must fire when a resource gateway is present or
+  // the OOB-swap gate loses its default-SG ids.
+  'AWS::VpcLattice::ResourceGateway',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -192,6 +192,13 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // 2026-07-14); an undeclared `false` is an out-of-band deactivate that blocks the option
   // from new provisioning — a bare false isTrivialEmpty would otherwise swallow.
   'AWS::ServiceCatalog::TagOption': { Active: () => true },
+  // A VPC Lattice resource configuration is always created with association-to-sharable-
+  // service-network allowed (the KNOWN_DEFAULTS true pin, lattice2-hunt 2026-07-15); an
+  // undeclared `false` is an out-of-band restriction a bare-false isTrivialEmpty would
+  // otherwise swallow.
+  'AWS::VpcLattice::ResourceConfiguration': {
+    AllowAssociationToSharableServiceNetwork: () => true,
+  },
   // SSE-SQS defaults ON, but is mutually exclusive with SSE-KMS: a queue that uses a KMS key
   // reads SqsManagedSseEnabled=false legitimately. Surface the OFF state only when the queue
   // uses no KMS key — i.e. encryption was genuinely disabled out of band.
@@ -557,6 +564,13 @@ export const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // sync with gather.ts DEFAULT_SG_LIST_TYPES. The association-echoed `VpcId` sibling is folded
   // via siblingClientVpnEndpointVpcs below.
   'AWS::EC2::ClientVpnEndpoint': 'SecurityGroupIds',
+  // A VPC Lattice resource gateway that declares no SecurityGroupIds reads back its VPC's
+  // default SG — the same single-SG AWS first-run default the ALB/ENI/Neptune cases fold
+  // (observed live, lattice2-hunt 2026-07-15). It is OOB-mutable (`vpc-lattice
+  // update-resource-gateway --security-group-ids`), so the derived VPC-default-SG gate
+  // folds the single default and surfaces an append/swap. Keep in sync with gather.ts
+  // DEFAULT_SG_LIST_TYPES.
+  'AWS::VpcLattice::ResourceGateway': 'SecurityGroupIds',
 };
 /** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
  *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into
@@ -1752,19 +1766,28 @@ function isCfnGeneratedName(
   // user-chosen name ending in `-<thisLogicalId>-<random>` is effectively impossible — value-
   // DEPENDENT, so a real user name (e.g. "my-custom-sg") still surfaces. Runs before the
   // constructPath gate so it folds regardless of whether the path survived.
+  // All dash-form comparisons below are CASE-INSENSITIVE: a lowercase-only-name service
+  // (VPC Lattice service network names must be lowercase) makes CFn mint the SAME
+  // `<stackName>-<logicalId>-<random>` form LOWERCASED ("CdkrdHunt0715Lattice" + "Sn" →
+  // "cdkrdhunt0715lattice-sn-f6xaf7zc2alb", observed live 2026-07-15), which the
+  // exact-case tests missed. Folding stays value-DEPENDENT — a user-chosen name equal to
+  // any casing of `<own stack>-<own logical id>-<12-char random>` is as implausible as
+  // the exact-case form, so the strictness rationale is unchanged.
+  const valueLc = value.toLowerCase();
   if (logicalId && CFN_RANDOM_SUFFIX.test(value)) {
-    const base = value.replace(CFN_RANDOM_SUFFIX, '');
-    if (base.length > logicalId.length && base.endsWith(`-${logicalId}`)) return true;
+    const base = valueLc.replace(CFN_RANDOM_SUFFIX, '');
+    const logicalLc = logicalId.toLowerCase();
+    if (base.length > logicalLc.length && base.endsWith(`-${logicalLc}`)) return true;
   }
   if (!constructPath) return false;
-  const stackName = constructPath.split('/')[0];
+  const stackName = constructPath.split('/')[0]?.toLowerCase();
   if (!stackName || !CFN_RANDOM_SUFFIX.test(value)) return false;
-  if (value.startsWith(`${stackName}-`)) return true;
+  if (valueLc.startsWith(`${stackName}-`)) return true;
   if (!logicalId) return false;
   // Truncated short-name form: `<stackPrefix>-<logicalIdPrefix>-<random>`. Logical ids are
   // alphanumeric (never '-'), so the LAST '-' in the de-suffixed base splits the two halves
   // even when the stack name itself contains dashes.
-  const base = value.replace(CFN_RANDOM_SUFFIX, '');
+  const base = valueLc.replace(CFN_RANDOM_SUFFIX, '');
   const sep = base.lastIndexOf('-');
   if (sep <= 0) return false;
   const stackPart = base.slice(0, sep);
@@ -1773,7 +1796,7 @@ function isCfnGeneratedName(
     stackPart.length < stackName.length &&
     stackName.startsWith(stackPart) &&
     logicalPart.length > 0 &&
-    logicalId.startsWith(logicalPart)
+    logicalId.toLowerCase().startsWith(logicalPart)
   );
 }
 

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -465,6 +465,70 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // ({enabled: false}) still surfaces. Observed live on a fresh vpclattice-listener
   // deploy (issue #483).
   'AWS::VpcLattice::ServiceNetwork': { SharingConfig: { enabled: true } },
+  // A VPC Lattice access log subscription attached without a ServiceNetworkLogType reads
+  // back the service default SERVICE (log service-network service traffic; the other enum
+  // value is RESOURCE for resource-configuration traffic). Equality-gated; a subscription
+  // switched to RESOURCE out of band still surfaces. Observed live on a fresh
+  // lattice2-hunt deploy (2026-07-15).
+  'AWS::VpcLattice::AccessLogSubscription': { ServiceNetworkLogType: 'SERVICE' },
+  // A barest VPC Lattice resource gateway (name/vpc/subnets only) reads back three service
+  // defaults the template never declared (observed live, lattice2-hunt 2026-07-15):
+  // IPV4 addressing, 16 IPv4 addresses per ENI, and PUBLIC DNS resolution for associated
+  // resource configurations. None are OOB-mutable (`update-resource-gateway` accepts only
+  // --security-group-ids, live-probed), so the equality-gated constants are purely
+  // first-run folds; a DUALSTACK / different-budget / PRIVATE gateway declares the value
+  // and is compared in the declared loop. (The undeclared SecurityGroupIds sibling is the
+  // VPC default SG — folded via the derived DEFAULT_SG_LIST_PATHS gate in classify.ts,
+  // #976 class, and it IS OOB-mutable so the swap/append gate keeps detection.)
+  'AWS::VpcLattice::ResourceGateway': {
+    IpAddressType: 'IPV4',
+    Ipv4AddressesPerEni: 16,
+    ResourceConfigDnsResolution: 'PUBLIC',
+  },
+  // A resource configuration created without AllowAssociationToSharableServiceNetwork
+  // reads back the service default `true`. A truthy standalone-boolean pin needs the
+  // paired classify.ts MEANINGFUL_WHEN_OFF entry (an out-of-band `false` — blocking the
+  // config from sharable service networks — is otherwise swallowed by isTrivialEmpty
+  // before the pin gate). Observed live on a fresh lattice2-hunt deploy (2026-07-15).
+  'AWS::VpcLattice::ResourceConfiguration': {
+    AllowAssociationToSharableServiceNetwork: true,
+  },
+  // A dedicated IP pool created with only a PoolName reads back the service default
+  // STANDARD scaling mode (the other enum value is MANAGED, which auto-leases billable
+  // IPs). Equality-gated; a pool converted to MANAGED out of band still surfaces.
+  // Observed live on a fresh misspack-hunt deploy (2026-07-15).
+  'AWS::SES::DedicatedIpPool': { ScalingMode: 'STANDARD' },
+  // A CodeDeploy application created without a ComputePlatform reads back the service
+  // default Server (the EC2/on-premises platform; the others are Lambda / ECS).
+  // createOnly — it can never drift out of band — so the equality-gated constant is a
+  // purely first-run fold. Observed live on a fresh echo3-hunt deploy (2026-07-15).
+  'AWS::CodeDeploy::Application': { ComputePlatform: 'Server' },
+  // A TGW VPC attachment created without Options reads back the whole creation-default
+  // options object (observed live on a fresh barest TGW + attachment, attach2-hunt
+  // 2026-07-15; note the ATTACHMENT-level DnsSupport default reads "disable" even though
+  // the TGW-level default is enable). Options IS OOB-mutable
+  // (`modify-transit-gateway-vpc-attachment --options`), so the equality-gated
+  // whole-object pin keeps detection: any option flipped out of band breaks the equality
+  // and the object surfaces. (Enum strings, not booleans — no isTrivialEmpty off-state
+  // hazard, so no MEANINGFUL_WHEN_OFF pairing is needed.)
+  'AWS::EC2::TransitGatewayAttachment': {
+    Options: {
+      DnsSupport: 'disable',
+      SecurityGroupReferencingSupport: 'enable',
+      Ipv6Support: 'disable',
+      ApplianceModeSupport: 'disable',
+    },
+  },
+  // A restore testing plan created with only the required selection/schedule reads back
+  // two top-level service defaults (documented + observed live, misspack-hunt
+  // 2026-07-15): a 24-hour start window and the Etc/UTC schedule timezone. Both are
+  // OOB-mutable (`backup update-restore-testing-plan`), so equality-gated constants keep
+  // detection. (The nested RecoveryPointSelection.SelectionWindowDays sibling folds via
+  // KNOWN_DEFAULT_PATHS — the selection block is partially declared and descends.)
+  'AWS::Backup::RestoreTestingPlan': {
+    StartWindowHours: 24,
+    ScheduleExpressionTimezone: 'Etc/UTC',
+  },
   // AmazonMQ Broker service defaults (observed live on the amazonmq-version-readgap
   // fixture): a broker created without these knobs reports all three as undeclared
   // first-run noise. AuthenticationStrategy is SIMPLE unless LDAP is configured;
@@ -2008,6 +2072,12 @@ export const KNOWN_DEFAULT_ONE_OF_PATHS: Record<string, Record<string, readonly 
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // A restore testing plan's RecoveryPointSelection declares only the required
+  // Algorithm/IncludeVaults/RecoveryPointTypes, so the block is partially declared and
+  // descends per-leaf: the service fills the documented 30-day selection window default.
+  // Equality-gated — a plan whose window was shortened/lengthened out of band still
+  // surfaces. Observed live on a fresh misspack-hunt deploy (2026-07-15).
+  'AWS::Backup::RestoreTestingPlan': { 'RecoveryPointSelection.SelectionWindowDays': 30 },
   // An IoT TopicRule that declares TopicRulePayload with only Sql + Actions reads back the
   // default `AwsIotSqlVersion: "2015-10-08"` — the older, stable compat default IoT assigns
   // when the version is unspecified (NOT a moving GA value). TopicRulePayload is partially
@@ -3591,6 +3661,16 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   declared loop). Fold value-independent (same class as the RDS KmsKeyId fold below). Corpus
   //   baked FP (#844).
   'AWS::Backup::BackupVault': new Set(['EncryptionKeyArn']),
+  //   AWS::Lambda::Version.Description — a version that declares no Description INHERITS the
+  //   FUNCTION's description at publish time (PublishVersion docs: "If not specified, the
+  //   function configuration's description is used"), so every CDK `currentVersion` of a
+  //   description-bearing function first-runs it as noise (observed live, echo3-hunt
+  //   2026-07-15). A published version is IMMUTABLE — the snapshot can never drift out of
+  //   band — and the inherited text lives on a DIFFERENT resource (the function, which may
+  //   even be cross-stack), so it is not reliably derivable here. Fold value-independent:
+  //   zero detection loss (immutable), and a user who pins a version description DECLARES
+  //   it, compared in the declared loop.
+  'AWS::Lambda::Version': new Set(['Description']),
   //   AWS::Batch::JobQueue.JobQueueType — a queue that declares no JobQueueType reads back
   //   the type AWS DERIVES from its attached compute environment (ECS_FARGATE for a Fargate
   //   CE, ECS for EC2, EKS for EKS). The value lives on a DIFFERENT resource (the CE), not in

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -282,6 +282,26 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // flavor of the class (not a silent no-op, a hard error). Write the `true` default (from
   // KNOWN_DEFAULTS) back explicitly.
   'AWS::ServiceCatalog::TagOption\0Active',
+  // lattice2 hunt (live-proven 2026-07-15): the VpcLattice UpdateResourceConfiguration
+  // handler IGNORES an omitted AllowAssociationToSharableServiceNetwork — an out-of-band
+  // `false` persisted through a `remove` revert (reported "reverted", convergence re-read
+  // false), while an explicit CC `add …: true` patch converges. Write the `true` default
+  // (from KNOWN_DEFAULTS) back explicitly.
+  'AWS::VpcLattice::ResourceConfiguration\0AllowAssociationToSharableServiceNetwork',
+  // misspack hunt (live-proven 2026-07-15, each property individually): the Backup
+  // UpdateRestoreTestingPlan handler IGNORES an omitted StartWindowHours AND an omitted
+  // ScheduleExpressionTimezone — an out-of-band 12 / America/New_York persisted through a
+  // `remove` revert (reported "reverted", convergence re-read the mutated value), while an
+  // explicit CC `add` patch converges. Write the 24 / Etc/UTC defaults (from
+  // KNOWN_DEFAULTS) back explicitly.
+  'AWS::Backup::RestoreTestingPlan\0StartWindowHours',
+  'AWS::Backup::RestoreTestingPlan\0ScheduleExpressionTimezone',
+  // attach2 hunt (live-proven 2026-07-15): the EC2 TransitGatewayAttachment handler
+  // IGNORES an omitted Options — an out-of-band DnsSupport=enable persisted through a
+  // `remove` revert (reported "reverted", convergence re-read enable), while an explicit
+  // CC `add` patch of the whole creation-default object converges. Write the Options
+  // default (from KNOWN_DEFAULTS) back explicitly.
+  'AWS::EC2::TransitGatewayAttachment\0Options',
   // Lambda UpdateFunctionUrlConfig IGNORES an omitted InvokeMode (live-proven on
   // revert-noop-probe 2026-07-14, #1583: a URL flipped BUFFERED->RESPONSE_STREAM out of
   // band, then `revert` planned a `remove`, reported reverted, yet the URL stayed

--- a/tests/corpus/AWS__Backup__RestoreTestingPlan.RestorePlan.json
+++ b/tests/corpus/AWS__Backup__RestoreTestingPlan.RestorePlan.json
@@ -1,0 +1,109 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RestorePlan",
+    "resourceType": "AWS::Backup::RestoreTestingPlan",
+    "physicalId": "cdkrd_hunt_0715_rtp",
+    "constructPath": "CdkrdHunt0715MissA/RestorePlan",
+    "declared": {
+      "RecoveryPointSelection": {
+        "Algorithm": "LATEST_WITHIN_WINDOW",
+        "IncludeVaults": ["*"],
+        "RecoveryPointTypes": ["SNAPSHOT"]
+      },
+      "RestoreTestingPlanName": "cdkrd_hunt_0715_rtp",
+      "ScheduleExpression": "cron(0 5 ? * MON *)",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ScheduleExpression": "cron(0 5 ? * MON *)",
+    "StartWindowHours": 24,
+    "RecoveryPointSelection": {
+      "SelectionWindowDays": 30,
+      "RecoveryPointTypes": ["SNAPSHOT"],
+      "IncludeVaults": ["*"],
+      "ExcludeVaults": [],
+      "Algorithm": "LATEST_WITHIN_WINDOW"
+    },
+    "RestoreTestingPlanArn": "arn:aws:backup:us-east-1:111111111111:restore-testing-plan:cdkrd_hunt_0715_rtp-6f9fda9d-03d8-4270-b95e-64a353444ae4",
+    "RestoreTestingPlanName": "cdkrd_hunt_0715_rtp",
+    "ScheduleExpressionTimezone": "Etc/UTC",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715MissA/a54a54d0-7f96-11f1-868c-1252f8d7fcb9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "RestorePlan",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0715MissA",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RestoreTestingPlanArn"],
+    "writeOnly": [],
+    "createOnly": ["RestoreTestingPlanName"],
+    "readOnlyPaths": ["RestoreTestingPlanArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RestoreTestingPlanName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "RecoveryPointSelection.ExcludeVaults",
+      "RecoveryPointSelection.IncludeVaults",
+      "RecoveryPointSelection.RecoveryPointTypes"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RestorePlan",
+      "resourceType": "AWS::Backup::RestoreTestingPlan",
+      "path": "StartWindowHours",
+      "actual": 24,
+      "physicalId": "cdkrd_hunt_0715_rtp",
+      "constructPath": "CdkrdHunt0715MissA/RestorePlan"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RestorePlan",
+      "resourceType": "AWS::Backup::RestoreTestingPlan",
+      "path": "ScheduleExpressionTimezone",
+      "actual": "Etc/UTC",
+      "physicalId": "cdkrd_hunt_0715_rtp",
+      "constructPath": "CdkrdHunt0715MissA/RestorePlan"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RestorePlan",
+      "resourceType": "AWS::Backup::RestoreTestingPlan",
+      "path": "RecoveryPointSelection.SelectionWindowDays",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "cdkrd_hunt_0715_rtp",
+      "constructPath": "CdkrdHunt0715MissA/RestorePlan"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeDeploy__Application.CdAppBarest.json
+++ b/tests/corpus/AWS__CodeDeploy__Application.CdAppBarest.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CdApp",
+    "resourceType": "AWS::CodeDeploy::Application",
+    "physicalId": "CdkrdHunt0715Echo3-CdApp-YBBgbqXWS3sn",
+    "constructPath": "CdkrdHunt0715Echo3/CdApp",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        },
+        {
+          "Key": "cdkrd:rev",
+          "Value": "2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ApplicationName": "CdkrdHunt0715Echo3-CdApp-YBBgbqXWS3sn",
+    "ComputePlatform": "Server",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "2",
+        "Key": "cdkrd:rev"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ApplicationName", "ComputePlatform"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApplicationName", "ComputePlatform"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CdApp",
+      "resourceType": "AWS::CodeDeploy::Application",
+      "path": "ComputePlatform",
+      "actual": "Server",
+      "physicalId": "CdkrdHunt0715Echo3-CdApp-YBBgbqXWS3sn",
+      "constructPath": "CdkrdHunt0715Echo3/CdApp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__TransitGatewayAttachment.TgwAttach.json
+++ b/tests/corpus/AWS__EC2__TransitGatewayAttachment.TgwAttach.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TgwAttach",
+    "resourceType": "AWS::EC2::TransitGatewayAttachment",
+    "physicalId": "tgw-attach-0bb26f80dca8fa797",
+    "constructPath": "CdkrdHunt0715Attach2/TgwAttach",
+    "declared": {
+      "SubnetIds": ["subnet-0896235b1d1f93cea"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TransitGatewayId": "tgw-0c7ec0b1cdf2ca982",
+      "VpcId": "vpc-015ba2924cb637b79"
+    }
+  },
+  "liveRaw": {
+    "Options": {
+      "Ipv6Support": "disable",
+      "ApplianceModeSupport": "disable",
+      "SecurityGroupReferencingSupport": "enable",
+      "DnsSupport": "disable"
+    },
+    "TransitGatewayId": "tgw-0c7ec0b1cdf2ca982",
+    "VpcId": "vpc-015ba2924cb637b79",
+    "Id": "tgw-attach-0bb26f80dca8fa797",
+    "SubnetIds": ["subnet-0896235b1d1f93cea"],
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0715Attach2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TgwAttach",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715Attach2/e1b86270-7f98-11f1-ae77-129b37054889",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["TransitGatewayId", "VpcId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TransitGatewayId", "VpcId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SubnetIds"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TgwAttach",
+      "resourceType": "AWS::EC2::TransitGatewayAttachment",
+      "path": "Options",
+      "actual": {
+        "Ipv6Support": "disable",
+        "ApplianceModeSupport": "disable",
+        "SecurityGroupReferencingSupport": "enable",
+        "DnsSupport": "disable"
+      },
+      "physicalId": "tgw-attach-0bb26f80dca8fa797",
+      "constructPath": "CdkrdHunt0715Attach2/TgwAttach"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EMR__SecurityConfiguration.EmrSecConfig.json
+++ b/tests/corpus/AWS__EMR__SecurityConfiguration.EmrSecConfig.json
@@ -1,0 +1,46 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EmrSecConfig",
+    "resourceType": "AWS::EMR::SecurityConfiguration",
+    "physicalId": "CdkrdHunt0715MissA-EmrSecConfig-IByt4m5FcQzf",
+    "constructPath": "CdkrdHunt0715MissA/EmrSecConfig",
+    "declared": {
+      "SecurityConfiguration": {
+        "EncryptionConfiguration": {
+          "EnableInTransitEncryption": false,
+          "EnableAtRestEncryption": false
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "SecurityConfiguration": {
+      "EncryptionConfiguration": {
+        "EnableAtRestEncryption": false,
+        "EnableInTransitEncryption": false
+      }
+    },
+    "Name": "CdkrdHunt0715MissA-EmrSecConfig-IByt4m5FcQzf"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name", "SecurityConfiguration"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "SecurityConfiguration"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__Version.FnVerInheritedDesc.json
+++ b/tests/corpus/AWS__Lambda__Version.FnVerInheritedDesc.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FnVer",
+    "resourceType": "AWS::Lambda::Version",
+    "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0715Echo3-Fn-v1FdsNKbQaBq:1",
+    "constructPath": "CdkrdHunt0715Echo3/FnVer",
+    "declared": {
+      "FunctionName": "CdkrdHunt0715Echo3-Fn-v1FdsNKbQaBq"
+    }
+  },
+  "liveRaw": {
+    "FunctionArn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0715Echo3-Fn-v1FdsNKbQaBq:1",
+    "FunctionName": "CdkrdHunt0715Echo3-Fn-v1FdsNKbQaBq",
+    "Description": "cdkrd echo3 rev1",
+    "RuntimePolicy": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Version": "1",
+    "CodeSha256": "5LxObmgqgeSSzmZ39Z6dXxyE4iHmDiqNc/M2yFxCT9Y="
+  },
+  "schema": {
+    "readOnly": ["FunctionArn", "Version"],
+    "writeOnly": [],
+    "createOnly": [
+      "CodeSha256",
+      "Description",
+      "FunctionName",
+      "ProvisionedConcurrencyConfig",
+      "RuntimePolicy"
+    ],
+    "readOnlyPaths": ["FunctionArn", "Version"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "CodeSha256",
+      "Description",
+      "FunctionName",
+      "ProvisionedConcurrencyConfig",
+      "RuntimePolicy"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "FnVer",
+      "resourceType": "AWS::Lambda::Version",
+      "path": "Description",
+      "actual": "cdkrd echo3 rev1",
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0715Echo3-Fn-v1FdsNKbQaBq:1",
+      "constructPath": "CdkrdHunt0715Echo3/FnVer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FnVer",
+      "resourceType": "AWS::Lambda::Version",
+      "path": "RuntimePolicy",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0715Echo3-Fn-v1FdsNKbQaBq:1",
+      "constructPath": "CdkrdHunt0715Echo3/FnVer"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "FnVer",
+      "resourceType": "AWS::Lambda::Version",
+      "path": "CodeSha256",
+      "actual": "5LxObmgqgeSSzmZ39Z6dXxyE4iHmDiqNc/M2yFxCT9Y=",
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0715Echo3-Fn-v1FdsNKbQaBq:1",
+      "constructPath": "CdkrdHunt0715Echo3/FnVer"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Location__APIKey.LocationKey.json
+++ b/tests/corpus/AWS__Location__APIKey.LocationKey.json
@@ -1,0 +1,79 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LocationKey",
+    "resourceType": "AWS::Location::APIKey",
+    "physicalId": "cdkrd-hunt-0715-key",
+    "constructPath": "CdkrdHunt0715MissA/LocationKey",
+    "declared": {
+      "KeyName": "cdkrd-hunt-0715-key",
+      "NoExpiry": true,
+      "Restrictions": {
+        "AllowActions": ["geo:GetMap*"],
+        "AllowResources": ["arn:aws:geo:us-east-1:111111111111:map/*"]
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "KeyName": "cdkrd-hunt-0715-key",
+    "Description": "",
+    "CreateTime": "2026-07-14T15:14:13.785Z",
+    "UpdateTime": "2026-07-14T15:14:13.785Z",
+    "KeyArn": "arn:aws:geo:us-east-1:111111111111:api-key/cdkrd-hunt-0715-key",
+    "Arn": "arn:aws:geo:us-east-1:111111111111:api-key/cdkrd-hunt-0715-key",
+    "Restrictions": {
+      "AllowActions": ["geo:GetMap*"],
+      "AllowResources": ["arn:aws:geo:us-east-1:111111111111:map/*"],
+      "AllowAndroidApps": [],
+      "AllowReferers": [],
+      "AllowAppleApps": []
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreateTime", "KeyArn", "UpdateTime"],
+    "writeOnly": ["ForceDelete", "ForceUpdate", "NoExpiry"],
+    "createOnly": ["KeyName"],
+    "readOnlyPaths": ["Arn", "CreateTime", "KeyArn", "UpdateTime"],
+    "writeOnlyPaths": ["ForceDelete", "ForceUpdate", "NoExpiry"],
+    "createOnlyPaths": ["KeyName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "Restrictions.AllowActions",
+      "Restrictions.AllowReferers",
+      "Restrictions.AllowResources"
+    ],
+    "unorderedObjectArrayPaths": ["Restrictions.AllowAndroidApps", "Restrictions.AllowAppleApps"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "LocationKey",
+      "resourceType": "AWS::Location::APIKey",
+      "path": "NoExpiry",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "cdkrd-hunt-0715-key",
+      "constructPath": "CdkrdHunt0715MissA/LocationKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SES__DedicatedIpPool.SesPool.json
+++ b/tests/corpus/AWS__SES__DedicatedIpPool.SesPool.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SesPool",
+    "resourceType": "AWS::SES::DedicatedIpPool",
+    "physicalId": "cdkrd-hunt-0715-pool",
+    "constructPath": "CdkrdHunt0715MissA/SesPool",
+    "declared": {
+      "PoolName": "cdkrd-hunt-0715-pool",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PoolName": "cdkrd-hunt-0715-pool",
+    "ScalingMode": "STANDARD",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0715MissA",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SesPool",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715MissA/a54a54d0-7f96-11f1-868c-1252f8d7fcb9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["PoolName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PoolName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SesPool",
+      "resourceType": "AWS::SES::DedicatedIpPool",
+      "path": "ScalingMode",
+      "actual": "STANDARD",
+      "physicalId": "cdkrd-hunt-0715-pool",
+      "constructPath": "CdkrdHunt0715MissA/SesPool"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SageMaker__ModelPackageGroup.MpGroup.json
+++ b/tests/corpus/AWS__SageMaker__ModelPackageGroup.MpGroup.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MpGroup",
+    "resourceType": "AWS::SageMaker::ModelPackageGroup",
+    "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:model-package-group/cdkrd-hunt-0715-mpg",
+    "constructPath": "CdkrdHunt0715MissB/MpGroup",
+    "declared": {
+      "ModelPackageGroupName": "cdkrd-hunt-0715-mpg",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ModelPackageGroupArn": "arn:aws:sagemaker:us-east-1:111111111111:model-package-group/cdkrd-hunt-0715-mpg",
+    "ModelPackageGroupName": "cdkrd-hunt-0715-mpg",
+    "CreationTime": "2026-07-14T15:12:16.241Z",
+    "ModelPackageGroupStatus": "Completed",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreationTime", "ModelPackageGroupArn", "ModelPackageGroupStatus"],
+    "writeOnly": [],
+    "createOnly": ["ModelPackageGroupDescription", "ModelPackageGroupName"],
+    "readOnlyPaths": ["CreationTime", "ModelPackageGroupArn", "ModelPackageGroupStatus"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ModelPackageGroupDescription", "ModelPackageGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SageMaker__Pipeline.SmPipeline.json
+++ b/tests/corpus/AWS__SageMaker__Pipeline.SmPipeline.json
@@ -1,0 +1,68 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SmPipeline",
+    "resourceType": "AWS::SageMaker::Pipeline",
+    "physicalId": "cdkrd-hunt-0715-pipeline",
+    "constructPath": "CdkrdHunt0715MissB/SmPipeline",
+    "declared": {
+      "PipelineDefinition": {
+        "PipelineDefinitionBody": "{\"Version\":\"2020-12-01\",\"Metadata\":{},\"Parameters\":[],\"Steps\":[{\"Name\":\"NoOp\",\"Type\":\"Fail\",\"Arguments\":{\"ErrorMessage\":\"noop\"}}]}"
+      },
+      "PipelineName": "cdkrd-hunt-0715-pipeline",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0715MissB-SmRole5F1DF09B-tqSAR1x3heYF",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PipelineName": "cdkrd-hunt-0715-pipeline",
+    "PipelineDisplayName": "cdkrd-hunt-0715-pipeline",
+    "PipelineDefinition": {
+      "PipelineDefinitionBody": "{\"Version\":\"2020-12-01\",\"Metadata\":{},\"Parameters\":[],\"Steps\":[{\"Name\":\"NoOp\",\"Type\":\"Fail\",\"Arguments\":{\"ErrorMessage\":\"noop\"}}]}"
+    },
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0715MissB-SmRole5F1DF09B-tqSAR1x3heYF",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0715MissB",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SmPipeline",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715MissB/5f7a0450-7f96-11f1-b4a1-1288903a1295",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["PipelineName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PipelineName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Transfer__Workflow.TransferWorkflow.json
+++ b/tests/corpus/AWS__Transfer__Workflow.TransferWorkflow.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TransferWorkflow",
+    "resourceType": "AWS::Transfer::Workflow",
+    "physicalId": "w-c5307bc89089912f1",
+    "constructPath": "CdkrdHunt0715MissA/TransferWorkflow",
+    "declared": {
+      "Steps": [
+        {
+          "DeleteStepDetails": {
+            "Name": "del"
+          },
+          "Type": "DELETE"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Steps": [
+      {
+        "Type": "DELETE",
+        "DeleteStepDetails": {
+          "SourceFileLocation": "${previous.file}",
+          "Name": "del"
+        }
+      }
+    ],
+    "Description": "",
+    "WorkflowId": "w-c5307bc89089912f1",
+    "Arn": "arn:aws:transfer:us-east-1:111111111111:workflow/w-c5307bc89089912f1",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715MissA/a54a54d0-7f96-11f1-868c-1252f8d7fcb9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "TransferWorkflow",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0715MissA",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "WorkflowId"],
+    "writeOnly": [],
+    "createOnly": ["Description", "OnExceptionSteps", "Steps"],
+    "readOnlyPaths": ["Arn", "WorkflowId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Description", "OnExceptionSteps", "Steps"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__VpcLattice__AccessLogSubscription.SnAls.json
+++ b/tests/corpus/AWS__VpcLattice__AccessLogSubscription.SnAls.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SnAls",
+    "resourceType": "AWS::VpcLattice::AccessLogSubscription",
+    "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:accesslogsubscription/als-050c9df2d22eadb57",
+    "constructPath": "CdkrdHunt0715Lattice/SnAls",
+    "declared": {
+      "DestinationArn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkrdHunt0715Lattice-SnLogs-NEv86TpqRYhh:*",
+      "ResourceIdentifier": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ResourceArn": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+    "ResourceId": "sn-035847d35c755a015",
+    "ServiceNetworkLogType": "SERVICE",
+    "Id": "als-050c9df2d22eadb57",
+    "Arn": "arn:aws:vpc-lattice:us-east-1:111111111111:accesslogsubscription/als-050c9df2d22eadb57",
+    "DestinationArn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkrdHunt0715Lattice-SnLogs-NEv86TpqRYhh:*",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0715Lattice",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715Lattice/7d0d3bf0-7f95-11f1-8193-12502256672f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "SnAls",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id", "ResourceArn", "ResourceId"],
+    "writeOnly": ["ResourceIdentifier"],
+    "createOnly": ["ResourceIdentifier"],
+    "readOnlyPaths": ["Arn", "Id", "ResourceArn", "ResourceId"],
+    "writeOnlyPaths": ["ResourceIdentifier"],
+    "createOnlyPaths": ["ResourceIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "SnAls",
+      "resourceType": "AWS::VpcLattice::AccessLogSubscription",
+      "path": "ResourceIdentifier",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:accesslogsubscription/als-050c9df2d22eadb57",
+      "constructPath": "CdkrdHunt0715Lattice/SnAls"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SnAls",
+      "resourceType": "AWS::VpcLattice::AccessLogSubscription",
+      "path": "ServiceNetworkLogType",
+      "actual": "SERVICE",
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:accesslogsubscription/als-050c9df2d22eadb57",
+      "constructPath": "CdkrdHunt0715Lattice/SnAls"
+    }
+  ]
+}

--- a/tests/corpus/AWS__VpcLattice__AuthPolicy.SnAuthPolicy.json
+++ b/tests/corpus/AWS__VpcLattice__AuthPolicy.SnAuthPolicy.json
@@ -1,0 +1,58 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SnAuthPolicy",
+    "resourceType": "AWS::VpcLattice::AuthPolicy",
+    "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+    "constructPath": "CdkrdHunt0715Lattice/SnAuthPolicy",
+    "declared": {
+      "Policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "vpc-lattice-svcs:Invoke",
+            "Resource": "*"
+          }
+        ]
+      },
+      "ResourceIdentifier": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015"
+    }
+  },
+  "liveRaw": {
+    "Policy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "vpc-lattice-svcs:Invoke",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": "*"
+        }
+      ]
+    },
+    "ResourceIdentifier": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+    "State": "Inactive"
+  },
+  "schema": {
+    "readOnly": ["State"],
+    "writeOnly": [],
+    "createOnly": ["ResourceIdentifier"],
+    "readOnlyPaths": ["State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ResourceIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__VpcLattice__ResourceConfiguration.Rc.json
+++ b/tests/corpus/AWS__VpcLattice__ResourceConfiguration.Rc.json
@@ -1,0 +1,102 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rc",
+    "resourceType": "AWS::VpcLattice::ResourceConfiguration",
+    "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:resourceconfiguration/rcfg-03ff8edffe8ef9ec1",
+    "constructPath": "CdkrdHunt0715Lattice/Rc",
+    "declared": {
+      "Name": "cdkrd-hunt-0715-rc",
+      "PortRanges": ["80"],
+      "ProtocolType": "TCP",
+      "ResourceConfigurationDefinition": {
+        "IpResource": "10.0.0.10"
+      },
+      "ResourceConfigurationType": "SINGLE",
+      "ResourceGatewayId": "rgw-062fc1eeaf119a6f6",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AllowAssociationToSharableServiceNetwork": true,
+    "ProtocolType": "TCP",
+    "ResourceConfigurationType": "SINGLE",
+    "PortRanges": ["80"],
+    "ResourceConfigurationDefinition": {
+      "IpResource": "10.0.0.10"
+    },
+    "Id": "rcfg-03ff8edffe8ef9ec1",
+    "ResourceGatewayId": "rgw-062fc1eeaf119a6f6",
+    "Arn": "arn:aws:vpc-lattice:us-east-1:111111111111:resourceconfiguration/rcfg-03ff8edffe8ef9ec1",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0715Lattice",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715Lattice/7d0d3bf0-7f95-11f1-8193-12502256672f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Rc",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-hunt-0715-rc"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": ["ResourceConfigurationAuthType", "ResourceConfigurationGroupId"],
+    "createOnly": [
+      "CustomDomainName",
+      "DomainVerificationId",
+      "GroupDomain",
+      "ProtocolType",
+      "ResourceConfigurationAuthType",
+      "ResourceConfigurationType",
+      "ResourceGatewayId"
+    ],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": ["ResourceConfigurationAuthType", "ResourceConfigurationGroupId"],
+    "createOnlyPaths": [
+      "CustomDomainName",
+      "DomainVerificationId",
+      "GroupDomain",
+      "ProtocolType",
+      "ResourceConfigurationAuthType",
+      "ResourceConfigurationType",
+      "ResourceGatewayId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["PortRanges"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Rc",
+      "resourceType": "AWS::VpcLattice::ResourceConfiguration",
+      "path": "AllowAssociationToSharableServiceNetwork",
+      "actual": true,
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:resourceconfiguration/rcfg-03ff8edffe8ef9ec1",
+      "constructPath": "CdkrdHunt0715Lattice/Rc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__VpcLattice__ResourceGateway.Rg.json
+++ b/tests/corpus/AWS__VpcLattice__ResourceGateway.Rg.json
@@ -1,0 +1,118 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rg",
+    "resourceType": "AWS::VpcLattice::ResourceGateway",
+    "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:resourcegateway/rgw-062fc1eeaf119a6f6",
+    "constructPath": "CdkrdHunt0715Lattice/Rg",
+    "declared": {
+      "Name": "cdkrd-hunt-0715-rg",
+      "SubnetIds": ["subnet-0c0b4b233f636f0f9"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcIdentifier": "vpc-0d262ec8c83e7881e"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "IPV4",
+    "VpcIdentifier": "vpc-0d262ec8c83e7881e",
+    "Ipv4AddressesPerEni": 16,
+    "Id": "rgw-062fc1eeaf119a6f6",
+    "ResourceConfigDnsResolution": "PUBLIC",
+    "Arn": "arn:aws:vpc-lattice:us-east-1:111111111111:resourcegateway/rgw-062fc1eeaf119a6f6",
+    "SubnetIds": ["subnet-0c0b4b233f636f0f9"],
+    "SecurityGroupIds": ["sg-0722af66254639599"],
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "Rg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0715Lattice",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715Lattice/7d0d3bf0-7f95-11f1-8193-12502256672f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "cdkrd-hunt-0715-rg"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "ResourceConfigDnsResolution",
+      "SubnetIds",
+      "VpcIdentifier"
+    ],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "ResourceConfigDnsResolution",
+      "SubnetIds",
+      "VpcIdentifier"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SecurityGroupIds", "SubnetIds"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Rg",
+      "resourceType": "AWS::VpcLattice::ResourceGateway",
+      "path": "IpAddressType",
+      "actual": "IPV4",
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:resourcegateway/rgw-062fc1eeaf119a6f6",
+      "constructPath": "CdkrdHunt0715Lattice/Rg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Rg",
+      "resourceType": "AWS::VpcLattice::ResourceGateway",
+      "path": "Ipv4AddressesPerEni",
+      "actual": 16,
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:resourcegateway/rgw-062fc1eeaf119a6f6",
+      "constructPath": "CdkrdHunt0715Lattice/Rg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Rg",
+      "resourceType": "AWS::VpcLattice::ResourceGateway",
+      "path": "ResourceConfigDnsResolution",
+      "actual": "PUBLIC",
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:resourcegateway/rgw-062fc1eeaf119a6f6",
+      "constructPath": "CdkrdHunt0715Lattice/Rg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Rg",
+      "resourceType": "AWS::VpcLattice::ResourceGateway",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-0722af66254639599"],
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:resourcegateway/rgw-062fc1eeaf119a6f6",
+      "constructPath": "CdkrdHunt0715Lattice/Rg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__VpcLattice__ServiceNetwork.SnLowercaseGenName.json
+++ b/tests/corpus/AWS__VpcLattice__ServiceNetwork.SnLowercaseGenName.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Sn",
+    "resourceType": "AWS::VpcLattice::ServiceNetwork",
+    "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+    "constructPath": "CdkrdHunt0715Lattice/Sn",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "LastUpdatedAt": "2026-07-14T15:05:57.150Z",
+    "SharingConfig": {
+      "enabled": true
+    },
+    "CreatedAt": "2026-07-14T15:05:57.150Z",
+    "Id": "sn-035847d35c755a015",
+    "AuthType": "NONE",
+    "Arn": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+    "Tags": [
+      {
+        "Value": "Sn",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0715Lattice",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715Lattice/7d0d3bf0-7f95-11f1-8193-12502256672f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "cdkrdhunt0715lattice-sn-f6xaf7zc2alb"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreatedAt", "Id", "LastUpdatedAt"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "CreatedAt", "Id", "LastUpdatedAt"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {
+      "AuthType": "NONE"
+    },
+    "defaultPaths": {
+      "AuthType": "NONE"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Sn",
+      "resourceType": "AWS::VpcLattice::ServiceNetwork",
+      "path": "SharingConfig",
+      "actual": {
+        "enabled": true
+      },
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+      "constructPath": "CdkrdHunt0715Lattice/Sn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Sn",
+      "resourceType": "AWS::VpcLattice::ServiceNetwork",
+      "path": "AuthType",
+      "actual": "NONE",
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+      "constructPath": "CdkrdHunt0715Lattice/Sn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Sn",
+      "resourceType": "AWS::VpcLattice::ServiceNetwork",
+      "path": "Name",
+      "actual": "cdkrdhunt0715lattice-sn-f6xaf7zc2alb",
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+      "constructPath": "CdkrdHunt0715Lattice/Sn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__VpcLattice__ServiceNetworkVpcAssociation.SnVpcAssoc.json
+++ b/tests/corpus/AWS__VpcLattice__ServiceNetworkVpcAssociation.SnVpcAssoc.json
@@ -1,0 +1,118 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SnVpcAssoc",
+    "resourceType": "AWS::VpcLattice::ServiceNetworkVpcAssociation",
+    "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetworkvpcassociation/snva-03c8bb5871ce7f536",
+    "constructPath": "CdkrdHunt0715Lattice/SnVpcAssoc",
+    "declared": {
+      "ServiceNetworkIdentifier": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcIdentifier": "vpc-0d262ec8c83e7881e"
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "PrivateDnsEnabled": false,
+    "VpcId": "vpc-0d262ec8c83e7881e",
+    "ServiceNetworkId": "sn-035847d35c755a015",
+    "DnsOptions": {
+      "PrivateDnsSpecifiedDomains": []
+    },
+    "CreatedAt": "2026-07-14T15:06:11.210Z",
+    "ServiceNetworkName": "cdkrdhunt0715lattice-sn-f6xaf7zc2alb",
+    "Id": "snva-03c8bb5871ce7f536",
+    "Arn": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetworkvpcassociation/snva-03c8bb5871ce7f536",
+    "SecurityGroupIds": [],
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "SnVpcAssoc",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0715Lattice",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0715Lattice/7d0d3bf0-7f95-11f1-8193-12502256672f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "ServiceNetworkArn": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetwork/sn-035847d35c755a015"
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "CreatedAt",
+      "Id",
+      "ServiceNetworkArn",
+      "ServiceNetworkId",
+      "ServiceNetworkName",
+      "Status",
+      "VpcId"
+    ],
+    "writeOnly": ["ServiceNetworkIdentifier", "VpcIdentifier"],
+    "createOnly": ["DnsOptions", "PrivateDnsEnabled", "ServiceNetworkIdentifier", "VpcIdentifier"],
+    "readOnlyPaths": [
+      "Arn",
+      "CreatedAt",
+      "Id",
+      "ServiceNetworkArn",
+      "ServiceNetworkId",
+      "ServiceNetworkName",
+      "Status",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["ServiceNetworkIdentifier", "VpcIdentifier"],
+    "createOnlyPaths": [
+      "DnsOptions",
+      "DnsOptions.PrivateDnsPreference",
+      "DnsOptions.PrivateDnsSpecifiedDomains",
+      "PrivateDnsEnabled",
+      "ServiceNetworkIdentifier",
+      "VpcIdentifier"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["DnsOptions.PrivateDnsSpecifiedDomains", "SecurityGroupIds"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "SnVpcAssoc",
+      "resourceType": "AWS::VpcLattice::ServiceNetworkVpcAssociation",
+      "path": "ServiceNetworkIdentifier",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetworkvpcassociation/snva-03c8bb5871ce7f536",
+      "constructPath": "CdkrdHunt0715Lattice/SnVpcAssoc"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "SnVpcAssoc",
+      "resourceType": "AWS::VpcLattice::ServiceNetworkVpcAssociation",
+      "path": "VpcIdentifier",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "arn:aws:vpc-lattice:us-east-1:111111111111:servicenetworkvpcassociation/snva-03c8bb5871ce7f536",
+      "constructPath": "CdkrdHunt0715Lattice/SnVpcAssoc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__XRay__ResourcePolicy.XrayPolicy.json
+++ b/tests/corpus/AWS__XRay__ResourcePolicy.XrayPolicy.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "XrayPolicy",
+    "resourceType": "AWS::XRay::ResourcePolicy",
+    "physicalId": "cdkrd-hunt-0715-xray",
+    "constructPath": "CdkrdHunt0715MissA/XrayPolicy",
+    "declared": {
+      "PolicyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"sns.amazonaws.com\"},\"Action\":[\"xray:PutTraceSegments\",\"xray:GetSamplingRules\"],\"Resource\":\"*\"}]}",
+      "PolicyName": "cdkrd-hunt-0715-xray"
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "cdkrd-hunt-0715-xray",
+    "PolicyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"sns.amazonaws.com\"},\"Action\":[\"xray:PutTraceSegments\",\"xray:GetSamplingRules\"],\"Resource\":\"*\"}]}"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["BypassPolicyLockoutCheck"],
+    "createOnly": ["PolicyName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["BypassPolicyLockoutCheck"],
+    "createOnlyPaths": ["PolicyName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/attach2-hunt/app.ts
+++ b/tests/integration/attach2-hunt/app.ts
@@ -1,0 +1,68 @@
+// Sibling-attachment echo probe batch 2 (the #1574 clientvpn-assoc class): deploy
+// parents WITH attachment-style siblings and first-check that shape — an echo the
+// parent-alone fixture can never materialize. Pairs not in attach-echo-hunt:
+// - EC2::TransitGateway + TransitGatewayAttachment (the attachment type itself is
+//   also corpus-uncovered) — does attaching materialize undeclared props on the
+//   TGW or the VPC?
+// - Two VPCs + VPCPeeringConnection — does an active peering materialize on
+//   either VPC read?
+// - SES::ConfigurationSet + ConfigurationSetEventDestination (the event
+//   destination type is corpus-uncovered; CW-dimension destination).
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnSubnet,
+  CfnTransitGateway,
+  CfnTransitGatewayAttachment,
+  CfnVPC,
+  CfnVPCPeeringConnection,
+} from "aws-cdk-lib/aws-ec2";
+import {
+  CfnConfigurationSet,
+  CfnConfigurationSetEventDestination,
+} from "aws-cdk-lib/aws-ses";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+const s = new Stack(app, "CdkrdHunt0715Attach2");
+
+const vpcA = new CfnVPC(s, "VpcA", { cidrBlock: "10.2.0.0/24" });
+const vpcB = new CfnVPC(s, "VpcB", { cidrBlock: "10.3.0.0/24" });
+const subnetA = new CfnSubnet(s, "SubnetA", {
+  vpcId: vpcA.ref,
+  cidrBlock: "10.2.0.0/25",
+  availabilityZone: "us-east-1a",
+});
+
+const tgw = new CfnTransitGateway(s, "Tgw", {});
+new CfnTransitGatewayAttachment(s, "TgwAttach", {
+  transitGatewayId: tgw.ref,
+  vpcId: vpcA.ref,
+  subnetIds: [subnetA.ref],
+});
+
+new CfnVPCPeeringConnection(s, "Peering", {
+  vpcId: vpcA.ref,
+  peerVpcId: vpcB.ref,
+});
+
+const cs = new CfnConfigurationSet(s, "ConfigSet", {
+  name: "cdkrd-hunt-0715-cs",
+});
+new CfnConfigurationSetEventDestination(s, "CsEventDest", {
+  configurationSetName: cs.ref,
+  eventDestination: {
+    matchingEventTypes: ["send", "bounce", "complaint"],
+    cloudWatchDestination: {
+      dimensionConfigurations: [
+        {
+          dimensionName: "cdkrd",
+          dimensionValueSource: "messageTag",
+          defaultDimensionValue: "none",
+        },
+      ],
+    },
+  },
+});

--- a/tests/integration/attach2-hunt/cdk.json
+++ b/tests/integration/attach2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/attach2-hunt/package.json
+++ b/tests/integration/attach2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-attach2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Sibling-attachment echo probe batch 2: TGW+attachment, VPC peering, SES config-set event destination. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/attach2-hunt/verify.sh
+++ b/tests/integration/attach2-hunt/verify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Barest first-run FP probe on attachment-echo pairs (batch 2): deploy,
+# assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail stays clean. Then the post-update echo probe: redeploy with
+# -c rev=2 (neutral tag update) and assert the re-check is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0715Attach2)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (attach2-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-attach2}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "=== redeploy with -c rev=2 (post-update echo probe) ==="
+npx cdk deploy -f --all --require-approval never -c rev=2 || fail "redeploy rev=2"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] post-update check MUST be CLEAN ==="
+  $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.rev2.out"
+  RC=${PIPESTATUS[0]}
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.rev2.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] post-update check not clean (rc=$RC)"
+done
+
+echo "INTEG OK (attach2-hunt)"

--- a/tests/integration/echo3-hunt/app.ts
+++ b/tests/integration/echo3-hunt/app.ts
@@ -1,0 +1,184 @@
+// Post-update echo probe batch 3 (see hunt-bugs skill "Post-update echo
+// materialization"): ~20 common types NOT in the first two echo sweeps
+// (second-deploy-echo covered Bucket/FileSystem/Function/LogGroup/Project/
+// Queue/Repository/Role/Rule/StateMachine/Stream/Table/Topic/UserPool/
+// WorkGroup; echo2 covered Alarm/DeliveryStream/RestApi-family/EventBus/
+// ManagedPolicy/MetricFilter/Parameter/Schedule/Secret/Subscription).
+// Deploy → first check → redeploy with -c rev=2 (tag update + a real
+// description/body update on types that support it) → re-check: every newly
+// materialized undeclared field is a latent second-deploy FP.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnApi, CfnStage } from "aws-cdk-lib/aws-apigatewayv2";
+import {
+  CfnApplication as CfnAppConfigApplication,
+  CfnConfigurationProfile,
+  CfnEnvironment,
+} from "aws-cdk-lib/aws-appconfig";
+import { CfnDataCatalog } from "aws-cdk-lib/aws-athena";
+import { CfnBackupPlan, CfnBackupVault } from "aws-cdk-lib/aws-backup";
+import { CfnDashboard } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnApplication as CfnCodeDeployApplication } from "aws-cdk-lib/aws-codedeploy";
+import { CfnUserPool, CfnUserPoolClient } from "aws-cdk-lib/aws-cognito";
+import {
+  CfnRouteTable,
+  CfnSecurityGroup,
+  CfnSubnet,
+  CfnVPC,
+} from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+import { CfnDatabase } from "aws-cdk-lib/aws-glue";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import {
+  CfnAlias,
+  CfnEventInvokeConfig,
+  CfnFunction,
+  CfnUrl,
+  CfnVersion,
+} from "aws-cdk-lib/aws-lambda";
+import { CfnDocument } from "aws-cdk-lib/aws-ssm";
+import { CfnActivity } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = String(app.node.tryGetContext("rev") ?? "1");
+if (rev !== "1") Tags.of(app).add("cdkrd:rev", rev);
+
+const s = new Stack(app, "CdkrdHunt0715Echo3");
+const acct = s.account;
+
+// --- VPC family (tag-updated only) ---
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.1.0.0/24" });
+new CfnSubnet(s, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.1.0.0/25",
+  availabilityZone: "us-east-1a",
+});
+new CfnRouteTable(s, "Rt", { vpcId: vpc.ref });
+new CfnSecurityGroup(s, "Sg", {
+  groupDescription: "cdkrd echo3 probe",
+  vpcId: vpc.ref,
+});
+
+// --- ECS (cluster tag-updated; task definition re-registers a revision) ---
+new CfnCluster(s, "EcsCluster", {});
+new CfnTaskDefinition(s, "TaskDef", {
+  family: "cdkrd-echo3",
+  requiresCompatibilities: ["FARGATE"],
+  networkMode: "awsvpc",
+  cpu: "256",
+  memory: "512",
+  containerDefinitions: [
+    { name: "app", image: "public.ecr.aws/docker/library/busybox:latest", essential: true },
+  ],
+});
+
+// --- Cognito client (no tags — rides the pool's update) ---
+const pool = new CfnUserPool(s, "Pool", {});
+new CfnUserPoolClient(s, "PoolClient", { userPoolId: pool.ref });
+
+// --- API Gateway v2 HTTP API + stage ---
+const api = new CfnApi(s, "HttpApi", {
+  name: "cdkrd-echo3-api",
+  protocolType: "HTTP",
+});
+new CfnStage(s, "HttpStage", {
+  apiId: api.ref,
+  stageName: "$default",
+  autoDeploy: true,
+});
+
+// --- AppConfig trio ---
+const acApp = new CfnAppConfigApplication(s, "AcApp", { name: "cdkrd-echo3-ac" });
+new CfnEnvironment(s, "AcEnv", { applicationId: acApp.ref, name: "env" });
+new CfnConfigurationProfile(s, "AcProfile", {
+  applicationId: acApp.ref,
+  name: "profile",
+  locationUri: "hosted",
+});
+
+// --- SSM document (tag-updated) ---
+new CfnDocument(s, "Doc", {
+  documentType: "Command",
+  content: {
+    schemaVersion: "2.2",
+    description: "cdkrd echo3 probe",
+    mainSteps: [
+      { action: "aws:runShellScript", name: "noop", inputs: { runCommand: ["true"] } },
+    ],
+  },
+});
+
+// --- Step Functions activity / CodeDeploy application ---
+new CfnActivity(s, "Activity", { name: "cdkrd-echo3-activity" });
+new CfnCodeDeployApplication(s, "CdApp", {});
+
+// --- Lambda satellite family (description threads rev = real update) ---
+const fnRole = new Role(s, "FnRole", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+});
+const fn = new CfnFunction(s, "Fn", {
+  runtime: "nodejs20.x",
+  handler: "index.handler",
+  role: fnRole.roleArn,
+  description: `cdkrd echo3 rev${rev}`,
+  code: { zipFile: "exports.handler = async () => ({ statusCode: 200 });" },
+});
+new CfnUrl(s, "FnUrl", { targetFunctionArn: fn.attrArn, authType: "NONE" });
+new CfnEventInvokeConfig(s, "FnEic", {
+  functionName: fn.ref,
+  qualifier: "$LATEST",
+  maximumRetryAttempts: 1,
+});
+const ver = new CfnVersion(s, "FnVer", { functionName: fn.ref });
+new CfnAlias(s, "FnAlias", {
+  functionName: fn.ref,
+  functionVersion: ver.attrVersion,
+  name: "live",
+});
+
+// --- CloudWatch dashboard (body threads rev = real update) ---
+new CfnDashboard(s, "Dash", {
+  dashboardBody: JSON.stringify({
+    widgets: [
+      {
+        type: "text",
+        x: 0,
+        y: 0,
+        width: 6,
+        height: 3,
+        properties: { markdown: `cdkrd echo3 rev${rev}` },
+      },
+    ],
+  }),
+});
+
+// --- Backup vault + plan ---
+const vault = new CfnBackupVault(s, "Vault", {
+  backupVaultName: "cdkrd_echo3_vault",
+});
+new CfnBackupPlan(s, "Plan", {
+  backupPlan: {
+    backupPlanName: "cdkrd-echo3-plan",
+    backupPlanRule: [
+      {
+        ruleName: "weekly",
+        targetBackupVault: vault.attrBackupVaultName,
+        scheduleExpression: "cron(0 5 ? * MON *)",
+      },
+    ],
+  },
+});
+
+// --- Athena data catalog / Glue database (description threads rev) ---
+new CfnDataCatalog(s, "Catalog", {
+  name: "cdkrd_echo3_catalog",
+  type: "GLUE",
+  parameters: { "catalog-id": acct },
+});
+new CfnDatabase(s, "GlueDb", {
+  catalogId: acct,
+  databaseInput: {
+    name: "cdkrd_echo3_db",
+    description: `cdkrd echo3 rev${rev}`,
+  },
+});

--- a/tests/integration/echo3-hunt/cdk.json
+++ b/tests/integration/echo3-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/echo3-hunt/package.json
+++ b/tests/integration/echo3-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-echo3-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Post-update echo probe batch 3: ~20 common types not in the first two echo sweeps. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/echo3-hunt/verify.sh
+++ b/tests/integration/echo3-hunt/verify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Barest first-run FP probe on ~20 common types (echo batch 3): deploy,
+# assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail stays clean. Then the post-update echo probe: redeploy with
+# -c rev=2 (neutral tag update) and assert the re-check is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0715Echo3)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (echo3-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-echo3}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "=== redeploy with -c rev=2 (post-update echo probe) ==="
+npx cdk deploy -f --all --require-approval never -c rev=2 || fail "redeploy rev=2"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] post-update check MUST be CLEAN ==="
+  $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.rev2.out"
+  RC=${PIPESTATUS[0]}
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.rev2.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] post-update check not clean (rc=$RC)"
+done
+
+echo "INTEG OK (echo3-hunt)"

--- a/tests/integration/lattice2-hunt/app.ts
+++ b/tests/integration/lattice2-hunt/app.ts
@@ -1,0 +1,83 @@
+// VPC Lattice family gap probe: the corpus covers ServiceNetwork / Service /
+// Listener / Rule / TargetGroup / ServiceNetworkServiceAssociation, but NOT
+// AuthPolicy, AccessLogSubscription, ServiceNetworkVpcAssociation,
+// ResourceGateway, or ResourceConfiguration (all CC-readable, single
+// primaryIdentifier — probed via describe-type). This is simultaneously a
+// sibling-ATTACHMENT echo probe: the barest ServiceNetwork deployed ALONE is
+// covered, so deploy it here WITH an auth policy + log subscription + VPC
+// association attached and first-check that shape (the clientvpn-assoc echo
+// class, #1574).
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+import {
+  CfnAccessLogSubscription,
+  CfnAuthPolicy,
+  CfnResourceConfiguration,
+  CfnResourceGateway,
+  CfnServiceNetwork,
+  CfnServiceNetworkVpcAssociation,
+} from "aws-cdk-lib/aws-vpclattice";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+const s = new Stack(app, "CdkrdHunt0715Lattice");
+
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.0.0.0/24" });
+const subnet = new CfnSubnet(s, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.0.0/24",
+  availabilityZone: "us-east-1a",
+});
+
+// Barest service network (Name undeclared → auto-generated) with three
+// attachments: auth policy (inactive on a NONE-auth network — the read echo is
+// the probe), access log subscription, and a VPC association.
+const sn = new CfnServiceNetwork(s, "Sn", {});
+
+new CfnAuthPolicy(s, "SnAuthPolicy", {
+  resourceIdentifier: sn.ref,
+  policy: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: "*",
+        Action: "vpc-lattice-svcs:Invoke",
+        Resource: "*",
+      },
+    ],
+  },
+});
+
+const lg = new CfnLogGroup(s, "SnLogs", {});
+
+new CfnAccessLogSubscription(s, "SnAls", {
+  resourceIdentifier: sn.ref,
+  destinationArn: lg.attrArn,
+});
+
+new CfnServiceNetworkVpcAssociation(s, "SnVpcAssoc", {
+  serviceNetworkIdentifier: sn.ref,
+  vpcIdentifier: vpc.ref,
+});
+
+const rg = new CfnResourceGateway(s, "Rg", {
+  name: "cdkrd-hunt-0715-rg",
+  vpcIdentifier: vpc.ref,
+  subnetIds: [subnet.ref],
+});
+
+new CfnResourceConfiguration(s, "Rc", {
+  name: "cdkrd-hunt-0715-rc",
+  resourceConfigurationType: "SINGLE",
+  resourceGatewayId: rg.attrId,
+  protocolType: "TCP",
+  portRanges: ["80"],
+  resourceConfigurationDefinition: {
+    ipResource: "10.0.0.10",
+  },
+});

--- a/tests/integration/lattice2-hunt/cdk.json
+++ b/tests/integration/lattice2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lattice2-hunt/package.json
+++ b/tests/integration/lattice2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lattice2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "VPC Lattice family gap + attachment-echo probe: AuthPolicy, AccessLogSubscription, ServiceNetworkVpcAssociation, ResourceGateway, ResourceConfiguration. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lattice2-hunt/verify.sh
+++ b/tests/integration/lattice2-hunt/verify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Barest first-run FP probe on the VPC Lattice family gap (one stack): deploy,
+# assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail stays clean. Then the post-update echo probe: redeploy with
+# -c rev=2 (neutral tag update) and assert the re-check is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0715Lattice)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (lattice2-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-lattice2}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "=== redeploy with -c rev=2 (post-update echo probe) ==="
+npx cdk deploy -f --all --require-approval never -c rev=2 || fail "redeploy rev=2"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] post-update check MUST be CLEAN ==="
+  $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.rev2.out"
+  RC=${PIPESTATUS[0]}
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.rev2.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] post-update check not clean (rc=$RC)"
+done
+
+echo "INTEG OK (lattice2-hunt)"

--- a/tests/integration/misspack-hunt/app.ts
+++ b/tests/integration/misspack-hunt/app.ts
@@ -1,0 +1,121 @@
+// Barest-form first-run FP probe: nine alive, cheap, CC-readable resource types
+// with ZERO corpus/fixture coverage (probed via describe-type: all single
+// primaryIdentifier + read handler). Most other uncovered types are dead
+// services (QLDB/CodeCommit/MediaStore/Evidently), account singletons
+// (Macie/Inspector), or too expensive (ACMPCA/FSx/EKS nodegroups) — this pack
+// is the surviving tail:
+// - EMR::SecurityConfiguration (barest: config JSON only, Name undeclared)
+// - SageMaker::ModelPackageGroup (name only) + SageMaker::Pipeline (Fail-step
+//   definition + role — barest MLOps pair)
+// - Transfer::Workflow (one DELETE step; Description undeclared)
+// - Location::APIKey (required Restrictions only; ExpireTime/NoExpiry undeclared)
+// - SES::DedicatedIpPool (pool name only — ScalingMode undeclared probes the
+//   STANDARD default fold; a pool without leased IPs is free)
+// - XRay::ResourcePolicy (name + document; BypassPolicyLockoutCheck write-only)
+// - Backup::RestoreTestingPlan (required selection/schedule only)
+// Stack A carries the no-dependency simple types; stack B the SageMaker pair,
+// so one create-time validation failure cannot roll back the whole probe.
+// (S3ObjectLambda::AccessPoint was in the pack but is CLOSED to new customers
+// — "available only to existing customers", live-determined 2026-07-15 — so
+// it joins the dead-service exclusion list, not the fixture.)
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnRestoreTestingPlan } from "aws-cdk-lib/aws-backup";
+import { CfnSecurityConfiguration } from "aws-cdk-lib/aws-emr";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnAPIKey } from "aws-cdk-lib/aws-location";
+import { CfnModelPackageGroup, CfnPipeline } from "aws-cdk-lib/aws-sagemaker";
+import { CfnDedicatedIpPool } from "aws-cdk-lib/aws-ses";
+import { CfnWorkflow } from "aws-cdk-lib/aws-transfer";
+import { CfnResourcePolicy } from "aws-cdk-lib/aws-xray";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+// `-c rev=2` threads a neutral tag update through every resource — the
+// post-update echo probe (redeploy with rev=2, re-check; see hunt-bugs skill).
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+// ---------------------------------------------------------------- stack A
+const a = new Stack(app, "CdkrdHunt0715MissA");
+
+new CfnSecurityConfiguration(a, "EmrSecConfig", {
+  securityConfiguration: {
+    EncryptionConfiguration: {
+      EnableInTransitEncryption: false,
+      EnableAtRestEncryption: false,
+    },
+  },
+});
+
+new CfnWorkflow(a, "TransferWorkflow", {
+  // deleteStepDetails is untyped (`any`) in the L1 — keys pass through to the
+  // template verbatim, so they must be CFn-cased (lowercase `name` fails early
+  // validation with "Unsupported property [name]").
+  steps: [{ type: "DELETE", deleteStepDetails: { Name: "del" } }],
+});
+
+new CfnAPIKey(a, "LocationKey", {
+  keyName: "cdkrd-hunt-0715-key",
+  // NoExpiry/ExpireTime cannot BOTH stay undeclared — the service rejects the
+  // barest form ("At least one of the following fields must be set", live
+  // 2026-07-15), so NoExpiry is part of the minimal config.
+  noExpiry: true,
+  restrictions: {
+    allowActions: ["geo:GetMap*"],
+    allowResources: [`arn:aws:geo:us-east-1:${a.account}:map/*`],
+  },
+});
+
+new CfnDedicatedIpPool(a, "SesPool", {
+  poolName: "cdkrd-hunt-0715-pool",
+});
+
+new CfnResourcePolicy(a, "XrayPolicy", {
+  policyName: "cdkrd-hunt-0715-xray",
+  policyDocument: JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "sns.amazonaws.com" },
+        Action: ["xray:PutTraceSegments", "xray:GetSamplingRules"],
+        Resource: "*",
+      },
+    ],
+  }),
+});
+
+new CfnRestoreTestingPlan(a, "RestorePlan", {
+  restoreTestingPlanName: "cdkrd_hunt_0715_rtp",
+  scheduleExpression: "cron(0 5 ? * MON *)",
+  recoveryPointSelection: {
+    algorithm: "LATEST_WITHIN_WINDOW",
+    includeVaults: ["*"],
+    recoveryPointTypes: ["SNAPSHOT"],
+  },
+});
+
+// ---------------------------------------------------------------- stack B
+const b = new Stack(app, "CdkrdHunt0715MissB");
+
+new CfnModelPackageGroup(b, "MpGroup", {
+  modelPackageGroupName: "cdkrd-hunt-0715-mpg",
+});
+
+const smRole = new Role(b, "SmRole", {
+  assumedBy: new ServicePrincipal("sagemaker.amazonaws.com"),
+});
+
+new CfnPipeline(b, "SmPipeline", {
+  pipelineName: "cdkrd-hunt-0715-pipeline",
+  roleArn: smRole.roleArn,
+  pipelineDefinition: {
+    PipelineDefinitionBody: JSON.stringify({
+      Version: "2020-12-01",
+      Metadata: {},
+      Parameters: [],
+      Steps: [{ Name: "NoOp", Type: "Fail", Arguments: { ErrorMessage: "noop" } }],
+    }),
+  },
+});
+

--- a/tests/integration/misspack-hunt/cdk.json
+++ b/tests/integration/misspack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/misspack-hunt/package.json
+++ b/tests/integration/misspack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-misspack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest first-run FP probe: EMR SecurityConfiguration, SageMaker Pipeline/ModelPackageGroup, Transfer Workflow, Location APIKey, SES DedicatedIpPool, XRay ResourcePolicy, Backup RestoreTestingPlan, S3ObjectLambda AccessPoint(+Policy). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/misspack-hunt/verify.sh
+++ b/tests/integration/misspack-hunt/verify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Barest first-run FP probe on nine uncovered types (two stacks): deploy,
+# assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail stays clean. Then the post-update echo probe: redeploy with
+# -c rev=2 (neutral tag update) and assert the re-check is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0715MissA CdkrdHunt0715MissB)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (misspack-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-misspack}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "=== redeploy with -c rev=2 (post-update echo probe) ==="
+npx cdk deploy -f --all --require-approval never -c rev=2 || fail "redeploy rev=2"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] post-update check MUST be CLEAN ==="
+  $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.rev2.out"
+  RC=${PIPESTATUS[0]}
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.rev2.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] post-update check not clean (rc=$RC)"
+done
+
+echo "INTEG OK (misspack-hunt)"

--- a/tests/noise-lattice2-misspack-folds.test.ts
+++ b/tests/noise-lattice2-misspack-folds.test.ts
@@ -1,0 +1,271 @@
+// 2026-07-15 hunt (lattice2-hunt + misspack-hunt fixtures): eleven first-run FPs on a
+// barest VPC Lattice family stack and a barest missing-type pack, all live-verified
+// (base binary surfaced each as [Potential Drift]; fixed binary first-checks CLEAN).
+// - VpcLattice AccessLogSubscription.ServiceNetworkLogType = SERVICE (constant)
+// - VpcLattice ResourceGateway IpAddressType/Ipv4AddressesPerEni/
+//   ResourceConfigDnsResolution (constants; not OOB-mutable — update-resource-gateway
+//   accepts only --security-group-ids) + SecurityGroupIds = VPC default SG (the #976
+//   derived DEFAULT_SG_LIST gate)
+// - VpcLattice ResourceConfiguration.AllowAssociationToSharableServiceNetwork = true
+//   (truthy standalone bool → paired MEANINGFUL_WHEN_OFF entry; the off-flip was
+//   live-proven to surface and to need a REVERT_SET_DEFAULT_PATHS entry)
+// - VpcLattice ServiceNetwork.Name: CFn mints the generated name LOWERCASED
+//   ("cdkrdhunt0715lattice-sn-f6xaf7zc2alb" for stack CdkrdHunt0715Lattice, logical id
+//   Sn) because lattice names must be lowercase — isCfnGeneratedName's exact-case
+//   comparisons missed it (now case-insensitive on the dash forms)
+// - SES DedicatedIpPool.ScalingMode = STANDARD (constant)
+// - Backup RestoreTestingPlan StartWindowHours=24 / ScheduleExpressionTimezone=Etc/UTC
+//   (top-level constants) + RecoveryPointSelection.SelectionWindowDays=30 (nested)
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('VpcLattice AccessLogSubscription first-run folds (2026-07-15 hunt)', () => {
+  const res: DesiredResource = {
+    logicalId: 'SnAls',
+    resourceType: 'AWS::VpcLattice::AccessLogSubscription',
+    physicalId: 'arn:aws:vpc-lattice:us-east-1:111111111111:accesslogsubscription/als-x',
+    declared: {
+      ResourceIdentifier: 'sn-035847d35c755a015',
+      DestinationArn: 'arn:aws:logs:us-east-1:111111111111:log-group:g',
+    },
+  };
+
+  it('folds the undeclared SERVICE log type to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { ...res.declared, ServiceNetworkLogType: 'SERVICE' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('ServiceNetworkLogType');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces a RESOURCE log type (not the default)', () => {
+    const f = classifyResource(
+      res,
+      { ...res.declared, ServiceNetworkLogType: 'RESOURCE' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ServiceNetworkLogType']);
+  });
+});
+
+describe('VpcLattice ResourceGateway first-run folds (2026-07-15 hunt)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Rg',
+    resourceType: 'AWS::VpcLattice::ResourceGateway',
+    physicalId: 'rgw-062fc1eeaf119a6f6',
+    declared: {
+      Name: 'cdkrd-hunt-0715-rg',
+      VpcIdentifier: 'vpc-1234567890abcdef0',
+      SubnetIds: ['subnet-1234567890abcdef0'],
+    },
+  };
+  const live = (over: Record<string, unknown> = {}) => ({
+    ...res.declared,
+    IpAddressType: 'IPV4',
+    Ipv4AddressesPerEni: 16,
+    ResourceConfigDnsResolution: 'PUBLIC',
+    SecurityGroupIds: ['sg-0722af66254639599'],
+    ...over,
+  });
+  const opts = { defaultSgIds: new Set(['sg-0722af66254639599']) };
+
+  it('folds the clean-deploy read (3 constants + VPC default SG) — first run is CLEAN', () => {
+    const f = classifyResource(res, live(), emptySchema, opts);
+    expect(pathsByTier(f, 'atDefault')).toEqual([
+      'IpAddressType',
+      'Ipv4AddressesPerEni',
+      'ResourceConfigDnsResolution',
+      'SecurityGroupIds',
+    ]);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces a non-default value on each constant', () => {
+    const f = classifyResource(
+      res,
+      live({ IpAddressType: 'DUALSTACK', Ipv4AddressesPerEni: 4 }),
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['IpAddressType', 'Ipv4AddressesPerEni']);
+  });
+
+  it('surfaces an out-of-band SG swap/append (the derived gate keeps detection)', () => {
+    const swap = classifyResource(
+      res,
+      live({ SecurityGroupIds: ['sg-0rogue0000000000a'] }),
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(swap, 'undeclared')).toEqual(['SecurityGroupIds']);
+    const append = classifyResource(
+      res,
+      live({ SecurityGroupIds: ['sg-0722af66254639599', 'sg-0rogue0000000000a'] }),
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(append, 'undeclared')).toEqual(['SecurityGroupIds']);
+  });
+});
+
+describe('VpcLattice ResourceConfiguration AllowAssociationToSharableServiceNetwork (2026-07-15 hunt)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Rc',
+    resourceType: 'AWS::VpcLattice::ResourceConfiguration',
+    physicalId: 'arn:aws:vpc-lattice:us-east-1:111111111111:resourceconfiguration/rcfg-x',
+    declared: {
+      Name: 'cdkrd-hunt-0715-rc',
+      ResourceConfigurationType: 'SINGLE',
+      ResourceGatewayId: 'rgw-062fc1eeaf119a6f6',
+      PortRanges: ['80'],
+      ProtocolType: 'TCP',
+      ResourceConfigurationDefinition: { IpResource: { IpAddress: '10.0.0.10' } },
+    },
+  };
+
+  it('folds the clean-deploy true to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { ...res.declared, AllowAssociationToSharableServiceNetwork: true },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('AllowAssociationToSharableServiceNetwork');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces an out-of-band false (the live-proven MEANINGFUL_WHEN_OFF flip)', () => {
+    const f = classifyResource(
+      res,
+      { ...res.declared, AllowAssociationToSharableServiceNetwork: false },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['AllowAssociationToSharableServiceNetwork']);
+  });
+});
+
+describe('VpcLattice ServiceNetwork lowercased CFn-generated Name (2026-07-15 hunt)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Sn',
+    resourceType: 'AWS::VpcLattice::ServiceNetwork',
+    physicalId: 'sn-035847d35c755a015',
+    constructPath: 'CdkrdHunt0715Lattice/Sn',
+    declared: { SharingConfig: { enabled: true } },
+  };
+
+  it('folds the lowercased <stack>-<logicalId>-<random> minted name as generated', () => {
+    const f = classifyResource(
+      res,
+      { ...res.declared, Name: 'cdkrdhunt0715lattice-sn-f6xaf7zc2alb' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'generated')).toEqual(['Name']);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('still surfaces a user-chosen lowercase name (value-dependent, not a blanket fold)', () => {
+    const f = classifyResource(res, { ...res.declared, Name: 'my-network' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Name']);
+  });
+});
+
+describe('SES DedicatedIpPool ScalingMode first-run fold (2026-07-15 hunt)', () => {
+  const res: DesiredResource = {
+    logicalId: 'SesPool',
+    resourceType: 'AWS::SES::DedicatedIpPool',
+    physicalId: 'cdkrd-hunt-0715-pool',
+    declared: { PoolName: 'cdkrd-hunt-0715-pool' },
+  };
+
+  it('folds the undeclared STANDARD scaling mode to atDefault', () => {
+    const f = classifyResource(res, { ...res.declared, ScalingMode: 'STANDARD' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toEqual(['ScalingMode']);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces a MANAGED pool (auto-leases billable IPs — not the default)', () => {
+    const f = classifyResource(res, { ...res.declared, ScalingMode: 'MANAGED' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ScalingMode']);
+  });
+});
+
+describe('Backup RestoreTestingPlan first-run folds (2026-07-15 hunt)', () => {
+  const res: DesiredResource = {
+    logicalId: 'RestorePlan',
+    resourceType: 'AWS::Backup::RestoreTestingPlan',
+    physicalId: 'cdkrd_hunt_0715_rtp',
+    declared: {
+      RestoreTestingPlanName: 'cdkrd_hunt_0715_rtp',
+      ScheduleExpression: 'cron(0 5 ? * MON *)',
+      RecoveryPointSelection: {
+        Algorithm: 'LATEST_WITHIN_WINDOW',
+        IncludeVaults: ['*'],
+        RecoveryPointTypes: ['SNAPSHOT'],
+      },
+    },
+  };
+  const live = (over: Record<string, unknown> = {}) => ({
+    ...res.declared,
+    StartWindowHours: 24,
+    ScheduleExpressionTimezone: 'Etc/UTC',
+    RecoveryPointSelection: {
+      ...(res.declared['RecoveryPointSelection'] as Record<string, unknown>),
+      SelectionWindowDays: 30,
+    },
+    ...over,
+  });
+
+  it('folds the clean-deploy read (2 top-level + 1 nested default) — first run is CLEAN', () => {
+    const f = classifyResource(res, live(), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toEqual([
+      'RecoveryPointSelection.SelectionWindowDays',
+      'ScheduleExpressionTimezone',
+      'StartWindowHours',
+    ]);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('surfaces each value changed off its default (the live-proven mutations)', () => {
+    const f = classifyResource(
+      res,
+      live({ StartWindowHours: 12, ScheduleExpressionTimezone: 'America/New_York' }),
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([
+      'ScheduleExpressionTimezone',
+      'StartWindowHours',
+    ]);
+    const nested = classifyResource(
+      res,
+      live({
+        RecoveryPointSelection: {
+          ...(res.declared['RecoveryPointSelection'] as Record<string, unknown>),
+          SelectionWindowDays: 7,
+        },
+      }),
+      emptySchema
+    );
+    expect(pathsByTier(nested, 'undeclared')).toEqual([
+      'RecoveryPointSelection.SelectionWindowDays',
+    ]);
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -731,6 +731,83 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  // misspack/lattice2 hunt (live-proven 2026-07-15, each property individually): the
+  // VpcLattice UpdateResourceConfiguration handler IGNORES an omitted
+  // AllowAssociationToSharableServiceNetwork, and the Backup UpdateRestoreTestingPlan
+  // handler IGNORES an omitted StartWindowHours AND ScheduleExpressionTimezone — all
+  // three persisted an out-of-band value through a `remove` revert that reported
+  // "reverted", while an explicit CC `add` patch converged. Each writes the
+  // KNOWN_DEFAULTS default back explicitly.
+  it('VpcLattice ResourceConfiguration AllowAssociationToSharableServiceNetwork (SET-DEFAULT) -> add op writing the true default', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::VpcLattice::ResourceConfiguration',
+      path: 'AllowAssociationToSharableServiceNetwork',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/AllowAssociationToSharableServiceNetwork',
+      value: true,
+      prior: false,
+    });
+  });
+
+  it('Backup RestoreTestingPlan StartWindowHours + ScheduleExpressionTimezone (SET-DEFAULT) -> add ops writing the 24 / Etc/UTC defaults', () => {
+    const fs = [
+      F({
+        tier: 'undeclared',
+        resourceType: 'AWS::Backup::RestoreTestingPlan',
+        path: 'StartWindowHours',
+        actual: 12,
+      }),
+      F({
+        tier: 'undeclared',
+        resourceType: 'AWS::Backup::RestoreTestingPlan',
+        path: 'ScheduleExpressionTimezone',
+        actual: 'America/New_York',
+      }),
+    ];
+    const plan = buildRevertPlan(fs, baseline([]));
+    const ops = plan.items.flatMap((i) => i.ops);
+    expect(ops).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ op: 'add', path: '/StartWindowHours', value: 24 }),
+        expect.objectContaining({
+          op: 'add',
+          path: '/ScheduleExpressionTimezone',
+          value: 'Etc/UTC',
+        }),
+      ])
+    );
+  });
+
+  it('#1642: EC2 TransitGatewayAttachment Options (SET-DEFAULT) -> add op writing the whole creation-default object', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::TransitGatewayAttachment',
+      path: 'Options',
+      actual: {
+        DnsSupport: 'enable',
+        SecurityGroupReferencingSupport: 'enable',
+        Ipv6Support: 'disable',
+        ApplianceModeSupport: 'disable',
+      },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Options',
+      value: {
+        DnsSupport: 'disable',
+        SecurityGroupReferencingSupport: 'enable',
+        Ipv6Support: 'disable',
+        ApplianceModeSupport: 'disable',
+      },
+    });
+  });
+
   it('#1619: Glue Crawler SchemaChangePolicy (SET-DEFAULT) -> add op writing the whole-object default', () => {
     const f = F({
       tier: 'undeclared',


### PR DESCRIPTION
## Summary

2026-07-15 bug hunt (5 rounds: offline audit / barest missing-type pack / post-update echo batch 3 / attachment-echo batch 2 / FN+revert-convergence piggybacks). **14 live-found first-run FPs fixed** across 4 issues, **4 revert set-default no-ops live-proven + fixed**, 17 new golden-corpus cases (14 previously-uncovered types), 4 committed regression fixtures.

Closes #1639. Closes #1640. Closes #1641. Closes #1642. (#1643 — SES CSED broken CC read handler → SDK_OVERRIDES reader — stays open; needs a new `client-ses` dep.)

## Fixes (each live-verified: base binary surfaced the FP, fixed binary first-checks CLEAN)

- **#1639 VpcLattice family** (`lattice2-hunt`): ALS `ServiceNetworkLogType=SERVICE`, RG `IpAddressType/Ipv4AddressesPerEni/ResourceConfigDnsResolution` (KNOWN_DEFAULTS; not OOB-mutable, live-probed), RG `SecurityGroupIds` via the derived DEFAULT_SG_LIST gate (+ gather prefetch registration), RC `AllowAssociationToSharableServiceNetwork` (KNOWN_DEFAULTS + paired MEANINGFUL_WHEN_OFF + RSDP), and **case-insensitive `isCfnGeneratedName` dash forms** — a lowercase-only-name service mints the CFn generated name lowercased (`cdkrdhunt0715lattice-sn-<random>`), which the exact-case branches missed.
- **#1640 misspack** (`misspack-hunt`): SES DedicatedIpPool `ScalingMode=STANDARD`; Backup RestoreTestingPlan `StartWindowHours=24` / `ScheduleExpressionTimezone=Etc/UTC` (KNOWN_DEFAULTS) + nested `RecoveryPointSelection.SelectionWindowDays=30` (KNOWN_DEFAULT_PATHS).
- **#1641 echo3** (`echo3-hunt`): CodeDeploy Application `ComputePlatform=Server` (createOnly constant); Lambda Version `Description` inherits the function's description at publish → value-independent (immutable snapshot, zero detection loss).
- **#1642 attach2** (`attach2-hunt`): TGW VPC attachment whole creation-default `Options` object (OOB-mutable → equality-gated whole-object pin keeps detection).

## Revert set-default no-ops (live-proven per property; explicit CC `add` converges each)

`REVERT_SET_DEFAULT_PATHS` += VpcLattice RC `AllowAssociationToSharableServiceNetwork`, Backup RTP `StartWindowHours` + `ScheduleExpressionTimezone`, TGW attachment `Options` — **4-in-4 no-op for this hunt's new folds** (batch-8 note added to the hunt skill). Each re-verified end-to-end with the fixed binary: mutate OOB → detect ("appeared since record") → `revert` → "CLEAN after revert" + live value back at the default.

## Also determined (no code change)

- Post-update echo sweep batch 3: ~20 more common types redeployed with a neutral rev-2 update — **zero echo FPs**.
- Attachment echoes: TGW+attachment and an active VPC peering materialize nothing undeclared on their parents; SES ConfigurationSet reads clean with an event destination attached.
- S3 Object Lambda is **closed to new customers** (live create rejection) — dead-service exclusion recorded in the hunt skill; same-account `Oam::Link` is rejected by the service.
- measure-noise over the grown corpus: no new candidates (the 17 new cases contribute zero undeclared noise).

## Verification

- `/check`: typecheck / lint+format / `vp pack` / `vp test run` — 308 files, 5977 tests, all pass (corpus-replay covers the 17 new cases).
- `/check-docs`: no docs-visible surface touched (fold/revert table entries only).
- `/verify-pr`: live evidence = the hunt itself (per-fix A/B + RSDP e2e reverts). **Core shared-name suite deferred** — diff is fold/revert table entries fully covered by unit tests + corpus replay and live-proven in the originating hunt; not re-run (per the R50 deferral rule).
- Cleanup: all 5 hunt stacks deleted via delstack; `sweep-orphans.sh` → **SWEEP CLEAN** (2 SageMaker lineage contexts + 1 leftover log group swept); bughunt gate released.
