### PR TITLE
fix(read): Route53 RecordSet added children fold to cross-region sibling-managed (#1651)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -9,6 +9,7 @@ import {
 import {
   DescribeSecurityGroupsCommand,
   DescribeSubnetsCommand,
+  DescribeRegionsCommand,
   EC2Client,
   GetDefaultCreditSpecificationCommand,
   GetEbsEncryptionByDefaultCommand,
@@ -760,6 +761,102 @@ export async function isManagedBySiblingStack(
     if (seg === 'unverified') sawUnverified = true;
   }
   return sawUnverified ? 'unverified' : 'notManaged';
+}
+
+// Combine a global-service child's per-region sibling probes into one verdict, fail-SAFE. Given a
+// child whose run-region probe was already a DEFINITIVE not-managed, sweep the OTHER enabled
+// regions: ANY region proving sibling ownership wins ('managed' — the child is CFn-managed, just by
+// a stack in another region, so NOT out of band); otherwise if ANY region was UNVERIFIABLE
+// (throttle / AccessDenied / network) return 'unverified' (report as coverage-incomplete, NEVER a
+// destructive DeleteResource on a record a foreign-region stack legitimately owns — #754/#959);
+// only when EVERY region is a definitive not-managed is the child a genuine out-of-band `added`
+// (#1651). `probeInRegion` is injected so this combine logic is unit-testable without AWS.
+export async function resolveCrossRegionSibling(
+  regions: string[],
+  probeInRegion: (region: string) => Promise<SiblingCheck>
+): Promise<SiblingCheck> {
+  let sawUnverified = false;
+  for (const region of regions) {
+    const r = await probeInRegion(region);
+    if (r === 'managed') return 'managed';
+    if (r === 'unverified') sawUnverified = true;
+  }
+  return sawUnverified ? 'unverified' : 'notManaged';
+}
+
+// A run-scoped cross-region sibling probe for GLOBAL-service children (#1651). The
+// AWS::Route53::RecordSet case: the zone is managed by a stack in the check's region, but its
+// records may be managed by other apps' stacks in DIFFERENT regions — invisible to the run-region
+// DescribeStackResources, so they false-flag `added`. When the run-region probe is a definitive
+// not-managed, `escalate` sweeps the account's OTHER enabled regions before concluding out-of-band.
+// Fail-SAFE throughout: if the enabled-region list cannot be enumerated (denied / throttled), or
+// any region's probe is unverifiable, it returns 'unverified' — coverage-incomplete, never a
+// destructive delete offer. The enabled-region list, per-region CloudFormation clients, and each
+// region's probe cache are memoized for the whole run (a zone can enumerate many candidate records).
+export interface CrossRegionSiblingProbe {
+  escalate(c: AddedChild): Promise<SiblingCheck>;
+}
+
+export function makeCrossRegionSiblingProbe(
+  accountId: string,
+  runRegion: string,
+  // Injectable for tests; defaults to a real EC2 DescribeRegions of the account's enabled regions
+  // (excluding the run region, already probed) and a real per-region CloudFormation probe.
+  deps?: {
+    enabledRegions?: () => Promise<string[] | undefined>;
+    probeInRegion?: (c: AddedChild, region: string) => Promise<SiblingCheck>;
+  }
+): CrossRegionSiblingProbe {
+  let regionsPromise: Promise<string[] | undefined> | undefined;
+  const cfnClients = new Map<string, CloudFormationClient>();
+  const caches = new Map<string, Map<string, SiblingCheck>>();
+
+  const fetchEnabledRegions =
+    deps?.enabledRegions ??
+    (async (): Promise<string[] | undefined> => {
+      try {
+        const ec2 = new EC2Client({ region: runRegion, ...READ_RETRY });
+        const res = await ec2.send(new DescribeRegionsCommand({ AllRegions: false }));
+        return (res.Regions ?? [])
+          .map((r) => r.RegionName)
+          .filter((n): n is string => typeof n === 'string' && n !== '' && n !== runRegion);
+      } catch {
+        // Cannot enumerate regions -> cannot prove the child is unmanaged everywhere. The caller
+        // fail-safes this to 'unverified' (never a destructive delete on a possibly foreign-managed
+        // record).
+        return undefined;
+      }
+    });
+  // Enumerate the enabled regions ONCE per run (a zone can enumerate many candidate records).
+  const enabledRegions = (): Promise<string[] | undefined> =>
+    (regionsPromise ??= fetchEnabledRegions());
+
+  const probeInRegion =
+    deps?.probeInRegion ??
+    ((c: AddedChild, region: string): Promise<SiblingCheck> => {
+      let client = cfnClients.get(region);
+      if (!client) {
+        client = new CloudFormationClient({ region, ...READ_RETRY });
+        cfnClients.set(region, client);
+      }
+      let cache = caches.get(region);
+      if (!cache) {
+        cache = new Map();
+        caches.set(region, cache);
+      }
+      // A global-service child's siblingLookupId is its bare CFn physical id (no `|` composite),
+      // so probe it directly against this region's account scope.
+      const physicalId = c.siblingLookupId ?? c.identifier;
+      return probeSiblingPhysicalId(client, c, physicalId, cache, accountId, region);
+    });
+
+  return {
+    async escalate(c: AddedChild): Promise<SiblingCheck> {
+      const regions = await enabledRegions();
+      if (regions === undefined) return 'unverified';
+      return resolveCrossRegionSibling(regions, (region) => probeInRegion(c, region));
+    },
+  };
 }
 
 interface ClassifyOpts {
@@ -1758,6 +1855,9 @@ export async function gatherFindings(
   // as drift (PR4). An enumeration failure is a coverage gap, not drift — surfaced as a
   // `skipped` finding on the parent so it is never silently lost.
   const siblingStackCache = new Map<string, SiblingCheck>();
+  // Cross-region escalation for GLOBAL-service children (Route53 RecordSet, #1651): built lazily,
+  // its enabled-region list + per-region clients/caches memoized for the whole run.
+  const crossRegionProbe = makeCrossRegionSiblingProbe(desired.accountId, region);
   for (const r of desired.resources) {
     const enumerate = CHILD_ENUMERATORS[r.resourceType];
     if (!enumerate || !r.physicalId) continue;
@@ -1776,13 +1876,20 @@ export async function gatherFindings(
       for (const c of children) {
         // A child CDK placed in a SIBLING stack of the same app (cross-stack refs, #666)
         // is fully CloudFormation-managed — not out of band, so skip it.
-        const sibling = await isManagedBySiblingStack(
+        let sibling = await isManagedBySiblingStack(
           cfn,
           c,
           siblingStackCache,
           desired.accountId,
           region
         );
+        // A GLOBAL-service child (Route53 RecordSet) whose run-region probe was a DEFINITIVE
+        // not-managed may still be CFn-managed by a stack in ANOTHER region (#1651) — the zone is
+        // managed here, its records elsewhere. Sweep the account's other enabled regions before
+        // reporting it out of band; the escalation is itself fail-safe ('unverified' on any doubt).
+        if (sibling === 'notManaged' && c.crossRegionSibling) {
+          sibling = await crossRegionProbe.escalate(c);
+        }
         if (sibling === 'managed') continue;
         if (sibling === 'unverified') {
           // The sibling-membership check FAILED (throttle / denied), so we cannot say whether this

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -276,6 +276,16 @@ export interface AddedChild {
   // signal wins: a foreign owner / endpoint ARN downgrades the ValidationError to `unverified`.
   ownerAccountId?: string | undefined; // the child's OWNING account (SNS subscription `Owner`)
   scopeArns?: string[] | undefined; // extra ARNs carrying the child's true account/region (SNS `Endpoint` when an ARN)
+  // GLOBAL-service child whose owning CloudFormation stack may live in ANY region (#1651). The
+  // sibling-membership probe runs on the check's own account+region, so a definitive local
+  // ValidationError only proves "not in a stack of THIS region" — a child fully CFn-managed by a
+  // stack in a DIFFERENT region reads as a false `added`. The canonical case: an
+  // AWS::Route53::RecordSet whose zone is managed by a stack in one region while its records are
+  // managed by other apps' stacks in another (Route53 is global; its records' physical id carries
+  // no region signal, so isDefinitiveNotManaged reads them LOCAL). When set, gather escalates a
+  // definitive local not-managed to a cross-region sweep of the account's enabled regions before
+  // concluding the child is genuinely out of band.
+  crossRegionSibling?: boolean | undefined;
 }
 
 export interface EnumeratorContext {
@@ -5389,6 +5399,27 @@ export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promi
 // usually omits it, so compare dot- and case-insensitively.
 const canonRoute53Name = (s: string): string => s.replace(/\.$/, '').toLowerCase();
 
+// Route53 stores/returns special characters in a record name as octal escapes (`\ooo`): a
+// wildcard `*.example.net` comes back as `\052.example.net.`, and space -> `\040`, etc. The
+// declared/template name (and the CloudFormation physical id, below) use the literal character.
+// Unescape before matching. Home of this helper (readRoute53RecordSet in read/overrides.ts
+// imports it from here) so its consumers can never drift from the enumerator's own escaping.
+// https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html
+export const unescapeRoute53Name = (s: string): string =>
+  s.replace(/\\(\d{3})/g, (_m, oct: string) => String.fromCharCode(Number.parseInt(oct, 8)));
+
+// The CloudFormation PhysicalResourceId of an AWS::Route53::RecordSet is the BARE record NAME
+// (verified live 2026-07-15: `DescribeStackResources --physical-resource-id <name>` resolves the
+// owning stack, the returned resource's PhysicalResourceId IS that bare name, and the A/AAAA
+// variants of one name SHARE it — while the cdkrd-internal `<ZoneId>_<Name>_<Type>` composite
+// [route53RecordSetIdentifier] matches NOTHING in any region). So the sibling-stack membership
+// probe (DescribeStackResources) MUST look the record up by this bare name, not by the composite
+// `identifier` (#1651). ListResourceRecordSets returns the name octal-escaped with a trailing dot
+// (`\052.example.net.`); CFn stores the literal, dot-less form (`*.example.net`), so unescape and
+// strip the trailing dot. NOT lowercased — the physical id preserves the name's case.
+export const route53RecordSetCfnPhysicalId = (liveName: string): string =>
+  unescapeRoute53Name(liveName).replace(/\.$/, '');
+
 // ACM DNS-validation CNAMEs (#1652): an AWS::CertificateManager::Certificate with
 // DomainValidationOptions.HostedZoneId makes the CFn/ACM handler write its validation record
 // (`_<32-hex>.<domain> CNAME _<token>.<random>.acm-validations.aws.`) DIRECTLY into the zone —
@@ -5489,6 +5520,13 @@ export function diffRoute53HostedZoneChildren(input: Route53HostedZoneChildInput
       identifier,
       label: `${type} ${name}`,
       live: r.live ?? { Name: r.name, Type: r.type },
+      // The CC `identifier` above is cdkrd's own `<ZoneId>_<Name>_<Type>` display/record token,
+      // NOT the CFn physical id — so the sibling probe must look the record up by the BARE record
+      // name (the real PhysicalResourceId, #1651). Route53 RecordSets are global-service children:
+      // their owning stack may sit in a different region than the zone, so mark them for the
+      // cross-region escalation in gather.
+      siblingLookupId: route53RecordSetCfnPhysicalId(r.name),
+      crossRegionSibling: true,
     });
   }
   return added;

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -190,6 +190,7 @@ import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { ResourceGoneError } from '../aws-errors.js';
 import { partitionForRegion } from '../desired/template-adapter.js';
+import { unescapeRoute53Name } from './child-enumerators.js';
 import { CLIENT_REQUEST_HANDLER, READ_RETRY } from './client-config.js';
 import { isDefinitiveDenial } from './kms-aliases.js';
 import { hashCaBundle, sha256Hex } from './pem.js';
@@ -1703,20 +1704,18 @@ const alignTrailingDot = (live: string | undefined, declared: unknown): string |
   return declHasDot ? (live.endsWith('.') ? live : `${live}.`) : live.replace(/\.$/, '');
 };
 
-// Route53 stores/returns special characters in a record name as octal escapes
-// (`\ooo`): a wildcard `*.example.net` comes back as `\052.example.net.`, and space
-// → `\040`, etc. The declared/template name uses the literal character, so a
-// verbatim compare misreads the wildcard record as absent — throwing ResourceGoneError
-// → a FALSE `deleted` finding (and leaving the record's returned Name as false
-// declared drift). Unescape before matching AND in the returned model so both the
-// existence check and the value compare see the literal form. See
-// https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html
-const unescapeRoute53Name = (s: string): string =>
-  s.replace(/\\(\d{3})/g, (_m, oct: string) => String.fromCharCode(Number.parseInt(oct, 8)));
-
-// AWS::Route53::RecordSet — CC API GetResource throws UnsupportedActionException.
-// Read via Route53 ListResourceRecordSets (the CFn physical id is
-// `<HostedZoneId>_<Name>_<Type>`; declared values are preferred, id is the fallback).
+// AWS::Route53::RecordSet — CC API GetResource throws UnsupportedActionException, read via
+// Route53 ListResourceRecordSets. Declared values (HostedZoneId / Name / Type) are the primary
+// source and are ALWAYS present for a declared record's read, so this reader keys on them.
+// NOTE on the physical id: the RecordSet's real CloudFormation PhysicalResourceId is the BARE
+// record NAME (`*.example.net`), NOT the `<HostedZoneId>_<Name>_<Type>` form an earlier comment
+// here claimed — that composite is cdkrd's own `route53RecordSetIdentifier` display token
+// (child-enumerators.ts), which never reaches this reader (#1651). The `physicalId.split('_')`
+// fallback below therefore only ever fires on a bare name (no `_`, or a `_`-prefixed name like
+// `_dmarc.example.com`) → `hasIdParts` is false → it contributes nothing; declared values carry
+// the read. (A record declared via HostedZoneName instead of HostedZoneId has no declared
+// HostedZoneId and the bare-name id cannot supply one, so such a read returns undefined — a known
+// gap, tracked separately; unchanged by #1651.)
 const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, region }) => {
   const parts = physicalId.split('_');
   const hasIdParts = parts.length >= 3;

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -98,6 +98,7 @@ import {
   diffNetworkAclEntryChildren,
   diffRdsClusterChildren,
   diffRoute53HostedZoneChildren,
+  route53RecordSetCfnPhysicalId,
   diffRouteTableChildren,
   diffS3BucketPolicy,
   diffSecretsManagerResourcePolicy,
@@ -4808,12 +4809,18 @@ describe('diffRoute53HostedZoneChildren (Route53 hosted zone record sets, #1042)
           Type: 'CNAME',
           ResourceRecords: ['evil.example.net'],
         },
+        // #1651: the sibling probe keys on the BARE record name (the real CFn physical id), NOT the
+        // `<ZoneId>_<Name>_<Type>` display identifier; RecordSets are global-service children.
+        siblingLookupId: 'login.example.com',
+        crossRegionSibling: true,
       },
       {
         resourceType: 'AWS::Route53::RecordSet',
         identifier: `${ZONE}__verify.example.com._TXT`,
         label: 'TXT _verify.example.com',
         live: { Name: '_verify.example.com.', Type: 'TXT' },
+        siblingLookupId: '_verify.example.com',
+        crossRegionSibling: true,
       },
     ]);
   });
@@ -4880,6 +4887,39 @@ describe('diffRoute53HostedZoneChildren (Route53 hosted zone record sets, #1042)
     });
     expect(added).toEqual([]);
   });
