### PR TITLE
feat(revert): Lambda::Permission SDK writer — RemovePermission+AddPermission rebuild with unprojected-condition guard

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -875,9 +875,12 @@ only when non-zero — unrecorded values are named as such, never folded into
     `Policies.*` declared drift still patches via CC. A resource with both kinds
     of findings splits into one `cc` item and one `sdk` item.
 - **Not revertable (reported honestly, never silently skipped)**:
-  `AWS::Lambda::Permission` (add/remove statement model keyed by StatementId, not a
-  settable document), `AWS::Budgets::Budget` (`UpdateBudget` needs a full NewBudget
-  the reader can't reconstruct), a `deleted` resource (`deleted — recreate via cdk
+  (`AWS::Lambda::Permission` and `AWS::Budgets::Budget` USED to head this list; both
+  graduated to SDK writers once their readers grew full projections — Budgets via
+  `budgets:UpdateBudget` #1676, Lambda Permission via a RemovePermission+AddPermission
+  single-statement rebuild #1714, which still REFUSES — honestly, per-resource — a
+  statement carrying a condition key the reader does not project, e.g.
+  `lambda:EventSourceToken`, rather than silently dropping it), a `deleted` resource (`deleted — recreate via cdk
 deploy`: a patch can't recreate a resource), a **create-only** property (drift on a
   HARD `createOnlyProperties` field needs a resource replacement, which an in-place
   `UpdateResource` can't do — caught from the schema at plan time, not at apply

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -31,7 +31,13 @@ import {
 } from '../normalize/noise.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
 import type { Finding, SchemaInfo } from '../types.js';
-import { SDK_DELETERS, SDK_NESTED_WRITERS, SDK_PROP_WRITERS, SDK_WRITERS } from './writers.js';
+import {
+  SDK_DELETERS,
+  SDK_NESTED_WRITERS,
+  SDK_PROP_WRITERS,
+  SDK_REBUILD_WRITER_TYPES,
+  SDK_WRITERS,
+} from './writers.js';
 
 // Per type, the writeOnly props that an SDK_SUPPLEMENTS reader makes COMPARABLE
 // (detection works) but Cloud Control still cannot revert via a nested sub-path patch
@@ -1340,8 +1346,17 @@ export function buildRevertPlan(
     }
     // create-only property: an in-place UpdateResource patch would be rejected (the
     // change needs a replacement) — report it now instead of failing at apply time.
+    // EXEMPT a type whose SDK writer REBUILDS the resource (#1714,
+    // SDK_REBUILD_WRITER_TYPES): a remove+re-create writer applies create-only changes
+    // by construction (Lambda::Permission — EVERY property is createOnly in the
+    // registry schema, the resource is CFn-immutable, yet RemovePermission +
+    // AddPermission converges the same statement identity in place).
     const schema = opts.schemas?.get(f.resourceType);
-    if (schema && isUnderCreateOnly(f.path, schema.createOnlyPaths)) {
+    if (
+      schema &&
+      isUnderCreateOnly(f.path, schema.createOnlyPaths) &&
+      !SDK_REBUILD_WRITER_TYPES.has(f.resourceType)
+    ) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -4,15 +4,14 @@
 // SDK. Covers the policy-document types (the common revert) plus IAM ManagedPolicy
 // (revert the default version's document).
 //
-// Still not-revertable by design (no SDK writer here):
-//   - AWS::Lambda::Permission: an ADD/REMOVE statement model keyed by StatementId
-//     (AddPermission/RemovePermission), NOT a settable whole-document property. A
-//     generic ops-based revert would have to diff the resource policy statements
-//     and add/remove each individually; the override READER only returns a thin
-//     best-effort match (FunctionName/Action/Principal, no StatementId / SourceArn
-//     / SourceAccount / EventSourceToken), so we cannot reconstruct the exact
-//     statement to re-add nor safely identify the one to remove. Reverting it
-//     blindly risks dropping or duplicating unrelated grants -> left not-revertable.
+// (AWS::Lambda::Permission WAS on the "still not-revertable" list — "the override READER
+// only returns a thin best-effort match (FunctionName/Action/Principal, no StatementId /
+// SourceArn / SourceAccount), so we cannot reconstruct the exact statement to re-add nor
+// safely identify the one to remove". That rationale went STALE (#1714, the #1676 Budgets
+// pattern): the reader now resolves statement identity EXACTLY (the CFn physical id IS the
+// statement Sid) and projects SourceArn / SourceAccount / PrincipalOrgID /
+// FunctionUrlAuthType, so a RemovePermission+AddPermission rebuild is safe — guarded by
+// writeLambdaPermission's refuse-on-unprojected-condition check below.)
 // (AWS::Budgets::Budget WAS on this list — "the reader returns only the scalar identity
 // subset, so a NewBudget reconstruction would be missing the required limit and would wipe
 // the cost filters/types". That rationale is now STALE: the reader projection caught up
@@ -142,6 +141,12 @@ import {
   type ResourceType,
 } from '@aws-sdk/client-config-service';
 import { KafkaClient, UpdateConfigurationCommand } from '@aws-sdk/client-kafka';
+import {
+  AddPermissionCommand,
+  GetPolicyCommand as LambdaGetPolicyCommand,
+  LambdaClient,
+  RemovePermissionCommand,
+} from '@aws-sdk/client-lambda';
 import {
   CodeBuildClient,
   type ReportExportConfig,
@@ -3203,7 +3208,84 @@ const writeBudget: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// AWS::Lambda::Permission (#1714) — an ADD/REMOVE statement model keyed by StatementId
+// (AddPermission/RemovePermission), not a settable whole-document property, so revert
+// REBUILDS the one statement: RemovePermission(Sid) + AddPermission(desired fields). The
+// CFn physical id IS the statement Sid (the reader matches on it), and desiredModel()
+// applies the revert ops to the reader projection (FunctionName / Action / Principal /
+// SourceArn / SourceAccount / PrincipalOrgID / FunctionUrlAuthType), so the re-added
+// statement carries the declared intent and drops an out-of-band-added scoping key.
+// GUARD (the residual truth of the old not-revertable rationale): the LIVE statement may
+// carry condition keys the reader does NOT project (lambda:EventSourceToken, an arbitrary
+// aws:* condition) — a blind rebuild would silently DROP them, so the writer refuses and
+// reports honestly instead. (A template-declared EventSourceToken always puts the
+// condition on the live statement too, so such permissions are always refused — never
+// half-rebuilt.)
+const LAMBDA_PERMISSION_PROJECTED_CONDITIONS: Record<string, ReadonlySet<string>> = {
+  ArnLike: new Set(['AWS:SourceArn']),
+  StringEquals: new Set(['AWS:SourceAccount', 'aws:PrincipalOrgID', 'lambda:FunctionUrlAuthType']),
+};
+const writeLambdaPermission: SdkWriter = async (ctx, ops) => {
+  const fn = str(ctx.declared['FunctionName']);
+  if (!fn) throw new Error('cannot resolve FunctionName for Lambda Permission revert');
+  const sid = str(ctx.physicalId);
+  if (!sid) throw new Error('cannot resolve the Lambda Permission StatementId for revert');
+  const c = new LambdaClient({ region: ctx.region, ...CLIENT_TIMEOUTS });
+  // Read the LIVE statement RAW (not the reader projection) — the guard must see every
+  // condition key AWS stores, including the ones the projection drops.
+  let liveStmt: Record<string, unknown> | undefined;
+  try {
+    const raw = (await c.send(new LambdaGetPolicyCommand({ FunctionName: fn }))).Policy;
+    const stmts =
+      (JSON.parse(raw ?? '{}') as { Statement?: Array<Record<string, unknown>> }).Statement ?? [];
+    liveStmt = stmts.find((s) => s['Sid'] === sid);
+  } catch (e) {
+    // No resource policy at all = nothing to remove; the AddPermission below re-creates.
+    if ((e as Error).name !== 'ResourceNotFoundException') throw e;
+  }
+  const liveCond = liveStmt?.['Condition'];
+  if (liveCond !== undefined && liveCond !== null && typeof liveCond === 'object') {
+    for (const [condOp, kv] of Object.entries(liveCond as Record<string, unknown>)) {
+      const projected = LAMBDA_PERMISSION_PROJECTED_CONDITIONS[condOp];
+      const keys = kv !== null && typeof kv === 'object' ? Object.keys(kv) : [];
+      const unprojected = projected ? keys.filter((k) => !projected.has(k)) : keys;
+      if (unprojected.length > 0)
+        throw new Error(
+          `Lambda Permission ${sid} carries a condition the reader does not project ` +
+            `(${condOp}: ${unprojected.join(', ')}) — a rebuild would silently drop it; ` +
+            `update the permission manually`
+        );
+    }
+  }
+  const desired = await desiredModel('AWS::Lambda::Permission', ctx, ops);
+  const action = str(desired['Action']);
+  const principal = str(desired['Principal']);
+  if (!action || !principal)
+    throw new Error('cannot resolve Action/Principal for Lambda Permission revert');
+  if (liveStmt) await c.send(new RemovePermissionCommand({ FunctionName: fn, StatementId: sid }));
+  await c.send(
+    new AddPermissionCommand({
+      FunctionName: fn,
+      StatementId: sid,
+      Action: action,
+      Principal: principal,
+      SourceArn: str(desired['SourceArn']),
+      SourceAccount: str(desired['SourceAccount']),
+      PrincipalOrgID: str(desired['PrincipalOrgID']),
+      FunctionUrlAuthType: str(desired['FunctionUrlAuthType']) as 'AWS_IAM' | 'NONE' | undefined,
+    })
+  );
+};
+
+// Types whose SDK writer REBUILDS the resource (remove + re-create with the same
+// identity) rather than patching it in place — so the plan's create-only bar must NOT
+// bar their findings (#1714): a rebuild applies create-only changes by construction.
+// Keep this in lockstep with the writer implementations; a type listed here without a
+// genuinely rebuilding writer would let a doomed in-place patch through.
+export const SDK_REBUILD_WRITER_TYPES: ReadonlySet<string> = new Set(['AWS::Lambda::Permission']);
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
+  'AWS::Lambda::Permission': writeLambdaPermission,
   'AWS::Budgets::Budget': writeBudget,
   'AWS::ApiGatewayV2::Stage': writeApiGatewayV2Stage,
   'AWS::ElasticBeanstalk::Application': writeElasticBeanstalkApplication,

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -2731,7 +2731,9 @@ describe('buildRevertPlan', () => {
       [
         F({ tier: 'readGap' }),
         F({ tier: 'unresolved' }),
-        F({ tier: 'declared', resourceType: 'AWS::Lambda::Permission', desired: {} }), // CC-gap, no SDK writer
+        // CC-gap read-override type with no SDK writer (DMS Endpoint is read-ONLY —
+        // ModifyEndpoint writers deferred; Lambda::Permission graduated to a writer in #1714)
+        F({ tier: 'declared', resourceType: 'AWS::DMS::Endpoint', desired: {} }),
         F({ tier: 'declared', physicalId: undefined, desired: 'x' }),
       ],
       undefined
@@ -2857,13 +2859,17 @@ describe('buildRevertPlan', () => {
     ]);
   });
 
-  it('Lambda Permission stays not-revertable, but Budgets Budget now routes to its SDK writer (#1676)', () => {
-    // Budgets Budget graduated out of the not-revertable set (it has writeBudget now); Lambda
-    // Permission stays barred (still no SDK writer — its ADD/REMOVE statement model is not
-    // reconstructable from the thin override reader).
+  it('Lambda Permission and Budgets Budget both route to their SDK writers (#1676, #1714)', () => {
+    // Both graduated out of the not-revertable set: Budgets via writeBudget (#1676),
+    // Lambda Permission via the RemovePermission+AddPermission rebuild writer (#1714).
     const plan = buildRevertPlan(
       [
-        F({ tier: 'declared', resourceType: 'AWS::Lambda::Permission', desired: {} }),
+        F({
+          tier: 'declared',
+          logicalId: 'Perm',
+          resourceType: 'AWS::Lambda::Permission',
+          desired: {},
+        }),
         F({
           tier: 'declared',
           resourceType: 'AWS::Budgets::Budget',
@@ -2875,12 +2881,35 @@ describe('buildRevertPlan', () => {
       ],
       undefined
     );
+    expect(plan.items).toHaveLength(2);
+    expect(plan.items.map((i) => [i.resourceType, i.kind]).sort()).toEqual([
+      ['AWS::Budgets::Budget', 'sdk'],
+      ['AWS::Lambda::Permission', 'sdk'],
+    ]);
+    expect(plan.notRevertable).toHaveLength(0);
+  });
+
+  it('#1714: a create-only path on a REBUILD-writer type is NOT barred (SDK_REBUILD_WRITER_TYPES)', () => {
+    // Every Lambda::Permission property is createOnly in the registry schema (the
+    // resource is CFn-immutable), but the remove+re-add writer applies the change by
+    // construction — the create-only bar must not fire. A non-rebuild type with the
+    // same schema shape stays barred (the S3 BucketName tests below).
+    const plan = buildRevertPlan(
+      [
+        F({
+          tier: 'declared',
+          resourceType: 'AWS::Lambda::Permission',
+          path: 'SourceArn',
+          desired: 'arn:aws:execute-api:us-east-1:1:api/*/GET/x',
+          actual: 'arn:aws:execute-api:us-east-1:1:ROGUE/*',
+        }),
+      ],
+      undefined,
+      { schemas: schemaWithCreateOnly('AWS::Lambda::Permission', 'SourceArn') }
+    );
     expect(plan.items).toHaveLength(1);
-    expect(plan.items[0]!.resourceType).toBe('AWS::Budgets::Budget');
     expect(plan.items[0]!.kind).toBe('sdk');
-    expect(plan.notRevertable).toHaveLength(1);
-    expect(plan.notRevertable[0]!.resourceType).toBe('AWS::Lambda::Permission');
-    expect(plan.notRevertable[0]!.reason).toContain('not revertable');
+    expect(plan.notRevertable).toHaveLength(0);
   });
 
   it('R35: UNRECORDED create-only value -> reason is unrecorded (record is the route)', () => {

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -142,6 +142,12 @@ import {
 } from '@aws-sdk/client-cloudcontrol';
 import { KafkaClient, UpdateConfigurationCommand } from '@aws-sdk/client-kafka';
 import {
+  AddPermissionCommand,
+  GetPolicyCommand as LambdaGetPolicyCommand,
+  LambdaClient,
+  RemovePermissionCommand,
+} from '@aws-sdk/client-lambda';
+import {
   BatchGetProjectsCommand,
   BatchGetReportGroupsCommand,
   CodeBuildClient,
@@ -242,6 +248,7 @@ const elasticache = mockClient(ElastiCacheClient);
 const memorydb = mockClient(MemoryDBClient);
 const ec2 = mockClient(EC2Client);
 const lex = mockClient(LexModelsV2Client);
+const lambda = mockClient(LambdaClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -303,6 +310,7 @@ beforeEach(() => {
   dax.reset();
   ec2.reset();
   lex.reset();
+  lambda.reset();
 });
 
 describe('CloudWatch AnomalyDetector writer (PutAnomalyDetector upsert, issue #461)', () => {
@@ -4621,5 +4629,104 @@ describe('Budgets Budget writer (UpdateBudget full-object reconstruction, #1676)
       '1782864000': { Amount: '100.0', Unit: 'USD' }, // untouched period preserved
       '1785542400': { Amount: '200', Unit: 'USD' }, // reverted to the declared value
     });
+  });
+});
+
+describe('AWS::Lambda::Permission writer (#1714 — RemovePermission+AddPermission rebuild)', () => {
+  const FN_ARN = 'arn:aws:lambda:us-east-1:123456789012:function:my-fn';
+  const permCtx = () =>
+    ctx({
+      physicalId: 'perm-sid-1',
+      declared: {
+        FunctionName: 'my-fn',
+        Action: 'lambda:InvokeFunction',
+        Principal: 'apigateway.amazonaws.com',
+        SourceArn: 'arn:aws:execute-api:us-east-1:123456789012:api1/*/GET/x',
+      },
+    });
+  const livePolicy = (stmt: Record<string, unknown>) => ({
+    Policy: JSON.stringify({ Version: '2012-10-17', Statement: [stmt] }),
+  });
+  const baseStmt = (over: Record<string, unknown> = {}) => ({
+    Sid: 'perm-sid-1',
+    Effect: 'Allow',
+    Action: 'lambda:InvokeFunction',
+    Resource: FN_ARN,
+    Principal: { Service: 'apigateway.amazonaws.com' },
+    Condition: {
+      ArnLike: { 'AWS:SourceArn': 'arn:aws:execute-api:us-east-1:123456789012:ROGUE/*' },
+    },
+    ...over,
+  });
+
+  it('rebuilds the statement with the declared SourceArn (remove then add, same Sid)', async () => {
+    lambda.on(LambdaGetPolicyCommand).resolves(livePolicy(baseStmt()));
+    lambda.on(RemovePermissionCommand).resolves({});
+    lambda.on(AddPermissionCommand).resolves({});
+    await SDK_WRITERS['AWS::Lambda::Permission'](permCtx(), [
+      {
+        op: 'add',
+        path: '/SourceArn',
+        value: 'arn:aws:execute-api:us-east-1:123456789012:api1/*/GET/x',
+        human: 'SourceArn -> deployed-template value',
+      },
+    ]);
+    const rm = lambda.commandCalls(RemovePermissionCommand);
+    expect(rm).toHaveLength(1);
+    expect(rm[0]!.args[0].input).toMatchObject({
+      FunctionName: 'my-fn',
+      StatementId: 'perm-sid-1',
+    });
+    const add = lambda.commandCalls(AddPermissionCommand);
+    expect(add).toHaveLength(1);
+    expect(add[0]!.args[0].input).toMatchObject({
+      FunctionName: 'my-fn',
+      StatementId: 'perm-sid-1',
+      Action: 'lambda:InvokeFunction',
+      Principal: 'apigateway.amazonaws.com',
+      SourceArn: 'arn:aws:execute-api:us-east-1:123456789012:api1/*/GET/x',
+    });
+    expect(add[0]!.args[0].input.PrincipalOrgID).toBeUndefined();
+  });
+
+  it('drops an out-of-band-added PrincipalOrgID on an undeclared remove op', async () => {
+    lambda.on(LambdaGetPolicyCommand).resolves(
+      livePolicy(
+        baseStmt({
+          Condition: {
+            ArnLike: { 'AWS:SourceArn': 'arn:aws:execute-api:us-east-1:123456789012:api1/*/GET/x' },
+            StringEquals: { 'aws:PrincipalOrgID': 'o-rogue' },
+          },
+        })
+      )
+    );
+    lambda.on(RemovePermissionCommand).resolves({});
+    lambda.on(AddPermissionCommand).resolves({});
+    await SDK_WRITERS['AWS::Lambda::Permission'](permCtx(), [
+      { op: 'remove', path: '/PrincipalOrgID', human: 'PrincipalOrgID -> remove' },
+    ]);
+    const add = lambda.commandCalls(AddPermissionCommand);
+    expect(add).toHaveLength(1);
+    expect(add[0]!.args[0].input.PrincipalOrgID).toBeUndefined();
+    expect(add[0]!.args[0].input.SourceArn).toBe(
+      'arn:aws:execute-api:us-east-1:123456789012:api1/*/GET/x'
+    );
+  });
+
+  it('REFUSES a statement carrying a condition the reader does not project (EventSourceToken)', async () => {
+    lambda.on(LambdaGetPolicyCommand).resolves(
+      livePolicy(
+        baseStmt({
+          Condition: { StringEquals: { 'lambda:EventSourceToken': 'tok-123' } },
+        })
+      )
+    );
+    await expect(
+      SDK_WRITERS['AWS::Lambda::Permission'](permCtx(), [
+        { op: 'add', path: '/SourceArn', value: 'x', human: 'SourceArn -> declared' },
+      ])
+    ).rejects.toThrow(/condition the reader does not project.*EventSourceToken/s);
+    expect(lambda.commandCalls(RemovePermissionCommand)).toHaveLength(0);
+    expect(lambda.commandCalls(AddPermissionCommand)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

`AWS::Lambda::Permission` graduates out of the not-revertable set (#1714, the #1676 Budgets pattern — the reader grew, the old rationale went stale).

- **`writeLambdaPermission`** (SDK_WRITERS): a RemovePermission + AddPermission single-statement rebuild. The CFn physical id IS the statement Sid; `desiredModel()` applies the revert ops to the reader projection (FunctionName / Action / Principal / SourceArn / SourceAccount / PrincipalOrgID / FunctionUrlAuthType), so the re-added statement carries the declared intent and drops an out-of-band-added scoping key.
- **Guard (the residual truth of the old rationale)**: the writer reads the LIVE statement RAW and REFUSES — an honest per-resource failure, never a silent drop — when it carries a condition key the reader does not project (`lambda:EventSourceToken`, arbitrary `aws:*` conditions). A rebuild would silently drop such a key.
- **`SDK_REBUILD_WRITER_TYPES`** (plan.ts): every Lambda::Permission property is createOnly in the registry schema (the resource is CFn-immutable), so the plan's create-only bar fired BEFORE the writer route — live-found on this PR's own first verify run. A rebuild-style writer applies create-only changes by construction, so the bar now exempts the set's members.

## Live proof (Cdkrd1714Verify, us-east-1)

deploy (fn + permission with a declared SourceArn) → first check CLEAN → record → OOB `remove-permission` + `add-permission` same Sid with a ROGUE SourceArn → `check --fail` exits 1 (`Perm.SourceArn` declared drift) → `revert` → `reverted: Perm`, live statement's SourceArn back to the DECLARED ARN (get-policy verified) → final check CLEAN. Stack torn down, SWEEP CLEAN.

Unit tests: 3 writer tests (rebuild with declared SourceArn / OOB PrincipalOrgID dropped on remove op / guard refusal with no writes sent) + plan tests (both graduated types route to sdk; create-only path on a rebuild-writer type not barred). Core integration suite deferred — offline + live-proven above.

Closes #1714.
