### PR TITLE
fix(diff): UDP-family ip-target preserve_client_ip FP, CapacityReservation first-run FPs + revert no-ops (hunt 2026-07-21)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -966,6 +966,50 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   default is `'true'` → first-run FP, #1664). A barest deploy of each mirrored-row
   variant is cheap (a TargetGroup needs no LB); grep the split tables for rows whose
   comment cites a DIFFERENT variant's deploy as evidence.
+- **Two split tables proven per-axis are still unproven per-COMBINATION — and the
+  merge ORDER between them is itself a fold decision.** Every row of BY_PROTOCOL and
+  BY_TARGET_TYPE had live evidence, yet a barest UDP/ip TargetGroup still first-ran a
+  `preserve_client_ip.enabled` FP (hunt 2026-07-21): the ip row's `'false'` is a
+  TCP/TLS-only default, but the cross combination UDP×ip had never been deployed
+  (variants5's UDP group omitted TargetType → took the `instance` row), and the merge
+  spread BY_TARGET_TYPE last so its default beat the protocol's FORCED value (AWS
+  forbids disabling client-IP preservation for UDP/TCP_UDP). Fix shape: a value the
+  protocol FORCES belongs in the protocol row and the protocol overrides merge LAST
+  (forced beats default). When a type has two variant axes, enumerate the cheap cross
+  products (a TG needs no LB) — per-axis green proves nothing about the intersection.
+- **Determination (2026-07-21): the non-default-region axis came back CLEAN.** The
+  first hunt ever run outside us-east-1 (region-hunt: a 15-type barest pack with the
+  widest KNOWN_DEFAULTS/bag surfaces — ALB/NLB/TGs, Lambda, DDB, Kinesis, SQS/SNS,
+  S3, Logs, ECR, Events, Athena WorkGroup, EFS — in ap-northeast-1) folded all 125
+  atDefault values correctly, and the SQS FN detect→revert leg converged, so the
+  constant tables are not us-east-1-baked for the common types. A future
+  region-sensitive default remains possible (rollout-lagged attribute families in
+  late-rollout regions like ap-northeast-3) but the broad axis is mined — don't
+  re-burn a wide region pack; reserve region probes for a specific suspected
+  rollout-lag value.
+- **Determination (2026-07-21): the #904 Processed-template path is live-proven.** A
+  raw-CFn `Transform: AWS::LanguageExtensions` stack (Fn::ForEach-expanded log groups
+  - an Fn::ToJsonString SSM parameter) checked CLEAN end-to-end via a hand-built
+    cdk.out pointing at the ORIGINAL unexpanded template (langext-hunt) — the deployed
+    Processed fallback resolved the expansion. No SAM/LanguageExtensions live gap
+    remains for the check path.
+- **An EC2-style `TagSpecifications` INPUT wrapper can be echoed back on read with
+  the CFN-propagated STACK tags inside — the #683 FP class one level down.** A barest
+  CapacityReservation echoed `TagSpecifications[{ResourceType, Tags:[cdkrd:ephemeral…]}]`
+  as undeclared Potential Drift (every hunt fixture stack-tags itself, so this FPs on
+  EVERY deploy of such a type; the `aws:*` members were already deep-stripped —
+  the propagated USER tag was the survivor). Fix shape: subtractPropagatedStackTags
+  now walks the wrapper generically (drop emptied specs / the emptied wrapper, keep
+  non-stack tags). The corpus had ZERO other liveRaw `TagSpecifications` echoes, so
+  the class is closed until a new type echoes the wrapper — if a first-run FP shows
+  a `TagSpecifications` husk, check this mechanism before adding a per-type fold.
+  Same hunt: the reservation's `EndDate` echoes the literal STRING "null" (pinned
+  as-is in KNOWN_DEFAULTS — display shows `="null"` quoted, which is the tell it is
+  a string, not a JSON null the trivial-empty drop would have eaten), and its
+  ModifyCapacityReservation is omit-ignored (InstanceMatchCriteria/EndDateType RSDP
+  entries; `EndDateType: unlimited` alone is REJECTED while the model still carries
+  EndDate — the set-default add must ride the same patch as the EndDate `remove`,
+  which the plan produces naturally).
 - **An FN detect-probe needs its resource at readGap=0 — a reader-projection readGap
   silently disables appeared-since-record for the WHOLE resource, and the report
   masks it as "No baseline yet".** The R62 mechanism only fires on snapshot-COMPLETE

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -73,6 +73,11 @@ export interface CorpusCase {
     region: string;
     kmsAliasTargets: Record<string, string>;
     oaiCanonicalIds: Record<string, string>;
+    // CFn STACK-level tags (#683), present only when non-empty AND this resource's live model
+    // carries a Tags/TagSpecifications array they could have been propagated into, so replay
+    // reproduces the stack-tag subtraction (the CapacityReservation TagSpecifications wrapper
+    // echo, hunt 2026-07-21). Optional for back-compat (older cases lack it).
+    stackTags?: Record<string, string>;
     // Sibling SecurityGroupIngress/Egress rules reflected into an SG's live arrays, keyed by
     // the SG's physical id. Only present (and only its own entry) on an AWS::EC2::SecurityGroup
     // case, so replay reproduces the sibling-rule subtraction; optional for back-compat.
@@ -155,6 +160,7 @@ export function buildCorpusCase(
     region: string;
     kmsAliasTargets: Record<string, string>;
     oaiCanonicalIds: Record<string, string>;
+    stackTags?: Record<string, string>;
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
     bucketNotificationManaged?: Set<string>;
     siblingEipAssociations?: Set<string>;
@@ -298,6 +304,13 @@ export function buildCorpusCase(
       region: opts.region,
       kmsAliasTargets: opts.kmsAliasTargets,
       oaiCanonicalIds: opts.oaiCanonicalIds,
+      // Carry the stack tags only when this resource's live model has an array they could have
+      // been propagated into — replay then reproduces the #683 subtraction without bloating
+      // every case (the TagSpecifications wrapper echo, hunt 2026-07-21).
+      ...(Object.keys(opts.stackTags ?? {}).length > 0 &&
+      (Array.isArray(liveRaw.Tags) || Array.isArray(liveRaw.TagSpecifications))
+        ? { stackTags: opts.stackTags }
+        : {}),
       ...(sgSibling && resource.physicalId
         ? { siblingSgRules: { [resource.physicalId]: sgSibling } }
         : {}),

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -134,13 +134,18 @@ function elbAttributeDefaultsFor(
   if (resourceType === 'AWS::ElasticLoadBalancingV2::TargetGroup') {
     const protocol = declared.Protocol ?? live.Protocol;
     const targetType = declared.TargetType ?? live.TargetType;
+    // Merge order: target-type defaults first, protocol overrides LAST — a value the
+    // PROTOCOL forces (UDP/TCP_UDP preserve_client_ip is always-on, not disableable)
+    // must beat a target-type DEFAULT (the ip row's TCP/TLS-only 'false', #1626); a
+    // barest UDP/ip group first-run-FP'd under the old order (echo4-hunt, 2026-07-21).
+    // Keys present in only one table are unaffected.
     return {
       ...shared,
-      ...(typeof protocol === 'string'
-        ? (ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL[protocol] ?? {})
-        : {}),
       ...(typeof targetType === 'string'
         ? (ELB_TG_ATTRIBUTE_DEFAULTS_BY_TARGET_TYPE[targetType] ?? {})
+        : {}),
+      ...(typeof protocol === 'string'
+        ? (ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL[protocol] ?? {})
         : {}),
     };
   }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1331,6 +1331,20 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     TransportProtocol: 'udp',
     SessionTimeoutHours: 24,
   },
+  // A barest capacity reservation (only AZ/count/platform/type declared) reads back the
+  // constant service defaults: shared tenancy, no end date ("unlimited" + the literal
+  // STRING "null" the handler echoes for the absent EndDate), and open instance
+  // matching. Observed live on a fresh reservation (us-east-1, zerocorpus-hunt,
+  // 2026-07-21). Equality-gated: an out-of-band change (`modify-capacity-reservation
+  // --instance-match-criteria targeted`, or setting an end date) no longer matches and
+  // surfaces as real undeclared drift. (Tenancy is createOnly — its pin only folds the
+  // first-run echo.)
+  'AWS::EC2::CapacityReservation': {
+    Tenancy: 'default',
+    EndDateType: 'unlimited',
+    EndDate: 'null',
+    InstanceMatchCriteria: 'open',
+  },
   // A DAX cluster that declares no ClusterEndpointEncryptionType reads back "NONE" (the
   // constant service default; the only other value, "TLS", is an explicit opt-in).
   // Observed live on a fresh DAX deploy (us-east-1, 2026-07-03; #554). Equality-gated.
@@ -4128,6 +4142,14 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   AllocationId/NetworkInterfaceId, compared in the declared loop). Observed live
   //   first-run (vpc-attach-min, 2026-07-12).
   'AWS::EC2::EIPAssociation': new Set(['PrivateIpAddress', 'EIP']),
+  //   AWS::EC2::CapacityReservation.AvailabilityZoneId — a reservation that declares
+  //   AvailabilityZone reads back the zone's per-ACCOUNT zone ID (use1-az1, ...): an
+  //   AWS-assigned identifier from the account's own AZ-name→AZ-id mapping, not
+  //   expressible as a constant and not derivable offline. createOnly (can never drift
+  //   out of band), and a user who cares pins AvailabilityZoneId INSTEAD of
+  //   AvailabilityZone — then it is declared and compared in the declared loop. Live
+  //   first-run (zerocorpus-hunt, 2026-07-21).
+  'AWS::EC2::CapacityReservation': new Set(['AvailabilityZoneId']),
   //   Core VPC-networking types whose undeclared, AWS-ASSIGNED, CREATE-ONLY placement identifiers
   //   read back on every first run. Each is a per-resource value AWS picks at creation from the
   //   surrounding VPC/subnet/region — never a constant we can pin, and never user intent when
@@ -4852,6 +4874,13 @@ export const ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL: Record<string, Record<string
     'proxy_protocol_v2.enabled': 'false',
     'target_health_state.unhealthy.connection_termination.enabled': 'true',
     'target_health_state.unhealthy.draining_interval_seconds': '0',
+    // Client IP preservation is FORCED ON for the UDP family (AWS forbids disabling
+    // it), so the BY_TARGET_TYPE ip row's 'false' — a TCP/TLS-only default, #1626 —
+    // must not win: the protocol row carries the forced value and classify merges the
+    // protocol overrides LAST. First-run-FP'd live on a barest UDP/ip group
+    // (echo4-hunt, 2026-07-21). A forced value cannot change out of band, so the
+    // constant can never hide a real change.
+    'preserve_client_ip.enabled': 'true',
   },
   TCP_UDP: {
     'stickiness.type': 'source_ip',
@@ -4859,6 +4888,9 @@ export const ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL: Record<string, Record<string
     'proxy_protocol_v2.enabled': 'false',
     'target_health_state.unhealthy.connection_termination.enabled': 'true',
     'target_health_state.unhealthy.draining_interval_seconds': '0',
+    // Same forced-on client IP preservation as the UDP row above (echo4-hunt,
+    // 2026-07-21).
+    'preserve_client_ip.enabled': 'true',
   },
 };
 

