### PR TITLE
fix(read): Route53 RecordSet declared via HostedZoneName resolves to a zone id (no readGap) (#1660)

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,7 +870,9 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `iam:GetUserPolicy`, `iam:GetGroupPolicy`, `iam:GetPolicy`, `iam:GetPolicyVersion`,
   `lambda:GetPolicy`, `budgets:ViewBudget`, `ec2:DescribeAddresses`,
   `ec2:DescribeLaunchTemplateVersions`, `ec2:DescribeNetworkAcls`,
-  `route53:ListResourceRecordSets`,
+  `route53:ListResourceRecordSets`, `route53:ListHostedZonesByName` (resolves a
+  RecordSet declared via `HostedZoneName` instead of `HostedZoneId` to its zone
+  id),
   `ses:DescribeReceiptRuleSet`, `ses:DescribeReceiptRule`, `ses:ListReceiptFilters`
   (the SES inbound receipt-rule family — `ReceiptRuleSet` / `ReceiptRule` /
   `ReceiptFilter` — has no Cloud Control handlers),

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -70,6 +70,8 @@ import {
   GlueClient,
 } from '@aws-sdk/client-glue';
 import {
+  ListHostedZonesByNameCommand,
+  type ListHostedZonesByNameCommandOutput,
   ListResourceRecordSetsCommand,
   type ListResourceRecordSetsCommandOutput,
   type ResourceRecordSet,
@@ -1714,14 +1716,42 @@ const alignTrailingDot = (live: string | undefined, declared: unknown): string |
 // fallback below therefore only ever fires on a bare name (no `_`, or a `_`-prefixed name like
 // `_dmarc.example.com`) → `hasIdParts` is false → it contributes nothing; declared values carry
 // the read. (A record declared via HostedZoneName instead of HostedZoneId has no declared
-// HostedZoneId and the bare-name id cannot supply one, so such a read returns undefined — a known
-// gap, tracked separately; unchanged by #1651.)
+// HostedZoneId and the bare-name id cannot supply one; such a read now resolves the name to a
+// zone id via ListHostedZonesByName below — #1660.)
+//
+// Resolve a Route53 HostedZoneName (apex, e.g. `example.com.`) to its zone id. A RecordSet may
+// reference its zone by NAME instead of id (both are valid CFn), and then neither the declared
+// props nor the bare-name physical id carry a zone id — without which ListResourceRecordSets
+// cannot be called and the record is a readGap (its declared drift invisible). Fail-OPEN
+// (undefined → readGap, the prior behaviour) when the name resolves to zero or MULTIPLE zones:
+// one apex name can host both a PUBLIC and a PRIVATE hosted zone, and picking the wrong one would
+// compare the record against the wrong zone. Only an unambiguous single match is used.
+const canonZone = (s: string): string => unescapeRoute53Name(s).replace(/\.$/, '').toLowerCase();
+const resolveHostedZoneIdByName = async (
+  c: Route53Client,
+  zoneName: string
+): Promise<string | undefined> => {
+  const target = canonZone(zoneName);
+  const r: ListHostedZonesByNameCommandOutput = await c.send(
+    // DNSName anchors the (lexicographically-sorted) listing at the target name, so any same-apex
+    // public/private pair lands at the front of the first page — no pagination needed to see both.
+    new ListHostedZonesByNameCommand({ DNSName: zoneName })
+  );
+  const matches = (r.HostedZones ?? []).filter((z) => !!z.Name && canonZone(z.Name) === target);
+  const only = matches.length === 1 ? matches[0] : undefined;
+  return only?.Id?.replace(/^\/hostedzone\//, '');
+};
 const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, region }) => {
   const parts = physicalId.split('_');
   const hasIdParts = parts.length >= 3;
-  const hostedZoneId = str(declared.HostedZoneId) ?? (hasIdParts ? parts[0] : undefined);
+  const c = new Route53Client({ region, ...READ_RETRY });
+  const declaredZoneId = str(declared.HostedZoneId);
+  let hostedZoneId = declaredZoneId ?? (hasIdParts ? parts[0] : undefined);
   const name = str(declared.Name) ?? (hasIdParts ? parts[1] : undefined);
   const type = str(declared.Type) ?? (hasIdParts ? parts[parts.length - 1] : undefined);
+  const zoneName = str(declared.HostedZoneName);
+  const byName = !declaredZoneId && !!zoneName;
+  if (!hostedZoneId && zoneName) hostedZoneId = await resolveHostedZoneIdByName(c, zoneName);
   if (!hostedZoneId || !name || !type) return undefined;
   // A name+type can have MANY records that differ only by SetIdentifier (weighted,
   // latency, failover, geolocation, multivalue routing — an L1 CfnRecordSet pattern).
@@ -1730,7 +1760,6 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
   // or missed entirely. Drop the cap (Route53's default page is 100 records from the
   // StartRecord cursor, which holds all variants of one name+type consecutively) and
   // disambiguate by SetIdentifier below.
-  const c = new Route53Client({ region, ...READ_RETRY });
   const canon = (s: string): string => unescapeRoute53Name(s).replace(/\.$/, '').toLowerCase();
   // Match the declared SetIdentifier too: a simple record declares none and AWS
   // returns none (undefined === undefined), while a weighted/latency variant matches
@@ -1786,7 +1815,13 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
       declared.Name
     ),
     Type: rec.Type,
-    HostedZoneId: hostedZoneId,
+    // Mirror the DECLARED zone identifier. A record declared via HostedZoneName has no declared
+    // HostedZoneId, so emitting the resolved id would surface it as undeclared drift on a clean
+    // deploy (and the declared HostedZoneName would readGap, never returned by the live read).
+    // Echo the declared name instead — it is an immutable identity input (changing it replaces the
+    // record), so echoing loses no meaningful detection. A record declared by id emits the id as
+    // before (including the physical-id fallback, where zoneName is absent).
+    ...(byName ? { HostedZoneName: zoneName } : { HostedZoneId: hostedZoneId }),
   };
   if (rec.TTL !== undefined) model.TTL = String(rec.TTL); // CFn TTL is a string
   const records = rec.ResourceRecords?.map((rr) => rr.Value).filter((v): v is string => !!v);

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -84,7 +84,11 @@ import {
   ListAccessKeysCommand,
   ListEntitiesForPolicyCommand,
 } from '@aws-sdk/client-iam';
