### PR TITLE
docs: scope the session-wrap Remaining-work section to this session's work

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -335,3 +335,9 @@ anything non-obvious you learned in memory.
 - **All changes via PR; never commit to `main`.** Develop in a git worktree with
   DISJOINT files; the orchestrator integrates. (`CLAUDE.md` → Workflow Rules.)
 - **Never download/run/install untrusted third-party content** (§0).
+- **Wrap with a Remaining-work section + Session-close verdict, scoped to the
+  issues this run actually worked.** This skill is the easiest place to get that
+  scope wrong: it starts from a backlog, so the issues you triaged but did NOT
+  pick up look like follow-ups. They are not. List only residuals of the lanes
+  you shipped (gaps, deferred polish, issues filed because of this work).
+  (`CLAUDE.md` → Workflow Rules.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,9 +280,17 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
 - **Every session-wrap / task-complete report MUST end with a "Remaining work"
   section AND a "Session close" verdict — unprompted** (mirrors go-to-k/cdkd#1257;
   the user should never have to ask "any follow-up tasks?" or "can I close this
-  session?"). **Remaining work** — exactly one of: **TODO (issue #N)** (work that
-  still needs doing later; the ONLY bucket that means follow-up tasks exist —
-  every entry MUST have a GitHub issue number, filed BEFORE reporting);
+  session?"). **Scope: only work THIS session created or touched.** The section
+  reports residuals of the task just finished: gaps in what was shipped, polish
+  deferred while doing it, and issues filed BECAUSE of this work. It is NOT a
+  backlog dump. Do not list pre-existing open issues that merely happen to be
+  unresolved, and once the session moves on to an unrelated task, stop carrying
+  forward items from the earlier unrelated work. If the current work leaves
+  nothing behind, the answer is "Nothing remaining" even when the repo has open
+  issues elsewhere. **Remaining work** — exactly one of: **TODO (issue #N)**
+  (work that still needs doing later; the ONLY bucket meaning follow-ups
+  exist — every entry MUST have a GitHub issue number, filed BEFORE
+  reporting);
   **Won't-do (decided + recorded)** (things consciously decided AGAINST doing,
   with a one-line reason and where the decision is recorded — PR body, in-code
   comment, issue comment; no action needed); **Nothing remaining** (an explicit


### PR DESCRIPTION
## Summary

Scopes the session-wrap **Remaining work** section to the work of the session
that is reporting. Mirrors go-to-k/cdkd#1262.

The rule (added in #1691) says every wrap report must end with a Remaining-work
section, but it never said whose work that section covers. In practice it gets
filled with pre-existing open issues that have nothing to do with the task just
finished, which buries the residuals that actually matter and reads as a
backlog dump.

The added clause states the scope explicitly: the section reports what THIS
session created or touched (gaps in what was just shipped, polish deferred while
doing it, issues filed because of this work), it is not a backlog dump, and when
the session moves on to an unrelated task it stops carrying forward items from
the earlier work. If the current work leaves nothing behind, the answer is
"Nothing remaining" even when the repo has open issues elsewhere.

The same note is added to the `work-issues` skill, which is the easiest place to
get this wrong: it starts from a backlog, so the issues triaged but not picked up
look like follow-ups.

## Test plan

Documentation only (CLAUDE.md wording plus one bullet in a skill). No source or
behavior change.