--- a/src/normalize/stack-tags.ts
+++ b/src/normalize/stack-tags.ts
@@ -1,17 +1,25 @@
 // #683 — CloudFormation STACK-level tag helpers.
 
-// The set of Tag KEYS a resource DECLARES on its top-level `Tags` list (a `{Key,Value}[]`).
-// Used to protect a declared tag key from the stack-tag subtraction below: a key the resource
-// itself declares is real intent and must stay in the live model so the declared loop compares
-// it (a value change on it still surfaces).
+// The set of Tag KEYS a resource DECLARES on its top-level `Tags` list (a `{Key,Value}[]`)
+// or inside a declared `TagSpecifications` wrapper (the EC2 create-time input shape —
+// `[{ResourceType, Tags: {Key,Value}[]}]`). Used to protect a declared tag key from the
+// stack-tag subtraction below: a key the resource itself declares is real intent and must
+// stay in the live model so the declared loop compares it (a value change on it still
+// surfaces).
 export const declaredTagKeys = (declared: unknown): ReadonlySet<string> => {
   const out = new Set<string>();
-  const tags = (declared as Record<string, unknown> | null | undefined)?.Tags;
-  if (Array.isArray(tags)) {
+  const collect = (tags: unknown) => {
+    if (!Array.isArray(tags)) return;
     for (const t of tags) {
       const k = (t as Record<string, unknown> | null | undefined)?.Key;
       if (typeof k === 'string') out.add(k);
     }
+  };
+  const d = declared as Record<string, unknown> | null | undefined;
+  collect(d?.Tags);
+  const specs = d?.TagSpecifications;
+  if (Array.isArray(specs)) {
+    for (const spec of specs) collect((spec as Record<string, unknown> | null | undefined)?.Tags);
   }
   return out;
 };
@@ -26,23 +34,57 @@ export const declaredTagKeys = (declared: unknown): ReadonlySet<string> => {
 // compared normally). Only an EXACT {Key,Value} match to a stack tag is dropped, so a
 // resource-level tag that merely shares a key with a stack tag but has a different value is
 // preserved (and its divergence still surfaces). Scoped to the standard top-level `Tags` list
-// (where CFN propagates them); map-shaped / differently-named tag properties are out of scope (#862).
+// (where CFN propagates them) plus the EC2 `TagSpecifications` input-wrapper echo (below);
+// map-shaped / differently-named tag properties are out of scope (#862).
+//
+// TagSpecifications: some EC2 registry handlers (CapacityReservation) echo the create-time
+// `TagSpecifications` INPUT wrapper back on read, with the propagated stack tags inside each
+// spec's `Tags` — an undeclared first-run FP on every stack-tagged deploy (live,
+// zerocorpus-hunt 2026-07-21; the `aws:*` members are already stripped by stripAwsTagsDeep).
+// Apply the same per-tag subtraction inside each spec, drop a spec whose Tags empty, and drop
+// the wrapper itself when every spec empties. A genuinely out-of-band tag (no stack-tag match)
+// survives and still surfaces.
 export const subtractPropagatedStackTags = (
   live: Record<string, unknown>,
   stackTags: Record<string, string>,
   declaredKeys: ReadonlySet<string>
 ): Record<string, unknown> => {
   if (Object.keys(stackTags).length === 0) return live;
-  const tags = live.Tags;
-  if (!Array.isArray(tags)) return live;
-  const filtered = tags.filter((t) => {
+  const keepTag = (t: unknown): boolean => {
     if (!t || typeof t !== 'object') return true;
     const key = (t as Record<string, unknown>).Key;
     const value = (t as Record<string, unknown>).Value;
     if (typeof key !== 'string') return true;
     if (declaredKeys.has(key)) return true; // declared intent — keep it, compared normally
     return !(key in stackTags && stackTags[key] === value); // drop the propagated stack tag
-  });
-  if (filtered.length === tags.length) return live; // nothing removed — preserve identity
-  return { ...live, Tags: filtered };
+  };
+  let out = live;
+  const tags = live.Tags;
+  if (Array.isArray(tags)) {
+    const filtered = tags.filter(keepTag);
+    if (filtered.length !== tags.length) out = { ...out, Tags: filtered };
+  }
+  const specs = out.TagSpecifications;
+  if (Array.isArray(specs)) {
+    let changed = false;
+    const filteredSpecs = specs
+      .map((spec) => {
+        const specTags = (spec as Record<string, unknown> | null | undefined)?.Tags;
+        if (!Array.isArray(specTags)) return spec;
+        const filtered = specTags.filter(keepTag);
+        if (filtered.length === specTags.length) return spec;
+        changed = true;
+        return { ...(spec as Record<string, unknown>), Tags: filtered };
+      })
+      .filter((spec) => {
+        const specTags = (spec as Record<string, unknown> | null | undefined)?.Tags;
+        return !(Array.isArray(specTags) && specTags.length === 0);
+      });
+    if (changed || filteredSpecs.length !== specs.length) {
+      out = { ...out };
+      if (filteredSpecs.length === 0) delete out.TagSpecifications;
+      else out.TagSpecifications = filteredSpecs;
+    }
+  }
+  return out;
 };

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -118,6 +118,18 @@ const CC_REVERTABLE_DESPITE_READ_OVERRIDE = new Set<string>([
 // entry here (#702): UpdateUserPool ignores an omitted property, so a fold WITHOUT an RSDP
 // entry silently reverts as a no-op `remove`. Keyed `${resourceType}\0${path}`.
 export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
+  // EC2 ModifyCapacityReservation leaves an OMITTED property unchanged — a bare `remove`
+  // of an out-of-band InstanceMatchCriteria=targeted or EndDateType=limited reports
+  // SUCCESS yet the live value persists (silent no-op, proven via explicit Cloud Control
+  // patches on a CLI-created reservation, hunt 2026-07-21). Writing the KNOWN_DEFAULTS
+  // defaults explicitly converges: `add /InstanceMatchCriteria open` restores open
+  // matching, and `add /EndDateType unlimited` combined with the sibling EndDate `remove`
+  // (the same resource patch) clears an out-of-band end date — unlimited ALONE is
+  // rejected while the model still carries EndDate, so the pair matters. (EndDate itself
+  // stays a plain `remove`: its KNOWN_DEFAULTS pin is the literal read-echo string
+  // "null", not a writable value.)
+  'AWS::EC2::CapacityReservation\0InstanceMatchCriteria',
+  'AWS::EC2::CapacityReservation\0EndDateType',
   // #1666: writeDlmLifecyclePolicy builds the Update payload from the desired model, so a
   // bare `remove` of the default-policy shorthand RetainInterval never reaches the call —
   // UpdateLifecyclePolicy keeps the live value (silent no-op, live-proven: an out-of-band

--- a/tests/capacityreservation-firstrun-fp.test.ts
+++ b/tests/capacityreservation-firstrun-fp.test.ts
@@ -1,0 +1,109 @@
+// Hunt 2026-07-21 (zerocorpus-hunt, CdkrdHunt0721Zc): a barest AWS::EC2::CapacityReservation
+// (only AZ/count/platform/type declared) first-ran SIX [Potential Drift] FPs. Fixes, per the
+// fold decision order:
+//   - Tenancy "default" / EndDateType "unlimited" / InstanceMatchCriteria "open" and the
+//     literal STRING "null" the handler echoes for the absent EndDate -> KNOWN_DEFAULTS
+//     (equality-gated constants; an out-of-band `modify-capacity-reservation` still surfaces).
+//   - AvailabilityZoneId ("use1-az1") -> value-independent: the per-ACCOUNT zone-id mapping of
+//     the declared AZ, an AWS-assigned identifier (createOnly; a user who cares declares
+//     AvailabilityZoneId instead, compared in the declared loop).
+//   - TagSpecifications -> the handler echoes the create-time INPUT wrapper containing the
+//     CFN-propagated STACK tags; subtractPropagatedStackTags now subtracts them inside the
+//     wrapper (dropping emptied specs / the emptied wrapper), keeping any non-stack tag.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+const declared = {
+  AvailabilityZone: 'us-east-1a',
+  InstanceCount: 1,
+  InstancePlatform: 'Linux/UNIX',
+  InstanceType: 't3.nano',
+};
+const mk = (): DesiredResource => ({
+  logicalId: 'Cr',
+  resourceType: 'AWS::EC2::CapacityReservation',
+  physicalId: 'cr-04de13f4a4e83d35e',
+  declared,
+});
+const stackTags = { 'cdkrd:ephemeral': '1' };
+// The live model as harvested on the fresh reservation (identifier/read-only members
+// trimmed to the classification-relevant surface).
+const liveModel = {
+  ...declared,
+  Tenancy: 'default',
+  EndDateType: 'unlimited',
+  EndDate: 'null',
+  InstanceMatchCriteria: 'open',
+  AvailabilityZoneId: 'use1-az1',
+  TagSpecifications: [
+    {
+      ResourceType: 'capacity-reservation',
+      Tags: [{ Key: 'cdkrd:ephemeral', Value: '1' }],
+    },
+  ],
+  EbsOptimized: false,
+  EphemeralStorage: false,
+};
+
+describe('AWS::EC2::CapacityReservation first-run folds (hunt 2026-07-21)', () => {
+  it('a barest reservation shows ZERO first-run potential drift', () => {
+    const f = classifyResource(mk(), structuredClone(liveModel), emptySchema, { stackTags });
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+    expect(pathsByTier(f, 'atDefault')).toContain('Tenancy');
+    expect(pathsByTier(f, 'atDefault')).toContain('EndDateType');
+    expect(pathsByTier(f, 'atDefault')).toContain('InstanceMatchCriteria');
+  });
+
+  it('an out-of-band instance-match-criteria change still surfaces (equality gate)', () => {
+    const f = classifyResource(
+      mk(),
+      { ...structuredClone(liveModel), InstanceMatchCriteria: 'targeted' },
+      emptySchema,
+      { stackTags }
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('InstanceMatchCriteria');
+  });
+
+  it('an out-of-band end date still surfaces (EndDate pin folds only the "null" echo)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...structuredClone(liveModel),
+        EndDateType: 'limited',
+        EndDate: '2027-01-01T00:00:00Z',
+      },
+      emptySchema,
+      { stackTags }
+    );
+    const undeclared = pathsByTier(f, 'undeclared');
+    expect(undeclared).toContain('EndDateType');
+    expect(undeclared).toContain('EndDate');
+  });
+
+  it('a NON-stack tag inside the TagSpecifications echo still surfaces', () => {
+    const live = structuredClone(liveModel);
+    (live.TagSpecifications[0] as { Tags: { Key: string; Value: string }[] }).Tags.push({
+      Key: 'rogue',
+      Value: 'evil',
+    });
+    const f = classifyResource(mk(), live, emptySchema, { stackTags });
+    expect(pathsByTier(f, 'undeclared')).toContain('TagSpecifications');
+  });
+});

--- a/tests/classify-elbv2-variants-1546.test.ts
+++ b/tests/classify-elbv2-variants-1546.test.ts
@@ -383,3 +383,82 @@ describe('#1664 UDP/TCP_UDP deregistration connection-termination default', () =
     ]);
   });
 });
