### PR TITLE
fix(read): Budgets CostTypes projection + ACM KeyAlgorithm canonicalization + StackSet TemplateBody fold

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2078,6 +2078,49 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   // Equality-gated — a plan whose window was shortened/lengthened out of band still
   // surfaces. Observed live on a fresh misspack-hunt deploy (2026-07-15).
   'AWS::Backup::RestoreTestingPlan': { 'RecoveryPointSelection.SelectionWindowDays': 30 },
+  // #1647: DescribeBudget returns the full 11-boolean CostTypes object for every budget —
+  // the documented cost-aggregation defaults (9 true, UseBlended/UseAmortized false),
+  // live-confirmed 2026-07-15. Pinned in BOTH shapes because the declared parent `Budget`
+  // always descends per-leaf (it carries BudgetName/BudgetType/...):
+  //   * the WHOLE-OBJECT pin folds a wholly-undeclared CostTypes (emitted as one sub-object)
+  //     — matchesKnownDefault is equality-gated per leaf, so ANY out-of-band flip (including
+  //     a truthy pin flipped false, which a per-leaf pin alone would lose to isTrivialEmpty)
+  //     breaks the match and re-surfaces the whole object;
+  //   * the per-leaf pins fold the undeclared truthy SIBLING leaves of a partially-declared
+  //     CostTypes (e.g. `{IncludeTax: true}` declared, ten live-only siblings). In that
+  //     shape a truthy sibling flipped false is swallowed by isTrivialEmpty before the pin
+  //     gate (#660 item 3) — CostTypes is cost-report scoping, not a security hazard, so no
+  //     MEANINGFUL_WHEN_OFF_NESTED pairing is added. The two FALSE defaults
+  //     (UseBlended/UseAmortized) have NO per-leaf pin: a live false is already dropped by
+  //     isTrivialEmpty before any pin gate, and a flip to true surfaces as undeclared with
+  //     or without one — a pin would be behaviorally dead (and every listed entry must
+  //     emit an atDefault finding, the classify.test audit invariant).
+  // A user who declares any leaf is compared in the declared dimension (fixing both the
+  // truthy-FP and the all-false-FN of #1647).
+  'AWS::Budgets::Budget': {
+    'Budget.CostTypes': {
+      IncludeTax: true,
+      IncludeSubscription: true,
+      UseBlended: false,
+      IncludeRefund: true,
+      IncludeCredit: true,
+      IncludeUpfront: true,
+      IncludeRecurring: true,
+      IncludeOtherSubscription: true,
+      IncludeSupport: true,
+      IncludeDiscount: true,
+      UseAmortized: false,
+    },
+    'Budget.CostTypes.IncludeTax': true,
+    'Budget.CostTypes.IncludeSubscription': true,
+    'Budget.CostTypes.IncludeRefund': true,
+    'Budget.CostTypes.IncludeCredit': true,
+    'Budget.CostTypes.IncludeUpfront': true,
+    'Budget.CostTypes.IncludeRecurring': true,
+    'Budget.CostTypes.IncludeOtherSubscription': true,
+    'Budget.CostTypes.IncludeSupport': true,
+    'Budget.CostTypes.IncludeDiscount': true,
+  },
   // An IoT TopicRule that declares TopicRulePayload with only Sql + Actions reads back the
   // default `AwsIotSqlVersion: "2015-10-08"` — the older, stable compat default IoT assigns
   // when the version is unspecified (NOT a moving GA value). TopicRulePayload is partially
@@ -4296,6 +4339,15 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   cfn-exec-role ARN shape: the `cdk-<qualifier>-cfn-exec-role-<acct>-<region>` role folds, any
   //   other RoleARN surfaces as undeclared (recordable, then watched).
   'AWS::CloudFormation::Stack': new Set(['TemplateBody', 'Capabilities']),
