### PR TITLE
fix(diff): DLM + UDP-family TargetGroup first-run FPs, DLM readGap/revert convergence (#1663 #1664 #1665 #1666)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -875,6 +875,29 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   lowercase-only-name service (VPC Lattice) mints its CFn generated name LOWERCASED
   (`cdkrdhunt0715lattice-sn-<random>`), which the exact-case isCfnGeneratedName
   branches missed until #1639.
+- **A per-variant fold TABLE row that was MIRRORED from a live-proven sibling is itself
+  unproven — audit the split tables for never-deployed rows.** The BY_PROTOCOL /
+  BY_LB_TYPE / BY_TARGET_TYPE-style variant tables are built one live variant at a
+  time, and the untested rows get filled by copying the proven sibling's constants
+  "for symmetry" — which bakes the do-NOT-copy-sibling-constants trap INTO the fold
+  table (ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL's UDP/TCP_UDP rows carried TCP's
+  `deregistration_delay.connection_termination.enabled: 'false'`; AWS's UDP-family
+  default is `'true'` → first-run FP, #1664). A barest deploy of each mirrored-row
+  variant is cheap (a TargetGroup needs no LB); grep the split tables for rows whose
+  comment cites a DIFFERENT variant's deploy as evidence.
+- **An FN detect-probe needs its resource at readGap=0 — a reader-projection readGap
+  silently disables appeared-since-record for the WHOLE resource, and the report
+  masks it as "No baseline yet".** The R62 mechanism only fires on snapshot-COMPLETE
+  resources; a declared prop the reader never projects (DLM's shorthand
+  `DefaultPolicy`, #1665) keeps the resource incomplete forever, so every undeclared
+  OOB change stays [Potential Drift] and `check --fail` exits 0 — and (pre-#1665) the
+  preamble printed "No baseline yet" right after a successful `record`, sending you
+  to re-record instead of at the readGap. When a detect probe unexpectedly misses:
+  check the target resource's `readGap=` in the info: footer FIRST, and either close
+  the gap (project the declared-shaped value from what the API does return, gated so
+  it never emits on other shapes — the #1660 lesson) or probe a readGap-free sibling
+  resource. The readGap-closing fix then needs the SAME live proof pair as any reader
+  fix: clean first run + detection restored.
 - **A clean result IS a result — but it must still leave an asset.** "6 common+rich
   stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do
   NOT manufacture a fix to have something to show. The deliverable of a bug-free

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -826,6 +826,9 @@ export async function runCheck(args: string[]): Promise<number> {
           // --show-all is inventory mode: list every undeclared value, including the
           // ones at an AWS default (otherwise folded to a count) (R86).
           expandAtDefault: a.showAll,
+          // #1665: baseline presence — --show-all skips applyBaseline, so it must not
+          // claim either way (mirrors the #1335 omit-when-unconsulted rule).
+          ...(a.showAll ? {} : { hasBaseline: baseline !== undefined }),
         });
       }
       const hasUnrecorded = reconciled.some((f) => f.unrecorded === true);

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -993,6 +993,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     KeyUsage: 'ENCRYPT_DECRYPT',
     Origin: 'AWS_KMS',
   },
+  // A default-policy shorthand DLM policy (`DefaultPolicy: VOLUME|INSTANCE`) that leaves
+  // RetainInterval unset reads back the documented default of 7 days (#1663; CreateInterval's
+  // sibling default is 1, and CopyTags/ExtendDeletion read back `false` — folded via
+  // isTrivialEmpty). Equality-gated: a retain interval changed out of band still surfaces.
+  // Proven live on a fresh kmsdlm-hunt deploy.
+  'AWS::DLM::LifecyclePolicy': {
+    RetainInterval: 7,
+  },
   'AWS::IAM::Group': {
     Path: '/',
   },
@@ -4397,6 +4405,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
 //   (#1501, live-repro'd 2026-07-12 on tests/integration/s3kms-ddb-batch-min).
 export const VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Batch::ComputeEnvironment': new Set(['ComputeResources.DesiredvCpus']),
+  // #1663: an interval-based schedule CreateRule that declares no Times reads back a
+  // creation-time-assigned start time (e.g. `Times: ["03:06"]` — DLM picks a time within a
+  // window after policy creation, different per resource). Not a constant and not derivable
+  // from the declared inputs, so it cannot be equality-gated; a user who cares about the
+  // start time DECLARES Times, which is then compared in the declared dimension. Proven
+  // live on a fresh kmsdlm-hunt deploy (undeclared-Times interval schedule).
+  'AWS::DLM::LifecyclePolicy': new Set(['PolicyDetails.Schedules.*.CreateRule.Times']),
   // #1540 hunt (CdkrdHunt0713cEnumChildren, 2026-07-13): DescribeAutoScalingGroups
   // augments every DECLARED tag entry with the read-only TagDescription echo fields
   // ResourceId (the group's own name) and ResourceType ("auto-scaling-group") — pure
@@ -4822,16 +4837,21 @@ export const ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL: Record<string, Record<string
     'target_health_state.unhealthy.connection_termination.enabled': 'true',
     'target_health_state.unhealthy.draining_interval_seconds': '0',
   },
+  // #1664: connection termination on deregistration defaults to TRUE for the UDP-family
+  // protocols (a flow that outlives deregistration must be cut for connectionless
+  // traffic) — the 'false' these two rows initially mirrored from the live-proven TCP
+  // row first-run-FP'd on a barest UDP/TCP_UDP group (variants5-hunt, 2026-07-17).
+  // Every other mirrored value below was live-confirmed correct on the same deploy.
   UDP: {
     'stickiness.type': 'source_ip',
-    'deregistration_delay.connection_termination.enabled': 'false',
+    'deregistration_delay.connection_termination.enabled': 'true',
     'proxy_protocol_v2.enabled': 'false',
     'target_health_state.unhealthy.connection_termination.enabled': 'true',
     'target_health_state.unhealthy.draining_interval_seconds': '0',
   },
   TCP_UDP: {
     'stickiness.type': 'source_ip',
-    'deregistration_delay.connection_termination.enabled': 'false',
+    'deregistration_delay.connection_termination.enabled': 'true',
     'proxy_protocol_v2.enabled': 'false',
     'target_health_state.unhealthy.connection_termination.enabled': 'true',
     'target_health_state.unhealthy.draining_interval_seconds': '0',

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -874,6 +874,19 @@ const readDlmLifecyclePolicy: OverrideReader = async ({ physicalId, declared, re
   } else if (Object.keys(details).length > 0) {
     model.PolicyDetails = details;
   }
+  // #1665: the declared DefaultPolicy ("VOLUME"|"INSTANCE") has no same-shaped field in the
+  // response — GetLifecyclePolicy reports a BOOLEAN Policy.DefaultPolicy plus the details'
+  // singular ResourceType ([Default policies only]). Project the declared-shaped enum back
+  // only when live CONFIRMS a default policy, so the declared value gains a live counterpart.
+  // Without it the prop was a genuine readGap, which (by the #795 completeness fail-safe)
+  // blocked the resource from ever being snapshot-complete and silently disabled
+  // appeared-since-record detection for EVERY undeclared out-of-band change on the policy.
+  // A custom policy (DefaultPolicy false/absent) never emits the key — no new undeclared FP
+  // (the #1660 readGap-fix lesson).
+  if (p.DefaultPolicy === true) {
+    const rt = str(details.ResourceType);
+    if (rt !== undefined) model.DefaultPolicy = rt;
+  }
   // Tags — AWS::DLM::LifecyclePolicy declares the LIST shape ([{Key, Value}]), but
   // GetLifecyclePolicy already returns the policy's tags as a { k: v } MAP on `Policy.Tags`
   // (no extra call / IAM perm). Convert to the CFn list shape so a declared `Tags` value has

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -109,6 +109,12 @@ export interface ReportOptions {
   // report agrees with check.ts's #727 stderr note (#883). Genuine gaps (CC-unsupported,
   // read errors) still render as "coverage incomplete".
   preDeploy?: boolean;
+  // #1665: whether this stack HAS a committed baseline. The unrecorded-values preamble
+  // used to claim "No baseline yet" unconditionally — wrong (and alarming) when a
+  // baseline exists and the values are unrecorded only because their resource is not
+  // snapshot-complete (a readGap/skipped member, the #795 fail-safe). `undefined` =
+  // baseline not consulted (--show-all / --pre-deploy) — keep the generic wording.
+  hasBaseline?: boolean;
   log?: (s: string) => void;
 }
 
@@ -489,9 +495,16 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
   // drift. Gated on the SHOWN count: nested undeclared values now surface too (R96 fold
   // removed), and they are exactly the live-only sub-keys this preamble describes.
   if (unrecordedShown.length > 0) {
+    // #1665: with a baseline PRESENT, unrecorded values mean their resource is not
+    // snapshot-complete (a readGap/skipped member kept `record` from capturing its full
+    // undeclared state — the #795 fail-safe), not that the stack was never recorded.
+    // Saying "No baseline yet" right after a `record` misled a real probe; name the
+    // actual reason so the user looks at the info: footer instead of re-recording.
     log(
       style.undeclaredTier(
-        "No baseline yet — these live-only values can't be confirmed as drift. Record them right from this `cdkrd check` prompt, or run `cdkrd record`."
+        opts.hasBaseline
+          ? "Not in your baseline — these live-only values are on resources record couldn't fully snapshot (see readGap/skipped in info:), so cdkrd can't confirm them as drift. Record to accept them."
+          : "No baseline yet — these live-only values can't be confirmed as drift. Record them right from this `cdkrd check` prompt, or run `cdkrd record`."
       )
     );
     log(''); // blank line so the no-baseline note reads as its own preamble, not a section header

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -118,6 +118,12 @@ const CC_REVERTABLE_DESPITE_READ_OVERRIDE = new Set<string>([
 // entry here (#702): UpdateUserPool ignores an omitted property, so a fold WITHOUT an RSDP
 // entry silently reverts as a no-op `remove`. Keyed `${resourceType}\0${path}`.
 export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
+  // #1666: writeDlmLifecyclePolicy builds the Update payload from the desired model, so a
+  // bare `remove` of the default-policy shorthand RetainInterval never reaches the call —
+  // UpdateLifecyclePolicy keeps the live value (silent no-op, live-proven: an out-of-band
+  // 7->5 survived a "reverted" report). Write the documented default 7 (the #1663
+  // KNOWN_DEFAULTS pin) explicitly so the revert converges.
+  'AWS::DLM::LifecyclePolicy\0RetainInterval',
   'AWS::IAM::Role\0MaxSessionDuration',
   // IAM UpdateRole ignores an omitted Description the same way it ignores an omitted
   // MaxSessionDuration (both are UpdateRole params) — a `remove` revert of an out-of-band

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -45,7 +45,6 @@ import {
 } from '@aws-sdk/client-cloudwatch';
 import {
   DLMClient,
-  GetLifecyclePolicyCommand,
   type SettablePolicyStateValues,
   UpdateLifecyclePolicyCommand,
 } from '@aws-sdk/client-dlm';
@@ -1357,16 +1356,15 @@ const writeDlmLifecyclePolicy: SdkWriter = async (ctx, ops) => {
   }
   const c = new DLMClient({ region: ctx.region, ...CLIENT_TIMEOUTS });
   const m = await desiredModel('AWS::DLM::LifecyclePolicy', ctx, ops);
-  let details = m.PolicyDetails as Record<string, unknown> | undefined;
-  if (details === undefined && DLM_DEFAULT_POLICY_SHORTHAND.some((k) => m[k] !== undefined)) {
-    // Shorthand style: Update only accepts a full PolicyDetails, so start from the live
-    // PolicyDetails (carries the immutable PolicyType/ResourceType the API folded in) and
-    // overlay the desired shorthand values.
-    const live = (await c.send(new GetLifecyclePolicyCommand({ PolicyId: id }))).Policy
-      ?.PolicyDetails as Record<string, unknown> | undefined;
-    details = { ...(live ?? {}) };
-    for (const k of DLM_DEFAULT_POLICY_SHORTHAND) if (m[k] !== undefined) details[k] = m[k];
-  }
+  const details = m.PolicyDetails as Record<string, unknown> | undefined;
+  // #1666: the default-policy shorthand keys are TOP-LEVEL UpdateLifecyclePolicy request
+  // params ([Default policies only] in the API); PolicyDetails is [Custom policies only].
+  // The previous shape — overlaying the shorthand values onto the live PolicyDetails and
+  // sending THAT — targeted the wrong request field for a default policy (written blind;
+  // the type had zero live fixtures until the 2026-07-17 hunt). Pass them through as-is.
+  const shorthand: Record<string, unknown> = {};
+  if (details === undefined)
+    for (const k of DLM_DEFAULT_POLICY_SHORTHAND) if (m[k] !== undefined) shorthand[k] = m[k];
   await c.send(
     new UpdateLifecyclePolicyCommand({
       PolicyId: id,
@@ -1374,6 +1372,7 @@ const writeDlmLifecyclePolicy: SdkWriter = async (ctx, ops) => {
       ...(str(m.State) !== undefined && { State: str(m.State) as SettablePolicyStateValues }),
       ...(str(m.ExecutionRoleArn) !== undefined && { ExecutionRoleArn: str(m.ExecutionRoleArn) }),
       ...(details !== undefined && { PolicyDetails: details as never }),
+      ...(shorthand as Partial<{ CreateInterval: number; RetainInterval: number }>),
     })
   );
 };

--- a/tests/classify-dlm-defaults-1663.test.ts
+++ b/tests/classify-dlm-defaults-1663.test.ts
@@ -1,0 +1,125 @@
+// #1663: two first-run FPs on a barest AWS::DLM::LifecyclePolicy (the first live fixture
+// for this SDK-override reader — both prior corpus cases DECLARED the suspect leaves, the
+// #615-class apparent-coverage trap):
+// - An interval-based schedule CreateRule that declares no Times reads back a
+//   creation-time-assigned start time (`Times: ["03:06"]`, different per resource) —
+//   not a constant and not derivable, so it folds via the tier-3 nested value-independent
+//   table (a user who cares about the start time declares Times → declared dimension).
+// - A default-policy shorthand that declares no RetainInterval reads back the documented
+//   constant default 7 — tier-1 equality-gated KNOWN_DEFAULTS, so a retain interval
+//   changed out of band still surfaces.
+// Live-repro'd 2026-07-17 (us-east-1) on the kmsdlm-hunt fixture; the
+// AWS__DLM__LifecyclePolicy.CustomPolicy/DefaultPolicy corpus cases pin both folds.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (findings: Finding[]) => findings.map((f) => `${f.tier}:${f.path}`).sort();
+
+// The barest custom-policy shape: an interval-based CreateRule with no Times declared.
+const customPolicy: DesiredResource = {
+  logicalId: 'CustomPolicy',
+  resourceType: 'AWS::DLM::LifecyclePolicy',
+  physicalId: 'policy-0123456789abcdef0',
+  declared: {
+    Description: 'custom snapshot policy',
+    ExecutionRoleArn: 'arn:aws:iam::111111111111:role/DlmRole',
+    State: 'ENABLED',
+    PolicyDetails: {
+      PolicyType: 'EBS_SNAPSHOT_MANAGEMENT',
+      ResourceTypes: ['VOLUME'],
+      TargetTags: [{ Key: 'cdkrd-hunt', Value: '0717' }],
+      Schedules: [
+        {
+          Name: 'daily',
+          CreateRule: { Interval: 12, IntervalUnit: 'HOURS' },
+          RetainRule: { Count: 1 },
+        },
+      ],
+    },
+  },
+};
+
+const customLive = (times: string[]) => ({
+  Description: 'custom snapshot policy',
+  State: 'ENABLED',
+  ExecutionRoleArn: 'arn:aws:iam::111111111111:role/DlmRole',
+  PolicyDetails: {
+    PolicyType: 'EBS_SNAPSHOT_MANAGEMENT',
+    ResourceTypes: ['VOLUME'],
+    ResourceLocations: ['CLOUD'],
+    TargetTags: [{ Key: 'cdkrd-hunt', Value: '0717' }],
+    Schedules: [
+      {
+        Name: 'daily',
+        CopyTags: false,
+        CreateRule: { Location: 'CLOUD', Interval: 12, IntervalUnit: 'HOURS', Times: times },
+        RetainRule: { Count: 1, Interval: 0 },
+      },
+    ],
+    PolicyLanguage: 'STANDARD',
+  },
+});
+
+// The default-policy shorthand shape (DefaultPolicy itself is a schema readGap — omitted
+// here so the empty schema doesn't manufacture an unrelated declared finding).
+const shorthandPolicy: DesiredResource = {
+  logicalId: 'DefaultPolicy',
+  resourceType: 'AWS::DLM::LifecyclePolicy',
+  physicalId: 'policy-0fedcba9876543210',
+  declared: {
+    CreateInterval: 1,
+    Description: 'default policy shorthand',
+    ExecutionRoleArn: 'arn:aws:iam::111111111111:role/DlmRole',
+    State: 'ENABLED',
+  },
+};
+
+const shorthandLive = (retainInterval: number) => ({
+  Description: 'default policy shorthand',
+  State: 'ENABLED',
+  ExecutionRoleArn: 'arn:aws:iam::111111111111:role/DlmRole',
+  CreateInterval: 1,
+  RetainInterval: retainInterval,
+  CopyTags: false,
+  ExtendDeletion: false,
+});
+
+describe('#1663 DLM LifecyclePolicy first-run default folds', () => {
+  it('folds an undeclared creation-assigned CreateRule.Times to atDefault (value-independent)', () => {
+    const f = classifyResource(customPolicy, customLive(['03:06']), emptySchema);
+    expect(tierPaths(f)).toEqual([
+      'atDefault:PolicyDetails.PolicyLanguage',
+      'atDefault:PolicyDetails.ResourceLocations',
+      'atDefault:PolicyDetails.Schedules[daily].CreateRule.Location',
+      'atDefault:PolicyDetails.Schedules[daily].CreateRule.Times',
+      'atDefault:PolicyDetails.Schedules[daily].RetainRule.Interval',
+    ]);
+  });
+
+  it('folds Times regardless of the assigned value (per-resource, value-independent)', () => {
+    const f = classifyResource(customPolicy, customLive(['21:45']), emptySchema);
+    expect(tierPaths(f)).toContain('atDefault:PolicyDetails.Schedules[daily].CreateRule.Times');
+  });
+
+  it('folds an undeclared shorthand RetainInterval at the documented default 7', () => {
+    const f = classifyResource(shorthandPolicy, shorthandLive(7), emptySchema);
+    expect(tierPaths(f)).toEqual(['atDefault:RetainInterval']);
+  });
+
+  it('still surfaces a RetainInterval changed away from the default (equality-gated)', () => {
+    const f = classifyResource(shorthandPolicy, shorthandLive(5), emptySchema);
+    expect(tierPaths(f)).toEqual(['undeclared:RetainInterval']);
+  });
+});

--- a/tests/classify-elbv2-variants-1546.test.ts
+++ b/tests/classify-elbv2-variants-1546.test.ts
@@ -320,3 +320,66 @@ describe('#1628 TCP/instance-target group preserve_client_ip default', () => {
     ]);
   });
 });
+
+// #1664 — the UDP-family deregistration connection-termination default is TRUE (the
+// 'false' initially mirrored from the live-proven TCP row first-run-FP'd on a barest
+// UDP/TCP_UDP group; TLS folds clean at 'false' like TCP). Live-proven 2026-07-17
+// (variants5-hunt); the AWS__ElasticLoadBalancingV2__TargetGroup.UdpTg/TcpUdpTg/TlsTg
+// corpus cases pin all three variants.
+describe('#1664 UDP/TCP_UDP deregistration connection-termination default', () => {
+  const mk = (protocol: string): DesiredResource => ({
+    logicalId: `${protocol}Tg`,
+    resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+    physicalId: `arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/${protocol.toLowerCase()}/abc`,
+    declared: { Protocol: protocol, Port: 53, VpcId: 'vpc-0123456789abcdef0' },
+  });
+  const udpBag = (termination: string) =>
+    attrs({
+      'deregistration_delay.connection_termination.enabled': termination,
+      'stickiness.type': 'source_ip',
+      'proxy_protocol_v2.enabled': 'false',
+    });
+
+  for (const protocol of ['UDP', 'TCP_UDP']) {
+    it(`folds the ${protocol} creation default "true" to atDefault (ZERO first-run drift)`, () => {
+      const f = classifyResource(
+        mk(protocol),
+        { ...mk(protocol).declared, TargetGroupAttributes: udpBag('true') },
+        emptySchema
+      );
+      expect(pathsByTier(f, 'undeclared')).toEqual([]);
+      expect(pathsByTier(f, 'atDefault')).toContain(
+        'TargetGroupAttributes[deregistration_delay.connection_termination.enabled]'
+      );
+    });
+
+    it(`an out-of-band ${protocol} termination DISABLE still surfaces (equality gate)`, () => {
+      const f = classifyResource(
+        mk(protocol),
+        { ...mk(protocol).declared, TargetGroupAttributes: udpBag('false') },
+        emptySchema
+      );
+      expect(pathsByTier(f, 'undeclared')).toEqual([
+        'TargetGroupAttributes[deregistration_delay.connection_termination.enabled]',
+      ]);
+    });
+  }
+
+  it('a TLS group keeps the "false" default — "true" there is a real divergence', () => {
+    const tls = mk('TLS');
+    const f = classifyResource(
+      tls,
+      { ...tls.declared, TargetGroupAttributes: udpBag('false') },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    const g = classifyResource(
+      tls,
+      { ...tls.declared, TargetGroupAttributes: udpBag('true') },
+      emptySchema
+    );
+    expect(pathsByTier(g, 'undeclared')).toEqual([
+      'TargetGroupAttributes[deregistration_delay.connection_termination.enabled]',
+    ]);
+  });
+});

--- a/tests/corpus/AWS__CloudFront__ResponseHeadersPolicy.RhpCors.json
+++ b/tests/corpus/AWS__CloudFront__ResponseHeadersPolicy.RhpCors.json
@@ -1,0 +1,81 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RhpCors",
+    "resourceType": "AWS::CloudFront::ResponseHeadersPolicy",
+    "physicalId": "b42808c4-febc-4ac4-9177-d8b8e21146ea",
+    "constructPath": "CdkrdHunt0717FpMisc/RhpCors",
+    "declared": {
+      "ResponseHeadersPolicyConfig": {
+        "CorsConfig": {
+          "AccessControlAllowCredentials": false,
+          "AccessControlAllowHeaders": {
+            "Items": ["X-Zebra-Header", "authorization", "Content-Type"]
+          },
+          "AccessControlAllowMethods": {
+            "Items": ["POST", "GET"]
+          },
+          "AccessControlAllowOrigins": {
+            "Items": ["https://example.com"]
+          },
+          "AccessControlExposeHeaders": {
+            "Items": ["X-Zulu-Expose", "content-length", "ETag"]
+          },
+          "OriginOverride": false
+        },
+        "Name": "CdkrdHunt0717RhpCors"
+      }
+    }
+  },
+  "liveRaw": {
+    "LastModifiedTime": "2026-07-16T15:15:55.991Z",
+    "Id": "b42808c4-febc-4ac4-9177-d8b8e21146ea",
+    "ResponseHeadersPolicyConfig": {
+      "CorsConfig": {
+        "AccessControlAllowCredentials": false,
+        "AccessControlAllowHeaders": {
+          "Items": ["X-Zebra-Header", "authorization", "Content-Type"]
+        },
+        "OriginOverride": false,
+        "AccessControlAllowMethods": {
+          "Items": ["POST", "GET"]
+        },
+        "AccessControlExposeHeaders": {
+          "Items": ["X-Zulu-Expose", "content-length", "ETag"]
+        },
+        "AccessControlAllowOrigins": {
+          "Items": ["https://example.com"]
+        }
+      },
+      "Name": "CdkrdHunt0717RhpCors"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id", "LastModifiedTime"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "LastModifiedTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlAllowHeaders.Items",
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlAllowMethods.Items",
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlAllowOrigins.Items",
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlExposeHeaders.Items"
+    ],
+    "unorderedObjectArrayPaths": [
+      "ResponseHeadersPolicyConfig.CustomHeadersConfig.Items",
+      "ResponseHeadersPolicyConfig.RemoveHeadersConfig.Items"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__DLM__LifecyclePolicy.CustomPolicy.json
+++ b/tests/corpus/AWS__DLM__LifecyclePolicy.CustomPolicy.json
@@ -1,0 +1,152 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CustomPolicy",
+    "resourceType": "AWS::DLM::LifecyclePolicy",
+    "physicalId": "policy-0b572b0e2d2dcc541",
+    "constructPath": "CdkrdHunt0717DlmB/CustomPolicy",
+    "declared": {
+      "Description": "cdkrd hunt 0717 custom snapshot policy",
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0717DlmB-DlmRoleCE7C5775-KcJNfbZJBitj",
+      "PolicyDetails": {
+        "PolicyType": "EBS_SNAPSHOT_MANAGEMENT",
+        "ResourceTypes": ["VOLUME"],
+        "Schedules": [
+          {
+            "CreateRule": {
+              "Interval": 12,
+              "IntervalUnit": "HOURS"
+            },
+            "Name": "cdkrd-hunt-daily",
+            "RetainRule": {
+              "Count": 1
+            }
+          }
+        ],
+        "TargetTags": [
+          {
+            "Key": "cdkrd-hunt",
+            "Value": "0717"
+          }
+        ]
+      },
+      "State": "ENABLED",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt 0717 custom snapshot policy",
+    "State": "ENABLED",
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0717DlmB-DlmRoleCE7C5775-KcJNfbZJBitj",
+    "PolicyDetails": {
+      "PolicyType": "EBS_SNAPSHOT_MANAGEMENT",
+      "ResourceTypes": ["VOLUME"],
+      "ResourceLocations": ["CLOUD"],
+      "TargetTags": [
+        {
+          "Key": "cdkrd-hunt",
+          "Value": "0717"
+        }
+      ],
+      "Schedules": [
+        {
+          "Name": "cdkrd-hunt-daily",
+          "CopyTags": false,
+          "CreateRule": {
+            "Location": "CLOUD",
+            "Interval": 12,
+            "IntervalUnit": "HOURS",
+            "Times": ["03:06"]
+          },
+          "RetainRule": {
+            "Count": 1,
+            "Interval": 0
+          }
+        }
+      ],
+      "PolicyLanguage": "STANDARD"
+    },
+    "Tags": [
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomPolicy",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "PolicyDetails.ResourceLocations",
+      "actual": ["CLOUD"],
+      "nested": true,
+      "physicalId": "policy-0b572b0e2d2dcc541",
+      "constructPath": "CdkrdHunt0717DlmB/CustomPolicy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomPolicy",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "PolicyDetails.Schedules[cdkrd-hunt-daily].CreateRule.Location",
+      "actual": "CLOUD",
+      "nested": true,
+      "physicalId": "policy-0b572b0e2d2dcc541",
+      "constructPath": "CdkrdHunt0717DlmB/CustomPolicy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomPolicy",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "PolicyDetails.Schedules[cdkrd-hunt-daily].CreateRule.Times",
+      "actual": ["03:06"],
+      "nested": true,
+      "physicalId": "policy-0b572b0e2d2dcc541",
+      "constructPath": "CdkrdHunt0717DlmB/CustomPolicy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomPolicy",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "PolicyDetails.Schedules[cdkrd-hunt-daily].RetainRule.Interval",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "policy-0b572b0e2d2dcc541",
+      "constructPath": "CdkrdHunt0717DlmB/CustomPolicy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomPolicy",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "PolicyDetails.PolicyLanguage",
+      "actual": "STANDARD",
+      "nested": true,
+      "physicalId": "policy-0b572b0e2d2dcc541",
+      "constructPath": "CdkrdHunt0717DlmB/CustomPolicy"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DLM__LifecyclePolicy.DefaultPolicy.json
+++ b/tests/corpus/AWS__DLM__LifecyclePolicy.DefaultPolicy.json
@@ -1,0 +1,68 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DefaultPolicy",
+    "resourceType": "AWS::DLM::LifecyclePolicy",
+    "physicalId": "policy-090b4ed616a61a2aa",
+    "constructPath": "CdkrdHunt0717DlmB/DefaultPolicy",
+    "declared": {
+      "CreateInterval": 1,
+      "DefaultPolicy": "VOLUME",
+      "Description": "cdkrd hunt 0717 default policy shorthand",
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0717DlmB-DlmRoleCE7C5775-KcJNfbZJBitj",
+      "State": "ENABLED",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt 0717 default policy shorthand",
+    "State": "ENABLED",
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0717DlmB-DlmRoleCE7C5775-KcJNfbZJBitj",
+    "CreateInterval": 1,
+    "RetainInterval": 7,
+    "CopyTags": false,
+    "ExtendDeletion": false,
+    "Tags": [
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ],
+    "DefaultPolicy": "VOLUME"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DefaultPolicy",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "RetainInterval",
+      "actual": 7,
+      "physicalId": "policy-090b4ed616a61a2aa",
+      "constructPath": "CdkrdHunt0717DlmB/DefaultPolicy"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TcpUdpTg.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TcpUdpTg.json
@@ -1,0 +1,374 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TcpUdpTg",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+    "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg",
+    "declared": {
+      "Port": 53,
+      "Protocol": "TCP_UDP",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcId": "vpc-0c0fcd13922b604fc"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Port": 53,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 10,
+    "Name": "CdkrdH-TcpUd-RZBTWMKFPDNR",
+    "VpcId": "vpc-0c0fcd13922b604fc",
+    "TargetGroupFullName": "targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "source_ip",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "deregistration_delay.connection_termination.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "target_health_state.unhealthy.draining_interval_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "true",
+        "Key": "preserve_client_ip.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "proxy_protocol_v2.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "target_health_state.unhealthy.connection_termination.enabled"
+      }
+    ],
+    "TargetType": "instance",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "TCP_UDP",
+    "TargetGroupName": "CdkrdH-TcpUd-RZBTWMKFPDNR",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0717Variants5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TcpUdpTg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0717Variants5/fd781c00-812b-11f1-95a9-12ee848f7c35",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-TcpUd-RZBTWMKFPDNR",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "TCP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[preserve_client_ip.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[proxy_protocol_v2.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.draining_interval_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetType",
+      "actual": "instance",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TcpUd-RZBTWMKFPDNR/ebf047f8e4785b34",
+      "constructPath": "CdkrdHunt0717Variants5/TcpUdpTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TlsTg.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TlsTg.json
@@ -1,0 +1,374 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TlsTg",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+    "constructPath": "CdkrdHunt0717Variants5/TlsTg",
+    "declared": {
+      "Port": 443,
+      "Protocol": "TLS",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcId": "vpc-0c0fcd13922b604fc"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Port": 443,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 10,
+    "Name": "CdkrdH-TlsTg-EBFMTD8QW4YQ",
+    "VpcId": "vpc-0c0fcd13922b604fc",
+    "TargetGroupFullName": "targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "source_ip",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "target_health_state.unhealthy.draining_interval_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "true",
+        "Key": "preserve_client_ip.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "proxy_protocol_v2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "deregistration_delay.connection_termination.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "target_health_state.unhealthy.connection_termination.enabled"
+      }
+    ],
+    "TargetType": "instance",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "TLS",
+    "TargetGroupName": "CdkrdH-TlsTg-EBFMTD8QW4YQ",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0717Variants5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TlsTg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0717Variants5/fd781c00-812b-11f1-95a9-12ee848f7c35",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-TlsTg-EBFMTD8QW4YQ",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "TCP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.connection_termination.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[preserve_client_ip.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[proxy_protocol_v2.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.draining_interval_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetType",
+      "actual": "instance",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsTg-EBFMTD8QW4YQ/6c7057109ff225ff",
+      "constructPath": "CdkrdHunt0717Variants5/TlsTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.UdpTg.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.UdpTg.json
@@ -1,0 +1,374 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "UdpTg",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+    "constructPath": "CdkrdHunt0717Variants5/UdpTg",
+    "declared": {
+      "Port": 53,
+      "Protocol": "UDP",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcId": "vpc-0c0fcd13922b604fc"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Port": 53,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 10,
+    "Name": "CdkrdH-UdpTg-EHNVKZWBM0GA",
+    "VpcId": "vpc-0c0fcd13922b604fc",
+    "TargetGroupFullName": "targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "source_ip",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "deregistration_delay.connection_termination.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "target_health_state.unhealthy.draining_interval_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "true",
+        "Key": "preserve_client_ip.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "proxy_protocol_v2.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "target_health_state.unhealthy.connection_termination.enabled"
+      }
+    ],
+    "TargetType": "instance",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "UDP",
+    "TargetGroupName": "CdkrdH-UdpTg-EHNVKZWBM0GA",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0717Variants5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "UdpTg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0717Variants5/fd781c00-812b-11f1-95a9-12ee848f7c35",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-UdpTg-EHNVKZWBM0GA",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "TCP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[preserve_client_ip.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[proxy_protocol_v2.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.draining_interval_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetType",
+      "actual": "instance",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UdpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-UdpTg-EHNVKZWBM0GA/c9b59d9c23408142",
+      "constructPath": "CdkrdHunt0717Variants5/UdpTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KMS__Key.EccSignKey.json
+++ b/tests/corpus/AWS__KMS__Key.EccSignKey.json
@@ -1,0 +1,142 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EccSignKey",
+    "resourceType": "AWS::KMS::Key",
+    "physicalId": "4b591a78-7cda-424a-97c0-89c9ca4a85ba",
+    "constructPath": "CdkrdHunt0717KmsA/EccSignKey",
+    "declared": {
+      "KeySpec": "ECC_NIST_P256",
+      "KeyUsage": "SIGN_VERIFY",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Origin": "AWS_KMS",
+    "MultiRegion": false,
+    "Description": "",
+    "KeyPolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "kms:*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "Enable IAM User Permissions"
+        }
+      ],
+      "Id": "key-default-1"
+    },
+    "KeySpec": "ECC_NIST_P256",
+    "Enabled": true,
+    "EnableKeyRotation": false,
+    "KeyUsage": "SIGN_VERIFY",
+    "KeyId": "4b591a78-7cda-424a-97c0-89c9ca4a85ba",
+    "Arn": "arn:aws:kms:us-east-1:111111111111:key/4b591a78-7cda-424a-97c0-89c9ca4a85ba",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "KeyId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck", "PendingWindowInDays", "RotationPeriodInDays"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "KeyId"],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "PendingWindowInDays",
+      "RotationPeriodInDays"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "defaultPaths": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EccSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Origin",
+      "actual": "AWS_KMS",
+      "physicalId": "4b591a78-7cda-424a-97c0-89c9ca4a85ba",
+      "constructPath": "CdkrdHunt0717KmsA/EccSignKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EccSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "MultiRegion",
+      "actual": false,
+      "physicalId": "4b591a78-7cda-424a-97c0-89c9ca4a85ba",
+      "constructPath": "CdkrdHunt0717KmsA/EccSignKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EccSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyPolicy",
+      "actual": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": ["kms:*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": ["111111111111"]
+            },
+            "Resource": ["*"],
+            "Sid": "Enable IAM User Permissions"
+          }
+        ],
+        "Id": "key-default-1"
+      },
+      "physicalId": "4b591a78-7cda-424a-97c0-89c9ca4a85ba",
+      "constructPath": "CdkrdHunt0717KmsA/EccSignKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EccSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "4b591a78-7cda-424a-97c0-89c9ca4a85ba",
+      "constructPath": "CdkrdHunt0717KmsA/EccSignKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KMS__Key.HmacKey.json
+++ b/tests/corpus/AWS__KMS__Key.HmacKey.json
@@ -1,0 +1,142 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HmacKey",
+    "resourceType": "AWS::KMS::Key",
+    "physicalId": "94c16034-9828-44f2-af13-8346c9d8d128",
+    "constructPath": "CdkrdHunt0717KmsA/HmacKey",
+    "declared": {
+      "KeySpec": "HMAC_256",
+      "KeyUsage": "GENERATE_VERIFY_MAC",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Origin": "AWS_KMS",
+    "MultiRegion": false,
+    "Description": "",
+    "KeyPolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "kms:*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "Enable IAM User Permissions"
+        }
+      ],
+      "Id": "key-default-1"
+    },
+    "KeySpec": "HMAC_256",
+    "Enabled": true,
+    "EnableKeyRotation": false,
+    "KeyUsage": "GENERATE_VERIFY_MAC",
+    "KeyId": "94c16034-9828-44f2-af13-8346c9d8d128",
+    "Arn": "arn:aws:kms:us-east-1:111111111111:key/94c16034-9828-44f2-af13-8346c9d8d128",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "KeyId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck", "PendingWindowInDays", "RotationPeriodInDays"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "KeyId"],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "PendingWindowInDays",
+      "RotationPeriodInDays"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "defaultPaths": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HmacKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Origin",
+      "actual": "AWS_KMS",
+      "physicalId": "94c16034-9828-44f2-af13-8346c9d8d128",
+      "constructPath": "CdkrdHunt0717KmsA/HmacKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HmacKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "MultiRegion",
+      "actual": false,
+      "physicalId": "94c16034-9828-44f2-af13-8346c9d8d128",
+      "constructPath": "CdkrdHunt0717KmsA/HmacKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HmacKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyPolicy",
+      "actual": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": ["kms:*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": ["111111111111"]
+            },
+            "Resource": ["*"],
+            "Sid": "Enable IAM User Permissions"
+          }
+        ],
+        "Id": "key-default-1"
+      },
+      "physicalId": "94c16034-9828-44f2-af13-8346c9d8d128",
+      "constructPath": "CdkrdHunt0717KmsA/HmacKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HmacKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "94c16034-9828-44f2-af13-8346c9d8d128",
+      "constructPath": "CdkrdHunt0717KmsA/HmacKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KMS__Key.NakedKey.json
+++ b/tests/corpus/AWS__KMS__Key.NakedKey.json
@@ -1,0 +1,158 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NakedKey",
+    "resourceType": "AWS::KMS::Key",
+    "physicalId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+    "constructPath": "CdkrdHunt0717KmsA/NakedKey",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Origin": "AWS_KMS",
+    "MultiRegion": false,
+    "Description": "",
+    "KeyPolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "kms:*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "Enable IAM User Permissions"
+        }
+      ],
+      "Id": "key-default-1"
+    },
+    "KeySpec": "SYMMETRIC_DEFAULT",
+    "Enabled": true,
+    "EnableKeyRotation": false,
+    "KeyUsage": "ENCRYPT_DECRYPT",
+    "KeyId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+    "Arn": "arn:aws:kms:us-east-1:111111111111:key/bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "KeyId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck", "PendingWindowInDays", "RotationPeriodInDays"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "KeyId"],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "PendingWindowInDays",
+      "RotationPeriodInDays"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "defaultPaths": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "NakedKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Origin",
+      "actual": "AWS_KMS",
+      "physicalId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+      "constructPath": "CdkrdHunt0717KmsA/NakedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NakedKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "MultiRegion",
+      "actual": false,
+      "physicalId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+      "constructPath": "CdkrdHunt0717KmsA/NakedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NakedKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyPolicy",
+      "actual": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": ["kms:*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": ["111111111111"]
+            },
+            "Resource": ["*"],
+            "Sid": "Enable IAM User Permissions"
+          }
+        ],
+        "Id": "key-default-1"
+      },
+      "physicalId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+      "constructPath": "CdkrdHunt0717KmsA/NakedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NakedKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeySpec",
+      "actual": "SYMMETRIC_DEFAULT",
+      "physicalId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+      "constructPath": "CdkrdHunt0717KmsA/NakedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NakedKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+      "constructPath": "CdkrdHunt0717KmsA/NakedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NakedKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyUsage",
+      "actual": "ENCRYPT_DECRYPT",
+      "physicalId": "bfbf9bf5-f340-4ce2-8482-49c1f6ada439",
+      "constructPath": "CdkrdHunt0717KmsA/NakedKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KMS__Key.RsaSignKey.json
+++ b/tests/corpus/AWS__KMS__Key.RsaSignKey.json
@@ -1,0 +1,142 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RsaSignKey",
+    "resourceType": "AWS::KMS::Key",
+    "physicalId": "1f955606-e25e-4b85-bd27-8139ecd016a4",
+    "constructPath": "CdkrdHunt0717KmsA/RsaSignKey",
+    "declared": {
+      "KeySpec": "RSA_2048",
+      "KeyUsage": "SIGN_VERIFY",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Origin": "AWS_KMS",
+    "MultiRegion": false,
+    "Description": "",
+    "KeyPolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "kms:*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "Enable IAM User Permissions"
+        }
+      ],
+      "Id": "key-default-1"
+    },
+    "KeySpec": "RSA_2048",
+    "Enabled": true,
+    "EnableKeyRotation": false,
+    "KeyUsage": "SIGN_VERIFY",
+    "KeyId": "1f955606-e25e-4b85-bd27-8139ecd016a4",
+    "Arn": "arn:aws:kms:us-east-1:111111111111:key/1f955606-e25e-4b85-bd27-8139ecd016a4",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "KeyId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck", "PendingWindowInDays", "RotationPeriodInDays"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "KeyId"],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "PendingWindowInDays",
+      "RotationPeriodInDays"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "defaultPaths": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RsaSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Origin",
+      "actual": "AWS_KMS",
+      "physicalId": "1f955606-e25e-4b85-bd27-8139ecd016a4",
+      "constructPath": "CdkrdHunt0717KmsA/RsaSignKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RsaSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "MultiRegion",
+      "actual": false,
+      "physicalId": "1f955606-e25e-4b85-bd27-8139ecd016a4",
+      "constructPath": "CdkrdHunt0717KmsA/RsaSignKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RsaSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyPolicy",
+      "actual": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": ["kms:*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": ["111111111111"]
+            },
+            "Resource": ["*"],
+            "Sid": "Enable IAM User Permissions"
+          }
+        ],
+        "Id": "key-default-1"
+      },
+      "physicalId": "1f955606-e25e-4b85-bd27-8139ecd016a4",
+      "constructPath": "CdkrdHunt0717KmsA/RsaSignKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RsaSignKey",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "1f955606-e25e-4b85-bd27-8139ecd016a4",
+      "constructPath": "CdkrdHunt0717KmsA/RsaSignKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__WAFv2__RegexPatternSet.RegexSetUnsorted.json
+++ b/tests/corpus/AWS__WAFv2__RegexPatternSet.RegexSetUnsorted.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RegexSet",
+    "resourceType": "AWS::WAFv2::RegexPatternSet",
+    "physicalId": "RegexSet-QhJ2vtRyxHqp|51e7c970-65a4-49c9-bac4-c65f161745b4|REGIONAL",
+    "constructPath": "CdkrdHunt0717FpMisc/RegexSet",
+    "declared": {
+      "RegularExpressionList": ["zzz.*", "aaa[0-9]+", "mmm-.*"],
+      "Scope": "REGIONAL",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "RegularExpressionList": ["zzz.*", "aaa[0-9]+", "mmm-.*"],
+    "Scope": "REGIONAL",
+    "Id": "51e7c970-65a4-49c9-bac4-c65f161745b4",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/regexpatternset/RegexSet-QhJ2vtRyxHqp/51e7c970-65a4-49c9-bac4-c65f161745b4",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0717FpMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "RegexSet",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0717FpMisc/36f0a9a0-8129-11f1-b6a3-0e15234e24e9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "RegexSet-QhJ2vtRyxHqp"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "RegexSet",
+      "resourceType": "AWS::WAFv2::RegexPatternSet",
+      "path": "Name",
+      "actual": "RegexSet-QhJ2vtRyxHqp",
+      "physicalId": "RegexSet-QhJ2vtRyxHqp|51e7c970-65a4-49c9-bac4-c65f161745b4|REGIONAL",
+      "constructPath": "CdkrdHunt0717FpMisc/RegexSet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__WAFv2__WebACL.CfAcl.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.CfAcl.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CfAcl",
+    "resourceType": "AWS::WAFv2::WebACL",
+    "physicalId": "CfAcl-lFuJ3bwEbTCj|7e819c39-5be2-4c3c-a0de-2acca4f86fb6|CLOUDFRONT",
+    "constructPath": "CdkrdHunt0717Variants5/CfAcl",
+    "declared": {
+      "DefaultAction": {
+        "Allow": {}
+      },
+      "Scope": "CLOUDFRONT",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": false,
+        "MetricName": "cdkrdHunt0717CfAcl",
+        "SampledRequestsEnabled": false
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "DefaultAction": {
+      "Allow": {}
+    },
+    "Scope": "CLOUDFRONT",
+    "Capacity": 0,
+    "Id": "7e819c39-5be2-4c3c-a0de-2acca4f86fb6",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:global/webacl/CfAcl-lFuJ3bwEbTCj/7e819c39-5be2-4c3c-a0de-2acca4f86fb6",
+    "OnSourceDDoSProtectionConfig": {
+      "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+    },
+    "Rules": [],
+    "VisibilityConfig": {
+      "MetricName": "cdkrdHunt0717CfAcl",
+      "SampledRequestsEnabled": false,
+      "CloudWatchMetricsEnabled": false
+    },
+    "LabelNamespace": "awswaf:111111111111:webacl:CfAcl-lFuJ3bwEbTCj:",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0717Variants5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CfAcl",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0717Variants5/fd781c00-812b-11f1-95a9-12ee848f7c35",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "CfAcl-lFuJ3bwEbTCj"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["AssociationConfig.RequestBody", "CustomResponseBodies"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CfAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
+      "physicalId": "CfAcl-lFuJ3bwEbTCj|7e819c39-5be2-4c3c-a0de-2acca4f86fb6|CLOUDFRONT",
+      "constructPath": "CdkrdHunt0717Variants5/CfAcl"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "CfAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "Name",
+      "actual": "CfAcl-lFuJ3bwEbTCj",
+      "physicalId": "CfAcl-lFuJ3bwEbTCj|7e819c39-5be2-4c3c-a0de-2acca4f86fb6|CLOUDFRONT",
+      "constructPath": "CdkrdHunt0717Variants5/CfAcl"
+    }
+  ]
+}

--- a/tests/integration/fpmisc-hunt/app.ts
+++ b/tests/integration/fpmisc-hunt/app.ts
@@ -1,0 +1,62 @@
+// Declared-tier FP probes predicted by the offline allowlist-gap audit (real AWS).
+// DETERMINATIONS (live, 2026-07-17, us-east-1): first check CLEAN on all three — each
+// service echoes the declared value VERBATIM, so none needs an allowlist entry:
+// - WAFv2::RegexPatternSet.RegularExpressionList: semantically a SET, but WAFv2
+//   preserves a non-sorted 3-element list's order/content exactly (no
+//   UNORDERED_ARRAY_PROPS gap). Pinned by the RegexSetUnsorted corpus case.
+// - CloudFront::ResponseHeadersPolicy CORS AllowHeaders/ExposeHeaders: CloudFront is
+//   case- AND order-preserving (unlike the folded ApiGwV2/Lambda-Url header sets in
+//   CASE_INSENSITIVE_ARRAY_PATHS — no entry needed). Pinned by the RhpCors corpus case.
+// - ECS::TaskDefinition networkMode "host": register-only (free, no instances);
+//   folds clean like bridge/awsvpc.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnResponseHeadersPolicy } from "aws-cdk-lib/aws-cloudfront";
+import { CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+import { CfnRegexPatternSet } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+const s = new Stack(app, "CdkrdHunt0717FpMisc");
+
+// Deliberately NON-sorted regex list — if WAFv2 stores it sorted/reordered, the
+// declared tier FPs on order.
+new CfnRegexPatternSet(s, "RegexSet", {
+  scope: "REGIONAL",
+  regularExpressionList: ["zzz.*", "aaa[0-9]+", "mmm-.*"],
+});
+
+// Mixed-case, non-sorted CORS header sets.
+new CfnResponseHeadersPolicy(s, "RhpCors", {
+  responseHeadersPolicyConfig: {
+    name: "CdkrdHunt0717RhpCors",
+    corsConfig: {
+      accessControlAllowCredentials: false,
+      accessControlAllowHeaders: {
+        items: ["X-Zebra-Header", "authorization", "Content-Type"],
+      },
+      accessControlAllowMethods: { items: ["POST", "GET"] },
+      accessControlAllowOrigins: { items: ["https://example.com"] },
+      accessControlExposeHeaders: {
+        items: ["X-Zulu-Expose", "content-length", "ETag"],
+      },
+      originOverride: false,
+    },
+  },
+});
+
+// host-mode EC2 task definition — register-only, no cluster/instances needed.
+new CfnTaskDefinition(s, "HostTaskDef", {
+  family: "cdkrd-hunt0717-host",
+  requiresCompatibilities: ["EC2"],
+  networkMode: "host",
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "public.ecr.aws/docker/library/busybox:latest",
+      memory: 128,
+    },
+  ],
+});