+
+  // #1651: siblingLookupId must be the record's real CFn PhysicalResourceId — the BARE record name:
+  // ListResourceRecordSets returns it octal-escaped with a trailing dot, but CFn stores the literal,
+  // dot-less form, and DescribeStackResources matches on that. Case is preserved (not lowercased).
+  it('sets siblingLookupId to the bare CFn physical id (octal-unescaped, trailing dot stripped, #1651)', () => {
+    const added = diffRoute53HostedZoneChildren({
+      hostedZoneId: ZONE,
+      zoneApex: 'example.net',
+      declaredRecords: [],
+      liveRecords: [
+        // Wildcard record: Route53 returns the octal escape `\052` for `*`.
+        {
+          name: '\\052.example.net.',
+          type: 'A',
+          live: { Name: '\\052.example.net.', Type: 'A' },
+        },
+        // Mixed-case name — the physical id preserves case (DNS resolution is case-insensitive but
+        // the CFn physical id is the name as stored).
+        { name: 'API.Example.NET.', type: 'A', live: { Name: 'API.Example.NET.', Type: 'A' } },
+      ],
+    });
+    expect(added.map((a) => a.siblingLookupId)).toEqual(['*.example.net', 'API.Example.NET']);
+    expect(added.every((a) => a.crossRegionSibling === true)).toBe(true);
+  });
+});
+
+describe('route53RecordSetCfnPhysicalId (#1651)', () => {
+  it('unescapes octal, strips the trailing dot, and preserves case', () => {
+    expect(route53RecordSetCfnPhysicalId('www.example.com.')).toBe('www.example.com');
+    expect(route53RecordSetCfnPhysicalId('\\052.example.net.')).toBe('*.example.net'); // wildcard
+    expect(route53RecordSetCfnPhysicalId('API.Example.NET.')).toBe('API.Example.NET'); // case kept
+    expect(route53RecordSetCfnPhysicalId('_dmarc.example.com.')).toBe('_dmarc.example.com'); // leading _
+  });
 });
 
 describe('enumerateRoute53HostedZoneChildren (#1042)', () => {
@@ -4942,6 +4982,8 @@ describe('enumerateRoute53HostedZoneChildren (#1042)', () => {
           TTL: '60',
           ResourceRecords: ['evil.net'],
         },
+        siblingLookupId: 'rogue.example.com',
+        crossRegionSibling: true,
       },
     ]);
     r53.restore();

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -29,7 +29,9 @@ import {
   gatherFindings,
   isDefinitiveNotManaged,
   isManagedBySiblingStack,
+  makeCrossRegionSiblingProbe,
   regatherTouched,
+  resolveCrossRegionSibling,
   type SiblingCheck,
 } from '../src/commands/gather.js';
 import type { AddedChild } from '../src/read/child-enumerators.js';
