### PR TITLE
fix(diff): fold Aurora DBCluster cluster-level AutoMinorVersionUpgrade echo of an instance-declared false (#1653)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -289,8 +289,20 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // a snapshot-restored resource, whose undeclared `false` is an inherited creation-time value
   // (see the `notRestored` note above) — live-proven on RDS::DBInstance.
   'AWS::RDS::DBInstance': { AutoMinorVersionUpgrade: notRestored('DBSnapshotIdentifier') },
+  // #1653: the cluster-level flag is genuinely cluster-level ONLY on a Multi-AZ DB cluster
+  // (engine mysql/postgres). On an Aurora cluster it ECHOES the member instances'
+  // instance-level setting: a writer DBInstance that DECLARES AutoMinorVersionUpgrade=false
+  // makes the undeclared cluster-level value read false at CREATION (declared intent on a
+  // sibling resource, not an out-of-band disable; a fresh all-default Aurora cluster reads
+  // true — corpus-confirmed on aurora-mysql / aurora-postgresql / ServerlessV2). So gate on
+  // the engine. Detection is preserved on Aurora via the member AWS::RDS::DBInstance entry
+  // above (undeclared flip) or the instance's declared loop (declared flip).
   'AWS::RDS::DBCluster': {
-    AutoMinorVersionUpgrade: notRestored('SnapshotIdentifier', 'SourceDBClusterIdentifier'),
+    AutoMinorVersionUpgrade: (ctx) => {
+      const engine = ctx.live['Engine'] ?? ctx.declared['Engine'];
+      if (typeof engine === 'string' && engine.startsWith('aurora')) return false;
+      return notRestored('SnapshotIdentifier', 'SourceDBClusterIdentifier')(ctx);
+    },
   },
   // A Neptune DBInstance has no instance-level restore source (only AWS::Neptune::DBCluster
   // restores from a snapshot; its member instances are always CREATED fresh and read the flag

--- a/tests/classify-restore-booleans-660.test.ts
+++ b/tests/classify-restore-booleans-660.test.ts
@@ -50,11 +50,13 @@ const CASES: Case[] = [
     baseDeclared: { DBInstanceClass: 'db.t3.micro', Engine: 'mariadb' },
   },
   {
+    // #1653: the off state is cluster-level-meaningful only on a Multi-AZ DB cluster
+    // (engine mysql/postgres) — the Aurora echo cases live in their own describe below.
     resourceType: 'AWS::RDS::DBCluster',
     flag: 'AutoMinorVersionUpgrade',
     restoreProp: 'SnapshotIdentifier',
     restoreValue: 'my-cluster-snap',
-    baseDeclared: { Engine: 'aurora-mysql' },
+    baseDeclared: { Engine: 'mysql' },
   },
   {
     resourceType: 'AWS::Neptune::DBInstance',
@@ -141,4 +143,65 @@ describe('#660 item 1 restore-risk version-upgrade booleans', () => {
       });
     }
   }
