### PR TITLE
fix(diff): Budgets CostTypes all-false off-flip FN and CloudFront continuous-deployment first-run FPs

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -830,6 +830,23 @@ grep ': true'` and pair every new truthy pin with its off-state gate. A SINGLE
   `ContinuousDeploymentPolicyId`, then attach it via a second `-c attach=1` UPDATE
   deploy (which doubles as a post-update echo probe; cloudfront-cd-hunt,
   2026-07-20).
+- **Bake `CDKRD_CORPUS_DIR` into a new fixture's verify.sh FIRST check from the
+  start** — a verify.sh without it that PASSES leaves nothing behind, and the
+  harvest then costs a full redeploy (the 2026-07-20 hunt re-deployed lambda-pc and
+  route53-policy solely to harvest what their passing first runs had already read).
+  Scope it to the first (clean) check line only, per the existing recording gotcha.
+- **A sibling-map fold fix is THREE-legged: gather builder + classify gate + corpus
+  recorder carry — and the builder must handle the RE-RESOLVED declared shape.**
+  Two live-hit sub-lessons from the staging reverse-pointer fold (cloudfront-cd-hunt
+  2026-07-20): (a) at classify time `Fn::GetAtt` refs in a sibling's declared props
+  have already collapsed to LITERAL strings (the resolver fills them from live
+  attributes), so a builder that only walks Ref/GetAtt finds nothing — match the
+  literal against the target's LIVE attribute (thread `liveModelMap(reads)` in) like
+  buildCloudFrontStagingDistCdPolicyIds does; (b) a fresh-harvested corpus case
+  replays WITHOUT the new classifyOpts key until `buildCorpusCase` carries the
+  per-resource entry (the corpus-replay failure is the tell), so add the recorder
+  carry in the same diff — and a case harvested BEFORE the carry existed needs its
+  opts hand-patched (self-consistently, from the expected finding's own value).
 - **Not every type is revertable — the FN half may stop at detection.** Route53
   RecordSet, for instance, has no SDK writer (`revert` says "type not revertable
   yet"), so a detect→revert→clean cycle can't complete. Prove the FN by mutating the

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -803,7 +803,33 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
 - **`example.com` / `.test` / `.example` are AWS-RESERVED for Route53 hosted zones**
   (`InvalidDomainNameException` on create). A Route53 fixture must use a non-reserved
   placeholder domain (e.g. `cdkrd-fphunt-x9z7q.com.`) — a public hosted zone for a
-  domain you don't own still creates fine (it just isn't authoritative).
+  domain you don't own still creates fine (it just isn't authoritative). The related
+  HealthCheck trap: Route53 REJECTS documentation-range IPs (`192.0.2.x` TEST-NET) in
+  `HealthCheckConfig.IPAddress` with a bare `InvalidRequest` — point the check at a
+  resolvable FQDN (`FullyQualifiedDomainName: example.com` IS fine here) instead
+  (route53-policy-hunt, 2026-07-20).
+- **A NEW all-boolean pin family can arrive via a READER-projection fix — re-run the
+  off-flip audit over the diff window, not just the historical tables.** The #1658
+  Budgets reader fix (projecting the full 11-boolean `CostTypes`) necessarily added a
+  whole-object + per-leaf all-`true` pin family, silently re-opening the #1092/#1635
+  all-boolean-object class: an out-of-band `update-budget` disabling ALL nine
+  `Include*` cost types read back an all-false object that `isTrivialEmpty` swallowed
+  — check stayed CLEAN while the budget was gutted (live-proven + fixed with a
+  `MEANINGFUL_WHEN_OFF_NESTED['AWS::Budgets::Budget']['Budget.CostTypes']` gate,
+  2026-07-20). The cheap recurring audit: `git diff <last-hunt>..HEAD -- noise.ts |
+grep ': true'` and pair every new truthy pin with its off-state gate. A SINGLE
+  off-flip usually still surfaces (surviving true siblings keep the object
+  non-trivial) — the mechanical probe must test the ALL-false shape. Bonus mechanics
+  learned: the offline classify-replay (synthesize the current reader's projection
+  into a harvested corpus case's liveRaw, flip, assert) proves the FN for free before
+  any deploy, and `DescribeBudget` RETURNS the all-false object (not vanished), so
+  the fix is the isTrivialEmpty gate, not the vanished-default baseline family.
+- **CloudFront ContinuousDeploymentPolicy cannot be attached at distribution
+  CREATION** ("Continuous deployment policy is not supported during distribution
+  creation" InvalidRequest) — a CD fixture must deploy the primary WITHOUT
+  `ContinuousDeploymentPolicyId`, then attach it via a second `-c attach=1` UPDATE
+  deploy (which doubles as a post-update echo probe; cloudfront-cd-hunt,
+  2026-07-20).
 - **Not every type is revertable — the FN half may stop at detection.** Route53
   RecordSet, for instance, has no SDK writer (`revert` says "type not revertable
   yet"), so a detect→revert→clean cycle can't complete. Prove the FN by mutating the

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -1320,6 +1320,75 @@ export function buildClientVpnEndpointSiblingVpcs(desired: Desired): Record<stri
   return out;
 }
 
+// Per STAGING CloudFront Distribution identity (logicalId + physicalId), the physical id of the
+// in-stack declared AWS::CloudFront::ContinuousDeploymentPolicy whose StagingDistributionDnsNames
+// references it. Attaching a policy materializes the reverse
+// `DistributionConfig.ContinuousDeploymentPolicyId` pointer on the STAGING distribution — a
+// deterministic echo of the stack's own declared link (the sibling-attachment echo class;
+// cloudfront-cd-hunt, 2026-07-20) — so classify folds a live pointer equal to the derived policy
+// id (an out-of-band re-link to a DIFFERENT policy still surfaces). The derivation is purely
+// in-stack: a RAW policy's StagingDistributionDnsNames elements are `Fn::GetAtt
+// [<distLogicalId>, DomainName]` (link by logical id) — but at classify time the declared model
+// is RE-RESOLVED and the GetAtt has already collapsed to the LITERAL domain string (live-hit on
+// the fixture's own first run), so literal elements are matched against each declared
+// distribution's LIVE `DomainName` via the optional `liveByLogical` map (the attribute is
+// registry-readOnly and stripped from the classify surface, so the raw live model is the only
+// place it exists). Unmatched literals map nothing (the pointer keeps surfacing — conservative);
+// conflicting links degrade to `null` (fail open) like the ClientVPN sibling map.
+export function buildCloudFrontStagingDistCdPolicyIds(
+  desired: Desired,
+  liveByLogical?: Map<string, Record<string, unknown>>
+): Record<string, string | null> {
+  const refLogicalId = (ref: unknown): string | undefined => {
+    if (ref && typeof ref === 'object') {
+      if ('Ref' in ref && typeof (ref as { Ref: unknown }).Ref === 'string')
+        return (ref as { Ref: string }).Ref;
+      if ('Fn::GetAtt' in ref) {
+        const g = (ref as { 'Fn::GetAtt': unknown })['Fn::GetAtt'];
+        if (Array.isArray(g) && typeof g[0] === 'string') return g[0];
+      }
+    }
+    return undefined;
+  };
+  const distIdentities = new Map<string, string[]>();
+  const distByDomain = new Map<string, string>(); // live DomainName -> dist logicalId
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::CloudFront::Distribution') continue;
+    const ids = [r.logicalId];
+    if (r.physicalId) ids.push(r.physicalId);
+    distIdentities.set(r.logicalId, ids);
+    const domain = liveByLogical?.get(r.logicalId)?.['DomainName'];
+    if (typeof domain === 'string' && domain) distByDomain.set(domain.toLowerCase(), r.logicalId);
+  }
+  const out: Record<string, string | null> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::CloudFront::ContinuousDeploymentPolicy') continue;
+    const cfg = (r.declared as Record<string, unknown> | undefined)?.[
+      'ContinuousDeploymentPolicyConfig'
+    ];
+    const dns =
+      cfg !== null && typeof cfg === 'object' && !Array.isArray(cfg)
+        ? (cfg as Record<string, unknown>)['StagingDistributionDnsNames']
+        : undefined;
+    if (!Array.isArray(dns)) continue;
+    // The policy's physical id IS the ContinuousDeploymentPolicyId the staging side echoes;
+    // without it (pre-deploy) there is nothing to equality-gate against → fail open (null).
+    const policyId = r.physicalId ?? null;
+    for (const el of dns) {
+      const distLogical =
+        refLogicalId(el) ??
+        (typeof el === 'string' ? distByDomain.get(el.toLowerCase()) : undefined);
+      if (distLogical === undefined) continue;
+      for (const key of distIdentities.get(distLogical) ?? []) {
+        // Two policies referencing the same distribution degrade to fail-open null.
+        if (key in out && out[key] !== policyId) out[key] = null;
+        else out[key] = policyId;
+      }
+    }
+  }
+  return out;
+}
+
 // #1498: the set of Subnet identities (logicalId + physicalId) whose IPv6 CIDR is assigned by a
 // sibling AWS::EC2::SubnetCidrBlock (the normal dual-stack CDK shape). The Subnet's own live model
 // echoes an undeclared Ipv6CidrBlock/Ipv6CidrBlocks that the SubnetCidrBlock sibling declares — so
