### PR TITLE
fix(read): DLM default policy with no declared shorthand key FP'd a whole-object PolicyDetails (#1668)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1000,6 +1000,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // Proven live on a fresh kmsdlm-hunt deploy.
   'AWS::DLM::LifecyclePolicy': {
     RetainInterval: 7,
+    // #1668: the sibling creation-frequency default (documented 1 day) — surfaces once the
+    // no-shorthand default-policy read projects it top-level. Equality-gated like
+    // RetainInterval; CopyTags/ExtendDeletion read back `false` (isTrivialEmpty).
+    CreateInterval: 1,
   },
   'AWS::IAM::Group': {
     Path: '/',

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -865,9 +865,14 @@ const readDlmLifecyclePolicy: OverrideReader = async ({ physicalId, declared, re
   // Emit in the template's style. The default-policy shorthand declares the schedule
   // knobs at the TOP level and no PolicyDetails; the API folds them into PolicyDetails, so
   // project just those keys back up. Every other case is a custom policy → PolicyDetails.
+  // #1668: live confirming a DEFAULT policy (Policy.DefaultPolicy) forces shorthand mode —
+  // a default policy that declares NO shorthand key at all (every knob has a server
+  // default) otherwise fell into the custom branch and emitted the API's folded
+  // PolicyDetails wholesale, a whole-object first-run FP the template never declared.
   const usesShorthand =
-    declared.PolicyDetails === undefined &&
-    DLM_DEFAULT_POLICY_SHORTHAND.some((k) => declared[k] !== undefined);
+    p.DefaultPolicy === true ||
+    (declared.PolicyDetails === undefined &&
+      DLM_DEFAULT_POLICY_SHORTHAND.some((k) => declared[k] !== undefined));
   if (usesShorthand) {
     for (const k of DLM_DEFAULT_POLICY_SHORTHAND)
       if (details[k] !== undefined) model[k] = details[k];

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -124,6 +124,9 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // 7->5 survived a "reverted" report). Write the documented default 7 (the #1663
   // KNOWN_DEFAULTS pin) explicitly so the revert converges.
   'AWS::DLM::LifecyclePolicy\0RetainInterval',
+  // #1668: CreateInterval shares the same writer/silent-no-op contract (a bare `remove`
+  // never reaches UpdateLifecyclePolicy) — write the documented default 1 explicitly.
+  'AWS::DLM::LifecyclePolicy\0CreateInterval',
   'AWS::IAM::Role\0MaxSessionDuration',
   // IAM UpdateRole ignores an omitted Description the same way it ignores an omitted
   // MaxSessionDuration (both are UpdateRole params) — a `remove` revert of an out-of-band

--- a/tests/classify-dlm-defaults-1663.test.ts
+++ b/tests/classify-dlm-defaults-1663.test.ts
@@ -123,3 +123,38 @@ describe('#1663 DLM LifecyclePolicy first-run default folds', () => {
     expect(tierPaths(f)).toEqual(['undeclared:RetainInterval']);
   });
 });
+
+// #1668 — the no-shorthand default-policy shape: the reader now projects the shorthand
+// keys top-level, so the undeclared CreateInterval must fold at its documented default 1
+// (equality-gated) alongside RetainInterval=7.
+describe('#1668 no-shorthand default policy folds', () => {
+  const bare: DesiredResource = {
+    logicalId: 'DefaultPolicyInstance',
+    resourceType: 'AWS::DLM::LifecyclePolicy',
+    physicalId: 'policy-0aaa1112223334445',
+    declared: {
+      Description: 'instance default policy',
+      ExecutionRoleArn: 'arn:aws:iam::111111111111:role/DlmRole',
+      State: 'ENABLED',
+    },
+  };
+  const live = (createInterval: number) => ({
+    Description: 'instance default policy',
+    State: 'ENABLED',
+    ExecutionRoleArn: 'arn:aws:iam::111111111111:role/DlmRole',
+    CreateInterval: createInterval,
+    RetainInterval: 7,
+    CopyTags: false,
+    ExtendDeletion: false,
+  });
+
+  it('folds the undeclared CreateInterval at the documented default 1', () => {
+    const f = classifyResource(bare, live(1), emptySchema);
+    expect(tierPaths(f)).toEqual(['atDefault:CreateInterval', 'atDefault:RetainInterval']);
+  });
+
+  it('still surfaces a CreateInterval changed away from the default (equality-gated)', () => {
+    const f = classifyResource(bare, live(3), emptySchema);
+    expect(tierPaths(f)).toEqual(['atDefault:RetainInterval', 'undeclared:CreateInterval']);
+  });
+});

--- a/tests/corpus/AWS__DLM__LifecyclePolicy.DefaultPolicyInstance.json
+++ b/tests/corpus/AWS__DLM__LifecyclePolicy.DefaultPolicyInstance.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DefaultPolicyInstance",
+    "resourceType": "AWS::DLM::LifecyclePolicy",
+    "physicalId": "policy-06cd9ebea2963ab4b",
+    "constructPath": "CdkrdHunt0717DlmB/DefaultPolicyInstance",
+    "declared": {
+      "DefaultPolicy": "INSTANCE",
+      "Description": "cdkrd hunt 0717b default policy instance barest",
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0717DlmB-DlmRoleCE7C5775-on0PhgCTZWJB",
+      "State": "ENABLED",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt 0717b default policy instance barest",
+    "State": "ENABLED",
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0717DlmB-DlmRoleCE7C5775-on0PhgCTZWJB",
+    "CreateInterval": 1,
+    "RetainInterval": 7,
+    "CopyTags": false,
+    "ExtendDeletion": false,
+    "DefaultPolicy": "INSTANCE",
+    "Tags": [
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DefaultPolicyInstance",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "CreateInterval",
+      "actual": 1,
+      "physicalId": "policy-06cd9ebea2963ab4b",
+      "constructPath": "CdkrdHunt0717DlmB/DefaultPolicyInstance"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DefaultPolicyInstance",
+      "resourceType": "AWS::DLM::LifecyclePolicy",
+      "path": "RetainInterval",
+      "actual": 7,
+      "physicalId": "policy-06cd9ebea2963ab4b",
+      "constructPath": "CdkrdHunt0717DlmB/DefaultPolicyInstance"
+    }
+  ]
+}

--- a/tests/integration/kmsdlm-hunt/app.ts
+++ b/tests/integration/kmsdlm-hunt/app.ts
@@ -7,6 +7,10 @@
 // (DefaultPolicy readGap blocked snapshot-completeness → appeared-since-record was
 // silently disabled), #1666 (RetainInterval revert no-op: RSDP + top-level shorthand
 // Update params). verify-detect.sh live-proves detection + revert convergence.
+// Follow-up #1668: a default policy with NO shorthand key declared (the
+// DefaultPolicyInstance shape below) fell into the reader's custom branch and FP'd a
+// whole-object PolicyDetails; DefaultPolicy===true now forces shorthand projection
+// (CreateInterval joins KNOWN_DEFAULTS + RSDP; detect→revert→converge live-proven).
 // - AWS::KMS::Key non-symmetric variants: every existing fixture/corpus key is
 //   symmetric (KNOWN_DEFAULTS pins KeySpec=SYMMETRIC_DEFAULT / KeyUsage=ENCRYPT_DECRYPT
 //   around that shape). Asymmetric RSA/ECC sign-verify keys and HMAC keys cannot
@@ -92,4 +96,15 @@ new CfnLifecyclePolicy(b, "DefaultPolicy", {
   state: "ENABLED",
   executionRoleArn: dlmRole.roleArn,
   createInterval: 1,
+});
+
+// Barest default policy with NO shorthand keys declared — only the live-required
+// Description/State + role (CreateInterval etc. all omitted). Probes the reader's
+// usesShorthand=false branch for a DEFAULT policy (the prior two policies both
+// declare a shorthand key), plus the INSTANCE variant axis (VOLUME above).
+new CfnLifecyclePolicy(b, "DefaultPolicyInstance", {
+  defaultPolicy: "INSTANCE",
+  description: "cdkrd hunt 0717b default policy instance barest",
+  state: "ENABLED",
+  executionRoleArn: dlmRole.roleArn,
 });

--- a/tests/overrides-dlm-defaultpolicy-1665.test.ts
+++ b/tests/overrides-dlm-defaultpolicy-1665.test.ts
@@ -93,3 +93,42 @@ describe('DLM default-policy DefaultPolicy projection (#1665)', () => {
     expect(out?.DefaultPolicy).toBeUndefined();
   });
 });