+});
+
+// #1653: on an Aurora cluster (engine `aurora*`) the cluster-level flag ECHOES the member
+// instances' instance-level setting — a writer DBInstance that DECLARES
+// AutoMinorVersionUpgrade=false makes the UNDECLARED cluster-level value read `false` at
+// CREATION. That is declared intent on a sibling resource, not an out-of-band disable, so it
+// must NOT surface (core invariant: clean deploy ⇒ zero potential drift). Out-of-band
+// detection on Aurora lives on the member AWS::RDS::DBInstance entry instead. Only a
+// Multi-AZ DB cluster (engine mysql/postgres — the CASES entry above) keeps the #660
+// off-state surface.
+describe('#1653 Aurora DBCluster cluster-level AutoMinorVersionUpgrade echo', () => {
+  const mkCluster = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'Cluster',
+    resourceType: 'AWS::RDS::DBCluster',
+    physicalId: 'my-aurora-cluster',
+    declared,
+  });
+
+  for (const engine of ['aurora', 'aurora-mysql', 'aurora-postgresql']) {
+    it(`${engine}: undeclared cluster-level false folds (instance-declared echo, no first-check FP)`, () => {
+      const declared = { Engine: engine };
+      const f = classifyResource(
+        mkCluster(declared),
+        { ...declared, AutoMinorVersionUpgrade: false },
+        emptySchema
+      );
+      expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    });
+
+    it(`${engine}: undeclared cluster-level true still folds atDefault`, () => {
+      const declared = { Engine: engine };
+      const f = classifyResource(
+        mkCluster(declared),
+        { ...declared, AutoMinorVersionUpgrade: true },
+        emptySchema
+      );
+      expect(pathsByTier(f, 'atDefault')).toContain('AutoMinorVersionUpgrade');
+      expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    });
+  }
+
+  it('engine known only from the LIVE model (declared side unresolved) still folds', () => {
+    // The predicate prefers live.Engine, so an intrinsic-declared Engine cannot flip the
+    // gate to the Multi-AZ (surface) path.
+    const f = classifyResource(
+      mkCluster({}),
+      { Engine: 'aurora-mysql', AutoMinorVersionUpgrade: false },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).not.toContain('AutoMinorVersionUpgrade');
+  });
+
+  it('postgres Multi-AZ engine keeps the #660 surface for the undeclared off state', () => {
+    const declared = { Engine: 'postgres' };
+    const f = classifyResource(
+      mkCluster(declared),
+      { ...declared, AutoMinorVersionUpgrade: false },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('AutoMinorVersionUpgrade');
+  });
 });


### PR DESCRIPTION
Closes #1653.

## What

Engine-gate the `AWS::RDS::DBCluster.AutoMinorVersionUpgrade` `MEANINGFUL_WHEN_OFF` predicate (added in #1520): the undeclared off state surfaces only on a Multi-AZ DB cluster (engine `mysql` / `postgres`), where the flag is genuinely cluster-level. On Aurora engines (`aurora*`) it no longer surfaces.

## Why

On an Aurora cluster the cluster-level flag ECHOES the member instances' instance-level setting. A writer `AWS::RDS::DBInstance` that DECLARES `AutoMinorVersionUpgrade: false` makes the undeclared cluster-level value read `false` at creation — declared intent on a sibling resource, not an out-of-band disable — so #1520's `notRestored(...)`-only gate produced a first-check `[Potential Drift]` FP on a clean Aurora ServerlessV2 deploy (core-invariant violation). The #1520 confirmation list (redis/memcached/valkey/postgres/sqlserver/Neptune/Redshift) did not include this Aurora shape; the committed corpus confirms a fresh all-default Aurora cluster reads `true` (aurora-mysql / aurora-postgresql / ServerlessV2, 4 fixtures).

Detection is preserved on Aurora: an out-of-band AMVU disable also shows on the member instances, caught by the existing `AWS::RDS::DBInstance` entry (undeclared) or the declared loop (declared). Multi-AZ DB clusters keep the #1520 behavior unchanged, and `REVERT_SET_DEFAULT_VALUES` keeps its DBCluster entry for that path.

## Verification

- Unit tests: Aurora (`aurora` / `aurora-mysql` / `aurora-postgresql`) undeclared `false` folds; undeclared `true` still folds `atDefault`; engine known only from the live model folds; Multi-AZ `mysql` / `postgres` undeclared `false` still surfaces; restored Multi-AZ cluster still folds. Full suite: 308 files / 5995 tests green.
- Live A/B (read-only `check` against a real Aurora ServerlessV2 cluster whose writer instance declares `AutoMinorVersionUpgrade: false`): the installed release surfaces the FP (`actual = false`, 1 potential drift); this branch's build reports CLEAN with every other tier count identical (atDefault=62 / generated=8 / readGap=2 / unresolved=2 / skipped=3).
- Shared CORE integration suite deferred — offline unit + committed-corpus replay + the per-PR live A/B above stand in (per the `/verify-pr` deferral rule); no fresh AWS deploys were made for this PR.