@@ -1949,6 +1951,89 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
       expect(
         isDefinitiveNotManaged('arn:aws:iam::111122223333:role/R', LOCAL_ACCOUNT, LOCAL_REGION)
       ).toBe(true);
+    });
+  });
+});
+
+describe('cross-region sibling probe (Route53 RecordSet global-service, #1651)', () => {
+  const recordChild = (): AddedChild => ({
+    resourceType: 'AWS::Route53::RecordSet',
+    identifier: 'Z1_api.example.com._A',
+    label: 'A api.example.com',
+    live: {},
+    siblingLookupId: 'api.example.com',
+    crossRegionSibling: true,
+  });
+
+  describe('resolveCrossRegionSibling (pure combine, fail-safe)', () => {
+    it('ANY region proving ownership wins -> managed (and short-circuits)', async () => {
+      const seen: string[] = [];
+      const r = await resolveCrossRegionSibling(['a', 'b', 'c'], (region) => {
+        seen.push(region);
+        return Promise.resolve<SiblingCheck>(region === 'b' ? 'managed' : 'notManaged');
+      });
+      expect(r).toBe('managed');
+      expect(seen).toEqual(['a', 'b']); // stopped at the managing region
+    });
+
+    it('no owner but ANY region unverifiable -> unverified (never a destructive delete)', async () => {
+      const map: Record<string, SiblingCheck> = {
+        a: 'notManaged',
+        b: 'unverified',
+        c: 'notManaged',
+      };
+      const r = await resolveCrossRegionSibling(['a', 'b', 'c'], (region) =>
+        Promise.resolve(map[region] ?? 'notManaged')
+      );
+      expect(r).toBe('unverified');
+    });
+
+    it('every region a definitive not-managed -> notManaged (genuine out-of-band)', async () => {
+      const r = await resolveCrossRegionSibling(['a', 'b'], () =>
+        Promise.resolve<SiblingCheck>('notManaged')
+      );
+      expect(r).toBe('notManaged');
+    });
+
+    it('no other regions -> notManaged (local definitive-miss stands)', async () => {
+      const r = await resolveCrossRegionSibling([], () => Promise.resolve<SiblingCheck>('managed'));
+      expect(r).toBe('notManaged');
+    });
+  });
+
+  describe('makeCrossRegionSiblingProbe.escalate', () => {
+    it('fails SAFE to unverified when the enabled-region list cannot be enumerated', async () => {
+      const probe = makeCrossRegionSiblingProbe('111122223333', 'us-east-1', {
+        enabledRegions: () => Promise.resolve(undefined),
+        probeInRegion: () => Promise.reject(new Error('must not be called')),
+      });
+      expect(await probe.escalate(recordChild())).toBe('unverified');
+    });
+
+    it('folds a record OWNED by a stack in another region -> managed', async () => {
+      const probe = makeCrossRegionSiblingProbe('111122223333', 'us-east-1', {
+        enabledRegions: () => Promise.resolve(['ap-northeast-1', 'eu-west-1']),
+        probeInRegion: (_c, region) =>
+          Promise.resolve<SiblingCheck>(region === 'ap-northeast-1' ? 'managed' : 'notManaged'),
+      });
+      expect(await probe.escalate(recordChild())).toBe('managed');
+    });
+
+    it('reports notManaged only when NO enabled region owns the record', async () => {
+      const probe = makeCrossRegionSiblingProbe('111122223333', 'us-east-1', {
+        enabledRegions: () => Promise.resolve(['ap-northeast-1', 'eu-west-1']),
+        probeInRegion: () => Promise.resolve<SiblingCheck>('notManaged'),
+      });
+      expect(await probe.escalate(recordChild())).toBe('notManaged');
+    });
+
+    it('downgrades to unverified when any region probe is unverifiable', async () => {
+      const probe = makeCrossRegionSiblingProbe('111122223333', 'us-east-1', {
+        enabledRegions: () => Promise.resolve(['ap-northeast-1', 'eu-west-1']),
+        probeInRegion: (_c, region) =>
+          Promise.resolve<SiblingCheck>(region === 'eu-west-1' ? 'unverified' : 'notManaged'),
+      });
+      expect(await probe.escalate(recordChild())).toBe('unverified');
     });
   });
 });