--- a/tests/integration/fpmisc-hunt/cdk.json
+++ b/tests/integration/fpmisc-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/fpmisc-hunt/package.json
+++ b/tests/integration/fpmisc-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-fpmisc-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Bug-hunt 2026-07-17 probe fixture (fpmisc-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/fpmisc-hunt/verify.sh
+++ b/tests/integration/fpmisc-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Bug-hunt 2026-07-17 probe: deploy the
+# stack, assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0717FpMisc)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (fpmisc-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-fpmisc}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # --fail exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "INTEG OK (fpmisc-hunt)"

--- a/tests/integration/kmsdlm-hunt/app.ts
+++ b/tests/integration/kmsdlm-hunt/app.ts
@@ -1,0 +1,95 @@
+// Barest-variant first-run FP probe (real AWS), two axes never exercised live.
+// DETERMINATIONS (live, 2026-07-17, us-east-1): KMS folds clean across ALL four key
+// variants (the symmetric-centric KNOWN_DEFAULTS pins are equality-gated, so the
+// asymmetric/HMAC shapes — which DECLARE KeySpec/KeyUsage — never hit them; the naked
+// key's default key policy folds too). DLM first-ran THREE bugs: #1663 (undeclared
+// interval CreateRule.Times materialization + shorthand RetainInterval=7), #1665
+// (DefaultPolicy readGap blocked snapshot-completeness → appeared-since-record was
+// silently disabled), #1666 (RetainInterval revert no-op: RSDP + top-level shorthand
+// Update params). verify-detect.sh live-proves detection + revert convergence.
+// - AWS::KMS::Key non-symmetric variants: every existing fixture/corpus key is
+//   symmetric (KNOWN_DEFAULTS pins KeySpec=SYMMETRIC_DEFAULT / KeyUsage=ENCRYPT_DECRYPT
+//   around that shape). Asymmetric RSA/ECC sign-verify keys and HMAC keys cannot
+//   rotate and carry different KeySpec/KeyUsage, so the symmetric-centric folds are
+//   unguarded here. Key4 is a fully naked symmetric key (no KeyPolicy declared) to
+//   probe the default-key-policy echo too.
+// - AWS::DLM::LifecyclePolicy: the SDK-override reader + writer have corpus cases but
+//   ZERO live fixtures — both projection styles (custom PolicyDetails vs the
+//   default-policy top-level shorthand, DLM_DEFAULT_POLICY_SHORTHAND) and the #1362
+//   map->list Tags projection never ran against a real deploy.
+// Stack A carries the KMS keys (safe), stack B the DLM pair (riskier create-time
+// validation), so one failure cannot roll back the other probe.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnLifecyclePolicy } from "aws-cdk-lib/aws-dlm";
+import { ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnKey } from "aws-cdk-lib/aws-kms";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+// ---------------------------------------------------------------- stack A: KMS
+const a = new Stack(app, "CdkrdHunt0717KmsA");
+
+// Asymmetric RSA sign/verify — KeySpec+KeyUsage are the create-time minimum.
+new CfnKey(a, "RsaSignKey", {
+  keySpec: "RSA_2048",
+  keyUsage: "SIGN_VERIFY",
+});
+// Asymmetric ECC sign/verify.
+new CfnKey(a, "EccSignKey", {
+  keySpec: "ECC_NIST_P256",
+  keyUsage: "SIGN_VERIFY",
+});
+// HMAC generate/verify.
+new CfnKey(a, "HmacKey", {
+  keySpec: "HMAC_256",
+  keyUsage: "GENERATE_VERIFY_MAC",
+});
+// Fully naked symmetric control: KeyPolicy undeclared — probes the default
+// key policy echo (a deterministic f(account) document).
+new CfnKey(a, "NakedKey", {});
+
+// ---------------------------------------------------------------- stack B: DLM
+const b = new Stack(app, "CdkrdHunt0717DlmB");
+
+const dlmRole = new Role(b, "DlmRole", {
+  assumedBy: new ServicePrincipal("dlm.amazonaws.com"),
+  managedPolicies: [
+    ManagedPolicy.fromAwsManagedPolicyName(
+      "service-role/AWSDataLifecycleManagerServiceRole"
+    ),
+  ],
+});
+
+// Custom policy — full PolicyDetails projection path.
+new CfnLifecyclePolicy(b, "CustomPolicy", {
+  description: "cdkrd hunt 0717 custom snapshot policy",
+  executionRoleArn: dlmRole.roleArn,
+  state: "ENABLED",
+  policyDetails: {
+    policyType: "EBS_SNAPSHOT_MANAGEMENT",
+    resourceTypes: ["VOLUME"],
+    targetTags: [{ key: "cdkrd-hunt", value: "0717" }],
+    schedules: [
+      {
+        name: "cdkrd-hunt-daily",
+        createRule: { interval: 12, intervalUnit: "HOURS" },
+        retainRule: { count: 1 },
+      },
+    ],
+  },
+});
+
+// Default-policy shorthand — the usesShorthand projection path. CreateInterval is
+// declared to select the shorthand branch; RetainInterval/CopyTags/ExtendDeletion
+// stay undeclared to probe their defaults. Description AND State are REQUIRED for
+// the default-policy form too (live-determined: DLM rejects the create without each).
+new CfnLifecyclePolicy(b, "DefaultPolicy", {
+  defaultPolicy: "VOLUME",
+  description: "cdkrd hunt 0717 default policy shorthand",
+  state: "ENABLED",
+  executionRoleArn: dlmRole.roleArn,
+  createInterval: 1,
+});

--- a/tests/integration/kmsdlm-hunt/cdk.json
+++ b/tests/integration/kmsdlm-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/kmsdlm-hunt/package.json
+++ b/tests/integration/kmsdlm-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-kmsdlm-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Bug-hunt 2026-07-17 probe fixture (kmsdlm-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/kmsdlm-hunt/verify-detect.sh
+++ b/tests/integration/kmsdlm-hunt/verify-detect.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Detection (FN) + revert-convergence probe for the kmsdlm-hunt pair (#1663 piggyback):
+# deploy -> first check CLEAN (proves the #1663 folds live) -> rev=2 redeploy echo probe
+# -> record -> out-of-band mutations (DLM shorthand RetainInterval 7->5; KMS NakedKey
+# disable) -> check --fail MUST detect -> revert -> LIVE values must converge (judge by
+# the live read, not the revert rc) -> final check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0717KmsA CdkrdHunt0717DlmB)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (kmsdlm-hunt detect): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check MUST be CLEAN (proves #1663 folds) ==="
+  $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+done
+
+echo "=== rev=2 redeploy (post-update echo probe) ==="
+npx cdk deploy -f --all --require-approval never -c rev=2 || fail "rev=2 deploy"
+for STACK in "${STACKS[@]}"; do
+  $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.rev2.out"
+  RC=${PIPESTATUS[0]}
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.rev2.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] post-update echo check not clean (rc=$RC)"
+done
+
+echo "=== record both stacks ==="
+for STACK in "${STACKS[@]}"; do
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+done
+
+DLM_ID=$(aws cloudformation describe-stack-resource --stack-name CdkrdHunt0717DlmB \
+  --logical-resource-id DefaultPolicy --region "$REGION" \
+  --query 'StackResourceDetail.PhysicalResourceId' --output text)
+KEY_ID=$(aws cloudformation describe-stack-resource --stack-name CdkrdHunt0717KmsA \
+  --logical-resource-id NakedKey --region "$REGION" \
+  --query 'StackResourceDetail.PhysicalResourceId' --output text)
+echo "DLM_ID=$DLM_ID KEY_ID=$KEY_ID"
+
+echo "=== OOB mutate: DLM RetainInterval 7->5, KMS NakedKey disable ==="
+aws dlm update-lifecycle-policy --policy-id "$DLM_ID" --retain-interval 5 --region "$REGION" || fail "dlm mutate"
+aws kms disable-key --key-id "$KEY_ID" --region "$REGION" || fail "kms disable"
+sleep 10
+
+echo "=== check MUST detect both ==="
+$CLI check CdkrdHunt0717DlmB --region "$REGION" --fail > /tmp/cdkrd-dlm.detect.out 2>&1
+[ $? -eq 1 ] || { cat /tmp/cdkrd-dlm.detect.out; fail "DLM drift not detected (RetainInterval)"; }
+grep -q "RetainInterval" /tmp/cdkrd-dlm.detect.out || { cat /tmp/cdkrd-dlm.detect.out; fail "RetainInterval not in DLM findings"; }
+$CLI check CdkrdHunt0717KmsA --region "$REGION" --fail > /tmp/cdkrd-kms.detect.out 2>&1
+[ $? -eq 1 ] || { cat /tmp/cdkrd-kms.detect.out; fail "KMS drift not detected (Enabled=false)"; }
+grep -q "Enabled" /tmp/cdkrd-kms.detect.out || { cat /tmp/cdkrd-kms.detect.out; fail "Enabled not in KMS findings"; }
+echo "detection OK (both)"
+
+echo "=== revert both ==="
+$CLI revert CdkrdHunt0717DlmB --region "$REGION" --yes | tee /tmp/cdkrd-dlm.revert.out || fail "dlm revert rc"
+$CLI revert CdkrdHunt0717KmsA --region "$REGION" --yes | tee /tmp/cdkrd-kms.revert.out || fail "kms revert rc"
+
+echo "=== judge by LIVE values ==="
+sleep 10
+RI_TOP=$(aws dlm get-lifecycle-policy --policy-id "$DLM_ID" --region "$REGION" --output json \
+  | python3 -c "import json,sys; p=json.load(sys.stdin)['Policy']; print(p.get('PolicyDetails',{}).get('RetainInterval', p.get('RetainInterval')))")
+echo "live RetainInterval after revert: $RI_TOP"
+[ "$RI_TOP" = "7" ] || fail "DLM RetainInterval did not converge to 7 (live=$RI_TOP) — RSDP candidate"
+KEY_STATE=$(aws kms describe-key --key-id "$KEY_ID" --region "$REGION" --query 'KeyMetadata.Enabled' --output text)
+echo "live KMS Enabled after revert: $KEY_STATE"
+[ "$KEY_STATE" = "True" ] || fail "KMS key did not re-enable (live=$KEY_STATE)"
+
+echo "=== final check MUST be CLEAN ==="
+for STACK in "${STACKS[@]}"; do
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] final check not clean"
+done
+
+echo "INTEG OK (kmsdlm-hunt detect)"

--- a/tests/integration/kmsdlm-hunt/verify.sh
+++ b/tests/integration/kmsdlm-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# KMS non-symmetric variants + DLM LifecyclePolicy barest live probe: deploy both
+# stacks, assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0717KmsA CdkrdHunt0717DlmB)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (kmsdlm-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-kmsdlm}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # --fail exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "INTEG OK (kmsdlm-hunt)"

--- a/tests/integration/notation2-hunt/app.ts
+++ b/tests/integration/notation2-hunt/app.ts
@@ -1,0 +1,65 @@
+// CloudFormation-notation live probes (real AWS) — the intrinsic-resolver audit
+// found these user-common notations have unit tests but ZERO live end-to-end runs:
+// - Fn::Cidr (+ Fn::Select over Fn::GetAtt): the IPv4 tiling math has never been
+//   compared against a real subnet's live CidrBlock echo — a mis-tile is a declared
+//   FP on CidrBlock.
+// - Fn::GetAZs (+ Fn::Select): zero unit tests; must land in the unresolved tier
+//   (fail-closed), never a declared FP.
+// - {{resolve:ssm:...}} dynamic reference in a Lambda environment variable: the
+//   declared value must stay unresolved (no declared FP against the live resolved
+//   value), and no revert plan may ever write the literal token to AWS.
+import { App, Fn, Stack, Tags } from "aws-cdk-lib";
+import { CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnParameter } from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+const s = new Stack(app, "CdkrdHunt0717Notation2");
+
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.61.0.0/16" });
+
+// CidrBlock = Fn::Select(i, Fn::Cidr(Fn::GetAtt Vpc.CidrBlock, 4, 8)) — the raw
+// token survives synth (attrCidrBlock is unresolvable locally).
+new CfnSubnet(s, "SubA", {
+  vpcId: vpc.ref,
+  cidrBlock: Fn.select(0, Fn.cidr(vpc.attrCidrBlock, 4, "8")),
+  availabilityZone: Fn.select(0, Fn.getAzs()),
+});
+new CfnSubnet(s, "SubB", {
+  vpcId: vpc.ref,
+  cidrBlock: Fn.select(2, Fn.cidr(vpc.attrCidrBlock, 4, "8")),
+  availabilityZone: Fn.select(1, Fn.getAzs()),
+});
+
+// {{resolve:ssm:...}} dynamic reference probe.
+const param = new CfnParameter(s, "Param", {
+  type: "String",
+  name: "cdkrd-hunt0717-notation-param",
+  value: "hunt-value-1",
+});
+
+const role = new Role(s, "FnRole", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+  managedPolicies: [
+    ManagedPolicy.fromAwsManagedPolicyName(
+      "service-role/AWSLambdaBasicExecutionRole"
+    ),
+  ],
+});
+
+const fn = new CfnFunction(s, "Fn", {
+  functionName: "cdkrd-hunt0717-notation-fn",
+  role: role.roleArn,
+  runtime: "nodejs20.x",
+  handler: "index.handler",
+  code: { zipFile: "exports.handler = async () => ({ ok: true });" },
+  environment: {
+    variables: { SSM_VAL: `{{resolve:ssm:${param.ref}}}` },
+  },
+});
+fn.addDependency(param);

