### PR TITLE
fix(noise): fold CodeDeploy DeploymentGroup creation defaults (DeploymentStyle, DeploymentConfigName)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -654,6 +654,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // codedeploy-deploymentgroup-readgap). Equality-gated, so a switch to IGNORE
     // still surfaces.
     OutdatedInstancesStrategy: 'UPDATE',
+    // A group created without either property reads back the documented creation
+    // defaults (live-observed on a minimal ApplicationName+ServiceRoleArn group,
+    // Cdkrd1718Verify / #1722 — the corpus Group case declared both, which is why
+    // replay never caught the first-run FP). Equality-gated: an out-of-band switch
+    // to BLUE_GREEN / WITH_TRAFFIC_CONTROL or another deployment config re-surfaces.
+    DeploymentConfigName: 'CodeDeployDefault.OneAtATime',
+    DeploymentStyle: { DeploymentType: 'IN_PLACE', DeploymentOption: 'WITHOUT_TRAFFIC_CONTROL' },
   },
   'AWS::EFS::FileSystem': {
     ThroughputMode: 'bursting',

--- a/tests/noise-codedeploy-dg-defaults-1722.test.ts
+++ b/tests/noise-codedeploy-dg-defaults-1722.test.ts
@@ -1,0 +1,95 @@
+// #1722: two first-run FPs on a minimal AWS::CodeDeploy::DeploymentGroup (just
+// ApplicationName + ServiceRoleArn + a group name — the CDK L1 minimal shape). A group
+// that declares neither DeploymentStyle nor DeploymentConfigName reads back the
+// documented creation defaults, which surfaced as [Potential Drift] on a first check.
+// The corpus Group case declares BOTH leaves, which is why replay never caught it (the
+// #615-class apparent-coverage trap). Both are stable constants → tier-1 equality-gated
+// KNOWN_DEFAULTS, so an out-of-band switch (BLUE_GREEN / WITH_TRAFFIC_CONTROL, or a
+// different deployment config) still surfaces. Live-repro'd 2026-08-03 on
+// Cdkrd1718Verify (us-east-1) during PR #1721's verification; reproduced on the
+// released 0.24.0 binary too (pre-existing, not an enumerator artifact).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (findings: Finding[]) => findings.map((f) => `${f.tier}:${f.path}`).sort();
+
+// The minimal declared shape from the live repro (Cdkrd1718Verify's CdGroup).
+const group: DesiredResource = {
+  logicalId: 'CdGroup',
+  resourceType: 'AWS::CodeDeploy::DeploymentGroup',
+  physicalId: 'cdkrd1718-declared-dg',
+  declared: {
+    ApplicationName: 'cdkrd1718-cd-app',
+    DeploymentGroupName: 'cdkrd1718-declared-dg',
+    ServiceRoleArn: 'arn:aws:iam::111111111111:role/cdkrd1718-codedeploy-role',
+  },
+};
+
+const live = (style: Record<string, unknown>, configName: string) => ({
+  ApplicationName: 'cdkrd1718-cd-app',
+  DeploymentGroupName: 'cdkrd1718-declared-dg',
+  ServiceRoleArn: 'arn:aws:iam::111111111111:role/cdkrd1718-codedeploy-role',
+  DeploymentStyle: style,
+  DeploymentConfigName: configName,
+  OutdatedInstancesStrategy: 'UPDATE',
+  AutoScalingGroups: [],
+  Ec2TagFilters: [],
+  OnPremisesInstanceTagFilters: [],
+  ECSServices: [],
+  TerminationHookEnabled: false,
+});
+
+const DEFAULT_STYLE = {
+  DeploymentType: 'IN_PLACE',
+  DeploymentOption: 'WITHOUT_TRAFFIC_CONTROL',
+};
+
+describe('#1722 CodeDeploy DeploymentGroup first-run default folds', () => {
+  it('folds the undeclared creation defaults to atDefault (zero potential drift)', () => {
+    const f = classifyResource(
+      group,
+      live(DEFAULT_STYLE, 'CodeDeployDefault.OneAtATime'),
+      emptySchema
+    );
+    expect(tierPaths(f)).toEqual([
+      'atDefault:DeploymentConfigName',
+      'atDefault:DeploymentStyle',
+      'atDefault:OutdatedInstancesStrategy',
+    ]);
+  });
+
+  it('still surfaces an out-of-band deployment config change (equality-gated)', () => {
+    const f = classifyResource(
+      group,
+      live(DEFAULT_STYLE, 'CodeDeployDefault.AllAtOnce'),
+      emptySchema
+    );
+    expect(tierPaths(f)).toContain('undeclared:DeploymentConfigName');
+    expect(tierPaths(f)).not.toContain('undeclared:DeploymentStyle');
+  });
+
+  it('still surfaces an out-of-band BLUE_GREEN / WITH_TRAFFIC_CONTROL style (equality-gated)', () => {
+    const f = classifyResource(
+      group,
+      live(
+        { DeploymentType: 'BLUE_GREEN', DeploymentOption: 'WITH_TRAFFIC_CONTROL' },
+        'CodeDeployDefault.OneAtATime'
+      ),
+      emptySchema
+    );
+    expect(tierPaths(f)).toContain('undeclared:DeploymentStyle');
+    expect(tierPaths(f)).not.toContain('undeclared:DeploymentConfigName');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two first-run FPs on a minimal `AWS::CodeDeploy::DeploymentGroup` found during PR #1721's live verification: a group that declares neither `DeploymentStyle` nor `DeploymentConfigName` (the CDK L1 minimal shape) read back the documented creation defaults and surfaced both as `[Potential Drift]` on a first `check` — a fold gap per the core invariant.

Fold strategy: **tier 1, equality-gated constants** appended to the existing `KNOWN_DEFAULTS['AWS::CodeDeploy::DeploymentGroup']` entry (which already pinned `OutdatedInstancesStrategy`):

- `DeploymentConfigName` → `"CodeDeployDefault.OneAtATime"`
- `DeploymentStyle` → `{ DeploymentType: "IN_PLACE", DeploymentOption: "WITHOUT_TRAFFIC_CONTROL" }` (whole-object pin)

Detection is preserved: an out-of-band switch to `BLUE_GREEN` / `WITH_TRAFFIC_CONTROL` or a different deployment config no longer matches the pin and re-surfaces (asserted in the regression test).

## Why the corpus never caught it

The existing corpus case (`AWS__CodeDeploy__DeploymentGroup.Group.json`) declares BOTH leaves — the #615-class apparent-coverage trap. The regression test uses the minimal declared shape + the harvested live model from the live repro instead.

## Tests

- `tests/noise-codedeploy-dg-defaults-1722.test.ts` — full tier:path assertion on the first-run fold (zero potential drift; the three defaults classify `atDefault`), plus both equality-gate directions (config change and style change each re-surface as `undeclared`). Fails 3/3 without the fix, passes with it.
- Full suite: 327 files / 6277 tests green; typecheck / lint+format / build green.

## Live evidence

Live-repro'd 2026-08-03 on `Cdkrd1718Verify` (us-east-1, minimal `ApplicationName` + `ServiceRoleArn` + group name): both leaves surfaced on a first `check`, identically on the released 0.24.0 binary (pre-existing, not a #1721 enumerator artifact). The harvested live values are pinned in the regression test and recorded in the issue body.

Closes #1722