### PR DESCRIPTION
Closes #1651.

## Problem

An `AWS::Route53::RecordSet` enumerated off a declared `AWS::Route53::HostedZone` was falsely flagged `[Added]` (with a destructive Cloud Control delete offer) whenever the record's owning CloudFormation stack lived in a **different region** than the zone's stack. This is a completely standard CDK topology: a stack owns the hosted zone (e.g. us-east-1) while other apps' stacks manage records in it from other regions (e.g. ap-northeast-1).

Two independent root causes:

1. **Wrong sibling-lookup id.** The sibling-membership probe (`DescribeStackResources`) keyed on cdkrd's own `route53RecordSetIdentifier` display token `<ZoneId>_<Name>_<Type>`, which is **not** the record's CloudFormation `PhysicalResourceId` and matches nothing. The real physical id is the **bare record name** (maintainer-verified live: `DescribeStackResources --physical-resource-id <name>` resolves the owning stack; the composite matches nothing in any region). The `overrides.ts` comment claiming the physical id is `<ZoneId>_<Name>_<Type>` was docs-drift.

2. **Region-scoped probe can't see a cross-region owner.** Even with the right id, the run-region `DescribeStackResources` `ValidationError`s for a record owned by a stack in another region, and a bare name parses as definitively local → false `added` persists.