--- a/tests/integration/notation2-hunt/cdk.json
+++ b/tests/integration/notation2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/notation2-hunt/package.json
+++ b/tests/integration/notation2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-notation2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Bug-hunt 2026-07-17 probe fixture (notation2-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/notation2-hunt/verify.sh
+++ b/tests/integration/notation2-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Bug-hunt 2026-07-17 probe: deploy the
+# stack, assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0717Notation2)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (notation2-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-notation2}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # --fail exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "INTEG OK (notation2-hunt)"

--- a/tests/integration/variants5-hunt/app.ts
+++ b/tests/integration/variants5-hunt/app.ts
@@ -1,0 +1,50 @@
+// Barest-variant first-run FP probe batch 5 (real AWS) — the two remaining cheap
+// axes from the 2026-07-17 variants audit:
+// - WAFv2::WebACL Scope CLOUDFRONT: every existing WAFv2 fixture is REGIONAL; the
+//   CLOUDFRONT scope lives on the global endpoint (us-east-1) and its echoes /
+//   read routing were never exercised.
+// - ELBv2::TargetGroup UDP / TLS / TCP_UDP protocols: TCP/HTTP/GENEVE/lambda are
+//   covered; the NLB protocol variants carry different health-check defaults
+//   (register-only — no load balancer needed, free).
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnTargetGroup } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+const s = new Stack(app, "CdkrdHunt0717Variants5");
+
+// CLOUDFRONT-scope barest ACL — no Rules, no Name.
+new CfnWebACL(s, "CfAcl", {
+  scope: "CLOUDFRONT",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    sampledRequestsEnabled: false,
+    cloudWatchMetricsEnabled: false,
+    metricName: "cdkrdHunt0717CfAcl",
+  },
+});
+
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.62.0.0/16" });
+
+// NLB protocol variants, barest: only Protocol/Port/VpcId declared — health-check
+// defaults (protocol/port/interval/threshold) are the probe surface.
+new CfnTargetGroup(s, "UdpTg", {
+  protocol: "UDP",
+  port: 53,
+  vpcId: vpc.ref,
+});
+new CfnTargetGroup(s, "TlsTg", {
+  protocol: "TLS",
+  port: 443,
+  vpcId: vpc.ref,
+});
+new CfnTargetGroup(s, "TcpUdpTg", {
+  protocol: "TCP_UDP",
+  port: 53,
+  vpcId: vpc.ref,
+});

