### PR TITLE
fix(diff): Chatbot SlackChannelId G/C prefix-tolerant equality (Slack id migration echo)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -906,6 +906,30 @@ const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpe
 const VALUE_INDEPENDENT_KEYED_ELEMENTS: Record<string, Record<string, ReadonlySet<string>>> = {
   'AWS::Cognito::UserPoolUser': { UserAttributes: new Set(['sub']) },
 };
+// #1650: Slack MIGRATED legacy private-group ids (`G…`) to modern conversation ids (`C…`)
+// preserving every character after the prefix, and Chatbot's read echoes the CURRENT
+// (migrated) id — so a template still holding the legacy `G0XXXXXXXXX` id reports a permanent
+// declared FP against the live `C0XXXXXXXXX` that `record` cannot accept. This is the #881
+// service-transformed-echo class, but the Chatbot registry schema carries no
+// `propertyTransform`, so a per-type table hosts the tolerance here (like the noise.ts
+// TRAILING_DOT_PATHS / VERSION_PREFIX_PATHS kin the declared loop already consults). Declared
+// and live are EQUAL when they differ ONLY by the leading 'G' vs 'C' with an identical
+// NON-EMPTY remainder (symmetric, though the real-world direction is declared G… vs live C…).
+// A genuine re-point to a different channel changes the remainder, so it still surfaces.
+const SLACK_ID_MIGRATION_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::Chatbot::SlackChannelConfiguration': new Set(['SlackChannelId']),
+};
+const SLACK_MIGRATION_PREFIXES: ReadonlySet<string> = new Set(['G', 'C']);
+function isSlackIdMigrationEqual(a: unknown, b: unknown): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  return (
+    a.length > 1 &&
+    b.length > 1 &&
+    SLACK_MIGRATION_PREFIXES.has(a[0] ?? '') &&
+    SLACK_MIGRATION_PREFIXES.has(b[0] ?? '') &&
+    a.slice(1) === b.slice(1)
+  );
+}
 // Nested object-arrays whose element identity is a NON-standard field (not Key/Id/
 // AttributeName/IndexName/Name). collectNestedUndeclared aligns identity-keyed arrays so a
 // live-only sub-key inside a declared element surfaces; without a known identity it skips
@@ -4758,6 +4782,15 @@ export function classifyResource(
       if (
         INTELLIGENT_TIERING_PATHS[resourceType]?.has(d.path) &&
         isIntelligentTieringMatch(d.stateValue, d.awsValue)
+      )
+        continue;
+      // Per-type Slack channel-id paths (#1650: Chatbot SlackChannelId) — a declared legacy
+      // G-prefixed group id that Slack migrated to the C-prefixed conversation id (identical
+      // non-empty remainder) is not drift; a genuine re-point to a different channel changes
+      // the remainder and still surfaces.
+      if (
+        SLACK_ID_MIGRATION_PATHS[resourceType]?.has(d.path) &&
+        isSlackIdMigrationEqual(d.stateValue, d.awsValue)
       )
         continue;
       // Unordered scalar-array sets — same elements in the service's canonical order

--- a/tests/classify-chatbot-slackchannelid-1650.test.ts
+++ b/tests/classify-chatbot-slackchannelid-1650.test.ts
@@ -1,0 +1,92 @@
+// #1650 — a Chatbot SlackChannelConfiguration declares a legacy Slack private-group id
+// (`G…`), but Slack migrated those conversations to modern C-prefixed conversation ids
+// preserving every character after the prefix, and Chatbot's read echoes the CURRENT
+// (migrated) id — a permanent declared FP (desired `G0XXXXXXXXX` vs live `C0XXXXXXXXX`)
+// on a configuration nobody re-pointed. classify treats declared and live as EQUAL when
+// they differ ONLY by the leading 'G' vs 'C' with an identical NON-EMPTY remainder
+// (SLACK_ID_MIGRATION_PATHS); a genuine re-point changes the remainder and still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const TYPE = 'AWS::Chatbot::SlackChannelConfiguration';
+
+// Assert on the FULL tier:path list (never tier-filtered) to catch double-reporting.
+const all = (fs: Finding[]) => fs.map((f) => `${f.tier}:${f.path}`).sort();
+
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'SlackChannel',
+  resourceType: TYPE,
+  physicalId: 'arn:aws:chatbot::123456789012:chat-configuration/slack-channel/cdkrd-hunt',
+  declared,
+});
+
+describe('#1650 Chatbot SlackChannelId Slack G->C id-migration echo', () => {
+  it('folds a declared legacy G-prefix id echoed back as the migrated C-prefix id', () => {
+    const res = mk({
+      SlackChannelId: 'G0ABCDEF123',
+      SlackWorkspaceId: 'T0AAAAAAA',
+      ConfigurationName: 'cdkrd-hunt',
+      IamRoleArn: 'arn:aws:iam::123456789012:role/cdkrd-hunt-chatbot',
+    });
+    const f = classifyResource(
+      res,
+      {
+        SlackChannelId: 'C0ABCDEF123',
+        SlackWorkspaceId: 'T0AAAAAAA',
+        ConfigurationName: 'cdkrd-hunt',
+        IamRoleArn: 'arn:aws:iam::123456789012:role/cdkrd-hunt-chatbot',
+      },
+      emptySchema
+    );
+    expect(all(f)).toEqual([]);
+  });
+
+  it('still surfaces a genuine re-point to a different channel (remainder differs)', () => {
+    const res = mk({ SlackChannelId: 'G0ABCDEF123' });
+    const f = classifyResource(res, { SlackChannelId: 'C0ZZZZZZ999' }, emptySchema);
+    expect(all(f)).toEqual(['declared:SlackChannelId']);
+  });
+
+  it('does not fold a bare prefix (empty remainder): declared "G" vs live "C" surfaces', () => {
+    const res = mk({ SlackChannelId: 'G' });
+    const f = classifyResource(res, { SlackChannelId: 'C' }, emptySchema);
+    expect(all(f)).toEqual(['declared:SlackChannelId']);
+  });
+
+  it('does not affect an unrelated path on the same type', () => {
+    const res = mk({ SlackChannelId: 'C0ABCDEF123', SlackWorkspaceId: 'G0ABCDEF123' });
+    const f = classifyResource(
+      res,
+      { SlackChannelId: 'C0ABCDEF123', SlackWorkspaceId: 'C0ABCDEF123' },
+      emptySchema
+    );
+    expect(all(f)).toEqual(['declared:SlackWorkspaceId']);
+  });
+
+  it('does not affect an unrelated resource type carrying G/C-shaped values', () => {
+    const res: DesiredResource = {
+      logicalId: 'Param',
+      resourceType: 'AWS::SSM::Parameter',
+      physicalId: 'cdkrd-hunt-param',
+      declared: { Name: 'cdkrd-hunt-param', Type: 'String', Value: 'G0ABCDEF123' },
+    };
+    const f = classifyResource(
+      res,
+      { Name: 'cdkrd-hunt-param', Type: 'String', Value: 'C0ABCDEF123' },
+      emptySchema
+    );
+    expect(all(f)).toEqual(['declared:Value']);
+  });
+});


