### PR TITLE
fix(read): ACM DNS-validation CNAME pattern fold for Route53 added children

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -5388,6 +5388,33 @@ export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promi
 // multivalue variants). Route53 stores names as FQDNs with a trailing `.` and the template
 // usually omits it, so compare dot- and case-insensitively.
 const canonRoute53Name = (s: string): string => s.replace(/\.$/, '').toLowerCase();
+
+// ACM DNS-validation CNAMEs (#1652): an AWS::CertificateManager::Certificate with
+// DomainValidationOptions.HostedZoneId makes the CFn/ACM handler write its validation record
+// (`_<32-hex>.<domain> CNAME _<token>.<random>.acm-validations.aws.`) DIRECTLY into the zone —
+// the record is not a stack resource in ANY stack, so no declared-record (or sibling-stack)
+// match can ever fold it, and every certificate shows a false `[Added]` CNAME on the zone.
+// Deterministic pattern fold, same mechanism as the apex NS/SOA filter below: a live CNAME
+// whose ResourceRecords are a SINGLE value inside acm-validations.aws is by construction an
+// ACM-managed validation record. No detection value is lost: both sides are ACM-minted tokens
+// a user cannot meaningfully author, and an attacker-created "validation" record would also
+// have to point at acm-validations.aws (granting nothing beyond what ACM itself does).
+// SES DKIM / verification records (`*.dkim.amazonses.com` CNAMEs, `_amazonses` TXT) are
+// DELIBERATELY NOT folded — a rogue DKIM CNAME is a mail-spoofing / takeover vector.
+const ACM_VALIDATION_TARGET = /\.acm-validations\.aws\.?$/i;
+const isAcmValidationRecord = (
+  type: string,
+  live: Record<string, unknown> | undefined
+): boolean => {
+  if (type !== 'CNAME') return false;
+  const values = live?.ResourceRecords;
+  return (
+    Array.isArray(values) &&
+    values.length === 1 &&
+    typeof values[0] === 'string' &&
+    ACM_VALIDATION_TARGET.test(values[0])
+  );
+};
 const route53RecordKey = (name: string, type: string, setIdentifier?: string): string =>
   `${canonRoute53Name(name)}|${type.toUpperCase()}${setIdentifier !== undefined ? `|${setIdentifier}` : ''}`;
 
