### PR TITLE
fix(baseline): confirm added resources created after record via enumeratedParents child-scan marker

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -1217,6 +1217,20 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   is a latent FP for the new type's users. Related fixture trap: a verify.sh
   `drift_entries` grep must match ADDED-tier entry lines too (`<id> ▸ <label> (AWS::…)`,
   multi-token before the type) — a `^\s+\S+ \(AWS::` pattern silently passes them.
+- **Added-after-record is CONFIRMED drift since #1737 — assert exit 1 on an OOB-added
+  probe, and expect plain `revert --yes` to delete it.** Before #1737, an OOB child
+  created AFTER `record` surfaced only as `[Potential Drift]` (`check --fail` exit 0 —
+  the 2026-08-09 enumrev2-hunt's live find), so older verify scripts never asserted the
+  exit code on the added step. A post-#1737 probe MUST assert `check --fail` exits 1
+  and the output carries `appeared since record`; the delete then plans WITHOUT
+  `--remove-unrecorded` (the flag still gates unrecorded/pre-record inventory and the
+  #764 recorded-changed state). Note the marker is stamped at `record` time — a
+  baseline recorded by an older binary keeps the potential-only behavior.
+- **A backgrounded `verify.sh 2>&1 | tail` reports the PIPELINE's exit (tail's 0) — an
+  INTEG FAIL reads as success.** The 2026-08-09 hunt's first enumrev2 run "completed
+  exit 0" while the log said `INTEG FAIL`. Run background verifies as
+  `./verify.sh > log 2>&1; echo "EXIT=$?"` (capture the exit before any pipe) — the
+  same lesson as the tracker's un-piped verify/clear rule, now for verify scripts.
 - **A clean result IS a result — but it must still leave an asset.** "6 common+rich
   stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do
   NOT manufacture a fix to have something to show. The deliverable of a bug-free

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,11 +47,15 @@ un-deployed code edits would show as false "drift".
     `added` tier (CHILD_ENUMERATORS; API GW REST resources + methods + authorizers + models + request validators + gateway responses + stages, API GW V2 routes + integrations + authorizers + stages, SNS topic subs + topic access policies, Lambda ESMs + function URLs + aliases + versions + resource-policy statements, EventBridge bus rules, Cognito user pool clients + groups + resource servers, AppSync data sources + resolvers + functions, CloudWatch Logs metric filters + subscription filters, ELBv2 listeners, ELBv2 listener rules, EC2 VPC subnets, EC2 VPC endpoints, EC2 VPC route tables, EC2 VPC network ACLs, EC2 VPC security groups, EC2 VPC NAT gateways + flow logs, EC2 route table routes, EC2 network ACL entries, ECS cluster services, KMS key aliases + grants, AppConfig environments + configuration profiles, EFS mount targets, RDS DB cluster instances, Route53 hosted zone record sets, S3 bucket resource policies, SQS queue access policies, Secrets Manager secret resource policies, Cognito user pool hosted-UI domains, AutoScaling group scheduled actions + lifecycle hooks, Glue database tables, EC2 transit gateway attachments + route tables, GuardDuty detector filters + IP/threat/trusted sets + publishing destinations, SSM maintenance window targets + tasks, Application Auto Scaling scaling policies, CodeDeploy application deployment groups, Elastic Beanstalk application versions + configuration templates). Resource-granularity
     sibling of undeclared, reconciled against the baseline the same way: each added
     child is read in FULL (CC GetResource) + normalized, so `record` snapshots it and a
-    later CHANGE surfaces as drift; an UNRECORDED added resource is Not-Recorded
-    inventory (not drift), a recorded+unchanged one is suppressed (PR4). Not a
-    per-property compare, so it runs outside classify. Revertable by Cloud Control
-    DeleteResource, or an SDK_DELETERS per-type delete where CC lacks DELETE support
-    (AppSync ApiKey, #1386); an unrecorded one needs --remove-unrecorded.
+    later CHANGE surfaces as drift; a recorded+unchanged one is suppressed (PR4). An
+    entry-less added child under a parent whose child scan was recorded complete (the
+    baseline `enumeratedParents` marker, #1737) provably APPEARED after the record →
+    confirmed "appeared since record" drift (fails --fail); under any other parent it
+    is Not-Recorded inventory (not drift). Not a per-property compare, so it runs
+    outside classify. Revertable by Cloud Control DeleteResource, or an SDK_DELETERS
+    per-type delete where CC lacks DELETE support (AppSync ApiKey, #1386); an
+    unrecorded one needs --remove-unrecorded (a confirmed appeared one is drift, so
+    it deletes flaglessly).
 6. report + exit code (report-only by default; --fail → 1 on drift; --strict → 1 on incomplete coverage; 2 error)
 ```
 

--- a/README.md
+++ b/README.md
@@ -694,7 +694,8 @@ The table of every drift kind and its section label is up in
   in full as _potential_ (unconfirmed) drift and don't drive the `--fail` exit;
   `result:` points you at `cdkrd record` to accept them (or `revert` to remove).
   Once a resource is fully snapshotted, a value that _appears_ later is real drift
-  (`appeared since record`).
+  (`appeared since record`) — and the same applies to a whole out-of-band-created
+  child resource once its parent's child inventory is recorded.
 - **`↳` origin hint**: when a finding's live value has a recognizable external
   source — e.g. the CloudWatch Application Signals / Lambda Insights
   auto-instrumentation footprint (an added Insights layer + tracer execution

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -948,7 +948,8 @@ replace it — lives in [why-a-baseline-file.md](why-a-baseline-file.md).
   "recordedPhysicalIds": { "<logicalId>": "<physical id at record>", ... },
   "recordedSourceFingerprints":
     { "<logicalId>::<path>": "<declared-source hash>", ... },
-  "observedDefaults": [ { "logicalId", "resourceType", "path" }, ... ] }
+  "observedDefaults": [ { "logicalId", "resourceType", "path" }, ... ],
+  "enumeratedParents": [ { "logicalId", "resourceType" }, ... ] }
 ```
 
 `observedDefaults` (additive, optional — #1637) records the CURATED top-level paths
@@ -965,6 +966,25 @@ re-typed / read-gapped / since-declared resources all stay silent, mirroring the
 removed-since-record guards), carrying the pin as `desired` so `revert` re-adds the
 default. Curated, NOT blanket: CC read shapes fluctuate across handler versions, so
 tracking every atDefault path would false-flag handler churn as deletion.
+
+`enumeratedParents` (additive, optional — #1737) records the declared PARENTS whose
+child-enumerator scan completed at record time AND whose then-present out-of-band
+children were all endorsed into `recorded` — the child inventory was recorded
+COMPLETE. It exists because the per-entry mechanism above is keyed per template
+resource, so an `added` child (synthesized logicalId, never in the template) could
+never be confirmed "appeared since record": an OOB-created child after `record`
+read as potential-only and `check --fail` exited 0 — the added tier could never
+fail CI (live-proven: an OOB `register-task-with-maintenance-window` and
+`create-configuration-template` both stayed exit 0 against a fresh baseline).
+With the marker, an entry-less added child under a marked parent is CONFIRMED
+"appeared since record" drift; old baselines / unmarked parents keep the safe
+potential-only behavior. The marker is only stamped by a binary whose enumerator
+actually scanned the parent, so a cdkrd upgrade that ADDS an enumerator can never
+false-confirm children that pre-date the record (#764's endorsement contract), and
+a parent with a present-but-unendorsed child (the user declined the selective
+picker) is DEMOTED at write time (the #790 completeness-demotion mirror). NOT
+monotonic by design: a re-record whose scan failed drops the marker, falling back
+to potential-only.
 
 `recordedPhysicalIds` (additive, optional — #674) records the PHYSICAL id each
 recorded-OR-snapshot-`complete` resource was captured against, so a later deploy

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -120,6 +120,26 @@ export interface BaselineFile {
   // KNOWN_DEFAULTS pin as the restore value. Additive & OPTIONAL: old committed
   // baselines have none and keep today's behavior until the next `record` stamps it.
   observedDefaults?: ObservedDefaultEntry[];
+  // #1737: declared PARENTS whose child-enumerator scan completed at record time AND
+  // whose then-present out-of-band children were all endorsed into `recorded` — the
+  // child inventory was recorded COMPLETE. An `added` finding with NO recorded entry
+  // under such a parent provably APPEARED after the record, so applyBaseline keeps it
+  // as CONFIRMED "created out of band" drift (it fails `check --fail`) instead of
+  // potential-only inventory. Additive & OPTIONAL: old committed baselines have none,
+  // and a marker is only stamped by a binary whose enumerator actually scanned the
+  // parent — so a cdkrd upgrade that ADDS an enumerator can never false-confirm
+  // pre-existing children (#764's endorsement contract stays honored). NOT monotonic
+  // by design: a re-record whose scan failed (or where the user declined to endorse a
+  // present child) drops the marker, falling back to the safe potential-only behavior.
+  enumeratedParents?: EnumeratedParentEntry[];
+}
+
+// #1737: one `enumeratedParents` marker — the parent's template identity (the same
+// logicalId+resourceType pair the `added` finding carries as parentLogicalId /
+// parentResourceType).
+export interface EnumeratedParentEntry {
+  logicalId: string;
+  resourceType: string;
 }
 
 // #1048: the known top-level keys of a baseline file (the `BaselineFile` fields). Used to
@@ -137,6 +157,7 @@ const KNOWN_BASELINE_KEYS = new Set<string>([
   'recordedPhysicalIds',
   'recordedSourceFingerprints',
   'observedDefaults',
+  'enumeratedParents',
 ]);
 // #1048: the known keys of a `recorded` array element. A typo'd key (`Value`, `vaule`) whose
 // intended `value` is then ABSENT reads as recorded `undefined` — a confirmed-drift false
@@ -296,6 +317,7 @@ export async function loadBaseline(
   validateRecordedPhysicalIds(parsed.recordedPhysicalIds, path);
   validateRecordedSourceFingerprints(parsed.recordedSourceFingerprints, path);
   validateObservedDefaults(parsed.observedDefaults, path);
+  validateEnumeratedParents(parsed.enumeratedParents, path);
   return parsed;
 }
 
@@ -439,6 +461,32 @@ function validateObservedDefaults(value: unknown, path: string): void {
   });
 }
 
+/**
+ * #1737: validate `enumeratedParents` (optional). When present it must be an array of
+ * { logicalId, resourceType } string pairs with no unknown keys — same loud-vs-silent
+ * principle as validateObservedDefaults (a malformed marker would silently disable the
+ * appeared-since-record confirmation this field exists to drive).
+ */
+function validateEnumeratedParents(value: unknown, path: string): void {
+  if (value === undefined) return;
+  const at = `baseline file ${path}: \`enumeratedParents\``;
+  if (!Array.isArray(value))
+    throw new Error(`${at} must be an array of { logicalId, resourceType }`);
+  value.forEach((entry, i) => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry))
+      throw new Error(`${at}[${i}] must be an object { logicalId, resourceType }`);
+    const obj = entry as Record<string, unknown>;
+    for (const k of ['logicalId', 'resourceType'] as const)
+      if (typeof obj[k] !== 'string')
+        throw new Error(`${at}[${i}]: "${k}" is required and must be a string`);
+    const unknown = Object.keys(obj).filter((k) => k !== 'logicalId' && k !== 'resourceType');
+    if (unknown.length > 0)
+      throw new Error(
+        `${at}[${i}]: unknown key(s) ${unknown.map((k) => `"${k}"`).join(', ')} — known keys: "logicalId", "resourceType"`
+      );
+  });
+}
+
 /** Deterministic order for `recorded` entries: lexicographic by (logicalId, path).
  *  The single point where order is imposed — read/compare logic is order-independent,
  *  so this only affects the bytes on disk. Without it the entries inherit findings
@@ -527,6 +575,16 @@ export async function writeBaselineFile(b: BaselineFile): Promise<string> {
             (a, c) =>
               (a.logicalId < c.logicalId ? -1 : a.logicalId > c.logicalId ? 1 : 0) ||
               (a.path < c.path ? -1 : a.path > c.path ? 1 : 0)
+          ),
+        }
+      : {}),
+    // #1737: same byte-stability for the child-scan-complete parent markers.
+    ...(b.enumeratedParents && b.enumeratedParents.length > 0
+      ? {
+          enumeratedParents: [...b.enumeratedParents].sort(
+            (a, c) =>
+              (a.logicalId < c.logicalId ? -1 : a.logicalId > c.logicalId ? 1 : 0) ||
+              (a.resourceType < c.resourceType ? -1 : a.resourceType > c.resourceType ? 1 : 0)
           ),
         }
       : {}),
@@ -634,6 +692,12 @@ export async function writeBaseline(
     // source — letting a later legit code deploy void the stale hash instead of
     // false-surfacing it. Optional: an omitting caller keeps today's behavior.
     declaredByLogical?: Map<string, Record<string, unknown>> | undefined;
+    // #1737: parents whose child-enumerator scan completed this gather run (Desired's
+    // `childScanComplete`). Written as the baseline `enumeratedParents` marker after
+    // demoting any parent with a present-but-unendorsed added child (the #790 mirror:
+    // declining to record a child must not let it later false-confirm as "appeared").
+    // Optional: an omitting caller writes no marker (safe potential-only behavior).
+    enumeratedParents?: EnumeratedParentEntry[] | undefined;
   } = {}
 ): Promise<{ path: string; count: number }> {
   const allIds = opts.allLogicalIds ?? [
@@ -673,8 +737,44 @@ export async function writeBaseline(
     // #1637: persist the curated paths observed AT their AWS default this run, so a later
     // out-of-band DELETION of the whole value (it vanishes from the live read) surfaces.
     ...buildObservedDefaults(findings, opts.previous),
+    // #1737: persist the child-scan-complete parent markers, so a later check can confirm
+    // that an added child with no recorded entry APPEARED after this record.
+    ...buildEnumeratedParents(opts.enumeratedParents, findings, recorded),
   });
   return { path, count: recorded.length };
+}
+
+/**
+ * #1737: finalize the `enumeratedParents` marker for this record run. Seeds from the
+ * gather's scan-complete parents, then DEMOTES any parent that has an `added` finding
+ * this run whose entry is NOT in the final recorded set — the user (selective picker /
+ * drop flow) or the run itself (a model-read-failed child buildRecorded skips) declined
+ * to endorse a PRESENT child, so marking the parent complete would let that child later
+ * false-confirm as "appeared since record" (the #790 completeness-demotion mirror).
+ * Deterministic sort; `{}` (spread to nothing) when empty so old-shaped baselines stay
+ * byte-identical. Pure + exported for unit tests.
+ */
+export function buildEnumeratedParents(
+  candidates: EnumeratedParentEntry[] | undefined,
+  findings: Finding[],
+  recorded: RecordedEntry[]
+): { enumeratedParents?: EnumeratedParentEntry[] } {
+  if (!candidates || candidates.length === 0) return {};
+  const recordedKeys = new Set(recorded.map(recordedKey));
+  const blocked = new Set<string>();
+  for (const f of findings) {
+    if (f.tier !== 'added' || f.parentLogicalId === undefined) continue;
+    if (!recordedKeys.has(recordedKey({ logicalId: f.logicalId, path: f.path })))
+      blocked.add(`${f.parentLogicalId}\0${f.parentResourceType}`);
+  }
+  const out = candidates
+    .filter((p) => !blocked.has(`${p.logicalId}\0${p.resourceType}`))
+    .sort(
+      (a, c) =>
+        (a.logicalId < c.logicalId ? -1 : a.logicalId > c.logicalId ? 1 : 0) ||
+        (a.resourceType < c.resourceType ? -1 : a.resourceType > c.resourceType ? 1 : 0)
+    );
+  return out.length > 0 ? { enumeratedParents: out } : {};
 }
 
 /**
@@ -1500,6 +1600,7 @@ export function applyBaseline(
     );
   const recorded = baseline.recorded;
   const complete = new Set(baseline.completeResources ?? []); // v1 file: nothing complete
+  const enumeratedParents = baseline.enumeratedParents ?? []; // pre-#1737 file: no confirms
   const kept: Finding[] = [];
   // #675: current template's logical-id set (optional). Recorded entries for a logicalId
   // NOT in it belong to a resource removed from the template — folded, never surfaced.
@@ -1571,10 +1672,12 @@ export function applyBaseline(
     // the WHOLE resource (path ''), not a property. A matching entry whose value is equal
     // is suppressed; a recorded value that CHANGED stays `added` drift with a "changed
     // since record" note + the baseline value on `desired` (so the report shows it); a
-    // resource with NO entry is unrecorded inventory (not drift). The completeResources /
-    // "appeared since record" mechanism is undeclared-only (it is keyed per template
-    // resource, and an added child has a synthesized id that never enters allLogicalIds),
-    // so a newly-appeared added resource is simply unrecorded until the user records it.
+    // resource with NO entry is unrecorded inventory (not drift) — UNLESS its parent
+    // carries the #1737 `enumeratedParents` marker (its child inventory was recorded
+    // complete), in which case the child provably APPEARED after the record and is
+    // confirmed drift. The completeResources mechanism itself stays undeclared-only (it
+    // is keyed per template resource, and an added child has a synthesized id that never
+    // enters allLogicalIds) — the marker is its added-tier, per-PARENT sibling.
     if (f.tier === 'added') {
       const entry = recorded.find((a) => entryMatches(a, f));
       // PR4: the full model could not be read this run — `actual` is only the identity
@@ -1592,6 +1695,26 @@ export function applyBaseline(
           ...f,
           desired: canonicalizeForCompare(entry.value, f.resourceType),
           note: f.note ? `${f.note}; changed since record` : 'changed since record',
+        });
+        continue;
+      }
+      // #1737: the parent's child inventory was recorded COMPLETE (`enumeratedParents`
+      // marker: its enumerator ran at record time and every then-present out-of-band
+      // child was endorsed), so a live child with NO entry provably APPEARED after the
+      // record — CONFIRMED drift (it fails `check --fail`), not undecided inventory.
+      // Old baselines (no marker) and unmarked parents keep the safe potential-only
+      // behavior below; the marker is only stamped by a binary whose enumerator actually
+      // scanned the parent, so a cdkrd upgrade that ADDS an enumerator can never
+      // false-confirm children that pre-date the record (#764 stays honored).
+      if (
+        f.parentLogicalId !== undefined &&
+        enumeratedParents.some(
+          (ep) => ep.logicalId === f.parentLogicalId && ep.resourceType === f.parentResourceType
+        )
+      ) {
+        kept.push({
+          ...f,
+          note: f.note ? `${f.note}; appeared since record` : 'appeared since record',
         });
         continue;
       }

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -435,6 +435,11 @@ export function addedFinding(
     physicalId: c.identifier,
     constructPath: `${parent.constructPath ?? parent.logicalId} ▸ ${c.label}`,
     resourceType: c.resourceType,
+    // #1737: explicit parent identity, so applyBaseline can match the finding against the
+    // baseline's `enumeratedParents` marker (appeared-since-record confirmation) without
+    // re-splitting the synthesized logicalId.
+    parentLogicalId: parent.logicalId,
+    parentResourceType: parent.resourceType,
     path: '',
     actual: read.model,
     note: read.ok
@@ -2039,6 +2044,10 @@ export async function gatherFindings(
   // Cross-region escalation for GLOBAL-service children (Route53 RecordSet, #1651): built lazily,
   // its enabled-region list + per-region clients/caches memoized for the whole run.
   const crossRegionProbe = makeCrossRegionSiblingProbe(desired.accountId, region);
+  // #1737: parents whose child scan COMPLETED this run — post-assigned onto `desired`
+  // below so `record` can write the baseline `enumeratedParents` marker (which is what
+  // lets a later check confirm a child with no entry APPEARED after the record).
+  const childScanComplete: { logicalId: string; resourceType: string }[] = [];
   for (const r of desired.resources) {
     const enumerate = CHILD_ENUMERATORS[r.resourceType];
     if (!enumerate || !r.physicalId) continue;
@@ -2097,6 +2106,10 @@ export async function gatherFindings(
         );
         findings.push(addedFinding(r, c, read));
       }
+      // The scan ran to completion — every live child of this parent is now either a
+      // declared match, a sibling-managed skip, or an emitted `added` finding, so the
+      // inventory is decidably COMPLETE for this run (#1737).
+      childScanComplete.push({ logicalId: r.logicalId, resourceType: r.resourceType });
     } catch (e) {
       findings.push({
         tier: 'skipped',
@@ -2107,6 +2120,7 @@ export async function gatherFindings(
       });
     }
   }
+  desired.childScanComplete = childScanComplete;
 
   // KMS managed-alias resolution (R9): only if the stack declares any `alias/aws/*`,
   // fetch alias -> target key id once so classify can tell a managed-default key from

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -743,6 +743,10 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
       allLogicalIds: desired.resources.map((r) => r.logicalId),
       previous: existing,
       physicalIdByLogical: physicalIdsByLogical(desired.resources),
+      // #1737: parents whose child scan completed this gather run — written as the
+      // baseline `enumeratedParents` marker (after writeBaseline's unendorsed-child
+      // demotion), enabling appeared-since-record confirmation for added children.
+      enumeratedParents: desired.childScanComplete,
       // declared models so the recordable-generated content hashes (Lambda CodeSha256,
       // Glue ScriptSha256) are stamped with their declared-source fingerprint — a later
       // legit code deploy then voids the stale hash instead of false-surfacing it.

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -35,6 +35,13 @@ export interface Desired {
   // but results may be unreliable — check prints this). REVIEW_IN_PROGRESS / deleting
   // states never reach here: loadDesired throws StackNotCheckableError for those.
   stackStatusWarning?: string | undefined;
+  // #1737: declared parents whose child-enumerator scan COMPLETED this gather run (type
+  // in CHILD_ENUMERATORS, parent read live, enumerate() returned without throwing).
+  // Post-assigned by gather (like stackTags — run-state metadata riding Desired so the
+  // record path can reach it without new plumbing): `record` writes these as the
+  // baseline `enumeratedParents` marker, which is what lets a LATER check confirm that
+  // a live child with no recorded entry under such a parent appeared after the record.
+  childScanComplete?: { logicalId: string; resourceType: string }[];
 }
 
 /** Parse a deployed template body (JSON or CFn-flavored YAML). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,15 @@ export interface Finding {
   // "changed since record" off the degraded snippet (it suppresses a recorded one until
   // a clean read, like a transiently-skipped resource). Self-heals on the next check.
   modelReadFailed?: boolean;
+  // added tier only (#1737): the DECLARED parent this out-of-band child was enumerated
+  // under (the CHILD_ENUMERATORS key resource). applyBaseline matches these against the
+  // baseline's `enumeratedParents` marker to decide whether a child with no recorded
+  // entry provably APPEARED after the record (the parent's child inventory was recorded
+  // complete) — confirmed drift — or is undecided inventory (potential only). Explicit
+  // fields rather than splitting the synthesized `logicalId` (whose child-identifier
+  // half may itself contain separators).
+  parentLogicalId?: string | undefined;
+  parentResourceType?: string | undefined;
   // readGap tier only (#1582): the readGap is a DECLARED WRITE-ONLY property (expectedly
   // unreadable), NOT a genuine coverage gap in the readable model. Unlike a real readGap it
   // must NOT disqualify the resource from `completeResources` — the undeclared readable model

--- a/tests/baseline-added-appeared-1737.test.ts
+++ b/tests/baseline-added-appeared-1737.test.ts
@@ -1,0 +1,159 @@
+// #1737: an added resource created AFTER `record` surfaced only as potential drift —
+// `check --fail` exited 0 on an OOB-created child (live-hit 2026-08-09 enumrev2-hunt: an
+// OOB register-task-with-maintenance-window and create-configuration-template both read
+// "no confirmed drift · 2 potential drift"), so the added tier could NEVER fail CI. The
+// fix records a per-parent child-scan-complete marker (`enumeratedParents`) at record
+// time; applyBaseline then CONFIRMS an entry-less added child under a marked parent as
+// "appeared since record" drift. Old baselines / unmarked parents keep the safe
+// potential-only behavior, and the destructive delete gate (revert) is unchanged.
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyBaseline,
+  buildEnumeratedParents,
+  type BaselineFile,
+} from '../src/baseline/baseline-file.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding } from '../src/types.js';
+
+const PARENT_TYPE = 'AWS::SSM::MaintenanceWindow';
+const CHILD_TYPE = 'AWS::SSM::MaintenanceWindowTask';
+
+function baseline(overrides: Partial<BaselineFile> = {}): BaselineFile {
+  return {
+    schemaVersion: 2,
+    stackName: 's',
+    region: 'r',
+    accountId: '111122223333',
+    capturedAt: '',
+    templateHash: '',
+    recorded: [],
+    completeResources: ['Window'],
+    enumeratedParents: [{ logicalId: 'Window', resourceType: PARENT_TYPE }],
+    ...overrides,
+  };
+}
+
+function addedChild(overrides: Partial<Finding> = {}): Finding {
+  return {
+    tier: 'added',
+    logicalId: 'Window/mw-1|task-1',
+    physicalId: 'mw-1|task-1',
+    resourceType: CHILD_TYPE,
+    parentLogicalId: 'Window',
+    parentResourceType: PARENT_TYPE,
+    path: '',
+    actual: { WindowId: 'mw-1', WindowTaskId: 'task-1', TaskArn: 'AWS-RunShellScript' },
+    note: 'created out of band — not in your CloudFormation template',
+    ...overrides,
+  };
+}
+
+describe('#1737 applyBaseline: appeared-since-record confirmation for added children', () => {
+  it('confirms an entry-less added child under a marked parent (fails --fail)', () => {
+    const out = applyBaseline([addedChild()], baseline(), {});
+    expect(out).toHaveLength(1);
+    expect(out[0]!.unrecorded).toBeUndefined();
+    expect(out[0]!.note).toContain('appeared since record');
+  });
+
+  it('keeps potential-only behavior for an UNMARKED parent', () => {
+    const out = applyBaseline([addedChild()], baseline({ enumeratedParents: [] }), {});
+    expect(out[0]!.unrecorded).toBe(true);
+    expect(out[0]!.note).not.toContain('appeared since record');
+  });
+
+  it('keeps potential-only behavior for a pre-#1737 baseline (no section)', () => {
+    const out = applyBaseline([addedChild()], baseline({ enumeratedParents: undefined }), {});
+    expect(out[0]!.unrecorded).toBe(true);
+  });
+
+  it('never confirms on a parent-TYPE mismatch (#793 twin)', () => {
+    const out = applyBaseline(
+      [addedChild({ parentResourceType: 'AWS::CodeDeploy::Application' })],
+      baseline(),
+      {}
+    );
+    expect(out[0]!.unrecorded).toBe(true);
+  });
+
+  it('never confirms a degraded (modelReadFailed) child', () => {
+    const out = applyBaseline([addedChild({ modelReadFailed: true })], baseline(), {});
+    expect(out[0]!.unrecorded).toBe(true);
+    expect(out[0]!.note).not.toContain('appeared since record');
+  });
+
+  it('a recorded, unchanged added child stays suppressed', () => {
+    const f = addedChild();
+    const out = applyBaseline(
+      [f],
+      baseline({
+        recorded: [{ logicalId: f.logicalId, resourceType: CHILD_TYPE, path: '', value: f.actual }],
+      }),
+      {}
+    );
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('#1737 buildEnumeratedParents (record-time capture + #790-mirror demotion)', () => {
+  const candidates = [
+    { logicalId: 'Window', resourceType: PARENT_TYPE },
+    { logicalId: 'EbApp', resourceType: 'AWS::ElasticBeanstalk::Application' },
+  ];
+
+  it('keeps a parent whose present added children were all endorsed', () => {
+    const f = addedChild();
+    const out = buildEnumeratedParents(
+      candidates,
+      [f],
+      [{ logicalId: f.logicalId, resourceType: CHILD_TYPE, path: '', value: f.actual }]
+    );
+    expect(out.enumeratedParents).toEqual([
+      { logicalId: 'EbApp', resourceType: 'AWS::ElasticBeanstalk::Application' },
+      { logicalId: 'Window', resourceType: PARENT_TYPE },
+    ]);
+  });
+
+  it('DEMOTES a parent with a present-but-unendorsed added child', () => {
+    const out = buildEnumeratedParents(candidates, [addedChild()], []);
+    expect(out.enumeratedParents).toEqual([
+      { logicalId: 'EbApp', resourceType: 'AWS::ElasticBeanstalk::Application' },
+    ]);
+  });
+
+  it('DEMOTES a parent whose added child was model-read-degraded (buildRecorded skips it)', () => {
+    // a modelReadFailed child never enters `recorded`, so the demotion falls out of the
+    // same entry-less test — asserted explicitly so the invariant is pinned.
+    const out = buildEnumeratedParents(candidates, [addedChild({ modelReadFailed: true })], []);
+    expect(out.enumeratedParents).toEqual([
+      { logicalId: 'EbApp', resourceType: 'AWS::ElasticBeanstalk::Application' },
+    ]);
+  });
+
+  it('spreads to nothing when no candidates', () => {
+    expect(buildEnumeratedParents(undefined, [], [])).toEqual({});
+    expect(buildEnumeratedParents([], [], [])).toEqual({});
+  });
+});
+
+describe('#1737 revert: a confirmed appeared-since-record added is drift, so it deletes flaglessly', () => {
+  // The --remove-unrecorded gates protect UNDECIDED inventory (unrecorded) and
+  // previously-ENDORSED resources (#764 recorded-changed). A confirmed appeared child is
+  // neither — it is drift against the recorded contract, so it flows into the plain
+  // delete-kind plan exactly like the long-pinned bare-added contract in revert-plan.test.ts.
+  it('plans the delete without --remove-unrecorded', () => {
+    const confirmed = applyBaseline([addedChild()], baseline(), {})[0]!;
+    const plan = buildRevertPlan([confirmed], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('delete');
+    expect(plan.items[0]!.physicalId).toBe('mw-1|task-1');
+  });
+
+  it('an UNRECORDED added (unmarked parent) still refuses without --remove-unrecorded', () => {
+    const potential = applyBaseline([addedChild()], baseline({ enumeratedParents: [] }), {})[0]!;
+    const plan = buildRevertPlan([potential], undefined);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable.some((n) => n.reason.includes('unrecorded'))).toBe(true);
+  });
+});

--- a/tests/integration/enumrev2-hunt/app.ts
+++ b/tests/integration/enumrev2-hunt/app.ts
@@ -1,0 +1,73 @@
+// CDK app for the cdk-real-drift enumrev2-hunt integration test (2026-08-09 hunt).
+// Completes the added->revert(DELETE) proof for the #1720/#1721 child-enumerator
+// family: the 2026-08-03 enum-added2-hunt proved the delete-kind plan path live for
+// MaintenanceWindowTarget / CodeDeploy DeploymentGroup / EB ApplicationVersion /
+// AppAutoScaling ScalingPolicy / GuardDuty Filter, but NOT for the two remaining
+// child types with distinct CC delete handlers:
+//   - AWS::SSM::MaintenanceWindowTask       (OOB register-task-with-maintenance-window)
+//   - AWS::ElasticBeanstalk::ConfigurationTemplate (OOB create-configuration-template)
+// Each parent carries one DECLARED child of the same type so the "declared children
+// are NOT flagged" half re-runs too. A first check (pre-record) must be CLEAN.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnApplication as CfnEbApplication,
+  CfnConfigurationTemplate,
+} from "aws-cdk-lib/aws-elasticbeanstalk";
+import {
+  CfnMaintenanceWindow,
+  CfnMaintenanceWindowTarget,
+  CfnMaintenanceWindowTask,
+} from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+
+// Solution stack names rot as platforms retire; verify.sh resolves the current
+// Docker/AL2023 one at run time and threads it in via `-c ss=...`.
+const solutionStack =
+  (app.node.tryGetContext("ss") as string | undefined) ??
+  "64bit Amazon Linux 2023 v4.13.3 running Docker";
+
+const stack = new Stack(app, "CdkrdHuntEnumRev0809");
+
+// ── SSM MaintenanceWindow + declared Target + declared Task ────────────────
+const window = new CfnMaintenanceWindow(stack, "Window", {
+  name: "cdkrd-hunt-mw-0809b",
+  allowUnassociatedTargets: false,
+  cutoff: 1,
+  duration: 2,
+  schedule: "rate(7 days)",
+});
+const target = new CfnMaintenanceWindowTarget(stack, "Target", {
+  windowId: window.ref,
+  resourceType: "INSTANCE",
+  targets: [{ key: "tag:cdkrd", values: ["hunt-0809b"] }],
+});
+new CfnMaintenanceWindowTask(stack, "Task", {
+  windowId: window.ref,
+  taskType: "RUN_COMMAND",
+  taskArn: "AWS-RunShellScript",
+  priority: 1,
+  targets: [{ key: "WindowTargetIds", values: [target.ref] }],
+  maxConcurrency: "1",
+  maxErrors: "1",
+});
+
+// ── Elastic Beanstalk Application + declared ConfigurationTemplate ─────────
+const ebApp = new CfnEbApplication(stack, "EbApp", {
+  applicationName: "cdkrd-hunt-eb-0809b",
+});
+const ebTemplate = new CfnConfigurationTemplate(stack, "EbTemplate", {
+  applicationName: ebApp.applicationName!,
+  solutionStackName: solutionStack,
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "SingleInstance",
+    },
+  ],
+});
+ebTemplate.addDependency(ebApp);
+
+app.synth();

--- a/tests/integration/enumrev2-hunt/cdk.json
+++ b/tests/integration/enumrev2-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/enumrev2-hunt/package.json
+++ b/tests/integration/enumrev2-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-enumrev2-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift enumrev2-hunt integration test (MW Task + EB ConfigurationTemplate added->revert-delete). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/enumrev2-hunt/verify.sh
+++ b/tests/integration/enumrev2-hunt/verify.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# enumrev2-hunt (2026-08-09): added->revert(DELETE) proof for the two child types
+# the 2026-08-03 run left unproven (distinct CC delete handlers):
+#   - AWS::SSM::MaintenanceWindowTask            (OOB register-task)
+#   - AWS::ElasticBeanstalk::ConfigurationTemplate (OOB create-configuration-template)
+# deploy -> first check CLEAN -> record -> OOB-add both -> check surfaces both as
+# added -> revert --remove-unrecorded deletes both (live-verified GONE) -> CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHuntEnumRev0809
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+EB_APP=cdkrd-hunt-eb-0809b
+OOB_TASK_ID=""
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  if [ -n "$OOB_TASK_ID" ] && [ -n "${WINDOW_ID:-}" ]; then
+    aws ssm deregister-task-from-maintenance-window --window-id "$WINDOW_ID" --window-task-id "$OOB_TASK_ID" --region "$REGION" >/dev/null 2>&1 || true
+  fi
+  aws elasticbeanstalk delete-configuration-template --application-name "$EB_APP" --template-name cdkrd-oob-tmpl --region "$REGION" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+drift_entries() {
+  sed -n '/\[Potential Drift/,/^──/p' "$1" | grep -E '^\s+\S+.* \(AWS::' || true
+}
+
+SS="$(aws elasticbeanstalk list-available-solution-stacks --region "$REGION" \
+  --query "SolutionStacks[?contains(@,'Amazon Linux 2023') && contains(@,'running Docker')]|[0]" --output text)"
+[ -n "$SS" ] && [ "$SS" != "None" ] || fail "could not resolve a Docker/AL2023 solution stack"
+echo "solution stack: $SS"
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" -c "ss=$SS" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] FIRST check (pre-record) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR_OVERRIDE:-/tmp/corpus-enumrev2-hunt}" $CLI check "$STACK" --region "$REGION" -c "ss=$SS" | tee "/tmp/cdkrd-$STACK.first.out"
+[ -z "$(drift_entries "/tmp/cdkrd-$STACK.first.out")" ] || { drift_entries "/tmp/cdkrd-$STACK.first.out"; fail "first check surfaced [Potential Drift] entries (fold gap)"; }
+
+echo "=== [$STACK] record + check MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" -c "ss=$SS" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" -c "ss=$SS" --fail || fail "expected CLEAN after record"
+
+WINDOW_ID=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::SSM::MaintenanceWindow'].PhysicalResourceId|[0]" --output text)
+DECLARED_TARGET_ID=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::SSM::MaintenanceWindowTarget'].PhysicalResourceId|[0]" --output text)
+
+echo "=== [$STACK] OOB-add: register-task + create-configuration-template ==="
+OOB_TASK_ID=$(aws ssm register-task-with-maintenance-window --window-id "$WINDOW_ID" \
+  --task-arn AWS-RunShellScript --task-type RUN_COMMAND \
+  --targets "Key=WindowTargetIds,Values=$DECLARED_TARGET_ID" \
+  --priority 2 --max-concurrency 1 --max-errors 1 --region "$REGION" \
+  --query 'WindowTaskId' --output text) || fail "oob register-task"
+aws elasticbeanstalk create-configuration-template --application-name "$EB_APP" \
+  --template-name cdkrd-oob-tmpl --solution-stack-name "$SS" --region "$REGION" >/dev/null || fail "oob create-configuration-template"
+
+echo "=== [$STACK] check MUST surface both OOB children as added ==="
+$CLI check "$STACK" --region "$REGION" -c "ss=$SS" --fail | tee "/tmp/cdkrd-$STACK.oob.out"
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "check did not fail with OOB children present"
+grep -q "$OOB_TASK_ID" "/tmp/cdkrd-$STACK.oob.out" || fail "OOB MaintenanceWindowTask not surfaced as added"
+grep -q "cdkrd-oob-tmpl" "/tmp/cdkrd-$STACK.oob.out" || fail "OOB EB ConfigurationTemplate not surfaced as added"
+# #1737: post-record OOB children must be CONFIRMED (appeared since record), not potential
+grep -q "appeared since record" "/tmp/cdkrd-$STACK.oob.out" || fail "OOB children not confirmed as appeared-since-record"
+
+echo "=== [$STACK] plain revert (no --remove-unrecorded) MUST delete both CONFIRMED OOB children ==="
+# #1737: appeared-since-record children are confirmed drift, so the delete plans flaglessly
+$CLI revert "$STACK" --region "$REGION" -c "ss=$SS" --yes | tee "/tmp/cdkrd-$STACK.revert.out"
+grep -qiE "NOT reverted|could not be confirmed|drift\(s\) remain" "/tmp/cdkrd-$STACK.revert.out" && fail "revert reported non-convergence deleting OOB children"
+aws ssm describe-maintenance-window-tasks --window-id "$WINDOW_ID" --region "$REGION" \
+  --query "Tasks[?WindowTaskId=='$OOB_TASK_ID']" --output text | grep -q . && fail "OOB task still exists after revert"
+aws elasticbeanstalk describe-applications --application-names "$EB_APP" --region "$REGION" \
+  --query 'Applications[0].ConfigurationTemplates' --output text | grep -q "cdkrd-oob-tmpl" && fail "OOB configuration template still exists after revert"
+OOB_TASK_ID="" # deleted by revert — cleanup must not re-try
+$CLI check "$STACK" --region "$REGION" -c "ss=$SS" --fail || fail "expected CLEAN after revert-deleting OOB children"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

2026-08-09 hunt (second sweep) find #2: with a FRESH baseline, an **out-of-band-CREATED child resource never became confirmed drift** — `check --fail` exited 0. Live repro (`CdkrdHuntEnumRev0809`, us-east-1): after `record`, an OOB `ssm register-task-with-maintenance-window` (an arbitrary-command execution surface) and an OOB `elasticbeanstalk create-configuration-template` both surfaced as `result: no confirmed drift · 2 potential drift`, exit 0. So the added tier could NEVER fail CI — contradicting the security motivation of the child enumerators themselves (#1713/#1718).

Root cause (documented in the old added-reconcile comment): the `completeResources` / appeared-since-record mechanism is undeclared-only — an added child's synthesized logicalId never enters `allLogicalIds`, so the baseline could not distinguish "appeared after record" from "this parent's children were never scanned at record time" (e.g. a baseline recorded by an older binary without that enumerator — #764's endorsement contract).

## Fix — a per-parent child-scan-complete marker

- **`BaselineFile.enumeratedParents`** (additive, optional — the #1637 `observedDefaults` precedent): parents whose child-enumerator scan COMPLETED at record time AND whose then-present out-of-band children were all endorsed into `recorded`. Stamped only by a binary whose enumerator actually scanned the parent → a cdkrd upgrade that ADDS an enumerator can never false-confirm pre-existing children (#764 honored). A present-but-unendorsed child (selective picker decline / model-read-failed) DEMOTES its parent at write time (the #790 completeness-demotion mirror). NOT monotonic by design (a failed scan drops the marker → safe potential-only fallback). Loud-validated like every baseline section (#1048/#794 principle).
- **gather**: `addedFinding` now carries explicit `parentLogicalId`/`parentResourceType`; the scan-complete list rides `Desired.childScanComplete` (the `stackTags` post-assign precedent — no new plumbing through every recordStack caller).
- **applyBaseline**: an entry-less added child under a marked parent is CONFIRMED `appeared since record` drift (fails `--fail`); unmarked parents / old baselines keep today's potential-only behavior.
- **revert**: a confirmed appeared child deletes via **plain `revert --yes`** — the long-pinned bare-added contract (`revert-plan.test.ts`); the `--remove-unrecorded` gates keep protecting UNDECIDED inventory and #764 recorded-changed (endorsed) resources. No plan.ts change.

## Tests + fixture

- `tests/baseline-added-appeared-1737.test.ts` — 12 units: confirm/unmarked/old-baseline/type-mismatch/degraded-read/recorded-suppressed apply paths; buildEnumeratedParents demotion + determinism; flagless delete + unrecorded still gated.
- `tests/integration/enumrev2-hunt/` — live E2E, INTEG PASS: deploy (MW + Target + Task, EB App + ConfigTemplate declared; first check CLEAN) → record → OOB task + template → `check --fail` **exits 1** with `appeared since record` → plain `revert --yes` deletes both (live-verified GONE) → CLEAN. This also completes the #1720/#1721 added→revert-DELETE family proof for the two child types the 2026-08-03 run left unproven (MaintenanceWindowTask, EB ConfigurationTemplate).
- Docs: DESIGN.md 5b, ARCHITECTURE.md baseline schema + new section paragraph, README potential-drift note; the stale in-code design comment updated.
- hunt-bugs SKILL.md: two new gotchas (post-#1737 exit-code assert for OOB-added probes; the backgrounded `verify.sh | tail` exit-masking trap that bit this hunt's first run).

## Verification

- typecheck / lint+format / build / `vp test run` (337 files, 6366 tests) green; markers check/docs/verify-pr set.
- Shared CORE integ suite **deferred** — the diff is unit-covered and live-proven end-to-end by this PR's own fixture run (per the verify-pr deferral rule).
- Old-baseline compatibility: pre-#1737 files load unchanged (optional key; loud-reject applies only to malformed content). A baseline written by THIS binary is loud-rejected by OLDER binaries — the accepted #1606 tradeoff, same as `observedDefaults`.
- Stacks torn down; SWEEP CLEAN; bughunt gate released.

Closes #1737