### PR DESCRIPTION
Closes #1650

## Summary

A Chatbot `AWS::Chatbot::SlackChannelConfiguration` that declares a legacy Slack private-group id (`G0XXXXXXXXX`) reports a permanent `[CFn-Declared Drift]` on `SlackChannelId`: Slack migrated legacy private-group ids to modern C-prefixed conversation ids preserving every character after the prefix, and Chatbot's read echoes the CURRENT (migrated) id — `desired="G0XXXXXXXXX"` vs `actual="C0XXXXXXXXX"` on a configuration nobody re-pointed. This is the #881 service-transformed-echo class, but the Chatbot registry schema carries no `propertyTransform`, so a per-type tolerance table hosts the fold in `classify.ts` (the same pattern as the noise.ts `TRAILING_DOT_PATHS` / `VERSION_PREFIX_PATHS` kin the declared loop already consults).

## Fix

`src/diff/classify.ts`:

- `SLACK_ID_MIGRATION_PATHS` — a type+path-scoped table: `AWS::Chatbot::SlackChannelConfiguration` → `SlackChannelId`.
- `isSlackIdMigrationEqual(a, b)` — declared and live are EQUAL when both are strings that differ ONLY by a leading `'G'` vs `'C'` with an identical NON-EMPTY remainder (symmetric, though the real-world direction is declared `G…` vs live `C…`).
- A declared-loop gate right after the Intelligent-Tiering tolerance, before the unordered-set folds.

Detection is preserved: a genuine re-point to a different channel changes the remainder, so it still surfaces as declared drift; a bare `"G"` vs `"C"` (empty remainder) is never folded; unrelated paths (`SlackWorkspaceId`) and unrelated types are untouched.

## Tests

`tests/classify-chatbot-slackchannelid-1650.test.ts` (asserts on the FULL `tier:path` finding list, never tier-filtered):

1. declared `G0ABCDEF123` vs live `C0ABCDEF123` → zero findings (folds) — **fails without the fix** (verified via `git stash`: 1 failed / 4 passed without, 5 passed with)
2. declared `G0ABCDEF123` vs live `C0ZZZZZZ999` (different remainder) → `declared:SlackChannelId` still surfaces
3. declared `"G"` vs live `"C"` (empty remainder) → drift surfaces
4. same type, unrelated path (`SlackWorkspaceId`) with G/C values → drift surfaces
5. unrelated type (`AWS::SSM::Parameter` `Value`) with G/C values → drift surfaces

## Gates

- `vp run typecheck` — 0 errors
- `vp check --fix` — pass
- `vp pack` — build complete
- `vp test run` — 309 files / 5992 tests passed
- markgate `check` + `docs` markers set (docs precedent: the #1452 classify-hosted echo tolerance, PR #1469, changed no docs — per-type tolerance entries are not enumerated per-entry in ARCHITECTURE.md's bullet list for classify-local tables)