+
+// #1668 — a default policy that declares NO shorthand key at all fell into the custom
+// branch and emitted the API's folded PolicyDetails wholesale (a whole-object first-run
+// FP). Live confirming a default policy (Policy.DefaultPolicy) now forces shorthand mode.
+describe('DLM no-shorthand default policy projection (#1668)', () => {
+  it('projects shorthand keys top-level (never PolicyDetails) when live confirms a default policy', async () => {
+    dlm.on(GetLifecyclePolicyCommand).resolves({
+      Policy: {
+        Description: 'instance default policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+        DefaultPolicy: true,
+        PolicyDetails: {
+          PolicyType: 'IMAGE_MANAGEMENT',
+          PolicyLanguage: 'SIMPLIFIED',
+          ResourceType: 'INSTANCE',
+          CreateInterval: 1,
+          RetainInterval: 7,
+          CopyTags: false,
+          ExtendDeletion: false,
+        },
+      },
+    } as never);
+    const out = await SDK_OVERRIDES['AWS::DLM::LifecyclePolicy'](
+      ctx({
+        DefaultPolicy: 'INSTANCE',
+        Description: 'instance default policy',
+        State: 'ENABLED',
+        ExecutionRoleArn: 'arn:aws:iam::123456789012:role/dlm',
+      })
+    );
+    expect(out?.PolicyDetails).toBeUndefined();
+    expect(out?.DefaultPolicy).toBe('INSTANCE');
+    expect(out?.CreateInterval).toBe(1);
+    expect(out?.RetainInterval).toBe(7);
+    expect(out?.CopyTags).toBe(false);
+    expect(out?.ExtendDeletion).toBe(false);
+  });
+});

