### PR TITLE
chore(build): unify the tsdown config into vite.config.ts

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from 'tsdown';
-
-export default defineConfig({
-  entry: ['src/cli.ts'],
-  format: 'esm',
-  platform: 'node',
-  target: 'node20',
-  clean: true,
-});


### PR DESCRIPTION
## Summary

Removes the root `tsdown.config.ts`, unifying all bundling configuration into `vite.config.ts`'s `pack` section — which is where `vp pack` actually reads it from.

## Why deletion IS the unification

`vp pack` drives tsdown entirely from the `pack` section of `vite.config.ts` and never loads the root `tsdown.config.ts`. Verified empirically in a clean worktree:

- With the file present vs deleted, `dist/cli.js` is **byte-identical** (same `shasum`).
- The clean-dist-before-build behavior (its `clean: true`) is unaffected — a junk file dropped into `dist/` is removed by `vp pack` either way (vp/tsdown default).
- `node dist/cli.js --version` smoke passes after removal.

Every setting the file carried (`entry: src/cli.ts`, `format: esm`, `platform: node`, `target: node20`) already lives in the `pack` section, so the file was a trap: edits to it silently had no effect on the shipped bundle. No references to `tsdown.config` exist anywhere in the repo (code, docs, or CI).

## Verification

- `vp run typecheck` / `vp check --fix` (0 errors) / `vp pack` / `vp test run` — all pass (316 files / 6075 tests)
- `dist/cli.js` sha identical before/after the removal