+
+// UDP/ip cross-axis (hunt 2026-07-21, echo4-hunt): client IP preservation is FORCED ON
+// for the UDP family (AWS forbids disabling it), but the BY_TARGET_TYPE ip row's
+// 'false' (a TCP/TLS-only default, #1626) was merged AFTER the protocol overrides and
+// won — so a barest UDP/ip (and TCP_UDP/ip) group first-ran a
+// preserve_client_ip.enabled="true" FP. The merge now spreads target-type first and
+// protocol LAST, and the UDP/TCP_UDP rows pin the forced 'true'.
+describe('UDP-family ip-target preserve_client_ip (protocol-forced beats target-type default)', () => {
+  const mk = (protocol: string, targetType?: string): DesiredResource => ({
+    logicalId: `Hunt${protocol}IpTg`,
+    resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+    physicalId: `arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/${protocol}/abc`,
+    declared: {
+      Protocol: protocol,
+      Port: 53,
+      VpcId: 'vpc-0123456789abcdef0',
+      ...(targetType ? { TargetType: targetType } : {}),
+      HealthCheckProtocol: 'TCP',
+    },
+  });
+  // connection-termination default is 'true' for the UDP family but 'false' for TCP (#1664).
+  const bag = (preserve: string, connTerm = 'true') =>
+    attrs({
+      'stickiness.type': 'source_ip',
+      'deregistration_delay.connection_termination.enabled': connTerm,
+      'proxy_protocol_v2.enabled': 'false',
+      'target_health_state.unhealthy.connection_termination.enabled': 'true',
+      'target_health_state.unhealthy.draining_interval_seconds': '0',
+      'preserve_client_ip.enabled': preserve,
+    });
+
+  it('folds the forced "true" on a barest UDP/ip group (ZERO first-run drift)', () => {
+    const r = mk('UDP', 'ip');
+    const f = classifyResource(
+      r,
+      { ...r.declared, TargetGroupAttributes: bag('true') },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('folds the forced "true" on a barest TCP_UDP/ip group too', () => {
+    const r = mk('TCP_UDP', 'ip');
+    const f = classifyResource(
+      r,
+      { ...r.declared, TargetGroupAttributes: bag('true') },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a TCP/ip group keeps the ip row "false" default — "true" there still surfaces (#1626 unchanged)', () => {
+    const r = mk('TCP', 'ip');
+    const clean = classifyResource(
+      r,
+      { ...r.declared, TargetGroupAttributes: bag('false', 'false') },
+      emptySchema
+    );
+    expect(pathsByTier(clean, 'undeclared')).toEqual([]);
+    const drifted = classifyResource(
+      r,
+      { ...r.declared, TargetGroupAttributes: bag('true', 'false') },
+      emptySchema
+    );
+    expect(pathsByTier(drifted, 'undeclared')).toEqual([
+      'TargetGroupAttributes[preserve_client_ip.enabled]',
+    ]);
+  });
+
+  it('a UDP/instance group still folds "true" (protocol row and instance row agree)', () => {
+    const r = mk('UDP');
+    const f = classifyResource(
+      r,
+      { ...r.declared, TargetType: 'instance', TargetGroupAttributes: bag('true') },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});

--- a/tests/corpus/AWS__Budgets__Budget.BudgetAad.json
+++ b/tests/corpus/AWS__Budgets__Budget.BudgetAad.json
@@ -1,0 +1,91 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BudgetAad",
+    "resourceType": "AWS::Budgets::Budget",
+    "physicalId": "cdkrd-hunt0721-aad",
+    "constructPath": "CdkrdHunt0721Echo4/BudgetAad",
+    "declared": {
+      "Budget": {
+        "AutoAdjustData": {
+          "AutoAdjustType": "HISTORICAL",
+          "HistoricalOptions": {
+            "BudgetAdjustmentPeriod": 6
+          }
+        },
+        "BudgetName": "cdkrd-hunt0721-aad",
+        "BudgetType": "COST",
+        "TimeUnit": "MONTHLY"
+      }
+    }
+  },
+  "liveRaw": {
+    "Budget": {
+      "BudgetName": "cdkrd-hunt0721-aad",
+      "BudgetType": "COST",
+      "TimeUnit": "MONTHLY",
+      "CostTypes": {
+        "IncludeTax": true,
+        "IncludeSubscription": true,
+        "UseBlended": false,
+        "IncludeRefund": true,
+        "IncludeCredit": true,
+        "IncludeUpfront": true,
+        "IncludeRecurring": true,
+        "IncludeOtherSubscription": true,
+        "IncludeSupport": true,
+        "IncludeDiscount": true,
+        "UseAmortized": false
+      },
+      "AutoAdjustData": {
+        "AutoAdjustType": "HISTORICAL",
+        "HistoricalOptions": {
+          "BudgetAdjustmentPeriod": 6
+        }
+      }
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["NotificationsWithSubscribers"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["NotificationsWithSubscribers"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "BudgetAad",
+      "resourceType": "AWS::Budgets::Budget",
+      "path": "Budget.CostTypes",
+      "actual": {
+        "IncludeTax": true,
+        "IncludeSubscription": true,
+        "UseBlended": false,
+        "IncludeRefund": true,
+        "IncludeCredit": true,
+        "IncludeUpfront": true,
+        "IncludeRecurring": true,
+        "IncludeOtherSubscription": true,
+        "IncludeSupport": true,
+        "IncludeDiscount": true,
+        "UseAmortized": false
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0721-aad",
+      "constructPath": "CdkrdHunt0721Echo4/BudgetAad"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__CapacityReservation.Cr.json
+++ b/tests/corpus/AWS__EC2__CapacityReservation.Cr.json
@@ -1,0 +1,179 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cr",
+    "resourceType": "AWS::EC2::CapacityReservation",
+    "physicalId": "cr-014fdc895b8abeedc",
+    "constructPath": "CdkrdHunt0721Zc/Cr",
+    "declared": {
+      "AvailabilityZone": "us-east-1a",
+      "InstanceCount": 1,
+      "InstancePlatform": "Linux/UNIX",
+      "InstanceType": "t3.nano"
+    }
+  },
+  "liveRaw": {
+    "Tenancy": "default",
+    "EndDateType": "unlimited",
+    "TagSpecifications": [
+      {
+        "ResourceType": "capacity-reservation",
+        "Tags": [
+          {
+            "Value": "CdkrdHunt0721Zc",
+            "Key": "aws:cloudformation:stack-name"
+          },
+          {
+            "Value": "Cr",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0721Zc/766a3cb0-8514-11f1-8015-0affe8e65b2b",
+            "Key": "aws:cloudformation:stack-id"
+          },
+          {
+            "Value": "1",
+            "Key": "cdkrd:ephemeral"
+          }
+        ]
+      }
+    ],
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "TotalInstanceCount": 1,
+    "EndDate": "null",
+    "CreateDate": "2026-07-21T14:57:27Z",
+    "EbsOptimized": false,
+    "StartDate": "2026-07-21T14:57:27Z",
+    "InstanceCount": 1,
+    "CapacityReservationArn": "arn:aws:ec2:us-east-1:111111111111:capacity-reservation/cr-014fdc895b8abeedc",
+    "OwnerId": "111111111111",
+    "State": "active",
+    "AvailableInstanceCount": 1,
+    "InstancePlatform": "Linux/UNIX",
+    "Id": "cr-014fdc895b8abeedc",
+    "CapacityAllocationSet": [],
+    "InstanceType": "t3.nano",
+    "EphemeralStorage": false,
+    "InstanceMatchCriteria": "open"
+  },
+  "schema": {
+    "readOnly": [
+      "AvailableInstanceCount",
+      "CapacityAllocationSet",
+      "CapacityReservationArn",
+      "CapacityReservationFleetId",
+      "CommitmentInfo",
+      "CreateDate",
+      "DeliveryPreference",
+      "Id",
+      "OwnerId",
+      "ReservationType",
+      "StartDate",
+      "State",
+      "TotalInstanceCount"
+    ],
+    "writeOnly": ["UnusedReservationBillingOwnerId"],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "EbsOptimized",
+      "EphemeralStorage",
+      "InstancePlatform",
+      "InstanceType",
+      "OutPostArn",
+      "PlacementGroupArn",
+      "TagSpecifications",
+      "Tenancy"
+    ],
+    "readOnlyPaths": [
+      "AvailableInstanceCount",
+      "CapacityAllocationSet",
+      "CapacityReservationArn",
+      "CapacityReservationFleetId",
+      "CommitmentInfo",
+      "CreateDate",
+      "DeliveryPreference",
+      "Id",
+      "OwnerId",
+      "ReservationType",
+      "StartDate",
+      "State",
+      "TotalInstanceCount"
+    ],
+    "writeOnlyPaths": ["UnusedReservationBillingOwnerId"],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "EbsOptimized",
+      "EphemeralStorage",
+      "InstancePlatform",
+      "InstanceType",
+      "OutPostArn",
+      "PlacementGroupArn",
+      "TagSpecifications",
+      "Tenancy"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["CapacityAllocationSet", "TagSpecifications"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Cr",
+      "resourceType": "AWS::EC2::CapacityReservation",
+      "path": "Tenancy",
+      "actual": "default",
+      "physicalId": "cr-014fdc895b8abeedc",
+      "constructPath": "CdkrdHunt0721Zc/Cr"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cr",
+      "resourceType": "AWS::EC2::CapacityReservation",
+      "path": "EndDateType",
+      "actual": "unlimited",
+      "physicalId": "cr-014fdc895b8abeedc",
+      "constructPath": "CdkrdHunt0721Zc/Cr"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cr",
+      "resourceType": "AWS::EC2::CapacityReservation",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "cr-014fdc895b8abeedc",
+      "constructPath": "CdkrdHunt0721Zc/Cr"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cr",
+      "resourceType": "AWS::EC2::CapacityReservation",
+      "path": "EndDate",
+      "actual": "null",
+      "physicalId": "cr-014fdc895b8abeedc",
+      "constructPath": "CdkrdHunt0721Zc/Cr"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cr",
+      "resourceType": "AWS::EC2::CapacityReservation",
+      "path": "InstanceMatchCriteria",
+      "actual": "open",
+      "physicalId": "cr-014fdc895b8abeedc",
+      "constructPath": "CdkrdHunt0721Zc/Cr"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__NetworkInsightsPath.NiPath.json
+++ b/tests/corpus/AWS__EC2__NetworkInsightsPath.NiPath.json
@@ -1,0 +1,98 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NiPath",
+    "resourceType": "AWS::EC2::NetworkInsightsPath",
+    "physicalId": "nip-096dc07024d12e049",
+    "constructPath": "CdkrdHunt0721Zc/NiPath",
+    "declared": {
+      "Destination": "eni-0e8d58891d972f68f",
+      "Protocol": "tcp",
+      "Source": "eni-0c25b2612d35c6bfe",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Destination": "eni-0e8d58891d972f68f",
+    "SourceArn": "arn:aws:ec2:us-east-1:111111111111:network-interface/eni-0c25b2612d35c6bfe",
+    "NetworkInsightsPathId": "nip-096dc07024d12e049",
+    "CreatedDate": "2026-07-21T14:57:58.870Z",
+    "NetworkInsightsPathArn": "arn:aws:ec2:us-east-1:111111111111:network-insights-path/nip-096dc07024d12e049",
+    "Protocol": "tcp",
+    "Source": "eni-0c25b2612d35c6bfe",
+    "DestinationArn": "arn:aws:ec2:us-east-1:111111111111:network-interface/eni-0e8d58891d972f68f",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0721Zc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "NiPath",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0721Zc/766a3cb0-8514-11f1-8015-0affe8e65b2b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CreatedDate",
+      "DestinationArn",
+      "NetworkInsightsPathArn",
+      "NetworkInsightsPathId",
+      "SourceArn"
+    ],
+    "writeOnly": [],
+    "createOnly": [
+      "Destination",
+      "DestinationIp",
+      "DestinationPort",
+      "FilterAtDestination",
+      "FilterAtSource",
+      "Protocol",
+      "Source",
+      "SourceIp"
+    ],
+    "readOnlyPaths": [
+      "CreatedDate",
+      "DestinationArn",
+      "NetworkInsightsPathArn",
+      "NetworkInsightsPathId",
+      "SourceArn"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "Destination",
+      "DestinationIp",
+      "DestinationPort",
+      "FilterAtDestination",
+      "FilterAtSource",
+      "Protocol",
+      "Source",
+      "SourceIp"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgTcpUdp.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgTcpUdp.json
@@ -1,0 +1,350 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TgTcpUdp",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+    "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp",
+    "declared": {
+      "HealthCheckIntervalSeconds": 30,
+      "HealthCheckProtocol": "TCP",
+      "Port": 53,
+      "Protocol": "TCP_UDP",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TargetType": "ip",
+      "VpcId": "vpc-0ded0cb21f1bf4520"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Port": 53,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 10,
+    "Name": "CdkrdH-TgTcp-BU0HDLW7QEE1",
+    "VpcId": "vpc-0ded0cb21f1bf4520",
+    "TargetGroupFullName": "targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "source_ip",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "deregistration_delay.connection_termination.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "target_health_state.unhealthy.draining_interval_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "true",
+        "Key": "preserve_client_ip.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "proxy_protocol_v2.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "target_health_state.unhealthy.connection_termination.enabled"
+      }
+    ],
+    "TargetType": "ip",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "TCP_UDP",
+    "TargetGroupName": "CdkrdH-TgTcp-BU0HDLW7QEE1",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0721Echo4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TgTcpUdp",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0721Echo4/094892e0-8513-11f1-9e25-0affcef7b981",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-TgTcp-BU0HDLW7QEE1",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[preserve_client_ip.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[proxy_protocol_v2.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.draining_interval_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgTcpUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgTcp-BU0HDLW7QEE1/8251c340df6c3d75",
+      "constructPath": "CdkrdHunt0721Echo4/TgTcpUdp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgUdp.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgUdp.json
@@ -1,0 +1,350 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TgUdp",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+    "constructPath": "CdkrdHunt0721Echo4/TgUdp",
+    "declared": {
+      "HealthCheckIntervalSeconds": 30,
+      "HealthCheckProtocol": "TCP",
+      "Port": 53,
+      "Protocol": "UDP",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TargetType": "ip",
+      "VpcId": "vpc-0ded0cb21f1bf4520"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Port": 53,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 10,
+    "Name": "CdkrdH-TgUdp-N88YR5FIFFJM",
+    "VpcId": "vpc-0ded0cb21f1bf4520",
+    "TargetGroupFullName": "targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "source_ip",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "deregistration_delay.connection_termination.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "target_health_state.unhealthy.draining_interval_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "true",
+        "Key": "preserve_client_ip.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "proxy_protocol_v2.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "target_health_state.unhealthy.connection_termination.enabled"
+      }
+    ],
+    "TargetType": "ip",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "UDP",
+    "TargetGroupName": "CdkrdH-TgUdp-N88YR5FIFFJM",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0721Echo4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TgUdp",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0721Echo4/094892e0-8513-11f1-9e25-0affcef7b981",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-TgUdp-N88YR5FIFFJM",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[preserve_client_ip.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[proxy_protocol_v2.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.draining_interval_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgUdp",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TgUdp-N88YR5FIFFJM/d7a7f2cc66b20a4a",
+      "constructPath": "CdkrdHunt0721Echo4/TgUdp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53Profiles__Profile.Profile.json
+++ b/tests/corpus/AWS__Route53Profiles__Profile.Profile.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Profile",
+    "resourceType": "AWS::Route53Profiles::Profile",
+    "physicalId": "rp-7c80988957664377",
+    "constructPath": "CdkrdHunt0721Zc/Profile",
+    "declared": {
+      "Name": "cdkrd-hunt0721-profile",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ShareStatus": "NOT_SHARED",
+    "Id": "rp-7c80988957664377",
+    "ClientToken": "89c08943-f4a0-37cf-b360-513641b7837c",
+    "Arn": "arn:aws:route53profiles:us-east-1:111111111111:profile/rp-7c80988957664377",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0721Zc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Profile",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0721Zc/766a3cb0-8514-11f1-8015-0affe8e65b2b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0721-profile"
+  },
+  "schema": {
+    "readOnly": ["Arn", "ClientToken", "Id", "ShareStatus"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "ClientToken", "Id", "ShareStatus"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53Profiles__ProfileAssociation.ProfileAssoc.json
+++ b/tests/corpus/AWS__Route53Profiles__ProfileAssociation.ProfileAssoc.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ProfileAssoc",
+    "resourceType": "AWS::Route53Profiles::ProfileAssociation",
+    "physicalId": "rpassoc-b2fa64b43a9140bf",
+    "constructPath": "CdkrdHunt0721Zc/ProfileAssoc",
+    "declared": {
+      "Name": "cdkrd-hunt0721-assoc",
+      "ProfileId": "rp-7c80988957664377",
+      "ResourceId": "vpc-0b753fe61f403d35d",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ProfileId": "rp-7c80988957664377",
+    "ResourceId": "vpc-0b753fe61f403d35d",
+    "Id": "rpassoc-b2fa64b43a9140bf",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0721Zc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "ProfileAssoc",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0721Zc/766a3cb0-8514-11f1-8015-0affe8e65b2b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0721-assoc"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["Arn"],
+    "createOnly": ["Name", "ProfileId", "ResourceId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["Arn"],
+    "createOnlyPaths": ["Name", "ProfileId", "ResourceId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/echo4-hunt/app.ts
+++ b/tests/integration/echo4-hunt/app.ts
@@ -1,0 +1,167 @@
+// Post-update echo probe (second deploy) over the post-2026-07-14 fold types that
+// never had a rev=2 update probe: UDP/TCP_UDP TargetGroups (#1664), DLM
+// LifecyclePolicy (#1663..#1669), Lambda Alias provisioned concurrency
+// (lambda-pc-hunt), Route 53 latency/failover records + HealthCheck
+// (route53-policy-hunt), and Budgets Budget fixed + auto-adjusting (#1678/#1679 —
+// a CFn UPDATE drives UpdateBudget, a fresh post-write echo surface for the new
+// writer/reader pair). Deploy -> first check CLEAN -> record -> redeploy -c rev=2
+// (real per-resource updates, not tag-only) -> re-check MUST stay CLEAN.
+import { App, Duration, Stack, Tags } from "aws-cdk-lib";
+import { CfnBudget } from "aws-cdk-lib/aws-budgets";
+import { CfnLifecyclePolicy } from "aws-cdk-lib/aws-dlm";
+import { CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnTargetGroup } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as route53 from "aws-cdk-lib/aws-route53";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = Number(app.node.tryGetContext("rev") ?? 1);
+if (rev > 1) Tags.of(app).add("cdkrd:rev", String(rev));
+
+const s = new Stack(app, "CdkrdHunt0721Echo4");
+
+// ---- UDP-family TargetGroups (#1664 rows) — a real update via the health-check
+// interval, which is mutable on NLB-family groups.
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.71.0.0/16" });
+new CfnTargetGroup(s, "TgUdp", {
+  protocol: "UDP",
+  port: 53,
+  vpcId: vpc.ref,
+  targetType: "ip",
+  healthCheckProtocol: "TCP",
+  healthCheckIntervalSeconds: rev > 1 ? 35 : 30,
+});
+new CfnTargetGroup(s, "TgTcpUdp", {
+  protocol: "TCP_UDP",
+  port: 53,
+  vpcId: vpc.ref,
+  targetType: "ip",
+  healthCheckProtocol: "TCP",
+  healthCheckIntervalSeconds: rev > 1 ? 35 : 30,
+});
+
+// ---- DLM custom policy (#1663..#1669 fold family) — Description update.
+const dlmRole = new Role(s, "DlmRole", {
+  assumedBy: new ServicePrincipal("dlm.amazonaws.com"),
+  managedPolicies: [
+    ManagedPolicy.fromAwsManagedPolicyName(
+      "service-role/AWSDataLifecycleManagerServiceRole",
+    ),
+  ],
+});
+new CfnLifecyclePolicy(s, "DlmPolicy", {
+  description: `cdkrd hunt 0721 echo probe rev${rev}`,
+  executionRoleArn: dlmRole.roleArn,
+  state: "ENABLED",
+  policyDetails: {
+    policyType: "EBS_SNAPSHOT_MANAGEMENT",
+    resourceTypes: ["VOLUME"],
+    targetTags: [{ key: "cdkrd-hunt", value: "0721" }],
+    schedules: [
+      {
+        name: "cdkrd-hunt-daily",
+        createRule: { interval: 12, intervalUnit: "HOURS" },
+        retainRule: { count: 1 },
+      },
+    ],
+  },
+});
+
+// ---- Lambda Alias with provisioned concurrency (lambda-pc-hunt types) — the
+// function Description change mints a new Version, repointing the alias and
+// re-provisioning PC: the full alias-update path.
+const fn = new lambda.Function(s, "Fn", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline('exports.handler = async () => "ok";'),
+  memorySize: 128,
+  timeout: Duration.seconds(3),
+  description: `cdkrd hunt 0721 rev${rev}`,
+});
+new lambda.Alias(s, "LiveAlias", {
+  aliasName: "live",
+  version: fn.currentVersion,
+  provisionedConcurrentExecutions: 1,
+});
+
+// ---- Route 53 latency + failover records (route53-policy-hunt types) — TTL and
+// failure-threshold updates. Placeholder domain (example.com/.test are AWS-reserved).
+const zone = new route53.PublicHostedZone(s, "Zone", {
+  zoneName: "cdkrd-hunt0721-e4x.com",
+});
+const ttl = rev > 1 ? "61" : "60";
+new route53.CfnRecordSet(s, "LatUse1", {
+  hostedZoneId: zone.hostedZoneId,
+  name: "lat.cdkrd-hunt0721-e4x.com.",
+  type: "A",
+  ttl,
+  resourceRecords: ["192.0.2.1"],
+  setIdentifier: "use1",
+  region: "us-east-1",
+});
+new route53.CfnRecordSet(s, "LatEuw1", {
+  hostedZoneId: zone.hostedZoneId,
+  name: "lat.cdkrd-hunt0721-e4x.com.",
+  type: "A",
+  ttl,
+  resourceRecords: ["192.0.2.2"],
+  setIdentifier: "euw1",
+  region: "eu-west-1",
+});
+// Health-check target must be a resolvable FQDN (Route 53 rejects TEST-NET IPs).
+const health = new route53.CfnHealthCheck(s, "PrimaryHealth", {
+  healthCheckConfig: {
+    type: "HTTP",
+    fullyQualifiedDomainName: "example.com",
+    port: 80,
+    resourcePath: "/",
+    requestInterval: 30,
+    failureThreshold: rev > 1 ? 4 : 3,
+  },
+});
+new route53.CfnRecordSet(s, "FailPrimary", {
+  hostedZoneId: zone.hostedZoneId,
+  name: "fo.cdkrd-hunt0721-e4x.com.",
+  type: "A",
+  ttl,
+  resourceRecords: ["192.0.2.20"],
+  setIdentifier: "primary",
+  failover: "PRIMARY",
+  healthCheckId: health.attrHealthCheckId,
+});
+new route53.CfnRecordSet(s, "FailSecondary", {
+  hostedZoneId: zone.hostedZoneId,
+  name: "fo.cdkrd-hunt0721-e4x.com.",
+  type: "A",
+  ttl,
+  resourceRecords: ["192.0.2.21"],
+  setIdentifier: "secondary",
+  failover: "SECONDARY",
+});
+
+// ---- Budgets: fixed-limit (amount update) + auto-adjusting (lookback update) —
+// each CFn update drives UpdateBudget, probing the post-write echo of the new
+// #1678 writer / #1679 reader surface.
+new CfnBudget(s, "BudgetFixed", {
+  budget: {
+    budgetName: "cdkrd-hunt0721-fixed",
+    budgetType: "COST",
+    timeUnit: "MONTHLY",
+    budgetLimit: { amount: rev > 1 ? 6 : 5, unit: "USD" },
+  },
+});
+new CfnBudget(s, "BudgetAad", {
+  budget: {
+    budgetName: "cdkrd-hunt0721-aad",
+    budgetType: "COST",
+    timeUnit: "MONTHLY",
+    autoAdjustData: {
+      autoAdjustType: "HISTORICAL",
+      historicalOptions: { budgetAdjustmentPeriod: rev > 1 ? 7 : 6 },
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/echo4-hunt/cdk.json
+++ b/tests/integration/echo4-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/echo4-hunt/package.json
+++ b/tests/integration/echo4-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-echo4-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-21 probe fixture (echo4-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/echo4-hunt/verify.sh
+++ b/tests/integration/echo4-hunt/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Post-update echo probe over post-2026-07-14 fold types (UDP TGs, DLM, Lambda PC
+# alias, Route 53 policy records, Budgets fixed + auto-adjusting): deploy, assert
+# the FIRST check (before record) is CLEAN, record, then redeploy with -c rev=2
+# (real per-resource updates) and assert the re-check stays CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0721Echo4
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (echo4-hunt): $*"; exit 1; }
+
+echo "=== deploy ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+echo "=== FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-echo4}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+# `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+[ "$RC" -eq 0 ] || fail "first check not clean (rc=$RC)"
+
+echo "=== record + check --fail ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "=== redeploy with -c rev=2 (post-update echo probe) ==="
+npx cdk deploy -f --all --require-approval never -c rev=2 || fail "redeploy rev=2"
+
+echo "=== post-update check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.rev2.out"
+RC=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.rev2.out" && RC=10
+[ "$RC" -eq 0 ] || fail "post-update check not clean (rc=$RC)"
+
+echo "INTEG OK (echo4-hunt)"

--- a/tests/integration/langext-hunt/template.json
+++ b/tests/integration/langext-hunt/template.json
@@ -1,0 +1,28 @@
+{
+  "Transform": "AWS::LanguageExtensions",
+  "Resources": {
+    "Fn::ForEach::LogGroups": [
+      "Name",
+      ["Alpha", "Beta", "Gamma"],
+      {
+        "Lg${Name}": {
+          "Type": "AWS::Logs::LogGroup",
+          "Properties": {
+            "LogGroupName": { "Fn::Sub": "cdkrd-hunt0721-langext-${Name}" },
+            "RetentionInDays": 7,
+            "Tags": [{ "Key": "cdkrd:ephemeral", "Value": "1" }]
+          }
+        }
+      }
+    ],
+    "JsonParam": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Name": "cdkrd-hunt0721-langext-json",
+        "Type": "String",
+        "Value": { "Fn::ToJsonString": { "alpha": 1, "beta": ["a", "b"] } },
+        "Tags": { "cdkrd:ephemeral": "1" }
+      }
+    }
+  }
+}

--- a/tests/integration/langext-hunt/template.yaml
+++ b/tests/integration/langext-hunt/template.yaml
@@ -1,0 +1,28 @@
+# Raw-CFn LanguageExtensions probe — the first LIVE exercise of the #904
+# Processed-template path (a Transform-bearing local template must be checked
+# against the DEPLOYED Processed template, where Fn::ForEach has been expanded
+# and Fn::ToJsonString collapsed to a literal).
+Transform: AWS::LanguageExtensions
+Resources:
+  'Fn::ForEach::LogGroups':
+    - Name
+    - [Alpha, Beta, Gamma]
+    - 'Lg${Name}':
+        Type: AWS::Logs::LogGroup
+        Properties:
+          LogGroupName: !Sub 'cdkrd-hunt0721-langext-${Name}'
+          RetentionInDays: 7
+          Tags:
+            - Key: 'cdkrd:ephemeral'
+              Value: '1'
+  JsonParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: cdkrd-hunt0721-langext-json
+      Type: String
+      Value:
+        Fn::ToJsonString:
+          alpha: 1
+          beta: [a, b]
+      Tags:
+        'cdkrd:ephemeral': '1'

--- a/tests/integration/langext-hunt/verify.sh
+++ b/tests/integration/langext-hunt/verify.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# LanguageExtensions live probe: deploy the raw-CFn template (Transform:
+# AWS::LanguageExtensions with Fn::ForEach + Fn::ToJsonString), hand-build a
+# minimal cdk.out pointing at the ORIGINAL (unexpanded) template, and assert
+# cdkrd's #904 Processed-template fallback makes the first check CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0721LangExt
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack -s "$STACK" -r "$REGION" -y -f >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (langext-hunt): $*"; exit 1; }
+
+echo "=== deploy (raw CloudFormation) ==="
+aws cloudformation deploy --region "$REGION" --stack-name "$STACK" \
+  --template-file template.yaml || fail "deploy"
+
+echo "=== hand-build cdk.out (template.json is the committed JSON twin of template.yaml) ==="
+rm -rf cdk.out && mkdir -p cdk.out
+cp template.json cdk.out/template.json || fail "template to json"
+cat > cdk.out/manifest.json <<EOF
+{
+  "version": "36.0.0",
+  "artifacts": {
+    "$STACK": {
+      "type": "aws:cloudformation:stack",
+      "environment": "aws://unknown-account/$REGION",
+      "properties": { "templateFile": "template.json", "stackName": "$STACK" }
+    }
+  }
+}
+EOF
+
+echo "=== FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-langext}" $CLI check "$STACK" --app cdk.out --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+[ "$RC" -eq 0 ] || fail "first check not clean (rc=$RC)"
+
+echo "=== record + check --fail ==="
+$CLI record "$STACK" --app cdk.out --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --app cdk.out --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "INTEG OK (langext-hunt)"

--- a/tests/integration/region-hunt/app.ts
+++ b/tests/integration/region-hunt/app.ts
@@ -1,0 +1,105 @@
+// Non-default-region first-run FP probe: every prior hunt ran in us-east-1, so a
+// KNOWN_DEFAULTS constant that AWS actually varies by region (AZ set, rollout
+// stage, per-region attribute families) has never been exercised. Deploy a barest
+// pack of the types with the LARGEST constant/bag fold surfaces in ap-northeast-1
+// and assert the first check is CLEAN; any [Potential Drift] is a region-sensitive
+// default baked as a global constant. Also the FN+revert leg proves detection and
+// revert plumbing in a non-default region.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnWorkGroup } from "aws-cdk-lib/aws-athena";
+import { CfnTable } from "aws-cdk-lib/aws-dynamodb";
+import { CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnRepository } from "aws-cdk-lib/aws-ecr";
+import { CfnFileSystem } from "aws-cdk-lib/aws-efs";
+import {
+  CfnLoadBalancer,
+  CfnTargetGroup,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { CfnRule } from "aws-cdk-lib/aws-events";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnStream } from "aws-cdk-lib/aws-kinesis";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+const s = new Stack(app, "CdkrdHunt0721Apne1", {
+  env: { region: "ap-northeast-1" },
+});
+
+// ---- network: internal ALB + NLB + both TG attribute families (the biggest
+// per-region attribute-bag surfaces).
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.72.0.0/16" });
+const subA = new CfnSubnet(s, "SubA", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.72.0.0/20",
+  availabilityZone: "ap-northeast-1a",
+});
+const subC = new CfnSubnet(s, "SubC", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.72.16.0/20",
+  availabilityZone: "ap-northeast-1c",
+});
+new CfnLoadBalancer(s, "Alb", {
+  scheme: "internal",
+  subnets: [subA.ref, subC.ref],
+});
+new CfnLoadBalancer(s, "Nlb", {
+  scheme: "internal",
+  type: "network",
+  subnets: [subA.ref],
+});
+new CfnTargetGroup(s, "TgHttp", {
+  protocol: "HTTP",
+  port: 80,
+  vpcId: vpc.ref,
+});
+new CfnTargetGroup(s, "TgTcp", {
+  protocol: "TCP",
+  port: 80,
+  vpcId: vpc.ref,
+  targetType: "ip",
+});
+
+// ---- barest compute/data/messaging types with wide KNOWN_DEFAULTS surfaces.
+const role = new CfnRole(s, "FnRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  managedPolicyArns: [
+    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+  ],
+});
+new CfnFunction(s, "Fn", {
+  code: { zipFile: 'exports.handler = async () => "ok";' },
+  handler: "index.handler",
+  runtime: "nodejs20.x",
+  role: role.attrArn,
+});
+new CfnTable(s, "Table", {
+  keySchema: [{ attributeName: "pk", keyType: "HASH" }],
+  attributeDefinitions: [{ attributeName: "pk", attributeType: "S" }],
+  provisionedThroughput: { readCapacityUnits: 1, writeCapacityUnits: 1 },
+});
+new CfnStream(s, "Stream", { shardCount: 1 });
+new CfnQueue(s, "Queue", {});
+new CfnTopic(s, "Topic", {});
+new CfnBucket(s, "Bucket", {});
+new CfnLogGroup(s, "Logs", {});
+new CfnRepository(s, "Repo", {});
+new CfnRule(s, "Rule", { scheduleExpression: "rate(1 day)" });
+new CfnWorkGroup(s, "Wg", { name: "cdkrd-hunt0721-wg" });
+new CfnFileSystem(s, "Efs", {});
+
+app.synth();

--- a/tests/integration/region-hunt/cdk.json
+++ b/tests/integration/region-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/region-hunt/package.json
+++ b/tests/integration/region-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-region-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-21 probe fixture (region-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/region-hunt/verify.sh
+++ b/tests/integration/region-hunt/verify.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Non-default-region probe (ap-northeast-1): barest pack of wide-fold-surface
+# types. First check MUST be CLEAN (any FP = region-sensitive default baked as a
+# constant). Then the FN+revert leg in the same region: record, mutate the queue's
+# undeclared VisibilityTimeout out of band, assert check --fail DETECTS (exit 1),
+# revert, assert the live value is restored and check is CLEAN again.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0721Apne1
+REGION="ap-northeast-1"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (region-hunt): $*"; exit 1; }
+
+echo "=== deploy (ap-northeast-1) ==="
+AWS_REGION="$REGION" npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+echo "=== FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-region}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+[ "$RC" -eq 0 ] || fail "first check not clean (rc=$RC)"
+
+echo "=== record + check --fail ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "=== FN leg: OOB VisibilityTimeout mutate must be DETECTED ==="
+QURL=$(aws sqs list-queues --region "$REGION" --queue-name-prefix "$STACK" \
+  --query 'QueueUrls[0]' --output text)
+[ -n "$QURL" ] && [ "$QURL" != "None" ] || fail "queue url not found"
+aws sqs set-queue-attributes --region "$REGION" --queue-url "$QURL" \
+  --attributes VisibilityTimeout=45 || fail "oob mutate"
+sleep 5
+$CLI check "$STACK" --region "$REGION" --fail && fail "OOB VisibilityTimeout change NOT detected (FN)"
+
+echo "=== revert must restore the default ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+VT=$(aws sqs get-queue-attributes --region "$REGION" --queue-url "$QURL" \
+  --attribute-names VisibilityTimeout --query 'Attributes.VisibilityTimeout' --output text)
+[ "$VT" = "30" ] || fail "revert did not restore VisibilityTimeout (live=$VT)"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
+
+echo "INTEG OK (region-hunt)"

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -211,6 +211,26 @@ resource_gone() {
           printf '%s' "$err" | grep -q 'InvalidVpcEndpointId.NotFound' && return 0
           return 1
           ;;
+        *:capacity-reservation/cr-*)
+          # arn:aws:ec2:<region>:<acct>:capacity-reservation/cr-<id> — a CANCELLED
+          # capacity reservation is terminal (billing stopped, nothing deletable
+          # remains) yet stays in both DescribeCapacityReservations and the tag index
+          # for a retention period (observed 2026-07-21 hunt: a CC-probe reservation
+          # cancelled minutes earlier kept the sweep RED). cancelled/expired counts as
+          # gone, as does a definitive NotFound; any other state (active, pending,
+          # payment-pending) keeps the ORPHAN RED (fail-safe).
+          id="${arn##*/}"
+          local crstate
+          if ! crstate="$(aws ec2 describe-capacity-reservations --capacity-reservation-ids "$id" --region "$REGION" \
+            --query 'CapacityReservations[0].State' --output text 2>&1)"; then
+            printf '%s' "$crstate" | grep -q 'NotFound' && return 0
+            return 1
+          fi
+          case "$(printf '%s' "$crstate" | tr -d '[:space:]')" in
+            cancelled | expired) return 0 ;;
+          esac
+          return 1
+          ;;
         *:instance/i-*)
           # arn:aws:ec2:<region>:<acct>:instance/i-<id> — the third RGT-lag subtype
           # (2026-07-11): a terminated instance stays in the tag index after EC2 has

--- a/tests/integration/zerocorpus-hunt/app.ts
+++ b/tests/integration/zerocorpus-hunt/app.ts
@@ -1,0 +1,54 @@
+// Zero-corpus cheap-tail probe: the three remaining common-ish types with no
+// corpus case at all — EC2 CapacityReservation (billed as a running t3.nano only
+// while the stack is up), Route 53 Profiles Profile + ProfileAssociation (the
+// association doubles as an attachment-shape probe on the VPC), and EC2
+// NetworkInsightsPath (free; only an ANALYSIS run costs). First check before
+// record MUST be CLEAN.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnCapacityReservation,
+  CfnNetworkInsightsPath,
+  CfnNetworkInterface,
+  CfnSubnet,
+  CfnVPC,
+} from "aws-cdk-lib/aws-ec2";
+import {
+  CfnProfile,
+  CfnProfileAssociation,
+} from "aws-cdk-lib/aws-route53profiles";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+const s = new Stack(app, "CdkrdHunt0721Zc");
+
+new CfnCapacityReservation(s, "Cr", {
+  availabilityZone: "us-east-1a",
+  instanceType: "t3.nano",
+  instancePlatform: "Linux/UNIX",
+  instanceCount: 1,
+});
+
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.73.0.0/16" });
+const sub = new CfnSubnet(s, "Sub", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.73.0.0/24",
+  availabilityZone: "us-east-1a",
+});
+
+const profile = new CfnProfile(s, "Profile", { name: "cdkrd-hunt0721-profile" });
+new CfnProfileAssociation(s, "ProfileAssoc", {
+  name: "cdkrd-hunt0721-assoc",
+  profileId: profile.attrId,
+  resourceId: vpc.ref,
+});
+
+const eniA = new CfnNetworkInterface(s, "EniA", { subnetId: sub.ref });
+const eniB = new CfnNetworkInterface(s, "EniB", { subnetId: sub.ref });
+new CfnNetworkInsightsPath(s, "NiPath", {
+  source: eniA.ref,
+  destination: eniB.ref,
+  protocol: "tcp",
+});
+
+app.synth();

--- a/tests/integration/zerocorpus-hunt/cdk.json
+++ b/tests/integration/zerocorpus-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/zerocorpus-hunt/package.json
+++ b/tests/integration/zerocorpus-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-zerocorpus-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-21 probe fixture (zerocorpus-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/zerocorpus-hunt/verify.sh
+++ b/tests/integration/zerocorpus-hunt/verify.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Zero-corpus cheap-tail probe (CapacityReservation, Route 53 Profiles +
+# association, NetworkInsightsPath): deploy, assert the FIRST check (before
+# record) is CLEAN, then record and assert check --fail stays clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0721Zc
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (zerocorpus-hunt): $*"; exit 1; }
+
+echo "=== deploy ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+echo "=== FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-zerocorpus}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+[ "$RC" -eq 0 ] || fail "first check not clean (rc=$RC)"
+
+echo "=== record + check --fail ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "=== FN leg: OOB InstanceMatchCriteria mutate must be DETECTED ==="
+CR_ID=$(aws ec2 describe-capacity-reservations --region "$REGION" \
+  --filters Name=state,Values=active "Name=tag:aws:cloudformation:stack-name,Values=$STACK" \
+  --query 'CapacityReservations[0].CapacityReservationId' --output text)
+[ -n "$CR_ID" ] && [ "$CR_ID" != "None" ] || fail "capacity reservation id not found"
+aws ec2 modify-capacity-reservation --region "$REGION" \
+  --capacity-reservation-id "$CR_ID" --instance-match-criteria targeted >/dev/null || fail "oob mutate"
+sleep 5
+$CLI check "$STACK" --region "$REGION" --fail && fail "OOB InstanceMatchCriteria change NOT detected (FN)"
+
+echo "=== revert must restore 'open' (set-default write — a bare remove silently no-ops) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+IMC=$(aws ec2 describe-capacity-reservations --region "$REGION" \
+  --capacity-reservation-ids "$CR_ID" \
+  --query 'CapacityReservations[0].InstanceMatchCriteria' --output text)
+[ "$IMC" = "open" ] || fail "revert did not restore InstanceMatchCriteria (live=$IMC)"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
+
+echo "INTEG OK (zerocorpus-hunt)"

--- a/tests/noise-stacktags-683.test.ts
+++ b/tests/noise-stacktags-683.test.ts
@@ -134,3 +134,80 @@ describe('#683 classifyResource end-to-end (zero tag FP on a --tags deploy)', ()
     expect(tier(f, 'undeclared')).toContain('Tags');
   });
 });
+
+// Hunt 2026-07-21 (zerocorpus-hunt): some EC2 registry handlers (CapacityReservation) echo the
+// create-time TagSpecifications INPUT wrapper back on read with the propagated stack tags
+// inside each spec — the same FP class one level down. The subtraction now reaches inside the
+// wrapper (dropping emptied specs and the emptied wrapper), and declaredTagKeys collects keys
+// from a DECLARED TagSpecifications so declared intent is still protected.
+describe('TagSpecifications wrapper subtraction (hunt 2026-07-21)', () => {
+  it('drops the wrapper when every spec holds only propagated stack tags', () => {
+    const out = subtractPropagatedStackTags(
+      {
+        TagSpecifications: [
+          { ResourceType: 'capacity-reservation', Tags: [{ Key: 'team', Value: 'platform' }] },
+        ],
+      },
+      stackTags,
+      new Set()
+    );
+    expect(out.TagSpecifications).toBeUndefined();
+  });
+
+  it('keeps a non-stack tag (and its spec) while subtracting the propagated ones', () => {
+    const out = subtractPropagatedStackTags(
+      {
+        TagSpecifications: [
+          {
+            ResourceType: 'capacity-reservation',
+            Tags: [
+              { Key: 'team', Value: 'platform' },
+              { Key: 'rogue', Value: 'evil' },
+            ],
+          },
+        ],
+      },
+      stackTags,
+      new Set()
+    );
+    expect(out.TagSpecifications).toEqual([
+      { ResourceType: 'capacity-reservation', Tags: [{ Key: 'rogue', Value: 'evil' }] },
+    ]);
+  });
+
+  it('a declared TagSpecifications key is protected from the subtraction', () => {
+    const keys = declaredTagKeys({
+      TagSpecifications: [
+        { ResourceType: 'capacity-reservation', Tags: [{ Key: 'team', Value: 'mine' }] },
+      ],
+    });
+    expect([...keys]).toEqual(['team']);
+    const out = subtractPropagatedStackTags(
+      {
+        TagSpecifications: [
+          { ResourceType: 'capacity-reservation', Tags: [{ Key: 'team', Value: 'platform' }] },
+        ],
+      },
+      stackTags,
+      keys
+    );
+    expect(out.TagSpecifications).toEqual([
+      { ResourceType: 'capacity-reservation', Tags: [{ Key: 'team', Value: 'platform' }] },
+    ]);
+  });
+
+  it('a value that differs from the stack tag is preserved (exact-match subtraction only)', () => {
+    const out = subtractPropagatedStackTags(
+      {
+        TagSpecifications: [
+          { ResourceType: 'capacity-reservation', Tags: [{ Key: 'team', Value: 'other' }] },
+        ],
+      },
+      stackTags,
+      new Set()
+    );
+    expect(out.TagSpecifications).toEqual([
+      { ResourceType: 'capacity-reservation', Tags: [{ Key: 'team', Value: 'other' }] },
+    ]);
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -4406,3 +4406,52 @@ describe('#748: toPointer splits dots only at bracket depth 0', () => {
     expect(toPointer('a/b')).toBe('/a~1b');
   });
 });
+
+// Hunt 2026-07-21: EC2 ModifyCapacityReservation leaves an OMITTED property unchanged —
+// bare `remove` reverts of InstanceMatchCriteria / EndDateType silently no-oped (proven
+// via explicit Cloud Control patches on a CLI-created reservation). The RSDP entries
+// write the KNOWN_DEFAULTS defaults explicitly; EndDate stays a plain `remove` (its pin
+// is the literal read-echo string "null", not a writable value) and rides the same
+// resource patch as the EndDateType set-default, which is the combination the live probe
+// proved to converge.
+describe('CapacityReservation revert set-defaults (hunt 2026-07-21)', () => {
+  it('InstanceMatchCriteria (SET-DEFAULT) -> add op writing "open", not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::CapacityReservation',
+      path: 'InstanceMatchCriteria',
+      actual: 'targeted',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/InstanceMatchCriteria',
+      value: 'open',
+      prior: 'targeted',
+    });
+  });
+
+  it('an out-of-band end date reverts as EndDateType set-default + EndDate remove in ONE patch', () => {
+    const fs = [
+      F({
+        tier: 'undeclared',
+        resourceType: 'AWS::EC2::CapacityReservation',
+        path: 'EndDateType',
+        actual: 'limited',
+      }),
+      F({
+        tier: 'undeclared',
+        resourceType: 'AWS::EC2::CapacityReservation',
+        path: 'EndDate',
+        actual: '2026-08-01T00:00:00Z',
+      }),
+    ];
+    const plan = buildRevertPlan(fs, baseline([]));
+    expect(plan.items).toHaveLength(1);
+    const ops = plan.items[0]!.ops;
+    expect(ops).toContainEqual(
+      expect.objectContaining({ op: 'add', path: '/EndDateType', value: 'unlimited' })
+    );
+    expect(ops).toContainEqual(expect.objectContaining({ op: 'remove', path: '/EndDate' }));
+  });
+});


### PR DESCRIPTION
## Summary

Five-round /hunt-bugs sweep (2026-07-21). Three bug classes found, fixed, unit-tested, and live-reproven; two fresh axes came back clean and are recorded as determinations.

### Bug 1 — ELBv2 TargetGroup UDP/TCP_UDP × ip cross-axis FP (echo4-hunt)

A barest UDP/ip (and TCP_UDP/ip) group first-ran `TargetGroupAttributes[preserve_client_ip.enabled]="true"` as Potential Drift. The `BY_TARGET_TYPE.ip` row's `'false'` (#1626) is a TCP/TLS-only default; AWS **forces** client-IP preservation ON for the UDP family (not disableable). Both split tables were live-proven per-axis, but the UDP×ip cross combination had never been deployed (variants5's UDP group omitted TargetType, so it took the instance row).

Fix: the UDP/TCP_UDP protocol rows pin the forced `'true'`, and `elbAttributeDefaultsFor` merges protocol overrides LAST (a protocol-forced value beats a target-type default). TCP/ip (`'false'`, #1626) and instance/alb behavior unchanged (regression tests included).

**Live A/B**: base binary FP'd ×2 → fixed binary: first check CLEAN, then a `-c rev=2` real-update redeploy (TGs, DLM, Lambda PC alias re-provision, R53 policy records, fixed + auto-adjusting Budgets) stayed CLEAN — the post-update echo probe for the post-07-14 fold types is also complete.

### Bug 2 — EC2 CapacityReservation six first-run FPs (zerocorpus-hunt)

Zero-corpus type; a barest reservation FP'd on `Tenancy` / `EndDateType` / `EndDate` / `InstanceMatchCriteria` / `AvailabilityZoneId` / `TagSpecifications`. Per the fold decision order:

- `KNOWN_DEFAULTS`: `Tenancy: 'default'`, `EndDateType: 'unlimited'`, `InstanceMatchCriteria: 'open'`, and the literal read-echo STRING `"null"` for `EndDate` (equality-gated — an out-of-band `modify-capacity-reservation` still surfaces, unit-proven).
- `AvailabilityZoneId` → value-independent: per-ACCOUNT zone-id mapping of the declared AZ (createOnly identifier; declaring AvailabilityZoneId instead keeps declared-loop detection).
- `TagSpecifications` → the handler echoes the create-time INPUT wrapper containing the CFN-propagated stack tags (`cdkrd:ephemeral`); `subtractPropagatedStackTags` now walks the wrapper generically (drop emptied specs/wrapper, keep any non-stack tag — detection preserved, unit-proven). The corpus recorder carries `stackTags` so replay reproduces the fold (corpus grep: no other type echoes the wrapper today).

**Live**: fixed binary first check CLEAN (atDefault 22→27).

### Bug 3 — CapacityReservation revert silent no-ops (revconv probe)

`ModifyCapacityReservation` ignores omitted properties: bare `remove` reverts of `InstanceMatchCriteria` / `EndDateType` report SUCCESS while the live value persists (proven via explicit Cloud Control patches on a CLI-created probe reservation; explicit `add` writes converge; `EndDateType: unlimited` alone is rejected while the model still carries `EndDate` — the set-default must ride the same patch as the EndDate `remove`, which the plan produces naturally). Fix: two `REVERT_SET_DEFAULT_PATHS` entries.

**Live end-to-end**: record → OOB `targeted` → detected (appeared since record) → `revert` wrote the default → live back to `open` → CLEAN.

### Clean determinations (recorded in the hunt skill)

- **First non-default-region pack** (region-hunt, ap-northeast-1; 15 wide-fold barest types): first check CLEAN (all 125 atDefault folds correct), SQS FN detect → revert converged. The constant tables are not us-east-1-baked.
- **First live proof of the #904 Processed-template path** (langext-hunt): raw-CFn `Transform: AWS::LanguageExtensions` (Fn::ForEach + Fn::ToJsonString) checked CLEAN via a hand-built cdk.out pointing at the ORIGINAL unexpanded template.

### Also

- sweep-orphans arm: a CANCELLED capacity reservation is terminal but lingers in the RGT tag index — counts as gone (script self-test 23/23).
- 7 new corpus cases: UDP/ip + TCP_UDP/ip TGs, auto-adjusting Budget, CapacityReservation, NetworkInsightsPath, Route53Profiles Profile + ProfileAssociation.
- 4 committed hunt fixtures: `echo4-hunt`, `region-hunt`, `zerocorpus-hunt`, `langext-hunt`.
- Hunt-skill gotchas: cross-axis lesson, region + LanguageExtensions determinations, TagSpecifications wrapper class.

### Verification

- typecheck / lint+format / build / unit tests (320 files, **6137 tests**) all green; corpus-replay 921 cases green.
- Live A/B per bug as above. Shared CORE suite **deferred** (diff fully covered by unit + corpus replay + originating-hunt live proof, per the verify-pr deferral rule).
- All 4 hunt stacks deleted via delstack, `SWEEP CLEAN` in us-east-1 + ap-northeast-1, bughunt gate released.

Note: issues for the three bugs were not filed (issue creation is denied for this session); the full repro evidence is in this PR + the committed fixtures.
