### PR TITLE
fix(hunt): 2026-07-22 sweep — RUM/GuardDuty revert no-ops, arm64 EB + GuardDuty entity-set first-run FPs

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -719,6 +719,23 @@ Drift"` the output — trusting the exit code let a real FP print INTEG OK.**
   is the exact inverse: ON_DEMAND materializes ShardCount). When a type has a mode
   axis, deploy the barest form of EACH mode and check which sibling props the OTHER
   mode's fold assumed declared.
+- **A mirrored variant row can be DEAD — the variant may be CFn-UNREACHABLE; a handler
+  400 naming another API is itself the determination.** The 2026-07-22 probe of the
+  ENGINE_DEFAULTS CacheCluster valkey arm (mirrored off the redis regex) failed create
+  with "This API doesn't support Valkey engine. Please use CreateReplicationGroup" —
+  standalone valkey CacheClusters cannot exist via CFn, so the mirrored row can never FP
+  (recorded as a noise.ts comment, fixture deleted). Two cheap-deploy lessons ride along:
+  (a) budget ONE extra failed create per exotic variant — the valkey run ALSO surfaced
+  that CreateCacheCluster demands `VpcSecurityGroupIds` for valkey before the engine
+  check (an engine-axis validation difference worth the fixture comment); (b) prove
+  UNREACHABLE before writing a live-proof fixture for a mirrored row — the docs listing
+  an engine/version for a service does not mean the CFn type accepts it.
+- **A zero-skip assert fixture must not use `autoDeleteObjects`** — its
+  CustomS3AutoDeleteObjects custom resource is ALWAYS `skipped=1` (custom resources are
+  never read), so a `grep skipped=` assert false-fails on an otherwise clean stack (hit
+  on gdsets2-hunt 2026-07-22). Use a plain DESTROY bucket — `delstack` force-deletes a
+  non-empty bucket at teardown anyway (the auto-delete Lambda's log group also lands in
+  the sweep's younger-than-2h protection window; delete it explicitly before verify).
 - **The variant axis extends to UNION-TYPED config blocks and to defaults the variant
   FLIPS on a sibling.** Two live instances (variants2-hunt, 2026-07-14): (a) Firehose's
   destination union — every fixture was ExtendedS3, so a barest

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2895,6 +2895,13 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string | string
   // whole-account default scope. createOnly (never drifts), but derived rather than value-
   // independent per the fold-strategy order. Live, hunt 2026-07-08 round F (#626).
   'AWS::ResourceExplorer2::View': { Scope: 'arn:{partition}:iam::{accountId}:root' },
+  // A GuardDuty entity set that declares no ExpectedBucketOwner reads back the resource's OWN
+  // account id — GuardDuty materializes the caller account as the default expected owner of
+  // the list bucket (gdsets2-hunt 2026-07-22, #1686; not an ARN, but the same deploy-context
+  // placeholder substitution). Equality-gated: an out-of-band switch to a DIFFERENT owner
+  // account (a real cross-account exposure change) still surfaces.
+  'AWS::GuardDuty::ThreatEntitySet': { ExpectedBucketOwner: '{accountId}' },
+  'AWS::GuardDuty::TrustedEntitySet': { ExpectedBucketOwner: '{accountId}' },
   // A Kinesis Video stream that declares no KMS key reads back the AWS-managed
   // `alias/aws/kinesisvideo` key ARN — f(partition, region, account). Equality-gated, so a
   // stream switched to a customer CMK (a real, mutable change) still surfaces. Live, hunt
@@ -3041,6 +3048,10 @@ export const ENGINE_DEFAULTS: Record<string, Record<string, (engine: string) => 
   // A cache cluster that declares no Port reads back the engine's default listener port —
   // 6379 for redis/valkey, 11211 for memcached. Derived from the live Engine and
   // equality-gated; an out-of-band port change still surfaces.
+  // The valkey arm is UNREACHABLE via CloudFormation (live-determined 2026-07-22): the
+  // CacheCluster handler rejects engine=valkey outright ("This API doesn't support Valkey
+  // engine. Please use CreateReplicationGroup"), so standalone valkey CacheClusters cannot
+  // exist — the regex arm stays only for defensive parity with the RG fold.
   'AWS::ElastiCache::CacheCluster': {
     Port: (e) => (/memcached/i.test(e) ? 11211 : /redis|valkey/i.test(e) ? 6379 : undefined),
   },
@@ -3623,13 +3634,16 @@ function isAllEbGeneratedGroups(value: unknown): boolean {
 // the platform's smallest burstable pair for the environment's processor architecture — a
 // DETERMINISTIC function of the sibling `aws:ec2:instances|SupportedArchitectures` option
 // (x86_64 when unset, EB's own default). Pinned from `describe-configuration-options` +
-// the harvested EB corpus (x86_64 → t3.micro/t3.small) and the EB arm64 docs
-// (arm64 → t4g.micro/t4g.small). Folding InstanceTypes against this set keeps a clean deploy
-// at zero drift while surfacing any first element AWS did not assign as a default — an OOB
-// instance-family bump (the silent p4d.24xlarge cost bomb).
+// the harvested EB corpus (x86_64 → t3.micro/t3.small). The arm64 row was originally the EB
+// docs pair (t4g.micro/t4g.small), but a live arm64 environment (ebarm-hunt 2026-07-22,
+// #1685) is assigned "t4g.micro, t4g.large" — the choice moves within t4g burstables by
+// era/platform, so the set is the UNION of the observed + documented pairs. Folding
+// InstanceTypes against this set keeps a clean deploy at zero drift while surfacing any
+// element AWS did not assign as a default — an OOB instance-family bump (the silent
+// p4d.24xlarge cost bomb).
 const EB_INSTANCE_TYPES_DEFAULT_BY_ARCH: Record<string, ReadonlySet<string>> = {
   x86_64: new Set(['t3.micro', 't3.small']),
-  arm64: new Set(['t4g.micro', 't4g.small']),
+  arm64: new Set(['t4g.micro', 't4g.small', 't4g.large']),
 };
 function ebInstanceTypesDefaultSet(
   supportedArchitectures: unknown

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -3561,6 +3561,11 @@ const readElbv2ListenerCertificate: OverrideReader = async ({ declared, region }
 
 export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::ElasticLoadBalancingV2::ListenerCertificate': readElbv2ListenerCertificate,
+  // NOTE (hunt 2026-07-22): still ZERO live coverage and cheaply unexercisable — a
+  // CFn-declared cert blocks CREATE on domain validation (needs real ownership), and a
+  // resource-IMPORT changeset of a CLI-imported cert is rejected ("ResourceTypes
+  // [AWS::CertificateManager::Certificate] are not supported for Import"). First live
+  // proof will have to come from a real-domain integ.
   'AWS::CertificateManager::Certificate': readAcmCertificate,
   'AWS::SES::ReceiptRuleSet': readSesReceiptRuleSet,
   'AWS::SES::ReceiptRule': readSesReceiptRule,

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -298,6 +298,17 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // reported "reverted" yet convergence re-read ENABLED). Write the {Status:"DISABLED"}
   // default (from KNOWN_DEFAULTS) back explicitly.
   'AWS::RUM::AppMonitor\0CustomEvents',
+  // revconv6 hunt (live-proven 2026-07-22, #1684): the sibling whole-object
+  // AppMonitorConfiguration rides the same selective UpdateAppMonitor call and no-ops the
+  // bare `remove` identically (an out-of-band SessionSampleRate=0.5 persisted through a
+  // revert that reported "reverted"). An explicit CC `add` of the KNOWN_DEFAULTS object
+  // converges (CC-probed live), so write the default back explicitly.
+  'AWS::RUM::AppMonitor\0AppMonitorConfiguration',
+  // gdsets2 hunt (live-proven 2026-07-22, #1687): GuardDuty UpdateFilter keeps an omitted
+  // Action (an out-of-band ARCHIVE persisted through a `remove` revert that reported
+  // "reverted"). An explicit CC `add /Action "NOOP"` converges (CC-probed live against a
+  // CLI-created filter), so write the KNOWN_DEFAULTS 'NOOP' back explicitly.
+  'AWS::GuardDuty::Filter\0Action',
   // barest4/ccpi hunt (live-proven 2026-07-14): ServiceCatalog UpdateTagOption REJECTS the
   // `remove` patch outright ("Active and new value cannot both be null") — the hard-reject
   // flavor of the class (not a silent no-op, a hard error). Write the `true` default (from

--- a/tests/corpus/AWS__ApiGatewayV2__ApiMapping.HuntApiMapping.json
+++ b/tests/corpus/AWS__ApiGatewayV2__ApiMapping.HuntApiMapping.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntApiMapping",
+    "resourceType": "AWS::ApiGatewayV2::ApiMapping",
+    "physicalId": "zqeejp",
+    "constructPath": "CdkrdHunt0722ApiMap/HuntApiMapping",
+    "declared": {
+      "ApiId": "17pl3et5bf",
+      "DomainName": "hunt0722-v2.cdkrd-hunt.example.com",
+      "Stage": "$default"
+    }
+  },
+  "liveRaw": {
+    "DomainName": "hunt0722-v2.cdkrd-hunt.example.com",
+    "Stage": "$default",
+    "ApiMappingId": "zqeejp",
+    "ApiMappingKey": "",
+    "ApiId": "17pl3et5bf"
+  },
+  "schema": {
+    "readOnly": ["ApiMappingId"],
+    "writeOnly": [],
+    "createOnly": ["DomainName"],
+    "readOnlyPaths": ["ApiMappingId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DomainName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGatewayV2__DomainName.HuntV2Domain.json
+++ b/tests/corpus/AWS__ApiGatewayV2__DomainName.HuntV2Domain.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntV2Domain",
+    "resourceType": "AWS::ApiGatewayV2::DomainName",
+    "physicalId": "hunt0722-v2.cdkrd-hunt.example.com",
+    "constructPath": "CdkrdHunt0722ApiMap/HuntV2Domain",
+    "declared": {
+      "DomainName": "hunt0722-v2.cdkrd-hunt.example.com",
+      "DomainNameConfigurations": [
+        {
+          "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/05157b27-63b7-4403-8184-b3e8b5efdd32",
+          "EndpointType": "REGIONAL"
+        }
+      ],
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      }
+    }
+  },
+  "liveRaw": {
+    "RoutingMode": "API_MAPPING_ONLY",
+    "RegionalHostedZoneId": "Z1UJRXOUMOOFQ8",
+    "RegionalDomainName": "d-qqk9esqm0f.execute-api.us-east-1.amazonaws.com",
+    "DomainName": "hunt0722-v2.cdkrd-hunt.example.com",
+    "DomainNameArn": "arn:aws:apigateway:us-east-1::/domainnames/hunt0722-v2.cdkrd-hunt.example.com",
+    "DomainNameConfigurations": [
+      {
+        "IpAddressType": "ipv4",
+        "SecurityPolicy": "TLS_1_2",
+        "EndpointType": "REGIONAL",
+        "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/05157b27-63b7-4403-8184-b3e8b5efdd32"
+      }
+    ],
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdHunt0722ApiMap",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0722ApiMap/db1f9af0-859c-11f1-918a-0e840500951f",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "HuntV2Domain"
+    }
+  },
+  "schema": {
+    "readOnly": ["DomainNameArn", "RegionalDomainName", "RegionalHostedZoneId"],
+    "writeOnly": [],
+    "createOnly": ["DomainName"],
+    "readOnlyPaths": ["DomainNameArn", "RegionalDomainName", "RegionalHostedZoneId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DomainName"],
+    "defaults": {
+      "RoutingMode": "API_MAPPING_ONLY"
+    },
+    "defaultPaths": {
+      "RoutingMode": "API_MAPPING_ONLY"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntV2Domain",
+      "resourceType": "AWS::ApiGatewayV2::DomainName",
+      "path": "RoutingMode",
+      "actual": "API_MAPPING_ONLY",
+      "physicalId": "hunt0722-v2.cdkrd-hunt.example.com",
+      "constructPath": "CdkrdHunt0722ApiMap/HuntV2Domain"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__BasePathMapping.HuntBasePathMapping.json
+++ b/tests/corpus/AWS__ApiGateway__BasePathMapping.HuntBasePathMapping.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntBasePathMapping",
+    "resourceType": "AWS::ApiGateway::BasePathMapping",
+    "physicalId": "hunt0722-v1.cdkrd-hunt.example.com|(none)",
+    "constructPath": "CdkrdHunt0722ApiMap/HuntBasePathMapping",
+    "declared": {
+      "DomainName": "hunt0722-v1.cdkrd-hunt.example.com",
+      "RestApiId": "ww46dbetaj",
+      "Stage": "prod"
+    }
+  },
+  "liveRaw": {
+    "DomainName": "hunt0722-v1.cdkrd-hunt.example.com",
+    "RestApiId": "ww46dbetaj",
+    "Stage": "prod",
+    "BasePath": ""
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["BasePath", "DomainName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["BasePath", "DomainName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__DomainName.HuntRestDomain.json
+++ b/tests/corpus/AWS__ApiGateway__DomainName.HuntRestDomain.json
@@ -1,0 +1,109 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRestDomain",
+    "resourceType": "AWS::ApiGateway::DomainName",
+    "physicalId": "hunt0722-v1.cdkrd-hunt.example.com",
+    "constructPath": "CdkrdHunt0722ApiMap/HuntRestDomain",
+    "declared": {
+      "DomainName": "hunt0722-v1.cdkrd-hunt.example.com",
+      "EndpointConfiguration": {
+        "Types": ["REGIONAL"]
+      },
+      "RegionalCertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/05157b27-63b7-4403-8184-b3e8b5efdd32",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "RoutingMode": "BASE_PATH_MAPPING_ONLY",
+    "RegionalHostedZoneId": "Z1UJRXOUMOOFQ8",
+    "RegionalDomainName": "d-3twyic8gk2.execute-api.us-east-1.amazonaws.com",
+    "DomainName": "hunt0722-v1.cdkrd-hunt.example.com",
+    "SecurityPolicy": "TLS_1_2",
+    "DomainNameArn": "arn:aws:apigateway:us-east-1::/domainnames/hunt0722-v1.cdkrd-hunt.example.com",
+    "EndpointConfiguration": {
+      "IpAddressType": "ipv4",
+      "Types": ["REGIONAL"]
+    },
+    "RegionalCertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/05157b27-63b7-4403-8184-b3e8b5efdd32",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "DistributionDomainName",
+      "DistributionHostedZoneId",
+      "DomainNameArn",
+      "RegionalDomainName",
+      "RegionalHostedZoneId"
+    ],
+    "writeOnly": [],
+    "createOnly": ["DomainName"],
+    "readOnlyPaths": [
+      "DistributionDomainName",
+      "DistributionHostedZoneId",
+      "DomainNameArn",
+      "RegionalDomainName",
+      "RegionalHostedZoneId"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DomainName"],
+    "defaults": {
+      "RoutingMode": "BASE_PATH_MAPPING_ONLY"
+    },
+    "defaultPaths": {
+      "RoutingMode": "BASE_PATH_MAPPING_ONLY"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRestDomain",
+      "resourceType": "AWS::ApiGateway::DomainName",
+      "path": "RoutingMode",
+      "actual": "BASE_PATH_MAPPING_ONLY",
+      "physicalId": "hunt0722-v1.cdkrd-hunt.example.com",
+      "constructPath": "CdkrdHunt0722ApiMap/HuntRestDomain"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRestDomain",
+      "resourceType": "AWS::ApiGateway::DomainName",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_2",
+      "physicalId": "hunt0722-v1.cdkrd-hunt.example.com",
+      "constructPath": "CdkrdHunt0722ApiMap/HuntRestDomain"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntRestDomain",
+      "resourceType": "AWS::ApiGateway::DomainName",
+      "path": "EndpointConfiguration.IpAddressType",
+      "actual": "ipv4",
+      "nested": true,
+      "physicalId": "hunt0722-v1.cdkrd-hunt.example.com",
+      "constructPath": "CdkrdHunt0722ApiMap/HuntRestDomain"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudFront__CachePolicy.HuntCachePolicy.json
+++ b/tests/corpus/AWS__CloudFront__CachePolicy.HuntCachePolicy.json
@@ -1,0 +1,79 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntCachePolicy",
+    "resourceType": "AWS::CloudFront::CachePolicy",
+    "physicalId": "4d463def-046d-40ab-97dc-055de5006eb4",
+    "constructPath": "CdkrdHunt0722CfPol/HuntCachePolicy",
+    "declared": {
+      "CachePolicyConfig": {
+        "DefaultTTL": 3600,
+        "MaxTTL": 86400,
+        "MinTTL": 0,
+        "Name": "cdkrd-hunt0722-cache-policy",
+        "ParametersInCacheKeyAndForwardedToOrigin": {
+          "CookiesConfig": {
+            "CookieBehavior": "whitelist",
+            "Cookies": ["zz-cookie", "aa-cookie", "mm-cookie"]
+          },
+          "EnableAcceptEncodingBrotli": false,
+          "EnableAcceptEncodingGzip": true,
+          "HeadersConfig": {
+            "HeaderBehavior": "whitelist",
+            "Headers": ["x-cdkrd-zz", "x-cdkrd-aa", "x-cdkrd-mm"]
+          },
+          "QueryStringsConfig": {
+            "QueryStringBehavior": "whitelist",
+            "QueryStrings": ["zz", "aa", "mm"]
+          }
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "CachePolicyConfig": {
+      "MinTTL": 0,
+      "MaxTTL": 86400,
+      "ParametersInCacheKeyAndForwardedToOrigin": {
+        "EnableAcceptEncodingBrotli": false,
+        "HeadersConfig": {
+          "Headers": ["x-cdkrd-zz", "x-cdkrd-aa", "x-cdkrd-mm"],
+          "HeaderBehavior": "whitelist"
+        },
+        "CookiesConfig": {
+          "Cookies": ["zz-cookie", "aa-cookie", "mm-cookie"],
+          "CookieBehavior": "whitelist"
+        },
+        "EnableAcceptEncodingGzip": true,
+        "QueryStringsConfig": {
+          "QueryStrings": ["zz", "aa", "mm"],
+          "QueryStringBehavior": "whitelist"
+        }
+      },
+      "DefaultTTL": 3600,
+      "Name": "cdkrd-hunt0722-cache-policy"
+    },
+    "LastModifiedTime": "2026-07-22T07:01:15.994Z",
+    "Id": "4d463def-046d-40ab-97dc-055de5006eb4"
+  },
+  "schema": {
+    "readOnly": ["Id", "LastModifiedTime"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "LastModifiedTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudFront__OriginRequestPolicy.HuntOrp.json
+++ b/tests/corpus/AWS__CloudFront__OriginRequestPolicy.HuntOrp.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOrp",
+    "resourceType": "AWS::CloudFront::OriginRequestPolicy",
+    "physicalId": "03e00355-f506-473d-a4c2-8dc0d2cae055",
+    "constructPath": "CdkrdHunt0722CfPol/HuntOrp",
+    "declared": {
+      "OriginRequestPolicyConfig": {
+        "CookiesConfig": {
+          "CookieBehavior": "whitelist",
+          "Cookies": ["zz-cookie", "aa-cookie", "mm-cookie"]
+        },
+        "HeadersConfig": {
+          "HeaderBehavior": "whitelist",
+          "Headers": ["x-cdkrd-zz", "x-cdkrd-aa", "x-cdkrd-mm"]
+        },
+        "Name": "cdkrd-hunt0722-orp",
+        "QueryStringsConfig": {
+          "QueryStringBehavior": "whitelist",
+          "QueryStrings": ["zz", "aa", "mm"]
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "LastModifiedTime": "2026-07-22T07:01:16.202Z",
+    "Id": "03e00355-f506-473d-a4c2-8dc0d2cae055",
+    "OriginRequestPolicyConfig": {
+      "HeadersConfig": {
+        "Headers": ["x-cdkrd-zz", "x-cdkrd-aa", "x-cdkrd-mm"],
+        "HeaderBehavior": "whitelist"
+      },
+      "CookiesConfig": {
+        "Cookies": ["zz-cookie", "aa-cookie", "mm-cookie"],
+        "CookieBehavior": "whitelist"
+      },
+      "QueryStringsConfig": {
+        "QueryStrings": ["zz", "aa", "mm"],
+        "QueryStringBehavior": "whitelist"
+      },
+      "Name": "cdkrd-hunt0722-orp"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id", "LastModifiedTime"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "LastModifiedTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudFront__ResponseHeadersPolicy.HuntRhp.json
+++ b/tests/corpus/AWS__CloudFront__ResponseHeadersPolicy.HuntRhp.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRhp",
+    "resourceType": "AWS::CloudFront::ResponseHeadersPolicy",
+    "physicalId": "24dff1d8-14b9-4c62-a92f-2eec789ec2e9",
+    "constructPath": "CdkrdHunt0722CfPol/HuntRhp",
+    "declared": {
+      "ResponseHeadersPolicyConfig": {
+        "CorsConfig": {
+          "AccessControlAllowCredentials": false,
+          "AccessControlAllowHeaders": {
+            "Items": ["X-Cdkrd-Zz", "X-Cdkrd-Aa", "X-Cdkrd-Mm"]
+          },
+          "AccessControlAllowMethods": {
+            "Items": ["POST", "GET", "DELETE"]
+          },
+          "AccessControlAllowOrigins": {
+            "Items": ["https://zz.example.com", "https://aa.example.com"]
+          },
+          "OriginOverride": true
+        },
+        "CustomHeadersConfig": {
+          "Items": [
+            {
+              "Header": "x-cdkrd-custom-zz",
+              "Override": true,
+              "Value": "zz"
+            },
+            {
+              "Header": "x-cdkrd-custom-aa",
+              "Override": false,
+              "Value": "aa"
+            }
+          ]
+        },
+        "Name": "cdkrd-hunt0722-rhp"
+      }
+    }
+  },
+  "liveRaw": {
+    "LastModifiedTime": "2026-07-22T07:01:16.224Z",
+    "Id": "24dff1d8-14b9-4c62-a92f-2eec789ec2e9",
+    "ResponseHeadersPolicyConfig": {
+      "CorsConfig": {
+        "AccessControlAllowCredentials": false,
+        "AccessControlAllowHeaders": {
+          "Items": ["X-Cdkrd-Zz", "X-Cdkrd-Aa", "X-Cdkrd-Mm"]
+        },
+        "OriginOverride": true,
+        "AccessControlAllowMethods": {
+          "Items": ["POST", "GET", "DELETE"]
+        },
+        "AccessControlExposeHeaders": {
+          "Items": []
+        },
+        "AccessControlAllowOrigins": {
+          "Items": ["https://zz.example.com", "https://aa.example.com"]
+        }
+      },
+      "CustomHeadersConfig": {
+        "Items": [
+          {
+            "Header": "x-cdkrd-custom-zz",
+            "Value": "zz",
+            "Override": true
+          },
+          {
+            "Header": "x-cdkrd-custom-aa",
+            "Value": "aa",
+            "Override": false
+          }
+        ]
+      },
+      "Name": "cdkrd-hunt0722-rhp"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id", "LastModifiedTime"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "LastModifiedTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlAllowHeaders.Items",
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlAllowMethods.Items",
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlAllowOrigins.Items",
+      "ResponseHeadersPolicyConfig.CorsConfig.AccessControlExposeHeaders.Items"
+    ],
+    "unorderedObjectArrayPaths": [
+      "ResponseHeadersPolicyConfig.CustomHeadersConfig.Items",
+      "ResponseHeadersPolicyConfig.RemoveHeadersConfig.Items"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__ApplicationVersion.HuntEbAppVersion.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__ApplicationVersion.HuntEbAppVersion.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEbAppVersion",
+    "resourceType": "AWS::ElasticBeanstalk::ApplicationVersion",
+    "physicalId": "cdkrdhunt0722ebav-huntebappversion-d82hufheyxde",
+    "constructPath": "CdkrdHunt0722EbAv/HuntEbAppVersion",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt0722-ebav",
+      "SourceBundle": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "dd3a0653a686247dfc940943303dc75a054d0a41a64ab1ef037be0c3794e038a.zip"
+      }
+    }
+  },
+  "liveRaw": {
+    "ApplicationName": "cdkrd-hunt0722-ebav",
+    "SourceBundle": {
+      "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+      "S3Key": "dd3a0653a686247dfc940943303dc75a054d0a41a64ab1ef037be0c3794e038a.zip"
+    },
+    "Id": "cdkrdhunt0722ebav-huntebappversion-d82hufheyxde"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["ApplicationName", "SourceBundle"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApplicationName", "SourceBundle"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnvArm64.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnvArm64.json
@@ -1,0 +1,1630 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbEnv",
+    "resourceType": "AWS::ElasticBeanstalk::Environment",
+    "physicalId": "cdkrd-hunt0722-ebarm-env",
+    "constructPath": "CdkrdHunt0722EbArm/EbEnv",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt0722-ebarm-app",
+      "EnvironmentName": "cdkrd-hunt0722-ebarm-env",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "SingleInstance"
+        },
+        {
+          "Namespace": "aws:autoscaling:launchconfiguration",
+          "OptionName": "IamInstanceProfile",
+          "Value": "CdkrdHunt0722EbArm-EbInstanceProfile-WLWaFXpgtDHu"
+        },
+        {
+          "Namespace": "aws:ec2:instances",
+          "OptionName": "SupportedArchitectures",
+          "Value": "arm64"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.4 running Docker",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.4",
+    "ApplicationName": "cdkrd-hunt0722-ebarm-app",
+    "EnvironmentName": "cdkrd-hunt0722-ebarm-env",
+    "Tier": {
+      "Type": "Standard",
+      "Version": "1.0",
+      "Name": "WebServer"
+    },
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.4 running Docker",
+    "EndpointURL": "34.206.26.109",
+    "CNAMEPrefix": "cdkrd-hunt0722-ebarm-env",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones",
+        "Value": "Any"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown",
+        "Value": "360"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Custom Availability Zones",
+        "Value": ""
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize",
+        "Value": "1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize",
+        "Value": "1"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "BlockDeviceMappings"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1",
+        "Value": "true"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "EC2KeyName"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "IamInstanceProfile",
+        "Value": "CdkrdHunt0722EbArm-EbInstanceProfile-WLWaFXpgtDHu"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId",
+        "Value": "ami-0f071adbd317ec356"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType",
+        "Value": "t4g.micro"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "LaunchTemplateTagPropagationEnabled"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval",
+        "Value": "5 minute"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeIOPS"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeSize"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeThroughput"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeType"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction",
+        "Value": "tcp,22,22,0.0.0.0/0"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SecurityGroups",
+        "Value": "awseb-e-tewurzz2rd-stack-AWSEBSecurityGroup-9jFKZBns37vb"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MaxBatchSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MinInstancesInService"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "PauseTime"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType",
+        "Value": "Time"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout",
+        "Value": "PT30M"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2974.0_20260710233326/sampleapp/EBSampleApp-Docker.zip"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2974.0_20260710233326/lib/hooks.tar.gz"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily",
+        "Value": "t4g"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes",
+        "Value": "t4g.micro, t4g.large"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy",
+        "Value": "capacity-optimized"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotMaxPrice"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures",
+        "Value": "arm64"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "AssociatePublicIpAddress"
+      },
+      {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme",
+        "Value": "public"
+      },
+      {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBSubnets"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "Subnets"
+      },
+      {
+        "ResourceName": "AWSEBSecurityGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "VPCId"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:application",
+        "OptionName": "Application Healthcheck URL",
+        "Value": ""
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize",
+        "Value": "100"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType",
+        "Value": "Percentage"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy",
+        "Value": "AllAtOnce"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout",
+        "Value": "600"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort",
+        "Value": "22"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType",
+        "Value": "Migration"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType",
+        "Value": "SingleInstance"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Bucket"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Key"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ServiceRole",
+        "Value": "AWSServiceRoleForElasticBeanstalk"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer",
+        "Value": "nginx"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument",
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled",
+        "Value": "true"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold",
+        "Value": "Ok"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType",
+        "Value": "enhanced"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "PreferredStartTime"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ServiceRoleForManagedUpdates",
+        "Value": ""
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "UpdateLevel"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances",
+        "Value": "true"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Endpoint"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol",
+        "Value": "email"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic ARN"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic Name"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase",
+        "Value": "false"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["EndpointURL"],
+    "writeOnly": ["TemplateName"],
+    "createOnly": ["ApplicationName", "CNAMEPrefix", "EnvironmentName", "SolutionStackName"],
+    "readOnlyPaths": ["EndpointURL"],
+    "writeOnlyPaths": ["TemplateName"],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "CNAMEPrefix",
+      "EnvironmentName",
+      "SolutionStackName",
+      "Tier.Name",
+      "Tier.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones",
+        "Value": "Any"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown",
+        "Value": "360"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Custom Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Custom Availability Zones",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize",
+        "Value": "1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize",
+        "Value": "1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|BlockDeviceMappings]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "BlockDeviceMappings"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|EC2KeyName]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "EC2KeyName"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId",
+        "Value": "ami-0f071adbd317ec356"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType",
+        "Value": "t4g.micro"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|LaunchTemplateTagPropagationEnabled]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "LaunchTemplateTagPropagationEnabled"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval",
+        "Value": "5 minute"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeIOPS]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeIOPS"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeSize]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeSize"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeThroughput]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeThroughput"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeType]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeType"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction",
+        "Value": "tcp,22,22,0.0.0.0/0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SecurityGroups",
+        "Value": "awseb-e-tewurzz2rd-stack-AWSEBSecurityGroup-9jFKZBns37vb"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|MaxBatchSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MaxBatchSize"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|MinInstancesInService]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MinInstancesInService"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|PauseTime]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "PauseTime"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType",
+        "Value": "Time"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout",
+        "Value": "PT30M"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2974.0_20260710233326/sampleapp/EBSampleApp-Docker.zip"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|EnvironmentVariables]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2974.0_20260710233326/lib/hooks.tar.gz"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily",
+        "Value": "t4g"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes",
+        "Value": "t4g.micro, t4g.large"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy",
+        "Value": "capacity-optimized"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotMaxPrice]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotMaxPrice"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|AssociatePublicIpAddress]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "AssociatePublicIpAddress"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme",
+        "Value": "public"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|ELBSubnets]",
+      "actual": {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBSubnets"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|Subnets]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "Subnets"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|VPCId]",
+      "actual": {
+        "ResourceName": "AWSEBSecurityGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "VPCId"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:application|Application Healthcheck URL]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:application",
+        "OptionName": "Application Healthcheck URL",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize",
+        "Value": "100"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType",
+        "Value": "Percentage"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy",
+        "Value": "AllAtOnce"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout",
+        "Value": "600"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort",
+        "Value": "22"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType",
+        "Value": "Migration"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ExternalExtensionsS3Bucket]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Bucket"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ExternalExtensionsS3Key]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Key"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ServiceRole]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ServiceRole",
+        "Value": "AWSServiceRoleForElasticBeanstalk"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer",
+        "Value": "nginx"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument",
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold",
+        "Value": "Ok"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType",
+        "Value": "enhanced"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|PreferredStartTime]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "PreferredStartTime"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ServiceRoleForManagedUpdates]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ServiceRoleForManagedUpdates",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|UpdateLevel]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "UpdateLevel"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Endpoint]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Endpoint"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol",
+        "Value": "email"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Topic ARN]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic ARN"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Topic Name]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic Name"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.4",
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "Tier",
+      "actual": {
+        "Type": "Standard",
+        "Version": "1.0",
+        "Name": "WebServer"
+      },
+      "physicalId": "cdkrd-hunt0722-ebarm-env",
+      "constructPath": "CdkrdHunt0722EbArm/EbEnv"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GuardDuty__PublishingDestination.HuntPubDest.json
+++ b/tests/corpus/AWS__GuardDuty__PublishingDestination.HuntPubDest.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPubDest",
+    "resourceType": "AWS::GuardDuty::PublishingDestination",
+    "physicalId": "5ccfc46ac74a4feddabf49854ccfbe0f",
+    "constructPath": "CdkrdHunt0722Gd2/HuntPubDest",
+    "declared": {
+      "DestinationProperties": {
+        "DestinationArn": "arn:aws:s3:::cdkrdhunt0722gd2-huntexportbucket6692dde4-cx0m39nlzoyu",
+        "KmsKeyArn": "arn:aws:kms:us-east-1:111111111111:key/f2be657f-924d-47d0-93f1-53144095f118"
+      },
+      "DestinationType": "S3",
+      "DetectorId": "7d64c86ad0974c0ba56a1f12290589c0",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Status": "PUBLISHING",
+    "PublishingFailureStartTimestamp": "-",
+    "DestinationProperties": {
+      "KmsKeyArn": "arn:aws:kms:us-east-1:111111111111:key/f2be657f-924d-47d0-93f1-53144095f118",
+      "DestinationArn": "arn:aws:s3:::cdkrdhunt0722gd2-huntexportbucket6692dde4-cx0m39nlzoyu"
+    },
+    "DetectorId": "7d64c86ad0974c0ba56a1f12290589c0",
+    "Id": "5ccfc46ac74a4feddabf49854ccfbe0f",
+    "DestinationType": "S3",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0722Gd2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntPubDest",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0722Gd2/17c5f9d0-85a3-11f1-9f36-0e40ba705f19",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id", "PublishingFailureStartTimestamp", "Status"],
+    "writeOnly": [],
+    "createOnly": ["DetectorId"],
+    "readOnlyPaths": ["Id", "PublishingFailureStartTimestamp", "Status"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DetectorId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__GuardDuty__ThreatEntitySet.HuntThreatEntitySet.json
+++ b/tests/corpus/AWS__GuardDuty__ThreatEntitySet.HuntThreatEntitySet.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntThreatEntitySet",
+    "resourceType": "AWS::GuardDuty::ThreatEntitySet",
+    "physicalId": "63a1ad38de01493082f89ca2eb119cc4|7d64c86ad0974c0ba56a1f12290589c0",
+    "constructPath": "CdkrdHunt0722Gd2/HuntThreatEntitySet",
+    "declared": {
+      "DetectorId": "7d64c86ad0974c0ba56a1f12290589c0",
+      "Name": "cdkrd-hunt0722-threat-entity-set",
+      "Format": "TXT",
+      "Location": "https://s3.amazonaws.com/cdkrd-hunt0722-gd-111111111111/threatlist.txt",
+      "Activate": true
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "Format": "TXT",
+    "CreatedAt": "2026-07-22T07:58:30Z",
+    "DetectorId": "7d64c86ad0974c0ba56a1f12290589c0",
+    "Id": "63a1ad38de01493082f89ca2eb119cc4",
+    "ErrorDetails": "",
+    "UpdatedAt": "2026-07-22T07:58:30Z",
+    "ExpectedBucketOwner": "111111111111",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0722Gd2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntThreatEntitySet",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0722Gd2/17c5f9d0-85a3-11f1-9f36-0e40ba705f19",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0722-threat-entity-set",
+    "Location": "https://s3.amazonaws.com/cdkrd-hunt0722-gd-111111111111/threatlist.txt"
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "ErrorDetails", "Id", "Status", "UpdatedAt"],
+    "writeOnly": ["Activate"],
+    "createOnly": ["DetectorId", "Format"],
+    "readOnlyPaths": ["CreatedAt", "ErrorDetails", "Id", "Status", "UpdatedAt"],
+    "writeOnlyPaths": ["Activate"],
+    "createOnlyPaths": ["DetectorId", "Format"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntThreatEntitySet",
+      "resourceType": "AWS::GuardDuty::ThreatEntitySet",
+      "path": "Activate",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "63a1ad38de01493082f89ca2eb119cc4|7d64c86ad0974c0ba56a1f12290589c0",
+      "constructPath": "CdkrdHunt0722Gd2/HuntThreatEntitySet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntThreatEntitySet",
+      "resourceType": "AWS::GuardDuty::ThreatEntitySet",
+      "path": "ExpectedBucketOwner",
+      "actual": "111111111111",
+      "physicalId": "63a1ad38de01493082f89ca2eb119cc4|7d64c86ad0974c0ba56a1f12290589c0",
+      "constructPath": "CdkrdHunt0722Gd2/HuntThreatEntitySet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GuardDuty__TrustedEntitySet.HuntTrustedEntitySet.json
+++ b/tests/corpus/AWS__GuardDuty__TrustedEntitySet.HuntTrustedEntitySet.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTrustedEntitySet",
+    "resourceType": "AWS::GuardDuty::TrustedEntitySet",
+    "physicalId": "4102c48b34674672b9a82f865cd93c38|7d64c86ad0974c0ba56a1f12290589c0",
+    "constructPath": "CdkrdHunt0722Gd2/HuntTrustedEntitySet",
+    "declared": {
+      "DetectorId": "7d64c86ad0974c0ba56a1f12290589c0",
+      "Name": "cdkrd-hunt0722-trusted-entity-set",
+      "Format": "TXT",
+      "Location": "https://s3.amazonaws.com/cdkrd-hunt0722-gd-111111111111/trustedlist.txt",
+      "Activate": true
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "Format": "TXT",
+    "CreatedAt": "2026-07-22T07:58:37Z",
+    "DetectorId": "7d64c86ad0974c0ba56a1f12290589c0",
+    "Id": "4102c48b34674672b9a82f865cd93c38",
+    "ErrorDetails": "",
+    "UpdatedAt": "2026-07-22T07:58:37Z",
+    "ExpectedBucketOwner": "111111111111",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0722Gd2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntTrustedEntitySet",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0722Gd2/17c5f9d0-85a3-11f1-9f36-0e40ba705f19",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0722-trusted-entity-set",
+    "Location": "https://s3.amazonaws.com/cdkrd-hunt0722-gd-111111111111/trustedlist.txt"
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "ErrorDetails", "Id", "Status", "UpdatedAt"],
+    "writeOnly": ["Activate"],
+    "createOnly": ["DetectorId", "Format"],
+    "readOnlyPaths": ["CreatedAt", "ErrorDetails", "Id", "Status", "UpdatedAt"],
+    "writeOnlyPaths": ["Activate"],
+    "createOnlyPaths": ["DetectorId", "Format"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntTrustedEntitySet",
+      "resourceType": "AWS::GuardDuty::TrustedEntitySet",
+      "path": "Activate",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "4102c48b34674672b9a82f865cd93c38|7d64c86ad0974c0ba56a1f12290589c0",
+      "constructPath": "CdkrdHunt0722Gd2/HuntTrustedEntitySet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTrustedEntitySet",
+      "resourceType": "AWS::GuardDuty::TrustedEntitySet",
+      "path": "ExpectedBucketOwner",
+      "actual": "111111111111",
+      "physicalId": "4102c48b34674672b9a82f865cd93c38|7d64c86ad0974c0ba56a1f12290589c0",
+      "constructPath": "CdkrdHunt0722Gd2/HuntTrustedEntitySet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.HuntSqsEsm.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.HuntSqsEsm.json
@@ -1,0 +1,140 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntSqsEsm",
+    "resourceType": "AWS::Lambda::EventSourceMapping",
+    "physicalId": "c30abf56-681d-4700-bbf6-9f5e6e3fc8f8",
+    "constructPath": "CdkrdHunt0722Esm/HuntSqsEsm",
+    "declared": {
+      "BatchSize": 10,
+      "EventSourceArn": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0722Esm-HuntQueue82B41AB3-6xGwvUJA5swS",
+      "FilterCriteria": {
+        "Filters": [
+          {
+            "Pattern": "{\"body\":{\"zz\":[{\"exists\":true}]}}"
+          },
+          {
+            "Pattern": "{\"body\":{\"aa\":[{\"exists\":true}]}}"
+          }
+        ]
+      },
+      "FunctionName": "CdkrdHunt0722Esm-HuntSqsFn74BB8624-SgayjXyjGaNL",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "BatchSize": 10,
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0722Esm-HuntSqsFn74BB8624-SgayjXyjGaNL",
+    "EventSourceMappingArn": "arn:aws:lambda:us-east-1:111111111111:event-source-mapping:c30abf56-681d-4700-bbf6-9f5e6e3fc8f8",
+    "Enabled": true,
+    "Id": "c30abf56-681d-4700-bbf6-9f5e6e3fc8f8",
+    "FilterCriteria": {
+      "Filters": [
+        {
+          "Pattern": "{\"body\":{\"zz\":[{\"exists\":true}]}}"
+        },
+        {
+          "Pattern": "{\"body\":{\"aa\":[{\"exists\":true}]}}"
+        }
+      ]
+    },
+    "EventSourceArn": "arn:aws:sqs:us-east-1:111111111111:CdkrdHunt0722Esm-HuntQueue82B41AB3-6xGwvUJA5swS",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0722Esm",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0722Esm/1ce830c0-859b-11f1-9915-0afffaff5795",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "HuntSqsEsm",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "MaximumBatchingWindowInSeconds": 0
+  },
+  "schema": {
+    "readOnly": ["EventSourceMappingArn", "Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "readOnlyPaths": ["EventSourceMappingArn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/fsx": "034b6547-ac4c-49ba-a576-1b8e236f6ceb",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqsEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "c30abf56-681d-4700-bbf6-9f5e6e3fc8f8",
+      "constructPath": "CdkrdHunt0722Esm/HuntSqsEsm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntSqsEsm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumBatchingWindowInSeconds",
+      "actual": 0,
+      "physicalId": "c30abf56-681d-4700-bbf6-9f5e6e3fc8f8",
+      "constructPath": "CdkrdHunt0722Esm/HuntSqsEsm"
+    }
+  ]
+}

--- a/tests/gdsets-expectedbucketowner-1686.test.ts
+++ b/tests/gdsets-expectedbucketowner-1686.test.ts
@@ -1,0 +1,62 @@
+// #1686 (gdsets2-hunt 2026-07-22): a barest GuardDuty ThreatEntitySet / TrustedEntitySet
+// (no ExpectedBucketOwner declared) reads back the resource's OWN account id — GuardDuty
+// materializes the caller account as the default expected owner of the list bucket, which
+// first-run-FP'd as [Potential Drift]. Folded via CONTEXT_ARN_DEFAULTS ({accountId}
+// placeholder — plain string, not an ARN), equality-gated so a DIFFERENT owner account (a
+// real cross-account exposure change) still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const opts = { accountId: '111111111111', region: 'us-east-1' };
+
+const tierPaths = (findings: Finding[]) => findings.map((f) => `${f.tier}:${f.path}`).sort();
+
+for (const resourceType of [
+  'AWS::GuardDuty::ThreatEntitySet',
+  'AWS::GuardDuty::TrustedEntitySet',
+] as const) {
+  describe(`#1686 ${resourceType} ExpectedBucketOwner own-account default`, () => {
+    const declared = {
+      DetectorId: 'd0123456789abcdef',
+      Name: 'cdkrd-hunt-set',
+      Format: 'TXT',
+      Location: 'https://s3.amazonaws.com/bucket/list.txt',
+      Activate: true,
+    };
+    const res: DesiredResource = {
+      logicalId: 'HuntSet',
+      resourceType,
+      physicalId: 'abcdef0123456789',
+      declared,
+    };
+    const live = { ...declared, ExpectedBucketOwner: '111111111111' };
+
+    it('folds the own-account ExpectedBucketOwner to atDefault (zero potential drift)', () => {
+      const f = classifyResource(res, live, emptySchema, opts);
+      expect(tierPaths(f)).toContain('atDefault:ExpectedBucketOwner');
+      expect(tierPaths(f).filter((t) => t.startsWith('undeclared:'))).toEqual([]);
+    });
+
+    it('SURFACES a different (cross-account) ExpectedBucketOwner', () => {
+      const f = classifyResource(
+        res,
+        { ...declared, ExpectedBucketOwner: '222222222222' },
+        emptySchema,
+        opts
+      );
+      expect(tierPaths(f)).toContain('undeclared:ExpectedBucketOwner');
+    });
+  });
+}

--- a/tests/integration/apimap-hunt/app.ts
+++ b/tests/integration/apimap-hunt/app.ts
@@ -1,0 +1,96 @@
+// Unexercised-adapter probe (real AWS): AWS::ApiGatewayV2::ApiMapping
+// (child-first composite `ApiMappingId|DomainName`) and
+// AWS::ApiGateway::BasePathMapping (compositeWith DomainName) both have
+// CC_IDENTIFIER_ADAPTERS entries with zero corpus and zero fixtures — deferred
+// by past hunts because they need a custom domain + ACM cert. A SELF-SIGNED
+// IMPORTED cert (out-of-band by verify.sh, CERT_ARN env) unblocks both:
+// API Gateway regional domains accept imported certs and never touch DNS.
+// Both mapping parents (HTTP API $default stage; REST API prod stage) are the
+// barest possible forms.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnBasePathMapping,
+  CfnDeployment,
+  CfnDomainName as CfnRestDomainName,
+  CfnMethod,
+  CfnResource as CfnApiResource,
+  CfnRestApi,
+  CfnStage,
+} from "aws-cdk-lib/aws-apigateway";
+import {
+  CfnApi,
+  CfnApiMapping,
+  CfnDomainName,
+  CfnStage as CfnV2Stage,
+} from "aws-cdk-lib/aws-apigatewayv2";
+
+const certArn = process.env.CERT_ARN;
+if (!certArn) throw new Error("CERT_ARN env is required (set by verify.sh)");
+const domainV2 = "hunt0722-v2.cdkrd-hunt.example.com";
+const domainV1 = "hunt0722-v1.cdkrd-hunt.example.com";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722ApiMap");
+
+// ---- HTTP API + $default stage + domain + ApiMapping
+const httpApi = new CfnApi(stack, "HuntHttpApi", {
+  name: "cdkrd-hunt0722-apimap-http",
+  protocolType: "HTTP",
+});
+const v2Stage = new CfnV2Stage(stack, "HuntHttpStage", {
+  apiId: httpApi.ref,
+  stageName: "$default",
+  autoDeploy: true,
+});
+const v2Domain = new CfnDomainName(stack, "HuntV2Domain", {
+  domainName: domainV2,
+  domainNameConfigurations: [
+    { certificateArn: certArn, endpointType: "REGIONAL" },
+  ],
+});
+const apiMapping = new CfnApiMapping(stack, "HuntApiMapping", {
+  apiId: httpApi.ref,
+  domainName: v2Domain.ref,
+  stage: "$default",
+});
+apiMapping.addDependency(v2Stage);
+
+// ---- REST API + prod stage + domain + BasePathMapping
+const restApi = new CfnRestApi(stack, "HuntRestApi", {
+  name: "cdkrd-hunt0722-apimap-rest",
+});
+const pingResource = new CfnApiResource(stack, "HuntPing", {
+  restApiId: restApi.ref,
+  parentId: restApi.attrRootResourceId,
+  pathPart: "ping",
+});
+const pingMethod = new CfnMethod(stack, "HuntPingGet", {
+  restApiId: restApi.ref,
+  resourceId: pingResource.ref,
+  httpMethod: "GET",
+  authorizationType: "NONE",
+  integration: { type: "MOCK", requestTemplates: { "application/json": '{"statusCode": 200}' } },
+});
+const deployment = new CfnDeployment(stack, "HuntDeployment", {
+  restApiId: restApi.ref,
+});
+deployment.addDependency(pingMethod);
+const restStage = new CfnStage(stack, "HuntRestStage", {
+  restApiId: restApi.ref,
+  deploymentId: deployment.ref,
+  stageName: "prod",
+});
+const restDomain = new CfnRestDomainName(stack, "HuntRestDomain", {
+  domainName: domainV1,
+  regionalCertificateArn: certArn,
+  endpointConfiguration: { types: ["REGIONAL"] },
+});
+const bpm = new CfnBasePathMapping(stack, "HuntBasePathMapping", {
+  domainName: restDomain.ref,
+  restApiId: restApi.ref,
+  stage: "prod",
+});
+bpm.addDependency(restStage);
+
+app.synth();

--- a/tests/integration/apimap-hunt/cdk.json
+++ b/tests/integration/apimap-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/apimap-hunt/package.json
+++ b/tests/integration/apimap-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-apimap-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 API GW custom-domain mapping adapter probe (apimap-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/apimap-hunt/verify.sh
+++ b/tests/integration/apimap-hunt/verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ApiGatewayV2 ApiMapping + ApiGateway BasePathMapping adapter probe: import a
+# self-signed cert to ACM out of band (regional API GW domains accept imported
+# certs; no DNS involved), deploy both mapping shapes, first check MUST be
+# CLEAN with zero skipped reads.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722ApiMap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+CERT_ARN=""
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  if [ -n "$CERT_ARN" ]; then
+    for _ in 1 2 3 4 5 6; do
+      aws acm delete-certificate --certificate-arn "$CERT_ARN" --region "$REGION" >/dev/null 2>&1 && break
+      sleep 20
+    done
+  fi
+  rm -rf .cdkrd cdk.out /tmp/cdkrd-apimap-cert
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] out-of-band prep: self-signed cert -> ACM import ==="
+mkdir -p /tmp/cdkrd-apimap-cert
+openssl req -x509 -newkey rsa:2048 -sha256 -days 3 -nodes \
+  -keyout /tmp/cdkrd-apimap-cert/key.pem -out /tmp/cdkrd-apimap-cert/cert.pem \
+  -subj "/CN=cdkrd-hunt.example.com" \
+  -addext "subjectAltName=DNS:hunt0722-v1.cdkrd-hunt.example.com,DNS:hunt0722-v2.cdkrd-hunt.example.com" \
+  >/dev/null 2>&1 || fail "openssl"
+CERT_ARN="$(aws acm import-certificate \
+  --certificate fileb:///tmp/cdkrd-apimap-cert/cert.pem \
+  --private-key fileb:///tmp/cdkrd-apimap-cert/key.pem \
+  --tags Key=cdkrd:ephemeral,Value=1 \
+  --region "$REGION" --query CertificateArn --output text)" || fail "acm import"
+export CERT_ARN
+echo "imported: $CERT_ARN"
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN + zero skipped ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-apimap}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out" && fail "resources skipped (composite-identifier read gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cfpol-hunt/app.ts
+++ b/tests/integration/cfpol-hunt/app.ts
@@ -1,0 +1,84 @@
+// Declared-tier reorder probe (real AWS): CloudFront CachePolicy folds only
+// HeadersConfig.Headers as an unordered nested set (noise.ts
+// UNORDERED_NESTED_OBJECT_ARRAY_PATHS) — the sibling CookiesConfig.Cookies and
+// QueryStringsConfig.QueryStrings whitelists share the identical set semantic
+// but are unguarded, and OriginRequestPolicy / ResponseHeadersPolicy have no
+// entries at all. Every existing corpus case is single-element, so a reorder
+// can't surface offline. This deploys multi-element, deliberately unsorted
+// lists on all three policy types and asserts the first check is CLEAN.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnCachePolicy,
+  CfnOriginRequestPolicy,
+  CfnResponseHeadersPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722CfPol");
+
+new CfnCachePolicy(stack, "HuntCachePolicy", {
+  cachePolicyConfig: {
+    name: "cdkrd-hunt0722-cache-policy",
+    minTtl: 0,
+    maxTtl: 86400,
+    defaultTtl: 3600,
+    parametersInCacheKeyAndForwardedToOrigin: {
+      enableAcceptEncodingGzip: true,
+      enableAcceptEncodingBrotli: false,
+      headersConfig: {
+        headerBehavior: "whitelist",
+        headers: ["x-cdkrd-zz", "x-cdkrd-aa", "x-cdkrd-mm"],
+      },
+      cookiesConfig: {
+        cookieBehavior: "whitelist",
+        cookies: ["zz-cookie", "aa-cookie", "mm-cookie"],
+      },
+      queryStringsConfig: {
+        queryStringBehavior: "whitelist",
+        queryStrings: ["zz", "aa", "mm"],
+      },
+    },
+  },
+});
+
+new CfnOriginRequestPolicy(stack, "HuntOrp", {
+  originRequestPolicyConfig: {
+    name: "cdkrd-hunt0722-orp",
+    headersConfig: {
+      headerBehavior: "whitelist",
+      headers: ["x-cdkrd-zz", "x-cdkrd-aa", "x-cdkrd-mm"],
+    },
+    cookiesConfig: {
+      cookieBehavior: "whitelist",
+      cookies: ["zz-cookie", "aa-cookie", "mm-cookie"],
+    },
+    queryStringsConfig: {
+      queryStringBehavior: "whitelist",
+      queryStrings: ["zz", "aa", "mm"],
+    },
+  },
+});
+
+new CfnResponseHeadersPolicy(stack, "HuntRhp", {
+  responseHeadersPolicyConfig: {
+    name: "cdkrd-hunt0722-rhp",
+    corsConfig: {
+      accessControlAllowCredentials: false,
+      accessControlAllowHeaders: { items: ["X-Cdkrd-Zz", "X-Cdkrd-Aa", "X-Cdkrd-Mm"] },
+      accessControlAllowMethods: { items: ["POST", "GET", "DELETE"] },
+      accessControlAllowOrigins: {
+        items: ["https://zz.example.com", "https://aa.example.com"],
+      },
+      originOverride: true,
+    },
+    customHeadersConfig: {
+      items: [
+        { header: "x-cdkrd-custom-zz", value: "zz", override: true },
+        { header: "x-cdkrd-custom-aa", value: "aa", override: false },
+      ],
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/cfpol-hunt/cdk.json
+++ b/tests/integration/cfpol-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cfpol-hunt/package.json
+++ b/tests/integration/cfpol-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cfpol-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 CloudFront policy reorder probe (cfpol-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cfpol-hunt/verify.sh
+++ b/tests/integration/cfpol-hunt/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# CloudFront policy-type reorder probe: deploy multi-element unsorted whitelist
+# sets on CachePolicy / OriginRequestPolicy / ResponseHeadersPolicy, then the
+# first check (before record) MUST be CLEAN, record, re-check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722CfPol
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-cfpol}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out" && fail "resources skipped (read gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ebappver-hunt/app.ts
+++ b/tests/integration/ebappver-hunt/app.ts
@@ -1,0 +1,36 @@
+// Unexercised-adapter probe (real AWS): AWS::ElasticBeanstalk::ApplicationVersion
+// has a CC_IDENTIFIER_ADAPTERS entry (compositeWith ApplicationName) with zero
+// corpus and zero fixture coverage — the composite `ApplicationName|Id` read
+// path has never run against a live resource. Deploy the barest Application +
+// ApplicationVersion (S3 source bundle via a CDK asset; no Environment — that
+// is the slow/expensive part) and assert the first check is CLEAN with zero
+// skipped reads.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnApplication, CfnApplicationVersion } from "aws-cdk-lib/aws-elasticbeanstalk";
+import { Asset } from "aws-cdk-lib/aws-s3-assets";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722EbAv");
+
+const bundle = new Asset(stack, "HuntBundle", {
+  path: path.join(here, "bundle"),
+});
+
+const ebApp = new CfnApplication(stack, "HuntEbApp", {
+  applicationName: "cdkrd-hunt0722-ebav",
+});
+
+new CfnApplicationVersion(stack, "HuntEbAppVersion", {
+  applicationName: ebApp.ref,
+  sourceBundle: {
+    s3Bucket: bundle.s3BucketName,
+    s3Key: bundle.s3ObjectKey,
+  },
+});
+
+app.synth();

--- a/tests/integration/ebappver-hunt/bundle/index.html
+++ b/tests/integration/ebappver-hunt/bundle/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<p>cdkrd ebappver-hunt placeholder bundle</p>

--- a/tests/integration/ebappver-hunt/cdk.json
+++ b/tests/integration/ebappver-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ebappver-hunt/package.json
+++ b/tests/integration/ebappver-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ebappver-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 EB ApplicationVersion adapter probe (ebappver-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ebappver-hunt/verify.sh
+++ b/tests/integration/ebappver-hunt/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# EB ApplicationVersion composite-adapter probe: deploy barest Application +
+# ApplicationVersion (no Environment), first check MUST be CLEAN with zero
+# skipped reads (a wrong composite order silently skips the read — #1523 class).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722EbAv
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN + zero skipped ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-ebappver}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out" && fail "resources skipped (composite-identifier read gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ebarm-hunt/app.ts
+++ b/tests/integration/ebarm-hunt/app.ts
@@ -1,0 +1,59 @@
+// Variant-row probe (real AWS): EB_INSTANCE_TYPES_DEFAULT_BY_ARCH['arm64']
+// ({t4g.micro, t4g.small}) was pinned FROM THE EB DOCS — the x86_64 sibling is
+// corpus-harvested but no arm64 environment ever ran live (the #1664 mirrored-
+// row class). Deploy a SingleInstance env declaring ONLY
+// aws:ec2:instances|SupportedArchitectures=arm64 (no InstanceTypes /
+// InstanceType), and assert the first check is CLEAN — if AWS's real arm64
+// default instance-type list differs from the docs pin, it first-run-FPs here.
+// The solution stack name moves over time, so verify.sh resolves the latest
+// Docker AL2023 stack and passes it via EB_STACK.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnApplication, CfnEnvironment } from "aws-cdk-lib/aws-elasticbeanstalk";
+import { CfnInstanceProfile, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+
+const solutionStack = process.env.EB_STACK;
+if (!solutionStack) throw new Error("EB_STACK env is required (set by verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722EbArm");
+
+const instanceRole = new Role(stack, "EbInstanceRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  managedPolicies: [
+    { managedPolicyArn: "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier" },
+  ],
+});
+const instanceProfile = new CfnInstanceProfile(stack, "EbInstanceProfile", {
+  roles: [instanceRole.roleName],
+});
+
+const application = new CfnApplication(stack, "EbApp", {
+  applicationName: "cdkrd-hunt0722-ebarm-app",
+});
+
+const environment = new CfnEnvironment(stack, "EbEnv", {
+  applicationName: application.applicationName!,
+  environmentName: "cdkrd-hunt0722-ebarm-env",
+  solutionStackName: solutionStack,
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "SingleInstance",
+    },
+    {
+      namespace: "aws:autoscaling:launchconfiguration",
+      optionName: "IamInstanceProfile",
+      value: instanceProfile.ref,
+    },
+    {
+      namespace: "aws:ec2:instances",
+      optionName: "SupportedArchitectures",
+      value: "arm64",
+    },
+  ],
+});
+environment.addDependency(application);
+
+app.synth();

--- a/tests/integration/ebarm-hunt/cdk.json
+++ b/tests/integration/ebarm-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ebarm-hunt/package.json
+++ b/tests/integration/ebarm-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ebarm-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 EB arm64 default-instance-types variant probe (ebarm-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ebarm-hunt/verify.sh
+++ b/tests/integration/ebarm-hunt/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# EB arm64 default-instance-types variant probe: resolve the latest Docker
+# AL2023 solution stack, deploy an arm64 SingleInstance env with NO instance
+# types declared, first check MUST be CLEAN (the docs-pinned t4g.micro/t4g.small
+# row is unproven live).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722EbArm
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+EB_STACK="$(aws elasticbeanstalk list-available-solution-stacks --region "$REGION" \
+  --query "SolutionStacks[?contains(@, 'Amazon Linux 2023') && contains(@, 'running Docker')] | [0]" --output text)"
+[ -n "$EB_STACK" ] && [ "$EB_STACK" != "None" ] || { echo "INTEG FAIL ($STACK): no AL2023 Docker solution stack"; exit 1; }
+export EB_STACK
+echo "using solution stack: $EB_STACK"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-ebarm}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ecsnet-hunt/app.ts
+++ b/tests/integration/ecsnet-hunt/app.ts
@@ -1,0 +1,60 @@
+// Revert-convergence probe (real AWS): ECS Service
+// NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp folds to 'DISABLED'
+// (KNOWN_DEFAULT_PATHS, #1610) but UpdateService is a SELECTIVE-modify API and
+// the ECS SDK_NESTED_WRITERS cover only ServiceConnect/VolumeConfigurations —
+// whether a bare `remove` (or the CC patch) converges an out-of-band
+// ENABLED flip back to DISABLED has never been probed. Barest Fargate service
+// with desiredCount 0 (no tasks ever launch — free), AssignPublicIp UNDECLARED.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnSecurityGroup, CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnService, CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722EcsNet");
+
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.72.0.0/16" });
+const subnet = new CfnSubnet(stack, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.72.0.0/24",
+  availabilityZone: "us-east-1a",
+});
+const sg = new CfnSecurityGroup(stack, "Sg", {
+  groupDescription: "cdkrd ecsnet-hunt",
+  vpcId: vpc.ref,
+});
+
+const cluster = new CfnCluster(stack, "HuntCluster", {
+  clusterName: "cdkrd-hunt0722-ecsnet",
+});
+
+const taskDef = new CfnTaskDefinition(stack, "HuntTaskDef", {
+  family: "cdkrd-hunt0722-ecsnet",
+  requiresCompatibilities: ["FARGATE"],
+  networkMode: "awsvpc",
+  cpu: "256",
+  memory: "512",
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "public.ecr.aws/docker/library/busybox:stable",
+      essential: true,
+    },
+  ],
+});
+
+new CfnService(stack, "HuntService", {
+  cluster: cluster.ref,
+  serviceName: "cdkrd-hunt0722-ecsnet-svc",
+  taskDefinition: taskDef.ref,
+  launchType: "FARGATE",
+  desiredCount: 0,
+  networkConfiguration: {
+    awsvpcConfiguration: {
+      subnets: [subnet.ref],
+      securityGroups: [sg.attrGroupId],
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/ecsnet-hunt/cdk.json
+++ b/tests/integration/ecsnet-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecsnet-hunt/package.json
+++ b/tests/integration/ecsnet-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecsnet-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 ECS AssignPublicIp revert-convergence probe (ecsnet-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecsnet-hunt/verify.sh
+++ b/tests/integration/ecsnet-hunt/verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ECS AssignPublicIp revert-convergence probe: deploy (desiredCount 0), first
+# check CLEAN, record, OOB flip AssignPublicIp ENABLED -> detect -> revert ->
+# LIVE value MUST be back to DISABLED.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722EcsNet
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+CLUSTER=cdkrd-hunt0722-ecsnet
+SVC=cdkrd-hunt0722-ecsnet-svc
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-ecsnet}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "=== [$STACK] OOB flip AssignPublicIp -> ENABLED ==="
+SUBNET="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SVC" --region "$REGION" \
+  --query 'services[0].networkConfiguration.awsvpcConfiguration.subnets[0]' --output text)"
+SG="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SVC" --region "$REGION" \
+  --query 'services[0].networkConfiguration.awsvpcConfiguration.securityGroups[0]' --output text)"
+aws ecs update-service --cluster "$CLUSTER" --service "$SVC" --region "$REGION" \
+  --network-configuration "awsvpcConfiguration={subnets=[$SUBNET],securityGroups=[$SG],assignPublicIp=ENABLED}" >/dev/null || fail "OOB update-service"
+sleep 20
+
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.mut.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "MISSED DETECTION: expected exit 1 after OOB AssignPublicIp flip (got $rc)"
+
+echo "=== [$STACK] revert + live convergence (AssignPublicIp MUST be DISABLED) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.rev.out" || fail "revert errored"
+sleep 20
+LIVE_API="$(aws ecs describe-services --cluster "$CLUSTER" --services "$SVC" --region "$REGION" \
+  --query 'services[0].networkConfiguration.awsvpcConfiguration.assignPublicIp' --output text)"
+[ "$LIVE_API" = "DISABLED" ] || fail "REVERT NO-OP: live assignPublicIp=$LIVE_API (expected DISABLED) — RSDP/writer candidate"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/esmfilter-hunt/app.ts
+++ b/tests/integration/esmfilter-hunt/app.ts
@@ -1,0 +1,64 @@
+// Lambda EventSourceMapping probes (real AWS):
+// 1. FilterCriteria.Filters is a set of {Pattern} objects with no identity
+//    key — no noise.ts allowlist covers it and no corpus case carries
+//    FilterCriteria at all, so whether Lambda reorders the set is unprobed.
+//    Deploy an SQS ESM with two filters, deliberately unsorted.
+// 2. A barest Kinesis ESM leaves ParallelizationFactor / TumblingWindow /
+//    Bisect* undeclared (first-run fold probe); verify.sh then mutates
+//    ParallelizationFactor out of band and probes detect -> revert -> live
+//    convergence (the bare-`remove` no-op class).
+import { App, Duration, Stack, Tags } from "aws-cdk-lib";
+import { Stream, StreamMode } from "aws-cdk-lib/aws-kinesis";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722Esm");
+
+const fnCode = lambda.Code.fromInline(
+  "exports.handler = async () => ({ statusCode: 200 });",
+);
+
+const queue = new Queue(stack, "HuntQueue", {
+  visibilityTimeout: Duration.seconds(120),
+});
+
+const sqsFn = new lambda.Function(stack, "HuntSqsFn", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: fnCode,
+});
+queue.grantConsumeMessages(sqsFn);
+
+new lambda.CfnEventSourceMapping(stack, "HuntSqsEsm", {
+  functionName: sqsFn.functionName,
+  eventSourceArn: queue.queueArn,
+  batchSize: 10,
+  filterCriteria: {
+    filters: [
+      { pattern: '{"body":{"zz":[{"exists":true}]}}' },
+      { pattern: '{"body":{"aa":[{"exists":true}]}}' },
+    ],
+  },
+});
+
+const stream = new Stream(stack, "HuntStream", {
+  streamMode: StreamMode.PROVISIONED,
+  shardCount: 1,
+});
+
+const kinesisFn = new lambda.Function(stack, "HuntKinesisFn", {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: fnCode,
+});
+stream.grantRead(kinesisFn);
+
+new lambda.CfnEventSourceMapping(stack, "HuntKinesisEsm", {
+  functionName: kinesisFn.functionName,
+  eventSourceArn: stream.streamArn,
+  startingPosition: "LATEST",
+});
+
+app.synth();

--- a/tests/integration/esmfilter-hunt/cdk.json
+++ b/tests/integration/esmfilter-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/esmfilter-hunt/package.json
+++ b/tests/integration/esmfilter-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-esmfilter-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 ESM FilterCriteria + Kinesis ESM probes (esmfilter-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/esmfilter-hunt/verify.sh
+++ b/tests/integration/esmfilter-hunt/verify.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# ESM probes: (1) FilterCriteria.Filters reorder FP on the SQS ESM; (2) barest
+# Kinesis ESM first-run fold; (3) ParallelizationFactor OOB mutate -> detect ->
+# revert -> LIVE convergence (bare-remove no-op class).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722Esm
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-esmfilter}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out" && fail "resources skipped (read gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "=== [$STACK] FN probe: mutate Kinesis ESM ParallelizationFactor 1->3 OOB ==="
+KESM_UUID="$(aws lambda list-event-source-mappings --region "$REGION" \
+  --query "EventSourceMappings[?contains(EventSourceArn, 'HuntStream')].UUID" --output text)"
+[ -n "$KESM_UUID" ] || fail "could not find Kinesis ESM UUID"
+aws lambda update-event-source-mapping --uuid "$KESM_UUID" --parallelization-factor 3 --region "$REGION" >/dev/null || fail "OOB mutate"
+sleep 20
+
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.mut.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "MISSED DETECTION: expected exit 1 after OOB ParallelizationFactor change (got $rc)"
+
+echo "=== [$STACK] revert + live convergence ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.rev.out" || fail "revert errored"
+sleep 20
+LIVE_PF="$(aws lambda get-event-source-mapping --uuid "$KESM_UUID" --region "$REGION" --query 'ParallelizationFactor' --output text)"
+[ "$LIVE_PF" = "1" ] || fail "REVERT NO-OP: live ParallelizationFactor=$LIVE_PF (expected 1) — RSDP candidate"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/gdsets2-hunt/app.ts
+++ b/tests/integration/gdsets2-hunt/app.ts
@@ -1,0 +1,100 @@
+// Unexercised GuardDuty adapter probes (real AWS): ThreatEntitySet /
+// TrustedEntitySet (compositeChildFirstWith DetectorId — pi is [Id, DetectorId])
+// and PublishingDestination (compositeWith DetectorId — pi is [DetectorId, Id])
+// all have CC_IDENTIFIER_ADAPTERS entries with zero corpus and zero fixtures;
+// a wrong composite order silently skips every read (#1523 class). Also a
+// Filter with UNDECLARED Action (folds KNOWN_DEFAULTS 'NOOP') for verify.sh's
+// OOB mutate -> detect -> revert -> live-convergence probe.
+// The entity-set list files are pre-uploaded out of band by verify.sh
+// (GD_BUCKET env); the findings-export bucket + KMS key are in-stack.
+// Entity sets use raw CfnResource — the L1s are newer than some aws-cdk-lib 2.x.
+import { App, CfnResource, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnDetector, CfnFilter, CfnPublishingDestination } from "aws-cdk-lib/aws-guardduty";
+import { PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const listBucket = process.env.GD_BUCKET;
+if (!listBucket) throw new Error("GD_BUCKET env is required (set by verify.sh)");
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722Gd2");
+
+const detector = new CfnDetector(stack, "HuntDetector", { enable: true });
+
+new CfnResource(stack, "HuntThreatEntitySet", {
+  type: "AWS::GuardDuty::ThreatEntitySet",
+  properties: {
+    DetectorId: detector.ref,
+    Name: "cdkrd-hunt0722-threat-entity-set",
+    Format: "TXT",
+    Location: `https://s3.amazonaws.com/${listBucket}/threatlist.txt`,
+    Activate: true,
+  },
+});
+
+new CfnResource(stack, "HuntTrustedEntitySet", {
+  type: "AWS::GuardDuty::TrustedEntitySet",
+  properties: {
+    DetectorId: detector.ref,
+    Name: "cdkrd-hunt0722-trusted-entity-set",
+    Format: "TXT",
+    Location: `https://s3.amazonaws.com/${listBucket}/trustedlist.txt`,
+    Activate: true,
+  },
+});
+
+new CfnFilter(stack, "HuntFilter", {
+  detectorId: detector.ref,
+  name: "cdkrd-hunt0722-filter",
+  findingCriteria: {
+    criterion: { severity: { Gte: 4 } },
+  },
+});
+
+// Findings-export destination: in-stack bucket + KMS key with GuardDuty grants.
+const exportKey = new Key(stack, "HuntExportKey", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  description: "cdkrd gdsets2-hunt findings export key",
+});
+exportKey.addToResourcePolicy(
+  new PolicyStatement({
+    principals: [new ServicePrincipal("guardduty.amazonaws.com")],
+    actions: ["kms:GenerateDataKey"],
+    resources: ["*"],
+  }),
+);
+
+// No autoDeleteObjects: its custom-resource Lambda is a `skipped=` line the
+// verify.sh zero-skip assert would trip on; delstack force-deletes the
+// non-empty bucket at teardown anyway.
+const exportBucket = new Bucket(stack, "HuntExportBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+exportBucket.addToResourcePolicy(
+  new PolicyStatement({
+    principals: [new ServicePrincipal("guardduty.amazonaws.com")],
+    actions: ["s3:GetBucketLocation"],
+    resources: [exportBucket.bucketArn],
+  }),
+);
+exportBucket.addToResourcePolicy(
+  new PolicyStatement({
+    principals: [new ServicePrincipal("guardduty.amazonaws.com")],
+    actions: ["s3:PutObject"],
+    resources: [exportBucket.arnForObjects("*")],
+  }),
+);
+
+const pubDest = new CfnPublishingDestination(stack, "HuntPubDest", {
+  detectorId: detector.ref,
+  destinationType: "S3",
+  destinationProperties: {
+    destinationArn: exportBucket.bucketArn,
+    kmsKeyArn: exportKey.keyArn,
+  },
+});
+if (exportBucket.policy) pubDest.addDependency(exportBucket.policy.node.defaultChild as CfnResource);
+
+app.synth();

--- a/tests/integration/gdsets2-hunt/cdk.json
+++ b/tests/integration/gdsets2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/gdsets2-hunt/package.json
+++ b/tests/integration/gdsets2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-gdsets2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 GuardDuty entity-set + publishing-destination adapter probe (gdsets2-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/gdsets2-hunt/verify.sh
+++ b/tests/integration/gdsets2-hunt/verify.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# GuardDuty entity-set / publishing-destination adapter probe + Filter Action
+# revert-convergence probe: prep list bucket, deploy, first check MUST be CLEAN
+# with zero skipped, record, OOB update-filter --action ARCHIVE -> detect ->
+# revert -> live action MUST be back to NOOP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722Gd2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+export GD_BUCKET="cdkrd-hunt0722-gd-${ACCOUNT}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  aws s3 rb "s3://$GD_BUCKET" --force >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] out-of-band prep: list bucket + files + guardduty read policy ==="
+aws s3 mb "s3://$GD_BUCKET" --region "$REGION" >/dev/null || fail "mb"
+printf '198.51.100.1\n' > /tmp/cdkrd-gd2-list.txt
+aws s3 cp /tmp/cdkrd-gd2-list.txt "s3://$GD_BUCKET/threatlist.txt" >/dev/null || fail "cp threatlist"
+aws s3 cp /tmp/cdkrd-gd2-list.txt "s3://$GD_BUCKET/trustedlist.txt" >/dev/null || fail "cp trustedlist"
+aws s3api put-bucket-policy --bucket "$GD_BUCKET" --policy "{
+  \"Version\": \"2012-10-17\",
+  \"Statement\": [{
+    \"Effect\": \"Allow\",
+    \"Principal\": { \"Service\": \"guardduty.amazonaws.com\" },
+    \"Action\": \"s3:GetObject\",
+    \"Resource\": \"arn:aws:s3:::$GD_BUCKET/*\"
+  }]
+}" || fail "bucket policy"
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN + zero skipped ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-gdsets2}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out" && fail "resources skipped (composite-identifier read gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "=== [$STACK] Filter Action probe: OOB NOOP -> ARCHIVE ==="
+DETECTOR_ID="$(aws guardduty list-detectors --region "$REGION" --query 'DetectorIds[0]' --output text)"
+[ -n "$DETECTOR_ID" ] && [ "$DETECTOR_ID" != "None" ] || fail "no detector id"
+aws guardduty update-filter --detector-id "$DETECTOR_ID" --filter-name cdkrd-hunt0722-filter --action ARCHIVE --region "$REGION" >/dev/null || fail "OOB update-filter"
+sleep 10
+
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.mut.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "MISSED DETECTION: expected exit 1 after OOB filter Action change (got $rc)"
+
+echo "=== [$STACK] revert + live convergence (Action MUST return to NOOP) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.rev.out" || fail "revert errored"
+sleep 10
+LIVE_ACTION="$(aws guardduty get-filter --detector-id "$DETECTOR_ID" --filter-name cdkrd-hunt0722-filter --region "$REGION" --query 'Action' --output text)"
+[ "$LIVE_ACTION" = "NOOP" ] || fail "REVERT NO-OP: live filter Action=$LIVE_ACTION (expected NOOP) — RSDP candidate"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/revconv6-hunt/app.ts
+++ b/tests/integration/revconv6-hunt/app.ts
@@ -1,0 +1,36 @@
+// Revert-convergence probe batch 9 (real AWS): two recently added
+// KNOWN_DEFAULT(_PATHS) folds whose update APIs are proven-SELECTIVE for a
+// SIBLING property (which needed an RSDP entry) but were never probed
+// themselves — the bare-`remove` silent-no-op class (#1571 family):
+// - Backup RestoreTestingPlan RecoveryPointSelection.SelectionWindowDays (30):
+//   StartWindowHours / ScheduleExpressionTimezone on the SAME
+//   UpdateRestoreTestingPlan call no-oped (#1640); this nested sibling rides
+//   the same call and was left unprobed.
+// - RUM AppMonitor AppMonitorConfiguration (whole-object pin): sibling
+//   CustomEvents on the SAME UpdateAppMonitor call no-oped (#1630).
+// Both are left UNDECLARED here; verify.sh mutates them out of band, asserts
+// detection, reverts, and asserts the LIVE value returned to the default.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnRestoreTestingPlan } from "aws-cdk-lib/aws-backup";
+import { CfnAppMonitor } from "aws-cdk-lib/aws-rum";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0722Rc6");
+
+new CfnRestoreTestingPlan(stack, "HuntRtp", {
+  restoreTestingPlanName: "cdkrd_hunt0722_rtp",
+  scheduleExpression: "cron(0 5 ? * MON *)",
+  recoveryPointSelection: {
+    algorithm: "LATEST_WITHIN_WINDOW",
+    includeVaults: ["*"],
+    recoveryPointTypes: ["SNAPSHOT"],
+  },
+});
+
+new CfnAppMonitor(stack, "HuntRumMonitor", {
+  name: "cdkrd-hunt0722-rum",
+  domain: "cdkrd-hunt.example.com",
+});
+
+app.synth();

--- a/tests/integration/revconv6-hunt/cdk.json
+++ b/tests/integration/revconv6-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revconv6-hunt/package.json
+++ b/tests/integration/revconv6-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revconv6-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Hunt 2026-07-22 revert-convergence probes (revconv6-hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revconv6-hunt/verify.sh
+++ b/tests/integration/revconv6-hunt/verify.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Revert-convergence probes: RestoreTestingPlan SelectionWindowDays + RUM
+# AppMonitorConfiguration. Deploy -> first check CLEAN -> record -> mutate both
+# OOB -> detect (exit 1) -> revert -> LIVE values MUST be back at defaults.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0722Rc6
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+RTP_NAME=cdkrd_hunt0722_rtp
+RUM_NAME=cdkrd-hunt0722-rum
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-revconv6}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "first check errored"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FALSE POSITIVE (expected zero Potential Drift)"
+grep -q "skipped=" "/tmp/cdkrd-$STACK.pre.out" && fail "resources skipped (read gap)"
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record FALSE POSITIVE"
+
+echo "=== [$STACK] OOB mutate: RTP SelectionWindowDays 30->7 ==="
+aws backup update-restore-testing-plan --restore-testing-plan-name "$RTP_NAME" \
+  --restore-testing-plan '{"RecoveryPointSelection":{"Algorithm":"LATEST_WITHIN_WINDOW","IncludeVaults":["*"],"RecoveryPointTypes":["SNAPSHOT"],"SelectionWindowDays":7}}' \
+  --region "$REGION" >/dev/null || fail "OOB update-restore-testing-plan"
+
+echo "=== [$STACK] OOB mutate: RUM SessionSampleRate 0.1->0.5 ==="
+aws rum update-app-monitor --name "$RUM_NAME" \
+  --app-monitor-configuration '{"SessionSampleRate":0.5}' \
+  --region "$REGION" >/dev/null || fail "OOB update-app-monitor"
+sleep 15
+
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.mut.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "MISSED DETECTION: expected exit 1 after OOB mutations (got $rc)"
+
+echo "=== [$STACK] revert + live convergence ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.rev.out" || fail "revert errored"
+sleep 15
+
+LIVE_SWD="$(aws backup get-restore-testing-plan --restore-testing-plan-name "$RTP_NAME" --region "$REGION" \
+  --query 'RestoreTestingPlan.RecoveryPointSelection.SelectionWindowDays' --output text)"
+[ "$LIVE_SWD" = "30" ] || fail "REVERT NO-OP (RTP): live SelectionWindowDays=$LIVE_SWD (expected 30) — RSDP candidate"
+
+LIVE_SSR="$(aws rum get-app-monitor --name "$RUM_NAME" --region "$REGION" \
+  --query 'AppMonitor.AppMonitorConfiguration.SessionSampleRate' --output text)"
+[ "$LIVE_SSR" = "0.1" ] || fail "REVERT NO-OP (RUM): live SessionSampleRate=$LIVE_SSR (expected 0.1) — RSDP candidate"
+
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-eb-instancetypes-1278.test.ts
+++ b/tests/noise-eb-instancetypes-1278.test.ts
@@ -58,6 +58,18 @@ describe('#1278 EB InstanceTypes folds against the architecture-derived default 
     expect(tier('t4g.micro, t4g.small', 'arm64')).toBe('atDefault');
   });
 
+  // #1685 (ebarm-hunt 2026-07-22): the docs pair above was never what a live arm64 env
+  // gets — AWS assigned "t4g.micro, t4g.large", which first-run-FP'd against the
+  // docs-only set. The arm64 row is now the union of observed + documented pairs.
+  it('folds the LIVE arm64 default pair t4g.micro,t4g.large (#1685)', () => {
+    expect(tier('t4g.micro, t4g.large', 'arm64')).toBe('atDefault');
+  });
+
+  it('still SURFACES an arm64 family bump away from t4g burstables (#1685)', () => {
+    expect(tier('m7g.large', 'arm64')).toBe('undeclared');
+    expect(tier('t4g.micro, c7g.xlarge', 'arm64')).toBe('undeclared');
+  });
+
   it('SURFACES an arm64 cost bomb (p4d) resize', () => {
     expect(tier('p4d.24xlarge', 'arm64')).toBe('undeclared');
   });

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -755,6 +755,54 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  // revconv6 hunt (live-proven 2026-07-22, #1684): the sibling whole-object
+  // AppMonitorConfiguration no-ops the bare remove on the same selective
+  // UpdateAppMonitor call; an explicit CC add of the KNOWN_DEFAULTS object converges.
+  it('RUM AppMonitor AppMonitorConfiguration (SET-DEFAULT) -> add op writing the default object, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RUM::AppMonitor',
+      path: 'AppMonitorConfiguration',
+      actual: {
+        IncludedPages: [],
+        ExcludedPages: [],
+        FavoritePages: [],
+        SessionSampleRate: 0.5,
+        Telemetries: [],
+      },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/AppMonitorConfiguration',
+      value: {
+        IncludedPages: [],
+        ExcludedPages: [],
+        FavoritePages: [],
+        SessionSampleRate: 0.1,
+        Telemetries: [],
+      },
+    });
+  });
+
+  // gdsets2 hunt (live-proven 2026-07-22, #1687): GuardDuty UpdateFilter keeps an omitted
+  // Action; the explicit CC add of the KNOWN_DEFAULTS 'NOOP' converges.
+  it('GuardDuty Filter Action (SET-DEFAULT) -> add op writing the NOOP default, not a no-op remove', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::GuardDuty::Filter',
+      path: 'Action',
+      actual: 'ARCHIVE',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Action',
+      value: 'NOOP',
+      prior: 'ARCHIVE',
+    });
+  });
+
   it('ServiceCatalog TagOption Active (SET-DEFAULT) -> add op writing the true default, not a rejected remove', () => {
     const f = F({
       tier: 'undeclared',


### PR DESCRIPTION
## Summary

2026-07-22 bug hunt (5 rounds: unexercised readers/adapters, declared-tier reorder audit, revert-convergence probes, mirrored variant rows, custom-domain unlock). **3 confirmed bugs, all fixed + live-re-proven; 4 determinations recorded; 11 new corpus cases; 8 new integ fixtures.**

Closes #1684, closes #1685, closes #1686, closes #1687.

### Bugs fixed (each live-found → issue → fix → unit test → live re-proof)

| # | Bug | Fix |
|---|-----|-----|
| #1684 | RUM AppMonitor `AppMonitorConfiguration` bare-remove revert silently no-ops (selective `UpdateAppMonitor`, sibling of #1630) | `REVERT_SET_DEFAULT_PATHS` entry (explicit CC `add` of the KNOWN_DEFAULTS object — convergence CC-probed live) |
| #1685 | arm64 EB env first-run FP: `EB_INSTANCE_TYPES_DEFAULT_BY_ARCH['arm64']` was docs-pinned `{t4g.micro,t4g.small}` but live AWS assigns `t4g.micro, t4g.large` (the #1664 mirrored-row class, flagged by this hunt's offline variant-table audit) | arm64 set → union `{t4g.micro,t4g.small,t4g.large}`; family bumps still surface |
| #1686 | GuardDuty ThreatEntitySet/TrustedEntitySet first-run FP: undeclared `ExpectedBucketOwner` echoes the own account id | `CONTEXT_ARN_DEFAULTS` `{accountId}` placeholder entries (equality-gated; cross-account switch still surfaces) |
| #1687 | GuardDuty Filter `Action` bare-remove revert silently no-ops (`UpdateFilter` selective; flagged by the RSDP audit) | `REVERT_SET_DEFAULT_PATHS` entry (explicit `add /Action NOOP` convergence CC-probed live) |

### Determinations (no code bug; recorded in comments/fixtures)

- **valkey CacheCluster is CFn-unreachable**: `CreateCacheCluster` rejects engine=valkey outright ("use CreateReplicationGroup") — the mirrored valkey Port arm can never FP (comment in noise.ts). Also: valkey CacheCluster create demands `VpcSecurityGroupIds` before the engine check (engine-axis validation difference).
- **ACM Certificate reader stays cheaply unexercisable**: CFn resource IMPORT is rejected for the type, and a declared cert blocks CREATE on validation (comment in overrides.ts).
- **Converge-via-bare-remove proven (no entries needed)**: Backup RestoreTestingPlan `RecoveryPointSelection.SelectionWindowDays`, Lambda ESM `ParallelizationFactor`, ECS Service `AssignPublicIp` (all detect→revert→live-value verified).
- **Reorder FP suspicions ruled out live**: CloudFront CachePolicy/OriginRequestPolicy/ResponseHeadersPolicy multi-element unsorted whitelists and Lambda ESM `FilterCriteria.Filters` all read back in declared order (multi-element corpus cases now pin this).

### Unexercised readers/adapters now live-proven clean

- EB `ApplicationVersion` (composite `ApplicationName|Id`)
- ApiGatewayV2 `ApiMapping` (child-first `ApiMappingId|DomainName`) + ApiGateway `BasePathMapping` — unlocked via self-signed imported ACM cert (regional API GW domains accept imported certs, no DNS)
- GuardDuty `ThreatEntitySet` / `TrustedEntitySet` (child-first `Id|DetectorId`) + `PublishingDestination` — zero `skipped=`

### Fixtures (all torn down; sweep clean)

`cfpol-hunt`, `esmfilter-hunt`, `ebappver-hunt`, `gdsets2-hunt`, `revconv6-hunt`, `ebarm-hunt`, `ecsnet-hunt`, `apimap-hunt`

### Corpus

11 new cases (EB ApplicationVersion, API GW v1/v2 DomainName + both mapping types, CF policy trio multi-element, ESM FilterCriteria, arm64 EB env, GuardDuty entity sets + publishing destination). `corpus-replay` green; `measure-noise` sweep shows zero new candidates from these cases.