@@ -2061,6 +2130,10 @@ export async function gatherFindings(
     clusterEchoModel: buildClusterEchoModels(desired),
     scalableTargetBands: buildScalableTargetBands(desired),
     siblingClientVpnEndpointVpcs: buildClientVpnEndpointSiblingVpcs(desired),
+    siblingCloudFrontCdPolicyIds: buildCloudFrontStagingDistCdPolicyIds(
+      desired,
+      liveModelMap(reads)
+    ),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 
@@ -2175,6 +2248,10 @@ export async function regatherTouched(
     clusterEchoModel: buildClusterEchoModels(desired),
     scalableTargetBands: buildScalableTargetBands(desired),
     siblingClientVpnEndpointVpcs: buildClientVpnEndpointSiblingVpcs(desired),
+    siblingCloudFrontCdPolicyIds: buildCloudFrontStagingDistCdPolicyIds(
+      desired,
+      liveModelMap(reads)
+    ),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -120,6 +120,11 @@ export interface CorpusCase {
     // classify's probe order), present only when a declared sibling target-network association
     // derives it, so replay reproduces the association-echoed `VpcId` fold. Optional for back-compat.
     siblingClientVpnEndpointVpcs?: Record<string, string | null>;
+    // This STAGING CloudFront Distribution's own sibling-derived ContinuousDeploymentPolicy id
+    // entry (keyed by logicalId, else physicalId — classify's probe order), present only when an
+    // in-stack declared policy links to it, so replay reproduces the reverse-pointer
+    // `DistributionConfig.ContinuousDeploymentPolicyId` fold. Optional for back-compat.
+    siblingCloudFrontCdPolicyIds?: Record<string, string | null>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -160,6 +165,7 @@ export function buildCorpusCase(
     siblingListenerPorts?: Record<string, number>;
     accountDefaults?: { dmsAllocatedStorageDefaults?: Record<string, number> };
     siblingClientVpnEndpointVpcs?: Record<string, string | null>;
+    siblingCloudFrontCdPolicyIds?: Record<string, string | null>;
   },
   findings: Finding[]
 ): CorpusCase {
@@ -249,6 +255,18 @@ export function buildCorpusCase(
         : resource.physicalId !== undefined && resource.physicalId in cvpnVpcMap
           ? resource.physicalId
           : undefined;
+  // Carry ONLY this Distribution's own sibling-derived ContinuousDeploymentPolicy id entry
+  // (same probe order as classify: logicalId first, then physicalId), so replay folds the
+  // staging reverse-pointer the same way the live check did.
+  const cfCdMap = opts.siblingCloudFrontCdPolicyIds;
+  const cfCdKey =
+    resource.resourceType !== 'AWS::CloudFront::Distribution' || cfCdMap === undefined
+      ? undefined
+      : resource.logicalId in cfCdMap
+        ? resource.logicalId
+        : resource.physicalId !== undefined && resource.physicalId in cfCdMap
+          ? resource.physicalId
+          : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
     resource: {
@@ -297,6 +315,9 @@ export function buildCorpusCase(
       ...(dmsStorageDefault ? { accountDefaults: dmsStorageDefault } : {}),
       ...(cvpnVpcKey !== undefined && cvpnVpcMap !== undefined
         ? { siblingClientVpnEndpointVpcs: { [cvpnVpcKey]: cvpnVpcMap[cvpnVpcKey] ?? null } }
+        : {}),
+      ...(cfCdKey !== undefined && cfCdMap !== undefined
+        ? { siblingCloudFrontCdPolicyIds: { [cfCdKey]: cfCdMap[cfCdKey] ?? null } }
         : {}),
     },
     expected: findings,

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -426,6 +426,21 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
   'AWS::EKS::Cluster': {
     'ResourcesVpcConfig.EndpointPublicAccess': () => true,
   },
+  // A budget's CostTypes is an ALL-BOOLEAN object whose nine Include* members default true
+  // (the #1658 `Budget.CostTypes` whole-object + per-leaf pins). An out-of-band
+  // `update-budget` disabling ALL nine (the budget then measures almost nothing — its
+  // alerts silently go dead) reads back an all-false object: the pin equality breaks, but
+  // the all-false object is trivially empty, so it was swallowed here before the pin gate
+  // — invisible (the #1092 GuardDuty DataSources / S3 PublicAccessBlockConfiguration
+  // shape; live-proven 2026-07-20 on a fresh budget-scope deploy: DescribeBudget RETURNS
+  // the all-false object, and check stayed CLEAN). A single off-flip already surfaces (the
+  // surviving true leaves keep the object non-trivial), so this gate closes exactly the
+  // all-false shape. Unconditionally meaningful when off: a user who wants cost types off
+  // DECLARES CostTypes (compared in the declared loop); a budget has no snapshot/restore
+  // lineage that could yield an untouched all-false.
+  'AWS::Budgets::Budget': {
+    'Budget.CostTypes': () => true,
+  },
   // #1530: an ECS service that ENABLES the deployment circuit breaker reads back the AWS-filled
   // sub-default ResetOnHealthyTask=true (the KNOWN_DEFAULT_PATHS pin, live-observed on a fresh
   // Fargate service). An out-of-band UpdateService flipping it false is swallowed by
@@ -1667,6 +1682,56 @@ function glueIcebergManagedParamsAtDefault(
   const managed = new Set(['table_type', 'metadata_location']);
   if (!Object.keys(params).every((k) => managed.has(k))) return false;
   return params.table_type === 'ICEBERG';
+}
+
+// A CloudFront ContinuousDeploymentPolicy's config carries the SAME traffic split in TWO
+// writable representations — the canonical `TrafficConfig` ({Type, SingleWeightConfig /
+// SingleHeaderConfig}) and the flattened console-era synonyms (`Type` +
+// `SingleWeightPolicyConfig` / `SingleHeaderPolicyConfig`, note the differing member name) —
+// and the CC read echoes BOTH regardless of which one the template declared. The undeclared
+// mirror representation first-run-FP'd on a fresh policy (cloudfront-cd-hunt, 2026-07-20:
+// declared TrafficConfig read back undeclared `Type: "SingleWeight"` +
+// `SingleWeightPolicyConfig: {Weight: 0.05}`). Tier-2 DERIVED fold, symmetric in both
+// directions: fold the undeclared member ONLY when it equals the value derived from the
+// DECLARED counterpart representation. Detection is preserved — the declared representation
+// is compared in the declared loop, and an out-of-band traffic change diverges the mirror
+// from the declared-derived value, so it surfaces too.
+function cloudFrontCdPolicySynonymAtDefault(
+  resourceType: string,
+  schemaPath: string,
+  value: unknown,
+  declared: Record<string, unknown>
+): boolean {
+  if (resourceType !== 'AWS::CloudFront::ContinuousDeploymentPolicy') return false;
+  const cfg = declared.ContinuousDeploymentPolicyConfig;
+  if (!isNestedObject(cfg)) return false;
+  const c = cfg as Record<string, unknown>;
+  const traffic = isNestedObject(c.TrafficConfig)
+    ? (c.TrafficConfig as Record<string, unknown>)
+    : undefined;
+  switch (schemaPath) {
+    // Flattened mirrors of a declared TrafficConfig.
+    case 'ContinuousDeploymentPolicyConfig.Type':
+      return traffic !== undefined && deepEqual(value, traffic.Type);
+    case 'ContinuousDeploymentPolicyConfig.SingleWeightPolicyConfig':
+      return traffic !== undefined && deepEqual(value, traffic.SingleWeightConfig);
+    case 'ContinuousDeploymentPolicyConfig.SingleHeaderPolicyConfig':
+      return traffic !== undefined && deepEqual(value, traffic.SingleHeaderConfig);
+    // The inverse: a template that declared the flattened form reads back the canonical
+    // TrafficConfig as the undeclared mirror.
+    case 'ContinuousDeploymentPolicyConfig.TrafficConfig': {
+      if (traffic !== undefined || !isNestedObject(value)) return false;
+      if (c.Type === undefined) return false;
+      const derived: Record<string, unknown> = { Type: c.Type };
+      if (c.SingleWeightPolicyConfig !== undefined)
+        derived.SingleWeightConfig = c.SingleWeightPolicyConfig;
+      if (c.SingleHeaderPolicyConfig !== undefined)
+        derived.SingleHeaderConfig = c.SingleHeaderPolicyConfig;
+      return deepEqual(value, derived);
+    }
+    default:
+      return false;
+  }
 }
 
 // #705: a Classic ELB (ElasticLoadBalancing::LoadBalancer) with an HTTPS/SSL listener but no
@@ -3014,6 +3079,14 @@ export function classifyResource(
     // association exists but its VPC is not derivable (imported subnet) → fail open (fold any VpcId).
     // NO entry = no declared association → a live VpcId is an out-of-band association echo, SURFACES.
     siblingClientVpnEndpointVpcs?: Record<string, string | null>;
+    // Per STAGING CloudFront Distribution identity (logicalId + physicalId), the physical id of
+    // the in-stack declared ContinuousDeploymentPolicy whose StagingDistributionDnsNames
+    // references it (gather.ts buildCloudFrontStagingDistCdPolicyIds). The policy materializes
+    // the reverse `DistributionConfig.ContinuousDeploymentPolicyId` pointer on the staging
+    // distribution — a deterministic echo of the stack's own declared link, folded when equal.
+    // `null` = a policy is declared but not linkable to a specific distribution (literal DNS
+    // names) → fail open. NO entry = out-of-band link → surfaces.
+    siblingCloudFrontCdPolicyIds?: Record<string, string | null>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -3987,6 +4060,32 @@ export function classifyResource(
       // #1553: a Config recorder's undeclared RecordingGroup.RecordingStrategy mirror, derived
       // from the live sibling RecordingGroup and equality-gated (helper above).
       configRecordingStrategyAtDefault(resourceType, schemaPath, value, live) ||
+      // A CloudFront ContinuousDeploymentPolicy's undeclared mirror representation of its own
+      // DECLARED traffic config (TrafficConfig ↔ flattened Type/SingleWeightPolicyConfig
+      // synonyms; helper above, cloudfront-cd-hunt 2026-07-20).
+      cloudFrontCdPolicySynonymAtDefault(resourceType, schemaPath, value, declared) ||
+      // A STAGING CloudFront distribution's undeclared `ContinuousDeploymentPolicyId` is the
+      // service-materialized REVERSE pointer to the in-stack ContinuousDeploymentPolicy that
+      // lists this distribution's DNS name (the sibling-attachment echo class; cloudfront-cd-hunt
+      // 2026-07-20). Tier-2 derived: fold only when it equals the sibling policy's physical id
+      // (gather.ts buildCloudFrontStagingDistCdPolicyIds; `null` = policy present but not
+      // linkable → fail open). No map entry = no declared policy targets this distribution →
+      // a live pointer is an out-of-band link and surfaces.
+      (resourceType === 'AWS::CloudFront::Distribution' &&
+        schemaPath === 'DistributionConfig.ContinuousDeploymentPolicyId' &&
+        typeof value === 'string' &&
+        (() => {
+          const m = opts.siblingCloudFrontCdPolicyIds;
+          const derived =
+            m === undefined
+              ? undefined
+              : logicalId in m
+                ? m[logicalId]
+                : physicalId !== undefined && physicalId in m
+                  ? m[physicalId]
+                  : undefined;
+          return derived !== undefined && (derived === null || derived === value);
+        })()) ||
       // #1624: a Glue Iceberg table's service-managed TableInput.Parameters pair
       // (table_type + moving metadata_location), shape-gated on the declared
       // OpenTableFormatInput.IcebergInput (helper above).

--- a/tests/budgets-costtypes-offflip.test.ts
+++ b/tests/budgets-costtypes-offflip.test.ts
@@ -1,0 +1,99 @@
+// Budgets CostTypes all-false off-flip (the #1092 GuardDuty DataSources / #1635 S3
+// PublicAccessBlockConfiguration all-boolean-object class, on the #1658 pins).
+//
+// An out-of-band `update-budget` disabling ALL nine Include* cost types on a budget
+// that does NOT declare CostTypes reads back an all-false object: the whole-object
+// `Budget.CostTypes` pin equality breaks, but the all-false object is trivially empty,
+// so isTrivialEmpty swallowed it in emitNested before the pin gate — the budget then
+// measures almost nothing and the gutting was invisible. Live-proven 2026-07-20
+// (us-east-1, budget-scope fixture): DescribeBudget RETURNS the all-false object (it
+// does not vanish from the read), and `check --fail` stayed CLEAN. Fixed by the
+// MEANINGFUL_WHEN_OFF_NESTED['AWS::Budgets::Budget']['Budget.CostTypes'] gate.
+//
+// Replays the harvested AWS__Budgets__Budget.MonthlyCost corpus case with the current
+// reader's full 11-boolean CostTypes projection synthesized into liveRaw (the case was
+// harvested under the pre-#1658 thin projection).
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  type CorpusCase,
+  decodeUnresolved,
+  reviveOpts,
+  reviveSchema,
+} from '../src/corpus/record.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource } from '../src/types.js';
+
+const corpusDir = join(dirname(fileURLToPath(import.meta.url)), 'corpus');
+
+// The full CostTypes object DescribeBudget returns for a fresh budget (live-observed
+// 2026-07-20): nine Include* members true, the two Use* members false.
+const fullCostTypes = (over: Record<string, boolean>) => ({
+  IncludeTax: true,
+  IncludeSubscription: true,
+  IncludeRefund: true,
+  IncludeCredit: true,
+  IncludeUpfront: true,
+  IncludeRecurring: true,
+  IncludeOtherSubscription: true,
+  IncludeSupport: true,
+  IncludeDiscount: true,
+  UseBlended: false,
+  UseAmortized: false,
+  ...over,
+});
+
+const ALL_OFF = {
+  IncludeTax: false,
+  IncludeSubscription: false,
+  IncludeRefund: false,
+  IncludeCredit: false,
+  IncludeUpfront: false,
+  IncludeRecurring: false,
+  IncludeOtherSubscription: false,
+  IncludeSupport: false,
+  IncludeDiscount: false,
+};
+
+const loadCase = () => {
+  const c = JSON.parse(
+    readFileSync(join(corpusDir, 'AWS__Budgets__Budget.MonthlyCost.json'), 'utf8')
+  ) as CorpusCase;
+  const resource = {
+    ...c.resource,
+    declared: decodeUnresolved(c.resource.declared),
+  } as DesiredResource;
+  return { c, resource };
+};
+
+const classifyWithCostTypes = (over: Record<string, boolean>) => {
+  const { c, resource } = loadCase();
+  const live = structuredClone(c.liveRaw) as Record<string, unknown>;
+  (live.Budget as Record<string, unknown>).CostTypes = fullCostTypes(over);
+  return classifyResource(resource, live, reviveSchema(c.schema), reviveOpts(c.opts));
+};
+
+describe('Budgets CostTypes all-boolean off-flip', () => {
+  it("a fresh budget's full-default CostTypes still folds (no CostTypes drift)", () => {
+    const got = classifyWithCostTypes({});
+    const drift = got.filter(
+      (f) =>
+        (f.tier === 'undeclared' || f.tier === 'declared') && String(f.path).includes('CostTypes')
+    );
+    expect(drift).toEqual([]);
+  });
+
+  it('a single out-of-band off-flip surfaces (regression guard for the non-trivial shape)', () => {
+    const got = classifyWithCostTypes({ IncludeTax: false });
+    const hits = got.filter((f) => f.tier === 'undeclared' && String(f.path).includes('CostTypes'));
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
+  it('the ALL-false off-flip surfaces instead of being swallowed as trivially empty (FN fix)', () => {
+    const got = classifyWithCostTypes(ALL_OFF);
+    const hits = got.filter((f) => f.tier === 'undeclared' && String(f.path).includes('CostTypes'));
+    expect(hits.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/classify-cloudfront-cd-echo.test.ts
+++ b/tests/classify-cloudfront-cd-echo.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildCloudFrontStagingDistCdPolicyIds } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+// First-run FPs found by the 2026-07-20 cloudfront-cd-hunt (a fresh two-phase continuous-
+// deployment stack: staging distribution + ContinuousDeploymentPolicy + primary attached via
+// UPDATE):
+//   1. The policy's config carries the SAME traffic split in TWO writable representations —
+//      the canonical `TrafficConfig` and the flattened console-era synonyms (`Type` +
+//      `SingleWeightPolicyConfig`) — and the CC read echoes BOTH. The undeclared mirror
+//      first-run-FP'd (`Type: "SingleWeight"`, `SingleWeightPolicyConfig: {Weight: 0.05}`).
+//      Fold: tier-2 derived from the DECLARED counterpart representation, symmetric.
+//   2. The STAGING distribution materializes the reverse pointer
+//      `DistributionConfig.ContinuousDeploymentPolicyId` to the in-stack policy that lists its
+//      DNS name (sibling-attachment echo). Fold: tier-2 sibling-derived
+//      (gather.buildCloudFrontStagingDistCdPolicyIds), equality-gated so an out-of-band
+//      re-link to a DIFFERENT policy still surfaces.
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(['Id', 'LastModifiedTime']),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: ['Id', 'LastModifiedTime'],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const POLICY_ID = '6fd4a2bb-b335-437f-83a0-1a7a9635666d';
+
+const byPath = (findings: Finding[], path: string) => findings.filter((f) => f.path === path);
+
+describe('CloudFront ContinuousDeploymentPolicy traffic-config synonym echo', () => {
+  const policyResource = (declaredCfg: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'CdPolicy',
+    resourceType: 'AWS::CloudFront::ContinuousDeploymentPolicy',
+    physicalId: POLICY_ID,
+    declared: { ContinuousDeploymentPolicyConfig: declaredCfg },
+  });
+
+  // The live CC read the hunt observed: both representations echoed.
+  const liveCfg = (over?: Record<string, unknown>): Record<string, unknown> => ({
+    ContinuousDeploymentPolicyConfig: {
+      Enabled: true,
+      StagingDistributionDnsNames: ['d2zvi88nqbrjcw.cloudfront.net'],
+      TrafficConfig: { Type: 'SingleWeight', SingleWeightConfig: { Weight: 0.05 } },
+      Type: 'SingleWeight',
+      SingleWeightPolicyConfig: { Weight: 0.05 },
+      ...over,
+    },
+  });
+
+  const declaredTraffic = {
+    Enabled: true,
+    StagingDistributionDnsNames: ['d2zvi88nqbrjcw.cloudfront.net'],
+    TrafficConfig: { Type: 'SingleWeight', SingleWeightConfig: { Weight: 0.05 } },
+  };
+
+  it('folds the undeclared flattened mirror of a declared TrafficConfig to atDefault', () => {
+    const got = classifyResource(policyResource(declaredTraffic), liveCfg(), emptySchema);
+    for (const path of [
+      'ContinuousDeploymentPolicyConfig.Type',
+      'ContinuousDeploymentPolicyConfig.SingleWeightPolicyConfig',
+    ]) {
+      const f = byPath(got, path);
+      expect(f).toHaveLength(1);
+      expect(f[0]?.tier).toBe('atDefault');
+    }
+  });
+
+  it('a mirror DIVERGED from the declared traffic config still surfaces (detection kept)', () => {
+    const got = classifyResource(
+      policyResource(declaredTraffic),
+      liveCfg({ SingleWeightPolicyConfig: { Weight: 0.15 } }),
+      emptySchema
+    );
+    const f = byPath(got, 'ContinuousDeploymentPolicyConfig.SingleWeightPolicyConfig');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.tier).toBe('undeclared');
+  });
+
+  it('the INVERSE declaration (flattened form declared) folds the undeclared TrafficConfig mirror', () => {
+    const declaredFlattened = {
+      Enabled: true,
+      StagingDistributionDnsNames: ['d2zvi88nqbrjcw.cloudfront.net'],
+      Type: 'SingleWeight',
+      SingleWeightPolicyConfig: { Weight: 0.05 },
+    };
+    const got = classifyResource(policyResource(declaredFlattened), liveCfg(), emptySchema);
+    const f = byPath(got, 'ContinuousDeploymentPolicyConfig.TrafficConfig');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.tier).toBe('atDefault');
+  });
+});
+
+describe('CloudFront staging distribution reverse-pointer echo (sibling map)', () => {
+  const distDeclared = {
+    DistributionConfig: {
+      Enabled: true,
+      Staging: true,
+      Origins: [
+        {
+          Id: 'origin1',
+          DomainName: 'example.com',
+          CustomOriginConfig: { OriginProtocolPolicy: 'https-only' },
+        },
+      ],
+      DefaultCacheBehavior: {
+        TargetOriginId: 'origin1',
+        ViewerProtocolPolicy: 'allow-all',
+        CachePolicyId: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad',
+      },
+    },
+  };
+  const stagingResource: DesiredResource = {
+    logicalId: 'StagingDist',
+    resourceType: 'AWS::CloudFront::Distribution',
+    physicalId: 'E2ABCDEF123456',
+    declared: distDeclared,
+  };
+  const liveDist = (policyId: string): Record<string, unknown> => ({
+    DistributionConfig: {
+      ...distDeclared.DistributionConfig,
+      ContinuousDeploymentPolicyId: policyId,
+    },
+  });
+
+  const desiredWithPolicy = (policyPhysicalId?: string): Desired =>
+    ({
+      resources: [
+        stagingResource,
+        {
+          logicalId: 'CdPolicy',
+          resourceType: 'AWS::CloudFront::ContinuousDeploymentPolicy',
+          physicalId: policyPhysicalId,
+          declared: {
+            ContinuousDeploymentPolicyConfig: {
+              Enabled: true,
+              StagingDistributionDnsNames: [{ 'Fn::GetAtt': ['StagingDist', 'DomainName'] }],
+              TrafficConfig: { Type: 'SingleWeight', SingleWeightConfig: { Weight: 0.05 } },
+            },
+          },
+        },
+      ],
+    }) as unknown as Desired;
+
+  it('(map) links the staging distribution to the policy via the GetAtt DNS-name reference', () => {
+    const map = buildCloudFrontStagingDistCdPolicyIds(desiredWithPolicy(POLICY_ID));
+    expect(map).toEqual({ StagingDist: POLICY_ID, E2ABCDEF123456: POLICY_ID });
+  });
+
+  it('(map) a policy without a physical id degrades to null (fail open)', () => {
+    const map = buildCloudFrontStagingDistCdPolicyIds(desiredWithPolicy(undefined));
+    expect(map).toEqual({ StagingDist: null, E2ABCDEF123456: null });
+  });
+
+  it('(map) links via the RESOLVED literal DNS name against the live DomainName (the classify-time shape)', () => {
+    // At classify time the declared model is re-resolved: the GetAtt has collapsed to the
+    // literal domain string, so the link is recovered from the distribution's LIVE DomainName.
+    const desired = {
+      resources: [
+        stagingResource,
+        {
+          logicalId: 'CdPolicy',
+          resourceType: 'AWS::CloudFront::ContinuousDeploymentPolicy',
+          physicalId: POLICY_ID,
+          declared: {
+            ContinuousDeploymentPolicyConfig: {
+              Enabled: true,
+              StagingDistributionDnsNames: ['d2zvi88nqbrjcw.cloudfront.net'],
+              TrafficConfig: { Type: 'SingleWeight', SingleWeightConfig: { Weight: 0.05 } },
+            },
+          },
+        },
+      ],
+    } as unknown as Desired;
+    const liveByLogical = new Map<string, Record<string, unknown>>([
+      ['StagingDist', { DomainName: 'd2zvi88nqbrjcw.cloudfront.net' }],
+    ]);
+    expect(buildCloudFrontStagingDistCdPolicyIds(desired, liveByLogical)).toEqual({
+      StagingDist: POLICY_ID,
+      E2ABCDEF123456: POLICY_ID,
+    });
+    // Without the live map the literal is unmatchable → nothing mapped (pointer would surface).
+    expect(buildCloudFrontStagingDistCdPolicyIds(desired)).toEqual({});
+  });
+
+  it('folds the reverse pointer equal to the sibling policy id to atDefault', () => {
+    const got = classifyResource(stagingResource, liveDist(POLICY_ID), emptySchema, {
+      siblingCloudFrontCdPolicyIds: buildCloudFrontStagingDistCdPolicyIds(
+        desiredWithPolicy(POLICY_ID)
+      ),
+    });
+    const f = byPath(got, 'DistributionConfig.ContinuousDeploymentPolicyId');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.tier).toBe('atDefault');
+  });
+
+  it('a pointer to a DIFFERENT policy surfaces (out-of-band re-link)', () => {
+    const got = classifyResource(
+      stagingResource,
+      liveDist('0000dead-beef-0000-0000-000000000000'),
+      emptySchema,
+      {
+        siblingCloudFrontCdPolicyIds: buildCloudFrontStagingDistCdPolicyIds(
+          desiredWithPolicy(POLICY_ID)
+        ),
+      }
+    );
+    const f = byPath(got, 'DistributionConfig.ContinuousDeploymentPolicyId');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.tier).toBe('undeclared');
+  });
+
+  it('with NO declared policy the pointer surfaces (out-of-band link)', () => {
+    const got = classifyResource(stagingResource, liveDist(POLICY_ID), emptySchema, {
+      siblingCloudFrontCdPolicyIds: {},
+    });
+    const f = byPath(got, 'DistributionConfig.ContinuousDeploymentPolicyId');
+    expect(f).toHaveLength(1);
+    expect(f[0]?.tier).toBe('undeclared');
+  });
+});

--- a/tests/corpus-record.test.ts
+++ b/tests/corpus-record.test.ts
@@ -193,4 +193,43 @@ describe('corpus recording (R63)', () => {
     );
     expect(plain.opts.bucketNotificationManaged).toBeUndefined();
   });
+
+  it('buildCorpusCase persists ONLY this distribution siblingCloudFrontCdPolicyIds entry', () => {
+    const dist: DesiredResource = {
+      logicalId: 'StagingDist',
+      resourceType: 'AWS::CloudFront::Distribution',
+      physicalId: 'E2ABCDEF123456',
+      declared: {},
+    };
+    const base = {
+      accountId: '',
+      region: 'us-east-1',
+      kmsAliasTargets: {},
+      oaiCanonicalIds: {},
+    };
+    const linked = buildCorpusCase(
+      dist,
+      {},
+      baseSchema,
+      {
+        ...base,
+        siblingCloudFrontCdPolicyIds: {
+          StagingDist: 'policy-1',
+          OtherDist: 'policy-2',
+        },
+      },
+      []
+    );
+    // Carries only THIS distribution's own entry (probe order: logicalId first).
+    expect(linked.opts.siblingCloudFrontCdPolicyIds).toEqual({ StagingDist: 'policy-1' });
+    // A distribution with no entry gets no key.
+    const plain = buildCorpusCase(
+      dist,
+      {},
+      baseSchema,
+      { ...base, siblingCloudFrontCdPolicyIds: { OtherDist: 'policy-2' } },
+      []
+    );
+    expect(plain.opts.siblingCloudFrontCdPolicyIds).toBeUndefined();
+  });
 });

--- a/tests/corpus/AWS__CloudFront__ContinuousDeploymentPolicy.CdPolicy.json
+++ b/tests/corpus/AWS__CloudFront__ContinuousDeploymentPolicy.CdPolicy.json
@@ -1,0 +1,82 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CdPolicy",
+    "resourceType": "AWS::CloudFront::ContinuousDeploymentPolicy",
+    "physicalId": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6",
+    "constructPath": "CdkrdHunt0720CfCd/CdPolicy",
+    "declared": {
+      "ContinuousDeploymentPolicyConfig": {
+        "Enabled": true,
+        "StagingDistributionDnsNames": ["d2ye9f1xy4vlf6.cloudfront.net"],
+        "TrafficConfig": {
+          "SingleWeightConfig": {
+            "Weight": 0.05
+          },
+          "Type": "SingleWeight"
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "ContinuousDeploymentPolicyConfig": {
+      "Type": "SingleWeight",
+      "Enabled": true,
+      "StagingDistributionDnsNames": ["d2ye9f1xy4vlf6.cloudfront.net"],
+      "TrafficConfig": {
+        "SingleWeightConfig": {
+          "Weight": 0.05
+        },
+        "Type": "SingleWeight"
+      },
+      "SingleWeightPolicyConfig": {
+        "Weight": 0.05
+      }
+    },
+    "LastModifiedTime": "2026-07-19T19:43:09.181Z",
+    "Id": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6"
+  },
+  "schema": {
+    "readOnly": ["Id", "LastModifiedTime"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "LastModifiedTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CdPolicy",
+      "resourceType": "AWS::CloudFront::ContinuousDeploymentPolicy",
+      "path": "ContinuousDeploymentPolicyConfig.Type",
+      "actual": "SingleWeight",
+      "nested": true,
+      "physicalId": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6",
+      "constructPath": "CdkrdHunt0720CfCd/CdPolicy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CdPolicy",
+      "resourceType": "AWS::CloudFront::ContinuousDeploymentPolicy",
+      "path": "ContinuousDeploymentPolicyConfig.SingleWeightPolicyConfig",
+      "actual": {
+        "Weight": 0.05
+      },
+      "nested": true,
+      "physicalId": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6",
+      "constructPath": "CdkrdHunt0720CfCd/CdPolicy"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudFront__Distribution.PrimaryDist.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.PrimaryDist.json
@@ -1,0 +1,343 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PrimaryDist",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "E1LG9RY47U1LQ4",
+    "constructPath": "CdkrdHunt0720CfCd/PrimaryDist",
+    "declared": {
+      "DistributionConfig": {
+        "ContinuousDeploymentPolicyId": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6",
+        "DefaultCacheBehavior": {
+          "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+          "TargetOriginId": "origin1",
+          "ViewerProtocolPolicy": "allow-all"
+        },
+        "Enabled": true,
+        "Origins": [
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only"
+            },
+            "DomainName": "example.com",
+            "Id": "origin1"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DistributionConfig": {
+      "Logging": {
+        "IncludeCookies": false,
+        "Bucket": "",
+        "Prefix": ""
+      },
+      "Comment": "",
+      "DefaultRootObject": "",
+      "Origins": [
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "origin1",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["SSLv3", "TLSv1"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        }
+      ],
+      "ViewerCertificate": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "PriceClass": "PriceClass_All",
+      "DefaultCacheBehavior": {
+        "Compress": false,
+        "FunctionAssociations": [],
+        "LambdaFunctionAssociations": [],
+        "TargetOriginId": "origin1",
+        "ViewerProtocolPolicy": "allow-all",
+        "GrpcConfig": {
+          "Enabled": false
+        },
+        "TrustedSigners": [],
+        "FieldLevelEncryptionId": "",
+        "TrustedKeyGroups": [],
+        "AllowedMethods": ["HEAD", "GET"],
+        "CachedMethods": ["HEAD", "GET"],
+        "SmoothStreaming": false,
+        "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+      },
+      "Staging": false,
+      "CustomErrorResponses": [],
+      "ContinuousDeploymentPolicyId": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6",
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "Enabled": true,
+      "Aliases": [],
+      "IPV6Enabled": true,
+      "WebACLId": "",
+      "HttpVersion": "http1.1",
+      "Restrictions": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "CacheBehaviors": []
+    },
+    "DomainName": "d43e5iurg57c.cloudfront.net",
+    "Id": "E1LG9RY47U1LQ4",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["DomainName", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["DomainName", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {
+      "DistributionConfig.CacheBehaviors.*.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.Compress": false,
+      "DistributionConfig.CacheBehaviors.*.DefaultTTL": 86400,
+      "DistributionConfig.CacheBehaviors.*.FieldLevelEncryptionId": "",
+      "DistributionConfig.CacheBehaviors.*.MaxTTL": 31536000,
+      "DistributionConfig.CacheBehaviors.*.MinTTL": 0,
+      "DistributionConfig.CacheBehaviors.*.SmoothStreaming": false,
+      "DistributionConfig.Comment": "",
+      "DistributionConfig.CustomErrorResponses.*.ErrorCachingMinTTL": 300,
+      "DistributionConfig.CustomOrigin.HTTPPort": 80,
+      "DistributionConfig.CustomOrigin.HTTPSPort": 443,
+      "DistributionConfig.DefaultCacheBehavior.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.CachePolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.Compress": false,
+      "DistributionConfig.DefaultCacheBehavior.DefaultTTL": 86400,
+      "DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId": "",
+      "DistributionConfig.DefaultCacheBehavior.MaxTTL": 31536000,
+      "DistributionConfig.DefaultCacheBehavior.MinTTL": 0,
+      "DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.RealtimeLogConfigArn": "",
+      "DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.SmoothStreaming": false,
+      "DistributionConfig.DefaultRootObject": "",
+      "DistributionConfig.HttpVersion": "http1.1",
+      "DistributionConfig.Logging.IncludeCookies": false,
+      "DistributionConfig.Logging.Prefix": "",
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPPort": 80,
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPSPort": 443,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginSSLProtocols": ["TLSv1", "SSLv3"],
+      "DistributionConfig.Origins.*.OriginPath": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginAccessIdentity": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.PriceClass": "PriceClass_All",
+      "DistributionConfig.S3Origin.OriginAccessIdentity": "",
+      "DistributionConfig.WebACLId": ""
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginSSLProtocols",
+      "actual": ["SSLv3", "TLSv1"],
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ViewerCertificate",
+      "actual": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.PriceClass",
+      "actual": "PriceClass_All",
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.AllowedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.CachedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.OriginGroups",
+      "actual": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.IPV6Enabled",
+      "actual": true,
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.HttpVersion",
+      "actual": "http1.1",
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PrimaryDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Restrictions",
+      "actual": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "nested": true,
+      "physicalId": "E1LG9RY47U1LQ4",
+      "constructPath": "CdkrdHunt0720CfCd/PrimaryDist"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudFront__Distribution.StagingDist.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.StagingDist.json
@@ -1,0 +1,356 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "StagingDist",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "E3FSJ4WUENSFWJ",
+    "constructPath": "CdkrdHunt0720CfCd/StagingDist",
+    "declared": {
+      "DistributionConfig": {
+        "DefaultCacheBehavior": {
+          "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+          "TargetOriginId": "origin1",
+          "ViewerProtocolPolicy": "allow-all"
+        },
+        "Enabled": true,
+        "Origins": [
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only"
+            },
+            "DomainName": "example.com",
+            "Id": "origin1"
+          }
+        ],
+        "Staging": true
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DistributionConfig": {
+      "Logging": {
+        "IncludeCookies": false,
+        "Bucket": "",
+        "Prefix": ""
+      },
+      "Comment": "",
+      "DefaultRootObject": "",
+      "Origins": [
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "origin1",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["SSLv3", "TLSv1"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        }
+      ],
+      "ViewerCertificate": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "PriceClass": "PriceClass_All",
+      "DefaultCacheBehavior": {
+        "Compress": false,
+        "FunctionAssociations": [],
+        "LambdaFunctionAssociations": [],
+        "TargetOriginId": "origin1",
+        "ViewerProtocolPolicy": "allow-all",
+        "GrpcConfig": {
+          "Enabled": false
+        },
+        "TrustedSigners": [],
+        "FieldLevelEncryptionId": "",
+        "TrustedKeyGroups": [],
+        "AllowedMethods": ["HEAD", "GET"],
+        "CachedMethods": ["HEAD", "GET"],
+        "SmoothStreaming": false,
+        "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+      },
+      "Staging": true,
+      "CustomErrorResponses": [],
+      "ContinuousDeploymentPolicyId": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6",
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "Enabled": true,
+      "Aliases": [],
+      "IPV6Enabled": true,
+      "WebACLId": "",
+      "HttpVersion": "http1.1",
+      "Restrictions": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "CacheBehaviors": []
+    },
+    "DomainName": "d2ye9f1xy4vlf6.cloudfront.net",
+    "Id": "E3FSJ4WUENSFWJ",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["DomainName", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["DomainName", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {
+      "DistributionConfig.CacheBehaviors.*.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.Compress": false,
+      "DistributionConfig.CacheBehaviors.*.DefaultTTL": 86400,
+      "DistributionConfig.CacheBehaviors.*.FieldLevelEncryptionId": "",
+      "DistributionConfig.CacheBehaviors.*.MaxTTL": 31536000,
+      "DistributionConfig.CacheBehaviors.*.MinTTL": 0,
+      "DistributionConfig.CacheBehaviors.*.SmoothStreaming": false,
+      "DistributionConfig.Comment": "",
+      "DistributionConfig.CustomErrorResponses.*.ErrorCachingMinTTL": 300,
+      "DistributionConfig.CustomOrigin.HTTPPort": 80,
+      "DistributionConfig.CustomOrigin.HTTPSPort": 443,
+      "DistributionConfig.DefaultCacheBehavior.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.CachePolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.Compress": false,
+      "DistributionConfig.DefaultCacheBehavior.DefaultTTL": 86400,
+      "DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId": "",
+      "DistributionConfig.DefaultCacheBehavior.MaxTTL": 31536000,
+      "DistributionConfig.DefaultCacheBehavior.MinTTL": 0,
+      "DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.RealtimeLogConfigArn": "",
+      "DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.SmoothStreaming": false,
+      "DistributionConfig.DefaultRootObject": "",
+      "DistributionConfig.HttpVersion": "http1.1",
+      "DistributionConfig.Logging.IncludeCookies": false,
+      "DistributionConfig.Logging.Prefix": "",
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPPort": 80,
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPSPort": 443,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginSSLProtocols": ["TLSv1", "SSLv3"],
+      "DistributionConfig.Origins.*.OriginPath": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginAccessIdentity": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.PriceClass": "PriceClass_All",
+      "DistributionConfig.S3Origin.OriginAccessIdentity": "",
+      "DistributionConfig.WebACLId": ""
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "siblingCloudFrontCdPolicyIds": {
+      "StagingDist": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.OriginSSLProtocols",
+      "actual": ["SSLv3", "TLSv1"],
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[origin1].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ViewerCertificate",
+      "actual": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.PriceClass",
+      "actual": "PriceClass_All",
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.AllowedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.CachedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ContinuousDeploymentPolicyId",
+      "actual": "90b13500-2b8e-4ebd-b8d7-8c66f55e76f6",
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.OriginGroups",
+      "actual": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.IPV6Enabled",
+      "actual": true,
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.HttpVersion",
+      "actual": "http1.1",
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "StagingDist",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Restrictions",
+      "actual": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "nested": true,
+      "physicalId": "E3FSJ4WUENSFWJ",
+      "constructPath": "CdkrdHunt0720CfCd/StagingDist"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Alias.HuntPcAlias.json
+++ b/tests/corpus/AWS__Lambda__Alias.HuntPcAlias.json
@@ -1,0 +1,58 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LiveAlias9B8FFEA9",
+    "resourceType": "AWS::Lambda::Alias",
+    "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0720LambdaPc-Fn9270CBC0-rSosQAKZwL6a:live",
+    "constructPath": "CdkrdHunt0720LambdaPc/LiveAlias",
+    "declared": {
+      "FunctionName": "CdkrdHunt0720LambdaPc-Fn9270CBC0-rSosQAKZwL6a",
+      "FunctionVersion": "1",
+      "Name": "live",
+      "ProvisionedConcurrencyConfig": {
+        "ProvisionedConcurrentExecutions": 1
+      }
+    }
+  },
+  "liveRaw": {
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0720LambdaPc-Fn9270CBC0-rSosQAKZwL6a",
+    "ProvisionedConcurrencyConfig": {
+      "ProvisionedConcurrentExecutions": 1
+    },
+    "Description": "",
+    "FunctionVersion": "1",
+    "AliasArn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0720LambdaPc-Fn9270CBC0-rSosQAKZwL6a:live",
+    "RoutingConfig": {},
+    "Name": "live"
+  },
+  "schema": {
+    "readOnly": ["AliasArn"],
+    "writeOnly": [],
+    "createOnly": ["FunctionName", "Name"],
+    "readOnlyPaths": ["AliasArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FunctionName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["RoutingConfig.AdditionalVersionWeights"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "LiveAlias9B8FFEA9",
+      "resourceType": "AWS::Lambda::Alias",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0720LambdaPc-Fn9270CBC0-rSosQAKZwL6a:live",
+      "constructPath": "CdkrdHunt0720LambdaPc/LiveAlias"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53__HealthCheck.PrimaryHealth.json
+++ b/tests/corpus/AWS__Route53__HealthCheck.PrimaryHealth.json
@@ -1,0 +1,69 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PrimaryHealth",
+    "resourceType": "AWS::Route53::HealthCheck",
+    "physicalId": "797c6bee-46a0-448e-9bb8-339a0fb1387e",
+    "constructPath": "CdkrdHunt0720R53Policy/PrimaryHealth",
+    "declared": {
+      "HealthCheckConfig": {
+        "FailureThreshold": 3,
+        "FullyQualifiedDomainName": "example.com",
+        "Port": 80,
+        "RequestInterval": 30,
+        "ResourcePath": "/",
+        "Type": "HTTP"
+      },
+      "HealthCheckTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "HealthCheckId": "797c6bee-46a0-448e-9bb8-339a0fb1387e",
+    "HealthCheckConfig": {
+      "EnableSNI": false,
+      "Type": "HTTP",
+      "ResourcePath": "/",
+      "FullyQualifiedDomainName": "example.com",
+      "MeasureLatency": false,
+      "Inverted": false,
+      "Port": 80,
+      "RequestInterval": 30,
+      "FailureThreshold": 3
+    },
+    "HealthCheckTags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["HealthCheckId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["HealthCheckId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "HealthCheckConfig.MeasureLatency",
+      "HealthCheckConfig.RequestInterval",
+      "HealthCheckConfig.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["HealthCheckConfig.ChildHealthChecks", "HealthCheckConfig.Regions"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__RecordSet.FailPrimary.json
+++ b/tests/corpus/AWS__Route53__RecordSet.FailPrimary.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FailPrimary",
+    "resourceType": "AWS::Route53::RecordSet",
+    "physicalId": "fo.cdkrd-hunt0720-x3f9.com",
+    "constructPath": "CdkrdHunt0720R53Policy/FailPrimary",
+    "declared": {
+      "Failover": "PRIMARY",
+      "HealthCheckId": "797c6bee-46a0-448e-9bb8-339a0fb1387e",
+      "HostedZoneId": "Z0164857358YUQJWZ03A5",
+      "Name": "fo.cdkrd-hunt0720-x3f9.com.",
+      "ResourceRecords": ["192.0.2.20"],
+      "SetIdentifier": "primary",
+      "TTL": "60",
+      "Type": "A"
+    }
+  },
+  "liveRaw": {
+    "Name": "fo.cdkrd-hunt0720-x3f9.com.",
+    "Type": "A",
+    "HostedZoneId": "Z0164857358YUQJWZ03A5",
+    "TTL": "60",
+    "ResourceRecords": ["192.0.2.20"],
+    "SetIdentifier": "primary",
+    "Failover": "PRIMARY",
+    "HealthCheckId": "797c6bee-46a0-448e-9bb8-339a0fb1387e"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["HostedZoneId", "HostedZoneName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HostedZoneId", "HostedZoneName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__RecordSet.FailSecondary.json
+++ b/tests/corpus/AWS__Route53__RecordSet.FailSecondary.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FailSecondary",
+    "resourceType": "AWS::Route53::RecordSet",
+    "physicalId": "fo.cdkrd-hunt0720-x3f9.com",
+    "constructPath": "CdkrdHunt0720R53Policy/FailSecondary",
+    "declared": {
+      "Failover": "SECONDARY",
+      "HostedZoneId": "Z0164857358YUQJWZ03A5",
+      "Name": "fo.cdkrd-hunt0720-x3f9.com.",
+      "ResourceRecords": ["192.0.2.21"],
+      "SetIdentifier": "secondary",
+      "TTL": "60",
+      "Type": "A"
+    }
+  },
+  "liveRaw": {
+    "Name": "fo.cdkrd-hunt0720-x3f9.com.",
+    "Type": "A",
+    "HostedZoneId": "Z0164857358YUQJWZ03A5",
+    "TTL": "60",
+    "ResourceRecords": ["192.0.2.21"],
+    "SetIdentifier": "secondary",
+    "Failover": "SECONDARY"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["HostedZoneId", "HostedZoneName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HostedZoneId", "HostedZoneName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__RecordSet.LatEuw1.json
+++ b/tests/corpus/AWS__Route53__RecordSet.LatEuw1.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LatEuw1",
+    "resourceType": "AWS::Route53::RecordSet",
+    "physicalId": "lat.cdkrd-hunt0720-x3f9.com",
+    "constructPath": "CdkrdHunt0720R53Policy/LatEuw1",
+    "declared": {
+      "HostedZoneId": "Z0164857358YUQJWZ03A5",
+      "Name": "lat.cdkrd-hunt0720-x3f9.com.",
+      "Region": "eu-west-1",
+      "ResourceRecords": ["192.0.2.2"],
+      "SetIdentifier": "euw1",
+      "TTL": "60",
+      "Type": "A"
+    }
+  },
+  "liveRaw": {
+    "Name": "lat.cdkrd-hunt0720-x3f9.com.",
+    "Type": "A",
+    "HostedZoneId": "Z0164857358YUQJWZ03A5",
+    "TTL": "60",
+    "ResourceRecords": ["192.0.2.2"],
+    "SetIdentifier": "euw1",
+    "Region": "eu-west-1"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["HostedZoneId", "HostedZoneName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HostedZoneId", "HostedZoneName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__RecordSet.LatUse1.json
+++ b/tests/corpus/AWS__Route53__RecordSet.LatUse1.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LatUse1",
+    "resourceType": "AWS::Route53::RecordSet",
+    "physicalId": "lat.cdkrd-hunt0720-x3f9.com",
+    "constructPath": "CdkrdHunt0720R53Policy/LatUse1",
+    "declared": {
+      "HostedZoneId": "Z0164857358YUQJWZ03A5",
+      "Name": "lat.cdkrd-hunt0720-x3f9.com.",
+      "Region": "us-east-1",
+      "ResourceRecords": ["192.0.2.1"],
+      "SetIdentifier": "use1",
+      "TTL": "60",
+      "Type": "A"
+    }
+  },
+  "liveRaw": {
+    "Name": "lat.cdkrd-hunt0720-x3f9.com.",
+    "Type": "A",
+    "HostedZoneId": "Z0164857358YUQJWZ03A5",
+    "TTL": "60",
+    "ResourceRecords": ["192.0.2.1"],
+    "SetIdentifier": "use1",
+    "Region": "us-east-1"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["HostedZoneId", "HostedZoneName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HostedZoneId", "HostedZoneName", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SES__ConfigurationSetEventDestination.Dest.json
+++ b/tests/corpus/AWS__SES__ConfigurationSetEventDestination.Dest.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Dest",
+    "resourceType": "AWS::SES::ConfigurationSetEventDestination",
+    "physicalId": "cdkrd-dest",
+    "constructPath": "CdkRealDriftIntegSesEventDestReadGap/Dest",
+    "declared": {
+      "ConfigurationSetName": "cdkrd-ses-reorder",
+      "EventDestination": {
+        "CloudWatchDestination": {
+          "DimensionConfigurations": [
+            {
+              "DefaultDimensionValue": "none",
+              "DimensionName": "ses-source",
+              "DimensionValueSource": "messageTag"
+            }
+          ]
+        },
+        "Enabled": true,
+        "MatchingEventTypes": ["DELIVERY", "BOUNCE", "SEND", "COMPLAINT"],
+        "Name": "cdkrd-dest"
+      }
+    }
+  },
+  "liveRaw": {
+    "ConfigurationSetName": "cdkrd-ses-reorder",
+    "EventDestination": {
+      "Name": "cdkrd-dest",
+      "Enabled": true,
+      "MatchingEventTypes": ["bounce", "complaint", "delivery", "send"],
+      "CloudWatchDestination": {
+        "DimensionConfigurations": [
+          {
+            "DimensionName": "ses-source",
+            "DimensionValueSource": "messageTag",
+            "DefaultDimensionValue": "none"
+          }
+        ]
+      }
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["ConfigurationSetName"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ConfigurationSetName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["EventDestination.MatchingEventTypes"],
+    "unorderedObjectArrayPaths": ["EventDestination.CloudWatchDestination.DimensionConfigurations"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/cloudfront-cd-hunt/app.ts
+++ b/tests/integration/cloudfront-cd-hunt/app.ts
@@ -1,0 +1,67 @@
+// False-positive probe: CloudFront continuous deployment — a staging distribution
+// (Staging: true), a ContinuousDeploymentPolicy (SingleWeight traffic split), and a
+// primary distribution carrying ContinuousDeploymentPolicyId. Zero prior corpus or
+// fixture coverage for AWS::CloudFront::ContinuousDeploymentPolicy or the staging
+// distribution shape. L1 throughout so only the minimum is declared.
+//
+// TWO-PHASE: CloudFront REJECTS a ContinuousDeploymentPolicyId at distribution
+// CREATION ("Continuous deployment policy is not supported during distribution
+// creation") — the id can only be attached via an UPDATE. Deploy once without the
+// context flag, then redeploy with `-c attach=1` to attach (which doubles as a
+// post-update echo probe on the primary distribution).
+import { App, Stack, Tags } from 'aws-cdk-lib';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+
+const app = new App();
+Tags.of(app).add('cdkrd:ephemeral', '1');
+
+const stack = new Stack(app, 'CdkrdHunt0720CfCd');
+
+// Managed CachingDisabled policy id (stable AWS constant).
+const CACHING_DISABLED = '4135ea2d-6df8-44a3-9df3-4b5a84be39ad';
+
+const baseConfig = {
+  enabled: true,
+  origins: [
+    {
+      id: 'origin1',
+      domainName: 'example.com',
+      customOriginConfig: {
+        originProtocolPolicy: 'https-only',
+      },
+    },
+  ],
+  defaultCacheBehavior: {
+    targetOriginId: 'origin1',
+    viewerProtocolPolicy: 'allow-all',
+    cachePolicyId: CACHING_DISABLED,
+  },
+};
+
+const staging = new cloudfront.CfnDistribution(stack, 'StagingDist', {
+  distributionConfig: {
+    ...baseConfig,
+    staging: true,
+  },
+});
+
+const cdPolicy = new cloudfront.CfnContinuousDeploymentPolicy(stack, 'CdPolicy', {
+  continuousDeploymentPolicyConfig: {
+    enabled: true,
+    stagingDistributionDnsNames: [staging.attrDomainName],
+    trafficConfig: {
+      type: 'SingleWeight',
+      singleWeightConfig: { weight: 0.05 },
+    },
+  },
+});
+
+const attach = app.node.tryGetContext('attach') === '1';
+new cloudfront.CfnDistribution(stack, 'PrimaryDist', {
+  distributionConfig: {
+    ...baseConfig,
+    ...(attach ? { continuousDeploymentPolicyId: cdPolicy.attrId } : {}),
+  },
+});
+
+app.synth();

--- a/tests/integration/cloudfront-cd-hunt/cdk.json
+++ b/tests/integration/cloudfront-cd-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront-cd-hunt/package.json
+++ b/tests/integration/cloudfront-cd-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront-cd-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cloudfront-cd-hunt false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudfront-cd-hunt/verify.sh
+++ b/tests/integration/cloudfront-cd-hunt/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS), TWO-PHASE: CloudFront rejects a
+# ContinuousDeploymentPolicyId at distribution creation, so deploy without it first,
+# then redeploy with `-c attach=1` to attach the policy via UPDATE. Both phases must
+# show ZERO [Potential Drift] on a pre-record check (phase 2 doubles as a post-update
+# echo probe), then record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0720CfCd
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] phase 1: deploy without the policy attachment ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy phase 1"
+
+echo "=== [$STACK] phase 1 check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.p1.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.p1.out" && fail "phase-1 first check must show zero [Potential Drift]"
+
+echo "=== [$STACK] phase 2: attach the continuous-deployment policy via UPDATE ==="
+npx cdk deploy -f "$STACK" -c attach=1 --require-approval never || fail "deploy phase 2 (attach)"
+
+echo "=== [$STACK] phase 2 check (post-update echo probe, corpus harvest) ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-cfcd $CLI check "$STACK" --region "$REGION" -c attach=1 | tee "/tmp/cdkrd-$STACK.p2.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.p2.out" && fail "phase-2 check must show zero [Potential Drift] (post-update echo)"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" -c attach=1 --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" -c attach=1 --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/lambda-pc-hunt/app.ts
+++ b/tests/integration/lambda-pc-hunt/app.ts
@@ -1,0 +1,28 @@
+// False-positive probe: Lambda provisioned concurrency (the first fixture to exercise
+// AWS::Lambda::Alias with ProvisionedConcurrencyConfig — a very common production
+// hardening measure with zero prior corpus/fixture coverage). The alias declares only
+// the concurrency; everything AWS materializes around it (routing config, PC state)
+// is the undeclared surface under probe.
+import { App, Duration, Stack, Tags } from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const app = new App();
+Tags.of(app).add('cdkrd:ephemeral', '1');
+
+const stack = new Stack(app, 'CdkrdHunt0720LambdaPc');
+
+const fn = new lambda.Function(stack, 'Fn', {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: 'index.handler',
+  code: lambda.Code.fromInline('exports.handler = async () => "ok";'),
+  memorySize: 128,
+  timeout: Duration.seconds(3),
+});
+
+new lambda.Alias(stack, 'LiveAlias', {
+  aliasName: 'live',
+  version: fn.currentVersion,
+  provisionedConcurrentExecutions: 1,
+});
+
+app.synth();

--- a/tests/integration/lambda-pc-hunt/cdk.json
+++ b/tests/integration/lambda-pc-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-pc-hunt/package.json
+++ b/tests/integration/lambda-pc-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-pc-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-pc-hunt false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-pc-hunt/verify.sh
+++ b/tests/integration/lambda-pc-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record) must
+# show ZERO [Potential Drift] (every entry there is a fold gap) -> record -> check
+# MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0720LambdaPc
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.first.out"; then
+  echo "--- FIRST-RUN FP: [Potential Drift] on a fresh un-mutated deploy (fold gap) ---"
+  fail "first check must show zero [Potential Drift]"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/route53-policy-hunt/app.ts
+++ b/tests/integration/route53-policy-hunt/app.ts
@@ -1,0 +1,72 @@
+// False-positive probe: Route 53 routing policies with SetIdentifier — latency and
+// failover records plus a HealthCheck. Weighted/geoproximity/multivalue have fixtures;
+// latency and failover records had zero corpus/fixture coverage. The zone uses a
+// placeholder domain (example.com/.test/.example are AWS-reserved and rejected); a
+// public zone for an unowned domain creates fine, it just is not authoritative.
+import { App, Stack, Tags } from 'aws-cdk-lib';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+
+const app = new App();
+Tags.of(app).add('cdkrd:ephemeral', '1');
+
+const stack = new Stack(app, 'CdkrdHunt0720R53Policy');
+
+const zone = new route53.PublicHostedZone(stack, 'Zone', {
+  zoneName: 'cdkrd-hunt0720-x3f9.com',
+});
+
+// Latency-based pair (same name, per-region SetIdentifier).
+new route53.CfnRecordSet(stack, 'LatUse1', {
+  hostedZoneId: zone.hostedZoneId,
+  name: 'lat.cdkrd-hunt0720-x3f9.com.',
+  type: 'A',
+  ttl: '60',
+  resourceRecords: ['192.0.2.1'],
+  setIdentifier: 'use1',
+  region: 'us-east-1',
+});
+new route53.CfnRecordSet(stack, 'LatEuw1', {
+  hostedZoneId: zone.hostedZoneId,
+  name: 'lat.cdkrd-hunt0720-x3f9.com.',
+  type: 'A',
+  ttl: '60',
+  resourceRecords: ['192.0.2.2'],
+  setIdentifier: 'euw1',
+  region: 'eu-west-1',
+});
+
+// Failover pair; the PRIMARY carries a health check. Route 53 REJECTS reserved /
+// documentation IPs (192.0.2.x) with InvalidRequest, so probe a resolvable FQDN
+// instead (example.com is reserved-but-resolvable; health status is irrelevant to
+// the drift probe).
+const health = new route53.CfnHealthCheck(stack, 'PrimaryHealth', {
+  healthCheckConfig: {
+    type: 'HTTP',
+    fullyQualifiedDomainName: 'example.com',
+    port: 80,
+    resourcePath: '/',
+    requestInterval: 30,
+    failureThreshold: 3,
+  },
+});
+new route53.CfnRecordSet(stack, 'FailPrimary', {
+  hostedZoneId: zone.hostedZoneId,
+  name: 'fo.cdkrd-hunt0720-x3f9.com.',
+  type: 'A',
+  ttl: '60',
+  resourceRecords: ['192.0.2.20'],
+  setIdentifier: 'primary',
+  failover: 'PRIMARY',
+  healthCheckId: health.attrHealthCheckId,
+});
+new route53.CfnRecordSet(stack, 'FailSecondary', {
+  hostedZoneId: zone.hostedZoneId,
+  name: 'fo.cdkrd-hunt0720-x3f9.com.',
+  type: 'A',
+  ttl: '60',
+  resourceRecords: ['192.0.2.21'],
+  setIdentifier: 'secondary',
+  failover: 'SECONDARY',
+});
+
+app.synth();

--- a/tests/integration/route53-policy-hunt/cdk.json
+++ b/tests/integration/route53-policy-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/route53-policy-hunt/package.json
+++ b/tests/integration/route53-policy-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-route53-policy-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift route53-policy-hunt false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/route53-policy-hunt/verify.sh
+++ b/tests/integration/route53-policy-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> FIRST check (pre-record) must
+# show ZERO [Potential Drift] (every entry there is a fold gap) -> record -> check
+# MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0720R53Policy
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record): every [Potential Drift] is a fold gap ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.first.out"
+if grep -q "Potential Drift" "/tmp/cdkrd-$STACK.first.out"; then
+  echo "--- FIRST-RUN FP: [Potential Drift] on a fresh un-mutated deploy (fold gap) ---"
+  fail "first check must show zero [Potential Drift]"
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

2026-07-20 bug hunt (~5 rounds, mixed angles). Two confirmed bug classes, both live-proven and fixed; three new fixtures and 10 corpus cases.

### Bug 1 — FN: Budgets `CostTypes` all-false off-flip invisible

The #1092/#1635 all-boolean-object class re-opened by the #1658 reader-projection pins: an out-of-band `update-budget` disabling ALL nine `Include*` cost types read back an all-false object that `isTrivialEmpty` swallowed in `emitNested` before the pin gate — `check --fail` stayed CLEAN while the budget silently stopped measuring almost everything. A SINGLE off-flip already surfaced (surviving `true` leaves keep the object non-trivial); the gap was exactly the all-false shape.

- Live evidence (us-east-1, budget-scope fixture): `DescribeBudget` RETURNS the all-false object (not the vanished-default class); base binary CLEAN (FN) → fix surfaces `Budget.Budget.CostTypes — appeared since record` → OOB restore → CLEAN.
- Fix: `MEANINGFUL_WHEN_OFF_NESTED['AWS::Budgets::Budget']['Budget.CostTypes']` gate (classify.ts).
- Tests: `tests/budgets-costtypes-offflip.test.ts` (clean full-default folds / single flip surfaces / all-false surfaces), replaying the harvested MonthlyCost corpus case with the current reader's 11-boolean projection synthesized in.
- Revert: Budgets is a known not-revertable type (documented in writers.ts) — unchanged.

### Bug 2 — FP: CloudFront continuous-deployment first-run noise (3 findings)

New `cloudfront-cd-hunt` fixture (first coverage of `AWS::CloudFront::ContinuousDeploymentPolicy` + staging distributions; two-phase because CloudFront rejects `ContinuousDeploymentPolicyId` at distribution CREATION) first-ran 3 `[Potential Drift]` entries on a fresh un-mutated deploy:

1. `ContinuousDeploymentPolicyConfig.Type` + `.SingleWeightPolicyConfig` — the config schema carries the SAME traffic split in TWO writable representations (canonical `TrafficConfig` vs flattened console-era synonyms; neither is registry-readOnly) and the CC read echoes BOTH. Fix: `cloudFrontCdPolicySynonymAtDefault` — tier-2 derived from the DECLARED counterpart representation, symmetric in both declaration directions; a diverged mirror still surfaces.
2. `StagingDist.DistributionConfig.ContinuousDeploymentPolicyId` — the sibling-attachment echo class (#1574): attaching a policy materializes the reverse pointer on the STAGING distribution. Fix: `gather.buildCloudFrontStagingDistCdPolicyIds` links policy → distribution via GetAtt refs AND (the actual classify-time shape) the re-resolved literal DNS name matched against the distribution's live `DomainName`; threaded via `classifyOpts.siblingCloudFrontCdPolicyIds`, equality-gated (an out-of-band re-link to a different policy surfaces), `null` = fail-open, no entry = surfaces. The corpus recorder carries the per-resource entry so replay reproduces the fold.

Live evidence: fixture INTEG PASS end to end with the fixed binary — phase-1 CLEAN, post-attach UPDATE CLEAN (post-update echo probe), record → CLEAN.

### Clean results (assets kept)

- Offline variant-table audit: every "unproven mirrored row" suspect (GWLB cross-zone, TLS TargetGroup, redis RG `AtRestEncryptionEnabled=false`, EB SpotFleet derived values, ElastiCache ServerlessCache) turned out already corpus-proven — zero deploys burned.
- `lambda-pc-hunt` (NEW): Lambda provisioned concurrency (first coverage) — first-run FP zero; OOB PC 1→2 detected (exit 1) after allocation READY; revert converged (live value back to 1). The initial "miss" was the documented #1582 propagation-lag gotcha, not a bug.
- `route53-policy-hunt` (NEW): latency + failover routing + HealthCheck — first-run FP zero; OOB record change detected; restore → CLEAN.
- SES ConfigurationSetEventDestination corpus case harvested (fixture existed, corpus was missing); ACM Certificate determined adequately covered (5 unit-test files; a CFn fixture is impractical — stack hangs on validation).
- 10 new corpus cases; measure-noise sweep: no new candidates.

### Verification

- `/check`: typecheck / lint+format / `vp pack` / 6100+ unit tests — all pass; corpus replay 914/914.
- `/verify-pr` set. Shared CORE suite **deferred** (diff fully covered by unit tests + corpus replay AND live-proven in this hunt's own deploys — per the R50 deferral rule).
- Cleanup: all 5 hunt stacks deleted (delstack), `sweep-orphans.sh` SWEEP CLEAN, bughunt gate released for both session owners.

Note: `gh issue create` was denied by the auto-mode permission classifier this session; prepared issue bodies for both bugs are in the hunt log and can be filed on request (this PR carries the full evidence).