## Fix

**Fix 1** (`child-enumerators.ts`, `overrides.ts`): the enumerator sets `siblingLookupId` to the record's real CFn physical id — the bare name, octal-unescaped (`\052.example.net.` → `*.example.net`), trailing-dot stripped, case preserved. `unescapeRoute53Name` moved into `child-enumerators.ts` and shared with the overrides reader; the stale physical-id comment is corrected.

**Fix 2** (`gather.ts`): RecordSets are marked a **global-service child** (`crossRegionSibling`). When the run-region probe is a *definitive* not-managed, gather escalates to a cross-region sweep of the account's enabled regions (`EC2 DescribeRegions`, lazily enumerated + memoized per run; per-region CFn clients + caches memoized). Combine is **fail-safe**:

- any region proving ownership → `managed` (folded),
- region-enumeration failure or any unverifiable region → `unverified` (coverage-incomplete, **never** a destructive delete),
- only an all-region definitive miss → `added`.

Rogue-record detection is fully preserved.

## Tests

- `child-enumerators.test.ts`: `siblingLookupId` = bare CFn physical id (octal-unescaped, dot-stripped, case-preserved) + `crossRegionSibling: true`; `route53RecordSetCfnPhysicalId` unit.
- `gather.test.ts`: `resolveCrossRegionSibling` combine (managed short-circuit / unverified / notManaged / empty), and `makeCrossRegionSiblingProbe.escalate` (region-enum-failure → unverified, cross-region owner → managed, all-miss → notManaged, any-unverifiable → unverified).
- Full suite: 6033 passing.

## Live verification (2-region fixture)

Deployed a zone stack in **us-east-1** + a record stack in **ap-northeast-1** referencing it, plus a directly-created out-of-band record. `cdkrd check <zone-stack> --region us-east-1`:

| Record | 0.22.2 (old) | this PR |
| --- | --- | --- |
| `api.*` (owned by the ap-northeast-1 stack) | ❌ false `[Added]` | ✅ folded (cross-region sibling found) |
| `rogue.*` (genuinely out of band) | `[Added]` | ✅ still `[Added]` |
| apex NS / SOA | filtered | filtered |

Fixture torn down with `delstack`; both regions `SWEEP CLEAN`.
