### PR TITLE
docs(readme): add one-place reference table of all check section labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ At the prompt you act on each finding: **record** it (accept and watch),
 ### Every kind of drift and how it prints
 
 Those are just the two a first run can show. The full set, confirmed or
-potential, and the section label each prints under:
+potential, what each is judged against, and the section label it prints under:
 
-| drift                                                                                    | prints as                | drives `--fail` |
-| ---------------------------------------------------------------------------------------- | ------------------------ | :-------------: |
-| a declared resource deleted out of band — the most blatant                               | `[Deleted]`              |       ✅        |
-| a declared property whose live value differs                                             | `[CFn-Declared Drift]`   |       ✅        |
-| a live-only value changed since your baseline — the differentiator                       | `[CFn-Undeclared Drift]` |       ✅        |
-| a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record | `[Added Resource]`       |       ✅        |
-| live-only values (and unrecorded added resources) with no baseline yet — unconfirmed     | `[Potential Drift]`      |       ❌        |
+| drift                                                                                    | judged against         | prints as                | drives `--fail` |
+| ---------------------------------------------------------------------------------------- | ---------------------- | ------------------------ | :-------------: |
+| a declared resource deleted out of band — the most blatant                               | the deployed template  | `[Deleted]`              |       ✅        |
+| a declared property whose live value differs — no baseline needed                        | the deployed template  | `[CFn-Declared Drift]`   |       ✅        |
+| a live-only value changed after you record it — the differentiator                       | your `.cdkrd` baseline | `[CFn-Undeclared Drift]` |       ✅        |
+| a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record | your `.cdkrd` baseline | `[Added Resource]`       |       ✅        |
+| live-only values (and unrecorded added resources) with no baseline yet — unconfirmed     | nothing yet            | `[Potential Drift]`      |       ❌        |
 
 `[CFn-Undeclared Drift]` and `[Added Resource]` are armed by recording — next
 section. Everything else `check` prints is informational, not drift — folded
