### PR TITLE
chore(hooks): scope branch-gate to opted-in repos

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -120,6 +120,18 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Repo opt-in scope (cdkd#1259): this gate protects repos that follow
+# the feature-branch + PR + markgate convention. A session rooted in
+# such a repo can still run git against OTHER repos (a personal blog, a
+# scratch clone) where committing straight to main is the normal
+# workflow; the gate must not fire there. Opt-in signal: a
+# `.markgate.yml` at the resolved target repo's top level. Repos
+# without it pass through untouched.
+target_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "")
+if [[ -z "$target_top" || ! -f "$target_top/.markgate.yml" ]]; then
+  exit 0
+fi
+
 # Read the branch from the resolved target dir. `-C` lets git operate
 # on a directory that isn't our cwd; if the dir doesn't exist or isn't
 # inside a git repo, symbolic-ref returns empty and we fall through to

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -25,6 +25,14 @@ git init -q -b main "$main_repo"
 git -C "$main_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 git init -q -b feature/x "$feature_repo"
 git -C "$feature_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+# Opt the fixtures into the gate (cdkd#1259): the gate only protects
+# repos with a .markgate.yml at the repo root.
+touch "$main_repo/.markgate.yml" "$feature_repo/.markgate.yml"
+# A repo WITHOUT .markgate.yml (e.g. a personal blog repo worked on
+# from a session rooted here) must never be gated, even on main.
+optout_repo="$TMPDIR/optout-repo"
+git init -q -b main "$optout_repo"
+git -C "$optout_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 
 pass=0
 fail=0
@@ -171,6 +179,21 @@ run_case "git -c commit.gpgSign=false commit on main blocked" 2 \
 # 11c. `git push --force` on main — `--force` after the subcommand.
 run_case "git push --force on main blocked" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin --force"}}' "$main_repo")"
+
+# --- REPO OPT-IN SCOPE cases (cdkd#1259) ---
+#
+# The gate must fire ONLY in repos that carry a .markgate.yml at the
+# repo root. Sessions rooted here can touch unrelated personal repos
+# (blog drafts, scratch clones) whose normal workflow is committing
+# straight to main; those must pass through untouched.
+
+# 11d. git commit on main in a NON-opted-in repo → allow.
+run_case "git commit on main in non-opted-in repo allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m ok"}}' "$optout_repo")"
+
+# 11e. git push on main in a NON-opted-in repo → allow.
+run_case "git push on main in non-opted-in repo allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin main"}}' "$optout_repo")"
 
 # --- Edge cases ---
 


### PR DESCRIPTION
## Summary
- Port of go-to-k/cdkd#1259 (fixed in cdkd by go-to-k/cdkd#1264): branch-gate.sh resolved its target repo from the tool call and fired in ANY git repository a session touched, including unrelated personal repos whose normal workflow is committing straight to main.
- The hook now early-exits unless the resolved target repo carries a `.markgate.yml` at its root (the opt-in signal). cdk-real-drift behavior is unchanged.
- Smoke test updated: fixtures opt in via a touched `.markgate.yml`, plus two new non-opted-in-repo pass cases (27 cases total).

## Test plan
- [x] branch-gate.test.sh: 27 cases pass (incl. the 2 new non-opted-in cases)