--- a/tests/integration/variants5-hunt/cdk.json
+++ b/tests/integration/variants5-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/variants5-hunt/package.json
+++ b/tests/integration/variants5-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-variants5-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Bug-hunt 2026-07-17 barest-variant batch 5: WAFv2 CLOUDFRONT-scope WebACL, ELBv2 TargetGroup UDP/TLS/TCP_UDP. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/variants5-hunt/verify.sh
+++ b/tests/integration/variants5-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Bug-hunt 2026-07-17 probe: deploy the
+# stack, assert the FIRST check (before record) is CLEAN, then record and assert
+# check --fail is still clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0717Variants5)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (variants5-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-variants5}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # --fail exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "INTEG OK (variants5-hunt)"

--- a/tests/overrides-dlm-defaultpolicy-1665.test.ts
+++ b/tests/overrides-dlm-defaultpolicy-1665.test.ts
@@ -1,0 +1,95 @@
+// #1665 — the declared DefaultPolicy ("VOLUME"|"INSTANCE") had no live counterpart in
+// readDlmLifecyclePolicy's model (GetLifecyclePolicy reports a BOOLEAN Policy.DefaultPolicy
+// plus the details' singular ResourceType), so it read as a genuine readGap — which (the
+// #795 completeness fail-safe) blocked the resource from ever being snapshot-complete and
+// silently disabled appeared-since-record detection for every undeclared out-of-band change
+// on the policy (live-hit: an OOB RetainInterval 7->5 stayed [Potential Drift] forever).
+// The reader now projects the declared-shaped enum back, gated on live CONFIRMING a default
+// policy — a custom policy never emits the key (the #1660 readGap-fix-FP lesson).
+import { GetLifecyclePolicyCommand, DLMClient } from '@aws-sdk/client-dlm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+const dlm = mockClient(DLMClient);
+beforeEach(() => dlm.reset());
+
+const ctx = (declared: Record<string, unknown>) => ({
+  physicalId: 'policy-0123456789abcdef0',
+  declared,
+  region: 'us-east-1',
+  accountId: '123456789012',
+});
+
+describe('DLM default-policy DefaultPolicy projection (#1665)', () => {
+  it('projects DefaultPolicy from the boolean + details.ResourceType (readGap closed)', async () => {
+    dlm.on(GetLifecyclePolicyCommand).resolves({
+      Policy: {
+        Description: 'default policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        DefaultPolicy: true,
+        PolicyDetails: {
+          PolicyLanguage: 'SIMPLIFIED',
+          ResourceType: 'VOLUME',
+          CreateInterval: 1,
+          RetainInterval: 7,
+        },
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::DLM::LifecyclePolicy'](
+      ctx({
+        DefaultPolicy: 'VOLUME',
+        CreateInterval: 1,
+        Description: 'default policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+      })
+    );
+    expect(out?.DefaultPolicy).toBe('VOLUME');
+    // shorthand keys still projected to the top level alongside it
+    expect(out?.CreateInterval).toBe(1);
+    expect(out?.RetainInterval).toBe(7);
+    expect(out?.PolicyDetails).toBeUndefined();
+  });
+
+  it('never emits DefaultPolicy for a custom policy (no fresh undeclared FP)', async () => {
+    dlm.on(GetLifecyclePolicyCommand).resolves({
+      Policy: {
+        Description: 'custom policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        PolicyDetails: {
+          PolicyType: 'EBS_SNAPSHOT_MANAGEMENT',
+          ResourceTypes: ['VOLUME'],
+          Schedules: [{ Name: 'daily' }],
+        },
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::DLM::LifecyclePolicy'](
+      ctx({
+        Description: 'custom policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        PolicyDetails: { PolicyType: 'EBS_SNAPSHOT_MANAGEMENT' },
+      })
+    );
+    expect(out?.DefaultPolicy).toBeUndefined();
+  });
+
+  it('stays an honest readGap when live confirms default but carries no ResourceType', async () => {
+    dlm.on(GetLifecyclePolicyCommand).resolves({
+      Policy: {
+        Description: 'default policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        DefaultPolicy: true,
+        PolicyDetails: { CreateInterval: 1 },
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::DLM::LifecyclePolicy'](
+      ctx({ DefaultPolicy: 'VOLUME', CreateInterval: 1 })
+    );
+    expect(out?.DefaultPolicy).toBeUndefined();
+  });
+});

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1029,3 +1029,30 @@ describe('#883 — --pre-deploy footer renders pending-creation skips as their o
     );
   });
 });
+
+describe('#1665 unrecorded preamble names the snapshot-completeness reason when a baseline exists', () => {
+  const U1665 = (path = 'P'): Finding => ({
+    tier: 'undeclared',
+    logicalId: 'L',
+    resourceType: 'AWS::X::Y',
+    path,
+    actual: 1,
+    unrecorded: true,
+  });
+
+  it('with hasBaseline: true, does NOT claim "No baseline yet" (it exists)', () => {
+    const { text } = run([U1665()], { hasBaseline: true });
+    expect(text).not.toContain('No baseline yet');
+    expect(text).toContain("record couldn't fully snapshot");
+    expect(text).toContain('[Potential Drift: 1]');
+  });
+
+  it('with hasBaseline: false or omitted, keeps the original no-baseline wording', () => {
+    for (const opts of [{ hasBaseline: false }, {}]) {
+      const { text } = run([U1665()], opts);
+      expect(text).toContain(
+        "No baseline yet — these live-only values can't be confirmed as drift"
+      );
+    }
+  });
+});

--- a/tests/revert-dlm-retaininterval-1666.test.ts
+++ b/tests/revert-dlm-retaininterval-1666.test.ts
@@ -1,0 +1,102 @@
+// #1666 — reverting an out-of-band default-policy RetainInterval change silently no-oped
+// (live-proven 2026-07-17: 7->5 mutated, revert planned a bare `remove`, reported
+// "reverted", the live value stayed 5). Two layers, both pinned here:
+// - PLAN: writeDlmLifecyclePolicy builds the Update payload from the desired model, so a
+//   removed key never reaches the call — RetainInterval needs the explicit set-default
+//   `add` (7 from the #1663 KNOWN_DEFAULTS pin) via REVERT_SET_DEFAULT_PATHS.
+// - WRITER: the default-policy shorthand keys are TOP-LEVEL UpdateLifecyclePolicy request
+//   params ([Default policies only]); PolicyDetails is [Custom policies only]. The old
+//   shorthand branch synthesized a live-overlaid PolicyDetails — the wrong request field
+//   for a default policy (written blind; zero live fixtures until the 2026-07-17 hunt).
+import {
+  GetLifecyclePolicyCommand,
+  DLMClient,
+  UpdateLifecyclePolicyCommand,
+} from '@aws-sdk/client-dlm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import type { BaselineFile } from '../src/baseline/baseline-file.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import { SDK_WRITERS } from '../src/revert/writers.js';
+import type { Finding } from '../src/types.js';
+
+const baseline = (recorded: BaselineFile['recorded']): BaselineFile => ({
+  schemaVersion: 1,
+  stackName: 's',
+  region: 'r',
+  accountId: '111122223333',
+  capturedAt: '',
+  templateHash: '',
+  recorded,
+});
+
+describe('#1666 DLM default-policy RetainInterval revert', () => {
+  it('plans an explicit set-default add (7 from KNOWN_DEFAULTS), not a bare remove', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'DefaultPolicy',
+      physicalId: 'policy-0abc',
+      resourceType: 'AWS::DLM::LifecyclePolicy',
+      path: 'RetainInterval',
+      actual: 5,
+    };
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/RetainInterval',
+      value: 7,
+      prior: 5,
+    });
+  });
+
+  const dlm = mockClient(DLMClient);
+  beforeEach(() => dlm.reset());
+
+  it('writer sends the shorthand keys as TOP-LEVEL Update params, never PolicyDetails', async () => {
+    // Live read (desiredModel's base): a default policy whose RetainInterval drifted to 5.
+    dlm.on(GetLifecyclePolicyCommand).resolves({
+      Policy: {
+        PolicyId: 'policy-0abc',
+        Description: 'default policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        DefaultPolicy: true,
+        PolicyDetails: {
+          PolicyLanguage: 'SIMPLIFIED',
+          ResourceType: 'VOLUME',
+          CreateInterval: 1,
+          RetainInterval: 5,
+        },
+      },
+    } as never);
+    dlm.on(UpdateLifecyclePolicyCommand).resolves({});
+    await SDK_WRITERS['AWS::DLM::LifecyclePolicy'](
+      {
+        physicalId: 'policy-0abc',
+        declared: {
+          DefaultPolicy: 'VOLUME',
+          CreateInterval: 1,
+          Description: 'default policy',
+          State: 'ENABLED',
+          ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        },
+        region: 'us-east-1',
+        accountId: '123456789012',
+      },
+      [
+        {
+          op: 'add',
+          path: '/RetainInterval',
+          value: 7,
+          human: 'RetainInterval -> AWS default (7)',
+        },
+      ]
+    );
+    const calls = dlm.commandCalls(UpdateLifecyclePolicyCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input as unknown as Record<string, unknown>;
+    expect(input.RetainInterval).toBe(7);
+    expect(input.CreateInterval).toBe(1);
+    expect(input.PolicyDetails).toBeUndefined();
+  });
+});

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -505,10 +505,15 @@ describe('DLM LifecyclePolicy writer (UpdateLifecyclePolicy, issue #468)', () =>
     expect(input.State).toBe('ENABLED');
   });
 