@@ -5449,6 +5476,9 @@ export function diffRoute53HostedZoneChildren(input: Route53HostedZoneChildInput
     // is NOT filtered.
     if (type === 'SOA') continue;
     if (type === 'NS' && apex !== undefined && name === apex) continue;
+    // ACM-managed DNS-validation CNAME (see isAcmValidationRecord above) — service-created,
+    // never a template resource, filtered like the apex SOA/NS.
+    if (isAcmValidationRecord(type, r.live)) continue;
     if (declared.has(route53RecordKey(r.name, r.type, r.setIdentifier))) continue;
     // NON_PROVISIONABLE in the CC registry -> this identifier is NOT a CC DeleteResource target
     // (see the block comment above); it is the best composite from the CC identity fields for

--- a/tests/route53-acm-validation-cname-1652.test.ts
+++ b/tests/route53-acm-validation-cname-1652.test.ts
@@ -1,0 +1,141 @@
+// #1652 — ACM DNS-validation CNAMEs false-'added' on hosted-zone stacks.
+//
+// An AWS::CertificateManager::Certificate with DomainValidationOptions.HostedZoneId makes
+// the CFn/ACM handler write its validation record
+// (`_<32-hex>.<domain> CNAME _<token>.<random>.acm-validations.aws.`) DIRECTLY into the
+// zone. The record is not a stack resource in ANY stack, so the declared-record match (and
+// the sibling-stack membership probe) can never fold it — every certificate showed a false
+// `[Added]` CNAME on the zone. Fix: a deterministic pattern fold in
+// diffRoute53HostedZoneChildren, same mechanism/placement as the apex NS/SOA filter: a live
+// CNAME whose ResourceRecords are a SINGLE value inside acm-validations.aws is by
+// construction ACM-managed. SES DKIM records are DELIBERATELY not folded (mail-spoofing /
+// takeover vector).
+import { describe, expect, it } from 'vite-plus/test';
+import { diffRoute53HostedZoneChildren } from '../src/read/child-enumerators.js';
+
+const ZONE = 'Z1234567890ABC';
+const APEX = 'example.com';
+
+const diff = (
+  liveRecords: {
+    name: string;
+    type: string;
+    setIdentifier?: string | undefined;
+    live?: Record<string, unknown> | undefined;
+  }[]
+) =>
+  diffRoute53HostedZoneChildren({
+    hostedZoneId: ZONE,
+    zoneApex: APEX,
+    declaredRecords: [],
+    liveRecords,
+  });
+
+describe('diffRoute53HostedZoneChildren — ACM DNS-validation CNAME fold (#1652)', () => {
+  it('folds an ACM validation CNAME (single ResourceRecord into acm-validations.aws, trailing dot)', () => {
+    const added = diff([
+      {
+        name: '_abc123def456abc123def456abc123de.example.com.',
+        type: 'CNAME',
+        live: {
+          Name: '_abc123def456abc123def456abc123de.example.com.',
+          Type: 'CNAME',
+          ResourceRecords: ['_deadbeefdeadbeefdeadbeefdeadbeef.xyzrandom.acm-validations.aws.'],
+        },
+      },
+    ]);
+    expect(added).toEqual([]);
+  });
+
+  it('folds the variant WITHOUT the trailing dot on the target value', () => {
+    const added = diff([
+      {
+        name: '_abc123def456abc123def456abc123de.example.com.',
+        type: 'CNAME',
+        live: {
+          Name: '_abc123def456abc123def456abc123de.example.com.',
+          Type: 'CNAME',
+          ResourceRecords: ['_deadbeefdeadbeefdeadbeefdeadbeef.xyzrandom.acm-validations.aws'],
+        },
+      },
+    ]);
+    expect(added).toEqual([]);
+  });
+
+  it('KEEPS an SES DKIM CNAME (dkim.amazonses.com) — rogue DKIM is a mail-spoofing vector', () => {
+    const added = diff([
+      {
+        name: 'token._domainkey.example.com.',
+        type: 'CNAME',
+        live: {
+          Name: 'token._domainkey.example.com.',
+          Type: 'CNAME',
+          ResourceRecords: ['foo.dkim.amazonses.com'],
+        },
+      },
+    ]);
+    expect(added.map((a) => a.label)).toEqual(['CNAME token._domainkey.example.com']);
+  });
+
+  it('KEEPS a CNAME with TWO ResourceRecords even when one matches (single-value requirement)', () => {
+    const added = diff([
+      {
+        name: '_abc123def456abc123def456abc123de.example.com.',
+        type: 'CNAME',
+        live: {
+          Name: '_abc123def456abc123def456abc123de.example.com.',
+          Type: 'CNAME',
+          ResourceRecords: [
+            '_deadbeefdeadbeefdeadbeefdeadbeef.xyzrandom.acm-validations.aws.',
+            'evil.example.net',
+          ],
+        },
+      },
+    ]);
+    expect(added.map((a) => a.label)).toEqual([
+      'CNAME _abc123def456abc123def456abc123de.example.com',
+    ]);
+  });
+
+  it('KEEPS a non-CNAME (TXT) whose value matches the target pattern (CNAME-only fold)', () => {
+    const added = diff([
+      {
+        name: '_probe.example.com.',
+        type: 'TXT',
+        live: {
+          Name: '_probe.example.com.',
+          Type: 'TXT',
+          ResourceRecords: ['_deadbeefdeadbeefdeadbeefdeadbeef.xyzrandom.acm-validations.aws.'],
+        },
+      },
+    ]);
+    expect(added.map((a) => a.label)).toEqual(['TXT _probe.example.com']);
+  });
+
+  it('leaves the existing apex NS/SOA behavior untouched (apex filtered, delegation NS kept)', () => {
+    const added = diff([
+      { name: 'example.com.', type: 'SOA', live: {} },
+      { name: 'example.com.', type: 'NS', live: {} }, // apex NS -> filtered
+      { name: 'sub.example.com.', type: 'NS', live: { Name: 'sub.example.com.', Type: 'NS' } }, // delegation -> kept
+      {
+        name: '_abc123def456abc123def456abc123de.example.com.',
+        type: 'CNAME',
+        live: {
+          Name: '_abc123def456abc123def456abc123de.example.com.',
+          Type: 'CNAME',
+          ResourceRecords: ['_deadbeefdeadbeefdeadbeefdeadbeef.xyzrandom.acm-validations.aws.'],
+        },
+      },
+    ]);
+    expect(added.map((a) => a.label)).toEqual(['NS sub.example.com']);
+  });
+
+  it('KEEPS a validation-shaped CNAME with NO live snippet (fail-safe: cannot verify the target)', () => {
+    // The enumerator always builds a `live` snippet, but the pure diff accepts records
+    // without one — an unverifiable target must NOT be assumed ACM-managed.
+    const added = diff([{ name: '_abc123def456abc123def456abc123de.example.com.', type: 'CNAME' }]);
+    expect(added.map((a) => a.label)).toEqual([
+      'CNAME _abc123def456abc123def456abc123de.example.com',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #1652

## Summary

ACM DNS-validation CNAMEs (`_<32-hex>.<domain> CNAME _<token>.<random>.acm-validations.aws.`) were false-flagged as `added` on hosted-zone stacks. They are written into the zone directly by the CFn/ACM handler when an `AWS::CertificateManager::Certificate` declares `DomainValidationOptions.HostedZoneId` — they are not stack resources in ANY stack, so no declared-record (or sibling-stack membership) match can ever fold them. A live dogfood check showed 6 of these among the `added` RecordSets on a hosted-zone stack.

Fix: a deterministic pattern fold in `diffRoute53HostedZoneChildren` (`src/read/child-enumerators.ts`), placed alongside the existing AWS-auto-created apex NS/SOA filter and using the same mechanism (skip before the declared check): a live **CNAME** whose `ResourceRecords` consist of a **single** value matching `/\.acm-validations\.aws\.?$/i` is by construction an ACM-managed DNS-validation record.

Rationale for the fold (no detection value lost): both sides are ACM-minted tokens a user cannot meaningfully author, and an attacker-created "validation" record would also have to point at `acm-validations.aws`, granting nothing beyond what ACM itself does.

Deliberately NOT folded: SES DKIM / verification records (`*.dkim.amazonses.com` CNAMEs, `_amazonses` TXT) — a rogue DKIM CNAME is a mail-spoofing / takeover vector, so they keep surfacing (covered by a test).

Companion issue #1651 (sibling probe id / cross-region) is deliberately OUT OF SCOPE for this PR — no `siblingLookupId` / probe logic is touched.

## Changes

- `src/read/child-enumerators.ts` — `isAcmValidationRecord` helper + skip in `diffRoute53HostedZoneChildren`, right after the apex NS/SOA filters.
- `tests/route53-acm-validation-cname-1652.test.ts` — new unit tests (fail without the fix — verified by stashing the src change: 3 failed).

## Test evidence

New tests (`tests/route53-acm-validation-cname-1652.test.ts`):

- folds an ACM validation CNAME (single ResourceRecord into acm-validations.aws, trailing dot)
- folds the variant WITHOUT the trailing dot on the target value
- KEEPS an SES DKIM CNAME (dkim.amazonses.com) — rogue DKIM is a mail-spoofing vector
- KEEPS a CNAME with TWO ResourceRecords even when one matches (single-value requirement)
- KEEPS a non-CNAME (TXT) whose value matches the target pattern (CNAME-only fold)
- leaves the existing apex NS/SOA behavior untouched (apex filtered, delegation NS kept)
- KEEPS a validation-shaped CNAME with NO live snippet (fail-safe: cannot verify the target)

Gates (all green):

- `vp run typecheck` — pass
- `vp check --fix` — 0 errors
- `vp pack` — build complete
- `vp test run` — 309 files, 5994 tests passed
