### PR TITLE
fix(diff): #1702 off-flip FN gates — Route53 EnableSNI (HTTPS-conditional), ImageBuilder ImageTestsEnabled, AppRunner IngressConfiguration + allLeavesAtSchemaDefault off-gate honor

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -925,6 +925,14 @@ grep ': true'` and pair every new truthy pin with its off-state gate. A SINGLE
   into a harvested corpus case's liveRaw, flip, assert) proves the FN for free before
   any deploy, and `DescribeBudget` RETURNS the all-false object (not vanished), so
   the fix is the isTrivialEmpty gate, not the vanished-default baseline family.
+  AND the inverse interaction (#1702, 2026-08-02): **adding a per-leaf pin for a
+  SIBLING leaf can silently re-fold a WHOLLY-undeclared off-flipped object** — the
+  #624 `allLeavesAtSchemaDefault` whole-object rule counts a false leaf as
+  trivially-empty and the newly-pinned sibling as at-default, so the flipped object
+  folds whole (the #911 ImageTestsConfiguration test caught it). Fixed generally
+  (a trivially-empty leaf with a firing MEANINGFUL_WHEN_OFF_NESTED gate refuses the
+  fold), but when adding per-leaf pins under a whole-object-pinned parent, re-run
+  the parent's off-flip test explicitly.
 - **CloudFront ContinuousDeploymentPolicy cannot be attached at distribution
   CREATION** ("Continuous deployment policy is not supported during distribution
   creation" InvalidRequest) — a CD fixture must deploy the primary WITHOUT

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -227,8 +227,11 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   // no restore/import/legacy path that yields an untouched `false`), so an undeclared `false`
   // is unambiguously an out-of-band disable. (The DB `AutoMinorVersionUpgrade` /
   // `AllowVersionUpgrade`, ELBv2 TargetGroup `HealthCheckEnabled` (Lambda-target conditional),
-  // and the nested Athena/EKS/Cognito-password/EnableSNI switches are DEFERRED to a live-verified
-  // follow-up — a snapshot-restored DB / a Lambda target group can read `false` legitimately.)
+  // and the nested Athena/EKS switches were DEFERRED to live-verified follow-ups — a
+  // snapshot-restored DB / a Lambda target group can read `false` legitimately. Athena/EKS
+  // landed in MEANINGFUL_WHEN_OFF_NESTED below; Cognito-password was determined NON-vulnerable
+  // (#1701 — the partial fill is false); EnableSNI landed as the CONDITIONAL Route53 entry
+  // below, #1702.)
   //
   // A VPC always resolves DNS by default; disabling it out of band breaks name resolution.
   'AWS::EC2::VPC': { EnableDnsSupport: () => true },
@@ -465,6 +468,44 @@ const MEANINGFUL_WHEN_OFF_NESTED: Record<
   // (#1701 determination: Cognito PasswordPolicy Require* leaves do NOT belong here — a
   // partially-declared policy is filled with FALSE by the service, so an undeclared false
   // is the creation state, not an out-of-band disable. See the noise.ts MinimumLength note.)
+  // #1702: an HTTPS(_STR_MATCH) health check fills EnableSNI=true at creation, and an
+  // out-of-band `update-health-check --no-enable-sni` reads back a PRESENT `false` (both
+  // live-probed 2026-08-02) that isTrivialEmpty swallowed — TLS SNI/cert-hostname
+  // validation silently off. CONDITIONAL on the check type: a non-HTTPS check legitimately
+  // reads `false` at creation (live-probed on an HTTP check the same day), so the gate
+  // fires only when the declared (or live) Type is the HTTPS pair.
+  'AWS::Route53::HealthCheck': {
+    'HealthCheckConfig.EnableSNI': ({ declared, live }) => {
+      const cfg = (declared['HealthCheckConfig'] ?? live['HealthCheckConfig']) as
+        | Record<string, unknown>
+        | undefined;
+      const t = cfg?.['Type'];
+      return t === 'HTTPS' || t === 'HTTPS_STR_MATCH';
+    },
+  },
+  // #1702: an App Runner service that declares NetworkConfiguration PARTIALLY (the
+  // standard egress/VPC-connector shape) emits the undeclared IngressConfiguration
+  // sub-object whole — the service fills {IsPubliclyAccessible: true} on that shape and
+  // an out-of-band update to PRIVATE reads back a PRESENT all-false object (both
+  // live-probed 2026-08-02), swallowed by isTrivialEmpty — the public/private ingress
+  // toggle silently flips. Unconditionally meaningful when off: a user who wants a
+  // private service DECLARES it, and a service has no snapshot/restore lineage yielding
+  // an untouched all-false. Paired with the KNOWN_DEFAULT_PATHS pin (the clean fold).
+  'AWS::AppRunner::Service': {
+    'NetworkConfiguration.IngressConfiguration': () => true,
+  },
+  // #1702: an ImagePipeline that declares ImageTestsConfiguration PARTIALLY (only
+  // TimeoutMinutes) emits the ImageTestsEnabled leaf alone — the service fills it `true`
+  // on that shape and an out-of-band `update-image-pipeline` disable reads back a PRESENT
+  // `false` (both live-probed via a CC read 2026-08-02), swallowed by isTrivialEmpty —
+  // image tests silently skipped (supply-chain adjacent). Unconditionally meaningful when
+  // off: a user who wants tests off DECLARES it, and a pipeline has no snapshot/restore
+  // lineage yielding an untouched false. (The wholly-undeclared off-flip already surfaces:
+  // the flipped whole object keeps the non-trivial TimeoutMinutes, breaking the
+  // whole-object pin equality.) Paired with the KNOWN_DEFAULT_PATHS per-leaf pins.
+  'AWS::ImageBuilder::ImagePipeline': {
+    'ImageTestsConfiguration.ImageTestsEnabled': () => true,
+  },
   // #1530: an ECS service that ENABLES the deployment circuit breaker reads back the AWS-filled
   // sub-default ResetOnHealthyTask=true (the KNOWN_DEFAULT_PATHS pin, live-observed on a fresh
   // Fargate service). An out-of-band UpdateService flipping it false is swallowed by
@@ -4241,7 +4282,24 @@ export function classifyResource(
   // schema-annotated defaults (e.g. KinesisVideo StreamStorageConfiguration `{DefaultStorageTier:"HOT"}`)
   // fold whole atDefault WITHOUT a per-type DESCEND_UNDECLARED_OBJECT_PATHS entry.
   const allLeavesAtSchemaDefault = (value: unknown, basePath: string): boolean => {
-    if (isTrivialEmpty(value)) return true;
+    if (isTrivialEmpty(value)) {
+      // #1702: a trivially-empty leaf (or all-false sub-object) whose path carries a pinned
+      // default AND a firing MEANINGFUL_WHEN_OFF_NESTED gate is an out-of-band OFF state,
+      // not an AWS-materialized default — refuse the fold so the enclosing object surfaces.
+      // (Without this, adding a per-leaf pin for a SIBLING leaf can silently re-fold a
+      // wholly-undeclared off-flipped object: the #911 ImageTestsConfiguration
+      // {ImageTestsEnabled:false, TimeoutMinutes:720} shape folded whole the moment
+      // TimeoutMinutes gained its 720 pin, because the false leaf counted as trivially-empty.)
+      const schemaPath = basePath.replace(/\[[^\]]*\]/g, '.*');
+      if (
+        schemaPath in knownDefPaths &&
+        !matchesKnownDefault(value, knownDefPaths[schemaPath]) &&
+        (MEANINGFUL_WHEN_OFF_NESTED[resourceType]?.[schemaPath]?.({ declared, live }) ?? false)
+      ) {
+        return false;
+      }
+      return true;
+    }
     if (Array.isArray(value)) return false;
     if (isNestedObject(value))
       return Object.entries(value).every(([sk, sv]) =>

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2542,7 +2542,36 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'TableInput.Retention': 0,
     'TableInput.StorageDescriptor.NumberOfBuckets': 0,
   },
+  // #1702: the PARTIAL-declaration dimension of the whole-object NetworkConfiguration
+  // pin — the standard VPC-connector/egress shape declares only EgressConfiguration, so
+  // the undeclared siblings emit at these nested paths (live-probed via a CC read
+  // 2026-08-02: the partial shape fills IngressConfiguration {IsPubliclyAccessible:true}
+  // and IpAddressType IPV4). The all-boolean IngressConfiguration pin pairs with a
+  // MEANINGFUL_WHEN_OFF_NESTED gate in classify.ts (an out-of-band flip to private reads
+  // back a PRESENT all-false object that isTrivialEmpty otherwise swallows); the
+  // IpAddressType constant is plainly equality-gated (a dualstack service surfaces).
+  'AWS::AppRunner::Service': {
+    'NetworkConfiguration.IngressConfiguration': { IsPubliclyAccessible: true },
+    'NetworkConfiguration.IpAddressType': 'IPV4',
+  },
+  // #1702: the PARTIAL-declaration dimension of the whole-object ImageTestsConfiguration
+  // pin (a pipeline declaring only TimeoutMinutes emits each undeclared leaf alone).
+  // ImageTestsEnabled fills `true` on the partial shape and an out-of-band disable reads
+  // back a PRESENT `false` (both live-probed via a CC read 2026-08-02) — paired with the
+  // MEANINGFUL_WHEN_OFF_NESTED gate in classify.ts so the lone false leaf surfaces
+  // (image tests silently skipped otherwise). TimeoutMinutes pins the documented 720
+  // default for the inverse partial shape (equality-gated; a non-default is a
+  // non-trivial number and surfaces with or without a pin).
+  'AWS::ImageBuilder::ImagePipeline': {
+    'ImageTestsConfiguration.ImageTestsEnabled': true,
+    'ImageTestsConfiguration.TimeoutMinutes': 720,
+  },
   'AWS::Route53::HealthCheck': {
+    // #1702: paired with a CONDITIONAL MEANINGFUL_WHEN_OFF_NESTED gate in classify.ts —
+    // an HTTPS(_STR_MATCH) check created without EnableSNI fills `true` and an
+    // out-of-band `--no-enable-sni` reads back a PRESENT `false` (both live-probed
+    // 2026-08-02), previously swallowed by isTrivialEmpty; a non-HTTPS check reads
+    // `false` at CREATION, so the gate fires only on the HTTPS pair.
     'HealthCheckConfig.EnableSNI': true,
     // A health check that declares neither RequestInterval nor FailureThreshold reads back
     // the AWS service defaults (30-second interval, 3 consecutive failures). Equality-gated:

--- a/tests/classify-offflip-1702.test.ts
+++ b/tests/classify-offflip-1702.test.ts
@@ -1,0 +1,214 @@
+// #1702 — the remaining truthy-pin off-flip FN candidates, live-probed 2026-08-02:
+// - Route53 HealthCheck HealthCheckConfig.EnableSNI: an HTTPS check fills `true` at
+//   creation and an out-of-band `--no-enable-sni` reads back a PRESENT `false`
+//   (previously swallowed by isTrivialEmpty); a non-HTTPS check reads `false` at
+//   CREATION, so the MEANINGFUL_WHEN_OFF_NESTED gate is CONDITIONAL on the type.
+// - ImageBuilder ImagePipeline ImageTestsConfiguration.ImageTestsEnabled: the partial
+//   shape (only TimeoutMinutes declared) fills `true`, and an out-of-band disable reads
+//   back a PRESENT `false` emitted as a lone leaf — per-leaf pins + an unconditional gate.
+// - AppRunner Service NetworkConfiguration.IngressConfiguration: the partial shape
+//   (only EgressConfiguration declared) fills {IsPubliclyAccessible: true} + IpAddressType
+//   IPV4, and an out-of-band flip to private reads back a PRESENT all-false object —
+//   whole-sub-object pin + unconditional gate, plus the IpAddressType per-leaf constant.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#1702 Route53 HealthCheck EnableSNI conditional off-flip gate', () => {
+  const mkHc = (config: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'Hc',
+    resourceType: 'AWS::Route53::HealthCheck',
+    physicalId: 'f2fee341-5bc6-4b4b-90ca-fa1235240a93',
+    declared: { HealthCheckConfig: config },
+  });
+  // The exact live fill from the 2026-08-02 probe (an HTTPS check declaring only
+  // Type + FQDN).
+  const httpsDeclared = { Type: 'HTTPS', FullyQualifiedDomainName: 'example.com' };
+  const httpsLiveClean = {
+    HealthCheckConfig: {
+      ...httpsDeclared,
+      EnableSNI: true,
+      MeasureLatency: false,
+      Inverted: false,
+      Port: 443,
+      RequestInterval: 30,
+      FailureThreshold: 3,
+    },
+  };
+
+  it('a clean HTTPS check folds the EnableSNI true fill (zero undeclared)', () => {
+    const f = classifyResource(mkHc(httpsDeclared), httpsLiveClean, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band --no-enable-sni on an HTTPS check surfaces (off-state gate)', () => {
+    const f = classifyResource(
+      mkHc(httpsDeclared),
+      {
+        HealthCheckConfig: {
+          ...httpsLiveClean['HealthCheckConfig'],
+          EnableSNI: false,
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['HealthCheckConfig.EnableSNI']);
+  });
+
+  it('a non-HTTPS check reading its creation-state EnableSNI false stays clean (conditional gate)', () => {
+    const httpDeclared = { Type: 'HTTP', FullyQualifiedDomainName: 'example.com' };
+    const f = classifyResource(
+      mkHc(httpDeclared),
+      {
+        HealthCheckConfig: {
+          ...httpDeclared,
+          EnableSNI: false,
+          MeasureLatency: false,
+          Inverted: false,
+          Port: 80,
+          RequestInterval: 30,
+          FailureThreshold: 3,
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+});
+
+describe('#1702 AppRunner Service partial-declared NetworkConfiguration', () => {
+  // The exact live fill from the 2026-08-02 probe (a service declaring only
+  // EgressConfiguration).
+  const declared = {
+    ServiceName: 'cdkrd-1702-ar',
+    SourceConfiguration: {
+      ImageRepository: {
+        ImageIdentifier: 'public.ecr.aws/aws-containers/hello-app-runner:latest',
+        ImageRepositoryType: 'ECR_PUBLIC',
+      },
+      AutoDeploymentsEnabled: false,
+    },
+    NetworkConfiguration: { EgressConfiguration: { EgressType: 'DEFAULT' } },
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'Svc',
+    resourceType: 'AWS::AppRunner::Service',
+    physicalId: 'arn:aws:apprunner:us-east-1:111111111111:service/cdkrd-1702-ar/abc123',
+    declared,
+  });
+  const liveNetClean = {
+    IpAddressType: 'IPV4',
+    EgressConfiguration: { EgressType: 'DEFAULT' },
+    IngressConfiguration: { IsPubliclyAccessible: true },
+  };
+
+  it('the partial shape folds the IngressConfiguration + IpAddressType fills (zero undeclared)', () => {
+    const f = classifyResource(
+      mk(),
+      { ...declared, NetworkConfiguration: liveNetClean },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band flip to private surfaces the all-false object (off-state gate)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        NetworkConfiguration: {
+          ...liveNetClean,
+          IngressConfiguration: { IsPubliclyAccessible: false },
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['NetworkConfiguration.IngressConfiguration']);
+  });
+
+  it('an out-of-band dualstack migration surfaces (IpAddressType equality gate)', () => {
+    const f = classifyResource(
+      mk(),
+      { ...declared, NetworkConfiguration: { ...liveNetClean, IpAddressType: 'DUAL_STACK' } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['NetworkConfiguration.IpAddressType']);
+  });
+});
+
+describe('#1702 ImageBuilder ImagePipeline partial-declared ImageTestsConfiguration', () => {
+  const declared = {
+    Name: 'cdkrd-1702-pipe',
+    ImageRecipeArn: 'arn:aws:imagebuilder:us-east-1:111111111111:image-recipe/r/1.0.0',
+    InfrastructureConfigurationArn:
+      'arn:aws:imagebuilder:us-east-1:111111111111:infrastructure-configuration/i',
+    ImageTestsConfiguration: { TimeoutMinutes: 90 },
+  };
+  const mk = (): DesiredResource => ({
+    logicalId: 'Pipe',
+    resourceType: 'AWS::ImageBuilder::ImagePipeline',
+    physicalId: 'arn:aws:imagebuilder:us-east-1:111111111111:image-pipeline/cdkrd-1702-pipe',
+    declared,
+  });
+
+  it('the partial shape folds the ImageTestsEnabled true fill (zero undeclared)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        ImageTestsConfiguration: { TimeoutMinutes: 90, ImageTestsEnabled: true },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('an out-of-band test disable surfaces as the lone false leaf (off-state gate)', () => {
+    const f = classifyResource(
+      mk(),
+      {
+        ...declared,
+        ImageTestsConfiguration: { TimeoutMinutes: 90, ImageTestsEnabled: false },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual(['ImageTestsConfiguration.ImageTestsEnabled']);
+  });
+
+  it('the inverse partial shape folds the TimeoutMinutes 720 fill and surfaces a change', () => {
+    const invDeclared = {
+      ...declared,
+      ImageTestsConfiguration: { ImageTestsEnabled: true },
+    };
+    const mkInv = (): DesiredResource => ({ ...mk(), declared: invDeclared });
+    const clean = classifyResource(
+      mkInv(),
+      { ...invDeclared, ImageTestsConfiguration: { ImageTestsEnabled: true, TimeoutMinutes: 720 } },
+      emptySchema
+    );
+    expect(pathsByTier(clean, 'undeclared')).toEqual([]);
+    const drifted = classifyResource(
+      mkInv(),
+      { ...invDeclared, ImageTestsConfiguration: { ImageTestsEnabled: true, TimeoutMinutes: 60 } },
+      emptySchema
+    );
+    expect(pathsByTier(drifted, 'undeclared')).toEqual(['ImageTestsConfiguration.TimeoutMinutes']);
+  });
+});


### PR DESCRIPTION
## #1702 — the remaining truthy-pin off-flip FN candidates, all three proven real and fixed

Live probes 2026-08-02 (details on the issue): every partial fill is truthy and every off state reads back PRESENT — so unlike the #1701 Cognito determination, all three audited FNs exist and are gate-fixable.

| Candidate | Partial fill (probed) | Off state (probed) | Fix |
|---|---|---|---|
| Route53 HealthCheck `HealthCheckConfig.EnableSNI` | HTTPS check fills `true`; HTTP control reads `false` AT CREATION | `--no-enable-sni` -> PRESENT `false` | **CONDITIONAL** `MEANINGFUL_WHEN_OFF_NESTED` gate (fires only on the HTTPS pair) |
| ImageBuilder ImagePipeline `ImageTestsConfiguration.ImageTestsEnabled` | only-TimeoutMinutes shape fills `true` | `update-image-pipeline` -> PRESENT lone `false` leaf | per-leaf pins (`ImageTestsEnabled: true`, `TimeoutMinutes: 720` for the inverse partial shape) + unconditional gate |
| AppRunner Service `NetworkConfiguration.IngressConfiguration` | egress-only shape fills `{IsPubliclyAccessible: true}` + `IpAddressType: IPV4` | update to private -> PRESENT all-false object | sub-object pin + unconditional gate, plus the `IpAddressType: 'IPV4'` per-leaf constant (latent partial-shape FP found alongside) |

### Deeper interaction (caught by the existing #911 test)

Adding a per-leaf pin for a SIBLING leaf made the #624 `allLeavesAtSchemaDefault` whole-object rule silently re-fold a WHOLLY-undeclared off-flipped `ImageTestsConfiguration` (`{ImageTestsEnabled:false, TimeoutMinutes:720}`): the false leaf counted as trivially-empty and the newly-pinned sibling as at-default. Fixed generally — a trivially-empty leaf whose path carries a firing `MEANINGFUL_WHEN_OFF_NESTED` gate now refuses the whole-object fold. SKILL.md gotcha extended so the next per-leaf-pin addition re-runs the parent's off-flip test.

### Verification

- Unit: 323 files / 6231 tests green; the 9 new tests each fail without their pin/gate; #911 pins the interaction fix.
- Live E2E (fix binary, throwaway `Cdkrd1702Verify` stack): first check CLEAN -> record -> OOB `--no-enable-sni` -> `check --fail` **exit 1** (`HealthCheckConfig.EnableSNI actual=false` surfaced — invisible before) -> restore -> CLEAN. Stack deleted via delstack, `sweep-orphans.sh` SWEEP CLEAN, bughunt gate released.
- ImageBuilder / AppRunner: CC-read-shape proven by the stackless probes (the SES-EmailIdentity precedent); unit tests pin the exact probed shapes.
- typecheck / lint+format / build green; docs: no docs-visible surface touched.

Closes #1702
