### PR TITLE
fix(hunt): 2026-08-01 sweep — GD entity-set ExpectedBucketOwner revert no-op (CONTEXT_ARN_DEFAULTS identity resolution), 11 first-run FP folds, GD DataSources off-flip gates

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -411,18 +411,33 @@ siblings, both proven by a STACKLESS CC probe: `cloudcontrol create-resource`
 pool+client, OOB-flip, bare `remove` no-ops, explicit `add` converges — the whole
 per-property proof for ~$0 and no fixture) all no-oped → RSDP entries; Backup RTP
 `RecoveryPointSelection.SelectionWindowDays`, Lambda ESM `ParallelizationFactor`, and
-ECS Service `AssignPublicIp` converged (no entries needed). **Remaining KNOWN
-UNPROBED RSDP candidates from that hunt's audit** (deliberately deferred — pick these
-up before re-auditing): OpenSearch `ClusterConfig.DedicatedMasterCount` (HIGH cost:
-dedicated-master domain, but the OS writer is documented-selective — strongest
-remaining candidate), EC2 VPCEndpointService `SupportedIpAddressTypes` (needs an
-NLB), SES DedicatedIpPool `ScalingMode` (SKIPPED ON PURPOSE: probing requires
-entering MANAGED, which bills per-IP-hour and has a cooldown back to STANDARD — a
-stuck-state risk; get cost sign-off first), Synthetics Canary
-`Schedule.DurationInSeconds`, Firehose `HttpEndpointDestinationConfiguration.*`
-(7 nested paths, complex), Lambda ESM `TumblingWindowInSeconds` (PF converged, TWIS
-probably does too — cheap confirm), VpcLattice ALS `ServiceNetworkLogType` (verify
-OOB mutability FIRST — likely create-only → skip-list, not RSDP).
+ECS Service `AssignPublicIp` converged (no entries needed).
+Batch 10 (2026-08-01 hunt) settled most of batch 9's deferred list for ~$0: **GuardDuty
+`ThreatEntitySet` + `TrustedEntitySet` `ExpectedBucketOwner` BOTH no-oped** (proven
+individually via stackless CC probes; the OOB API accepts a FOREIGN account id on an
+INACTIVE set — an ACTIVE set validates against the real bucket owner and rejects it
+with AccessDeniedException, so an E2E fixture leg must target an Activate:false set —
+the drift is real and security-typed) — and exposed a STRUCTURAL gap:
+the pin lives in `CONTEXT_ARN_DEFAULTS` (`{accountId}` placeholder), which
+plan.ts did not consult at all, so no plain RSDP entry could express the fix. #1694
+adds RSDP entries + an `opts.identity`-resolved `contextArnDefaultFor` fallback in
+`revertOp` — any future CONTEXT_ARN_DEFAULTS pin gets revert convergence by adding
+the RSDP key alone. **Lambda ESM `TumblingWindowInSeconds` CONVERGED** via the bare
+`remove` (like PF) — but ONLY when the probe patch rides the
+`/DestinationConfig/OnFailure` husk removal (`CC_UPDATE_REJECTED_EMPTY_PATHS`,
+#1611): a raw stackless probe WITHOUT the husk op fails with "The Destination field
+is required" and proves nothing — when a stackless CC probe errors, check the type's
+husk table entry before concluding anything. **VpcLattice ALS
+`ServiceNetworkLogType` closed offline** (update API takes only destination-arn —
+not OOB-mutable, in-code note). **SES `ScalingMode` closed from docs**
+(MANAGED→STANDARD is unsupported by the service — detect-only forever, no probe can
+help; in-code note). **Remaining deferred candidates**: OpenSearch
+`ClusterConfig.DedicatedMasterCount` (HIGH cost, and NOTE: it is a NESTED
+KNOWN_DEFAULT_PATHS pin, so plan.ts already emits an explicit `add` — the residual
+risk is only the #763 explicit-write-ignored class, low), EC2 VPCEndpointService
+`SupportedIpAddressTypes` (needs a dualstack NLB in IPv6 subnets), Synthetics Canary
+`Schedule.DurationInSeconds` + Firehose `HttpEndpointDestinationConfiguration.*`
+(nested pins — same auto-`add` note as OpenSearch, low residual).
 Piggyback the convergence
 probe on every NEW KNOWN_DEFAULTS fold a hunt ships (mutate → revert → re-read) —
 it is ~1-in-3 to need an RSDP entry, and the probe is nearly free while the stack
@@ -876,6 +891,24 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   `HealthCheckConfig.IPAddress` with a bare `InvalidRequest` — point the check at a
   resolvable FQDN (`FullyQualifiedDomainName: example.com` IS fine here) instead
   (route53-policy-hunt, 2026-07-20).
+- **A PARTIALLY-declared block's service fill can DIFFER from the wholly-undeclared
+  default — live-probe the PARTIAL shape before adding nested true pins + off-flip
+  gates.** Cognito fills an UpdateUserPool/CreateUserPool partial PasswordPolicy with
+  `Require*: FALSE` (the all-true defaults apply only when Policies is wholly
+  undeclared), so the audited "Require\* off-flip FN" did not exist and the attempted
+  true-pins + MEANINGFUL_WHEN_OFF_NESTED gates CREATED a first-run FP — caught by
+  corpus-replay on a REAL partial-declared case (Users0A0EEA89), exactly the guard the
+  corpus exists to be (#1701 determination). GuardDuty's DataSources fills the SAME
+  all-true in both shapes (CC-probed 2026-08-01), so its partial-dimension pins+gates
+  are correct (#1700). The cheap discriminator: `cloudcontrol create-resource` with
+  the partial shape, read back the fill, delete — one minute, no stack. And BEFORE
+  filing a nested off-flip FN, grep the corpus for a partial-declared case of that
+  block: a false-filled sibling in a CLEAN case is the disproof.
+- **`grep -c "Potential Drift"` counts the summary HEADER line — a verify.sh that
+  allows one by-design entry (the TrustStore sha256) must count the indented ENTRY
+  lines inside the block** (`sed -n '/\[Potential Drift/,/^──/p' | grep -E '^\s+\S+ \(AWS::'`),
+  or a fully-clean-but-for-the-allowed-entry run false-fails on the header (hit on
+  elbpack-hunt 2026-08-01).
 - **A NEW all-boolean pin family can arrive via a READER-projection fix — re-run the
   off-flip audit over the diff window, not just the historical tables.** The #1658
   Budgets reader fix (projecting the full 11-boolean `CostTypes`) necessarily added a

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -123,6 +123,11 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // DEFAULT_SG_LIST_PATHS, so the prefetch must fire when a resource gateway is present or
   // the OOB-swap gate loses its default-SG ids.
   'AWS::VpcLattice::ResourceGateway',
+  // #1699: a barest Interface VPC endpoint that declares no SecurityGroupIds is placed into
+  // the VPC's default SG (live, elbpack-hunt 2026-08-01) — registered in classify
+  // DEFAULT_SG_LIST_PATHS, so the prefetch must fire when a VPC endpoint is present or the
+  // OOB-swap gate loses its default-SG ids.
+  'AWS::EC2::VPCEndpoint',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —
@@ -1335,6 +1340,27 @@ export function buildClientVpnEndpointSiblingVpcs(desired: Desired): Record<stri
 // registry-readOnly and stripped from the classify surface, so the raw live model is the only
 // place it exists). Unmatched literals map nothing (the pointer keeps surfacing — conservative);
 // conflicting links degrade to `null` (fail open) like the ClientVPN sibling map.
+// #1704: per SOURCE DBInstance physical id, that source's LIVE model — a read replica
+// (declared SourceDBInstanceIdentifier, which the resolver has already collapsed to the
+// source's physical id for an in-stack Ref) equality-gates its inherited
+// Engine/AllocatedStorage/MasterUsername echoes against the source's live values in
+// classify. Only in-stack DBInstances appear here; an out-of-stack source finds no entry
+// and the inherited values stay unfolded (fail-safe).
+export function buildRdsReplicaSourceModels(
+  desired: Desired,
+  liveByLogical?: Map<string, Record<string, unknown>>
+): Record<string, Record<string, unknown>> {
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::RDS::DBInstance') continue;
+    const live = liveByLogical?.get(r.logicalId);
+    if (!live) continue;
+    const id = live['DBInstanceIdentifier'] ?? r.physicalId;
+    if (typeof id === 'string' && id !== '') out[id] = live;
+  }
+  return out;
+}
+
 export function buildCloudFrontStagingDistCdPolicyIds(
   desired: Desired,
   liveByLogical?: Map<string, Record<string, unknown>>
@@ -2134,6 +2160,7 @@ export async function gatherFindings(
       desired,
       liveModelMap(reads)
     ),
+    siblingRdsSourceModels: buildRdsReplicaSourceModels(desired, liveModelMap(reads)),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 
@@ -2252,6 +2279,7 @@ export async function regatherTouched(
       desired,
       liveModelMap(reads)
     ),
+    siblingRdsSourceModels: buildRdsReplicaSourceModels(desired, liveModelMap(reads)),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
   };
 

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1294,6 +1294,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     // which never includes the (unpickable) GetTemplate-masked readGaps the whole-array
     // mask guard correlates against.
     maskReadGapKeys: maskReadGapKeysOf(reconciled),
+    // so a CONTEXT_ARN_DEFAULTS-pinned set-default (GuardDuty entity-set
+    // ExpectedBucketOwner, #1694) resolves its {accountId}/{region} placeholder.
+    identity: { accountId: gathered.desired.accountId, region },
   });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -120,7 +120,14 @@ export interface CorpusCase {
     // present only on an AWS::DMS::ReplicationInstance case and carrying ONLY the declared class's
     // entry, so replay reproduces the derived AllocatedStorage fold. Without it a fresh-harvested RI
     // replays the undeclared default storage as false drift. Optional for back-compat.
-    accountDefaults?: { dmsAllocatedStorageDefaults?: Record<string, number> };
+    // #1697 extends the carry to ebsEncryptionByDefault, present only on an AWS::EC2::Volume
+    // case (the account-level EBS default-encryption flag folds the undeclared Encrypted echo
+    // at record time; without the carry a fresh-harvested volume replays without the fold and
+    // the recorded atDefault finding mismatches).
+    accountDefaults?: {
+      dmsAllocatedStorageDefaults?: Record<string, number>;
+      ebsEncryptionByDefault?: boolean;
+    };
     // This ClientVpnEndpoint's own sibling-derived VPC entry (keyed by logicalId, else physicalId —
     // classify's probe order), present only when a declared sibling target-network association
     // derives it, so replay reproduces the association-echoed `VpcId` fold. Optional for back-compat.
@@ -130,6 +137,11 @@ export interface CorpusCase {
     // in-stack declared policy links to it, so replay reproduces the reverse-pointer
     // `DistributionConfig.ContinuousDeploymentPolicyId` fold. Optional for back-compat.
     siblingCloudFrontCdPolicyIds?: Record<string, string | null>;
+    // #1704: the SOURCE DBInstance's live model, keyed by its DBInstanceIdentifier — present
+    // only on a read-replica case (declared SourceDBInstanceIdentifier resolving to an
+    // in-stack sibling), so replay reproduces the inherited-echo folds. Optional for
+    // back-compat.
+    siblingRdsSourceModels?: Record<string, Record<string, unknown>>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -169,9 +181,13 @@ export function buildCorpusCase(
     clusterEchoModel?: Record<string, Record<string, unknown>>;
     rdsOptionSettingDefaults?: Record<string, Record<string, Record<string, string | null>>>;
     siblingListenerPorts?: Record<string, number>;
-    accountDefaults?: { dmsAllocatedStorageDefaults?: Record<string, number> };
+    accountDefaults?: {
+      dmsAllocatedStorageDefaults?: Record<string, number>;
+      ebsEncryptionByDefault?: boolean;
+    };
     siblingClientVpnEndpointVpcs?: Record<string, string | null>;
     siblingCloudFrontCdPolicyIds?: Record<string, string | null>;
+    siblingRdsSourceModels?: Record<string, Record<string, unknown>>;
   },
   findings: Finding[]
 ): CorpusCase {
@@ -248,6 +264,13 @@ export function buildCorpusCase(
           },
         }
       : undefined;
+  // #1697: carry the account EBS default-encryption flag on a Volume case, so replay
+  // reproduces the accountDefaults-derived Encrypted fold.
+  const ebsEncDefault =
+    resource.resourceType === 'AWS::EC2::Volume' &&
+    opts.accountDefaults?.ebsEncryptionByDefault !== undefined
+      ? { ebsEncryptionByDefault: opts.accountDefaults.ebsEncryptionByDefault }
+      : undefined;
   // Carry ONLY this ClientVpnEndpoint's own sibling-derived VPC entry. classify probes the map by
   // logicalId first, then physicalId — carry the key that is present (`null` is meaningful: an
   // in-stack association whose VPC was not derivable → fail-open fold), so replay folds the
@@ -273,6 +296,19 @@ export function buildCorpusCase(
         : resource.physicalId !== undefined && resource.physicalId in cfCdMap
           ? resource.physicalId
           : undefined;
+  // Carry ONLY the source model a read-replica case actually derives from (keyed by the
+  // replica's declared SourceDBInstanceIdentifier), so replay folds the inherited echoes
+  // the same way the live check did.
+  const rdsSrcMap = opts.siblingRdsSourceModels;
+  const rdsSrcKey =
+    resource.resourceType === 'AWS::RDS::DBInstance' && rdsSrcMap !== undefined
+      ? (() => {
+          const srcId = (resource.declared as Record<string, unknown> | undefined)?.[
+            'SourceDBInstanceIdentifier'
+          ];
+          return typeof srcId === 'string' && srcId in rdsSrcMap ? srcId : undefined;
+        })()
+      : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
     resource: {
@@ -325,12 +361,17 @@ export function buildCorpusCase(
         ? { rdsOptionSettingDefaults: { [resource.physicalId]: rdsOptCatalog } }
         : {}),
       ...(gaListenerPort ? { siblingListenerPorts: gaListenerPort } : {}),
-      ...(dmsStorageDefault ? { accountDefaults: dmsStorageDefault } : {}),
+      ...(dmsStorageDefault || ebsEncDefault
+        ? { accountDefaults: { ...(dmsStorageDefault ?? {}), ...(ebsEncDefault ?? {}) } }
+        : {}),
       ...(cvpnVpcKey !== undefined && cvpnVpcMap !== undefined
         ? { siblingClientVpnEndpointVpcs: { [cvpnVpcKey]: cvpnVpcMap[cvpnVpcKey] ?? null } }
         : {}),
       ...(cfCdKey !== undefined && cfCdMap !== undefined
         ? { siblingCloudFrontCdPolicyIds: { [cfCdKey]: cfCdMap[cfCdKey] ?? null } }
+        : {}),
+      ...(rdsSrcKey !== undefined && rdsSrcMap !== undefined && rdsSrcMap[rdsSrcKey]
+        ? { siblingRdsSourceModels: { [rdsSrcKey]: rdsSrcMap[rdsSrcKey] } }
         : {}),
     },
     expected: findings,

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -447,6 +447,24 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
   'AWS::Budgets::Budget': {
     'Budget.CostTypes': () => true,
   },
+  // #1700: the PARTIAL-declaration dimension of the #1092 GuardDuty DataSources gate — the
+  // common CDK shape declares one protection (s3Logs), so the undeclared siblings emit at
+  // these nested paths, and an out-of-band `update-detector` disable reads back an
+  // all-boolean all-false sub-object that isTrivialEmpty swallows before the nested pin
+  // gate (EKS audit logs / EBS malware scan / S3 protection silently off). Unconditionally
+  // meaningful when off: a user who wants a protection off DECLARES it (compared in the
+  // declared loop); a detector has no snapshot/restore lineage yielding an untouched
+  // all-false. Paired with the KNOWN_DEFAULT_PATHS all-true pins (the clean-deploy fold).
+  'AWS::GuardDuty::Detector': {
+    'DataSources.S3Logs': () => true,
+    'DataSources.Kubernetes': () => true,
+    'DataSources.Kubernetes.AuditLogs': () => true,
+    'DataSources.MalwareProtection': () => true,
+    'DataSources.MalwareProtection.ScanEc2InstanceWithFindings': () => true,
+  },
+  // (#1701 determination: Cognito PasswordPolicy Require* leaves do NOT belong here — a
+  // partially-declared policy is filled with FALSE by the service, so an undeclared false
+  // is the creation state, not an out-of-band disable. See the noise.ts MinimumLength note.)
   // #1530: an ECS service that ENABLES the deployment circuit breaker reads back the AWS-filled
   // sub-default ResetOnHealthyTask=true (the KNOWN_DEFAULT_PATHS pin, live-observed on a fresh
   // Fargate service). An out-of-band UpdateService flipping it false is swallowed by
@@ -614,6 +632,12 @@ export const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // folds the single default and surfaces an append/swap. Keep in sync with gather.ts
   // DEFAULT_SG_LIST_TYPES.
   'AWS::VpcLattice::ResourceGateway': 'SecurityGroupIds',
+  // #1699 (live 2026-08-01 elbpack-hunt): a barest Interface VPC endpoint that declares no
+  // SecurityGroupIds is placed into the VPC's default SG — the same single-SG first-run
+  // default. OOB-mutable (`ec2 modify-vpc-endpoint --add/--remove-security-group-ids`), so
+  // the derived gate folds the single default and surfaces an append/swap. Keep in sync
+  // with gather.ts DEFAULT_SG_LIST_TYPES.
+  'AWS::EC2::VPCEndpoint': 'SecurityGroupIds',
 };
 /** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
  *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into
@@ -3093,6 +3117,12 @@ export function classifyResource(
     // `null` = a policy is declared but not linkable to a specific distribution (literal DNS
     // names) → fail open. NO entry = out-of-band link → surfaces.
     siblingCloudFrontCdPolicyIds?: Record<string, string | null>;
+    // #1704: per SOURCE DBInstance identifier (physical id), that source's LIVE model — so a
+    // read replica (declared SourceDBInstanceIdentifier) can equality-gate the properties RDS
+    // copies from the source at creation (Engine/AllocatedStorage/MasterUsername; built in
+    // gather.ts buildRdsReplicaSourceModels from in-stack DBInstance reads). NO entry (an
+    // out-of-stack source) leaves the inherited values unfolded — fail-safe, recordable.
+    siblingRdsSourceModels?: Record<string, Record<string, unknown>>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -3379,6 +3409,16 @@ export function classifyResource(
           Engine: declared['Engine'],
         }
       : undefined;
+  // #1704: SourceDBInstanceIdentifier is writeOnly, so the strip below removes it from
+  // `declared` before the read-replica derived overlay can key on it (the #1500 trap —
+  // the live side reads it back only as a readGap, so it cannot be recovered there
+  // either). Snapshot it here, pre-strip.
+  const rdsReplicaSourceId =
+    resourceType === 'AWS::RDS::DBInstance' &&
+    typeof declared['SourceDBInstanceIdentifier'] === 'string' &&
+    declared['SourceDBInstanceIdentifier'] !== ''
+      ? (declared['SourceDBInstanceIdentifier'] as string)
+      : undefined;
   // writeOnly cannot be read back: strip it from the DECLARED side too so it is never
   // compared (the LIVE side was already stripped by normalizeLiveModel above).
   deepStripPaths(declared, schema.writeOnlyPaths);
@@ -3503,6 +3543,12 @@ export function classifyResource(
       ...(targetType === 'alb'
         ? { HealthCheckTimeoutSeconds: 6, Matcher: { HttpCode: '200-399' } }
         : {}),
+      // #1696 (hunt 2026-08-01, GENEVE x instance + HTTPS barest groups): a GWLB (GENEVE)
+      // group's HC defaults are TCP on the FIXED port 80 (not traffic-port — the earlier
+      // GENEVE x ip case DECLARED both, hiding this), and an HTTPS group's HC protocol
+      // default FOLLOWS the group protocol (HTTPS, not the base HTTP pin).
+      ...(protocol === 'GENEVE' ? { HealthCheckProtocol: 'TCP', HealthCheckPort: '80' } : {}),
+      ...(protocol === 'HTTPS' ? { HealthCheckProtocol: 'HTTPS' } : {}),
       ...(protocolVersion === 'GRPC' ? { Matcher: { GrpcCode: '12' } } : {}),
     };
   }
@@ -3785,6 +3831,62 @@ export function classifyResource(
   // Derive the expected default from the declared endpoint type and equality-gate it (fold
   // tier 2): an out-of-band flip of either value away from the PRIVATE default still
   // surfaces. The base EDGE/REGIONAL constants stay for the other endpoint types.
+  // #1705: a PROVISIONED Keyspaces table's WarmThroughput echoes ITS OWN provisioned
+  // capacity (live 2026-08-01: RCU/WCU 1/1 echoed {1, 1}) — the 12000/4000 KNOWN_DEFAULTS
+  // constant is the ON_DEMAND shape and stays the fall-through. Derive from the declared
+  // ProvisionedThroughput and equality-gate (fold tier 2): an out-of-band capacity change
+  // still surfaces (the echo tracks the CURRENT capacity, which the declared dimension
+  // also compares).
+  if (resourceType === 'AWS::Cassandra::Table') {
+    const pt = (declared['BillingMode'] as Record<string, unknown> | undefined)?.[
+      'ProvisionedThroughput'
+    ] as Record<string, unknown> | undefined;
+    const rcu = pt?.['ReadCapacityUnits'];
+    const wcu = pt?.['WriteCapacityUnits'];
+    if (typeof rcu === 'number' && typeof wcu === 'number') {
+      knownDef = {
+        ...knownDef,
+        WarmThroughput: { ReadUnitsPerSecond: rcu, WriteUnitsPerSecond: wcu },
+      };
+    }
+  }
+  // #1704: an RDS read replica (SourceDBInstanceIdentifier declared) INHERITS properties
+  // the template never declares. BackupRetentionPeriod defaults to 0 on a replica (unlike
+  // the source's 1); Engine/AllocatedStorage/MasterUsername are copied from the source at
+  // creation — derived from the in-stack source sibling's LIVE model
+  // (opts.siblingRdsSourceModels, keyed by the source's DBInstanceIdentifier, built in
+  // gather.ts). Equality-gated (fold tier 2): a replica whose value diverges from the
+  // source still surfaces; an OUT-of-stack source leaves the values unfolded (fail-safe).
+  // (SourceDBInstanceIdentifier is writeOnly — read from the pre-strip snapshot
+  // `rdsReplicaSourceId`, never from the stripped `declared`; the #1500 trap.)
+  if (resourceType === 'AWS::RDS::DBInstance' && rdsReplicaSourceId !== undefined) {
+    knownDef = { ...knownDef, BackupRetentionPeriod: 0 };
+    const src = opts.siblingRdsSourceModels?.[rdsReplicaSourceId];
+    if (src) {
+      const inherit: Record<string, unknown> = {};
+      for (const k of ['Engine', 'AllocatedStorage', 'MasterUsername']) {
+        if (src[k] !== undefined) inherit[k] = src[k];
+      }
+      knownDef = { ...knownDef, ...inherit };
+    }
+  }
+  // #1703: a health check that omits HealthCheckConfig.Port reads back the type-derived
+  // default — 80 for the HTTP pair, 443 for the HTTPS pair (TCP requires an explicit Port,
+  // so no arm exists there). Derive from the declared Type and equality-gate (fold tier 2):
+  // an out-of-band port change still surfaces, and a declared Port is compared in the
+  // declared dimension. Live-found on a barest HTTP check (freepack-hunt 2026-08-01).
+  if (resourceType === 'AWS::Route53::HealthCheck') {
+    const hcType = (declared['HealthCheckConfig'] as Record<string, unknown> | undefined)?.['Type'];
+    const defaultPort =
+      hcType === 'HTTP' || hcType === 'HTTP_STR_MATCH'
+        ? 80
+        : hcType === 'HTTPS' || hcType === 'HTTPS_STR_MATCH'
+          ? 443
+          : undefined;
+    if (defaultPort !== undefined) {
+      knownDefPaths = { ...knownDefPaths, 'HealthCheckConfig.Port': defaultPort };
+    }
+  }
   if (resourceType === 'AWS::ApiGateway::RestApi') {
     const types = (declared['EndpointConfiguration'] as Record<string, unknown> | undefined)?.[
       'Types'

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -389,7 +389,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // tumbling window (the documented defaults). SQS sources never carry either prop, so
     // the entries can't mis-fold there. Equality-gated — raise the parallelization or set
     // a real window out of band and it no longer matches, so it re-surfaces. Observed live
-    // on barest DDB + Kinesis mappings (esm-hunt, 2026-07-14, #1608).
+    // on barest DDB + Kinesis mappings (esm-hunt, 2026-07-14, #1608). Revert-convergence
+    // determination (stackless CC probe 2026-08-01): TumblingWindowInSeconds CONVERGES via
+    // the bare `remove` (like ParallelizationFactor, batch 9) — no RSDP entry needed. The
+    // probe patch must ride the /DestinationConfig/OnFailure husk removal (the
+    // CC_UPDATE_REJECTED_EMPTY_PATHS mechanism, #1611) or the whole update is rejected.
     ParallelizationFactor: 1,
     TumblingWindowInSeconds: 0,
   },
@@ -467,9 +471,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::VpcLattice::ServiceNetwork': { SharingConfig: { enabled: true } },
   // A VPC Lattice access log subscription attached without a ServiceNetworkLogType reads
   // back the service default SERVICE (log service-network service traffic; the other enum
-  // value is RESOURCE for resource-configuration traffic). Equality-gated; a subscription
-  // switched to RESOURCE out of band still surfaces. Observed live on a fresh
-  // lattice2-hunt deploy (2026-07-15).
+  // value is RESOURCE for resource-configuration traffic). Observed live on a fresh
+  // lattice2-hunt deploy (2026-07-15). Revert-convergence determination (2026-08-01 hunt):
+  // NOT OOB-mutable — `update-access-log-subscription` accepts only the identifier +
+  // --destination-arn, so the value can never drift out of band and no RSDP probe /
+  // entry is needed (the ResourceGateway class below); purely a first-run fold.
   'AWS::VpcLattice::AccessLogSubscription': { ServiceNetworkLogType: 'SERVICE' },
   // A barest VPC Lattice resource gateway (name/vpc/subnets only) reads back three service
   // defaults the template never declared (observed live, lattice2-hunt 2026-07-15):
@@ -496,7 +502,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // A dedicated IP pool created with only a PoolName reads back the service default
   // STANDARD scaling mode (the other enum value is MANAGED, which auto-leases billable
   // IPs). Equality-gated; a pool converted to MANAGED out of band still surfaces.
-  // Observed live on a fresh misspack-hunt deploy (2026-07-15).
+  // Observed live on a fresh misspack-hunt deploy (2026-07-15). Revert-convergence
+  // determination (2026-08-01, from the API docs — no paid probe): the service supports
+  // ONLY STANDARD->MANAGED; a MANAGED pool cannot be converted back
+  // (PutDedicatedIpPoolScalingAttributes rejects it), so a revert of that drift can never
+  // converge — DETECT-ONLY by service design, no RSDP entry can fix it, and the revert
+  // failure the user sees is the service's own rejection (honest). Do not re-probe.
   'AWS::SES::DedicatedIpPool': { ScalingMode: 'STANDARD' },
   // A CodeDeploy application created without a ComputePlatform reads back the service
   // default Server (the EC2/on-premises platform; the others are Lambda / ECS).
@@ -1462,6 +1473,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     InstanceLifecyclePolicy: { RetentionTriggers: { TerminateHookAbandon: 'terminate' } },
     CapacityReservationSpecification: { CapacityReservationPreference: 'default' },
   },
+  // A Size+AZ-only volume reads back the era default type gp2 (#1697, live 2026-08-01
+  // freepack-hunt; the gp2 Iops:100 / gp3 Iops:3000+Throughput:125 echoes already fold via
+  // the schema defaults). Equality-gated — an out-of-band type change still surfaces; if AWS
+  // ever moves the era default to gp3, the pin re-surfaces on fresh deploys and graduates to
+  // KNOWN_DEFAULT_ONE_OF per the era-dependent rule.
+  'AWS::EC2::Volume': {
+    VolumeType: 'gp2',
+  },
   // A warm pool that declares no MinSize reads back MinSize:0 — the documented
   // constant default ("minimum 0 warmed instances"). Observed undeclared on a fresh
   // ecs-capacityprovider-rich deploy. Equality-gated: raise it out of band and it
@@ -1896,9 +1915,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ReplicationSpecification: { ReplicationStrategy: 'SINGLE_REGION' },
   },
   'AWS::Cassandra::Table': {
+    // (#1705: this 12000/4000 constant is the ON_DEMAND shape only — a PROVISIONED table
+    // echoes ITS OWN provisioned capacity, derived in classify.ts from the declared
+    // BillingMode.ProvisionedThroughput; this constant stays the fall-through.)
     WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
     EncryptionSpecification: { EncryptionType: 'AWS_OWNED_KMS_KEY' },
     CdcSpecification: { Status: 'DISABLED' },
+    // A table with no TTL configured echoes the numeric 0 "no default TTL" sentinel
+    // (#1705, live 2026-08-01 statepack-hunt — the prior sole corpus case DECLARED it).
+    // Equality-gated: an out-of-band TTL still surfaces.
+    DefaultTimeToLive: 0,
   },
   // EMR Serverless application service defaults (observed live on the
   // misc-0cov-rich fixture): x86_64 architecture and managed-persistence
@@ -2098,6 +2124,44 @@ export const KNOWN_DEFAULT_ONE_OF_PATHS: Record<string, Record<string, readonly 
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // A barest MixedInstancesPolicy ASG (only LaunchTemplateSpecification + Overrides
+  // declared) reads back the whole InstancesDistribution object holding the five documented
+  // constant defaults (#1695, live 2026-08-01 freepack-hunt — the MIP union branch was never
+  // deployed before; every prior fixture used the flat LaunchTemplate branch). The declared
+  // parent MixedInstancesPolicy descends (it carries LaunchTemplate), so the wholly-undeclared
+  // sub-object is emitted whole and equality-gated: any out-of-band distribution change (a
+  // spot percentage, a different allocation strategy) breaks the match and surfaces.
+  'AWS::AutoScaling::AutoScalingGroup': {
+    'MixedInstancesPolicy.InstancesDistribution': {
+      OnDemandAllocationStrategy: 'prioritized',
+      OnDemandBaseCapacity: 0,
+      OnDemandPercentageAboveBaseCapacity: 100,
+      SpotAllocationStrategy: 'lowest-price',
+      SpotInstancePools: 2,
+    },
+  },
+  // An mTLS listener (MutualAuthentication {Mode:'verify', TrustStoreArn} declared — the
+  // ATTACHED shape, vs the whole-object {Mode:'off'} pin observed on a plain HTTPS listener)
+  // descends per leaf and materializes the undeclared AdvertiseTrustStoreCaNames 'off'
+  // default (#1698, live 2026-08-01 elbpack-hunt — the #1574 attachment-echo class).
+  // Equality-gated: an out-of-band flip to 'on' still surfaces. (The sibling
+  // IgnoreClientCertificateExpiry false leaf is trivially-empty-dropped; its ON flip reads
+  // back `true`, which is non-trivial and surfaces normally.)
+  'AWS::ElasticLoadBalancingV2::Listener': {
+    'MutualAuthentication.AdvertiseTrustStoreCaNames': 'off',
+  },
+  // #1700: the PARTIAL-declaration dimension of the whole-object DataSources pin (the common
+  // CDK shape declares only one protection, e.g. s3Logs) — the undeclared siblings emit at
+  // these nested paths. All-true sub-objects fold here (equality-gated), and each path is
+  // paired with a MEANINGFUL_WHEN_OFF_NESTED gate in classify.ts so an out-of-band disable
+  // (an all-false, trivially-empty read — the #1092 shape one level down) still surfaces.
+  'AWS::GuardDuty::Detector': {
+    'DataSources.S3Logs': { Enable: true },
+    'DataSources.Kubernetes': { AuditLogs: { Enable: true } },
+    'DataSources.Kubernetes.AuditLogs': { Enable: true },
+    'DataSources.MalwareProtection': { ScanEc2InstanceWithFindings: { EbsVolumes: true } },
+    'DataSources.MalwareProtection.ScanEc2InstanceWithFindings': { EbsVolumes: true },
+  },
   // A restore testing plan's RecoveryPointSelection declares only the required
   // Algorithm/IncludeVaults/RecoveryPointTypes, so the block is partially declared and
   // descends per-leaf: the service fills the documented 30-day selection window default.
@@ -2361,6 +2425,19 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // reads back the 7-day default (observed live); a pool that sets a different value
     // no longer matches and surfaces (equality-gated).
     'Policies.PasswordPolicy.TemporaryPasswordValidityDays': 7,
+    // #1701 determination (2026-08-01): a PARTIALLY-declared PasswordPolicy is filled with
+    // Require*=FALSE by the service (real corpus proof: Users0A0EEA89 declares
+    // RequireNumbers/RequireSymbols true and reads back RequireLowercase/RequireUppercase
+    // FALSE on a clean deploy) — the all-true defaults apply ONLY to a wholly-undeclared
+    // Policies (the whole-object pin above). So the audited Require* off-flip FN does NOT
+    // exist here: an undeclared-false leaf IS the creation state (nothing to detect), an
+    // OOB weakening of a declared-true leaf is DECLARED drift, and an OOB strengthening
+    // reads a non-trivial `true` that surfaces normally. Do NOT add true pins or
+    // MEANINGFUL_WHEN_OFF_NESTED gates for them (tried; the corpus replay caught the FP).
+    // MinimumLength is different: the service fills the documented 8 when a partial
+    // policy omits it (probed live 2026-08-01), so the equality-gated pin folds the echo
+    // and an out-of-band 6 still surfaces as a non-trivial number.
+    'Policies.PasswordPolicy.MinimumLength': 8,
     // A DECLARED standard schema attribute (email/name, keyed by Name via
     // NESTED_ARRAY_IDENTITY) that omits its data type / string constraints reads back
     // Cognito's constant defaults: a String attribute with a 0..2048 length range. The
@@ -3431,7 +3508,12 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   // top-level GENERATED_LOGICALID gate can't derive it from THIS resource) — a per-resource
   // AWS-assigned identifier, never user intent when undeclared. Fold value-independent. Live,
   // hunt 2026-07-08 #639.
-  'AWS::AutoScaling::AutoScalingGroup': new Set(['LaunchTemplate.LaunchTemplateName']),
+  // (#1695 adds the MixedInstancesPolicy branch: the SAME minted-name echo one level deeper,
+  // beside the declared LaunchTemplateSpecification.LaunchTemplateId.)
+  'AWS::AutoScaling::AutoScalingGroup': new Set([
+    'LaunchTemplate.LaunchTemplateName',
+    'MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateName',
+  ]),
   // An MSK cluster that declares no EncryptionInfo reads back EncryptionAtRest holding the
   // account's AWS-managed `alias/aws/kafka` key ARN (a per-account AWS-assigned key id embedding
   // a GUID — never a constant, never user intent when undeclared, the RDS/DynamoDB KmsKeyId echo
@@ -4082,10 +4164,16 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   AZ placement reads back the AZ(s) AWS picked from its subnet group (["us-east-1a"]) —
   //   subnet-group-derived, not user intent when undeclared; a user who pins placement
   //   DECLARES it and is then compared in the declared loop.
+  //   AWS::ElastiCache::CacheCluster.EngineVersion — a barest memcached cluster that
+  //   declares no version reads back the GA track AWS assigned ("1.6" today, #1706 live
+  //   2026-08-01) — the same moving-GA-version class as the ReplicationGroup twin below;
+  //   a user who cares declares it (then compared in the declared loop, with the
+  //   VERSION_PREFIX_PATHS track normalization).
   'AWS::ElastiCache::CacheCluster': new Set([
     'PreferredMaintenanceWindow',
     'SnapshotWindow',
     'PreferredAvailabilityZones',
+    'EngineVersion',
   ]),
   //   AWS::ElastiCache::ReplicationGroup.EngineVersion — a RG that declares no EngineVersion
   //   reads back the current GA patch AWS assigned (valkey "9.1.0" today), which AWS moves

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -11,11 +11,13 @@
 // CC-gap types (revert for those is a follow-up).
 import type { BaselineFile } from '../baseline/baseline-file.js';
 import { withinStackPath } from '../construct-path.js';
+import { partitionForRegion } from '../desired/template-adapter.js';
 import { GETTEMPLATE_MASK_NOTE } from '../diff/classify.js';
 import { TAG_PROPERTY_NAMES } from '../normalize/cc-api-strip.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
   awsManagedTags,
+  CONTEXT_ARN_DEFAULTS,
   isCfnTemplateNonAsciiMask,
   JSON_STRING_PROPS,
   KNOWN_DEFAULT_PATHS,
@@ -313,6 +315,14 @@ export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // "reverted"). An explicit CC `add /Action "NOOP"` converges (CC-probed live against a
   // CLI-created filter), so write the KNOWN_DEFAULTS 'NOOP' back explicitly.
   'AWS::GuardDuty::Filter\0Action',
+  // hunt 2026-08-01 (#1694, stackless CC probes, BOTH types proven individually): the
+  // GuardDuty Update{Threat,Trusted}EntitySet handlers keep an omitted ExpectedBucketOwner
+  // (an out-of-band foreign owner id — accepted unvalidated by the OOB API — persisted
+  // through a bare `remove` that reported SUCCESS); an explicit CC `add` of the caller
+  // account id converges. The default is the CONTEXT_ARN_DEFAULTS '{accountId}' placeholder,
+  // resolved from opts.identity at plan time (see revertOp).
+  'AWS::GuardDuty::ThreatEntitySet\0ExpectedBucketOwner',
+  'AWS::GuardDuty::TrustedEntitySet\0ExpectedBucketOwner',
   // barest4/ccpi hunt (live-proven 2026-07-14): ServiceCatalog UpdateTagOption REJECTS the
   // `remove` patch outright ("Active and new value cannot both be null") — the hard-reject
   // flavor of the class (not a silent no-op, a hard error). Write the `true` default (from
@@ -972,6 +982,12 @@ export interface RevertOptions {
   // server-side model, so a CC UpdateResource of ANY property on the same resource fails
   // model validation ("expected type JSONObject, found Null") unless the patch also drops it.
   liveByLogical?: Map<string, Record<string, unknown>>;
+  // The stack's deploy identity, so a REVERT_SET_DEFAULT_PATHS entry whose default lives in
+  // CONTEXT_ARN_DEFAULTS (a {partition}/{region}/{accountId}-templated value, e.g. GuardDuty
+  // entity-set ExpectedBucketOwner, #1694) can resolve the placeholder at plan time. Absent
+  // (unit calls without it) the resolution is skipped and the op falls back to the bare
+  // `remove` — fail-safe, same as before.
+  identity?: { accountId?: string; region?: string };
 }
 
 // True when a finding path is AT or UNDER any create-only schema path. The schema's
@@ -1478,7 +1494,7 @@ export function buildRevertPlan(
       const sib = opts.siblingSgRules?.[f.physicalId]?.[sgSide] ?? [];
       if (sib.length > 0) toRevert = { ...f, desired: [...(f.desired as unknown[]), ...sib] };
     }
-    const op = revertOp(toRevert, recorded);
+    const op = revertOp(toRevert, recorded, opts.identity);
     const key = `${f.logicalId} ${kind}${propScoped ? ` ${f.path}` : ''}`;
     const item =
       itemsByLogical.get(key) ??
@@ -1567,7 +1583,35 @@ function coerceDeclaredScalar(desired: unknown, live: unknown): unknown {
   return desired;
 }
 
-function revertOp(f: Finding, recorded: BaselineFile['recorded']): PatchOp {
+// Resolve a CONTEXT_ARN_DEFAULTS template for the set-default revert path: the same
+// {partition}/{region}/{accountId} substitution classify uses for the fold side (#1694).
+// Undefined when the type/path has no template or the identity is unresolved — the caller
+// then falls through to the bare `remove` (fail-safe).
+function contextArnDefaultFor(
+  resourceType: string,
+  path: string,
+  identity: RevertOptions['identity']
+): unknown {
+  const template = CONTEXT_ARN_DEFAULTS[resourceType]?.[path];
+  if (template === undefined) return undefined;
+  const { accountId, region } = identity ?? {};
+  if (accountId === undefined || accountId === '' || region === undefined || region === '') {
+    return undefined;
+  }
+  const partition = partitionForRegion(region).partition;
+  const substitute = (t: string): string =>
+    t
+      .replace('{partition}', partition)
+      .replace('{region}', region)
+      .replace('{accountId}', accountId);
+  return Array.isArray(template) ? template.map(substitute) : substitute(template);
+}
+
+function revertOp(
+  f: Finding,
+  recorded: BaselineFile['recorded'],
+  identity?: RevertOptions['identity']
+): PatchOp {
   const pointer = toPointer(f.path);
   if (f.tier === 'declared') {
     return {
@@ -1619,7 +1663,9 @@ function revertOp(f: Finding, recorded: BaselineFile['recorded']): PatchOp {
   // at-default first sighting; if it is somehow absent we fall through to `remove`.
   const setDefaultKey = `${f.resourceType}\0${f.path}`;
   const knownDefault =
-    KNOWN_DEFAULTS[f.resourceType]?.[f.path] ?? REVERT_SET_DEFAULT_VALUES[setDefaultKey];
+    KNOWN_DEFAULTS[f.resourceType]?.[f.path] ??
+    REVERT_SET_DEFAULT_VALUES[setDefaultKey] ??
+    contextArnDefaultFor(f.resourceType, f.path, identity);
   if (knownDefault !== undefined && REVERT_SET_DEFAULT_PATHS.has(setDefaultKey)) {
     return {
       op: 'add',

--- a/tests/classify-hunt-0801.test.ts
+++ b/tests/classify-hunt-0801.test.ts
@@ -1,0 +1,514 @@
+// 2026-08-01 hunt (freepack) first-run FP fixes, live-proven on CdkrdHunt0801FreeA:
+// - #1695 ASG MixedInstancesPolicy: the whole-object InstancesDistribution constant
+//   echo + the referenced LT's minted-name echo inside LaunchTemplateSpecification.
+// - #1696 TargetGroup cross-variants: GENEVE health checks default to TCP on the
+//   FIXED port 80 (not traffic-port), and an HTTPS group's HC protocol default
+//   FOLLOWS the group protocol.
+// - #1697 EC2 Volume: a Size+AZ-only volume echoes the era default VolumeType gp2.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (findings: Finding[]) => findings.map((f) => `${f.tier}:${f.path}`).sort();
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1695 ASG MixedInstancesPolicy first-run echoes', () => {
+  const declared = {
+    MinSize: '0',
+    MaxSize: '0',
+    DesiredCapacity: '0',
+    VPCZoneIdentifier: ['subnet-0123456789abcdef0'],
+    MixedInstancesPolicy: {
+      LaunchTemplate: {
+        LaunchTemplateSpecification: {
+          LaunchTemplateId: 'lt-0de70a90a79de7e5c',
+          Version: '1',
+        },
+        Overrides: [{ InstanceType: 't3.micro' }],
+      },
+    },
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'MipAsg',
+    resourceType: 'AWS::AutoScaling::AutoScalingGroup',
+    physicalId: 'CdkrdHunt0801FreeA-MipAsg-abc',
+    declared,
+  });
+  const liveMip = {
+    InstancesDistribution: {
+      OnDemandAllocationStrategy: 'prioritized',
+      OnDemandBaseCapacity: 0,
+      OnDemandPercentageAboveBaseCapacity: 100,
+      SpotInstancePools: 2,
+      SpotAllocationStrategy: 'lowest-price',
+    },
+    LaunchTemplate: {
+      LaunchTemplateSpecification: {
+        LaunchTemplateName: 'Lt_7FhOViharN3u',
+        Version: '1',
+        LaunchTemplateId: 'lt-0de70a90a79de7e5c',
+      },
+      Overrides: [{ InstanceType: 't3.micro' }],
+    },
+  };
+
+  it('folds the InstancesDistribution constants + the minted LT-name echo (zero undeclared)', () => {
+    const f = classifyResource(mk(), { ...declared, MixedInstancesPolicy: liveMip }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band spot-distribution change still surfaces (equality gate)', () => {
+    const drifted = {
+      ...liveMip,
+      InstancesDistribution: {
+        ...liveMip.InstancesDistribution,
+        OnDemandPercentageAboveBaseCapacity: 50,
+      },
+    };
+    const f = classifyResource(mk(), { ...declared, MixedInstancesPolicy: drifted }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['MixedInstancesPolicy.InstancesDistribution']);
+  });
+});
+
+describe('#1696 TargetGroup GENEVE x instance / HTTPS health-check defaults', () => {
+  const mkTg = (declared: Record<string, unknown>, logicalId: string): DesiredResource => ({
+    logicalId,
+    resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+    physicalId: `arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/${logicalId}/abc`,
+    declared,
+  });
+
+  const geneveDeclared = {
+    Protocol: 'GENEVE',
+    Port: 6081,
+    TargetType: 'instance',
+    VpcId: 'vpc-0123456789abcdef0',
+  };
+  const geneveLive = {
+    ...geneveDeclared,
+    HealthCheckIntervalSeconds: 10,
+    HealthCheckEnabled: true,
+    HealthCheckTimeoutSeconds: 5,
+    HealthyThresholdCount: 5,
+    HealthCheckProtocol: 'TCP',
+    HealthCheckPort: '80',
+  };
+
+  it('GENEVE x instance: the TCP/80 health-check echoes fold (zero undeclared)', () => {
+    const f = classifyResource(mkTg(geneveDeclared, 'GeneveInstTg'), geneveLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('GENEVE: an out-of-band health-check port change still surfaces', () => {
+    const f = classifyResource(
+      mkTg(geneveDeclared, 'GeneveInstTg'),
+      { ...geneveLive, HealthCheckPort: '8080' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['HealthCheckPort']);
+  });
+
+  const httpsDeclared = {
+    Protocol: 'HTTPS',
+    Port: 443,
+    VpcId: 'vpc-0123456789abcdef0',
+  };
+  const httpsLive = {
+    ...httpsDeclared,
+    HealthCheckIntervalSeconds: 30,
+    Matcher: { HttpCode: '200' },
+    HealthCheckPath: '/',
+    HealthCheckEnabled: true,
+    HealthCheckTimeoutSeconds: 5,
+    HealthyThresholdCount: 5,
+    HealthCheckProtocol: 'HTTPS',
+    TargetType: 'instance',
+    HealthCheckPort: 'traffic-port',
+  };
+
+  it('HTTPS group: the HC-protocol-follows-protocol echo folds (zero undeclared)', () => {
+    const f = classifyResource(mkTg(httpsDeclared, 'HttpsTg'), httpsLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('HTTPS group: an out-of-band HC-protocol downgrade to HTTP still surfaces', () => {
+    const f = classifyResource(
+      mkTg(httpsDeclared, 'HttpsTg'),
+      { ...httpsLive, HealthCheckProtocol: 'HTTP' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['HealthCheckProtocol']);
+  });
+});
+
+describe('#1698 mTLS listener AdvertiseTrustStoreCaNames attach echo', () => {
+  const declared = {
+    LoadBalancerArn: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/x/abc',
+    Protocol: 'HTTPS',
+    Port: 443,
+    Certificates: [{ CertificateArn: 'arn:aws:acm:us-east-1:111111111111:certificate/dummy' }],
+    MutualAuthentication: {
+      Mode: 'verify',
+      TrustStoreArn: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/ts/abc',
+    },
+    DefaultActions: [
+      {
+        Type: 'fixed-response',
+        FixedResponseConfig: { StatusCode: '200', ContentType: 'text/plain' },
+      },
+    ],
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'MtlsListener',
+    resourceType: 'AWS::ElasticLoadBalancingV2::Listener',
+    physicalId: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/x/abc/def',
+    declared,
+  });
+
+  it('folds the undeclared AdvertiseTrustStoreCaNames off default on the attached shape', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        MutualAuthentication: {
+          ...declared.MutualAuthentication,
+          IgnoreClientCertificateExpiry: false,
+          AdvertiseTrustStoreCaNames: 'off',
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band flip to on still surfaces (equality gate)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        MutualAuthentication: {
+          ...declared.MutualAuthentication,
+          AdvertiseTrustStoreCaNames: 'on',
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([
+      'MutualAuthentication.AdvertiseTrustStoreCaNames',
+    ]);
+  });
+});
+
+describe('#1699 barest Interface VPCEndpoint default-SG gate', () => {
+  const declared = {
+    VpcId: 'vpc-0123456789abcdef0',
+    ServiceName: 'com.amazonaws.us-east-1.sqs',
+    VpcEndpointType: 'Interface',
+    SubnetIds: ['subnet-0123456789abcdef0'],
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'SqsIfEp',
+    resourceType: 'AWS::EC2::VPCEndpoint',
+    physicalId: 'vpce-0123456789abcdef0',
+    declared,
+  });
+
+  it('folds the single VPC-default SG to atDefault', () => {
+    const f = classifyResource(
+      mk(),
+      { ...declared, SecurityGroupIds: ['sg-0d2cd899a027df8ca'] },
+      emptySchema,
+      { defaultSgIds: new Set(['sg-0d2cd899a027df8ca']) }
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band SG append still surfaces (single-default gate)', () => {
+    const f = classifyResource(
+      mk(),
+      { ...declared, SecurityGroupIds: ['sg-0d2cd899a027df8ca', 'sg-0rogue'] },
+      emptySchema,
+      { defaultSgIds: new Set(['sg-0d2cd899a027df8ca']) }
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['SecurityGroupIds']);
+  });
+});
+
+describe('#1700 GuardDuty Detector partial-declared DataSources off-flip', () => {
+  const declared = {
+    Enable: true,
+    DataSources: { S3Logs: { Enable: true } },
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'Detector',
+    resourceType: 'AWS::GuardDuty::Detector',
+    physicalId: 'b3c66db5f2a2481997d50aa4460d2141',
+    declared,
+  });
+  const liveClean = {
+    ...declared,
+    DataSources: {
+      S3Logs: { Enable: true },
+      Kubernetes: { AuditLogs: { Enable: true } },
+      MalwareProtection: { ScanEc2InstanceWithFindings: { EbsVolumes: true } },
+    },
+  };
+
+  it('clean partial-declared deploy: the all-true siblings fold (zero undeclared)', () => {
+    const f = classifyResource(mk(), liveClean, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band all-false disable of a sibling protection surfaces (off-state gate)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        DataSources: {
+          S3Logs: { Enable: true },
+          Kubernetes: { AuditLogs: { Enable: false } },
+          MalwareProtection: { ScanEc2InstanceWithFindings: { EbsVolumes: true } },
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['DataSources.Kubernetes']);
+  });
+});
+
+describe('#1701 Cognito UserPool partial-declared PasswordPolicy (determination)', () => {
+  // A partially-declared PasswordPolicy is filled with Require*=FALSE by the service
+  // (corpus proof: Users0A0EEA89) — an undeclared false leaf is the CREATION state, so it
+  // must stay invisible; only the MinimumLength 8 fill is a foldable constant default.
+  const noLenDeclared = {
+    UserPoolName: 'hunt-pool',
+    Policies: { PasswordPolicy: { TemporaryPasswordValidityDays: 7 } },
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'Pool',
+    resourceType: 'AWS::Cognito::UserPool',
+    physicalId: 'us-east-1_dj8cDsvBc',
+    declared: noLenDeclared,
+  });
+  const filledPolicy = {
+    MinimumLength: 8,
+    RequireLowercase: false,
+    RequireNumbers: false,
+    RequireSymbols: false,
+    RequireUppercase: false,
+    TemporaryPasswordValidityDays: 7,
+  };
+
+  it('the service-filled partial shape (MinimumLength 8 + false Require* fills) is clean', () => {
+    const f = classifyResource(
+      mk(),
+      { ...noLenDeclared, Policies: { PasswordPolicy: filledPolicy } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band MinimumLength weakening to 6 surfaces (equality gate on the 8 pin)', () => {
+    const f = classifyResource(
+      mk(),
+      { ...noLenDeclared, Policies: { PasswordPolicy: { ...filledPolicy, MinimumLength: 6 } } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['Policies.PasswordPolicy.MinimumLength']);
+  });
+});
+
+describe('#1703 Route53 HealthCheck type-derived Port default', () => {
+  const mkHc = (config: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'HttpHc',
+    resourceType: 'AWS::Route53::HealthCheck',
+    physicalId: 'hc-0123',
+    declared: { HealthCheckConfig: config },
+  });
+
+  it('a barest HTTP check folds the undeclared Port 80 echo', () => {
+    const cfg = { Type: 'HTTP', FullyQualifiedDomainName: 'example.com' };
+    const f = classifyResource(mkHc(cfg), { HealthCheckConfig: { ...cfg, Port: 80 } }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an HTTPS check folds 443, and an out-of-band port change surfaces', () => {
+    const cfg = { Type: 'HTTPS', FullyQualifiedDomainName: 'example.com' };
+    const clean = classifyResource(
+      mkHc(cfg),
+      { HealthCheckConfig: { ...cfg, Port: 443 } },
+      emptySchema
+    );
+    expect(pathsByTier(clean, 'undeclared')).toEqual([]);
+    const drifted = classifyResource(
+      mkHc(cfg),
+      { HealthCheckConfig: { ...cfg, Port: 8443 } },
+      emptySchema
+    );
+    expect(pathsByTier(drifted, 'undeclared')).toEqual(['HealthCheckConfig.Port']);
+  });
+});
+
+describe('#1704 RDS read-replica inherited echoes', () => {
+  const declared = {
+    SourceDBInstanceIdentifier: 'src-db-0801',
+    DBInstanceClass: 'db.t4g.micro',
+  };
+  // The REAL schema marks SourceDBInstanceIdentifier writeOnly — the overlay must key on
+  // the PRE-strip snapshot (the #1500 trap; an emptySchema here would hide a regression
+  // where the derivation reads the stripped `declared` and silently no-ops, exactly what
+  // the first statepack live run caught).
+  const replicaSchema: SchemaInfo = {
+    ...emptySchema,
+    writeOnly: new Set(['SourceDBInstanceIdentifier']),
+    writeOnlyPaths: ['SourceDBInstanceIdentifier'],
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'ReplicaDb',
+    resourceType: 'AWS::RDS::DBInstance',
+    physicalId: 'replica-db-0801',
+    // fresh object per call — classify strips writeOnly paths from `declared` in place
+    declared: { ...declared },
+  });
+  const liveInherited = {
+    DBInstanceClass: 'db.t4g.micro',
+    Engine: 'postgres',
+    AllocatedStorage: '400',
+    MasterUsername: 'cdkrdhunt',
+    BackupRetentionPeriod: 0,
+  };
+  const srcModels = {
+    'src-db-0801': {
+      DBInstanceIdentifier: 'src-db-0801',
+      Engine: 'postgres',
+      AllocatedStorage: '400',
+      MasterUsername: 'cdkrdhunt',
+    },
+  };
+
+  it('folds the source-inherited echoes + the replica BackupRetentionPeriod 0 (zero undeclared)', () => {
+    const f = classifyResource(mk(), liveInherited, replicaSchema, {
+      siblingRdsSourceModels: srcModels,
+    });
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a replica value diverging from the source still surfaces (equality gate)', () => {
+    const f = classifyResource(mk(), { ...liveInherited, AllocatedStorage: '500' }, replicaSchema, {
+      siblingRdsSourceModels: srcModels,
+    });
+    expect(pathsByTier(f, 'undeclared')).toEqual(['AllocatedStorage']);
+  });
+
+  it('an out-of-stack source (no sibling model) leaves the inherited values unfolded — fail-safe', () => {
+    const f = classifyResource(mk(), liveInherited, replicaSchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual(['AllocatedStorage', 'Engine', 'MasterUsername']);
+  });
+});
+
+describe('#1705 Cassandra Table TTL constant + provisioned WarmThroughput derivation', () => {
+  const mkTable = (declared: Record<string, unknown>, logicalId: string): DesiredResource => ({
+    logicalId,
+    resourceType: 'AWS::Cassandra::Table',
+    physicalId: 'cdkrd_hunt0801|barest0801',
+    declared,
+  });
+
+  it('a barest table folds the DefaultTimeToLive 0 echo', () => {
+    const declared = {
+      KeyspaceName: 'cdkrd_hunt0801',
+      TableName: 'barest0801',
+      PartitionKeyColumns: [{ ColumnName: 'pk', ColumnType: 'text' }],
+    };
+    const f = classifyResource(
+      mkTable(declared, 'BarestTable'),
+      { ...declared, DefaultTimeToLive: 0 },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('a PROVISIONED table folds WarmThroughput echoing its own declared capacity', () => {
+    const declared = {
+      KeyspaceName: 'cdkrd_hunt0801',
+      TableName: 'prov0801',
+      PartitionKeyColumns: [{ ColumnName: 'pk', ColumnType: 'text' }],
+      BillingMode: {
+        Mode: 'PROVISIONED',
+        ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 },
+      },
+    };
+    const clean = classifyResource(
+      mkTable(declared, 'ProvTable'),
+      {
+        ...declared,
+        WarmThroughput: { ReadUnitsPerSecond: 1, WriteUnitsPerSecond: 1 },
+        DefaultTimeToLive: 0,
+      },
+      emptySchema
+    );
+    expect(pathsByTier(clean, 'undeclared')).toEqual([]);
+    const drifted = classifyResource(
+      mkTable(declared, 'ProvTable'),
+      { ...declared, WarmThroughput: { ReadUnitsPerSecond: 9000, WriteUnitsPerSecond: 9000 } },
+      emptySchema
+    );
+    expect(pathsByTier(drifted, 'undeclared')).toEqual(['WarmThroughput']);
+  });
+});
+
+describe('#1706 memcached CacheCluster undeclared EngineVersion (moving GA version)', () => {
+  const declared = {
+    Engine: 'memcached',
+    CacheNodeType: 'cache.t3.micro',
+    NumCacheNodes: 2,
+    CacheSubnetGroupName: 'cdkrd-subnets',
+    VpcSecurityGroupIds: ['sg-0123456789abcdef0'],
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'Memcached0801',
+    resourceType: 'AWS::ElastiCache::CacheCluster',
+    physicalId: 'cdkrdhunt0801-memcached',
+    declared,
+  });
+
+  it('folds the undeclared GA track echo value-independently (zero undeclared)', () => {
+    const f = classifyResource(mk(), { ...declared, EngineVersion: '1.6' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});
+
+describe('#1697 EC2 Volume VolumeType gp2 era default', () => {
+  const declared = { AvailabilityZone: 'us-east-1a', Size: 10 };
+  const mk = (): DesiredResource => ({
+    logicalId: 'BarestVol',
+    resourceType: 'AWS::EC2::Volume',
+    physicalId: 'vol-0eeb30b7ba7374872',
+    declared,
+  });
+
+  it('a Size+AZ-only volume folds the gp2 echo (zero undeclared)', () => {
+    const f = classifyResource(mk(), { ...declared, VolumeType: 'gp2' }, emptySchema);
+    expect(tierPaths(f)).toEqual(['atDefault:VolumeType']);
+  });
+
+  it('an out-of-band type migration still surfaces', () => {
+    const f = classifyResource(mk(), { ...declared, VolumeType: 'gp3' }, emptySchema);
+    expect(tierPaths(f)).toEqual(['undeclared:VolumeType']);
+  });
+});

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.MipAsg.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.MipAsg.json
@@ -1,0 +1,298 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MipAsg",
+    "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+    "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+    "constructPath": "CdkrdHunt0801FreeA/MipAsg",
+    "declared": {
+      "DesiredCapacity": "0",
+      "MaxSize": "0",
+      "MinSize": "0",
+      "MixedInstancesPolicy": {
+        "LaunchTemplate": {
+          "LaunchTemplateSpecification": {
+            "LaunchTemplateId": "lt-05c5b28b02e10a163",
+            "Version": "__cdkrd_corpus_unresolved__"
+          },
+          "Overrides": [
+            {
+              "InstanceType": "t3.micro"
+            }
+          ]
+        }
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "PropagateAtLaunch": true,
+          "Value": "1"
+        }
+      ],
+      "VPCZoneIdentifier": ["subnet-06feffef2d46455c6"]
+    }
+  },
+  "liveRaw": {
+    "LoadBalancerNames": [],
+    "ServiceLinkedRoleARN": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+    "TargetGroupARNs": [],
+    "AvailabilityZoneIds": ["use1-az1"],
+    "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:111111111111:autoScalingGroup:83900e04-e44b-4668-b1da-c50a3ccfda6c:autoScalingGroupName/CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+    "Cooldown": "300",
+    "AvailabilityZones": ["us-east-1a"],
+    "AvailabilityZoneDistribution": {
+      "CapacityDistributionStrategy": "balanced-best-effort"
+    },
+    "DesiredCapacity": "0",
+    "HealthCheckGracePeriod": 0,
+    "MetricsCollection": [],
+    "InstanceLifecyclePolicy": {
+      "RetentionTriggers": {
+        "TerminateHookAbandon": "terminate"
+      }
+    },
+    "MaxSize": "0",
+    "NewInstancesProtectedFromScaleIn": false,
+    "MinSize": "0",
+    "TerminationPolicies": ["Default"],
+    "AutoScalingGroupName": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+    "MixedInstancesPolicy": {
+      "InstancesDistribution": {
+        "OnDemandAllocationStrategy": "prioritized",
+        "OnDemandBaseCapacity": 0,
+        "OnDemandPercentageAboveBaseCapacity": 100,
+        "SpotInstancePools": 2,
+        "SpotAllocationStrategy": "lowest-price"
+      },
+      "LaunchTemplate": {
+        "LaunchTemplateSpecification": {
+          "LaunchTemplateName": "Lt_kXZD0Ed2XvHu",
+          "Version": "1",
+          "LaunchTemplateId": "lt-05c5b28b02e10a163"
+        },
+        "Overrides": [
+          {
+            "InstanceType": "t3.micro"
+          }
+        ]
+      }
+    },
+    "VPCZoneIdentifier": ["subnet-06feffef2d46455c6"],
+    "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "default"
+    },
+    "Tags": [
+      {
+        "ResourceId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+        "Value": "MipAsg",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:logical-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801FreeA/d1173eb0-8d8e-11f1-90a7-0affd9b7fb2d",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+        "Value": "CdkrdHunt0801FreeA",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-name",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+        "Value": "1",
+        "ResourceType": "auto-scaling-group",
+        "Key": "cdkrd:ephemeral",
+        "PropagateAtLaunch": true
+      }
+    ],
+    "HealthCheckType": "EC2"
+  },
+  "schema": {
+    "readOnly": ["AutoScalingGroupARN"],
+    "writeOnly": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnly": ["AutoScalingGroupName", "InstanceId"],
+    "readOnlyPaths": ["AutoScalingGroupARN"],
+    "writeOnlyPaths": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnlyPaths": ["AutoScalingGroupName", "InstanceId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AvailabilityZoneIds",
+      "AvailabilityZones",
+      "NotificationConfiguration.NotificationTypes",
+      "TargetGroupARNs",
+      "VPCZoneIdentifier"
+    ],
+    "unorderedObjectArrayPaths": ["LifecycleHookSpecificationList", "TrafficSources"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "MixedInstancesPolicy",
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "ServiceLinkedRoleARN",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneIds",
+      "actual": ["use1-az1"],
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Cooldown",
+      "actual": "300",
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a"],
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneDistribution",
+      "actual": {
+        "CapacityDistributionStrategy": "balanced-best-effort"
+      },
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckGracePeriod",
+      "actual": 0,
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "InstanceLifecyclePolicy",
+      "actual": {
+        "RetentionTriggers": {
+          "TerminateHookAbandon": "terminate"
+        }
+      },
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "TerminationPolicies",
+      "actual": ["Default"],
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "CapacityReservationSpecification",
+      "actual": {
+        "CapacityReservationPreference": "default"
+      },
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckType",
+      "actual": "EC2",
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "MixedInstancesPolicy.InstancesDistribution",
+      "actual": {
+        "OnDemandAllocationStrategy": "prioritized",
+        "OnDemandBaseCapacity": 0,
+        "OnDemandPercentageAboveBaseCapacity": 100,
+        "SpotInstancePools": 2,
+        "SpotAllocationStrategy": "lowest-price"
+      },
+      "nested": true,
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateName",
+      "actual": "Lt_kXZD0Ed2XvHu",
+      "nested": true,
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Tags[cdkrd:ephemeral].ResourceId",
+      "actual": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "nested": true,
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MipAsg",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Tags[cdkrd:ephemeral].ResourceType",
+      "actual": "auto-scaling-group",
+      "nested": true,
+      "physicalId": "CdkrdHunt0801FreeA-MipAsg-mcl9mO3va2iH",
+      "constructPath": "CdkrdHunt0801FreeA/MipAsg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cassandra__Table.BarestTable.json
+++ b/tests/corpus/AWS__Cassandra__Table.BarestTable.json
@@ -1,0 +1,166 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BarestTable",
+    "resourceType": "AWS::Cassandra::Table",
+    "physicalId": "cdkrd_hunt0801|barest0801",
+    "constructPath": "CdkrdHunt0801State/BarestTable",
+    "declared": {
+      "KeyspaceName": "cdkrd_hunt0801",
+      "PartitionKeyColumns": [
+        {
+          "ColumnName": "pk",
+          "ColumnType": "text"
+        }
+      ],
+      "TableName": "barest0801",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ClusteringKeyColumns": [],
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "KeyspaceName": "cdkrd_hunt0801",
+    "EncryptionSpecification": {
+      "EncryptionType": "AWS_OWNED_KMS_KEY"
+    },
+    "TableName": "barest0801",
+    "PointInTimeRecoveryEnabled": false,
+    "CdcSpecification": {
+      "Status": "DISABLED"
+    },
+    "ClientSideTimestampsEnabled": false,
+    "PartitionKeyColumns": [
+      {
+        "ColumnName": "pk",
+        "ColumnType": "text"
+      }
+    ],
+    "BillingMode": {
+      "Mode": "ON_DEMAND"
+    },
+    "DefaultTimeToLive": 0,
+    "RegularColumns": [],
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["AutoScalingSpecifications", "ReplicaSpecifications"],
+    "createOnly": [
+      "ClientSideTimestampsEnabled",
+      "ClusteringKeyColumns",
+      "KeyspaceName",
+      "PartitionKeyColumns",
+      "TableName"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["AutoScalingSpecifications", "ReplicaSpecifications"],
+    "createOnlyPaths": [
+      "ClientSideTimestampsEnabled",
+      "ClusteringKeyColumns",
+      "KeyspaceName",
+      "PartitionKeyColumns",
+      "TableName"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "ClusteringKeyColumns.*.OrderBy": "ASC",
+      "BillingMode.Mode": "ON_DEMAND",
+      "EncryptionSpecification.EncryptionType": "AWS_OWNED_KMS_KEY",
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.AutoScalingDisabled": false,
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.AutoScalingDisabled": false,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0,
+      "CdcSpecification.ViewType": "NEW_AND_OLD_IMAGES",
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.AutoScalingDisabled": false,
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["RegularColumns"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "cdkrd_hunt0801|barest0801",
+      "constructPath": "CdkrdHunt0801State/BarestTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "EncryptionSpecification",
+      "actual": {
+        "EncryptionType": "AWS_OWNED_KMS_KEY"
+      },
+      "physicalId": "cdkrd_hunt0801|barest0801",
+      "constructPath": "CdkrdHunt0801State/BarestTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "CdcSpecification",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "cdkrd_hunt0801|barest0801",
+      "constructPath": "CdkrdHunt0801State/BarestTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "BillingMode",
+      "actual": {
+        "Mode": "ON_DEMAND"
+      },
+      "physicalId": "cdkrd_hunt0801|barest0801",
+      "constructPath": "CdkrdHunt0801State/BarestTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "DefaultTimeToLive",
+      "actual": 0,
+      "physicalId": "cdkrd_hunt0801|barest0801",
+      "constructPath": "CdkrdHunt0801State/BarestTable"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cassandra__Table.ProvTable.json
+++ b/tests/corpus/AWS__Cassandra__Table.ProvTable.json
@@ -1,0 +1,166 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ProvTable",
+    "resourceType": "AWS::Cassandra::Table",
+    "physicalId": "cdkrd_hunt0801|prov0801",
+    "constructPath": "CdkrdHunt0801State/ProvTable",
+    "declared": {
+      "BillingMode": {
+        "Mode": "PROVISIONED",
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 1,
+          "WriteCapacityUnits": 1
+        }
+      },
+      "KeyspaceName": "cdkrd_hunt0801",
+      "PartitionKeyColumns": [
+        {
+          "ColumnName": "pk",
+          "ColumnType": "text"
+        }
+      ],
+      "TableName": "prov0801",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ClusteringKeyColumns": [],
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 1,
+      "WriteUnitsPerSecond": 1
+    },
+    "KeyspaceName": "cdkrd_hunt0801",
+    "EncryptionSpecification": {
+      "EncryptionType": "AWS_OWNED_KMS_KEY"
+    },
+    "TableName": "prov0801",
+    "PointInTimeRecoveryEnabled": false,
+    "CdcSpecification": {
+      "Status": "DISABLED"
+    },
+    "ClientSideTimestampsEnabled": false,
+    "PartitionKeyColumns": [
+      {
+        "ColumnName": "pk",
+        "ColumnType": "text"
+      }
+    ],
+    "BillingMode": {
+      "Mode": "PROVISIONED",
+      "ProvisionedThroughput": {
+        "WriteCapacityUnits": 1,
+        "ReadCapacityUnits": 1
+      }
+    },
+    "DefaultTimeToLive": 0,
+    "RegularColumns": [],
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["AutoScalingSpecifications", "ReplicaSpecifications"],
+    "createOnly": [
+      "ClientSideTimestampsEnabled",
+      "ClusteringKeyColumns",
+      "KeyspaceName",
+      "PartitionKeyColumns",
+      "TableName"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["AutoScalingSpecifications", "ReplicaSpecifications"],
+    "createOnlyPaths": [
+      "ClientSideTimestampsEnabled",
+      "ClusteringKeyColumns",
+      "KeyspaceName",
+      "PartitionKeyColumns",
+      "TableName"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "ClusteringKeyColumns.*.OrderBy": "ASC",
+      "BillingMode.Mode": "ON_DEMAND",
+      "EncryptionSpecification.EncryptionType": "AWS_OWNED_KMS_KEY",
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.AutoScalingDisabled": false,
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.AutoScalingDisabled": false,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0,
+      "CdcSpecification.ViewType": "NEW_AND_OLD_IMAGES",
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.AutoScalingDisabled": false,
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["RegularColumns"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ProvTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 1,
+        "WriteUnitsPerSecond": 1
+      },
+      "physicalId": "cdkrd_hunt0801|prov0801",
+      "constructPath": "CdkrdHunt0801State/ProvTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ProvTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "EncryptionSpecification",
+      "actual": {
+        "EncryptionType": "AWS_OWNED_KMS_KEY"
+      },
+      "physicalId": "cdkrd_hunt0801|prov0801",
+      "constructPath": "CdkrdHunt0801State/ProvTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ProvTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "CdcSpecification",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "cdkrd_hunt0801|prov0801",
+      "constructPath": "CdkrdHunt0801State/ProvTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ProvTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "DefaultTimeToLive",
+      "actual": 0,
+      "physicalId": "cdkrd_hunt0801|prov0801",
+      "constructPath": "CdkrdHunt0801State/ProvTable"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EgressOnlyInternetGateway.Eigw.json
+++ b/tests/corpus/AWS__EC2__EgressOnlyInternetGateway.Eigw.json
@@ -1,0 +1,51 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Eigw",
+    "resourceType": "AWS::EC2::EgressOnlyInternetGateway",
+    "physicalId": "eigw-03e5fa14823112e27",
+    "constructPath": "CdkrdHunt0801Elb/Eigw",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcId": "vpc-0c41e4b2249864c89"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-0c41e4b2249864c89",
+    "Id": "eigw-03e5fa14823112e27",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPCCidrBlock.V6.json
+++ b/tests/corpus/AWS__EC2__VPCCidrBlock.V6.json
@@ -1,0 +1,88 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "V6",
+    "resourceType": "AWS::EC2::VPCCidrBlock",
+    "physicalId": "vpc-cidr-assoc-024f102d8ac39c945",
+    "constructPath": "CdkrdHunt0801Elb/V6",
+    "declared": {
+      "AmazonProvidedIpv6CidrBlock": true,
+      "VpcId": "vpc-0c41e4b2249864c89"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-0c41e4b2249864c89",
+    "Ipv6AddressAttribute": "public",
+    "IpSource": "amazon",
+    "Ipv6CidrBlockNetworkBorderGroup": "us-east-1",
+    "Id": "vpc-cidr-assoc-024f102d8ac39c945",
+    "Ipv6CidrBlock": "2600:1f10:4294:8000::/56",
+    "AmazonProvidedIpv6CidrBlock": true
+  },
+  "schema": {
+    "readOnly": ["Id", "IpSource", "Ipv6AddressAttribute"],
+    "writeOnly": ["Ipv4IpamPoolId", "Ipv4NetmaskLength", "Ipv6IpamPoolId", "Ipv6NetmaskLength"],
+    "createOnly": [
+      "AmazonProvidedIpv6CidrBlock",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6CidrBlockNetworkBorderGroup",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength",
+      "Ipv6Pool",
+      "VpcId"
+    ],
+    "readOnlyPaths": ["Id", "IpSource", "Ipv6AddressAttribute"],
+    "writeOnlyPaths": [
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AmazonProvidedIpv6CidrBlock",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6CidrBlockNetworkBorderGroup",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength",
+      "Ipv6Pool",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "V6",
+      "resourceType": "AWS::EC2::VPCCidrBlock",
+      "path": "Ipv6CidrBlockNetworkBorderGroup",
+      "actual": "us-east-1",
+      "physicalId": "vpc-cidr-assoc-024f102d8ac39c945",
+      "constructPath": "CdkrdHunt0801Elb/V6"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "V6",
+      "resourceType": "AWS::EC2::VPCCidrBlock",
+      "path": "Ipv6CidrBlock",
+      "actual": "2600:1f10:4294:8000::/56",
+      "physicalId": "vpc-cidr-assoc-024f102d8ac39c945",
+      "constructPath": "CdkrdHunt0801Elb/V6"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VPCEndpoint.SqsIfEp.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.SqsIfEp.json
@@ -1,0 +1,180 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SqsIfEp",
+    "resourceType": "AWS::EC2::VPCEndpoint",
+    "physicalId": "vpce-039d4ef9c1c3675ef",
+    "constructPath": "CdkrdHunt0801Elb/SqsIfEp",
+    "declared": {
+      "ServiceName": "com.amazonaws.us-east-1.sqs",
+      "SubnetIds": ["subnet-079da9827dc19df2b"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcEndpointType": "Interface",
+      "VpcId": "vpc-0c41e4b2249864c89"
+    }
+  },
+  "liveRaw": {
+    "PrivateDnsEnabled": false,
+    "IpAddressType": "ipv4",
+    "ServiceRegion": "us-east-1",
+    "CreationTimestamp": "Sat 8 1 9:55:58 UTC 2026",
+    "DnsOptions": {
+      "PrivateDnsOnlyForInboundResolverEndpoint": "NotSpecified",
+      "PrivateDnsSpecifiedDomains": ["*"],
+      "DnsRecordIpType": "ipv4",
+      "PrivateDnsPreference": "VERIFIED_DOMAINS_ONLY"
+    },
+    "NetworkInterfaceIds": ["eni-0a844e08478a0d21c"],
+    "DnsEntries": [
+      "Z7HUB22UULQXV:vpce-039d4ef9c1c3675ef-5godbqhm.sqs.us-east-1.vpce.amazonaws.com",
+      "Z7HUB22UULQXV:vpce-039d4ef9c1c3675ef-5godbqhm-us-east-1a.sqs.us-east-1.vpce.amazonaws.com"
+    ],
+    "ResourceConfigurationArn": "",
+    "SecurityGroupIds": ["sg-04a605bef1837e493"],
+    "SubnetIds": ["subnet-079da9827dc19df2b"],
+    "ServiceNetworkArn": "",
+    "VpcId": "vpc-0c41e4b2249864c89",
+    "RouteTableIds": [],
+    "ServiceName": "com.amazonaws.us-east-1.sqs",
+    "PolicyDocument": {
+      "Statement": [
+        {
+          "Action": "*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": "*"
+        }
+      ]
+    },
+    "VpcEndpointType": "Interface",
+    "Id": "vpce-039d4ef9c1c3675ef",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801Elb",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SqsIfEp",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801Elb/147afc00-8d8f-11f1-a64b-126cee05623d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreationTimestamp", "DnsEntries", "Id", "NetworkInterfaceIds"],
+    "writeOnly": [],
+    "createOnly": [
+      "ResourceConfigurationArn",
+      "ServiceName",
+      "ServiceNetworkArn",
+      "ServiceRegion",
+      "VpcEndpointType",
+      "VpcId"
+    ],
+    "readOnlyPaths": ["CreationTimestamp", "DnsEntries", "Id", "NetworkInterfaceIds"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DnsOptions.PrivateDnsPreference",
+      "DnsOptions.PrivateDnsSpecifiedDomains",
+      "ResourceConfigurationArn",
+      "ServiceName",
+      "ServiceNetworkArn",
+      "ServiceRegion",
+      "VpcEndpointType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "DnsEntries",
+      "NetworkInterfaceIds",
+      "RouteTableIds",
+      "SecurityGroupIds",
+      "SubnetIds"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SqsIfEp",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "vpce-039d4ef9c1c3675ef",
+      "constructPath": "CdkrdHunt0801Elb/SqsIfEp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SqsIfEp",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "ServiceRegion",
+      "actual": "us-east-1",
+      "physicalId": "vpce-039d4ef9c1c3675ef",
+      "constructPath": "CdkrdHunt0801Elb/SqsIfEp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SqsIfEp",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "DnsOptions",
+      "actual": {
+        "PrivateDnsOnlyForInboundResolverEndpoint": "NotSpecified",
+        "PrivateDnsSpecifiedDomains": ["*"],
+        "DnsRecordIpType": "ipv4",
+        "PrivateDnsPreference": "VERIFIED_DOMAINS_ONLY"
+      },
+      "physicalId": "vpce-039d4ef9c1c3675ef",
+      "constructPath": "CdkrdHunt0801Elb/SqsIfEp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SqsIfEp",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-04a605bef1837e493"],
+      "physicalId": "vpce-039d4ef9c1c3675ef",
+      "constructPath": "CdkrdHunt0801Elb/SqsIfEp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SqsIfEp",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "PolicyDocument",
+      "actual": {
+        "Statement": [
+          {
+            "Action": ["*"],
+            "Effect": "Allow",
+            "Principal": "*",
+            "Resource": ["*"]
+          }
+        ]
+      },
+      "physicalId": "vpce-039d4ef9c1c3675ef",
+      "constructPath": "CdkrdHunt0801Elb/SqsIfEp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Volume.BarestVol.json
+++ b/tests/corpus/AWS__EC2__Volume.BarestVol.json
@@ -1,0 +1,111 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BarestVol",
+    "resourceType": "AWS::EC2::Volume",
+    "physicalId": "vol-0da2dec764f017447",
+    "constructPath": "CdkrdHunt0801FreeA/BarestVol",
+    "declared": {
+      "AvailabilityZone": "us-east-1a",
+      "Size": 10,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MultiAttachEnabled": false,
+    "VolumeId": "vol-0da2dec764f017447",
+    "VolumeType": "gp2",
+    "Encrypted": false,
+    "Size": 10,
+    "AutoEnableIO": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "Iops": 100,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801FreeA/d1173eb0-8d8e-11f1-90a7-0affd9b7fb2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "BarestVol",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0801FreeA",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["VolumeId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["VolumeId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "accountDefaults": {
+      "ebsEncryptionByDefault": false
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestVol",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "VolumeType",
+      "actual": "gp2",
+      "physicalId": "vol-0da2dec764f017447",
+      "constructPath": "CdkrdHunt0801FreeA/BarestVol"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestVol",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "Encrypted",
+      "actual": false,
+      "physicalId": "vol-0da2dec764f017447",
+      "constructPath": "CdkrdHunt0801FreeA/BarestVol"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestVol",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "vol-0da2dec764f017447",
+      "constructPath": "CdkrdHunt0801FreeA/BarestVol"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BarestVol",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "Iops",
+      "actual": 100,
+      "physicalId": "vol-0da2dec764f017447",
+      "constructPath": "CdkrdHunt0801FreeA/BarestVol"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Volume.Gp3Vol0801.json
+++ b/tests/corpus/AWS__EC2__Volume.Gp3Vol0801.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Gp3Vol0801",
+    "resourceType": "AWS::EC2::Volume",
+    "physicalId": "vol-07ef350059b589e96",
+    "constructPath": "CdkrdHunt0801FreeA/Gp3Vol0801",
+    "declared": {
+      "AvailabilityZone": "us-east-1a",
+      "Size": 10,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VolumeType": "gp3"
+    }
+  },
+  "liveRaw": {
+    "MultiAttachEnabled": false,
+    "VolumeId": "vol-07ef350059b589e96",
+    "VolumeType": "gp3",
+    "Encrypted": false,
+    "Size": 10,
+    "AutoEnableIO": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "Throughput": 125,
+    "Iops": 3000,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801FreeA/d1173eb0-8d8e-11f1-90a7-0affd9b7fb2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "Gp3Vol0801",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdHunt0801FreeA",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["VolumeId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["VolumeId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "accountDefaults": {
+      "ebsEncryptionByDefault": false
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Gp3Vol0801",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "Encrypted",
+      "actual": false,
+      "physicalId": "vol-07ef350059b589e96",
+      "constructPath": "CdkrdHunt0801FreeA/Gp3Vol0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Gp3Vol0801",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "vol-07ef350059b589e96",
+      "constructPath": "CdkrdHunt0801FreeA/Gp3Vol0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Gp3Vol0801",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "Throughput",
+      "actual": 125,
+      "physicalId": "vol-07ef350059b589e96",
+      "constructPath": "CdkrdHunt0801FreeA/Gp3Vol0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Gp3Vol0801",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "Iops",
+      "actual": 3000,
+      "physicalId": "vol-07ef350059b589e96",
+      "constructPath": "CdkrdHunt0801FreeA/Gp3Vol0801"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Memcached0801.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Memcached0801.json
@@ -1,0 +1,198 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Memcached0801",
+    "resourceType": "AWS::ElastiCache::CacheCluster",
+    "physicalId": "cdk-me-nvdv4tcz9mnt",
+    "constructPath": "CdkrdHunt0801State/Memcached0801",
+    "declared": {
+      "CacheNodeType": "cache.t3.micro",
+      "CacheSubnetGroupName": "cdkrdhunt0801state-cachesubnets-y26nl80igfqn",
+      "Engine": "memcached",
+      "NumCacheNodes": 2,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcSecurityGroupIds": ["sg-090ed3cd866568e74"]
+    }
+  },
+  "liveRaw": {
+    "EngineVersion": "1.6",
+    "CacheSubnetGroupName": "cdkrdhunt0801state-cachesubnets-y26nl80igfqn",
+    "Port": 11211,
+    "CacheParameterGroupName": "default.memcached1.6",
+    "PreferredMaintenanceWindow": "sun:03:30-sun:04:30",
+    "AutoMinorVersionUpgrade": true,
+    "NumCacheNodes": 2,
+    "ConfigurationEndpoint": {
+      "Address": "cdk-me-nvdv4tcz9mnt.jzgy0l.cfg.use1.cache.amazonaws.com",
+      "Port": "11211"
+    },
+    "CacheNodeType": "cache.t3.micro",
+    "RedisEndpoint": {
+      "Address": "",
+      "Port": ""
+    },
+    "TransitEncryptionEnabled": false,
+    "PreferredAvailabilityZones": ["us-east-1b", "us-east-1b"],
+    "VpcSecurityGroupIds": ["sg-090ed3cd866568e74"],
+    "NetworkType": "ipv4",
+    "IpDiscovery": "ipv4",
+    "ClusterName": "cdk-me-nvdv4tcz9mnt",
+    "LogDeliveryConfigurations": [],
+    "Engine": "memcached",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "AZMode": "single-az"
+  },
+  "schema": {
+    "readOnly": ["ConfigurationEndpoint", "RedisEndpoint"],
+    "writeOnly": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZone",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnly": [
+      "CacheSubnetGroupName",
+      "ClusterName",
+      "Engine",
+      "NetworkType",
+      "Port",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "readOnlyPaths": [
+      "ConfigurationEndpoint",
+      "ConfigurationEndpoint.Address",
+      "ConfigurationEndpoint.Port",
+      "RedisEndpoint",
+      "RedisEndpoint.Address",
+      "RedisEndpoint.Port"
+    ],
+    "writeOnlyPaths": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZone",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "CacheSubnetGroupName",
+      "ClusterName",
+      "Engine",
+      "NetworkType",
+      "Port",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZones",
+      "SnapshotArns",
+      "VpcSecurityGroupIds"
+    ],
+    "unorderedObjectArrayPaths": ["LogDeliveryConfigurations"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "EngineVersion",
+      "actual": "1.6",
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "Port",
+      "actual": 11211,
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "CacheParameterGroupName",
+      "actual": "default.memcached1.6",
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "sun:03:30-sun:04:30",
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "PreferredAvailabilityZones",
+      "actual": ["us-east-1b", "us-east-1b"],
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Memcached0801",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "AZMode",
+      "actual": "single-az",
+      "physicalId": "cdk-me-nvdv4tcz9mnt",
+      "constructPath": "CdkrdHunt0801State/Memcached0801"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.MtlsListener.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.MtlsListener.json
@@ -1,0 +1,211 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MtlsListener",
+    "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6/b1bf2f121a76a2d8",
+    "constructPath": "CdkrdHunt0801Elb/MtlsListener",
+    "declared": {
+      "Certificates": [
+        {
+          "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/7a56ea31-baec-47b3-bfc7-4345eebe9990"
+        }
+      ],
+      "DefaultActions": [
+        {
+          "FixedResponseConfig": {
+            "ContentType": "text/plain",
+            "StatusCode": "200"
+          },
+          "Type": "fixed-response"
+        }
+      ],
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "MutualAuthentication": {
+        "Mode": "verify",
+        "TrustStoreArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt0801-mtls-ts/b7b3f5fb556ce0cb"
+      },
+      "Port": 443,
+      "Protocol": "HTTPS"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6/b1bf2f121a76a2d8",
+    "MutualAuthentication": {
+      "IgnoreClientCertificateExpiry": false,
+      "Mode": "verify",
+      "TrustStoreArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt0801-mtls-ts/b7b3f5fb556ce0cb",
+      "AdvertiseTrustStoreCaNames": "off"
+    },
+    "ListenerAttributes": [
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_tls_cipher_suite.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_serial_number.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_origin.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.content_security_policy.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_leaf.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_tls_version.header_name"
+      },
+      {
+        "Value": "true",
+        "Key": "routing.http.response.server.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_frame_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_methods.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_issuer.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_validity.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_credentials.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.request.x_amzn_mtls_clientcert_subject.header_name"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_content_type_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_expose_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.strict_transport_security.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_max_age.header_value"
+      }
+    ],
+    "SslPolicy": "ELBSecurityPolicy-2016-08",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+    "DefaultActions": [
+      {
+        "FixedResponseConfig": {
+          "ContentType": "text/plain",
+          "StatusCode": "200"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "Port": 443,
+    "Certificates": [
+      {
+        "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/7a56ea31-baec-47b3-bfc7-4345eebe9990"
+      }
+    ],
+    "Protocol": "HTTPS",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801Elb",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "MtlsListener",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801Elb/147afc00-8d8f-11f1-a64b-126cee05623d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": ["DefaultActions.*.AuthenticateOidcConfig.ClientSecret"],
+    "createOnlyPaths": ["LoadBalancerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "DefaultActions.*.AuthenticateCognitoConfig.AuthenticationRequestExtraParams",
+      "DefaultActions.*.AuthenticateOidcConfig.AuthenticationRequestExtraParams"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MtlsListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "ListenerAttributes[routing.http.response.server.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6/b1bf2f121a76a2d8",
+      "constructPath": "CdkrdHunt0801Elb/MtlsListener"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MtlsListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "SslPolicy",
+      "actual": "ELBSecurityPolicy-2016-08",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6/b1bf2f121a76a2d8",
+      "constructPath": "CdkrdHunt0801Elb/MtlsListener"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MtlsListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "MutualAuthentication.AdvertiseTrustStoreCaNames",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6/b1bf2f121a76a2d8",
+      "constructPath": "CdkrdHunt0801Elb/MtlsListener"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.TlsListener.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.TlsListener.json
@@ -1,0 +1,107 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TlsListener",
+    "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5/73fc138fa678ce83",
+    "constructPath": "CdkrdHunt0801Elb/TlsListener",
+    "declared": {
+      "Certificates": [
+        {
+          "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/7a56ea31-baec-47b3-bfc7-4345eebe9990"
+        }
+      ],
+      "DefaultActions": [
+        {
+          "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-NlbTl-TOAJN2VSDUTO/7abfb2b566916e7a",
+          "Type": "forward"
+        }
+      ],
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "Port": 443,
+      "Protocol": "TLS"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5/73fc138fa678ce83",
+    "SslPolicy": "ELBSecurityPolicy-2016-08",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+    "DefaultActions": [
+      {
+        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-NlbTl-TOAJN2VSDUTO/7abfb2b566916e7a",
+        "Type": "forward",
+        "ForwardConfig": {
+          "TargetGroupStickinessConfig": {
+            "Enabled": false
+          },
+          "TargetGroups": [
+            {
+              "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-NlbTl-TOAJN2VSDUTO/7abfb2b566916e7a"
+            }
+          ]
+        }
+      }
+    ],
+    "Port": 443,
+    "Certificates": [
+      {
+        "CertificateArn": "arn:aws:acm:us-east-1:111111111111:certificate/7a56ea31-baec-47b3-bfc7-4345eebe9990"
+      }
+    ],
+    "Protocol": "TLS",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801Elb",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TlsListener",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801Elb/147afc00-8d8f-11f1-a64b-126cee05623d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": ["DefaultActions.*.AuthenticateOidcConfig.ClientSecret"],
+    "createOnlyPaths": ["LoadBalancerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "DefaultActions.*.AuthenticateCognitoConfig.AuthenticationRequestExtraParams",
+      "DefaultActions.*.AuthenticateOidcConfig.AuthenticationRequestExtraParams"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "SslPolicy",
+      "actual": "ELBSecurityPolicy-2016-08",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5/73fc138fa678ce83",
+      "constructPath": "CdkrdHunt0801Elb/TlsListener"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.DsAlb.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.DsAlb.json
@@ -1,0 +1,392 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DsAlb",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+    "constructPath": "CdkrdHunt0801Elb/DsAlb",
+    "declared": {
+      "IpAddressType": "dualstack",
+      "Scheme": "internet-facing",
+      "Subnets": ["subnet-079da9827dc19df2b", "subnet-0446fe2c6aba19d9d"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Type": "application"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "dualstack",
+    "SecurityGroups": ["sg-04a605bef1837e493"],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "append",
+        "Key": "routing.http.xff_header_processing.mode"
+      },
+      {
+        "Value": "true",
+        "Key": "routing.http2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "waf.fail_open.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "defensive",
+        "Key": "routing.http.desync_mitigation_mode"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.prefix"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.preserve_host_header.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "health_check_logs.s3.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.xff_client_port.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "3600",
+        "Key": "client_keep_alive.seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.drop_invalid_header_fields.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "connection_logs.s3.enabled"
+      },
+      {
+        "Value": "60",
+        "Key": "idle_timeout.timeout_seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "ipv6.deny_all_igw_traffic"
+      }
+    ],
+    "Scheme": "internet-facing",
+    "DNSName": "CdkrdH-DsAlb-HesW4mhrjLmx-35561451.us-east-1.elb.amazonaws.com",
+    "Name": "CdkrdH-DsAlb-HesW4mhrjLmx",
+    "LoadBalancerName": "CdkrdH-DsAlb-HesW4mhrjLmx",
+    "Subnets": ["subnet-079da9827dc19df2b", "subnet-0446fe2c6aba19d9d"],
+    "Type": "application",
+    "CanonicalHostedZoneID": "Z35SXDOTRQ7X7K",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801Elb",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "DsAlb",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801Elb/147afc00-8d8f-11f1-a64b-126cee05623d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "LoadBalancerFullName": "app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-0446fe2c6aba19d9d"
+      },
+      {
+        "SubnetId": "subnet-079da9827dc19df2b"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "defaultPaths": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "unorderedScalarPaths": ["SecurityGroups", "Subnets"],
+    "unorderedObjectArrayPaths": ["SubnetMappings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "SecurityGroups",
+      "actual": ["sg-04a605bef1837e493"],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[access_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[client_keep_alive.seconds]",
+      "actual": "3600",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[connection_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[deletion_protection.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[health_check_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[idle_timeout.timeout_seconds]",
+      "actual": "60",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[ipv6.deny_all_igw_traffic]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.desync_mitigation_mode]",
+      "actual": "defensive",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.drop_invalid_header_fields.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.preserve_host_header.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.x_amzn_tls_version_and_cipher_suite.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.xff_client_port.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.xff_header_processing.mode]",
+      "actual": "append",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http2.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[waf.fail_open.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[zonal_shift.config.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "Name",
+      "actual": "CdkrdH-DsAlb-HesW4mhrjLmx",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsAlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdH-DsAlb-HesW4mhrjLmx/ad792ca18e21d9e6",
+      "constructPath": "CdkrdHunt0801Elb/DsAlb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.DsNlb.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.DsNlb.json
@@ -1,0 +1,227 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DsNlb",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+    "constructPath": "CdkrdHunt0801Elb/DsNlb",
+    "declared": {
+      "IpAddressType": "dualstack",
+      "Scheme": "internet-facing",
+      "Subnets": ["subnet-079da9827dc19df2b", "subnet-0446fe2c6aba19d9d"],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Type": "network"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "dualstack",
+    "SecurityGroups": [],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "0",
+        "Key": "secondary_ips.auto_assigned.per_subnet"
+      },
+      {
+        "Value": "any_availability_zone",
+        "Key": "dns_record.client_routing_policy"
+      },
+      {
+        "Value": "false",
+        "Key": "ipv6.deny_all_igw_traffic"
+      }
+    ],
+    "Scheme": "internet-facing",
+    "DNSName": "CdkrdH-DsNlb-KHO9JpXWBV8y-27597fee657a80a5.elb.us-east-1.amazonaws.com",
+    "Name": "CdkrdH-DsNlb-KHO9JpXWBV8y",
+    "LoadBalancerName": "CdkrdH-DsNlb-KHO9JpXWBV8y",
+    "Subnets": ["subnet-079da9827dc19df2b", "subnet-0446fe2c6aba19d9d"],
+    "Type": "network",
+    "CanonicalHostedZoneID": "Z26RNL4JYFTOTI",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801Elb",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "DsNlb",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801Elb/147afc00-8d8f-11f1-a64b-126cee05623d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "LoadBalancerFullName": "net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-0446fe2c6aba19d9d"
+      },
+      {
+        "SubnetId": "subnet-079da9827dc19df2b"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "defaultPaths": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "unorderedScalarPaths": ["SecurityGroups", "Subnets"],
+    "unorderedObjectArrayPaths": ["SubnetMappings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[access_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[deletion_protection.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[dns_record.client_routing_policy]",
+      "actual": "any_availability_zone",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[ipv6.deny_all_igw_traffic]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[secondary_ips.auto_assigned.per_subnet]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[zonal_shift.config.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "Name",
+      "actual": "CdkrdH-DsNlb-KHO9JpXWBV8y",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DsNlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkrdH-DsNlb-KHO9JpXWBV8y/27597fee657a80a5",
+      "constructPath": "CdkrdHunt0801Elb/DsNlb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.GeneveInstTg.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.GeneveInstTg.json
@@ -1,0 +1,247 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GeneveInstTg",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+    "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg",
+    "declared": {
+      "Port": 6081,
+      "Protocol": "GENEVE",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TargetType": "instance",
+      "VpcId": "vpc-0940ba5e394c1054e"
+    }
+  },
+  "liveRaw": {
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+    "HealthCheckIntervalSeconds": 10,
+    "LoadBalancerArns": [],
+    "Port": 6081,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 5,
+    "Name": "CdkrdH-Genev-SPNMIQPXOGBG",
+    "VpcId": "vpc-0940ba5e394c1054e",
+    "TargetGroupFullName": "targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "source_ip_dest_ip_proto",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "no_rebalance",
+        "Key": "target_failover.on_deregistration"
+      },
+      {
+        "Value": "no_rebalance",
+        "Key": "target_failover.on_unhealthy"
+      }
+    ],
+    "TargetType": "instance",
+    "HealthCheckPort": "80",
+    "Protocol": "GENEVE",
+    "TargetGroupName": "CdkrdH-Genev-SPNMIQPXOGBG",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801FreeA",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "GeneveInstTg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801FreeA/d1173eb0-8d8e-11f1-90a7-0affd9b7fb2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-Genev-SPNMIQPXOGBG",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "TCP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip_dest_ip_proto",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_failover.on_deregistration]",
+      "actual": "no_rebalance",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_failover.on_unhealthy]",
+      "actual": "no_rebalance",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GeneveInstTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "80",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Genev-SPNMIQPXOGBG/007194e55a0487c2ba",
+      "constructPath": "CdkrdHunt0801FreeA/GeneveInstTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.HttpsTg.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.HttpsTg.json
@@ -1,0 +1,415 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HttpsTg",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+    "constructPath": "CdkrdHunt0801FreeA/HttpsTg",
+    "declared": {
+      "Port": 443,
+      "Protocol": "HTTPS",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VpcId": "vpc-0940ba5e394c1054e"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Matcher": {
+      "HttpCode": "200"
+    },
+    "HealthCheckPath": "/",
+    "Port": 443,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "ProtocolVersion": "HTTP1",
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 5,
+    "Name": "CdkrdH-Https-OBITEAZXRAWD",
+    "VpcId": "vpc-0940ba5e394c1054e",
+    "TargetGroupFullName": "targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "HTTPS",
+    "TargetGroupAttributes": [
+      {
+        "Value": "lb_cookie",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.app_cookie.duration_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.lb_cookie.duration_seconds"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "slow_start.duration_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "off",
+        "Key": "load_balancing.algorithm.anomaly_mitigation"
+      },
+      {
+        "Value": "",
+        "Key": "stickiness.app_cookie.cookie_name"
+      },
+      {
+        "Value": "round_robin",
+        "Key": "load_balancing.algorithm.type"
+      }
+    ],
+    "TargetType": "instance",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "HTTPS",
+    "TargetGroupName": "CdkrdH-Https-OBITEAZXRAWD",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801FreeA",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HttpsTg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801FreeA/d1173eb0-8d8e-11f1-90a7-0affd9b7fb2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Matcher",
+      "actual": {
+        "HttpCode": "200"
+      },
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPath",
+      "actual": "/",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "ProtocolVersion",
+      "actual": "HTTP1",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-Https-OBITEAZXRAWD",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "HTTPS",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.algorithm.anomaly_mitigation]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.algorithm.type]",
+      "actual": "round_robin",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[slow_start.duration_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.app_cookie.duration_seconds]",
+      "actual": "86400",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.lb_cookie.duration_seconds]",
+      "actual": "86400",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "lb_cookie",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetType",
+      "actual": "instance",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpsTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-Https-OBITEAZXRAWD/ad6208f9368a3644",
+      "constructPath": "CdkrdHunt0801FreeA/HttpsTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TlsIpTg.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TlsIpTg.json
@@ -1,0 +1,369 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TlsIpTg",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+    "constructPath": "CdkrdHunt0801FreeA/TlsIpTg",
+    "declared": {
+      "Port": 443,
+      "Protocol": "TLS",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TargetType": "ip",
+      "VpcId": "vpc-0940ba5e394c1054e"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Port": 443,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 10,
+    "Name": "CdkrdH-TlsIp-IPEVB2EGCWV3",
+    "VpcId": "vpc-0940ba5e394c1054e",
+    "TargetGroupFullName": "targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "TCP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "source_ip",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "target_health_state.unhealthy.draining_interval_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "false",
+        "Key": "proxy_protocol_v2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "deregistration_delay.connection_termination.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "preserve_client_ip.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "target_health_state.unhealthy.connection_termination.enabled"
+      }
+    ],
+    "TargetType": "ip",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "TLS",
+    "TargetGroupName": "CdkrdH-TlsIp-IPEVB2EGCWV3",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801FreeA",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TlsIpTg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801FreeA/d1173eb0-8d8e-11f1-90a7-0affd9b7fb2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 10,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdH-TlsIp-IPEVB2EGCWV3",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "TCP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.connection_termination.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[preserve_client_ip.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[proxy_protocol_v2.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "source_ip",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.connection_termination.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_health_state.unhealthy.draining_interval_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TlsIpTg",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdH-TlsIp-IPEVB2EGCWV3/ceecb0df083e3687",
+      "constructPath": "CdkrdHunt0801FreeA/TlsIpTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.Ts0801.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TrustStore.Ts0801.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Ts0801",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt0801-mtls-ts/b7b3f5fb556ce0cb",
+    "constructPath": "CdkrdHunt0801Elb/Ts0801",
+    "declared": {
+      "CaCertificatesBundleS3Bucket": "cdkrd-hunt0801-elb-ts-111111111111",
+      "CaCertificatesBundleS3Key": "ca-bundle.pem",
+      "Name": "cdkrd-hunt0801-mtls-ts",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "TrustStoreArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt0801-mtls-ts/b7b3f5fb556ce0cb",
+    "NumberOfCaCertificates": 1,
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801Elb",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Ts0801",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801Elb/147afc00-8d8f-11f1-a64b-126cee05623d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0801-mtls-ts",
+    "CaCertificatesBundleSha256": "74cbbe6ce3ec1fcd832a5c38ff7c70f52fa588549bfc8b9776b595c970bb0c50"
+  },
+  "schema": {
+    "readOnly": ["NumberOfCaCertificates", "Status", "TrustStoreArn"],
+    "writeOnly": [
+      "CaCertificatesBundleS3Bucket",
+      "CaCertificatesBundleS3Key",
+      "CaCertificatesBundleS3ObjectVersion"
+    ],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["NumberOfCaCertificates", "Status", "TrustStoreArn"],
+    "writeOnlyPaths": [
+      "CaCertificatesBundleS3Bucket",
+      "CaCertificatesBundleS3Key",
+      "CaCertificatesBundleS3ObjectVersion"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Ts0801",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleS3Bucket",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt0801-mtls-ts/b7b3f5fb556ce0cb",
+      "constructPath": "CdkrdHunt0801Elb/Ts0801"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "Ts0801",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleS3Key",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt0801-mtls-ts/b7b3f5fb556ce0cb",
+      "constructPath": "CdkrdHunt0801Elb/Ts0801"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Ts0801",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TrustStore",
+      "path": "CaCertificatesBundleSha256",
+      "actual": "74cbbe6ce3ec1fcd832a5c38ff7c70f52fa588549bfc8b9776b595c970bb0c50",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:truststore/cdkrd-hunt0801-mtls-ts/b7b3f5fb556ce0cb",
+      "constructPath": "CdkrdHunt0801Elb/Ts0801"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__Connection.BasicConn.json
+++ b/tests/corpus/AWS__Events__Connection.BasicConn.json
@@ -1,0 +1,71 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BasicConn",
+    "resourceType": "AWS::Events::Connection",
+    "physicalId": "BasicConn-vkW9Uwe5xc6U",
+    "constructPath": "CdkrdHunt0801FreeB/BasicConn",
+    "declared": {
+      "AuthParameters": {
+        "BasicAuthParameters": {
+          "Password": "Cdkrd-hunt-0801-probe!",
+          "Username": "cdkrd-hunt"
+        }
+      },
+      "AuthorizationType": "BASIC"
+    }
+  },
+  "liveRaw": {
+    "SecretArn": "arn:aws:secretsmanager:us-east-1:111111111111:secret:events!connection/BasicConn-vkW9Uwe5xc6U/aa46c18f-d2ee-41ae-ae24-164ac67ddf50-Me4SFb",
+    "AuthParameters": {
+      "BasicAuthParameters": {
+        "Username": "cdkrd-hunt"
+      }
+    },
+    "Arn": "arn:aws:events:us-east-1:111111111111:connection/BasicConn-vkW9Uwe5xc6U/a0f0ffbb-846d-496f-97e6-44b845de40a0",
+    "ArnForPolicy": "arn:aws:events:us-east-1:111111111111:connection/BasicConn-vkW9Uwe5xc6U",
+    "AuthorizationType": "BASIC",
+    "Name": "BasicConn-vkW9Uwe5xc6U"
+  },
+  "schema": {
+    "readOnly": ["Arn", "ArnForPolicy", "SecretArn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "Arn",
+      "ArnForPolicy",
+      "AuthParameters.ConnectivityParameters.ResourceParameters.ResourceAssociationArn",
+      "InvocationConnectivityParameters.ResourceParameters.ResourceAssociationArn",
+      "SecretArn"
+    ],
+    "writeOnlyPaths": [
+      "AuthParameters.ApiKeyAuthParameters.ApiKeyValue",
+      "AuthParameters.BasicAuthParameters.Password",
+      "AuthParameters.InvocationHttpParameters",
+      "AuthParameters.OAuthParameters.ClientParameters.ClientSecret",
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.BodyParameters",
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.HeaderParameters",
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.QueryStringParameters"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.HeaderParameters.*.IsValueSecret": true,
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.QueryStringParameters.*.IsValueSecret": true,
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.BodyParameters.*.IsValueSecret": true,
+      "AuthParameters.InvocationHttpParameters.HeaderParameters.*.IsValueSecret": true,
+      "AuthParameters.InvocationHttpParameters.QueryStringParameters.*.IsValueSecret": true,
+      "AuthParameters.InvocationHttpParameters.BodyParameters.*.IsValueSecret": true
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__GuardDuty__ThreatEntitySet.HuntThreatEntitySetInactive.json
+++ b/tests/corpus/AWS__GuardDuty__ThreatEntitySet.HuntThreatEntitySetInactive.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntThreatEntitySetInactive",
+    "resourceType": "AWS::GuardDuty::ThreatEntitySet",
+    "physicalId": "4ec810cd615b4e8ca0ffd33eec7c487b|948bc06f17ec47f68383d8b9a1a991e8",
+    "constructPath": "CdkrdHunt0722Gd2/HuntThreatEntitySetInactive",
+    "declared": {
+      "DetectorId": "948bc06f17ec47f68383d8b9a1a991e8",
+      "Name": "cdkrd-hunt0722-threat-entity-set-inactive",
+      "Format": "TXT",
+      "Location": "https://s3.amazonaws.com/cdkrd-hunt0722-gd-111111111111/threatlist.txt",
+      "Activate": false
+    }
+  },
+  "liveRaw": {
+    "Status": "INACTIVE",
+    "Format": "TXT",
+    "CreatedAt": "2026-08-01T10:24:53Z",
+    "DetectorId": "948bc06f17ec47f68383d8b9a1a991e8",
+    "Id": "4ec810cd615b4e8ca0ffd33eec7c487b",
+    "ErrorDetails": "",
+    "UpdatedAt": "2026-08-01T10:24:53Z",
+    "ExpectedBucketOwner": "111111111111",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0722Gd2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntThreatEntitySetInactive",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0722Gd2/32b1ad50-8d93-11f1-a9a3-0affe0ff1f93",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-hunt0722-threat-entity-set-inactive",
+    "Location": "https://s3.amazonaws.com/cdkrd-hunt0722-gd-111111111111/threatlist.txt"
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "ErrorDetails", "Id", "Status", "UpdatedAt"],
+    "writeOnly": ["Activate"],
+    "createOnly": ["DetectorId", "Format"],
+    "readOnlyPaths": ["CreatedAt", "ErrorDetails", "Id", "Status", "UpdatedAt"],
+    "writeOnlyPaths": ["Activate"],
+    "createOnlyPaths": ["DetectorId", "Format"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntThreatEntitySetInactive",
+      "resourceType": "AWS::GuardDuty::ThreatEntitySet",
+      "path": "Activate",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "4ec810cd615b4e8ca0ffd33eec7c487b|948bc06f17ec47f68383d8b9a1a991e8",
+      "constructPath": "CdkrdHunt0722Gd2/HuntThreatEntitySetInactive"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntThreatEntitySetInactive",
+      "resourceType": "AWS::GuardDuty::ThreatEntitySet",
+      "path": "ExpectedBucketOwner",
+      "actual": "111111111111",
+      "physicalId": "4ec810cd615b4e8ca0ffd33eec7c487b|948bc06f17ec47f68383d8b9a1a991e8",
+      "constructPath": "CdkrdHunt0722Gd2/HuntThreatEntitySetInactive"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.ReplicaDb.json
+++ b/tests/corpus/AWS__RDS__DBInstance.ReplicaDb.json
@@ -1,0 +1,596 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ReplicaDb",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+    "constructPath": "CdkrdHunt0801State/ReplicaDb",
+    "declared": {
+      "DBInstanceClass": "db.t4g.micro",
+      "SourceDBInstanceIdentifier": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-08-01T10:56:03Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "5432",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-ASEWXM2C4KEGZ3FC3BFYLWWWZY",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.postgres18",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+    "Endpoint": {
+      "Address": "cdkrdhunt0801state-replicadb-03v6lphwcbbf.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "5432",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "MultiAZ": false,
+    "Engine": "postgres",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801State",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "ReplicaDb",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801State/965b37c0-8d95-11f1-b02c-123fc70247a7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "IsStorageConfigUpgradeAvailable": false,
+    "EngineVersion": "18.3",
+    "StorageType": "gp2",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.t4g.micro",
+    "AvailabilityZone": "us-east-1b",
+    "OptionGroupName": "default:postgres-18",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "default",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+    "AllocatedStorage": "400",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "cdkrdhunt",
+    "PubliclyAccessible": true,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-08-01T10:57:16.012Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "06:32-07:02",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "LicenseModel": "postgresql-license",
+    "PreferredMaintenanceWindow": "fri:07:57-fri:08:27",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-0a26e23e2310ee0c9"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 0,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "siblingRdsSourceModels": {
+      "cdkrdhunt0801state-srcdb-vmkqexdy4u6v": {
+        "DatabaseInsightsMode": "standard",
+        "StorageEncrypted": false,
+        "StatusInfos": [],
+        "CertificateDetails": {
+          "ValidTill": "2027-08-01T10:44:19Z",
+          "CAIdentifier": "rds-ca-rsa2048-g1"
+        },
+        "Port": "5432",
+        "AdditionalStorageVolumes": [],
+        "StorageThroughput": 0,
+        "DbiResourceId": "db-VGJ73G47CECNBND5H43I6OOZME",
+        "ReadReplicaDBClusterIdentifiers": [],
+        "MonitoringInterval": 0,
+        "DBParameterGroupName": "default.postgres18",
+        "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+        "Endpoint": {
+          "Address": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v.caxxotukouxo.us-east-1.rds.amazonaws.com",
+          "Port": "5432",
+          "HostedZoneId": "Z2R2ITUGPM61AM"
+        },
+        "LatestRestorableTime": "2026-08-01T10:54:48Z",
+        "MultiAZ": false,
+        "Engine": "postgres",
+        "Tags": [
+          {
+            "Value": "CdkrdHunt0801State",
+            "Key": "aws:cloudformation:stack-name"
+          },
+          {
+            "Value": "SrcDb",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801State/965b37c0-8d95-11f1-b02c-123fc70247a7",
+            "Key": "aws:cloudformation:stack-id"
+          },
+          {
+            "Value": "1",
+            "Key": "cdkrd:ephemeral"
+          }
+        ],
+        "IsStorageConfigUpgradeAvailable": false,
+        "EngineVersion": "18.3",
+        "StorageType": "gp2",
+        "DBInstanceStatus": "available",
+        "DBInstanceClass": "db.t4g.micro",
+        "AvailabilityZone": "us-east-1d",
+        "OptionGroupName": "default:postgres-18",
+        "EnablePerformanceInsights": false,
+        "ReadReplicaDBInstanceIdentifiers": ["cdkrdhunt0801state-replicadb-03v6lphwcbbf"],
+        "AutoMinorVersionUpgrade": true,
+        "DBSubnetGroupName": "default",
+        "DeletionProtection": false,
+        "DBInstanceIdentifier": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+        "AllocatedStorage": "400",
+        "MasterUserSecret": {},
+        "DBSecurityGroups": [],
+        "MasterUsername": "cdkrdhunt",
+        "PubliclyAccessible": true,
+        "AssociatedRoles": [],
+        "InstanceCreateTime": "2026-08-01T10:45:38.498Z",
+        "ProcessorFeatures": [],
+        "PreferredBackupWindow": "06:32-07:02",
+        "NetworkType": "IPV4",
+        "DedicatedLogVolume": false,
+        "CopyTagsToSnapshot": false,
+        "EngineLifecycleSupport": "open-source-rds-extended-support",
+        "LicenseModel": "postgresql-license",
+        "PreferredMaintenanceWindow": "fri:07:57-fri:08:27",
+        "BackupTarget": "region",
+        "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+        "ManageMasterUserPassword": false,
+        "VPCSecurityGroups": ["sg-0a26e23e2310ee0c9"],
+        "EnableIAMDatabaseAuthentication": false,
+        "BackupRetentionPeriod": 1,
+        "EnableCloudwatchLogsExports": []
+      }
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "SourceDBInstanceIdentifier",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "5432",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.postgres18",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Engine",
+      "actual": "postgres",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineVersion",
+      "actual": "18.3",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageType",
+      "actual": "gp2",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1b",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:postgres-18",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBSubnetGroupName",
+      "actual": "default",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AllocatedStorage",
+      "actual": "400",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUsername",
+      "actual": "cdkrdhunt",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PubliclyAccessible",
+      "actual": true,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "06:32-07:02",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "postgresql-license",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "fri:07:57-fri:08:27",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "VPCSecurityGroups",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupRetentionPeriod",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0801state-replicadb-03v6lphwcbbf",
+      "constructPath": "CdkrdHunt0801State/ReplicaDb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.SrcDb.json
+++ b/tests/corpus/AWS__RDS__DBInstance.SrcDb.json
@@ -1,0 +1,493 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SrcDb",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+    "constructPath": "CdkrdHunt0801State/SrcDb",
+    "declared": {
+      "AllocatedStorage": "400",
+      "DBInstanceClass": "db.t4g.micro",
+      "Engine": "postgres",
+      "MasterUserPassword": "Cdkrd-hunt0801-pg!",
+      "MasterUsername": "cdkrdhunt",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-08-01T10:44:19Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "5432",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-VGJ73G47CECNBND5H43I6OOZME",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.postgres18",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+    "Endpoint": {
+      "Address": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "5432",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "LatestRestorableTime": "2026-08-01T10:54:48Z",
+    "MultiAZ": false,
+    "Engine": "postgres",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0801State",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SrcDb",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0801State/965b37c0-8d95-11f1-b02c-123fc70247a7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "IsStorageConfigUpgradeAvailable": false,
+    "EngineVersion": "18.3",
+    "StorageType": "gp2",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.t4g.micro",
+    "AvailabilityZone": "us-east-1d",
+    "OptionGroupName": "default:postgres-18",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": ["cdkrdhunt0801state-replicadb-03v6lphwcbbf"],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "default",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+    "AllocatedStorage": "400",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "cdkrdhunt",
+    "PubliclyAccessible": true,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-08-01T10:45:38.498Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "06:32-07:02",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "LicenseModel": "postgresql-license",
+    "PreferredMaintenanceWindow": "fri:07:57-fri:08:27",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-0a26e23e2310ee0c9"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 1,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "5432",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.postgres18",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineVersion",
+      "actual": "18.3",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageType",
+      "actual": "gp2",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1d",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:postgres-18",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBSubnetGroupName",
+      "actual": "default",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PubliclyAccessible",
+      "actual": true,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "06:32-07:02",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "postgresql-license",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "fri:07:57-fri:08:27",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "VPCSecurityGroups",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDb",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cdkrdhunt0801state-srcdb-vmkqexdy4u6v",
+      "constructPath": "CdkrdHunt0801State/SrcDb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53__HealthCheck.HttpHc.json
+++ b/tests/corpus/AWS__Route53__HealthCheck.HttpHc.json
@@ -1,0 +1,95 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HttpHc",
+    "resourceType": "AWS::Route53::HealthCheck",
+    "physicalId": "21d082bf-8731-4e83-afce-cf9633b0e3c8",
+    "constructPath": "CdkrdHunt0801FreeB/HttpHc",
+    "declared": {
+      "HealthCheckConfig": {
+        "FullyQualifiedDomainName": "example.com",
+        "Type": "HTTP"
+      },
+      "HealthCheckTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "HealthCheckId": "21d082bf-8731-4e83-afce-cf9633b0e3c8",
+    "HealthCheckConfig": {
+      "EnableSNI": false,
+      "Type": "HTTP",
+      "FullyQualifiedDomainName": "example.com",
+      "MeasureLatency": false,
+      "Inverted": false,
+      "Port": 80,
+      "RequestInterval": 30,
+      "FailureThreshold": 3
+    },
+    "HealthCheckTags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["HealthCheckId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["HealthCheckId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "HealthCheckConfig.MeasureLatency",
+      "HealthCheckConfig.RequestInterval",
+      "HealthCheckConfig.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["HealthCheckConfig.ChildHealthChecks", "HealthCheckConfig.Regions"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpHc",
+      "resourceType": "AWS::Route53::HealthCheck",
+      "path": "HealthCheckConfig.Port",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "21d082bf-8731-4e83-afce-cf9633b0e3c8",
+      "constructPath": "CdkrdHunt0801FreeB/HttpHc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpHc",
+      "resourceType": "AWS::Route53::HealthCheck",
+      "path": "HealthCheckConfig.RequestInterval",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "21d082bf-8731-4e83-afce-cf9633b0e3c8",
+      "constructPath": "CdkrdHunt0801FreeB/HttpHc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpHc",
+      "resourceType": "AWS::Route53::HealthCheck",
+      "path": "HealthCheckConfig.FailureThreshold",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "21d082bf-8731-4e83-afce-cf9633b0e3c8",
+      "constructPath": "CdkrdHunt0801FreeB/HttpHc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53__HealthCheck.TcpHc.json
+++ b/tests/corpus/AWS__Route53__HealthCheck.TcpHc.json
@@ -1,0 +1,86 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TcpHc",
+    "resourceType": "AWS::Route53::HealthCheck",
+    "physicalId": "d1a51ed2-7f91-4a47-884c-6b267ee2b7f2",
+    "constructPath": "CdkrdHunt0801FreeB/TcpHc",
+    "declared": {
+      "HealthCheckConfig": {
+        "FullyQualifiedDomainName": "example.com",
+        "Port": 443,
+        "Type": "TCP"
+      },
+      "HealthCheckTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "HealthCheckId": "d1a51ed2-7f91-4a47-884c-6b267ee2b7f2",
+    "HealthCheckConfig": {
+      "EnableSNI": false,
+      "Type": "TCP",
+      "FullyQualifiedDomainName": "example.com",
+      "MeasureLatency": false,
+      "Inverted": false,
+      "Port": 443,
+      "RequestInterval": 30,
+      "FailureThreshold": 3
+    },
+    "HealthCheckTags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["HealthCheckId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["HealthCheckId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "HealthCheckConfig.MeasureLatency",
+      "HealthCheckConfig.RequestInterval",
+      "HealthCheckConfig.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["HealthCheckConfig.ChildHealthChecks", "HealthCheckConfig.Regions"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpHc",
+      "resourceType": "AWS::Route53::HealthCheck",
+      "path": "HealthCheckConfig.RequestInterval",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "d1a51ed2-7f91-4a47-884c-6b267ee2b7f2",
+      "constructPath": "CdkrdHunt0801FreeB/TcpHc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpHc",
+      "resourceType": "AWS::Route53::HealthCheck",
+      "path": "HealthCheckConfig.FailureThreshold",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "d1a51ed2-7f91-4a47-884c-6b267ee2b7f2",
+      "constructPath": "CdkrdHunt0801FreeB/TcpHc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Subscription.LambdaSub.json
+++ b/tests/corpus/AWS__SNS__Subscription.LambdaSub.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LambdaSub",
+    "resourceType": "AWS::SNS::Subscription",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0801FreeB-Topic0801-E0EuBYPOjLvb:0579c206-0ed0-4eab-a7ce-395335f490d7",
+    "constructPath": "CdkrdHunt0801FreeB/LambdaSub",
+    "declared": {
+      "Endpoint": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0801FreeB-SubFn02DC7AFC-alessgpsfH66",
+      "Protocol": "lambda",
+      "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0801FreeB-Topic0801-E0EuBYPOjLvb"
+    }
+  },
+  "liveRaw": {
+    "RawMessageDelivery": false,
+    "Endpoint": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdHunt0801FreeB-SubFn02DC7AFC-alessgpsfH66",
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0801FreeB-Topic0801-E0EuBYPOjLvb",
+    "Arn": "arn:aws:sns:us-east-1:111111111111:CdkrdHunt0801FreeB-Topic0801-E0EuBYPOjLvb:0579c206-0ed0-4eab-a7ce-395335f490d7",
+    "Protocol": "lambda"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["Region"],
+    "createOnly": ["Endpoint", "Protocol", "TopicArn"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["Region"],
+    "createOnlyPaths": ["Endpoint", "Protocol", "TopicArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/elbpack-hunt/app.ts
+++ b/tests/integration/elbpack-hunt/app.ts
@@ -1,0 +1,154 @@
+// ELBv2 pack first-run FP probe (2026-08-01 hunt):
+// - dualstack ALB + dualstack NLB (no fixture has ever deployed IpAddressType
+//   dualstack; the ipv6.deny_all_igw_traffic row in the shared LB-attribute
+//   table cites a dualstack ALB deploy that was never harvested, and the NLB
+//   arm is untested).
+// - NLB TLS listener (the SslPolicy KNOWN_DEFAULTS row was mirrored from an
+//   HTTPS/ALB listener deploy — "the same default applies to an NLB TLS
+//   listener" was never live-proven; AlpnPolicy echo also unprobed).
+// - mTLS: an HTTPS listener with MutualAuthentication verify + TrustStore
+//   attached (the {Mode:'off'} whole-object fold was observed on a plain HTTPS
+//   listener; the attached shape may materialize sibling leaves —
+//   IgnoreClientCertificateExpiry etc. — the attachment-echo class).
+// - barest Interface VPC endpoint (the only Interface-endpoint fixture declares
+//   SecurityGroupIds/SubnetIds/PrivateDnsEnabled; undeclared → default-SG echo
+//   + DnsOptions defaults).
+// The ACM cert (self-signed, imported out of band) arrives via CDKRD_HUNT_CERT_ARN;
+// the TrustStore CA bundle bucket via CDKRD_HUNT_TS_BUCKET (see verify.sh).
+import { App, Fn, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnEgressOnlyInternetGateway,
+  CfnInternetGateway,
+  CfnRoute,
+  CfnRouteTable,
+  CfnSubnet,
+  CfnSubnetRouteTableAssociation,
+  CfnVPC,
+  CfnVPCCidrBlock,
+  CfnVPCEndpoint,
+  CfnVPCGatewayAttachment,
+} from "aws-cdk-lib/aws-ec2";
+import {
+  CfnListener,
+  CfnLoadBalancer,
+  CfnTargetGroup,
+  CfnTrustStore,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const certArn = process.env.CDKRD_HUNT_CERT_ARN;
+const tsBucket = process.env.CDKRD_HUNT_TS_BUCKET;
+if (!certArn || !tsBucket) {
+  throw new Error("CDKRD_HUNT_CERT_ARN and CDKRD_HUNT_TS_BUCKET must be set (see verify.sh)");
+}
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const s = new Stack(app, "CdkrdHunt0801Elb");
+
+// Dualstack VPC: amazon-provided IPv6, two public subnets (ALB needs 2 AZs).
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.65.0.0/16" });
+const v6 = new CfnVPCCidrBlock(s, "V6", {
+  vpcId: vpc.ref,
+  amazonProvidedIpv6CidrBlock: true,
+});
+const igw = new CfnInternetGateway(s, "Igw");
+const att = new CfnVPCGatewayAttachment(s, "IgwAtt", {
+  vpcId: vpc.ref,
+  internetGatewayId: igw.ref,
+});
+new CfnEgressOnlyInternetGateway(s, "Eigw", { vpcId: vpc.ref });
+const rt = new CfnRouteTable(s, "Rt", { vpcId: vpc.ref });
+const defRoute = new CfnRoute(s, "DefRoute", {
+  routeTableId: rt.ref,
+  destinationCidrBlock: "0.0.0.0/0",
+  gatewayId: igw.ref,
+});
+defRoute.addDependency(att);
+const v6Route = new CfnRoute(s, "V6Route", {
+  routeTableId: rt.ref,
+  destinationIpv6CidrBlock: "::/0",
+  gatewayId: igw.ref,
+});
+v6Route.addDependency(att);
+
+const v6cidrs = Fn.cidr(Fn.select(0, vpc.attrIpv6CidrBlocks), 2, "64");
+const mkSubnet = (id: string, az: string, cidr: string, v6idx: number) => {
+  const sn = new CfnSubnet(s, id, {
+    vpcId: vpc.ref,
+    availabilityZone: az,
+    cidrBlock: cidr,
+    ipv6CidrBlock: Fn.select(v6idx, v6cidrs),
+    mapPublicIpOnLaunch: false,
+  });
+  sn.addDependency(v6);
+  new CfnSubnetRouteTableAssociation(s, `${id}Assoc`, {
+    subnetId: sn.ref,
+    routeTableId: rt.ref,
+  });
+  return sn;
+};
+const sn1 = mkSubnet("Pub1", "us-east-1a", "10.65.0.0/24", 0);
+const sn2 = mkSubnet("Pub2", "us-east-1b", "10.65.1.0/24", 1);
+
+// TrustStore (CA bundle pre-created by verify.sh).
+const ts = new CfnTrustStore(s, "Ts0801", {
+  name: "cdkrd-hunt0801-mtls-ts",
+  caCertificatesBundleS3Bucket: tsBucket,
+  caCertificatesBundleS3Key: "ca-bundle.pem",
+});
+
+// Dualstack internet-facing ALB, SecurityGroups UNDECLARED (default-SG echo).
+const alb = new CfnLoadBalancer(s, "DsAlb", {
+  type: "application",
+  scheme: "internet-facing",
+  ipAddressType: "dualstack",
+  subnets: [sn1.ref, sn2.ref],
+});
+// HTTPS listener with mTLS verify + attached TrustStore; fixed-response (no TG).
+new CfnListener(s, "MtlsListener", {
+  loadBalancerArn: alb.ref,
+  protocol: "HTTPS",
+  port: 443,
+  certificates: [{ certificateArn: certArn }],
+  mutualAuthentication: {
+    mode: "verify",
+    trustStoreArn: ts.attrTrustStoreArn,
+  },
+  defaultActions: [
+    {
+      type: "fixed-response",
+      fixedResponseConfig: { statusCode: "200", contentType: "text/plain" },
+    },
+  ],
+});
+
+// Dualstack internet-facing NLB + TLS listener (mirrored SslPolicy row probe).
+const nlb = new CfnLoadBalancer(s, "DsNlb", {
+  type: "network",
+  scheme: "internet-facing",
+  ipAddressType: "dualstack",
+  subnets: [sn1.ref, sn2.ref],
+});
+const tlsTg = new CfnTargetGroup(s, "NlbTlsTg", {
+  protocol: "TLS",
+  port: 443,
+  targetType: "instance",
+  vpcId: vpc.ref,
+});
+new CfnListener(s, "TlsListener", {
+  loadBalancerArn: nlb.ref,
+  protocol: "TLS",
+  port: 443,
+  certificates: [{ certificateArn: certArn }],
+  defaultActions: [{ type: "forward", targetGroupArn: tlsTg.ref }],
+});
+
+// Barest Interface endpoint: only service + type + vpc + one subnet declared.
+new CfnVPCEndpoint(s, "SqsIfEp", {
+  vpcId: vpc.ref,
+  serviceName: "com.amazonaws.us-east-1.sqs",
+  vpcEndpointType: "Interface",
+  subnetIds: [sn1.ref],
+});
+
+app.synth();

--- a/tests/integration/elbpack-hunt/cdk.json
+++ b/tests/integration/elbpack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elbpack-hunt/package.json
+++ b/tests/integration/elbpack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elbpack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "ELBv2 pack first-run FP probe (2026-08-01): dualstack ALB+NLB, NLB TLS listener (mirrored SslPolicy row), mTLS verify listener with attached TrustStore (attachment-echo shape), barest Interface VPC endpoint. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elbpack-hunt/verify.sh
+++ b/tests/integration/elbpack-hunt/verify.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ELBv2 pack first-run FP probe (real AWS). Pre-creates a self-signed ACM cert
+# (imported) + the TrustStore CA-bundle bucket out of band, deploys, asserts the
+# FIRST check is CLEAN (modulo the BY-DESIGN TrustStore CaCertificatesBundleSha256
+# integrity signal, #505), records, asserts clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0801Elb
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ACCT="$(aws sts get-caller-identity --query Account --output text)"
+export CDKRD_HUNT_TS_BUCKET="cdkrd-hunt0801-elb-ts-$ACCT"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  aws s3 rb "s3://$CDKRD_HUNT_TS_BUCKET" --force >/dev/null 2>&1 || true
+  if [ -n "${CDKRD_HUNT_CERT_ARN:-}" ]; then
+    for i in 1 2 3 4 5 6; do
+      aws acm delete-certificate --certificate-arn "$CDKRD_HUNT_CERT_ARN" --region "$REGION" >/dev/null 2>&1 && break
+      sleep 20
+    done
+  fi
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== pre-create self-signed cert (ACM import) + CA bundle bucket ==="
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/cdkrd-elb-key.pem -out /tmp/cdkrd-elb-cert.pem \
+  -days 7 -nodes -subj "/CN=cdkrd-hunt0801-elb.internal" 2>/dev/null || fail "openssl"
+CDKRD_HUNT_CERT_ARN=$(aws acm import-certificate --certificate fileb:///tmp/cdkrd-elb-cert.pem \
+  --private-key fileb:///tmp/cdkrd-elb-key.pem --region "$REGION" \
+  --tags Key=cdkrd:ephemeral,Value=1 --query CertificateArn --output text) || fail "acm import"
+export CDKRD_HUNT_CERT_ARN
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/cdkrd-elb-ca-key.pem -out /tmp/cdkrd-elb-ca.pem \
+  -days 7 -nodes -subj "/CN=cdkrd-hunt0801-mtls-ca.internal" 2>/dev/null || fail "openssl ca"
+aws s3api create-bucket --bucket "$CDKRD_HUNT_TS_BUCKET" --region "$REGION" >/dev/null || true
+aws s3 cp /tmp/cdkrd-elb-ca.pem "s3://$CDKRD_HUNT_TS_BUCKET/ca-bundle.pem" >/dev/null || fail "s3 cp"
+
+echo "=== deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== FIRST check (no baseline): only the TrustStore sha256 signal may appear ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-elbpack0801}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+# Count the drift ENTRY lines (indented `<id>.<path> (AWS::...)`) inside the block, not the
+# block header; the only allowed entry is the by-design TrustStore sha256 signal (#505).
+NON_SHA=$(sed -n '/\[Potential Drift/,/^──/p' "/tmp/cdkrd-$STACK.pre.out" \
+  | grep -E '^\s+\S+ \(AWS::' | grep -vc "CaCertificatesBundleSha256" || true)
+[ "$NON_SHA" -eq 0 ] || fail "first check surfaced $NON_SHA non-sha256 potential drift entries"
+
+echo "=== record + check --fail ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "INTEG OK (elbpack-hunt)"

--- a/tests/integration/freepack-hunt/app.ts
+++ b/tests/integration/freepack-hunt/app.ts
@@ -1,0 +1,153 @@
+// Barest-variant first-run FP probe (2026-08-01 hunt) — the free/near-free pack
+// from the coverage audit:
+// - ASG MixedInstancesPolicy union branch (every existing ASG fixture uses the
+//   flat LaunchTemplate branch; MIP's InstancesDistribution defaults are the
+//   probe surface). Min/Max/Desired 0 → zero instances → free.
+// - ELBv2 TargetGroup protocol×target-type CROSS products never deployed:
+//   GENEVE×instance, TLS×ip (per-axis rows exist; the intersections do not, the
+//   #1664/#1683 class), plus the never-deployed HTTPS protocol barest.
+// - EC2 Volume with NO KNOWN_DEFAULTS entry at all: barest (Size-only → gp2
+//   echoes) and gp3-declared (Iops 3000 / Throughput 125 echoes).
+// - Route53 HealthCheck with RequestInterval/FailureThreshold UNDECLARED (all 3
+//   corpus cases declare exactly the two folded values) + a TCP-type check.
+// - Events Connection BASIC auth branch (only API_KEY ever deployed; no
+//   KNOWN_DEFAULTS entry for the type).
+// - SNS Subscription lambda protocol (all 4 corpus cases are sqs).
+import { App, CfnResource, Duration, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnLaunchTemplate,
+  CfnSubnet,
+  CfnVPC,
+  CfnVolume,
+} from "aws-cdk-lib/aws-ec2";
+import { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import { CfnTargetGroup } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { CfnHealthCheck } from "aws-cdk-lib/aws-route53";
+import { CfnConnection } from "aws-cdk-lib/aws-events";
+import { CfnSubscription, CfnTopic } from "aws-cdk-lib/aws-sns";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+// ---------- Stack A: VPC-scoped free probes ----------
+const a = new Stack(app, "CdkrdHunt0801FreeA");
+const vpc = new CfnVPC(a, "Vpc", { cidrBlock: "10.64.0.0/16" });
+const subnet = new CfnSubnet(a, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.64.0.0/24",
+  availabilityZone: "us-east-1a",
+});
+
+// Barest MixedInstancesPolicy ASG: only the LaunchTemplate spec + one override
+// declared — InstancesDistribution and its five defaults are the probe surface.
+const lt = new CfnLaunchTemplate(a, "Lt", {
+  launchTemplateData: {
+    instanceType: "t3.micro",
+    imageId:
+      "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}}",
+  },
+});
+new CfnAutoScalingGroup(a, "MipAsg", {
+  minSize: "0",
+  maxSize: "0",
+  desiredCapacity: "0",
+  vpcZoneIdentifier: [subnet.ref],
+  mixedInstancesPolicy: {
+    launchTemplate: {
+      launchTemplateSpecification: {
+        launchTemplateId: lt.ref,
+        version: lt.attrLatestVersionNumber,
+      },
+      overrides: [{ instanceType: "t3.micro" }],
+    },
+  },
+});
+
+// Never-deployed protocol×target-type crosses + the HTTPS protocol barest.
+new CfnTargetGroup(a, "GeneveInstTg", {
+  protocol: "GENEVE",
+  port: 6081,
+  targetType: "instance",
+  vpcId: vpc.ref,
+});
+new CfnTargetGroup(a, "TlsIpTg", {
+  protocol: "TLS",
+  port: 443,
+  targetType: "ip",
+  vpcId: vpc.ref,
+});
+new CfnTargetGroup(a, "HttpsTg", {
+  protocol: "HTTPS",
+  port: 443,
+  vpcId: vpc.ref,
+});
+
+// EC2 Volume: barest (Size only → VolumeType gp2 echo?) and gp3-declared
+// (Iops/Throughput echoes).
+new CfnVolume(a, "BarestVol", {
+  availabilityZone: "us-east-1a",
+  size: 10,
+});
+new CfnVolume(a, "Gp3Vol0801", {
+  availabilityZone: "us-east-1a",
+  size: 10,
+  volumeType: "gp3",
+});
+
+// ---------- Stack B: global/API free probes ----------
+const b = new Stack(app, "CdkrdHunt0801FreeB");
+
+// Barest HTTP health check: Type + FQDN only — RequestInterval/FailureThreshold/
+// Port/MeasureLatency/Inverted/Disabled all undeclared.
+new CfnHealthCheck(b, "HttpHc", {
+  healthCheckConfig: {
+    type: "HTTP",
+    fullyQualifiedDomainName: "example.com",
+  },
+});
+// TCP-type check (never deployed; EnableSNI fold must NOT mis-apply here).
+new CfnHealthCheck(b, "TcpHc", {
+  healthCheckConfig: {
+    type: "TCP",
+    fullyQualifiedDomainName: "example.com",
+    port: 443,
+  },
+});
+
+// Events Connection BASIC auth branch. The password is write-only; the probe is
+// the AuthParameters echo shape (redaction husks) + any undeclared defaults.
+new CfnConnection(b, "BasicConn", {
+  authorizationType: "BASIC",
+  authParameters: {
+    basicAuthParameters: {
+      username: "cdkrd-hunt",
+      password: "Cdkrd-hunt-0801-probe!",
+    },
+  },
+});
+
+// SNS Subscription, lambda protocol (all corpus subscriptions are sqs).
+const topic = new CfnTopic(b, "Topic0801");
+const fn = new Function(b, "SubFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler=async()=>({});"),
+  timeout: Duration.seconds(10),
+});
+new CfnSubscription(b, "LambdaSub", {
+  protocol: "lambda",
+  topicArn: topic.ref,
+  endpoint: fn.functionArn,
+});
+new CfnResource(b, "SubPerm", {
+  type: "AWS::Lambda::Permission",
+  properties: {
+    Action: "lambda:InvokeFunction",
+    FunctionName: fn.functionName,
+    Principal: "sns.amazonaws.com",
+    SourceArn: topic.ref,
+  },
+});
+
+app.synth();

--- a/tests/integration/freepack-hunt/cdk.json
+++ b/tests/integration/freepack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/freepack-hunt/package.json
+++ b/tests/integration/freepack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-freepack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest-variant first-run FP probe (2026-08-01): ASG MixedInstancesPolicy, TG protocol x target-type crosses (GENEVE x instance, TLS x ip, HTTPS), EC2 Volume barest/gp3, Route53 HealthCheck undeclared interval/threshold + TCP, Events Connection BASIC, SNS lambda subscription. Plus an ASG MaxSize FN detect->revert leg. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/freepack-hunt/verify.sh
+++ b/tests/integration/freepack-hunt/verify.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Free-pack first-run FP probe (real AWS): deploy both stacks, assert the FIRST
+# check (before record) is CLEAN, record, assert check --fail clean; then the FN
+# leg — mutate the declared ASG MaxSize out of band, assert check --fail exits 1,
+# revert, assert clean + the live value converged back.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0801FreeA CdkrdHunt0801FreeB)
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (freepack-hunt): $*"; exit 1; }
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-freepack0801}" $CLI check "$STACK" --region "$REGION" --fail \
+    | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail || fail "[$STACK] post-record check not clean"
+done
+
+echo "=== FN leg: OOB-mutate declared ASG MaxSize (0 -> 2) ==="
+ASG_NAME=$(aws autoscaling describe-auto-scaling-groups --region "$REGION" \
+  --query 'AutoScalingGroups[?starts_with(AutoScalingGroupName, `CdkrdHunt0801FreeA-MipAsg`)].AutoScalingGroupName' \
+  --output text)
+[ -n "$ASG_NAME" ] || fail "ASG not found"
+aws autoscaling update-auto-scaling-group --auto-scaling-group-name "$ASG_NAME" \
+  --max-size 2 --region "$REGION" || fail "OOB mutate"
+sleep 10
+
+echo "=== check MUST detect (exit 1) ==="
+$CLI check CdkrdHunt0801FreeA --region "$REGION" --fail
+RC=$?
+[ "$RC" -eq 1 ] || fail "expected drift exit 1, got $RC"
+
+echo "=== revert MUST converge MaxSize back to 0 ==="
+$CLI revert CdkrdHunt0801FreeA --region "$REGION" --yes | tee "/tmp/cdkrd-freeA.revert.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "revert rc"
+grep -q "NOT reverted" "/tmp/cdkrd-freeA.revert.out" && fail "revert reported NOT reverted"
+sleep 10
+LIVE_MAX=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG_NAME" \
+  --region "$REGION" --query 'AutoScalingGroups[0].MaxSize' --output text)
+[ "$LIVE_MAX" = "0" ] || fail "live MaxSize not reverted (got $LIVE_MAX)"
+
+echo "=== post-revert check MUST be CLEAN ==="
+$CLI check CdkrdHunt0801FreeA --region "$REGION" --fail || fail "post-revert check not clean"
+
+echo "INTEG OK (freepack-hunt)"

--- a/tests/integration/gdsets2-hunt/app.ts
+++ b/tests/integration/gdsets2-hunt/app.ts
@@ -34,6 +34,22 @@ new CfnResource(stack, "HuntThreatEntitySet", {
   },
 });
 
+// INACTIVE set for the #1694 ExpectedBucketOwner revert leg: GuardDuty validates
+// the expected owner against the REAL bucket owner only for ACTIVE sets
+// (update-threat-entity-set on an active set rejects a foreign owner with
+// AccessDeniedException — live-determined 2026-08-01), so the reachable
+// OOB-divergence shape is an inactive set.
+new CfnResource(stack, "HuntThreatEntitySetInactive", {
+  type: "AWS::GuardDuty::ThreatEntitySet",
+  properties: {
+    DetectorId: detector.ref,
+    Name: "cdkrd-hunt0722-threat-entity-set-inactive",
+    Format: "TXT",
+    Location: `https://s3.amazonaws.com/${listBucket}/threatlist.txt`,
+    Activate: false,
+  },
+});
+
 new CfnResource(stack, "HuntTrustedEntitySet", {
   type: "AWS::GuardDuty::TrustedEntitySet",
   properties: {

--- a/tests/integration/gdsets2-hunt/verify.sh
+++ b/tests/integration/gdsets2-hunt/verify.sh
@@ -68,4 +68,30 @@ LIVE_ACTION="$(aws guardduty get-filter --detector-id "$DETECTOR_ID" --filter-na
 [ "$LIVE_ACTION" = "NOOP" ] || fail "REVERT NO-OP: live filter Action=$LIVE_ACTION (expected NOOP) — RSDP candidate"
 $CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
 
+echo "=== [$STACK] #1694 ExpectedBucketOwner probe: OOB own-account -> foreign ==="
+# Target the INACTIVE set: GuardDuty validates the expected owner against the real
+# bucket owner for ACTIVE sets (foreign value rejected with AccessDeniedException,
+# live-determined 2026-08-01), so only the inactive set can carry the divergence.
+TES_ID=""
+for id in $(aws guardduty list-threat-entity-sets --detector-id "$DETECTOR_ID" --region "$REGION" --query 'ThreatEntitySetIds[]' --output text); do
+  NAME="$(aws guardduty get-threat-entity-set --detector-id "$DETECTOR_ID" --threat-entity-set-id "$id" --region "$REGION" --query 'Name' --output text)"
+  [ "$NAME" = "cdkrd-hunt0722-threat-entity-set-inactive" ] && TES_ID="$id" && break
+done
+[ -n "$TES_ID" ] || fail "no inactive threat entity set id"
+aws guardduty update-threat-entity-set --detector-id "$DETECTOR_ID" --threat-entity-set-id "$TES_ID" \
+  --expected-bucket-owner 111122223333 --region "$REGION" || fail "OOB update-threat-entity-set"
+sleep 10
+
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.ebo.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "MISSED DETECTION: expected exit 1 after OOB ExpectedBucketOwner change (got $rc)"
+
+echo "=== [$STACK] #1694 revert: EBO MUST converge back to the caller account (explicit set-default) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.eborev.out" || fail "EBO revert errored"
+grep -q "NOT reverted" "/tmp/cdkrd-$STACK.eborev.out" && fail "EBO revert reported NOT reverted"
+sleep 10
+LIVE_EBO="$(aws guardduty get-threat-entity-set --detector-id "$DETECTOR_ID" --threat-entity-set-id "$TES_ID" --region "$REGION" --query 'ExpectedBucketOwner' --output text)"
+[ "$LIVE_EBO" = "$ACCOUNT" ] || fail "EBO REVERT NO-OP: live ExpectedBucketOwner=$LIVE_EBO (expected $ACCOUNT) — the #1694 bare-remove class"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-EBO-revert check not clean"
+
 echo "INTEG PASS ($STACK)"

--- a/tests/integration/statepack-hunt/app.ts
+++ b/tests/integration/statepack-hunt/app.ts
@@ -1,0 +1,97 @@
+// Stateful-pack first-run FP probe (2026-08-01 hunt):
+// - RDS non-Aurora with AllocatedStorage 400 and StorageType UNDECLARED — the
+//   ENGINE_DEFAULTS StorageType:'gp2' fold self-flags this open gap in its own
+//   comment ("a large-storage config AWS provisions as gp3 by default would not
+//   match"): postgres >=400 GiB materializes gp3 (+ Iops/StorageThroughput?).
+// - RDS read replica (SourceDBInstanceIdentifier): a creation mode never
+//   deployed — the replica inherits source properties the template never
+//   declares (EngineVersion, AllocatedStorage, BackupRetentionPeriod 0, ...).
+// - ElastiCache memcached barest: the ENGINE_DEFAULTS Port 11211 arm was
+//   mirrored from the redis deploy (the only memcached fixture DECLARES Port /
+//   AZMode / EngineVersion); NumCacheNodes 2 also probes the cross-az default.
+// - Cassandra (Keyspaces) barest table (BillingMode echo undeclared) and
+//   PROVISIONED table (the WarmThroughput {12000,4000} constant was harvested
+//   from an ON_DEMAND read — a provisioned table may echo its own capacity).
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnDBInstance } from "aws-cdk-lib/aws-rds";
+import { CfnCacheCluster, CfnSubnetGroup } from "aws-cdk-lib/aws-elasticache";
+import { CfnKeyspace, CfnTable } from "aws-cdk-lib/aws-cassandra";
+import { CfnSecurityGroup, CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const s = new Stack(app, "CdkrdHunt0801State");
+
+// RDS source: engine/class/storage/creds ONLY — no StorageType, no
+// EngineVersion, no BackupRetentionPeriod (default 1 keeps replica-creation
+// legal). 400 GiB is the gp3-default territory the gp2 fold self-flags.
+const src = new CfnDBInstance(s, "SrcDb", {
+  engine: "postgres",
+  dbInstanceClass: "db.t4g.micro",
+  allocatedStorage: "400",
+  masterUsername: "cdkrdhunt",
+  masterUserPassword: "Cdkrd-hunt0801-pg!",
+});
+src.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+// Read replica: creation-mode axis — only the source pointer + class declared.
+const replica = new CfnDBInstance(s, "ReplicaDb", {
+  sourceDbInstanceIdentifier: src.ref,
+  dbInstanceClass: "db.t4g.micro",
+});
+replica.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+// memcached barest (needs a subnet group in a VPC-only account setup; keep the
+// cluster itself barest: engine + node type + count only).
+const vpc = new CfnVPC(s, "Vpc", { cidrBlock: "10.66.0.0/16" });
+const sn1 = new CfnSubnet(s, "Sn1", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.66.0.0/24",
+  availabilityZone: "us-east-1a",
+});
+const sn2 = new CfnSubnet(s, "Sn2", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.66.1.0/24",
+  availabilityZone: "us-east-1b",
+});
+const cacheSubnets = new CfnSubnetGroup(s, "CacheSubnets", {
+  description: "cdkrd hunt0801 memcached subnets",
+  subnetIds: [sn1.ref, sn2.ref],
+});
+// Engine-axis validation difference (a finding in itself, like the valkey
+// VpcSecurityGroupIds demand): CreateCacheCluster REJECTS a subnet-group
+// memcached cluster without VpcSecurityGroupIds ("VpcSecurityGroupIds must be
+// specified") while redis accepts the same shape — declare the minimum SG.
+const mcSg = new CfnSecurityGroup(s, "McSg", {
+  groupDescription: "cdkrd hunt0801 memcached sg",
+  vpcId: vpc.ref,
+});
+const mc = new CfnCacheCluster(s, "Memcached0801", {
+  engine: "memcached",
+  cacheNodeType: "cache.t3.micro",
+  numCacheNodes: 2,
+  cacheSubnetGroupName: cacheSubnets.ref,
+  vpcSecurityGroupIds: [mcSg.attrGroupId],
+});
+mc.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+// Keyspaces: barest table + PROVISIONED table (WarmThroughput constant probe).
+const ks = new CfnKeyspace(s, "Ks0801", { keyspaceName: "cdkrd_hunt0801" });
+const barestTable = new CfnTable(s, "BarestTable", {
+  keyspaceName: "cdkrd_hunt0801",
+  tableName: "barest0801",
+  partitionKeyColumns: [{ columnName: "pk", columnType: "text" }],
+});
+barestTable.addDependency(ks);
+const provTable = new CfnTable(s, "ProvTable", {
+  keyspaceName: "cdkrd_hunt0801",
+  tableName: "prov0801",
+  partitionKeyColumns: [{ columnName: "pk", columnType: "text" }],
+  billingMode: {
+    mode: "PROVISIONED",
+    provisionedThroughput: { readCapacityUnits: 1, writeCapacityUnits: 1 },
+  },
+});
+provTable.addDependency(ks);
+
+app.synth();

--- a/tests/integration/statepack-hunt/cdk.json
+++ b/tests/integration/statepack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/statepack-hunt/package.json
+++ b/tests/integration/statepack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-statepack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Stateful-pack first-run FP probe (2026-08-01): RDS 400GiB gp3-default arm + read replica creation mode, ElastiCache memcached barest (Port 11211 mirrored arm), Keyspaces barest + PROVISIONED tables (WarmThroughput constant probe). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/statepack-hunt/verify.sh
+++ b/tests/integration/statepack-hunt/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Stateful-pack first-run FP probe (real AWS). RDS creates are SLOW (~30-45 min
+# with the replica) — run this script as a background task; it polls via cdk
+# deploy's own wait. Asserts the FIRST check (before record) is CLEAN, records,
+# asserts check --fail clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0801State
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy (slow: RDS source + replica) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-statepack0801}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+[ "$RC" -eq 0 ] || fail "first check not clean (rc=$RC)"
+
+echo "=== record + check --fail ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "INTEG OK (statepack-hunt)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -1219,6 +1219,8 @@ describe('noise suppressors', () => {
       WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
       EncryptionSpecification: { EncryptionType: 'AWS_OWNED_KMS_KEY' },
       CdcSpecification: { Status: 'DISABLED' },
+      // #1705: the numeric "no default TTL" echo on a barest table (statepack-hunt 2026-08-01).
+      DefaultTimeToLive: 0,
     });
     expect(KNOWN_DEFAULTS['AWS::EMRServerless::Application']).toEqual({
       Architecture: 'X86_64',

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -861,6 +861,60 @@ describe('buildRevertPlan', () => {
   // three persisted an out-of-band value through a `remove` revert that reported
   // "reverted", while an explicit CC `add` patch converged. Each writes the
   // KNOWN_DEFAULTS default back explicitly.
+  // #1694 (hunt 2026-08-01, stackless CC probes, both types proven individually): the
+  // GuardDuty Update{Threat,Trusted}EntitySet handlers keep an omitted ExpectedBucketOwner,
+  // and the default is a CONTEXT_ARN_DEFAULTS '{accountId}' placeholder — resolved from
+  // opts.identity at plan time. Without identity the plan falls back to the bare remove
+  // (fail-safe; the real CLI path always threads it).
+  it('GuardDuty ThreatEntitySet ExpectedBucketOwner (SET-DEFAULT) -> add op writing the resolved caller account id', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::GuardDuty::ThreatEntitySet',
+      path: 'ExpectedBucketOwner',
+      actual: '999988887777',
+    });
+    const plan = buildRevertPlan([f], baseline([]), {
+      identity: { accountId: '111122224444', region: 'us-east-1' },
+    });
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ExpectedBucketOwner',
+      value: '111122224444',
+      prior: '999988887777',
+    });
+  });
+
+  it('GuardDuty TrustedEntitySet ExpectedBucketOwner (SET-DEFAULT) -> add op writing the resolved caller account id', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::GuardDuty::TrustedEntitySet',
+      path: 'ExpectedBucketOwner',
+      actual: '999988887777',
+    });
+    const plan = buildRevertPlan([f], baseline([]), {
+      identity: { accountId: '111122224444', region: 'us-east-1' },
+    });
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/ExpectedBucketOwner',
+      value: '111122224444',
+    });
+  });
+
+  it('GuardDuty entity-set ExpectedBucketOwner WITHOUT identity -> fail-safe bare remove (no fabricated value)', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::GuardDuty::ThreatEntitySet',
+      path: 'ExpectedBucketOwner',
+      actual: '999988887777',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'remove',
+      path: '/ExpectedBucketOwner',
+    });
+  });
+
   it('VpcLattice ResourceConfiguration AllowAssociationToSharableServiceNetwork (SET-DEFAULT) -> add op writing the true default', () => {
     const f = F({
       tier: 'undeclared',


### PR DESCRIPTION
## 2026-08-01 bug-hunt sweep

Five-round hunt (offline audits -> barest-variant FP sweep -> RSDP convergence probes -> FN detect/revert legs -> off-flip audit), 4 fixture packs all INTEG OK on the final binary. 12 issues filed, 11 fixed here, 1 deferred (#1702).

### Revert bug (the headline)

- **#1694** GuardDuty `ThreatEntitySet`/`TrustedEntitySet` `ExpectedBucketOwner`: bare `remove` silently no-ops (both types proven individually by stackless CC probes). Structural root cause: the pin lives in `CONTEXT_ARN_DEFAULTS` (`{accountId}` placeholder) which `plan.ts` never consulted — no plain RSDP entry could express the fix. Ships RSDP entries + an `opts.identity`-resolved `contextArnDefaultFor` fallback in `revertOp` (any future CONTEXT_ARN_DEFAULTS pin now converges by adding the RSDP key alone). E2E-proven live via the gdsets2 fixture's new INACTIVE-set leg (ACTIVE sets reject a foreign owner — AccessDeniedException — so the reachable drift shape is an inactive set; determination in the fixture + SKILL.md).

### First-run FP folds (live-found, live-re-proven clean)

- **#1695** ASG MixedInstancesPolicy: `InstancesDistribution` 5-constant whole-object pin + the MIP-branch `LaunchTemplateName` minted-name echo (the flat branch's existing GENERATED_NESTED_PATHS entry, one level deeper).
- **#1696** TG cross-variants: GENEVE HC defaults derive TCP + fixed port 80; HTTPS groups derive the protocol-following HC protocol.
- **#1697** EC2 Volume `VolumeType: gp2` (the type had NO KNOWN_DEFAULTS at all) + the `ebsEncryptionByDefault` corpus-recorder accountDefaults carry (a pre-existing recorder-carry gap the new cases exposed).
- **#1698** mTLS listener attach echo: `MutualAuthentication.AdvertiseTrustStoreCaNames: 'off'` (the #1574 attachment-echo class).
- **#1699** barest Interface VPCEndpoint default-SG echo -> one-entry DEFAULT_SG_LIST gate addition (classify + gather prefetch; OOB swap/append detection kept).
- **#1703** Route53 HealthCheck `Port` derives from the check Type (HTTP 80 / HTTPS 443).
- **#1704** RDS read-replica inherited echoes: sibling-source live-model derivation (gather builder `buildRdsReplicaSourceModels` + classify overlay + corpus-recorder carry) + the replica `BackupRetentionPeriod: 0` constant. The overlay keys on the PRE-writeonly-strip `SourceDBInstanceIdentifier` snapshot — the #1500 trap recurred and cost one RDS redeploy; the unit test now uses the real write-only schema.
- **#1705** Cassandra Table `DefaultTimeToLive: 0` + PROVISIONED `WarmThroughput` derived from the declared capacity (the harvested 12000/4000 constant is ON_DEMAND-only, as the coverage audit predicted).
- **#1706** memcached CacheCluster undeclared `EngineVersion` joins the moving-GA-version value-independent set.

### FN off-flip audit (the #1092 class, partial-declaration dimension)

- **#1700** GuardDuty Detector partial-declared `DataSources`: nested sub-object pins + `MEANINGFUL_WHEN_OFF_NESTED` gates. The all-true partial fill was CC-probed live; the all-false OOB disable (EKS audit logs / EBS malware scan / S3 protection silently off) was invisible before.
- **#1701** determination: Cognito partial-declared PasswordPolicy fills `Require*` **FALSE** (corpus case Users0A0EEA89 proves it; the attempted true-pin fix was caught as an FP by corpus-replay) — the audited FN does not exist. Only the `MinimumLength: 8` partial-fill pin ships, with the in-code determination note.
- **#1702** (open, deferred): AppRunner IngressConfiguration / ImageBuilder ImageTestsEnabled / R53 EnableSNI conditional — each needs its own off-state-shape probe.

### Batch-10 revert-convergence determinations (in-code notes)

Lambda ESM `TumblingWindowInSeconds` converges via bare remove (riding the OnFailure husk removal — a raw probe without it proves nothing); VpcLattice ALS `ServiceNetworkLogType` not OOB-mutable; SES DedicatedIpPool `ScalingMode` detect-only by service design (MANAGED->STANDARD unsupported).

### Assets

- 24 new golden-corpus cases (ASG MIP, Volume barest/gp3, 3 TG crosses, dualstack ALB/NLB, NLB TLS + mTLS listeners, attached TrustStore, Interface VPCE, R53 HCs, Events BASIC connection, SNS lambda sub, RDS source+replica pair with the sibling-model carry, memcached, 2 Cassandra tables, inactive GD entity set).
- 3 committed regression fixtures (freepack/elbpack/statepack) + the gdsets2 EBO leg; FN legs live-verified (ASG MaxSize detect->revert->converge, GD EBO detect->revert->converge).
- SKILL.md: batch-10 notes + two new gotchas (partial-fill vs wholly-undeclared fill; Potential-Drift header-line count trap).

### Verification

`/check` + `/check-docs` + `/verify-pr` green (322 files / 6222 tests; typecheck/lint/build pass; docs: no docs-visible surface touched). Live legs: 4 fixtures INTEG OK on the final binary. **Core shared-name suite deferred** — this diff is fold/revert-table work fully covered by unit tests + corpus replay and live-proven by this hunt's own fixtures (per the verify-pr deferral rule; it runs at the next clean-window release verification). AWS side: all 5 hunt stacks deleted, `sweep-orphans.sh` SWEEP CLEAN, bughunt gate released.

Closes #1694, closes #1695, closes #1696, closes #1697, closes #1698, closes #1699, closes #1700, closes #1701, closes #1703, closes #1704, closes #1705, closes #1706