-  it('default-policy shorthand: overlays the desired shorthand key onto the live PolicyDetails', async () => {
+  it('default-policy shorthand: sends the shorthand keys as TOP-LEVEL Update params (#1666)', async () => {
+    // The shorthand keys are [Default policies only] TOP-LEVEL UpdateLifecyclePolicy
+    // request params; PolicyDetails is [Custom policies only]. The writer used to
+    // synthesize a live-overlaid PolicyDetails here — the wrong request field for a
+    // default policy (written blind; zero live fixtures until the 2026-07-17 hunt).
     dlm.on(GetLifecyclePolicyCommand).resolves({
       Policy: {
         PolicyId: 'policy-0def',
+        DefaultPolicy: true,
         PolicyDetails: {
           PolicyType: 'EBS_SNAPSHOT_MANAGEMENT',
           PolicyLanguage: 'SIMPLIFIED',
@@ -535,11 +540,10 @@ describe('DLM LifecyclePolicy writer (UpdateLifecyclePolicy, issue #468)', () =>
     );
     const input = dlm.commandCalls(UpdateLifecyclePolicyCommand)[0]!.args[0]
       .input as unknown as Record<string, unknown>;
-    const details = input.PolicyDetails as Record<string, unknown>;
-    // the immutable PolicyType/ResourceType survive from the live read; the drifted
-    // shorthand key is reverted
-    expect(details.PolicyType).toBe('EBS_SNAPSHOT_MANAGEMENT');
-    expect(details.CreateInterval).toBe(12);
+    // the drifted shorthand key is reverted top-level; PolicyDetails is never sent
+    expect(input.CreateInterval).toBe(12);
+    expect(input.RetainInterval).toBe(7);
+    expect(input.PolicyDetails).toBeUndefined();
   });
 
   it('throws when the policy id cannot be resolved', async () => {


### PR DESCRIPTION
## Summary

2026-07-17 bug hunt (fix + PR goal): **four live-proven bugs found and fixed**, plus the fixtures, 12 golden-corpus cases, and no-risk determinations the hunt produced.

### Bugs fixed (all live-repro'd and live-re-proven on real AWS, us-east-1)

- **#1663 fix(diff)** — barest `AWS::DLM::LifecyclePolicy` first-run FPs: an undeclared interval `CreateRule` reads back a creation-assigned `Times` (folded tier-3 via `VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS` — per-resource, not derivable), and the default-policy shorthand materializes `RetainInterval: 7` (folded tier-1 via `KNOWN_DEFAULTS`, equality-gated). Both prior corpus cases DECLARED the suspect leaves — the #615-class apparent-coverage trap; the type had zero live fixtures.
- **#1664 fix(diff)** — `ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL`'s UDP/TCP_UDP rows had MIRRORED TCP's `deregistration_delay.connection_termination.enabled: 'false'`; AWS's UDP-family default is **`'true'`** (live-proven on a barest UDP/TCP_UDP TargetGroup; TLS correctly stays `'false'`). The "do NOT copy a sibling variant's constants" trap, baked into the fold table itself.
- **#1665 fix(read/report)** — the declared `DefaultPolicy` enum had no live counterpart (genuine readGap), which by the #795 completeness fail-safe **silently disabled appeared-since-record detection for the whole resource** (an OOB `RetainInterval` change never became confirmed drift; `check --fail` exited 0). The reader now projects it from `Policy.DefaultPolicy` + `PolicyDetails.ResourceType`, gated to never emit on a custom policy (#1660 lesson). Also: the unrecorded preamble claimed "No baseline yet" right after a successful `record` — it now names the snapshot-completeness reason when a baseline exists (`hasBaseline` threaded through `ReportOptions`).
- **#1666 fix(revert)** — reverting the OOB `RetainInterval` claimed success but silently no-oped. Two layers: an RSDP entry (`AWS::DLM::LifecyclePolicy\0RetainInterval`, default 7 from the #1663 pin) so the plan writes the default explicitly, and the writer now sends default-policy shorthand keys as **top-level** `UpdateLifecyclePolicy` params (`PolicyDetails` is [Custom policies only] — the old branch, written blind with zero live fixtures, targeted the wrong request field).

### Live proof (kmsdlm-hunt `verify-detect.sh`, final run INTEG OK)

deploy → first check **CLEAN** (proves #1663+#1665) → `rev=2` redeploy echo probe CLEAN → record → OOB mutate (DLM `RetainInterval` 7→5 + KMS key disable) → `check --fail` **detects both** (proves #1665 restored R62) → revert → **live `RetainInterval` back to 7** (proves #1666) + KMS key re-enabled → final check CLEAN. variants5-hunt re-run INTEG OK (proves #1664).

### Clean determinations (also assets)

- KMS `RSA_2048`/`ECC_NIST_P256`/`HMAC_256`/naked-symmetric key variants: all CLEAN (4 corpus cases).
- WAFv2 RegexPatternSet preserves a non-sorted list verbatim; CloudFront ResponseHeadersPolicy CORS headers are case+order-preserving; ECS host-mode TaskDefinition clean — three predicted allowlist gaps live-determined **no-risk** (fixture comments + corpus pins).
- `Fn::Cidr` live-verified end-to-end (resolved tiling matched real subnet CIDRs); `Fn::GetAZs` + `{{resolve:ssm:...}}` land fail-closed in `unresolved`, no FP.
- WAFv2 CLOUDFRONT-scope WebACL barest: CLEAN.
- DLM default-policy shorthand requires `Description` AND `State` at create (fixture comment).

### Fixtures / corpus / skill

- New integ fixtures: `kmsdlm-hunt` (+`verify-detect.sh`), `fpmisc-hunt`, `notation2-hunt`, `variants5-hunt`.
- 12 new golden-corpus cases (KMS×4, DLM×2, TG×3, WAFv2×2, CloudFront RHP×1); DLM `DefaultPolicy` case pins the closed readGap.
- hunt-bugs skill: two new gotchas (mirrored variant-table rows are unproven; a reader-projection readGap silently disables the R62 detect probe and masks as "No baseline yet").
- measure-noise sweep run: no genuine new candidates (all CANDIDATEs were known mutated-case artifacts).

### Verification

- `/check`: typecheck / lint+format / `vp pack` / **6070 tests in 316 files** all pass.
- `/check-docs`: consistent (`SDK_WRITERS`/`SDK_OVERRIDES` key sets unchanged; README transcript depicts the unchanged no-baseline wording).
- `/verify-pr`: live-test = this hunt's own end-to-end proofs; shared CORE suite **deferred** (diff fully covered by unit tests + corpus replay + originating-hunt live proof — logged per R50).
- Cleanup: all 8 deployed stacks deleted, `sweep-orphans.sh` **SWEEP CLEAN**, bughunt gate released.

Closes #1663, closes #1664, closes #1665, closes #1666.