+  //   AWS::CloudFormation::StackSet — the StackSet twin of the Stack `TemplateBody` fold above
+  //   (#1649): an asset-based StackSet (CDK `StackSetTemplate.fromStackSetStack`) declares
+  //   `TemplateURL` (write-only → readGap) while the live read returns the materialized
+  //   `TemplateBody` — the ENTIRE child template as one string, surfacing as [Potential Drift]
+  //   on every first check. Same rationale: the body is the deterministic materialization of a
+  //   versioned asset URL the user delegated to AWS, it changes on every legitimate redeploy,
+  //   and it is unpinnable → value-independent. A user who cares about the body DECLARES
+  //   `TemplateBody`, which stays compared in the declared dimension.
+  'AWS::CloudFormation::StackSet': new Set(['TemplateBody']),
   //   AWS::SageMaker::MonitoringSchedule — the resource schema marks ONLY
   //   [MonitoringScheduleArn, CreationTime, LastModifiedTime] readOnly, so three AWS-managed
   //   RUNTIME-STATE props leak as undeclared on a clean deploy (a schema gap — they are

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -587,9 +587,16 @@ const readBudget: OverrideReader = async ({ physicalId, declared, accountId, reg
   // returns `{}` (or omits it) for an unfiltered budget, which `isTrivialEmpty`
   // suppresses, so a budget that declares no filters stays CLEAN; a declared filter set
   // is compared, and one added out of band surfaces. The projection still stays thin
-  // where it must: COMPUTED fields (CalculatedSpend) and AWS-defaulted blobs (TimePeriod's
-  // 2087 end date, the full CostTypes default set) are deliberately NOT offered — they
-  // would be live-only noise.
+  // where it must: COMPUTED fields (CalculatedSpend) and the AWS-defaulted TimePeriod
+  // (its 2087 end date) are deliberately NOT offered — they would be live-only noise.
+  //
+  // CostTypes IS projected (#1647): omitting it made classify's removed-declared-collection
+  // branch fire on any truthy declared CostTypes (`desired={"IncludeTax":true}
+  // actual=undefined` false drift on every clean check), while an all-false declared
+  // CostTypes was swallowed by the isTrivialEmpty exemption — so a declared CostTypes was
+  // never compared in EITHER direction. DescribeBudget returns the full 11-boolean object;
+  // the undeclared default set folds via the KNOWN_DEFAULT_PATHS `Budget.CostTypes.*`
+  // constants (noise.ts), so a budget that declares no CostTypes stays CLEAN.
   // PlannedBudgetLimits — a time-phased budget's per-period limits. Omitting it made an
   // out-of-band change to a future month's limit invisible (a declared one became a
   // readGap; an undeclared one wholly invisible). FP-safe: DescribeBudget returns it ONLY
@@ -611,6 +618,7 @@ const readBudget: OverrideReader = async ({ physicalId, declared, accountId, reg
       ...(b.BudgetLimit !== undefined && { BudgetLimit: b.BudgetLimit }),
       ...(b.PlannedBudgetLimits !== undefined && { PlannedBudgetLimits: b.PlannedBudgetLimits }),
       ...(b.CostFilters !== undefined && { CostFilters: b.CostFilters }),
+      ...(b.CostTypes !== undefined && { CostTypes: b.CostTypes }),
       ...(aad && {
         AutoAdjustData: {
           ...(aad.AutoAdjustType !== undefined && { AutoAdjustType: aad.AutoAdjustType }),
@@ -3248,6 +3256,23 @@ const readSesConfigurationSetEventDestination: OverrideReader = async ({
 //     rather than a fabricated projection — projecting the runtime shape against the declared
 //     input shape would false-flag every cert.
 const ACM_DEFAULT_TRANSPARENCY = 'ENABLED';
+// #1648: DescribeCertificate returns a HYPHENATED KeyAlgorithm spelling ("RSA-2048") for
+// some certificates (era-/path-dependent — live-observed on 2024-era certs in two regions)
+// while the SDK enum and the CFn resource schema both spell it with an underscore
+// ("RSA_2048"). The mismatch broke BOTH dimensions: the KNOWN_DEFAULTS RSA_2048 pin never
+// folded (permanent first-run [Potential Drift]) and a declared RSA_2048 false-flagged
+// declared drift. Canonicalize reader-side onto the CFn enum spelling via an EXPLICIT map
+// of the known enum members only — an unknown/future value passes through untouched (never
+// mangle a spelling we have not verified).
+const ACM_KEY_ALGORITHM_CANONICAL: Record<string, string> = {
+  'RSA-1024': 'RSA_1024',
+  'RSA-2048': 'RSA_2048',
+  'RSA-3072': 'RSA_3072',
+  'RSA-4096': 'RSA_4096',
+  'EC-prime256v1': 'EC_prime256v1',
+  'EC-secp384r1': 'EC_secp384r1',
+  'EC-secp521r1': 'EC_secp521r1',
+};
 const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region }) => {
   const arn = str(physicalId);
   // The CFn physical id of an ACM certificate IS its ARN; without it we cannot address it.
@@ -3258,7 +3283,9 @@ const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region
   if (!cert) return undefined;
   const model: Record<string, unknown> = {};
   if (str(cert.DomainName)) model.DomainName = cert.DomainName;
-  if (str(cert.KeyAlgorithm)) model.KeyAlgorithm = cert.KeyAlgorithm;
+  const keyAlg = str(cert.KeyAlgorithm);
+  // Canonicalize the hyphenated live spelling onto the CFn enum spelling (#1648).
+  if (keyAlg) model.KeyAlgorithm = ACM_KEY_ALGORITHM_CANONICAL[keyAlg] ?? keyAlg;
   // SANs only when declared — AWS always folds DomainName in as an implied SAN, so an
   // undeclared live list would false-flag every single-domain cert (see note above).
   const declaredSans = Array.isArray(declared.SubjectAlternativeNames)

--- a/tests/acm-keyalgorithm-1648.test.ts
+++ b/tests/acm-keyalgorithm-1648.test.ts
@@ -1,0 +1,125 @@
+// #1648 — ACM KeyAlgorithm hyphen/underscore spelling. DescribeCertificate returns a
+// HYPHENATED spelling ("RSA-2048") for some certificates (era-/path-dependent) while the
+// SDK enum + CFn schema spell it "RSA_2048" — so the #1090 KNOWN_DEFAULTS pin never
+// matched and every such cert surfaced a permanent first-run [Potential Drift] (and a
+// declared RSA_2048 would false-flag declared drift). Fix: readAcmCertificate
+// canonicalizes the hyphenated live spelling onto the CFn enum spelling via an explicit
+// map of the KNOWN enum members only; unknown values pass through untouched.
+import {
+  ACMClient,
+  DescribeCertificateCommand,
+  type KeyAlgorithm,
+  ListTagsForCertificateCommand,
+} from '@aws-sdk/client-acm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const acm = mockClient(ACMClient);
+const ARN = 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012';
+const read = (declared: Record<string, unknown>) =>
+  SDK_OVERRIDES['AWS::CertificateManager::Certificate']({
+    physicalId: ARN,
+    declared,
+    region: 'us-east-1',
+    accountId: '123456789012',
+  });
+const mockCert = (keyAlgorithm: string) => {
+  acm.on(DescribeCertificateCommand).resolves({
+    Certificate: {
+      CertificateArn: ARN,
+      DomainName: 'example.com',
+      // cast: the hyphenated live spellings under test are NOT members of the SDK's
+      // KeyAlgorithm enum — that spelling gap IS the #1648 bug being exercised.
+      KeyAlgorithm: keyAlgorithm as KeyAlgorithm,
+    },
+  });
+  acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+};
+
+describe('#1648 readAcmCertificate KeyAlgorithm canonicalization', () => {
+  beforeEach(() => acm.reset());
+
+  it('canonicalizes the hyphenated RSA-2048 onto the CFn enum spelling RSA_2048', async () => {
+    mockCert('RSA-2048');
+    expect(await read({ DomainName: 'example.com' })).toMatchObject({
+      KeyAlgorithm: 'RSA_2048',
+    });
+  });
+
+  it('canonicalizes a hyphenated EC form (EC-prime256v1 -> EC_prime256v1)', async () => {
+    mockCert('EC-prime256v1');
+    expect(await read({ DomainName: 'example.com' })).toMatchObject({
+      KeyAlgorithm: 'EC_prime256v1',
+    });
+  });
+
+  it('passes the underscore spelling through unchanged', async () => {
+    mockCert('RSA_2048');
+    expect(await read({ DomainName: 'example.com' })).toMatchObject({
+      KeyAlgorithm: 'RSA_2048',
+    });
+  });
+
+  it('passes an UNKNOWN future value through untouched (never mangle unverified spellings)', async () => {
+    mockCert('RSA-8192');
+    expect(await read({ DomainName: 'example.com' })).toMatchObject({
+      KeyAlgorithm: 'RSA-8192',
+    });
+  });
+});
+
+// End-to-end: the canonicalized reader output now hits the #1090 KNOWN_DEFAULTS RSA_2048
+// pin, so a hyphen-era cert that declares no KeyAlgorithm folds to atDefault.
+const acmSchema: SchemaInfo = {
+  readOnly: new Set(['Id']),
+  writeOnly: new Set(),
+  createOnly: new Set(['DomainName', 'SubjectAlternativeNames', 'KeyAlgorithm']),
+  readOnlyPaths: ['Id'],
+  writeOnlyPaths: [],
+  createOnlyPaths: ['DomainName', 'SubjectAlternativeNames', 'KeyAlgorithm'],
+  defaults: {},
+  defaultPaths: {},
+};
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'Cert',
+  resourceType: 'AWS::CertificateManager::Certificate',
+  physicalId: ARN,
+  declared,
+});
+const all = (fs: Finding[]) => fs.map((f) => `${f.tier}:${f.path}`).sort();
+
+describe('#1648 canonicalized KeyAlgorithm reaches the KNOWN_DEFAULTS fold', () => {
+  beforeEach(() => acm.reset());
+
+  it('a hyphen-era cert with no declared KeyAlgorithm folds to atDefault — zero first-run drift', async () => {
+    mockCert('RSA-2048');
+    const live = (await read({ DomainName: 'example.com' })) as Record<string, unknown>;
+    const findings = classifyResource(mk({ DomainName: 'example.com' }), live, acmSchema);
+    // FULL tier:path list (#747): only the atDefault fold, no undeclared/declared leak.
+    expect(all(findings)).toEqual(['atDefault:KeyAlgorithm']);
+  });
+
+  it('a declared RSA_2048 against a hyphen-echoing cert no longer false-flags declared drift', async () => {
+    mockCert('RSA-2048');
+    const live = (await read({ DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' })) as Record<
+      string,
+      unknown
+    >;
+    const findings = classifyResource(
+      mk({ DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' }),
+      live,
+      acmSchema
+    );
+    expect(all(findings)).toEqual([]);
+  });
+
+  it('a genuinely different algorithm still surfaces — detection preserved', async () => {
+    mockCert('EC-prime256v1');
+    const live = (await read({ DomainName: 'example.com' })) as Record<string, unknown>;
+    const findings = classifyResource(mk({ DomainName: 'example.com' }), live, acmSchema);
+    expect(all(findings)).toEqual(['undeclared:KeyAlgorithm']);
+  });
+});

--- a/tests/budgets-costtypes-1647.test.ts
+++ b/tests/budgets-costtypes-1647.test.ts
@@ -1,0 +1,160 @@
+// #1647 — Budgets CostTypes. readBudget deliberately omitted CostTypes from its
+// projection, so classify's removed-declared-collection branch fired on any truthy
+// declared CostTypes (`desired={"IncludeTax":true} actual=undefined` false drift on every
+// clean check) while an all-false declared CostTypes was swallowed by the isTrivialEmpty
+// exemption — a declared CostTypes was never compared in EITHER direction. Two-part fix:
+//   F1 readBudget projects CostTypes (DescribeBudget returns the full 11-boolean object).
+//   F2 KNOWN_DEFAULT_PATHS pins the 11 documented constants (`Budget.CostTypes.*`,
+//      9 true + UseBlended/UseAmortized false, live-confirmed 2026-07-15), equality-gated
+//      so the undeclared default set folds to zero first-run drift while an out-of-band
+//      truthy flip (UseBlended/UseAmortized -> true) still surfaces.
+import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// The exact live-observed 11-boolean default set from budgets:DescribeBudget (#1647).
+const LIVE_COST_TYPES_DEFAULTS = {
+  IncludeTax: true,
+  IncludeSubscription: true,
+  UseBlended: false,
+  IncludeRefund: true,
+  IncludeCredit: true,
+  IncludeUpfront: true,
+  IncludeRecurring: true,
+  IncludeOtherSubscription: true,
+  IncludeSupport: true,
+  IncludeDiscount: true,
+  UseAmortized: false,
+};
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+// FULL tier:path list (not tier-filtered) so double-reporting cannot hide (#747).
+const all = (fs: Finding[]) => fs.map((f) => `${f.tier}:${f.path}`).sort();
+
+const mk = (declaredBudget: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'CfnBudget',
+  resourceType: 'AWS::Budgets::Budget',
+  physicalId: 'my-budget',
+  declared: { Budget: declaredBudget },
+});
+const liveBudget = (costTypes: Record<string, unknown>): Record<string, unknown> => ({
+  Budget: {
+    BudgetName: 'my-budget',
+    BudgetType: 'COST',
+    TimeUnit: 'MONTHLY',
+    BudgetLimit: { Amount: '5.0', Unit: 'USD' },
+    CostTypes: costTypes,
+  },
+});
+const baseDeclared = {
+  BudgetName: 'my-budget',
+  BudgetType: 'COST',
+  TimeUnit: 'MONTHLY',
+  BudgetLimit: { Amount: 5, Unit: 'USD' },
+};
+
+describe('#1647 F1 readBudget projects CostTypes', () => {
+  const budgets = mockClient(BudgetsClient);
+  beforeEach(() => budgets.reset());
+
+  it('projects the full live CostTypes object so a declared CostTypes is actually compared', async () => {
+    budgets.on(DescribeBudgetCommand).resolves({
+      Budget: {
+        BudgetName: 'b',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        CostTypes: LIVE_COST_TYPES_DEFAULTS,
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::Budgets::Budget']({
+      physicalId: 'b',
+      declared: { Budget: { BudgetName: 'b' } },
+      region: 'us-east-1',
+      accountId: '123456789012',
+    });
+    expect(out).toEqual({
+      Budget: {
+        BudgetName: 'b',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        CostTypes: LIVE_COST_TYPES_DEFAULTS,
+      },
+    });
+  });
+});
+
+describe('#1647 F2 CostTypes KNOWN_DEFAULT_PATHS folds', () => {
+  it('an UNDECLARED CostTypes at the full 11-boolean default set folds — zero drift on a clean check', () => {
+    const findings = classifyResource(
+      mk(baseDeclared),
+      liveBudget(LIVE_COST_TYPES_DEFAULTS),
+      emptySchema
+    );
+    // FULL list: nothing but atDefault-tier fold(s) for CostTypes — no declared, no
+    // undeclared, no double-reporting.
+    expect(all(findings)).toEqual(['atDefault:Budget.CostTypes']);
+  });
+
+  it('declared IncludeTax:true matching the live true is clean (the #1647 FP direction)', () => {
+    const findings = classifyResource(
+      mk({ ...baseDeclared, CostTypes: { IncludeTax: true } }),
+      liveBudget(LIVE_COST_TYPES_DEFAULTS),
+      emptySchema
+    );
+    expect(all(findings).filter((p) => p.startsWith('declared:'))).toEqual([]);
+    expect(all(findings).filter((p) => p.startsWith('undeclared:'))).toEqual([]);
+  });
+
+  it('declared IncludeTax:false vs live true MUST surface declared drift (the #1647 FN direction)', () => {
+    const findings = classifyResource(
+      mk({ ...baseDeclared, CostTypes: { IncludeTax: false } }),
+      liveBudget(LIVE_COST_TYPES_DEFAULTS),
+      emptySchema
+    );
+    const declared = findings.filter((f) => f.tier === 'declared');
+    expect(declared.length).toBeGreaterThan(0);
+    expect(declared.some((f) => f.path.startsWith('Budget.CostTypes'))).toBe(true);
+  });
+
+  it('an out-of-band flip AWAY from a default (UseBlended false -> true) still surfaces', () => {
+    const findings = classifyResource(
+      mk(baseDeclared),
+      liveBudget({ ...LIVE_COST_TYPES_DEFAULTS, UseBlended: true }),
+      emptySchema
+    );
+    // The divergent leaf breaks the fold: the finding must land in the undeclared tier
+    // (whole-object or per-leaf), never fold silently.
+    const undeclared = findings.filter((f) => f.tier === 'undeclared');
+    expect(undeclared.length).toBeGreaterThan(0);
+    expect(undeclared.some((f) => f.path.startsWith('Budget.CostTypes'))).toBe(true);
+    // and it is not ALSO reported atDefault (no double-reporting)
+    expect(all(findings).filter((p) => p.startsWith('atDefault:Budget.CostTypes'))).toEqual([]);
+  });
+
+  it('an out-of-band truthy-pin flip (IncludeTax true -> false) surfaces via the whole-object pin', () => {
+    // The wholly-undeclared CostTypes is emitted as ONE sub-object, so the equality-gated
+    // whole-object pin re-surfaces even a true->false leaf flip (which a per-leaf pin alone
+    // would lose to isTrivialEmpty).
+    const findings = classifyResource(
+      mk(baseDeclared),
+      liveBudget({ ...LIVE_COST_TYPES_DEFAULTS, IncludeTax: false }),
+      emptySchema
+    );
+    const undeclared = findings.filter((f) => f.tier === 'undeclared');
+    expect(undeclared.some((f) => f.path.startsWith('Budget.CostTypes'))).toBe(true);
+    expect(all(findings).filter((p) => p.startsWith('atDefault:Budget.CostTypes'))).toEqual([]);
+  });
+});

--- a/tests/stackset-templatebody-1649.test.ts
+++ b/tests/stackset-templatebody-1649.test.ts
@@ -1,0 +1,75 @@
+// #1649 — StackSet TemplateBody first-run FP. An asset-based StackSet (CDK
+// `StackSetTemplate.fromStackSetStack`) declares TemplateURL (write-only -> readGap)
+// while the live read returns the materialized TemplateBody — the entire child template
+// as one string — which surfaced as [Potential Drift] on every first check.
+// AWS::CloudFormation::Stack already folds TemplateBody value-independently (#723);
+// this adds the same entry for AWS::CloudFormation::StackSet. A DECLARED TemplateBody
+// stays compared in the declared dimension (detection preserved for users who declare it).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// The StackSet registry schema marks TemplateURL writeOnly (why the declared side is a
+// readGap, never a compare) and StackSetId readOnly.
+const stackSetSchema: SchemaInfo = {
+  readOnly: new Set(['StackSetId']),
+  writeOnly: new Set(['TemplateURL']),
+  createOnly: new Set(['StackSetName', 'PermissionModel']),
+  readOnlyPaths: ['StackSetId'],
+  writeOnlyPaths: ['TemplateURL'],
+  createOnlyPaths: ['StackSetName', 'PermissionModel'],
+  defaults: {},
+  defaultPaths: {},
+};
+const BODY = '{"Resources":{"Topic":{"Type":"AWS::SNS::Topic"}}}';
+const mk = (declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'ConfigStackSet',
+  resourceType: 'AWS::CloudFormation::StackSet',
+  physicalId: 'my-stackset:1111-2222',
+  declared,
+});
+// FULL tier:path list (not tier-filtered) so double-reporting cannot hide (#747).
+const all = (fs: Finding[]) => fs.map((f) => `${f.tier}:${f.path}`).sort();
+
+describe('#1649 StackSet TemplateBody value-independent fold', () => {
+  it('folds the UNDECLARED materialized TemplateBody of an asset-based StackSet — zero first-run drift', () => {
+    const findings = classifyResource(
+      mk({
+        StackSetName: 'my-stackset',
+        PermissionModel: 'SELF_MANAGED',
+        TemplateURL: 'https://s3.us-east-1.amazonaws.com/cdk-assets/abc123.json',
+      }),
+      { StackSetName: 'my-stackset', PermissionModel: 'SELF_MANAGED', TemplateBody: BODY },
+      stackSetSchema
+    );
+    // FULL list: the body folds atDefault (value-independent) and the write-only declared
+    // TemplateURL stays an honest readGap — no undeclared leak, no declared finding.
+    expect(all(findings)).toEqual(['atDefault:TemplateBody', 'readGap:TemplateURL']);
+  });
+
+  it('a DECLARED TemplateBody is still compared — declared drift surfaces', () => {
+    const findings = classifyResource(
+      mk({ StackSetName: 'my-stackset', PermissionModel: 'SELF_MANAGED', TemplateBody: BODY }),
+      {
+        StackSetName: 'my-stackset',
+        PermissionModel: 'SELF_MANAGED',
+        TemplateBody:
+          '{"Resources":{"Topic":{"Type":"AWS::SNS::Topic","Properties":{"FifoTopic":true}}}}',
+      },
+      stackSetSchema
+    );
+    const declared = findings.filter((f) => f.tier === 'declared');
+    expect(declared.map((f) => f.path)).toContain('TemplateBody');
+    // the value-independent fold must NOT also swallow it into atDefault
+    expect(all(findings).filter((p) => p === 'atDefault:TemplateBody')).toEqual([]);
+  });
+
+  it('a declared TemplateBody equal to the live one is clean', () => {
+    const findings = classifyResource(
+      mk({ StackSetName: 'my-stackset', PermissionModel: 'SELF_MANAGED', TemplateBody: BODY }),
+      { StackSetName: 'my-stackset', PermissionModel: 'SELF_MANAGED', TemplateBody: BODY },
+      stackSetSchema
+    );
+    expect(all(findings)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1647
Closes #1648
Closes #1649

Three first-run FP fixes bundled in one lane (shared files: `src/read/overrides.ts`, `src/normalize/noise.ts`).

## #1647 — Budgets: declared CostTypes never compared (FP + hidden FN)

`readBudget` deliberately omitted `CostTypes` from its projection, so classify's removed-declared-collection branch fired on any truthy declared CostTypes (`desired={"IncludeTax":true} actual=undefined` on every clean check), while an all-false declared CostTypes was swallowed by the `isTrivialEmpty` exemption — never compared in either direction.

**Fix (fold tier 1):**
- `readBudget` now projects `CostTypes` (live-confirmed in the issue: `budgets:DescribeBudget` returns the full 11-boolean object).
- `KNOWN_DEFAULT_PATHS` pins the documented defaults in two shapes:
  - a **whole-object pin** `Budget.CostTypes` (all 11 booleans) — folds a wholly-undeclared CostTypes; `matchesKnownDefault` is equality-gated per leaf, so ANY out-of-band flip (including a truthy pin flipped false) breaks the match and re-surfaces;
  - **per-leaf pins** for the 9 `true` defaults — fold the undeclared siblings of a partially-declared CostTypes. The two `false` defaults (`UseBlended`/`UseAmortized`) have no per-leaf pin: a live `false` is dropped by `isTrivialEmpty` before any pin gate and a flip to `true` surfaces with or without one (a pin would be behaviorally dead, and the classify.test audit requires every entry to emit an atDefault finding).

## #1648 — ACM: KeyAlgorithm hyphen/underscore spelling never folds

Live `acm:DescribeCertificate` returns the HYPHENATED spelling (`"RSA-2048"`) for some certs (era-/path-dependent) while the SDK enum + CFn schema spell it `RSA_2048` — so the #1090 `KNOWN_DEFAULTS` pin never matched (permanent `[Potential Drift]` on every such cert) and a declared `RSA_2048` would false-flag declared drift.

**Fix:** `readAcmCertificate` canonicalizes reader-side via an explicit map of the 7 known enum members (`RSA-1024/2048/3072/4096`, `EC-prime256v1/secp384r1/secp521r1` → underscore forms). Unknown/future values pass through untouched (never mangle unverified spellings). Reader-side canonicalization fixes BOTH the undeclared and declared dimensions.

## #1649 — StackSet: materialized TemplateBody surfaces on every asset-based StackSet

Asset-based StackSets declare `TemplateURL` (write-only → readGap); the live read returns the materialized `TemplateBody` — the entire child template — as undeclared Potential Drift on every first check. `AWS::CloudFormation::Stack` already has this exact fold (#723); StackSet never got the entry.

**Fix:** `AWS::CloudFormation::StackSet: TemplateBody` added to `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`, mirroring the #723 rationale (the body is the deterministic materialization of a versioned asset URL the user delegated; a user who cares declares `TemplateBody`, which stays compared in the declared dimension). The optional tier-2 S3 fetch is NOT implemented (per the issue).

## Tests

All new tests FAIL without the fix (verified via `git stash` of `src/`: 8 failed → all 16 pass with the fix). Classify assertions use the FULL `tier:path` list (#747) where the finding set is deterministic.

- `tests/budgets-costtypes-1647.test.ts` (6): reader projects CostTypes; undeclared full default set folds to exactly `['atDefault:Budget.CostTypes']`; declared `IncludeTax:true` clean; declared `IncludeTax:false` vs live `true` surfaces declared drift (the FN direction); OOB `UseBlended→true` surfaces undeclared; OOB `IncludeTax→false` surfaces via the whole-object pin.
- `tests/acm-keyalgorithm-1648.test.ts` (7): reader canonicalizes `RSA-2048`→`RSA_2048` and `EC-prime256v1`→`EC_prime256v1`; underscore + unknown values pass through; end-to-end classify folds a hyphen-era cert to exactly `['atDefault:KeyAlgorithm']`; declared `RSA_2048` vs hyphen-echo → zero findings; a genuinely different algorithm still surfaces.
- `tests/stackset-templatebody-1649.test.ts` (3): undeclared body folds to exactly `['atDefault:TemplateBody', 'readGap:TemplateURL']`; a declared body that differs surfaces declared drift (not swallowed by the fold); an equal declared body is clean.

## Gates

- `vp run typecheck` — pass
- `vp check --fix` — pass (0 errors)
- `vp pack` — pass
- `vp test run` — 311 files, 6003/6003 pass (includes the KNOWN_DEFAULT_PATHS audit in `tests/classify.test.ts` and the existing Budgets/StackSet corpus-replay cases)

## Live evidence / deferrals (verify-pr)

- All three fixes originate from the 2026-07-15 live dogfood run; the issues carry the raw live repro (DescribeBudget CostTypes JSON, the hyphenated DescribeCertificate spelling observed on 6 certs in 2 regions, the StackSet check output). The unit tests replay those live models verbatim.
- A fresh real-AWS live deploy for this PR was NOT run (denied by the session's permission policy); shared CORE integration suite deferred — offline + corpus + originating-dogfood-verified, not re-run.