@@ -271,20 +271,14 @@ undeployed code changes don't show up as drift by default. `--pre-deploy` invert
 that, checking live state against the freshly synthesized template (see
 [`--pre-deploy`](#--pre-deploy)).
 
-### The kinds of drift
+### Naming and mechanics
 
-Named so "declared" is never ambiguous (`CFn-declared` means **in the deployed
-template**, not your CDK code and not your `.cdkrd` baseline):
-
-| term                           | source                               | how it's judged                                                         |
-| ------------------------------ | ------------------------------------ | ----------------------------------------------------------------------- |
-| **CFn-declared**               | in the deployed template             | vs the deployed template; drift from the first run, no baseline needed  |
-| **CFn-undeclared** (live-only) | on the resource, not in the template | vs your `.cdkrd` baseline; the key differentiator                       |
-| **Added resource**             | a whole resource not in the template | reconciled against the baseline like an undeclared property (see below) |
-| **Deleted**                    | in the template, gone live           | the most blatant drift; always fails `--fail`                           |
-
-(`CFn-undeclared` is a template axis; `recorded` / `unrecorded` is a separate
-baseline-file axis: whether you've snapshotted that value yet.)
+The kinds themselves, and the label each prints under, are the
+[table in How to use](#every-kind-of-drift-and-how-it-prints). The names are
+chosen so "declared" is never ambiguous: `CFn-declared` means **in the deployed
+template**, not your CDK code and not your `.cdkrd` baseline. (`CFn-undeclared`
+is a template axis; `recorded` / `unrecorded` is a separate baseline-file axis:
+whether you've snapshotted that value yet.)
 
 The mechanics:
 

--- a/README.md
+++ b/README.md
@@ -146,23 +146,22 @@ At the prompt you act on each finding: **record** it (accept and watch),
 Those are just the two a first run can show. The full set, confirmed or
 potential:
 
-| label                    | drift                                                                                      | judged against               | appears            |
-| ------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------- | ------------------ |
-| `[CFn-Declared Drift]`   | a declared property whose live value differs                                               | the deployed template        | from the first run |
-| `[CFn-Undeclared Drift]` | a live-only value changed out of band — the differentiator                                 | your `.cdkrd` baseline       | after you `record` |
-| `[Added Resource]`       | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record   | your `.cdkrd` baseline       | after you `record` |
-| `[Deleted]`              | a resource deleted out of band — declared, or an added one you recorded — the most blatant | the template / your baseline | from the first run |
-| `[Potential Drift]`      | live-only values (and unrecorded added resources) — unconfirmed                            | nothing yet                  | until you `record` |
+| label                    | drift                                                                                     | judged against               | appears            |
+| ------------------------ | ----------------------------------------------------------------------------------------- | ---------------------------- | ------------------ |
+| `[CFn-Declared Drift]`   | a declared property whose live value differs                                              | the deployed template        | from the first run |
+| `[CFn-Undeclared Drift]` | a live-only value changed out of band (the differentiator)                                | your `.cdkrd` baseline       | after you `record` |
+| `[Added Resource]`       | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record  | your `.cdkrd` baseline       | after you `record` |
+| `[Deleted]`              | a declared resource, or an added one you recorded, deleted out of band (the most blatant) | the template / your baseline | from the first run |
+| `[Potential Drift]`      | unconfirmed live-only values (and unrecorded added resources)                             | nothing yet                  | until you `record` |
 
-The first four are confirmed drift — what fails CI (see
+The first four are confirmed drift, the kind that fails CI (see
 [In CI](#in-ci)); `[Potential Drift]`, being unconfirmed, never does: it waits
 for your record / revert / ignore decision. Record it (next section) and it
 leaves the report but **stays watched**: a later out-of-band change to that
 value surfaces as confirmed `[CFn-Undeclared Drift]`, and a whole recorded
-resource comes back as `[Added Resource]` if changed — `[Deleted]` if deleted.
-Everything else `check` prints is informational, not
-drift — folded into a one-line `info:` footer and detailed in
-[Output](#output).
+resource comes back as `[Added Resource]` if changed, or `[Deleted]` if
+deleted. Everything else `check` prints is informational, not drift: it is
+folded into a one-line `info:` footer and detailed in [Output](#output).
 
 ### Recording
 
@@ -187,8 +186,8 @@ result: 1 drift(s) (undeclared=1)
 ```
 
 The same applies one level up: a whole out-of-band resource you've recorded
-surfaces as **`[Added Resource]`** if its live model changes after the record —
-see [Added out-of-band resources](#added-out-of-band-resources).
+surfaces as **`[Added Resource]`** if its live model changes after the record
+(see [Added out-of-band resources](#added-out-of-band-resources)).
 
 `record` covers live-only state only, not a `[CFn-Declared Drift]`; the other
 verbs are in [The model](#the-model-one-verb-you-run-three-it-offers).
@@ -307,12 +306,12 @@ A whole child resource that exists live but isn't in your template (e.g. an API
 Gateway `ANY` method added on `/` via the console) is the resource-level sibling
 of an undeclared property, and is reconciled the same way against your baseline:
 
-| state                       | reported as                                                      |
-| --------------------------- | ---------------------------------------------------------------- |
-| added, **not** recorded     | **Potential Drift** (no baseline, unconfirmed)                   |
-| recorded, unchanged         | suppressed                                                       |
-| recorded, **changed** since | failing drift (`[Added Resource]`)                               |
-| recorded, **deleted** since | failing drift (`[Deleted]` — record keeps watching; detect-only) |
+| state                       | reported as                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| added, **not** recorded     | **Potential Drift** (no baseline, unconfirmed)                  |
+| recorded, unchanged         | suppressed                                                      |
+| recorded, **changed** since | failing drift (`[Added Resource]`)                              |
+| recorded, **deleted** since | failing drift (`[Deleted]`: record keeps watching; detect-only) |
 
 `cdk drift` / CFn drift detection compare only template-declared resources, so an
 out-of-band addition is invisible to them. Decide it like any finding: `record`

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ potential:
 
 The first four are confirmed drift — what fails CI (see
 [In CI](#in-ci)); `[Potential Drift]`, being unconfirmed, never does: it waits
-for your record / revert / ignore decision. `[CFn-Undeclared Drift]` and
-`[Added Resource]` are armed by recording — next section. Everything else
-`check` prints is informational, not drift — folded into a one-line `info:`
-footer and detailed in [Output](#output).
+for your record / revert / ignore decision. Recording it (next section) makes
+it go quiet — and if the value then changes out of band _again_, it comes back
+confirmed: as `[CFn-Undeclared Drift]`, or `[Added Resource]` for a whole
+resource. Everything else `check` prints is informational, not drift — folded
+into a one-line `info:` footer and detailed in [Output](#output).
 
 ### Recording
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Each block above is one kind of finding, and neither needed a baseline:
   value is really noise, [please report it](https://github.com/go-to-k/cdk-real-drift/issues)
   so it becomes a fold-table fix.
 
+These are the two kinds a first run can show. Recording arms two more confirmed
+tiers — `[CFn-Undeclared Drift]` just below, and `[Added Resource]` for a whole
+[out-of-band resource](#added-out-of-band-resources) — and every section label
+`check` prints is listed in one place in [Output](#output).
+
 At the prompt you act on each finding: **record** it (accept and watch),
 **revert** it (undo the change), or **ignore** it (stop reporting).
 
@@ -162,6 +167,10 @@ your CloudFormation template, the kind `cdk drift` can't see:
 result: 1 drift(s) (undeclared=1)
 ─────────────────────────────────
 ```
+
+The same applies one level up: a whole out-of-band resource you've recorded
+surfaces as **`[Added Resource]`** if its live model changes after the record —
+see [Added out-of-band resources](#added-out-of-band-resources).
 
 `record` covers live-only state only, not a `[CFn-Declared Drift]`; the other
 verbs are in [The model](#the-model-one-verb-you-run-three-it-offers).
@@ -657,8 +666,20 @@ info:
   run with --verbose for the list
 ```
 
-- **Drift tiers** (`deleted` / `declared` / `undeclared`) are always listed in
-  full and drive the `--fail` exit. They are the point.
+Every `[Section Label]` the report can print, in one place:
+
+| section label                                                                                      | what it is                                                                                                | drives `--fail` |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | :-------------: |
+| `[Deleted]`                                                                                        | a declared resource deleted out of band — the most blatant drift                                          |       ✅        |
+| `[CFn-Declared Drift]`                                                                             | a property declared in the deployed template whose live value differs                                     |       ✅        |
+| `[CFn-Undeclared Drift]`                                                                           | a live-only value (not in the template) that changed since your `.cdkrd` baseline — the differentiator    |       ✅        |
+| `[Added Resource]`                                                                                 | a recorded [out-of-band resource](#added-out-of-band-resources) whose live model changed since the record |       ✅        |
+| `[Potential Drift]`                                                                                | live-only values (and unrecorded added resources) with no baseline yet — unconfirmed, detailed below      |       ❌        |
+| `[At AWS Default]` / `[AWS Generated]` / `[Ignored]` / `[Read Gap]` / `[Unresolved]` / `[Skipped]` | informational — folded into the one-line `info:` footer; `--verbose` expands them to full sections        |       ❌        |
+
+- The four **confirmed drift tiers** (`deleted` / `declared` / `undeclared` /
+  `added`) are always listed in full and drive the `--fail` exit. They are the
+  point.
 - **`[Potential Drift: N]`**: undeclared values with no baseline yet; cdkrd
   can't tell an intentional setting from an out-of-band change, so they're listed
   in full as _potential_ (unconfirmed) drift and don't drive the `--fail` exit;

--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ At the prompt you act on each finding: **record** it (accept and watch),
 Those are just the two a first run can show. The full set, confirmed or
 potential:
 
-| label                    | drift                                                                                      | judged against               |
-| ------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------- |
-| `[CFn-Declared Drift]`   | a declared property whose live value differs — no baseline needed                          | the deployed template        |
-| `[CFn-Undeclared Drift]` | a live-only value changed after you record it — the differentiator                         | your `.cdkrd` baseline       |
-| `[Added Resource]`       | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record   | your `.cdkrd` baseline       |
-| `[Deleted]`              | a resource deleted out of band — declared, or an added one you recorded — the most blatant | the template / your baseline |
-| `[Potential Drift]`      | live-only values (and unrecorded added resources) with no baseline yet — unconfirmed       | nothing yet                  |
+| label                    | drift                                                                                      | judged against               | appears            |
+| ------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------- | ------------------ |
+| `[CFn-Declared Drift]`   | a declared property whose live value differs                                               | the deployed template        | from the first run |
+| `[CFn-Undeclared Drift]` | a live-only value changed out of band — the differentiator                                 | your `.cdkrd` baseline       | after you `record` |
+| `[Added Resource]`       | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record   | your `.cdkrd` baseline       | after you `record` |
+| `[Deleted]`              | a resource deleted out of band — declared, or an added one you recorded — the most blatant | the template / your baseline | from the first run |
+| `[Potential Drift]`      | live-only values (and unrecorded added resources) — unconfirmed                            | nothing yet                  | until you `record` |
 
 The first four are confirmed drift — what fails CI (see
 [In CI](#in-ci)); `[Potential Drift]`, being unconfirmed, never does: it waits

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ potential, what each is judged against, and the section label it prints under:
 
 | drift                                                                                    | judged against         | prints as                | drives `--fail` |
 | ---------------------------------------------------------------------------------------- | ---------------------- | ------------------------ | :-------------: |
-| a declared resource deleted out of band — the most blatant                               | the deployed template  | `[Deleted]`              |       ✅        |
 | a declared property whose live value differs — no baseline needed                        | the deployed template  | `[CFn-Declared Drift]`   |       ✅        |
 | a live-only value changed after you record it — the differentiator                       | your `.cdkrd` baseline | `[CFn-Undeclared Drift]` |       ✅        |
 | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record | your `.cdkrd` baseline | `[Added Resource]`       |       ✅        |
+| a declared resource deleted out of band — the most blatant                               | the deployed template  | `[Deleted]`              |       ✅        |
 | live-only values (and unrecorded added resources) with no baseline yet — unconfirmed     | nothing yet            | `[Potential Drift]`      |       ❌        |
 
 `[CFn-Undeclared Drift]` and `[Added Resource]` are armed by recording — next

--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ At the prompt you act on each finding: **record** it (accept and watch),
 ### Every kind of drift and how it prints
 
 Those are just the two a first run can show. The full set, confirmed or
-potential, what each is judged against, and the section label it prints under:
+potential:
 
-| drift                                                                                    | judged against         | prints as                | drives `--fail` |
-| ---------------------------------------------------------------------------------------- | ---------------------- | ------------------------ | :-------------: |
-| a declared property whose live value differs — no baseline needed                        | the deployed template  | `[CFn-Declared Drift]`   |       ✅        |
-| a live-only value changed after you record it — the differentiator                       | your `.cdkrd` baseline | `[CFn-Undeclared Drift]` |       ✅        |
-| a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record | your `.cdkrd` baseline | `[Added Resource]`       |       ✅        |
-| a declared resource deleted out of band — the most blatant                               | the deployed template  | `[Deleted]`              |       ✅        |
-| live-only values (and unrecorded added resources) with no baseline yet — unconfirmed     | nothing yet            | `[Potential Drift]`      |       ❌        |
+| label                    | drift                                                                                      | judged against               | drives `--fail` |
+| ------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------- | :-------------: |
+| `[CFn-Declared Drift]`   | a declared property whose live value differs — no baseline needed                          | the deployed template        |       ✅        |
+| `[CFn-Undeclared Drift]` | a live-only value changed after you record it — the differentiator                         | your `.cdkrd` baseline       |       ✅        |
+| `[Added Resource]`       | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record   | your `.cdkrd` baseline       |       ✅        |
+| `[Deleted]`              | a resource deleted out of band — declared, or an added one you recorded — the most blatant | the template / your baseline |       ✅        |
+| `[Potential Drift]`      | live-only values (and unrecorded added resources) with no baseline yet — unconfirmed       | nothing yet                  |       ❌        |
 
 `[CFn-Undeclared Drift]` and `[Added Resource]` are armed by recording — next
 section. Everything else `check` prints is informational, not drift — folded
@@ -301,11 +301,12 @@ A whole child resource that exists live but isn't in your template (e.g. an API
 Gateway `ANY` method added on `/` via the console) is the resource-level sibling
 of an undeclared property, and is reconciled the same way against your baseline:
 
-| state                       | reported as                                    |
-| --------------------------- | ---------------------------------------------- |
-| added, **not** recorded     | **Potential Drift** (no baseline, unconfirmed) |
-| recorded, unchanged         | suppressed                                     |
-| recorded, **changed** since | failing drift                                  |
+| state                       | reported as                                                      |
+| --------------------------- | ---------------------------------------------------------------- |
+| added, **not** recorded     | **Potential Drift** (no baseline, unconfirmed)                   |
+| recorded, unchanged         | suppressed                                                       |
+| recorded, **changed** since | failing drift (`[Added Resource]`)                               |
+| recorded, **deleted** since | failing drift (`[Deleted]` — record keeps watching; detect-only) |
 
 `cdk drift` / CFn drift detection compare only template-declared resources, so an
 out-of-band addition is invisible to them. Decide it like any finding: `record`

--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ The first four are confirmed drift — what fails CI (see
 [In CI](#in-ci)); `[Potential Drift]`, being unconfirmed, never does: it waits
 for your record / revert / ignore decision. Record it (next section) and it
 leaves the report but **stays watched**: a later out-of-band change to that
-value surfaces as confirmed `[CFn-Undeclared Drift]` — or `[Added Resource]`
-for a whole resource. Everything else `check` prints is informational, not
+value surfaces as confirmed `[CFn-Undeclared Drift]`, and a whole recorded
+resource comes back as `[Added Resource]` if changed — `[Deleted]` if deleted.
+Everything else `check` prints is informational, not
 drift — folded into a one-line `info:` footer and detailed in
 [Output](#output).
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,13 @@ Each block above is one kind of finding, and neither needed a baseline:
   value is really noise, [please report it](https://github.com/go-to-k/cdk-real-drift/issues)
   so it becomes a fold-table fix.
 
-These are just the two a first run can show. Every kind of drift (confirmed or
-potential) and the section label it prints under:
+At the prompt you act on each finding: **record** it (accept and watch),
+**revert** it (undo the change), or **ignore** it (stop reporting).
+
+### Every kind of drift and how it prints
+
+Those are just the two a first run can show. The full set, confirmed or
+potential, and the section label each prints under:
 
 | drift                                                                                    | prints as                | drives `--fail` |
 | ---------------------------------------------------------------------------------------- | ------------------------ | :-------------: |
@@ -152,9 +157,6 @@ potential) and the section label it prints under:
 `[CFn-Undeclared Drift]` and `[Added Resource]` are armed by recording — next
 section. Everything else `check` prints is informational, not drift — folded
 into a one-line `info:` footer and detailed in [Output](#output).
-
-At the prompt you act on each finding: **record** it (accept and watch),
-**revert** it (undo the change), or **ignore** it (stop reporting).
 
 ### Recording
 
@@ -677,7 +679,7 @@ info:
 ```
 
 The table of every drift kind and its section label is up in
-[How to use](#your-first-run-needs-no-baseline); the mechanics:
+[How to use](#every-kind-of-drift-and-how-it-prints); the mechanics:
 
 - The four **confirmed drift tiers** (`deleted` / `declared` / `undeclared` /
   `added`) are always listed in full and drive the `--fail` exit. They are the

--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ potential:
 
 The first four are confirmed drift — what fails CI (see
 [In CI](#in-ci)); `[Potential Drift]`, being unconfirmed, never does: it waits
-for your record / revert / ignore decision. Recording it (next section) makes
-it go quiet — and if the value then changes out of band _again_, it comes back
-confirmed: as `[CFn-Undeclared Drift]`, or `[Added Resource]` for a whole
-resource. Everything else `check` prints is informational, not drift — folded
-into a one-line `info:` footer and detailed in [Output](#output).
+for your record / revert / ignore decision. Record it (next section) and it
+leaves the report but **stays watched**: a later out-of-band change to that
+value surfaces as confirmed `[CFn-Undeclared Drift]` — or `[Added Resource]`
+for a whole resource. Everything else `check` prints is informational, not
+drift — folded into a one-line `info:` footer and detailed in
+[Output](#output).
 
 ### Recording
 

--- a/README.md
+++ b/README.md
@@ -146,17 +146,20 @@ At the prompt you act on each finding: **record** it (accept and watch),
 Those are just the two a first run can show. The full set, confirmed or
 potential:
 
-| label                    | drift                                                                                      | judged against               | drives `--fail` |
-| ------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------- | :-------------: |
-| `[CFn-Declared Drift]`   | a declared property whose live value differs — no baseline needed                          | the deployed template        |       ✅        |
-| `[CFn-Undeclared Drift]` | a live-only value changed after you record it — the differentiator                         | your `.cdkrd` baseline       |       ✅        |
-| `[Added Resource]`       | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record   | your `.cdkrd` baseline       |       ✅        |
-| `[Deleted]`              | a resource deleted out of band — declared, or an added one you recorded — the most blatant | the template / your baseline |       ✅        |
-| `[Potential Drift]`      | live-only values (and unrecorded added resources) with no baseline yet — unconfirmed       | nothing yet                  |       ❌        |
+| label                    | drift                                                                                      | judged against               |
+| ------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------- |
+| `[CFn-Declared Drift]`   | a declared property whose live value differs — no baseline needed                          | the deployed template        |
+| `[CFn-Undeclared Drift]` | a live-only value changed after you record it — the differentiator                         | your `.cdkrd` baseline       |
+| `[Added Resource]`       | a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record   | your `.cdkrd` baseline       |
+| `[Deleted]`              | a resource deleted out of band — declared, or an added one you recorded — the most blatant | the template / your baseline |
+| `[Potential Drift]`      | live-only values (and unrecorded added resources) with no baseline yet — unconfirmed       | nothing yet                  |
 
-`[CFn-Undeclared Drift]` and `[Added Resource]` are armed by recording — next
-section. Everything else `check` prints is informational, not drift — folded
-into a one-line `info:` footer and detailed in [Output](#output).
+The first four are confirmed drift — what fails CI (see
+[In CI](#in-ci)); `[Potential Drift]`, being unconfirmed, never does: it waits
+for your record / revert / ignore decision. `[CFn-Undeclared Drift]` and
+`[Added Resource]` are armed by recording — next section. Everything else
+`check` prints is informational, not drift — folded into a one-line `info:`
+footer and detailed in [Output](#output).
 
 ### Recording
 

--- a/README.md
+++ b/README.md
@@ -138,10 +138,20 @@ Each block above is one kind of finding, and neither needed a baseline:
   value is really noise, [please report it](https://github.com/go-to-k/cdk-real-drift/issues)
   so it becomes a fold-table fix.
 
-These are the two kinds a first run can show. Recording arms two more confirmed
-tiers — `[CFn-Undeclared Drift]` just below, and `[Added Resource]` for a whole
-[out-of-band resource](#added-out-of-band-resources) — and every section label
-`check` prints is listed in one place in [Output](#output).
+These are just the two a first run can show. Every kind of drift (confirmed or
+potential) and the section label it prints under:
+
+| drift                                                                                    | prints as                | drives `--fail` |
+| ---------------------------------------------------------------------------------------- | ------------------------ | :-------------: |
+| a declared resource deleted out of band — the most blatant                               | `[Deleted]`              |       ✅        |
+| a declared property whose live value differs                                             | `[CFn-Declared Drift]`   |       ✅        |
+| a live-only value changed since your baseline — the differentiator                       | `[CFn-Undeclared Drift]` |       ✅        |
+| a recorded [out-of-band resource](#added-out-of-band-resources) changed since the record | `[Added Resource]`       |       ✅        |
+| live-only values (and unrecorded added resources) with no baseline yet — unconfirmed     | `[Potential Drift]`      |       ❌        |
+
+`[CFn-Undeclared Drift]` and `[Added Resource]` are armed by recording — next
+section. Everything else `check` prints is informational, not drift — folded
+into a one-line `info:` footer and detailed in [Output](#output).
 
 At the prompt you act on each finding: **record** it (accept and watch),
 **revert** it (undo the change), or **ignore** it (stop reporting).
@@ -666,16 +676,8 @@ info:
   run with --verbose for the list
 ```
 
-Every `[Section Label]` the report can print, in one place:
-
-| section label                                                                                      | what it is                                                                                                | drives `--fail` |
-| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | :-------------: |
-| `[Deleted]`                                                                                        | a declared resource deleted out of band — the most blatant drift                                          |       ✅        |
-| `[CFn-Declared Drift]`                                                                             | a property declared in the deployed template whose live value differs                                     |       ✅        |
-| `[CFn-Undeclared Drift]`                                                                           | a live-only value (not in the template) that changed since your `.cdkrd` baseline — the differentiator    |       ✅        |
-| `[Added Resource]`                                                                                 | a recorded [out-of-band resource](#added-out-of-band-resources) whose live model changed since the record |       ✅        |
-| `[Potential Drift]`                                                                                | live-only values (and unrecorded added resources) with no baseline yet — unconfirmed, detailed below      |       ❌        |
-| `[At AWS Default]` / `[AWS Generated]` / `[Ignored]` / `[Read Gap]` / `[Unresolved]` / `[Skipped]` | informational — folded into the one-line `info:` footer; `--verbose` expands them to full sections        |       ❌        |
+The table of every drift kind and its section label is up in
+[How to use](#your-first-run-needs-no-baseline); the mechanics:
 
 - The four **confirmed drift tiers** (`deleted` / `declared` / `undeclared` /
   `added`) are always listed in full and drive the `--fail` exit. They are the


### PR DESCRIPTION
## Why

The `check` report speaks in bracketed section labels (`[CFn-Declared Drift]`, `[Potential Drift]`, ...), but the README had no single place enumerating them:

- `[Added Resource]` was never explained outside its own deep section ("Added out-of-band resources"), and the "How to use" narrative never mentioned it.
- The "Output" section's lead bullet listed the drift tiers as `deleted` / `declared` / `undeclared` — internal names, and **missing `added`** (which is a confirmed drift tier in `DRIFT_TIERS`).
- The `--verbose`-only informational sections (`[At AWS Default]` etc.) appeared nowhere as UI labels.

A user seeing a label in the output had no one-stop table to look it up.

## What

README-only:

- **Output**: lead with a table of all 11 section labels (UI spelling, per `TIER_NAMES` in `src/report/report.ts`), what each means, and whether it drives `--fail`; the old drift-tiers bullet is folded under it with `added` included.
- **How to use**: after the first-run bullets, a forward pointer to the two record-armed confirmed tiers and to the Output label table (keeps the "bullets explain the first-run example" structure — an unrecorded added resource can only appear as `[Potential Drift]` on a first run, so the example can't show it).
- **Recording**: one sentence on the resource-level twin — a recorded added resource that changes later surfaces as `[Added Resource]`.

All claims cross-checked against `src/report/report.ts` (`TIER_NAMES` / `TIER_NOTES` / `DRIFT_TIERS` / the unrecorded → `[Potential Drift]` section, and the `--verbose` / `--show-all` expansion — the table says "`--verbose` expands", not "only `--verbose`", because `--show-all` also expands `[At AWS Default]`).

## Gates

- `check`: typecheck / lint+format / build / 313 files, 6037 tests — all pass
- `docs`: deep review of the README diff vs `src/report/report.ts` — consistent
- docs-only PR (no `src/**`), so `verify-pr` is exempt per `.markgate.yml`
