### PR TITLE
docs(diff): document the cluster/member off-state echo check for MEANINGFUL_WHEN_OFF entries (#1653 retrospective)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -166,6 +166,16 @@ const ELB_ATTRIBUTE_BAGS: Record<string, string> = {
 // Route53 HealthCheck reads EnableSNI=false. The predicate returns true only when the OFF
 // state is a genuine divergence in THIS resource's config. Add an entry ONLY after a live
 // confirm that the OFF state is meaningful in EVERY clean-deploy configuration of the type.
+//
+// #1653: for a CLUSTER-scoped type with member-instance resources (RDS / DocDB / Neptune /
+// ElastiCache / MemoryDB / Redshift), "every clean-deploy configuration" INCLUDES the shape
+// where a MEMBER INSTANCE declares the flag off while the cluster leaves it undeclared —
+// per-resource corpus fixtures (nothing declared anywhere) never exhibit it. A cluster-level
+// read can ECHO the members' instance-level setting (Aurora AutoMinorVersionUpgrade: a writer
+// DBInstance declaring false makes the undeclared cluster value read false at CREATION), so
+// that off state is declared intent on a sibling resource, not an out-of-band disable. Where
+// the echo exists, gate the cluster entry out (detection stays on the member-instance entry);
+// see the AWS::RDS::DBCluster engine gate below.
 type OffStateContext = { declared: Record<string, unknown>; live: Record<string, unknown> };
 // #660 item 1: a MEANINGFUL_WHEN_OFF predicate for a `true`-default switch that a snapshot /
 // point-in-time RESTORE can carry over as an untouched `false`. A fresh, NON-restored resource


### PR DESCRIPTION
Follow-up to #1653 / #1655.

## What

Comment-only: extend the `MEANINGFUL_WHEN_OFF` table's "Add an entry ONLY after…" guidance in `src/diff/classify.ts` with the cluster/member echo caveat that #1520 missed — for a cluster-scoped type with member-instance resources, "every clean-deploy configuration" includes the shape where a MEMBER INSTANCE declares the flag off while the cluster leaves it undeclared (the cluster-level read can echo the members' instance-level setting, as Aurora `AutoMinorVersionUpgrade` does).

This encodes the #1653 retrospective in the repo itself (next to where entries are added) instead of in one machine's session memory, so any contributor or agent adding a cluster-scoped entry sees it.

## Verification

- Comment-only change: `dist/cli.js` builds **byte-identical** to main (sha256 `284bd9dd…` on both), so there is no runtime behavior to live-test.
- Full gates green anyway: typecheck / lint+format / build / 308 files, 5995 tests.
