### PR TITLE
chore(deps): bump pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,7 @@
     "url": "https://github.com/go-to-k/cdk-real-drift/issues"
   },
   "type": "module",
-  "packageManager": "pnpm@10.15.1",
-  "pnpm": {
-    "overrides": {
-      "@smithy/types": "4.15.0"
-    }
-  },
+  "packageManager": "pnpm@11.14.0",
   "keywords": [
     "cdk",
     "cloudformation",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm settings (pnpm >= 11 no longer reads the package.json "pnpm" field —
+# https://pnpm.io/settings). Settings-only: this repo is a single package, not a
+# multi-package workspace, so there is deliberately no "packages" list here.
+overrides:
+  '@smithy/types': 4.15.0


### PR DESCRIPTION
## Summary

Bumps the pinned package manager from pnpm 10.15.1 to **pnpm 11.14.0** (current `latest`).

## Changes

- `packageManager`: `pnpm@10.15.1` → `pnpm@11.14.0`.
- **pnpm 11 no longer reads the package.json `pnpm` field** ([settings moved](https://pnpm.io/settings)) — without migration the `@smithy/types` override would be **silently dropped**. Moved it to a new settings-only `pnpm-workspace.yaml` (deliberately no `packages` list; the repo stays a single package).

## Verification

- `pnpm-lock.yaml` is **untouched** by this PR: a full pnpm 11.14.0 install reproduces the identical lockfile (still `lockfileVersion: '9.0'`), and the override still pins `@smithy/types@4.15.0` across the graph (173 lockfile references intact) — so no conflict surface with other open PRs.
- `vp install --frozen-lockfile` honors the `packageManager` pin and runs **pnpm v11.14.0** locally — CI takes the same path.
- `vp run typecheck` / `vp check --fix` (0 errors) / `vp pack` + `dist/cli.js --version` smoke / `vp test run` (316 files / 6075 tests) — all pass under the pnpm 11 install.