--- a/tests/revert-dlm-retaininterval-1666.test.ts
+++ b/tests/revert-dlm-retaininterval-1666.test.ts
@@ -100,3 +100,23 @@ describe('#1666 DLM default-policy RetainInterval revert', () => {
     expect(input.PolicyDetails).toBeUndefined();
   });
 });
+
+describe('#1668 DLM default-policy CreateInterval revert', () => {
+  it('plans an explicit set-default add (1 from KNOWN_DEFAULTS), not a bare remove', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'DefaultPolicyInstance',
+      physicalId: 'policy-0abc',
+      resourceType: 'AWS::DLM::LifecyclePolicy',
+      path: 'CreateInterval',
+      actual: 3,
+    };
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/CreateInterval',
+      value: 1,
+      prior: 3,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to the 2026-07-17 hunt (#1667): the one shape that hunt left unexercised — a default-policy `AWS::DLM::LifecyclePolicy` declaring **no shorthand key at all** — first-runs a **whole-object `PolicyDetails` FP**. Fixes #1668.

```
[Potential Drift: 1]
  DefaultPolicyInstance.PolicyDetails (AWS::DLM::LifecyclePolicy)
      actual ={"PolicyType":"IMAGE_MANAGEMENT","PolicyLanguage":"SIMPLIFIED","ResourceType":"INSTANCE","CreateInterval":1,"RetainInterval":7,"CopyTags":false,"ExtendDeletion":false}
```

`readDlmLifecyclePolicy`'s `usesShorthand` gate required ≥1 DECLARED shorthand key, so the barest (and most natural) default-policy declaration fell into the custom branch and emitted the API's folded `PolicyDetails` wholesale. The #1663 fixture declared `CreateInterval: 1`, masking the branch.

## Changes

- **read**: `Policy.DefaultPolicy === true` forces shorthand projection — a default policy always reads back declared-shaped top-level keys, never `PolicyDetails`.
- **diff**: `CreateInterval: 1` joins the DLM `KNOWN_DEFAULTS` pin (documented default, equality-gated) — it surfaces top-level once the projection lands.
- **revert**: `CreateInterval` RSDP entry (same silent-no-op writer contract as #1666's `RetainInterval`; the #1666 writer sends it as the top-level Update param).

## Live proof (us-east-1, INSTANCE-variant barest policy)

first check **CLEAN** → `record` → OOB `--create-interval 3` → `check --fail` exit 1 (**appeared since record** — completeness intact thanks to #1665) → `revert` plans `CreateInterval -> AWS default` → **live value converges to 1** → final check CLEAN. Stack deleted, `sweep-orphans.sh` SWEEP CLEAN, gate released.

## Verification

- 316 test files / **6075 tests** pass (new reader/classify/plan unit tests; `DefaultPolicyInstance` corpus case pins the fold + the INSTANCE `IMAGE_MANAGEMENT` echo).
- `/check` + `/check-docs` + `/verify-pr` markers set; shared CORE suite deferred (diff fully covered by unit tests + corpus replay + this session's live proof — logged per R50).

Closes #1668.