-import { ListResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
+import {
+  ListHostedZonesByNameCommand,
+  ListResourceRecordSetsCommand,
+  Route53Client,
+} from '@aws-sdk/client-route-53';
 import {
   DescribeResourceCommand as DescribeLakeFormationResourceCommand,
   EntityNotFoundException as LakeFormationEntityNotFoundException,
@@ -771,6 +775,91 @@ describe('SDK overrides', () => {
       // No HostedZoneId/Name/Type in declared and a non-composite physical id -> the
       // query can't be formed: stay skipped (NOT deleted), the list is never even called.
       expect(await SDK_OVERRIDES['AWS::Route53::RecordSet'](ctx({}, 'opaque-id'))).toBeUndefined();
+    });
+
+    it('#1660: resolves a record declared via HostedZoneName (no HostedZoneId) to a zone id and reads it', async () => {
+      // A record can reference its zone by NAME instead of id (both valid CFn). The bare-name
+      // physical id carries no zone id either, so without resolving the name this would be a
+      // readGap. ListHostedZonesByName resolves the apex -> zone id, then the record is read.
+      route53.on(ListHostedZonesByNameCommand).resolves({
+        HostedZones: [{ Id: '/hostedzone/Z9', Name: 'example.com.', CallerReference: 'r1' }],
+      });
+      route53.on(ListResourceRecordSetsCommand).resolves({
+        ResourceRecordSets: [
+          { Name: 'x.example.com.', Type: 'TXT', TTL: 300, ResourceRecords: [{ Value: '"hi"' }] },
+        ],
+      });
+      const out = (await SDK_OVERRIDES['AWS::Route53::RecordSet'](
+        ctx(
+          { HostedZoneName: 'example.com.', Name: 'x.example.com.', Type: 'TXT' },
+          'x.example.com'
+        )
+      )) as Record<string, unknown>;
+      expect(out).toMatchObject({ Type: 'TXT', TTL: '300', ResourceRecords: ['"hi"'] });
+      // the resolved (prefix-stripped) zone id is used for ListResourceRecordSets
+      const listCall = route53.commandCalls(ListResourceRecordSetsCommand)[0];
+      expect(listCall.args[0].input.HostedZoneId).toBe('Z9');
+      // the model MIRRORS the declared identifier: echoes HostedZoneName, does NOT emit the
+      // resolved HostedZoneId (which would surface as undeclared drift on a clean deploy).
+      expect(out.HostedZoneName).toBe('example.com.');
+      expect(out.HostedZoneId).toBeUndefined();
+    });
+
+    it('#1660: fail-open (readGap) when a HostedZoneName resolves to MULTIPLE zones (public/private split)', async () => {
+      // One apex can host both a public and a private zone; picking either would compare the
+      // record against the wrong zone, so stay a readGap (undefined) and never list records.
+      route53.on(ListHostedZonesByNameCommand).resolves({
+        HostedZones: [
+          { Id: '/hostedzone/Zpub', Name: 'example.com.', CallerReference: 'r1' },
+          { Id: '/hostedzone/Zpriv', Name: 'example.com.', CallerReference: 'r2' },
+        ],
+      });
+      expect(
+        await SDK_OVERRIDES['AWS::Route53::RecordSet'](
+          ctx(
+            { HostedZoneName: 'example.com.', Name: 'x.example.com.', Type: 'TXT' },
+            'x.example.com'
+          )
+        )
+      ).toBeUndefined();
+      expect(route53.commandCalls(ListResourceRecordSetsCommand)).toHaveLength(0);
+    });
+
+    it('#1660: fail-open (readGap) when a HostedZoneName resolves to ZERO zones', async () => {
+      route53.on(ListHostedZonesByNameCommand).resolves({
+        // ListHostedZonesByName returns the lexicographically-nearest zones even with no exact
+        // match; the exact-apex filter must reject them.
+        HostedZones: [
+          { Id: '/hostedzone/Zother', Name: 'other.example.org.', CallerReference: 'r3' },
+        ],
+      });
+      expect(
+        await SDK_OVERRIDES['AWS::Route53::RecordSet'](
+          ctx(
+            { HostedZoneName: 'example.com.', Name: 'x.example.com.', Type: 'TXT' },
+            'x.example.com'
+          )
+        )
+      ).toBeUndefined();
+      expect(route53.commandCalls(ListResourceRecordSetsCommand)).toHaveLength(0);
+    });
+
+    it('#1660: a declared HostedZoneId still wins — ListHostedZonesByName is not called', async () => {
+      route53.on(ListResourceRecordSetsCommand).resolves({
+        ResourceRecordSets: [
+          { Name: 'x.example.com.', Type: 'TXT', TTL: 60, ResourceRecords: [{ Value: '"hi"' }] },
+        ],
+      });
+      const out = await SDK_OVERRIDES['AWS::Route53::RecordSet'](
+        ctx({
+          HostedZoneId: 'Z1',
+          HostedZoneName: 'example.com.',
+          Name: 'x.example.com.',
+          Type: 'TXT',
+        })
+      );
+      expect(out).toMatchObject({ Type: 'TXT', HostedZoneId: 'Z1' });
+      expect(route53.commandCalls(ListHostedZonesByNameCommand)).toHaveLength(0);
     });
 
     it('matches a WILDCARD record: Route53 returns `\\052.` for a declared `*.` (no false deleted)', async () => {


### PR DESCRIPTION
Closes #1660.

## Problem

A declared `AWS::Route53::RecordSet` that references its zone via **`HostedZoneName`**
(instead of `HostedZoneId`) could not be read by the SDK override
`readRoute53RecordSet` (`src/read/overrides.ts`). The reader sourced the zone id only
from `str(declared.HostedZoneId)` or a `physicalId.split('_')` fallback, but:

- with `HostedZoneName`, `declared.HostedZoneId` is undefined; and
- the RecordSet's real CFn `PhysicalResourceId` is the **bare record name** (#1651 /
  PR #1659), which carries no zone id.

So `hostedZoneId` stayed undefined → the reader returned undefined → the record was a
**readGap**, and a console/CLI change to such a record went undetected against the
template.

## Fix

`readRoute53RecordSet` now resolves a declared `HostedZoneName` → zone id via
`route53:ListHostedZonesByName` (exact-apex match, case/trailing-dot canonicalized)
before `ListResourceRecordSets`. **Fail-OPEN** (readGap, the prior behaviour) when the
name resolves to **zero or multiple** zones — one apex can host both a **public** and a
**private** hosted zone, and comparing the record against the wrong one would be worse
than the readGap. A declared `HostedZoneId` still wins and skips the lookup entirely.

## Tests

- reads a record declared via `HostedZoneName` (asserts the resolved, `/hostedzone/`-
  stripped zone id is used for `ListResourceRecordSets`) — fails without the fix;
- fail-open (readGap, no list call) when the name resolves to **multiple** zones
  (public/private split);
- fail-open when the name resolves to **zero** exact-apex matches;
- a declared `HostedZoneId` short-circuits the name lookup (`ListHostedZonesByName` not
  called).

README IAM-permissions list gains `route53:ListHostedZonesByName`.

## Note on the base

Builds on #1659 (both edit `readRoute53RecordSet`; #1660 relies on the bare-name
physical-id finding from #1659). #1659 has now merged, so this PR is rebased onto
`main` and the diff is just the `HostedZoneName` resolution.
