### PR TITLE
fix(hunt): 2026-08-10 sweep — writer-proof pack (3 revert bugs), ECS DAEMON folds, RDS mixed-case Engine/Family, RecordSetGroup added-FP, EB LB sg-id gate

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -469,6 +469,24 @@ an LB-attached fixture would be needed. And a REVERT-DELETE flavor: an `added`
 as an `SDK_DELETERS` entry splitting the enumerator identifier `db|table` (#1724);
 when an added-child revert fails this way, prefer the #1431 SDK-deleter route over
 the honest-notRevertable set whenever the service has a one-call delete.
+Batch 13 (2026-08-10 hunt, the "writer-proof pack"): the Round-0 offline audit found
+the READ side fully corpus-exercised but ~10 SDK writers/deleters that had NEVER run
+live — one nearly-free stack (`wrtpack-hunt`) mutate→detect→revert→live-assert'd all
+of them at once and found THREE revert bugs in one run: **Budgets `writeBudget`
+crashed on a template-declared NUMERIC `BudgetLimit.Amount`** (the CFn schema allows
+a number, the API models Spend.Amount as a STRING → SerializationException; #1744 —
+when writing a writer, check every CFn-numeric/API-string field, the Spend shape
+recurs); **an UNDECLARED ELB attribute-bag element (`TargetGroupAttributes[key]`)
+was pre-barred by the generic nested-array-element gate** before the per-key prop
+writer could take it (#1745 — when a "not revertable" reason fires on a path a
+writer COULD serve, check the bar's ordering before accepting it); and **ECS DAEMON
+`DeploymentConfiguration` remove was REJECTED outright** because the CC
+read-modify-write model still carried the ECS-managed `DesiredCount` echo ("daemon
+scheduling strategy does not support a desired count") — the #1710
+companion-removes flavor, fixed with a derived whole-object explicit `add` + an
+`AWS::ECS::Service\0DeploymentConfiguration` companion entry (#1740). The audit
+shape ("which writers have zero live evidence?") is repeatable and cheap — re-run it
+whenever a few new writers have accumulated.
 Piggyback the convergence
 probe on every NEW KNOWN_DEFAULTS fold a hunt ships (mutate → revert → re-read) —
 it is ~1-in-3 to need an RSDP entry, and the probe is nearly free while the stack
@@ -986,6 +1004,26 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   lines inside the block** (`sed -n '/\[Potential Drift/,/^──/p' | grep -E '^\s+\S+ \(AWS::'`),
   or a fully-clean-but-for-the-allowed-entry run false-fails on the header (hit on
   elbpack-hunt 2026-08-01).
+- **A detect-assert grep needle must target the finding PATH line, not a nested value
+  key — long `actual =` values are TRUNCATED with `…` in the report.** A DAEMON band
+  change surfaced as the whole `DeploymentConfiguration` object whose JSON was cut
+  right before `MinimumHealthyPercent`, so `grep MinimumHealthyPercent` false-failed a
+  successful detection (variants6-hunt 2026-08-10). Grep `Logical.Prop` instead.
+- **Never relaunch a verify.sh while the previous instance's cleanup trap is still
+  running.** The old trap's `delstack` + `rm -rf cdk.out` race the new run two ways:
+  the fresh `cdk.out` is deleted mid-deploy (ENOENT on the template asset), or the
+  new deploy hits `DELETE_IN_PROGRESS state and can not be updated`. Both hit on
+  2026-08-10; wait for the old PROCESS to exit AND `describe-stacks` to 404 before
+  relaunching.
+- **Cognito Sync is closed to new customers** (`SetCognitoEvents` →
+  NotAuthorizedException "no longer accepting new customers"), so the IdentityPool
+  `CognitoEvents` prop writer AND its drift are unreachable from current accounts —
+  determination recorded in wrtpack-hunt; don't re-probe. Same family of service-side
+  closures as S3 Object Lambda / QLDB in the missing-type audit.
+- **A Cloud Map Service in an HTTP namespace is API-ONLY and cannot be updated**
+  ("Service in API-only namespace cannot be updated") — an UpdateService writer
+  probe needs a DNS-namespace service (PrivateDnsNamespace + DnsConfig), and the
+  update JSON must re-include DnsConfig or it is deleted (wrtpack-hunt 2026-08-10).
 - **A NEW all-boolean pin family can arrive via a READER-projection fix — re-run the
   off-flip audit over the diff window, not just the historical tables.** The #1658
   Budgets reader fix (projecting the full 11-boolean `CostTypes`) necessarily added a

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -143,6 +143,67 @@ const DEFAULT_SUBNET_LIST_TYPES: ReadonlySet<string> = new Set([
 // ANY error — missing ec2:DescribeSecurityGroups, throttle, network) so classify keeps folding the
 // undeclared SG list and a clean deploy never gains a first-run false positive. The derived
 // swap/append detection is therefore best-effort and requires ec2:DescribeSecurityGroups.
+// #1746: resolve the raw sg-ids an EB Environment's SecurityGroups options echo (the
+// environment's own generated LB / instance security group) to their GroupNames, so the
+// classify gate can run the ANCHORED generated-name shapes against them. Collected from
+// the LIVE models (the echo is live-only by definition); one DescribeSecurityGroups call
+// filtered by group-id (tolerant of already-deleted ids, unlike the GroupIds parameter).
+// Returns undefined on ANY error — classify then SURFACES the raw-id element (fail-closed:
+// folding an arbitrary sg-id would resurrect the #1264 rogue-SG-hiding bug).
+const EB_SG_OPTION_KEYS = new Set([
+  'aws:elb:loadbalancer|SecurityGroups',
+  'aws:autoscaling:launchconfiguration|SecurityGroups',
+]);
+export function collectEbSecurityGroupIds(
+  resources: readonly { logicalId: string; resourceType: string }[],
+  liveById: ReadonlyMap<string, Record<string, unknown>>
+): string[] {
+  const ids = new Set<string>();
+  for (const r of resources) {
+    if (r.resourceType !== 'AWS::ElasticBeanstalk::Environment') continue;
+    const live = liveById.get(r.logicalId);
+    if (!live) continue;
+    const settings = live.OptionSettings;
+    if (!Array.isArray(settings)) continue;
+    for (const s of settings) {
+      if (!s || typeof s !== 'object') continue;
+      const e = s as Record<string, unknown>;
+      if (!EB_SG_OPTION_KEYS.has(`${String(e.Namespace)}|${String(e.OptionName)}`)) continue;
+      if (typeof e.Value !== 'string') continue;
+      for (const el of e.Value.split(',')) {
+        const t = el.trim();
+        if (/^sg-[0-9a-f]+$/i.test(t)) ids.add(t);
+      }
+    }
+  }
+  return [...ids];
+}
+async function fetchSgNamesByIds(
+  region: string,
+  ids: readonly string[]
+): Promise<Record<string, string> | undefined> {
+  try {
+    const c = new EC2Client({ region, ...READ_RETRY });
+    const out: Record<string, string> = {};
+    let token: string | undefined;
+    do {
+      const r = await c.send(
+        new DescribeSecurityGroupsCommand({
+          Filters: [{ Name: 'group-id', Values: [...ids] }],
+          NextToken: token,
+        })
+      );
+      for (const g of r.SecurityGroups ?? []) {
+        if (g.GroupId && g.GroupName) out[g.GroupId] = g.GroupName;
+      }
+      token = r.NextToken;
+    } while (token);
+    return out;
+  } catch {
+    return undefined;
+  }
+}
+
 const defaultSgIdsCache = new Map<string, Set<string>>();
 async function fetchDefaultSgIds(region: string): Promise<Set<string>> {
   const cached = defaultSgIdsCache.get(region);
@@ -2263,6 +2324,13 @@ export async function gatherFindings(
     ),
     siblingRdsSourceModels: buildRdsReplicaSourceModels(desired, liveModelMap(reads)),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
+    // #1746: resolve the sg-ids an EB Environment's SecurityGroups options echo (its own
+    // generated LB / instance SG) to GroupNames, so classify's anchored generated-name
+    // gate can fold the raw-id form. Only when a live env actually echoes ids.
+    ebSgNamesById: await (async () => {
+      const ids = collectEbSecurityGroupIds(desired.resources, liveModelMap(reads));
+      return ids.length > 0 ? fetchSgNamesByIds(region, ids) : undefined;
+    })(),
   };
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
@@ -2394,6 +2462,13 @@ export async function regatherTouched(
       new Map([...gathered.liveByLogical, ...liveModelMap(reads)])
     ),
     rdsOptionSettingDefaults: await buildRdsOptionSettingDefaults(desired, region),
+    // #1746: mirror the primary gather's EB sg-id -> GroupName prefetch (same merged map
+    // as the sibling builders above so an untouched env's echo still resolves).
+    ebSgNamesById: await (async () => {
+      const merged = new Map([...gathered.liveByLogical, ...liveModelMap(reads)]);
+      const ids = collectEbSecurityGroupIds(desired.resources, merged);
+      return ids.length > 0 ? fetchSgNamesByIds(region, ids) : undefined;
+    })(),
   };
 
   const fresh: Finding[] = [];

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1722,6 +1722,10 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     if (item.kind === 'delete' || !okIds.has(item.logicalId)) continue;
     for (const op of item.ops) {
       if (op.op !== 'remove' && op.op !== 'add') continue;
+      // #967/#1740: a CONTRACT op is patch plumbing, not a user-chosen revert — a companion
+      // remove of an AWS-managed echo (the DAEMON DesiredCount) persists by design and must
+      // not drive a "NOT reverted" verdict.
+      if (op.contract) continue;
       const dotted = op.path.replace(/^\//, '').replace(/\//g, '.');
       const key = `${item.logicalId}\0${dotted}`;
       if (!preActual.has(key)) continue;

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -147,6 +147,10 @@ export interface CorpusCase {
     // in-stack sibling), so replay reproduces the inherited-echo folds. Optional for
     // back-compat.
     siblingRdsSourceModels?: Record<string, Record<string, unknown>>;
+    // #1746: sg-id -> GroupName for the sg-ids this EB Environment's SecurityGroups options
+    // echo, so replay resolves the raw-id echo through the anchored generated-name gate the
+    // same way the live check did. Optional for back-compat.
+    ebSgNamesById?: Record<string, string>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -194,6 +198,7 @@ export function buildCorpusCase(
     siblingClientVpnEndpointVpcs?: Record<string, string | null>;
     siblingCloudFrontCdPolicyIds?: Record<string, string | null>;
     siblingRdsSourceModels?: Record<string, Record<string, unknown>>;
+    ebSgNamesById?: Record<string, string> | undefined;
   },
   findings: Finding[]
 ): CorpusCase {
@@ -395,6 +400,13 @@ export function buildCorpusCase(
         : {}),
       ...(rdsSrcKey !== undefined && rdsSrcMap !== undefined && rdsSrcMap[rdsSrcKey]
         ? { siblingRdsSourceModels: { [rdsSrcKey]: rdsSrcMap[rdsSrcKey] } }
+        : {}),
+      // #1746: carry the sg-id -> GroupName map on an EB Environment case, so replay
+      // resolves the raw-id SecurityGroups echo through the anchored gate identically.
+      ...(resource.resourceType === 'AWS::ElasticBeanstalk::Environment' &&
+      opts.ebSgNamesById &&
+      Object.keys(opts.ebSgNamesById).length > 0
+        ? { ebSgNamesById: opts.ebSgNamesById }
         : {}),
     },
     expected: findings,

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -16,6 +16,8 @@ import {
 } from '../normalize/arn-identity.js';
 import { stripCcApiAwsManagedFields } from '../normalize/cc-api-strip.js';
 import {
+  ecsDaemonDerivedMaximumPercent,
+  ecsDaemonDerivedMinimumHealthyPercent,
   elbTargetGroupDerivedHealthCheckPort,
   elbTargetGroupDerivedHealthCheckProtocol,
   logsDeliveryDerivedRetention,
@@ -128,7 +130,10 @@ import { calculateResourceDrift, deepEqual } from './drift-calculator.js';
 // discriminators (LoadBalancer Type; TargetGroup Protocol / TargetType), declared
 // preferred with the live echo as fallback. A discriminator that matches no override
 // leaves the shared values standing; every value stays equality-gated at the call site.
-function elbAttributeDefaultsFor(
+// Exported (#1745): revert/plan sources the same per-key defaults when reverting an
+// UNDECLARED bag element (`TargetGroupAttributes[<key>]` appeared since record) back to
+// its AWS default — classify and revert can never disagree on the value.
+export function elbAttributeDefaultsFor(
   resourceType: string,
   declared: Record<string, unknown>,
   live: Record<string, unknown>
@@ -159,7 +164,7 @@ function elbAttributeDefaultsFor(
   return shared;
 }
 
-const ELB_ATTRIBUTE_BAGS: Record<string, string> = {
+export const ELB_ATTRIBUTE_BAGS: Record<string, string> = {
   'AWS::ElasticLoadBalancingV2::LoadBalancer': 'LoadBalancerAttributes',
   'AWS::ElasticLoadBalancingV2::TargetGroup': 'TargetGroupAttributes',
   'AWS::ElasticLoadBalancingV2::Listener': 'ListenerAttributes',
@@ -1509,7 +1514,12 @@ interface CompositeSubsetSpec {
   // full live array, return 'atDefault' when the entry is at its AWS first-run default (folds,
   // invariant) or 'undeclared' otherwise (surfaces — a change away from the default). Absent →
   // every live-only entry is 'undeclared' (recorded inventory; a later change still surfaces).
-  entryTier?: (entry: Record<string, unknown>, liveArray: unknown) => 'atDefault' | 'undeclared';
+  entryTier?: (
+    entry: Record<string, unknown>,
+    liveArray: unknown,
+    // #1746: sg-id -> GroupName map for the EB SecurityGroups gate (gather prefetch)
+    ebSgNamesById?: Readonly<Record<string, string>>
+  ) => 'atDefault' | 'undeclared';
 }
 // AWS (both an EB ConfigurationTemplate and an Environment) materializes the FULL option set
 // from the declared subset; fold each service-filled extra to its first-run default (equality-
@@ -1518,7 +1528,8 @@ interface CompositeSubsetSpec {
 // back via the SDK_SUPPLEMENTS DescribeConfigurationSettings reader (writeOnly-but-readable).
 const ebOptionSettingsEntryTier: NonNullable<CompositeSubsetSpec['entryTier']> = (
   entry,
-  liveArray
+  liveArray,
+  ebSgNamesById
 ) => {
   const arr = Array.isArray(liveArray) ? (liveArray as Record<string, unknown>[]) : [];
   const envEntry = arr.find((e) => e && e.OptionName === 'EnvironmentType');
@@ -1532,7 +1543,8 @@ const ebOptionSettingsEntryTier: NonNullable<CompositeSubsetSpec['entryTier']> =
     entry.OptionName,
     entry.Value,
     envType,
-    siblingOption
+    siblingOption,
+    ebSgNamesById
   );
 };
 const ebOptionSettingsSubsetSpec: CompositeSubsetSpec = {
@@ -3113,6 +3125,11 @@ export function classifyResource(
     // DERIVED equality gate rather than a value-independent one: a single default SG folds, a
     // 2+-element APPEND or a single non-default SG SWAP surfaces. Undefined/empty → fail open (fold).
     defaultSgIds?: ReadonlySet<string>;
+    // #1746: sg-id -> GroupName for the sg-ids an EB Environment's SecurityGroups options echo
+    // (one DescribeSecurityGroups call in gather), so the anchored generated-name gate can
+    // resolve a raw-id echo. Undefined / missing id → the element SURFACES (fail-closed —
+    // folding an arbitrary sg-id would resurrect the #1264 rogue-SG-hiding bug).
+    ebSgNamesById?: Readonly<Record<string, string>>;
     // #1269: the account/region DEFAULT-VPC subnet ids, prefetched by gather.ts so the UNDECLARED
     // default-subnet-list fold (RedshiftServerless Workgroup SubnetIds) is a DERIVED gate: a
     // workgroup that declares no SubnetIds is placed into the default VPC and reads back all its
@@ -3817,12 +3834,43 @@ export function classifyResource(
     const engineType = declared['EngineType'];
     const engineStorageDefault: Record<string, string> = {
       ACTIVEMQ: 'EFS',
+      // live-proven 2026-08-10 (mq-rabbit-hunt): a barest RabbitMQ broker reads back
+      // StorageType EBS + a clean first run — the row is no longer a doc-derived mirror.
+      // (RabbitMQ also REJECTS mq.t3.micro at create — m5+ only, an engine-axis
+      // validation difference recorded in the fixture.)
       RABBITMQ: 'EBS',
     };
     const storageDefault =
       typeof engineType === 'string' ? engineStorageDefault[engineType.toUpperCase()] : undefined;
     if (storageDefault !== undefined) {
       knownDef = { ...knownDef, StorageType: storageDefault };
+    }
+  }
+  // #1740: a DAEMON-scheduled ECS service's rollout band defaults are 100/0, not the
+  // REPLICA 200/100 the static pins encode (live, variants6-hunt 2026-08-10). Overlay the
+  // whole-object DeploymentConfiguration pin and the two per-leaf gates with the derived
+  // band (fold tier 2, equality-gated — an out-of-band band change still surfaces; revert
+  // derives the same values via derivedRevertDefaultFor).
+  if (resourceType === 'AWS::ECS::Service') {
+    const daemonMax = ecsDaemonDerivedMaximumPercent(declared['SchedulingStrategy']);
+    const daemonMin = ecsDaemonDerivedMinimumHealthyPercent(declared['SchedulingStrategy']);
+    if (daemonMax !== undefined && daemonMin !== undefined) {
+      const dcPin = knownDef['DeploymentConfiguration'];
+      if (dcPin && typeof dcPin === 'object') {
+        knownDef = {
+          ...knownDef,
+          DeploymentConfiguration: {
+            ...(dcPin as Record<string, unknown>),
+            MaximumPercent: daemonMax,
+            MinimumHealthyPercent: daemonMin,
+          },
+        };
+      }
+      knownDefPaths = {
+        ...knownDefPaths,
+        'DeploymentConfiguration.MaximumPercent': daemonMax,
+        'DeploymentConfiguration.MinimumHealthyPercent': daemonMin,
+      };
     }
   }
   // #975: a CE AnomalySubscription declaring the LEGACY numeric `Threshold` reads back an
@@ -5013,7 +5061,7 @@ export function classifyResource(
             const r = lo as Record<string, unknown>;
             const key = ckSubsetSpec.keyFields.map((f) => String(r[f])).join('|');
             findings.push({
-              tier: ckSubsetSpec.entryTier?.(r, d.awsValue) ?? 'undeclared',
+              tier: ckSubsetSpec.entryTier?.(r, d.awsValue, opts.ebSgNamesById) ?? 'undeclared',
               logicalId,
               resourceType,
               path: `${d.path}[${key}]`,
@@ -5658,6 +5706,13 @@ export function classifyResource(
       (VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k) &&
         !isTrivialEmpty(v) &&
         !(k in knownDef)) ||
+      // #1740: a DAEMON-scheduled ECS service's DesiredCount is ECS-MANAGED — it mirrors
+      // the current container-instance count and CANNOT be declared for DAEMON, so any
+      // echoed value is AWS's runtime state, not user intent (value-independent by
+      // construction; live variants6-hunt 2026-08-10).
+      (resourceType === 'AWS::ECS::Service' &&
+        k === 'DesiredCount' &&
+        declared['SchedulingStrategy'] === 'DAEMON') ||
       // #705: a Classic ELB's undeclared Policies folds atDefault ONLY when it is exactly the
       // AWS default SSL negotiation policy (by PolicyName); a downgrade / added policy surfaces.
       clbDefaultSslPoliciesAtDefault(resourceType, k, v) ||

--- a/src/normalize/derived-defaults.ts
+++ b/src/normalize/derived-defaults.ts
@@ -67,3 +67,40 @@ export function rdsReplicaDerivedBackupRetention(
 ): number | undefined {
   return sourceDbInstanceIdentifier !== undefined ? 0 : undefined;
 }
+
+// ECS Service: a DAEMON-scheduled service's rollout band defaults differ from the
+// REPLICA band the static pins encode — MaximumPercent 100 / MinimumHealthyPercent 0
+// (#1740, live variants6-hunt 2026-08-10). The static KNOWN_DEFAULT_PATHS entries
+// stay 200/100 for REPLICA services.
+export function ecsDaemonDerivedMaximumPercent(schedulingStrategy: unknown): number | undefined {
+  return schedulingStrategy === 'DAEMON' ? 100 : undefined;
+}
+export function ecsDaemonDerivedMinimumHealthyPercent(
+  schedulingStrategy: unknown
+): number | undefined {
+  return schedulingStrategy === 'DAEMON' ? 0 : undefined;
+}
+
+// ECS Service (DAEMON): the WHOLE-OBJECT DeploymentConfiguration revert default. A bare
+// `remove` is impossible live: the CC read-modify-write model carries the ECS-managed
+// DesiredCount echo, which the ECS API rejects for DAEMON ("The daemon scheduling strategy
+// does not support a desired count") — so revert writes this explicit object (the exact
+// live-observed DAEMON creation default, variants6-hunt 2026-08-10) and a
+// REVERT_COMPANION_REMOVES entry drops the DesiredCount echo from the same patch.
+export function ecsDaemonDerivedDeploymentConfiguration(
+  schedulingStrategy: unknown
+): Record<string, unknown> | undefined {
+  if (schedulingStrategy !== 'DAEMON') return undefined;
+  return {
+    BakeTimeInMinutes: 0,
+    Strategy: 'ROLLING',
+    DeploymentCircuitBreaker: {
+      ThresholdConfiguration: { Type: 'BOUNDED_PERCENT', Value: 50 },
+      Enable: false,
+      ResetOnHealthyTask: true,
+      Rollback: false,
+    },
+    MaximumPercent: 100,
+    MinimumHealthyPercent: 0,
+  };
+}

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3775,17 +3775,31 @@ export const EB_OPTION_VALUE_INDEPENDENT: ReadonlySet<string> = new Set([
 //     `AWSEB…SecurityGroup` logical-id shape.
 // A rogue SG (`eb update-environment …SecurityGroups=sg-…`, `my-awseb-backdoor`) matches
 // none of these anchored shapes and surfaces.
-function isEbGeneratedGroup(el: string): boolean {
-  const name = el.trim();
+// #1746: a LIVE classic-LB environment echoes the option as the RAW sg-id of its own
+// generated LB security group (not a name) — resolve the id to its GroupName (the
+// gather-prefetched `sgNamesById` map, one DescribeSecurityGroups call) and apply the
+// SAME anchored shapes. An unresolvable id (lookup denied / a foreign SG) SURFACES —
+// fail-closed, because folding an arbitrary sg-id would resurrect the #1264
+// rogue-SG-hiding bug.
+function isEbGeneratedGroup(el: string, sgNamesById?: Readonly<Record<string, string>>): boolean {
+  let name = el.trim();
   if (name === '') return false;
+  if (/^sg-[0-9a-f]+$/i.test(name)) {
+    const resolved = sgNamesById?.[name];
+    if (resolved === undefined) return false;
+    name = resolved;
+  }
   // resolved environment-resource name: awseb-e-<envid>-…
   if (/^awseb-e-/i.test(name)) return true;
   // resolved name carrying the CFn logical fragment, or the bare logical id (Ref echo)
   return /AWSEB(LoadBalancer)?SecurityGroup/.test(name);
 }
-function isAllEbGeneratedGroups(value: unknown): boolean {
+function isAllEbGeneratedGroups(
+  value: unknown,
+  sgNamesById?: Readonly<Record<string, string>>
+): boolean {
   if (typeof value !== 'string' || value === '') return false;
-  return value.split(',').every((el) => isEbGeneratedGroup(el));
+  return value.split(',').every((el) => isEbGeneratedGroup(el, sgNamesById));
 }
 // #1278/#1263: when the user declares no `aws:ec2:instances|InstanceTypes` option, EB assigns
 // the platform's smallest burstable pair for the environment's processor architecture — a
@@ -3821,7 +3835,10 @@ export function ebOptionSettingTier(
   // #893: look up a SIBLING option's live Value on the same environment (returns undefined
   // when absent). Threaded by the classify caller from the full OptionSettings array so a
   // derived default (InstanceType = InstanceTypes[0]) can be computed and equality-gated.
-  siblingOption?: (namespace: string, optionName: string) => unknown
+  siblingOption?: (namespace: string, optionName: string) => unknown,
+  // #1746: sg-id -> GroupName map (gather prefetch) so a raw-id SecurityGroups echo can be
+  // resolved and run through the anchored generated-name shapes.
+  sgNamesById?: Readonly<Record<string, string>>
 ): 'atDefault' | 'undeclared' {
   // An unset option: DescribeConfigurationSettings returns many option keys with a null or
   // empty Value (BlockDeviceMappings, VPCId, Notification*, RootVolume*, …). Unset is not
@@ -3833,7 +3850,7 @@ export function ebOptionSettingTier(
     key === 'aws:autoscaling:launchconfiguration|SecurityGroups' ||
     key === 'aws:elb:loadbalancer|SecurityGroups'
   ) {
-    return isAllEbGeneratedGroups(value) ? 'atDefault' : 'undeclared';
+    return isAllEbGeneratedGroups(value, sgNamesById) ? 'atDefault' : 'undeclared';
   }
   // #893: InstanceType — derived default = the first element of the sibling InstanceTypes
   // option; a bump that differs (the silent cost bomb) surfaces. When the sibling is absent
@@ -5271,17 +5288,24 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // DBParameterGroupName/DBSubnetGroupName pair additionally live-proven E2E on
   // rds-replica-hunt, 2026-08-02). A reference differing only by case can never be real
   // drift — these names are case-insensitively unique in their services.
+  // #1741: `Engine` joins the family — RDS engine-name matching is case-insensitive with a
+  // lowercase store (`describe-db-engine-versions --engine MySQL` resolves and returns
+  // `mysql`; the OptionGroup `EngineName: "MySQL"` CC probe stored `mysql`, 2026-08-10), so
+  // a template declaring `Engine: MySQL` reads back `mysql` — a permanent declared FP. Two
+  // engines differing beyond case are a genuine replacement and still surface.
   'AWS::RDS::DBInstance': new Set([
     'DBInstanceIdentifier',
     'DBParameterGroupName',
     'DBSubnetGroupName',
     'OptionGroupName',
     'DBClusterIdentifier',
+    'Engine',
   ]),
   'AWS::RDS::DBCluster': new Set([
     'DBClusterIdentifier',
     'DBClusterParameterGroupName',
     'DBSubnetGroupName',
+    'Engine',
   ]),
   // The "stored as a lowercase string" identifier family — ElastiCache, DocumentDB,
   // Neptune, and DMS all lowercase their resource identifier on creation (AWS CLI help:
@@ -5362,9 +5386,16 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // as this entry). All are create-only names, so case-insensitive equality hides no
   // revertable drift (a genuine rename is a replacement). Neptune/DocDB spell the CFn
   // property `Name`.
-  'AWS::RDS::DBParameterGroup': new Set(['DBParameterGroupName']),
-  'AWS::RDS::DBClusterParameterGroup': new Set(['DBClusterParameterGroupName']),
-  'AWS::RDS::OptionGroup': new Set(['OptionGroupName']),
+  // #1741: `Family` / `EngineName` join their owning types — the CFn/CC handlers ACCEPT a
+  // mixed-case value and the service stores it lowercased (stackless CC probes 2026-08-10:
+  // DBParameterGroup `Family: "MySQL8.4"` -> `mysql8.4`, DBClusterParameterGroup
+  // `Family: "Aurora-MySQL8.0"` -> `aurora-mysql8.0`, OptionGroup `EngineName: "MySQL"` ->
+  // `mysql`; mixed-case OptionGroup EngineName + DBParameterGroup Family also E2E-witnessed
+  // via CloudFormation in allowpack-hunt). All create-only, so case-insensitive equality
+  // hides no revertable drift.
+  'AWS::RDS::DBParameterGroup': new Set(['DBParameterGroupName', 'Family']),
+  'AWS::RDS::DBClusterParameterGroup': new Set(['DBClusterParameterGroupName', 'Family']),
+  'AWS::RDS::OptionGroup': new Set(['OptionGroupName', 'EngineName']),
   'AWS::RDS::DBSubnetGroup': new Set(['DBSubnetGroupName']),
   'AWS::Neptune::DBParameterGroup': new Set(['Name']),
   'AWS::Neptune::DBClusterParameterGroup': new Set(['Name']),

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -5673,6 +5673,48 @@ function route53ZoneRefMatches(
   );
 }
 
+// Declared RecordSets targeting a zone, collected from BOTH declaration forms. Standalone
+// `AWS::Route53::RecordSet` resources match on their own zone ref; `AWS::Route53::
+// RecordSetGroup` members (#1742) match on the GROUP-level zone ref (HostedZoneId /
+// HostedZoneName) or — legal but uncommon — a per-member ref. Without the group walk every
+// group member was flagged `added` (live, allowpack-hunt 2026-08-10), and a revert
+// --remove-unrecorded would have DELETED the user's own declared records. Pure + exported
+// for tests.
+export function collectDeclaredRoute53Records(
+  resources: readonly { resourceType: string; declared: Record<string, unknown> }[],
+  hostedZoneId: string,
+  zoneApex: string | undefined
+): { name: string; type: string; setIdentifier?: string | undefined }[] {
+  const declaredRecords: { name: string; type: string; setIdentifier?: string | undefined }[] = [];
+  const pushDeclared = (rec: Record<string, unknown>) => {
+    const name = typeof rec.Name === 'string' ? rec.Name : undefined;
+    const type = typeof rec.Type === 'string' ? rec.Type : undefined;
+    if (name && type) {
+      declaredRecords.push({
+        name,
+        type,
+        setIdentifier: typeof rec.SetIdentifier === 'string' ? rec.SetIdentifier : undefined,
+      });
+    }
+  };
+  for (const r of resources) {
+    if (r.resourceType === 'AWS::Route53::RecordSet') {
+      if (!route53ZoneRefMatches(r.declared, hostedZoneId, zoneApex)) continue;
+      pushDeclared(r.declared);
+    } else if (r.resourceType === 'AWS::Route53::RecordSetGroup') {
+      const groupMatches = route53ZoneRefMatches(r.declared, hostedZoneId, zoneApex);
+      const sets = Array.isArray(r.declared.RecordSets) ? r.declared.RecordSets : [];
+      for (const rs of sets) {
+        if (!rs || typeof rs !== 'object') continue;
+        const rec = rs as Record<string, unknown>;
+        if (!groupMatches && !route53ZoneRefMatches(rec, hostedZoneId, zoneApex)) continue;
+        pushDeclared(rec);
+      }
+    }
+  }
+  return declaredRecords;
+}
+
 export async function enumerateRoute53HostedZoneChildren(
   ctx: EnumeratorContext
 ): Promise<AddedChild[]> {
@@ -5687,21 +5729,7 @@ export async function enumerateRoute53HostedZoneChildren(
   // Declared RecordSets targeting THIS zone (by HostedZoneId or HostedZoneName). Each is a
   // SEPARATE CloudFormation resource, so the template lists every declared one; a live record
   // matching none is out of band.
-  const declaredRecords: { name: string; type: string; setIdentifier?: string | undefined }[] = [];
-  for (const r of desired.resources) {
-    if (r.resourceType !== 'AWS::Route53::RecordSet') continue;
-    if (!route53ZoneRefMatches(r.declared, hostedZoneId, zoneApex)) continue;
-    const name = typeof r.declared.Name === 'string' ? r.declared.Name : undefined;
-    const type = typeof r.declared.Type === 'string' ? r.declared.Type : undefined;
-    if (name && type) {
-      declaredRecords.push({
-        name,
-        type,
-        setIdentifier:
-          typeof r.declared.SetIdentifier === 'string' ? r.declared.SetIdentifier : undefined,
-      });
-    }
-  }
+  const declaredRecords = collectDeclaredRoute53Records(desired.resources, hostedZoneId, zoneApex);
 
   const client = new Route53Client({ region, ...READ_RETRY });
   const records = await pageResourceRecordSets(client, hostedZoneId);

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -12,9 +12,16 @@
 import type { BaselineFile } from '../baseline/baseline-file.js';
 import { withinStackPath } from '../construct-path.js';
 import { partitionForRegion } from '../desired/template-adapter.js';
-import { GETTEMPLATE_MASK_NOTE } from '../diff/classify.js';
+import {
+  ELB_ATTRIBUTE_BAGS,
+  elbAttributeDefaultsFor,
+  GETTEMPLATE_MASK_NOTE,
+} from '../diff/classify.js';
 import { TAG_PROPERTY_NAMES } from '../normalize/cc-api-strip.js';
 import {
+  ecsDaemonDerivedDeploymentConfiguration,
+  ecsDaemonDerivedMaximumPercent,
+  ecsDaemonDerivedMinimumHealthyPercent,
   elbTargetGroupDerivedHealthCheckPort,
   elbTargetGroupDerivedHealthCheckProtocol,
   logsDeliveryDerivedRetention,
@@ -724,6 +731,21 @@ export function isUnrevertableNested(f: Finding): boolean {
   return isNestedUndeclared(f) && f.path.includes('[');
 }
 
+// #1745: an ELB attribute-bag element path (`LoadBalancerAttributes[<key>]` /
+// `TargetGroupAttributes[<key>]` / `ListenerAttributes[<key>]`). Unlike a generic
+// nested array element (unpatchable via a flat RFC6902 pointer), the bags have a
+// PER-KEY SDK writer (R78 `attributeKey` ops) and a curated per-key default table, so
+// an undeclared bag element IS revertable when both resolve — see the bar exemption
+// and the revertOp branch.
+export function elbAttributeBagElementOf(
+  f: Pick<Finding, 'resourceType' | 'path'>
+): { prop: string; key: string } | undefined {
+  const bag = ELB_ATTRIBUTE_BAGS[f.resourceType];
+  if (!bag || !f.path.startsWith(`${bag}[`) || !f.path.endsWith(']')) return undefined;
+  const key = f.path.slice(bag.length + 1, -1);
+  return key ? { prop: bag, key } : undefined;
+}
+
 // An out-of-band ManagedPolicy attachment member (a live-only `Roles[x]`/`Users[x]`/
 // `Groups[x]` — the union, surfaced as nested undeclared). Unlike a generic nested
 // undeclared value, this one HAS a precise, flat SDK op to undo it (DetachX-Policy by
@@ -1278,7 +1300,26 @@ export function buildRevertPlan(
     // record is reconstructed (baseline-file.ts) WITHOUT the flag, but keeps its nested
     // path. A top-level undeclared path is a single key (never contains '.'/'['), and
     // declared drift is a different tier — so this never blocks a top-level revert.
-    if (isUnrevertableNested(f) && !isManagedPolicyAttachmentMember(f) && !isNestedSdkWritable(f)) {
+    // #1745: an ELB attribute-bag element escapes the array-element bar when the per-key
+    // prop writer exists AND a revert value resolves (the baseline-recorded value, or the
+    // curated per-key default) — the bar's rationale (no flat pointer) does not apply to
+    // an attributeKey-routed SDK write. No writer / no value → stays barred (honest).
+    const bagElement = elbAttributeBagElementOf(f);
+    const bagElementRevertible =
+      bagElement !== undefined &&
+      !SDK_WRITERS[f.resourceType] &&
+      SDK_PROP_WRITERS[f.resourceType]?.[bagElement.prop] !== undefined &&
+      (f.desired !== undefined ||
+        recorded.some((a) => a.logicalId === f.logicalId && a.path === f.path) ||
+        elbAttributeDefaultsFor(f.resourceType, opts.declaredForLogical?.(f.logicalId) ?? {}, {})[
+          bagElement.key
+        ] !== undefined);
+    if (
+      isUnrevertableNested(f) &&
+      !isManagedPolicyAttachmentMember(f) &&
+      !isNestedSdkWritable(f) &&
+      !bagElementRevertible
+    ) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,
@@ -1446,7 +1487,8 @@ export function buildRevertPlan(
     // split into one cc item and one sdk item per scoped path — key the grouping
     // by kind (+ path when prop-scoped) so each item resolves to ONE writer.
     const propScoped =
-      !SDK_WRITERS[f.resourceType] && SDK_PROP_WRITERS[f.resourceType]?.[f.path] !== undefined;
+      !SDK_WRITERS[f.resourceType] &&
+      SDK_PROP_WRITERS[f.resourceType]?.[bagElement?.prop ?? f.path] !== undefined;
     // A nested-path SDK writer (SDK_NESTED_WRITERS) reverts a DEEP sub-field its predicate
     // matches (e.g. ApiGateway Method integration knobs). Unlike propScoped, every matching
     // nested op of one resource batches into ONE sdk item (no path suffix in the key below) —
@@ -1571,7 +1613,9 @@ export function buildRevertPlan(
     }
     const declaredModel = opts.declaredForLogical?.(f.logicalId);
     const op = revertOp(toRevert, recorded, opts.identity, declaredModel);
-    const key = `${f.logicalId} ${kind}${propScoped ? ` ${f.path}` : ''}`;
+    // (#1745: a bag element groups under its BAG prop so declared per-key drift and
+    // undeclared bag elements of one resource land in the same writer item)
+    const key = `${f.logicalId} ${kind}${propScoped ? ` ${bagElement?.prop ?? f.path}` : ''}`;
     const item =
       itemsByLogical.get(key) ??
       ({
@@ -1601,6 +1645,11 @@ export function buildRevertPlan(
         item.ops.push({
           op: 'remove',
           path: siblingPointer,
+          // #967 contract semantics: plumbing that exists only to make the CC patch valid —
+          // never a standalone selectable row, and the convergence no-op detector skips it
+          // (an ECS-managed DesiredCount echo persists by design after the DAEMON
+          // DeploymentConfiguration revert, #1740 — flagging it was a false NOT-reverted).
+          contract: true,
           human: `${sibling} -> remove (incompatible with the restored default)`,
         });
       }
@@ -1736,6 +1785,22 @@ function derivedRevertDefaultFor(
   if (resourceType === 'AWS::RDS::DBInstance' && path === 'BackupRetentionPeriod') {
     return rdsReplicaDerivedBackupRetention(declared['SourceDBInstanceIdentifier']);
   }
+  // #1740: a DAEMON-scheduled ECS service's rollout band derives 100/0 (the static
+  // KNOWN_DEFAULT_PATHS entries carry the REPLICA 200/100 — sourcing them here would
+  // wrong-write a DAEMON service's band). The whole-object arm exists because the bare
+  // `remove` is live-impossible (the CC model's DesiredCount echo fails DAEMON
+  // validation) — see ecsDaemonDerivedDeploymentConfiguration + the companion remove.
+  if (resourceType === 'AWS::ECS::Service') {
+    if (path === 'DeploymentConfiguration') {
+      return ecsDaemonDerivedDeploymentConfiguration(declared['SchedulingStrategy']);
+    }
+    if (path === 'DeploymentConfiguration.MaximumPercent') {
+      return ecsDaemonDerivedMaximumPercent(declared['SchedulingStrategy']);
+    }
+    if (path === 'DeploymentConfiguration.MinimumHealthyPercent') {
+      return ecsDaemonDerivedMinimumHealthyPercent(declared['SchedulingStrategy']);
+    }
+  }
   // Unreachable in practice (PutRetentionPolicy rejects DELIVERY groups, so the value
   // cannot drift out of band) — kept for the classify/revert single-source invariant.
   if (resourceType === 'AWS::Logs::LogGroup' && path === 'RetentionInDays') {
@@ -1766,6 +1831,13 @@ export const REVERT_COMPANION_REMOVES: Record<string, (value: unknown) => readon
       : value === 'io1' || value === 'io2'
         ? ['Throughput']
         : [],
+  // #1740: reverting a DAEMON service's DeploymentConfiguration while the CC model still
+  // carries the ECS-managed DesiredCount echo fails with "The daemon scheduling strategy
+  // does not support a desired count for services" (live, variants6-hunt 2026-08-10) —
+  // drop the echo from the same patch. The live-presence + not-declared gates keep a
+  // REPLICA service's DECLARED DesiredCount untouched, and an undeclared one is
+  // no-change-on-absence for the ECS provider.
+  'AWS::ECS::Service\0DeploymentConfiguration': () => ['DesiredCount'],
 };
 
 function revertOp(
@@ -1801,6 +1873,34 @@ function revertOp(
   // `prior` carries the finding's current live value for property-scoped SDK
   // writers (per-entry revert); Cloud Control serialization ignores it.
   const wasRecorded = recorded.find((a) => a.logicalId === f.logicalId && a.path === f.path);
+  // #1745: an ELB attribute-bag element reverts via the per-key prop writer (R78
+  // attributeKey ops), never a CC pointer — the bracket path is flat-unpatchable, but
+  // the write mechanism and value source both exist. Value preference: the baseline
+  // value when the finding carries/records one (restore), else the curated per-key
+  // default (shared elbAttributeDefaultsFor, so classify and revert can never
+  // disagree). The plan-loop bar already refused the no-writer / no-value cases.
+  const bagEl = elbAttributeBagElementOf(f);
+  if (bagEl) {
+    const baselineValue = f.desired !== undefined ? f.desired : wasRecorded?.value;
+    const value =
+      baselineValue !== undefined
+        ? baselineValue
+        : elbAttributeDefaultsFor(f.resourceType, declaredModel ?? {}, {})[bagEl.key];
+    if (value !== undefined) {
+      return {
+        op: 'add',
+        path: toPointer(bagEl.prop),
+        value,
+        prior: f.actual,
+        attributeKey: bagEl.key,
+        human: `${bagEl.prop}[${bagEl.key}] -> ${
+          baselineValue !== undefined
+            ? 'baseline value'
+            : 'AWS default (undeclared, not in baseline)'
+        }`,
+      };
+    }
+  }
   if (f.actual === undefined && f.desired !== undefined) {
     // removed-undeclared finding: re-add the baseline value
     return {

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -237,7 +237,12 @@ import {
 } from '@aws-sdk/client-servicediscovery';
 import { SetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { SetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
-import { type Budget, BudgetsClient, UpdateBudgetCommand } from '@aws-sdk/client-budgets';
+import {
+  type Budget,
+  BudgetsClient,
+  type Spend,
+  UpdateBudgetCommand,
+} from '@aws-sdk/client-budgets';
 import { partitionForRegion } from '../desired/template-adapter.js';
 import { NESTED_ARRAY_IDENTITY } from '../diff/classify.js';
 import { deepEqual } from '../diff/drift-calculator.js';
@@ -3204,6 +3209,21 @@ const writeBudget: SdkWriter = async (ctx, ops) => {
   // limit would convert the budget to a fixed one (a wrong write). Drop BudgetLimit when
   // AutoAdjustData is present so the budget stays auto-adjusting.
   const newBudget: Budget = budget.AutoAdjustData ? { ...budget, BudgetLimit: undefined } : budget;
+  // #1744: the CFn schema allows a NUMERIC Spend.Amount (a template declares
+  // `BudgetLimit: {Amount: 100}`), but the Budgets API models Amount as a STRING — the
+  // SDK serializer rejects the number ("NUMBER_VALUE can not be converted to a String",
+  // live wrtpack-hunt 2026-08-10). Stringify every Spend.Amount before the write.
+  const stringifySpend = (s: unknown): Spend | undefined => {
+    if (!s || typeof s !== 'object') return undefined;
+    const sp = s as Record<string, unknown>;
+    return { ...sp, ...(sp.Amount !== undefined && { Amount: String(sp.Amount) }) } as Spend;
+  };
+  if (newBudget.BudgetLimit) newBudget.BudgetLimit = stringifySpend(newBudget.BudgetLimit);
+  if (newBudget.PlannedBudgetLimits) {
+    newBudget.PlannedBudgetLimits = Object.fromEntries(
+      Object.entries(newBudget.PlannedBudgetLimits).map(([k, v]) => [k, stringifySpend(v)])
+    ) as Record<string, Spend>;
+  }
   await new BudgetsClient({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
     new UpdateBudgetCommand({ AccountId: ctx.accountId, NewBudget: newBudget })
   );

--- a/tests/corpus/AWS__AmazonMQ__Broker.RabbitBroker.json
+++ b/tests/corpus/AWS__AmazonMQ__Broker.RabbitBroker.json
@@ -1,0 +1,237 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Broker",
+    "resourceType": "AWS::AmazonMQ::Broker",
+    "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+    "constructPath": "CdkrdHunt0810Mq/Broker",
+    "declared": {
+      "AutoMinorVersionUpgrade": true,
+      "BrokerName": "cdkrd-0810-rabbit",
+      "DeploymentMode": "SINGLE_INSTANCE",
+      "EngineType": "RABBITMQ",
+      "HostInstanceType": "mq.m5.large",
+      "PubliclyAccessible": true,
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Users": [
+        {
+          "Password": "cdkrd-hunt-0810-pw!A1",
+          "Username": "cdkrdhunt"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AuthenticationStrategy": "SIMPLE",
+    "SubnetIds": ["subnet-0839f35959eaf9126"],
+    "StompEndpoints": [],
+    "MqttEndpoints": [],
+    "AmqpEndpoints": ["amqps://b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2.mq.us-east-1.on.aws:5671"],
+    "DeploymentMode": "SINGLE_INSTANCE",
+    "EngineType": "RABBITMQ",
+    "EncryptionOptions": {
+      "UseAwsOwnedKey": true
+    },
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Mq",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Broker",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Mq/565b6f20-94aa-11f1-9f73-0ec6625581b5",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "StorageType": "EBS",
+    "ConfigurationRevision": "1",
+    "MaintenanceWindowStartTime": {
+      "DayOfWeek": "MONDAY",
+      "TimeOfDay": "17:00",
+      "TimeZone": "UTC"
+    },
+    "HostInstanceType": "mq.m5.large",
+    "AutoMinorVersionUpgrade": true,
+    "Logs": {
+      "General": false
+    },
+    "ConsoleURLs": ["https://b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2.mq.us-east-1.on.aws"],
+    "ConfigurationId": "c-5789d12a-8b4a-4233-9e2d-6105e35763fc",
+    "DataReplicationMode": "NONE",
+    "BrokerName": "cdkrd-0810-rabbit",
+    "EngineVersionCurrent": "3.13.7",
+    "WssEndpoints": [],
+    "IpAddresses": [],
+    "OpenWireEndpoints": [],
+    "Id": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+    "PubliclyAccessible": true,
+    "Arn": "arn:aws:mq:us-east-1:111111111111:broker:cdkrd-0810-rabbit:b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2"
+  },
+  "schema": {
+    "readOnly": [
+      "AmqpEndpoints",
+      "Arn",
+      "ConfigurationId",
+      "ConfigurationRevision",
+      "ConsoleURLs",
+      "EngineVersionCurrent",
+      "Id",
+      "IpAddresses",
+      "MqttEndpoints",
+      "OpenWireEndpoints",
+      "StompEndpoints",
+      "WssEndpoints"
+    ],
+    "writeOnly": ["Configuration", "DataReplicationPrimaryBrokerArn", "EngineVersion", "Users"],
+    "createOnly": [
+      "AuthenticationStrategy",
+      "BrokerName",
+      "DeploymentMode",
+      "EncryptionOptions",
+      "EngineType",
+      "PubliclyAccessible",
+      "StorageType",
+      "SubnetIds"
+    ],
+    "readOnlyPaths": [
+      "AmqpEndpoints",
+      "Arn",
+      "ConfigurationId",
+      "ConfigurationRevision",
+      "ConsoleURLs",
+      "EngineVersionCurrent",
+      "Id",
+      "IpAddresses",
+      "MqttEndpoints",
+      "OpenWireEndpoints",
+      "StompEndpoints",
+      "WssEndpoints"
+    ],
+    "writeOnlyPaths": [
+      "Configuration",
+      "DataReplicationPrimaryBrokerArn",
+      "EngineVersion",
+      "LdapServerMetadata.ServiceAccountPassword",
+      "Users"
+    ],
+    "createOnlyPaths": [
+      "AuthenticationStrategy",
+      "BrokerName",
+      "DeploymentMode",
+      "EncryptionOptions",
+      "EngineType",
+      "PubliclyAccessible",
+      "StorageType",
+      "SubnetIds"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AmqpEndpoints",
+      "ConsoleURLs",
+      "IpAddresses",
+      "MqttEndpoints",
+      "OpenWireEndpoints",
+      "ResourceShareArns",
+      "SecurityGroups",
+      "StompEndpoints",
+      "SubnetIds",
+      "WssEndpoints"
+    ],
+    "unorderedObjectArrayPaths": ["Users"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "Users",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+      "constructPath": "CdkrdHunt0810Mq/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "AuthenticationStrategy",
+      "actual": "SIMPLE",
+      "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+      "constructPath": "CdkrdHunt0810Mq/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "SubnetIds",
+      "actual": ["subnet-0839f35959eaf9126"],
+      "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+      "constructPath": "CdkrdHunt0810Mq/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "EncryptionOptions",
+      "actual": {
+        "UseAwsOwnedKey": true
+      },
+      "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+      "constructPath": "CdkrdHunt0810Mq/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "StorageType",
+      "actual": "EBS",
+      "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+      "constructPath": "CdkrdHunt0810Mq/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "MaintenanceWindowStartTime",
+      "actual": {
+        "DayOfWeek": "MONDAY",
+        "TimeOfDay": "17:00",
+        "TimeZone": "UTC"
+      },
+      "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+      "constructPath": "CdkrdHunt0810Mq/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "DataReplicationMode",
+      "actual": "NONE",
+      "physicalId": "b-a15bd5d4-f4bf-42bc-96ef-8ba5abb140b2",
+      "constructPath": "CdkrdHunt0810Mq/Broker"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Batch__ComputeEnvironment.SpotCe.json
+++ b/tests/corpus/AWS__Batch__ComputeEnvironment.SpotCe.json
@@ -1,0 +1,144 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SpotCe",
+    "resourceType": "AWS::Batch::ComputeEnvironment",
+    "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/cdkrd-0810v-spotce",
+    "constructPath": "CdkrdHunt0810Var/SpotCe",
+    "declared": {
+      "ComputeEnvironmentName": "cdkrd-0810v-spotce",
+      "ComputeResources": {
+        "InstanceRole": "arn:aws:iam::111111111111:instance-profile/CdkrdHunt0810Var-BatchInstanceProfile-AuGzsfvO0HaQ",
+        "InstanceTypes": ["optimal"],
+        "MaxvCpus": 1,
+        "MinvCpus": 0,
+        "SecurityGroupIds": ["sg-0434023ccb8de2ad9"],
+        "SpotIamFleetRole": "arn:aws:iam::111111111111:role/CdkrdHunt0810Var-SpotFleetRole-1Ea5yFPQRxlG",
+        "Subnets": ["subnet-0eed3f0cb3854dce1"],
+        "Type": "SPOT"
+      },
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Type": "MANAGED"
+    }
+  },
+  "liveRaw": {
+    "Type": "MANAGED",
+    "ServiceRole": "arn:aws:iam::111111111111:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch",
+    "ComputeEnvironmentName": "cdkrd-0810v-spotce",
+    "ComputeResources": {
+      "Subnets": ["subnet-0eed3f0cb3854dce1"],
+      "Type": "SPOT",
+      "MinvCpus": 0,
+      "SpotIamFleetRole": "arn:aws:iam::111111111111:role/CdkrdHunt0810Var-SpotFleetRole-1Ea5yFPQRxlG",
+      "MaxvCpus": 1,
+      "InstanceRole": "arn:aws:iam::111111111111:instance-profile/CdkrdHunt0810Var-BatchInstanceProfile-AuGzsfvO0HaQ",
+      "InstanceTypes": ["optimal"],
+      "Ec2Configuration": [
+        {
+          "ImageType": "ECS_AL2023"
+        }
+      ],
+      "SecurityGroupIds": ["sg-0434023ccb8de2ad9"],
+      "DesiredvCpus": 0
+    },
+    "State": "ENABLED",
+    "ComputeEnvironmentArn": "arn:aws:batch:us-east-1:111111111111:compute-environment/cdkrd-0810v-spotce",
+    "Tags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "schema": {
+    "readOnly": ["ComputeEnvironmentArn"],
+    "writeOnly": ["ReplaceComputeEnvironment", "UpdatePolicy"],
+    "createOnly": ["ComputeEnvironmentName", "EksConfiguration", "Tags", "Type"],
+    "readOnlyPaths": [
+      "ComputeEnvironmentArn",
+      "ComputeResources.Ec2Configuration.*.BatchImageStatus"
+    ],
+    "writeOnlyPaths": [
+      "ComputeResources.UpdateToLatestImageVersion",
+      "ReplaceComputeEnvironment",
+      "UpdatePolicy"
+    ],
+    "createOnlyPaths": [
+      "ComputeEnvironmentName",
+      "ComputeResources.SpotIamFleetRole",
+      "EksConfiguration",
+      "Tags",
+      "Type"
+    ],
+    "defaults": {
+      "ReplaceComputeEnvironment": true
+    },
+    "defaultPaths": {
+      "ComputeResources.UpdateToLatestImageVersion": false,
+      "ReplaceComputeEnvironment": true,
+      "UpdatePolicy.TerminateJobsOnUpdate": false,
+      "UpdatePolicy.JobExecutionTimeoutMinutes": 30,
+      "EksConfiguration.EksClusterArn": false,
+      "EksConfiguration.KubernetesNamespace": false
+    },
+    "unorderedScalarPaths": [
+      "ComputeResources.InstanceTypes",
+      "ComputeResources.SecurityGroupIds",
+      "ComputeResources.Subnets"
+    ],
+    "unorderedObjectArrayPaths": [
+      "ComputeResources.Ec2Configuration",
+      "ComputeResources.LaunchTemplate.Overrides"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SpotCe",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ServiceRole",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/batch.amazonaws.com/AWSServiceRoleForBatch",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/cdkrd-0810v-spotce",
+      "constructPath": "CdkrdHunt0810Var/SpotCe"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SpotCe",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/cdkrd-0810v-spotce",
+      "constructPath": "CdkrdHunt0810Var/SpotCe"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SpotCe",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ComputeResources.Ec2Configuration",
+      "actual": [
+        {
+          "ImageType": "ECS_AL2023"
+        }
+      ],
+      "nested": true,
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/cdkrd-0810v-spotce",
+      "constructPath": "CdkrdHunt0810Var/SpotCe"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SpotCe",
+      "resourceType": "AWS::Batch::ComputeEnvironment",
+      "path": "ComputeResources.DesiredvCpus",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:batch:us-east-1:111111111111:compute-environment/cdkrd-0810v-spotce",
+      "constructPath": "CdkrdHunt0810Var/SpotCe"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__Service.DaemonService.json
+++ b/tests/corpus/AWS__ECS__Service.DaemonService.json
@@ -1,0 +1,173 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DaemonService",
+    "resourceType": "AWS::ECS::Service",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+    "constructPath": "CdkrdHunt0810Var/DaemonService",
+    "declared": {
+      "Cluster": "cdkrd-0810v-cluster",
+      "LaunchType": "EC2",
+      "SchedulingStrategy": "DAEMON",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-0810v-td:6"
+    }
+  },
+  "liveRaw": {
+    "HealthCheckGracePeriodSeconds": 0,
+    "EnableECSManagedTags": false,
+    "EnableExecuteCommand": false,
+    "PlacementConstraints": [],
+    "Cluster": "cdkrd-0810v-cluster",
+    "ServiceArn": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+    "DesiredCount": 0,
+    "PlacementStrategies": [],
+    "DeploymentController": {
+      "Type": "ECS"
+    },
+    "LaunchType": "EC2",
+    "Name": "CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+    "AvailabilityZoneRebalancing": "DISABLED",
+    "SchedulingStrategy": "DAEMON",
+    "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-0810v-td:6",
+    "ServiceName": "CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+    "DeploymentConfiguration": {
+      "BakeTimeInMinutes": 0,
+      "Strategy": "ROLLING",
+      "DeploymentCircuitBreaker": {
+        "ThresholdConfiguration": {
+          "Type": "BOUNDED_PERCENT",
+          "Value": 50
+        },
+        "Enable": false,
+        "ResetOnHealthyTask": true,
+        "Rollback": false
+      },
+      "MaximumPercent": 100,
+      "MinimumHealthyPercent": 0
+    },
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Name", "ServiceArn"],
+    "writeOnly": ["ForceNewDeployment", "Monitoring"],
+    "createOnly": ["Cluster", "Role", "SchedulingStrategy", "ServiceName"],
+    "readOnlyPaths": ["Name", "ServiceArn"],
+    "writeOnlyPaths": ["ForceNewDeployment", "Monitoring"],
+    "createOnlyPaths": ["Cluster", "Role", "SchedulingStrategy", "ServiceName"],
+    "defaults": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "defaultPaths": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "unorderedScalarPaths": [
+      "NetworkConfiguration.AwsvpcConfiguration.SecurityGroups",
+      "NetworkConfiguration.AwsvpcConfiguration.Subnets"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["ServiceConnectConfiguration.LogConfiguration.Options"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DaemonService",
+      "resourceType": "AWS::ECS::Service",
+      "path": "HealthCheckGracePeriodSeconds",
+      "actual": 0,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "constructPath": "CdkrdHunt0810Var/DaemonService"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DaemonService",
+      "resourceType": "AWS::ECS::Service",
+      "path": "EnableExecuteCommand",
+      "actual": false,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "constructPath": "CdkrdHunt0810Var/DaemonService"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DaemonService",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DesiredCount",
+      "actual": 0,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "constructPath": "CdkrdHunt0810Var/DaemonService"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DaemonService",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentController",
+      "actual": {
+        "Type": "ECS"
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "constructPath": "CdkrdHunt0810Var/DaemonService"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DaemonService",
+      "resourceType": "AWS::ECS::Service",
+      "path": "AvailabilityZoneRebalancing",
+      "actual": "DISABLED",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "constructPath": "CdkrdHunt0810Var/DaemonService"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "DaemonService",
+      "resourceType": "AWS::ECS::Service",
+      "path": "ServiceName",
+      "actual": "CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "constructPath": "CdkrdHunt0810Var/DaemonService"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DaemonService",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentConfiguration",
+      "actual": {
+        "BakeTimeInMinutes": 0,
+        "Strategy": "ROLLING",
+        "DeploymentCircuitBreaker": {
+          "ThresholdConfiguration": {
+            "Type": "BOUNDED_PERCENT",
+            "Value": 50
+          },
+          "Enable": false,
+          "ResetOnHealthyTask": true,
+          "Rollback": false
+        },
+        "MaximumPercent": 100,
+        "MinimumHealthyPercent": 0
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/cdkrd-0810v-cluster/CdkrdHunt0810Var-DaemonService-MdHrEZT8rLIt",
+      "constructPath": "CdkrdHunt0810Var/DaemonService"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__Environment.LoadBalancedEnv.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__Environment.LoadBalancedEnv.json
@@ -1,0 +1,2278 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbEnv",
+    "resourceType": "AWS::ElasticBeanstalk::Environment",
+    "physicalId": "cdkrd-0810-eblb-env",
+    "constructPath": "CdkrdHunt0810EbLb/EbEnv",
+    "declared": {
+      "ApplicationName": "cdkrd-0810-eblb-app",
+      "EnvironmentName": "cdkrd-0810-eblb-env",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "LoadBalanced"
+        },
+        {
+          "Namespace": "aws:autoscaling:launchconfiguration",
+          "OptionName": "InstanceType",
+          "Value": "t3.micro"
+        },
+        {
+          "Namespace": "aws:autoscaling:launchconfiguration",
+          "OptionName": "IamInstanceProfile",
+          "Value": "CdkrdHunt0810EbLb-EbInstanceProfile-xpzttlP4wPYm"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+    "ApplicationName": "cdkrd-0810-eblb-app",
+    "EnvironmentName": "cdkrd-0810-eblb-env",
+    "Tier": {
+      "Type": "Standard",
+      "Version": "1.0",
+      "Name": "WebServer"
+    },
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker",
+    "EndpointURL": "awseb-e-t-AWSEBLoa-HY5X37OBFUNB-1076127214.us-east-1.elb.amazonaws.com",
+    "CNAMEPrefix": "cdkrd-0810-eblb-env",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones",
+        "Value": "Any"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown",
+        "Value": "360"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Custom Availability Zones",
+        "Value": ""
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize",
+        "Value": "4"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize",
+        "Value": "1"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "BlockDeviceMappings"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1",
+        "Value": "true"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "EC2KeyName"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "IamInstanceProfile",
+        "Value": "CdkrdHunt0810EbLb-EbInstanceProfile-xpzttlP4wPYm"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId",
+        "Value": "ami-0787263f73f2dcb8b"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType",
+        "Value": "t3.micro"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "LaunchTemplateTagPropagationEnabled"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval",
+        "Value": "5 minute"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeIOPS"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeSize"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeThroughput"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeType"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction",
+        "Value": "tcp,22,22,0.0.0.0/0"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SecurityGroups",
+        "Value": "awseb-e-tkdxhicv56-stack-AWSEBSecurityGroup-lmTuiSUu19oM"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration",
+        "Value": "5"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods",
+        "Value": "1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement",
+        "Value": "-1"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold",
+        "Value": "2000000"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName",
+        "Value": "NetworkOut"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period",
+        "Value": "5"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic",
+        "Value": "Average"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit",
+        "Value": "Bytes"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement",
+        "Value": "1"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold",
+        "Value": "6000000"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MaxBatchSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MinInstancesInService"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "PauseTime"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType",
+        "Value": "Time"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout",
+        "Value": "PT30M"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily",
+        "Value": "t3"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes",
+        "Value": "t3.micro"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy",
+        "Value": "capacity-optimized"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage",
+        "Value": "70"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotMaxPrice"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures",
+        "Value": "x86_64"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "AssociatePublicIpAddress"
+      },
+      {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme",
+        "Value": "public"
+      },
+      {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBSubnets"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "Subnets"
+      },
+      {
+        "ResourceName": "AWSEBSecurityGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "VPCId"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:application",
+        "OptionName": "Application Healthcheck URL",
+        "Value": ""
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize",
+        "Value": "100"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType",
+        "Value": "Percentage"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy",
+        "Value": "AllAtOnce"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout",
+        "Value": "600"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort",
+        "Value": "22"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType",
+        "Value": "Migration"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType",
+        "Value": "LoadBalanced"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Bucket"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Key"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType",
+        "Value": "classic"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ServiceRole",
+        "Value": "AWSServiceRoleForElasticBeanstalk"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer",
+        "Value": "nginx"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument",
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled",
+        "Value": "true"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold",
+        "Value": "Ok"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType",
+        "Value": "enhanced"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "PreferredStartTime"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ServiceRoleForManagedUpdates",
+        "Value": ""
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "UpdateLevel"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances",
+        "Value": "true"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Endpoint"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol",
+        "Value": "email"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic ARN"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic Name"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold",
+        "Value": "3"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval",
+        "Value": "10"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target",
+        "Value": "TCP:80"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout",
+        "Value": "5"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold",
+        "Value": "5"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol",
+        "Value": "HTTP"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled",
+        "Value": "true"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol",
+        "Value": "HTTP"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "SSLCertificateId"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort",
+        "Value": "80"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort",
+        "Value": "OFF"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol",
+        "Value": "HTTP"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol",
+        "Value": "HTTPS"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SSLCertificateId"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups",
+        "Value": "sg-0d7dd3230b4de77a4"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout",
+        "Value": "20"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout",
+        "Value": "60"
+      },
+      {
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase",
+        "Value": "false"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["EndpointURL"],
+    "writeOnly": ["TemplateName"],
+    "createOnly": ["ApplicationName", "CNAMEPrefix", "EnvironmentName", "SolutionStackName"],
+    "readOnlyPaths": ["EndpointURL"],
+    "writeOnlyPaths": ["TemplateName"],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "CNAMEPrefix",
+      "EnvironmentName",
+      "SolutionStackName",
+      "Tier.Name",
+      "Tier.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "ebSgNamesById": {
+      "sg-0d7dd3230b4de77a4": "awseb-e-tkdxhicv56-stack-AWSEBLoadBalancerSecurityGroup-TKenVHyZDb4g"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones",
+        "Value": "Any"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown",
+        "Value": "360"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Custom Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Custom Availability Zones",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize",
+        "Value": "4"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize",
+        "Value": "1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|BlockDeviceMappings]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "BlockDeviceMappings"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|EC2KeyName]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "EC2KeyName"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId",
+        "Value": "ami-0787263f73f2dcb8b"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|LaunchTemplateTagPropagationEnabled]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "LaunchTemplateTagPropagationEnabled"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval",
+        "Value": "5 minute"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeIOPS]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeIOPS"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeSize]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeSize"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeThroughput]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeThroughput"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeType]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeType"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction",
+        "Value": "tcp,22,22,0.0.0.0/0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SecurityGroups",
+        "Value": "awseb-e-tkdxhicv56-stack-AWSEBSecurityGroup-lmTuiSUu19oM"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|BreachDuration]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration",
+        "Value": "5"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|EvaluationPeriods]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods",
+        "Value": "1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement",
+        "Value": "-1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold",
+        "Value": "2000000"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|MeasureName]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName",
+        "Value": "NetworkOut"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|Period]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period",
+        "Value": "5"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|Statistic]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic",
+        "Value": "Average"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|Unit]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit",
+        "Value": "Bytes"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement",
+        "Value": "1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold",
+        "Value": "6000000"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|MaxBatchSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MaxBatchSize"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|MinInstancesInService]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MinInstancesInService"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|PauseTime]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "PauseTime"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType",
+        "Value": "Time"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout",
+        "Value": "PT30M"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|EnvironmentVariables]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily",
+        "Value": "t3"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes",
+        "Value": "t3.micro"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy",
+        "Value": "capacity-optimized"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage",
+        "Value": "70"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotMaxPrice]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotMaxPrice"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures",
+        "Value": "x86_64"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|AssociatePublicIpAddress]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "AssociatePublicIpAddress"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme",
+        "Value": "public"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|ELBSubnets]",
+      "actual": {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBSubnets"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|Subnets]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "Subnets"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|VPCId]",
+      "actual": {
+        "ResourceName": "AWSEBSecurityGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "VPCId"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:application|Application Healthcheck URL]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:application",
+        "OptionName": "Application Healthcheck URL",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize",
+        "Value": "100"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType",
+        "Value": "Percentage"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy",
+        "Value": "AllAtOnce"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout",
+        "Value": "600"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort",
+        "Value": "22"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType",
+        "Value": "Migration"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ExternalExtensionsS3Bucket]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Bucket"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ExternalExtensionsS3Key]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Key"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|LoadBalancerType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType",
+        "Value": "classic"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ServiceRole]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ServiceRole",
+        "Value": "AWSServiceRoleForElasticBeanstalk"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer",
+        "Value": "nginx"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument",
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold",
+        "Value": "Ok"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType",
+        "Value": "enhanced"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|PreferredStartTime]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "PreferredStartTime"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ServiceRoleForManagedUpdates]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ServiceRoleForManagedUpdates",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|UpdateLevel]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "UpdateLevel"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Endpoint]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Endpoint"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol",
+        "Value": "email"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Topic ARN]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic ARN"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Topic Name]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic Name"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:healthcheck|HealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold",
+        "Value": "3"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:healthcheck|Interval]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval",
+        "Value": "10"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:healthcheck|Target]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target",
+        "Value": "TCP:80"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:healthcheck|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout",
+        "Value": "5"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:healthcheck|UnhealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold",
+        "Value": "5"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:listener:80|InstancePort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:listener:80|InstanceProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol",
+        "Value": "HTTP"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol",
+        "Value": "HTTP"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:listener:80|SSLCertificateId]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "SSLCertificateId"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:loadbalancer|CrossZone]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort",
+        "Value": "80"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPSPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort",
+        "Value": "OFF"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol",
+        "Value": "HTTP"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerSSLPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol",
+        "Value": "HTTPS"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:loadbalancer|SSLCertificateId]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SSLCertificateId"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:loadbalancer|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups",
+        "Value": "sg-0d7dd3230b4de77a4"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout",
+        "Value": "20"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elb:policies|ConnectionSettingIdleTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout",
+        "Value": "60"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "Tier",
+      "actual": {
+        "Type": "Standard",
+        "Version": "1.0",
+        "Name": "WebServer"
+      },
+      "physicalId": "cdkrd-0810-eblb-env",
+      "constructPath": "CdkrdHunt0810EbLb/EbEnv"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.TcpUdpListener.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.TcpUdpListener.json
@@ -1,0 +1,103 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TcpUdpListener",
+    "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/cdkrd-0810v-nlb/432b7954855f911c/82444f8517ef06de",
+    "constructPath": "CdkrdHunt0810Var/TcpUdpListener",
+    "declared": {
+      "DefaultActions": [
+        {
+          "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-0810v-tu-tg/05818f2964167e88",
+          "Type": "forward"
+        }
+      ],
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-0810v-nlb/432b7954855f911c",
+      "Port": 54,
+      "Protocol": "TCP_UDP"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/cdkrd-0810v-nlb/432b7954855f911c/82444f8517ef06de",
+    "ListenerAttributes": [
+      {
+        "Value": "350",
+        "Key": "tcp.idle_timeout.seconds"
+      }
+    ],
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-0810v-nlb/432b7954855f911c",
+    "DefaultActions": [
+      {
+        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-0810v-tu-tg/05818f2964167e88",
+        "Type": "forward",
+        "ForwardConfig": {
+          "TargetGroupStickinessConfig": {
+            "Enabled": false
+          },
+          "TargetGroups": [
+            {
+              "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-0810v-tu-tg/05818f2964167e88"
+            }
+          ]
+        }
+      }
+    ],
+    "Port": 54,
+    "Protocol": "TCP_UDP",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Var",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TcpUdpListener",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Var/c5403370-94b0-11f1-b059-0ef131302bd7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": ["DefaultActions.*.AuthenticateOidcConfig.ClientSecret"],
+    "createOnlyPaths": ["LoadBalancerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "DefaultActions.*.AuthenticateCognitoConfig.AuthenticationRequestExtraParams",
+      "DefaultActions.*.AuthenticateOidcConfig.AuthenticationRequestExtraParams"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TcpUdpListener",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "ListenerAttributes[tcp.idle_timeout.seconds]",
+      "actual": "350",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/cdkrd-0810v-nlb/432b7954855f911c/82444f8517ef06de",
+      "constructPath": "CdkrdHunt0810Var/TcpUdpListener"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.UdpListener.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.UdpListener.json
@@ -1,0 +1,86 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "UdpListener",
+    "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/cdkrd-0810v-nlb/432b7954855f911c/b35decea7f387098",
+    "constructPath": "CdkrdHunt0810Var/UdpListener",
+    "declared": {
+      "DefaultActions": [
+        {
+          "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-0810v-udp-tg/a286d5299944b210",
+          "Type": "forward"
+        }
+      ],
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-0810v-nlb/432b7954855f911c",
+      "Port": 53,
+      "Protocol": "UDP"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/net/cdkrd-0810v-nlb/432b7954855f911c/b35decea7f387098",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-0810v-nlb/432b7954855f911c",
+    "DefaultActions": [
+      {
+        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-0810v-udp-tg/a286d5299944b210",
+        "Type": "forward",
+        "ForwardConfig": {
+          "TargetGroupStickinessConfig": {
+            "Enabled": false
+          },
+          "TargetGroups": [
+            {
+              "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-0810v-udp-tg/a286d5299944b210"
+            }
+          ]
+        }
+      }
+    ],
+    "Port": 53,
+    "Protocol": "UDP",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Var",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "UdpListener",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Var/c5403370-94b0-11f1-b059-0ef131302bd7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": ["DefaultActions.*.AuthenticateOidcConfig.ClientSecret"],
+    "createOnlyPaths": ["LoadBalancerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "DefaultActions.*.AuthenticateCognitoConfig.AuthenticationRequestExtraParams",
+      "DefaultActions.*.AuthenticateOidcConfig.AuthenticationRequestExtraParams"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__RDS__DBParameterGroup.MixedCaseFamily.json
+++ b/tests/corpus/AWS__RDS__DBParameterGroup.MixedCaseFamily.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Dpg",
+    "resourceType": "AWS::RDS::DBParameterGroup",
+    "physicalId": "cdkrd-0810a-dpg",
+    "constructPath": "CdkrdHunt0810Allow/Dpg",
+    "declared": {
+      "DBParameterGroupName": "cdkrd-0810a-dpg",
+      "Description": "cdkrd 0810 allowpack",
+      "Family": "MySQL8.4",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DBParameterGroupName": "cdkrd-0810a-dpg",
+    "Description": "cdkrd 0810 allowpack",
+    "Parameters": {},
+    "Family": "mysql8.4",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Allow",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Dpg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Allow/461684d0-94ad-11f1-ab4e-0affd2ec42e1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DBParameterGroupName", "Description", "Family"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DBParameterGroupName", "Description", "Family"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__RDS__OptionGroup.MixedCaseEngineName.json
+++ b/tests/corpus/AWS__RDS__OptionGroup.MixedCaseEngineName.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Og",
+    "resourceType": "AWS::RDS::OptionGroup",
+    "physicalId": "cdkrd-0810a-og",
+    "constructPath": "CdkrdHunt0810Allow/Og",
+    "declared": {
+      "EngineName": "MySQL",
+      "MajorEngineVersion": "8.4",
+      "OptionGroupDescription": "cdkrd 0810 allowpack",
+      "OptionGroupName": "cdkrd-0810a-og",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "OptionGroupDescription": "cdkrd 0810 allowpack",
+    "OptionGroupName": "cdkrd-0810a-og",
+    "OptionConfigurations": [],
+    "MajorEngineVersion": "8.4",
+    "EngineName": "mysql",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Allow",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Og",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Allow/461684d0-94ad-11f1-ab4e-0affd2ec42e1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["EngineName", "MajorEngineVersion", "OptionGroupDescription", "OptionGroupName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "EngineName",
+      "MajorEngineVersion",
+      "OptionGroupDescription",
+      "OptionGroupName"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionConfigurations"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    },
+    "rdsOptionSettingDefaults": {
+      "cdkrd-0810a-og": {
+        "MARIADB_AUDIT_PLUGIN": {
+          "SERVER_AUDIT_FILE_ROTATIONS": null,
+          "SERVER_AUDIT_EVENTS": "CONNECT,QUERY",
+          "SERVER_AUDIT_LOGGING": "ON",
+          "SERVER_AUDIT_INCL_USERS": null,
+          "SERVER_AUDIT_FILE_PATH": "/rdsdbdata/log/audit/",
+          "SERVER_AUDIT_EXCL_USERS": null,
+          "SERVER_AUDIT": "FORCE_PLUS_PERMANENT",
+          "SERVER_AUDIT_FILE_ROTATE_SIZE": null,
+          "SERVER_AUDIT_QUERY_LOG_LIMIT": "1024"
+        }
+      }
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__HostedZone.RsgZone.json
+++ b/tests/corpus/AWS__Route53__HostedZone.RsgZone.json
@@ -1,0 +1,58 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Zone",
+    "resourceType": "AWS::Route53::HostedZone",
+    "physicalId": "Z0879385SJQYCXQF64RB",
+    "constructPath": "CdkrdHunt0810Allow/Zone",
+    "declared": {
+      "HostedZoneTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "Name": "cdkrd-fphunt-a0810.com."
+    }
+  },
+  "liveRaw": {
+    "HostedZoneTags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "HostedZoneFeatures": {
+      "EnableAcceleratedRecovery": false
+    },
+    "HostedZoneConfig": {},
+    "Id": "Z0879385SJQYCXQF64RB",
+    "NameServers": [
+      "ns-553.awsdns-05.net",
+      "ns-94.awsdns-11.com",
+      "ns-1588.awsdns-06.co.uk",
+      "ns-1496.awsdns-59.org"
+    ],
+    "Name": "cdkrd-fphunt-a0810.com."
+  },
+  "schema": {
+    "readOnly": ["Id", "NameServers"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id", "NameServers"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["VPCs"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__Bucket.DateLifecycle.json
+++ b/tests/corpus/AWS__S3__Bucket.DateLifecycle.json
@@ -1,0 +1,239 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Bucket",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+    "constructPath": "CdkrdHunt0810Allow/Bucket",
+    "declared": {
+      "LifecycleConfiguration": {
+        "Rules": [
+          {
+            "ExpirationDate": "2027-01-01T00:00:00Z",
+            "Id": "date-expire",
+            "Prefix": "archive/",
+            "Status": "Enabled",
+            "Transitions": [
+              {
+                "StorageClass": "GLACIER",
+                "TransitionDate": "2026-12-01T00:00:00Z"
+              }
+            ]
+          }
+        ]
+      },
+      "NotificationConfiguration": {
+        "EventBridgeConfiguration": {
+          "EventBridgeEnabled": true
+        }
+      },
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrdhunt0810allow-bucket-ecd3ouvbjagy.s3-website-us-east-1.amazonaws.com",
+    "NotificationConfiguration": {
+      "TopicConfigurations": [],
+      "QueueConfigurations": [],
+      "LambdaConfigurations": [],
+      "EventBridgeConfiguration": {
+        "EventBridgeEnabled": true
+      }
+    },
+    "LifecycleConfiguration": {
+      "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+      "Rules": [
+        {
+          "Status": "Enabled",
+          "ExpirationDate": "2027-01-01T00:00:00Z",
+          "Transitions": [
+            {
+              "TransitionDate": "2026-12-01T00:00:00Z",
+              "StorageClass": "GLACIER"
+            }
+          ],
+          "Id": "date-expire",
+          "Prefix": "archive/"
+        }
+      ]
+    },
+    "DualStackDomainName": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy.s3.dualstack.us-east-1.amazonaws.com",
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+    "RegionalDomainName": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "Arn": "arn:aws:s3:::cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Allow",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Bucket",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Allow/461684d0-94ad-11f1-ab4e-0affd2ec42e1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+      "constructPath": "CdkrdHunt0810Allow/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+      "constructPath": "CdkrdHunt0810Allow/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+      "constructPath": "CdkrdHunt0810Allow/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+      "constructPath": "CdkrdHunt0810Allow/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "LifecycleConfiguration.TransitionDefaultMinimumObjectSize",
+      "actual": "all_storage_classes_128K",
+      "nested": true,
+      "physicalId": "cdkrdhunt0810allow-bucket-ecd3ouvbjagy",
+      "constructPath": "CdkrdHunt0810Allow/Bucket"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.PartialDeliveryPolicy.json
+++ b/tests/corpus/AWS__SNS__Topic.PartialDeliveryPolicy.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Topic",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:cdkrd-0810a-topic",
+    "constructPath": "CdkrdHunt0810Allow/Topic",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TopicName": "cdkrd-0810a-topic"
+    }
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-0810a-topic",
+    "FifoTopic": false,
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Allow",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Topic",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Allow/461684d0-94ad-11f1-ab4e-0affd2ec42e1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "cdkrd-0810a-topic"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["DeliveryStatusLogging", "Subscription"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ServiceDiscovery__Service.DnsSvc.json
+++ b/tests/corpus/AWS__ServiceDiscovery__Service.DnsSvc.json
@@ -1,0 +1,95 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Svc",
+    "resourceType": "AWS::ServiceDiscovery::Service",
+    "physicalId": "srv-oljjlzoxcj3uafqw",
+    "constructPath": "CdkrdHunt0810Wrt/Svc",
+    "declared": {
+      "Description": "cdkrd 0810 writer hunt svc",
+      "DnsConfig": {
+        "DnsRecords": [
+          {
+            "TTL": 60,
+            "Type": "A"
+          }
+        ],
+        "RoutingPolicy": "MULTIVALUE"
+      },
+      "Name": "cdkrd-0810w-svc",
+      "NamespaceId": "ns-xotqrau7tiqhrkp5",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-0810w-svc",
+    "Description": "cdkrd 0810 writer hunt svc",
+    "NamespaceId": "ns-xotqrau7tiqhrkp5",
+    "Type": "DNS_HTTP",
+    "DnsConfig": {
+      "RoutingPolicy": "MULTIVALUE",
+      "DnsRecords": [
+        {
+          "Type": "A",
+          "TTL": 60
+        }
+      ]
+    },
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdHunt0810Wrt"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "Svc"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Wrt/468d3b70-94ad-11f1-aa91-12787c3aadc7"
+      },
+      {
+        "Key": "cdkrd:ephemeral",
+        "Value": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["HealthCheckCustomConfig", "Name", "NamespaceId", "Type"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HealthCheckCustomConfig", "Name", "NamespaceId", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["ServiceAttributes"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Svc",
+      "resourceType": "AWS::ServiceDiscovery::Service",
+      "path": "Type",
+      "actual": "DNS_HTTP",
+      "physicalId": "srv-oljjlzoxcj3uafqw",
+      "constructPath": "CdkrdHunt0810Wrt/Svc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__WAFv2__RuleGroup.MixedCaseQueryArg.json
+++ b/tests/corpus/AWS__WAFv2__RuleGroup.MixedCaseQueryArg.json
@@ -1,0 +1,152 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RuleGroup",
+    "resourceType": "AWS::WAFv2::RuleGroup",
+    "physicalId": "cdkrd-0810a-rg|c9ca734a-0e89-4c8d-9056-efb7594fabeb|REGIONAL",
+    "constructPath": "CdkrdHunt0810Allow/RuleGroup",
+    "declared": {
+      "Capacity": 25,
+      "Name": "cdkrd-0810a-rg",
+      "Rules": [
+        {
+          "Action": {
+            "Count": {}
+          },
+          "Name": "qarg",
+          "Priority": 0,
+          "Statement": {
+            "ByteMatchStatement": {
+              "FieldToMatch": {
+                "SingleQueryArgument": {
+                  "Name": "SessionId"
+                }
+              },
+              "PositionalConstraint": "EXACTLY",
+              "SearchString": "x",
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NONE"
+                }
+              ]
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": false,
+            "MetricName": "cdkrd0810aQarg",
+            "SampledRequestsEnabled": false
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": false,
+        "MetricName": "cdkrd0810aRg",
+        "SampledRequestsEnabled": false
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "Scope": "REGIONAL",
+    "Capacity": 25,
+    "AvailableLabels": [],
+    "Id": "c9ca734a-0e89-4c8d-9056-efb7594fabeb",
+    "ConsumedLabels": [],
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/rulegroup/cdkrd-0810a-rg/c9ca734a-0e89-4c8d-9056-efb7594fabeb",
+    "Rules": [
+      {
+        "Action": {
+          "Count": {}
+        },
+        "Priority": 0,
+        "Statement": {
+          "ByteMatchStatement": {
+            "SearchStringBase64": "eA==",
+            "TextTransformations": [
+              {
+                "Type": "NONE",
+                "Priority": 0
+              }
+            ],
+            "PositionalConstraint": "EXACTLY",
+            "SearchString": "x",
+            "FieldToMatch": {
+              "SingleQueryArgument": {
+                "Name": "sessionid"
+              }
+            }
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "cdkrd0810aQarg",
+          "SampledRequestsEnabled": false,
+          "CloudWatchMetricsEnabled": false
+        },
+        "Name": "qarg"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "cdkrd0810aRg",
+      "SampledRequestsEnabled": false,
+      "CloudWatchMetricsEnabled": false
+    },
+    "LabelNamespace": "awswaf:111111111111:rulegroup:cdkrd-0810a-rg:",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Allow",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "RuleGroup",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Allow/461684d0-94ad-11f1-ab4e-0affd2ec42e1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-0810a-rg"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": [
+      "Arn",
+      "AvailableLabels.*.Name",
+      "ConsumedLabels.*.Name",
+      "Id",
+      "LabelNamespace"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["CustomResponseBodies"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__WAFv2__WebACL.MixedCaseHeader.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.MixedCaseHeader.json
@@ -1,0 +1,164 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WebAcl",
+    "resourceType": "AWS::WAFv2::WebACL",
+    "physicalId": "cdkrd-0810a-acl|a1f6c56c-0dc8-48be-8968-f91ec5a9f785|REGIONAL",
+    "constructPath": "CdkrdHunt0810Allow/WebAcl",
+    "declared": {
+      "DefaultAction": {
+        "Allow": {}
+      },
+      "Name": "cdkrd-0810a-acl",
+      "Rules": [
+        {
+          "Action": {
+            "Block": {}
+          },
+          "Name": "hdr",
+          "Priority": 0,
+          "Statement": {
+            "ByteMatchStatement": {
+              "FieldToMatch": {
+                "SingleHeader": {
+                  "Name": "User-Agent"
+                }
+              },
+              "PositionalConstraint": "CONTAINS",
+              "SearchString": "cdkrd-hunt",
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NONE"
+                }
+              ]
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": false,
+            "MetricName": "cdkrd0810aHdr",
+            "SampledRequestsEnabled": false
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": false,
+        "MetricName": "cdkrd0810aAcl",
+        "SampledRequestsEnabled": false
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "DefaultAction": {
+      "Allow": {}
+    },
+    "Scope": "REGIONAL",
+    "Capacity": 10,
+    "Id": "a1f6c56c-0dc8-48be-8968-f91ec5a9f785",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-0810a-acl/a1f6c56c-0dc8-48be-8968-f91ec5a9f785",
+    "OnSourceDDoSProtectionConfig": {
+      "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+    },
+    "Rules": [
+      {
+        "Action": {
+          "Block": {}
+        },
+        "Priority": 0,
+        "Statement": {
+          "ByteMatchStatement": {
+            "SearchStringBase64": "Y2RrcmQtaHVudA==",
+            "TextTransformations": [
+              {
+                "Type": "NONE",
+                "Priority": 0
+              }
+            ],
+            "PositionalConstraint": "CONTAINS",
+            "SearchString": "cdkrd-hunt",
+            "FieldToMatch": {
+              "SingleHeader": {
+                "Name": "user-agent"
+              }
+            }
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "cdkrd0810aHdr",
+          "SampledRequestsEnabled": false,
+          "CloudWatchMetricsEnabled": false
+        },
+        "Name": "hdr"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "cdkrd0810aAcl",
+      "SampledRequestsEnabled": false,
+      "CloudWatchMetricsEnabled": false
+    },
+    "LabelNamespace": "awswaf:111111111111:webacl:cdkrd-0810a-acl:",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0810Allow",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "WebAcl",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0810Allow/461684d0-94ad-11f1-ab4e-0affd2ec42e1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "cdkrd-0810a-acl"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["AssociationConfig.RequestBody", "CustomResponseBodies"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
+      "physicalId": "cdkrd-0810a-acl|a1f6c56c-0dc8-48be-8968-f91ec5a9f785|REGIONAL",
+      "constructPath": "CdkrdHunt0810Allow/WebAcl"
+    }
+  ]
+}

--- a/tests/hunt-2026-08-10-folds.test.ts
+++ b/tests/hunt-2026-08-10-folds.test.ts
@@ -1,0 +1,460 @@
+// 2026-08-10 hunt regressions:
+//  - #1740: ECS DAEMON scheduling — the rollout band derives 100/0 (not the REPLICA
+//    200/100 pins) and DesiredCount is ECS-managed (value-independent for DAEMON).
+//  - #1741: RDS stores engine names / parameter-group families lowercased while the
+//    CFn handlers accept mixed case — declared-side case tolerance.
+//  - #1742: Route53 RecordSetGroup members are template-declared records — the zone
+//    child-enumerator must not flag them `added`.
+//  - #1745: an undeclared ELB attribute-bag element reverts via the per-key prop
+//    writer (attributeKey) with the recorded/curated value — not `notRevertable`.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { collectEbSecurityGroupIds } from '../src/commands/gather.js';
+import { ebOptionSettingTier } from '../src/normalize/noise.js';
+import { collectDeclaredRoute53Records } from '../src/read/child-enumerators.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (findings: Finding[]) => findings.map((f) => `${f.tier}:${f.path}`).sort();
+
+// The full DAEMON-band echo captured live (variants6-hunt corpus, 2026-08-10).
+const DAEMON_DEPLOYMENT_CONFIGURATION = {
+  BakeTimeInMinutes: 0,
+  Strategy: 'ROLLING',
+  DeploymentCircuitBreaker: {
+    ThresholdConfiguration: { Type: 'BOUNDED_PERCENT', Value: 50 },
+    Enable: false,
+    ResetOnHealthyTask: true,
+    Rollback: false,
+  },
+  MaximumPercent: 100,
+  MinimumHealthyPercent: 0,
+};
+
+describe('#1740 ECS DAEMON scheduling variant', () => {
+  const daemonService = (): DesiredResource => ({
+    logicalId: 'DaemonService',
+    resourceType: 'AWS::ECS::Service',
+    physicalId: 'arn:aws:ecs:us-east-1:111111111111:service/c/daemon-svc',
+    declared: {
+      Cluster: 'c',
+      TaskDefinition: 'td:1',
+      LaunchType: 'EC2',
+      SchedulingStrategy: 'DAEMON',
+    },
+  });
+
+  it('folds the DAEMON rollout band + ECS-managed DesiredCount on a clean first run', () => {
+    const findings = classifyResource(
+      daemonService(),
+      {
+        Cluster: 'c',
+        TaskDefinition: 'td:1',
+        LaunchType: 'EC2',
+        SchedulingStrategy: 'DAEMON',
+        DesiredCount: 0,
+        DeploymentConfiguration: DAEMON_DEPLOYMENT_CONFIGURATION,
+      },
+      emptySchema
+    );
+    // the FULL tier:path list — nothing may surface as undeclared/declared
+    expect(tierPaths(findings)).toEqual([
+      'atDefault:DeploymentConfiguration',
+      'atDefault:DesiredCount',
+    ]);
+  });
+
+  it('DesiredCount folds value-independently for DAEMON (ECS moves it with the fleet)', () => {
+    const findings = classifyResource(
+      daemonService(),
+      {
+        Cluster: 'c',
+        TaskDefinition: 'td:1',
+        LaunchType: 'EC2',
+        SchedulingStrategy: 'DAEMON',
+        DesiredCount: 7,
+      },
+      emptySchema
+    );
+    expect(tierPaths(findings)).toEqual(['atDefault:DesiredCount']);
+  });
+
+  it('an out-of-band DAEMON band change still surfaces (equality gate preserved)', () => {
+    const findings = classifyResource(
+      daemonService(),
+      {
+        Cluster: 'c',
+        TaskDefinition: 'td:1',
+        LaunchType: 'EC2',
+        SchedulingStrategy: 'DAEMON',
+        DeploymentConfiguration: {
+          ...DAEMON_DEPLOYMENT_CONFIGURATION,
+          MinimumHealthyPercent: 50,
+        },
+      },
+      emptySchema
+    );
+    // the changed band no longer matches the derived whole-object pin, so it SURFACES
+    // (as the whole object or the leaf — either way detection is preserved, never folded)
+    const surfaced = findings.filter(
+      (f) => f.tier === 'undeclared' && f.path.startsWith('DeploymentConfiguration')
+    );
+    expect(surfaced.length).toBeGreaterThan(0);
+  });
+
+  it('a REPLICA service still folds the 200/100 band (static pins untouched)', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'Replica',
+        resourceType: 'AWS::ECS::Service',
+        physicalId: 'arn:aws:ecs:us-east-1:111111111111:service/c/replica-svc',
+        declared: { Cluster: 'c', TaskDefinition: 'td:1', DesiredCount: 1 },
+      },
+      {
+        Cluster: 'c',
+        TaskDefinition: 'td:1',
+        DesiredCount: 1,
+        SchedulingStrategy: 'REPLICA',
+        DeploymentConfiguration: {
+          ...DAEMON_DEPLOYMENT_CONFIGURATION,
+          MaximumPercent: 200,
+          MinimumHealthyPercent: 100,
+        },
+      },
+      emptySchema
+    );
+    expect(tierPaths(findings)).toEqual([
+      'atDefault:DeploymentConfiguration',
+      'atDefault:SchedulingStrategy',
+    ]);
+  });
+
+  it('reverting a DAEMON band leaf writes the DERIVED 100/0 explicitly (not the REPLICA 200/100)', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'DaemonService',
+      resourceType: 'AWS::ECS::Service',
+      physicalId: 'arn:aws:ecs:us-east-1:111111111111:service/c/daemon-svc',
+      path: 'DeploymentConfiguration.MinimumHealthyPercent',
+      actual: 50,
+      nested: true,
+    };
+    const plan = buildRevertPlan([f], undefined, {
+      declaredForLogical: () => ({ SchedulingStrategy: 'DAEMON' }),
+    });
+    expect(plan.notRevertable).toEqual([]);
+    const op = plan.items[0]!.ops[0]!;
+    expect(op.op).toBe('add');
+    expect(op.value).toBe(0);
+  });
+});
+
+describe('#1741 RDS mixed-case Engine/EngineName/Family declared echoes fold', () => {
+  const CASES: [string, Record<string, unknown>, Record<string, unknown>][] = [
+    [
+      'AWS::RDS::OptionGroup',
+      { OptionGroupName: 'og', EngineName: 'MySQL', MajorEngineVersion: '8.4' },
+      { OptionGroupName: 'og', EngineName: 'mysql', MajorEngineVersion: '8.4' },
+    ],
+    [
+      'AWS::RDS::DBParameterGroup',
+      { DBParameterGroupName: 'pg', Family: 'MySQL8.4', Description: 'd' },
+      { DBParameterGroupName: 'pg', Family: 'mysql8.4', Description: 'd' },
+    ],
+    [
+      'AWS::RDS::DBClusterParameterGroup',
+      { DBClusterParameterGroupName: 'cpg', Family: 'Aurora-MySQL8.0', Description: 'd' },
+      { DBClusterParameterGroupName: 'cpg', Family: 'aurora-mysql8.0', Description: 'd' },
+    ],
+    [
+      'AWS::RDS::DBInstance',
+      { DBInstanceIdentifier: 'db', Engine: 'MySQL', DBInstanceClass: 'db.t3.micro' },
+      { DBInstanceIdentifier: 'db', Engine: 'mysql', DBInstanceClass: 'db.t3.micro' },
+    ],
+    [
+      'AWS::RDS::DBCluster',
+      { DBClusterIdentifier: 'cl', Engine: 'Aurora-MySQL' },
+      { DBClusterIdentifier: 'cl', Engine: 'aurora-mysql' },
+    ],
+  ];
+  for (const [type, declared, live] of CASES) {
+    it(`${type}: case-only echo folds`, () => {
+      const findings = classifyResource(
+        { logicalId: 'R', resourceType: type, physicalId: 'r', declared },
+        live,
+        emptySchema
+      );
+      expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+    });
+  }
+
+  it('a real engine change (beyond case) still surfaces', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'R',
+        resourceType: 'AWS::RDS::OptionGroup',
+        physicalId: 'og',
+        declared: { OptionGroupName: 'og', EngineName: 'MySQL', MajorEngineVersion: '8.4' },
+      },
+      { OptionGroupName: 'og', EngineName: 'postgres', MajorEngineVersion: '8.4' },
+      emptySchema
+    );
+    expect(findings.filter((f) => f.tier === 'declared').map((f) => f.path)).toEqual([
+      'EngineName',
+    ]);
+  });
+});
+
+describe('#1742 RecordSetGroup members are declared records', () => {
+  const ZONE = 'Z123EXAMPLE';
+  it('collects group members via the group-level zone ref', () => {
+    const declared = collectDeclaredRoute53Records(
+      [
+        {
+          resourceType: 'AWS::Route53::RecordSetGroup',
+          declared: {
+            HostedZoneId: ZONE,
+            RecordSets: [
+              { Name: 'MiXeD-Case.example-hunt.com', Type: 'A', TTL: '300' },
+              { Name: 'txt.example-hunt.com.', Type: 'TXT', SetIdentifier: 'x' },
+            ],
+          },
+        },
+      ],
+      ZONE,
+      'example-hunt.com.'
+    );
+    expect(declared).toEqual([
+      { name: 'MiXeD-Case.example-hunt.com', type: 'A', setIdentifier: undefined },
+      { name: 'txt.example-hunt.com.', type: 'TXT', setIdentifier: 'x' },
+    ]);
+  });
+
+  it('honors a per-member zone ref and skips members of OTHER zones', () => {
+    const declared = collectDeclaredRoute53Records(
+      [
+        {
+          resourceType: 'AWS::Route53::RecordSetGroup',
+          declared: {
+            RecordSets: [
+              { Name: 'a.example-hunt.com', Type: 'A', HostedZoneId: ZONE },
+              { Name: 'b.other.com', Type: 'A', HostedZoneId: 'ZOTHER' },
+            ],
+          },
+        },
+      ],
+      ZONE,
+      'example-hunt.com.'
+    );
+    expect(declared).toEqual([{ name: 'a.example-hunt.com', type: 'A', setIdentifier: undefined }]);
+  });
+
+  it('standalone RecordSet collection is unchanged', () => {
+    const declared = collectDeclaredRoute53Records(
+      [
+        {
+          resourceType: 'AWS::Route53::RecordSet',
+          declared: { HostedZoneId: ZONE, Name: 'solo.example-hunt.com', Type: 'CNAME' },
+        },
+      ],
+      ZONE,
+      'example-hunt.com.'
+    );
+    expect(declared).toEqual([
+      { name: 'solo.example-hunt.com', type: 'CNAME', setIdentifier: undefined },
+    ]);
+  });
+});
+
+describe('#1745 undeclared ELB attribute-bag element reverts via the per-key writer', () => {
+  const tgFinding = (over: Partial<Finding> = {}): Finding => ({
+    tier: 'undeclared',
+    logicalId: 'Tg',
+    resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+    physicalId: 'arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/tg/abc',
+    path: 'TargetGroupAttributes[deregistration_delay.timeout_seconds]',
+    actual: '45',
+    nested: true,
+    ...over,
+  });
+
+  it('appeared-since-record: writes the curated per-key default via attributeKey', () => {
+    const plan = buildRevertPlan([tgFinding()], undefined, {
+      declaredForLogical: () => ({ Protocol: 'TCP', TargetType: 'instance' }),
+    });
+    expect(plan.notRevertable).toEqual([]);
+    const item = plan.items[0]!;
+    expect(item.kind).toBe('sdk');
+    const op = item.ops[0]!;
+    expect(op.attributeKey).toBe('deregistration_delay.timeout_seconds');
+    expect(op.value).toBe('300');
+  });
+
+  it('recorded-then-changed: restores the baseline value', () => {
+    const plan = buildRevertPlan(
+      [tgFinding()],
+      {
+        recorded: [
+          {
+            logicalId: 'Tg',
+            path: 'TargetGroupAttributes[deregistration_delay.timeout_seconds]',
+            value: '120',
+          },
+        ],
+      } as never,
+      { declaredForLogical: () => ({ Protocol: 'TCP', TargetType: 'instance' }) }
+    );
+    expect(plan.notRevertable).toEqual([]);
+    expect(plan.items[0]!.ops[0]!.value).toBe('120');
+  });
+
+  it('a bag with NO per-key writer (ListenerAttributes) stays honestly not-revertable', () => {
+    const plan = buildRevertPlan(
+      [
+        tgFinding({
+          logicalId: 'L',
+          resourceType: 'AWS::ElasticLoadBalancingV2::Listener',
+          path: 'ListenerAttributes[tcp.idle_timeout.seconds]',
+          actual: '400',
+        }),
+      ],
+      undefined,
+      {}
+    );
+    expect(plan.items).toEqual([]);
+    expect(plan.notRevertable.map((n) => n.path)).toEqual([
+      'ListenerAttributes[tcp.idle_timeout.seconds]',
+    ]);
+  });
+
+  it('an unknown key with no curated default stays honestly not-revertable', () => {
+    const plan = buildRevertPlan(
+      [tgFinding({ path: 'TargetGroupAttributes[custom.attribute.nobody.knows]' })],
+      undefined,
+      { declaredForLogical: () => ({ Protocol: 'TCP', TargetType: 'instance' }) }
+    );
+    expect(plan.items).toEqual([]);
+    expect(plan.notRevertable).toHaveLength(1);
+  });
+});
+
+describe('#1746 EB SecurityGroups raw sg-id echo resolves through the anchored gate', () => {
+  const SG_ID = 'sg-08ffdc7eb70b6418a';
+  const tier = (sgNamesById?: Readonly<Record<string, string>>) =>
+    ebOptionSettingTier(
+      'aws:elb:loadbalancer',
+      'SecurityGroups',
+      SG_ID,
+      'LoadBalanced',
+      undefined,
+      sgNamesById
+    );
+
+  it('folds when the id resolves to the environment-generated group name', () => {
+    expect(tier({ [SG_ID]: 'awseb-e-abc123-stack-AWSEBLoadBalancerSecurityGroup-1A2B3C' })).toBe(
+      'atDefault'
+    );
+  });
+  it('surfaces when the id resolves to a NON-generated (rogue) group name', () => {
+    expect(tier({ [SG_ID]: 'my-rogue-group' })).toBe('undeclared');
+  });
+  it('surfaces when the id cannot be resolved (fail-closed, the #1264 posture)', () => {
+    expect(tier(undefined)).toBe('undeclared');
+    expect(tier({})).toBe('undeclared');
+  });
+  it('generated NAMES still fold without any map (existing behavior)', () => {
+    expect(
+      ebOptionSettingTier(
+        'aws:autoscaling:launchconfiguration',
+        'SecurityGroups',
+        'awseb-e-abc123-stack-AWSEBSecurityGroup-XYZ',
+        'LoadBalanced'
+      )
+    ).toBe('atDefault');
+  });
+
+  it('collectEbSecurityGroupIds extracts ids from EB env SecurityGroups options only', () => {
+    const ids = collectEbSecurityGroupIds(
+      [
+        { logicalId: 'EbEnv', resourceType: 'AWS::ElasticBeanstalk::Environment' },
+        { logicalId: 'Other', resourceType: 'AWS::S3::Bucket' },
+      ],
+      new Map([
+        [
+          'EbEnv',
+          {
+            OptionSettings: [
+              {
+                Namespace: 'aws:elb:loadbalancer',
+                OptionName: 'SecurityGroups',
+                Value: `${SG_ID},awseb-e-abc-stack-AWSEBSecurityGroup-X`,
+              },
+              { Namespace: 'aws:elb:loadbalancer', OptionName: 'CrossZone', Value: 'sg-deadbeef' },
+            ],
+          },
+        ],
+      ])
+    );
+    expect(ids).toEqual([SG_ID]);
+  });
+});
+
+describe('#1740 DAEMON whole-object DeploymentConfiguration revert', () => {
+  it('writes the derived DAEMON object explicitly + companion-removes the DesiredCount echo', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'DaemonService',
+      resourceType: 'AWS::ECS::Service',
+      physicalId: 'arn:aws:ecs:us-east-1:111111111111:service/c/daemon-svc',
+      path: 'DeploymentConfiguration',
+      actual: { MaximumPercent: 100, MinimumHealthyPercent: 50 },
+    };
+    const plan = buildRevertPlan([f], undefined, {
+      declaredForLogical: () => ({ SchedulingStrategy: 'DAEMON' }),
+      liveByLogical: new Map([
+        ['DaemonService', { DesiredCount: 3, DeploymentConfiguration: f.actual }],
+      ]) as never,
+    });
+    expect(plan.notRevertable).toEqual([]);
+    const ops = plan.items[0]!.ops;
+    const add = ops.find((o) => o.path === '/DeploymentConfiguration')!;
+    expect(add.op).toBe('add');
+    expect((add.value as Record<string, unknown>).MaximumPercent).toBe(100);
+    expect((add.value as Record<string, unknown>).MinimumHealthyPercent).toBe(0);
+    // the ECS-managed DesiredCount echo rides the same patch as a remove — the DAEMON
+    // validation rejects any model that still carries it (live, variants6-hunt). It is a
+    // CONTRACT op: the echo persists by design after the revert, so the convergence no-op
+    // detector must skip it (a non-contract companion false-flagged "NOT reverted" live).
+    const companion = ops.find((o) => o.op === 'remove' && o.path === '/DesiredCount');
+    expect(companion).toBeDefined();
+    expect(companion!.contract).toBe(true);
+  });
+
+  it('a REPLICA service reverting DeploymentConfiguration keeps its DECLARED DesiredCount', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Svc',
+      resourceType: 'AWS::ECS::Service',
+      physicalId: 'arn:aws:ecs:us-east-1:111111111111:service/c/svc',
+      path: 'DeploymentConfiguration',
+      actual: { MaximumPercent: 150 },
+    };
+    const plan = buildRevertPlan([f], undefined, {
+      declaredForLogical: () => ({ DesiredCount: 2 }),
+      liveByLogical: new Map([['Svc', { DesiredCount: 2 }]]) as never,
+    });
+    const ops = plan.items[0]!.ops;
+    expect(ops.some((o) => o.op === 'remove' && o.path === '/DesiredCount')).toBe(false);
+  });
+});

--- a/tests/integration/allowpack-hunt/app.ts
+++ b/tests/integration/allowpack-hunt/app.ts
@@ -1,0 +1,163 @@
+// 2026-08-10 hunt: predicted allowlist-gap FPs (Round-0 offline audit) — each
+// resource declares the exact shape whose live echo is suspected to diverge
+// from the declared value by a pure normalization cdkrd does not fold yet:
+//  - S3 LifecycleConfiguration DATE-valued rules (ExpirationDate /
+//    TransitionDate): no ISO-8601/timestamp normalization exists anywhere in
+//    normalize/; the live read may re-serialize the midnight-UTC date.
+//    Rider: NotificationConfiguration EventBridgeEnabled (absent from the
+//    declared-key corpus inventory entirely).
+//  - SNS Topic DeliveryPolicy: a PARTIAL healthyRetryPolicy is expanded by the
+//    service into the full document (the JSON_STRING_DEFAULT_FILLS class,
+//    which has a single CE CostCategory entry).
+//  - Route53 RecordSetGroup: the whole RecordSet fold family (case, trailing
+//    dot, ResourceRecords reorder) keys on AWS::Route53::RecordSet only —
+//    RecordSetGroup nests the same objects under RecordSets.* and none match.
+//  - WAFv2 WebACL / RuleGroup FieldToMatch.SingleHeader.Name declared in mixed
+//    case: WAF stores header names LOWERCASED (proven for the sibling
+//    LoggingConfiguration RedactedFields entry; the WebACL/RuleGroup statement
+//    paths have no entry and are variable-depth).
+// First `check` (pre-record) must show ZERO [Potential Drift].
+//  - RDS OptionGroup EngineName / DBParameterGroup Family declared in mixed
+//    case: the CC handler ACCEPTS "MySQL" / "MySQL8.4" and stores lowercased
+//    (stackless CC probe 2026-08-10) — the #1712 owning-prop entries cover the
+//    *name* identifiers only, not these enum-ish props.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnDBParameterGroup, CfnOptionGroup } from "aws-cdk-lib/aws-rds";
+import { CfnHostedZone, CfnRecordSetGroup } from "aws-cdk-lib/aws-route53";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+import { CfnRuleGroup, CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0810Allow");
+
+// --- S3 lifecycle date rules + EventBridge notification ---
+const bucket = new CfnBucket(stack, "Bucket", {
+  lifecycleConfiguration: {
+    rules: [
+      {
+        id: "date-expire",
+        status: "Enabled",
+        prefix: "archive/",
+        expirationDate: new Date("2027-01-01T00:00:00Z"),
+        transitions: [{ storageClass: "GLACIER", transitionDate: new Date("2026-12-01T00:00:00Z") }],
+      },
+    ],
+  },
+  notificationConfiguration: {
+    eventBridgeConfiguration: { eventBridgeEnabled: true },
+  },
+});
+bucket.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+// --- SNS topic with a PARTIAL DeliveryPolicy (service fills the rest) ---
+new CfnTopic(stack, "Topic", {
+  topicName: "cdkrd-0810a-topic",
+  deliveryPolicy: {
+    http: {
+      defaultHealthyRetryPolicy: { numRetries: 5 },
+    },
+  },
+});
+
+// --- Route53 hosted zone + RecordSetGroup (mixed case, no trailing dot, multi-value) ---
+const zone = new CfnHostedZone(stack, "Zone", {
+  name: "cdkrd-fphunt-a0810.com.",
+});
+new CfnRecordSetGroup(stack, "Records", {
+  hostedZoneId: zone.attrId,
+  recordSets: [
+    {
+      // mixed case + NO trailing dot — Route53 stores lowercased + dotted
+      name: "MiXeD-Case.cdkrd-fphunt-a0810.com",
+      type: "A",
+      ttl: "300",
+      resourceRecords: ["192.0.2.1"],
+    },
+    {
+      // multi-value TXT declared non-sorted — reorder probe
+      name: "txt.cdkrd-fphunt-a0810.com.",
+      type: "TXT",
+      ttl: "300",
+      resourceRecords: ['"zulu"', '"alpha"', '"mike"'],
+    },
+  ],
+});
+
+// --- WAFv2 WebACL + RuleGroup with mixed-case header names ---
+new CfnWebACL(stack, "WebAcl", {
+  name: "cdkrd-0810a-acl",
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    cloudWatchMetricsEnabled: false,
+    metricName: "cdkrd0810aAcl",
+    sampledRequestsEnabled: false,
+  },
+  rules: [
+    {
+      name: "hdr",
+      priority: 0,
+      action: { block: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: false,
+        metricName: "cdkrd0810aHdr",
+        sampledRequestsEnabled: false,
+      },
+      statement: {
+        byteMatchStatement: {
+          fieldToMatch: { singleHeader: { Name: "User-Agent" } },
+          positionalConstraint: "CONTAINS",
+          searchString: "cdkrd-hunt",
+          textTransformations: [{ priority: 0, type: "NONE" }],
+        },
+      },
+    },
+  ],
+});
+new CfnRuleGroup(stack, "RuleGroup", {
+  name: "cdkrd-0810a-rg",
+  scope: "REGIONAL",
+  capacity: 25,
+  visibilityConfig: {
+    cloudWatchMetricsEnabled: false,
+    metricName: "cdkrd0810aRg",
+    sampledRequestsEnabled: false,
+  },
+  rules: [
+    {
+      name: "qarg",
+      priority: 0,
+      action: { count: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: false,
+        metricName: "cdkrd0810aQarg",
+        sampledRequestsEnabled: false,
+      },
+      statement: {
+        byteMatchStatement: {
+          fieldToMatch: { singleQueryArgument: { Name: "SessionId" } },
+          positionalConstraint: "EXACTLY",
+          searchString: "x",
+          textTransformations: [{ priority: 0, type: "NONE" }],
+        },
+      },
+    },
+  ],
+});
+
+// --- RDS mixed-case EngineName / Family (stored lowercased) ---
+new CfnOptionGroup(stack, "Og", {
+  optionGroupName: "cdkrd-0810a-og",
+  engineName: "MySQL",
+  majorEngineVersion: "8.4",
+  optionGroupDescription: "cdkrd 0810 allowpack",
+});
+new CfnDBParameterGroup(stack, "Dpg", {
+  dbParameterGroupName: "cdkrd-0810a-dpg",
+  family: "MySQL8.4",
+  description: "cdkrd 0810 allowpack",
+});
+
+app.synth();

--- a/tests/integration/allowpack-hunt/cdk.json
+++ b/tests/integration/allowpack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/allowpack-hunt/package.json
+++ b/tests/integration/allowpack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-allowpack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "2026-08-10 hunt: predicted allowlist-gap FPs — S3 lifecycle date rules + EventBridge notification, SNS partial DeliveryPolicy expansion, Route53 RecordSetGroup fold-family bypass, WAFv2 mixed-case SingleHeader/SingleQueryArgument names. First-run FP probe via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/allowpack-hunt/verify.sh
+++ b/tests/integration/allowpack-hunt/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# 2026-08-10 hunt: allowlist-gap first-run FP probe.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0810Allow
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN (allowlist-gap FP probe) ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-allowpack}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP (see /tmp/cdkrd-$STACK.pre.out)"
+
+echo "=== [$STACK] record -> check --fail MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check"
+
+echo "INTEG OK ($STACK)"

--- a/tests/integration/eb-lb-hunt/app.ts
+++ b/tests/integration/eb-lb-hunt/app.ts
@@ -1,0 +1,60 @@
+// 2026-08-10 hunt: a LIVE LoadBalanced Elastic Beanstalk Environment — every
+// existing Environment fixture is SingleInstance (the LoadBalanced shape was only
+// ever deployed as a ConfigurationTemplate, which is where the derived rows were
+// pinned). A live LoadBalanced env materializes the `aws:elb:*` / LoadBalancerType
+// option families the SingleInstance envs never read back — the
+// `aws:elasticbeanstalk:environment|LoadBalancerType: 'classic'` flat constant and
+// the ~20 `aws:elb:*` EB_OPTION_DEFAULTS rows are the suspected gap.
+// First `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnEnvironment,
+} from "aws-cdk-lib/aws-elasticbeanstalk";
+import { CfnInstanceProfile, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+
+const SOLUTION_STACK = "64bit Amazon Linux 2023 v4.13.3 running Docker";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0810EbLb");
+
+const instanceRole = new Role(stack, "EbInstanceRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  managedPolicies: [
+    { managedPolicyArn: "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier" },
+  ],
+});
+const instanceProfile = new CfnInstanceProfile(stack, "EbInstanceProfile", {
+  roles: [instanceRole.roleName],
+});
+
+const application = new CfnApplication(stack, "EbApp", {
+  applicationName: "cdkrd-0810-eblb-app",
+});
+
+const environment = new CfnEnvironment(stack, "EbEnv", {
+  applicationName: application.applicationName!,
+  environmentName: "cdkrd-0810-eblb-env",
+  solutionStackName: SOLUTION_STACK,
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "LoadBalanced",
+    },
+    {
+      namespace: "aws:autoscaling:launchconfiguration",
+      optionName: "InstanceType",
+      value: "t3.micro",
+    },
+    {
+      namespace: "aws:autoscaling:launchconfiguration",
+      optionName: "IamInstanceProfile",
+      value: instanceProfile.ref,
+    },
+  ],
+});
+environment.addDependency(application);
+
+app.synth();

--- a/tests/integration/eb-lb-hunt/cdk.json
+++ b/tests/integration/eb-lb-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eb-lb-hunt/package.json
+++ b/tests/integration/eb-lb-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eb-lb-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "2026-08-10 hunt: LIVE LoadBalanced Elastic Beanstalk environment — the aws:elb:* / LoadBalancerType option families never read back from a live env. First-run FP probe via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eb-lb-hunt/verify.sh
+++ b/tests/integration/eb-lb-hunt/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# 2026-08-10 hunt: LoadBalanced EB env first-run FP probe (slow create ~10 min).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0810EbLb
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN (LoadBalanced env FP probe) ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-eblb}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP (see /tmp/cdkrd-$STACK.pre.out)"
+
+echo "=== [$STACK] record -> check --fail MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check"
+
+echo "INTEG OK ($STACK)"

--- a/tests/integration/mq-rabbit-hunt/app.ts
+++ b/tests/integration/mq-rabbit-hunt/app.ts
@@ -1,0 +1,28 @@
+// 2026-08-10 hunt: AmazonMQ Broker EngineType=RABBITMQ — the classify.ts
+// engineStorageDefault RABBITMQ row ('EBS') is a doc-derived MIRRORED row with
+// no live citation (the one corpus broker is ACTIVEMQ). Beyond StorageType,
+// RabbitMQ echoes a different Logging shape (no Audit log), a different
+// endpoint family (Amqp only), and possibly different AuthenticationStrategy /
+// EncryptionOptions echoes — none engine-gated today.
+// First `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnBroker } from "aws-cdk-lib/aws-amazonmq";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0810Mq");
+
+// engine-axis validation difference (live, 2026-08-10): RabbitMQ REJECTS
+// mq.t3.micro ("does not support host instance type") while ActiveMQ accepts it
+// — new RabbitMQ brokers need the m5+ family.
+new CfnBroker(stack, "Broker", {
+  brokerName: "cdkrd-0810-rabbit",
+  engineType: "RABBITMQ",
+  hostInstanceType: "mq.m5.large",
+  deploymentMode: "SINGLE_INSTANCE",
+  publiclyAccessible: true,
+  autoMinorVersionUpgrade: true,
+  users: [{ username: "cdkrdhunt", password: "cdkrd-hunt-0810-pw!A1" }],
+});
+
+app.synth();

--- a/tests/integration/mq-rabbit-hunt/cdk.json
+++ b/tests/integration/mq-rabbit-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/mq-rabbit-hunt/package.json
+++ b/tests/integration/mq-rabbit-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-mq-rabbit-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "2026-08-10 hunt: AmazonMQ RABBITMQ broker — the mirrored engineStorageDefault row + engine-dependent echo shapes, never live-deployed. First-run FP probe via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/mq-rabbit-hunt/verify.sh
+++ b/tests/integration/mq-rabbit-hunt/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# 2026-08-10 hunt: RabbitMQ broker first-run FP probe (slow create ~10 min).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0810Mq
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN (RABBITMQ variant probe) ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-mqrabbit}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP (see /tmp/cdkrd-$STACK.pre.out)"
+
+echo "=== [$STACK] record -> check --fail MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check"
+
+echo "INTEG OK ($STACK)"

--- a/tests/integration/variants6-hunt/app.ts
+++ b/tests/integration/variants6-hunt/app.ts
@@ -1,0 +1,138 @@
+// 2026-08-10 hunt: un-deployed variant branches (Round-0 audit).
+//  - ECS Service SchedulingStrategy=DAEMON — every corpus service is REPLICA;
+//    AWS documents the DAEMON rollout band as MaximumPercent=100 /
+//    MinimumHealthyPercent=0, which the REPLICA-derived 200/100 pins would
+//    mis-fold; DesiredCount is undeclarable for DAEMON and echoes ECS's count.
+//  - Batch ComputeEnvironment ComputeResources.Type=SPOT — corpus covers
+//    EC2 / FARGATE / FARGATE_SPOT / UNMANAGED; the EC2-SPOT arm reads back
+//    BidPercentage / AllocationStrategy echoes with no fold.
+//  - Glue Job Command.Name=glueray — RULED OUT live (2026-08-10): create fails
+//    with "Account not allowed to submit Glue Ray job Post Deprecation" — Ray
+//    jobs are deprecated and CFn-unreachable for current accounts, so the
+//    glueetl-scoped 'Command.PythonVersion': '2' pin can never FP on a Ray job.
+//  - NLB UDP + TCP_UDP listeners — Listener attributes have no BY_PROTOCOL
+//    split (unlike TargetGroup); the UDP arms never deployed.
+// First `check` (pre-record) must show ZERO [Potential Drift].
+import { App, Fn, Stack, Tags } from "aws-cdk-lib";
+import { CfnComputeEnvironment } from "aws-cdk-lib/aws-batch";
+import { CfnSecurityGroup, CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnService, CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+import {
+  CfnListener,
+  CfnLoadBalancer,
+  CfnTargetGroup,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { CfnInstanceProfile, CfnRole } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0810Var");
+
+// --- shared VPC ---
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.0.0.0/24" });
+const subnet = new CfnSubnet(stack, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.0.0/25",
+  availabilityZone: Fn.select(0, Fn.getAzs()),
+});
+
+// --- ECS DAEMON service (no DesiredCount, no DeploymentConfiguration) ---
+const cluster = new CfnCluster(stack, "EcsCluster", {
+  clusterName: "cdkrd-0810v-cluster",
+});
+const taskDef = new CfnTaskDefinition(stack, "TaskDef", {
+  family: "cdkrd-0810v-td",
+  requiresCompatibilities: ["EC2"],
+  containerDefinitions: [
+    { name: "app", image: "public.ecr.aws/docker/library/busybox:stable", memory: 128 },
+  ],
+});
+new CfnService(stack, "DaemonService", {
+  cluster: cluster.ref,
+  taskDefinition: taskDef.ref,
+  launchType: "EC2",
+  schedulingStrategy: "DAEMON",
+});
+
+// --- Batch EC2-SPOT compute environment (MinvCpus 0 -> no instances launch) ---
+const sg = new CfnSecurityGroup(stack, "BatchSg", {
+  groupDescription: "cdkrd 0810 batch spot",
+  vpcId: vpc.ref,
+});
+const instanceRole = new CfnRole(stack, "BatchInstanceRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      { Effect: "Allow", Principal: { Service: "ec2.amazonaws.com" }, Action: "sts:AssumeRole" },
+    ],
+  },
+  managedPolicyArns: [
+    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
+  ],
+});
+const instanceProfile = new CfnInstanceProfile(stack, "BatchInstanceProfile", {
+  roles: [instanceRole.ref],
+});
+const spotFleetRole = new CfnRole(stack, "SpotFleetRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "spotfleet.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  managedPolicyArns: ["arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"],
+});
+new CfnComputeEnvironment(stack, "SpotCe", {
+  computeEnvironmentName: "cdkrd-0810v-spotce",
+  type: "MANAGED",
+  computeResources: {
+    type: "SPOT",
+    minvCpus: 0,
+    maxvCpus: 1,
+    subnets: [subnet.ref],
+    securityGroupIds: [sg.ref],
+    instanceTypes: ["optimal"],
+    instanceRole: instanceProfile.attrArn,
+    spotIamFleetRole: spotFleetRole.attrArn,
+  },
+});
+
+// --- internal NLB + UDP / TCP_UDP listeners ---
+const nlb = new CfnLoadBalancer(stack, "Nlb", {
+  name: "cdkrd-0810v-nlb",
+  type: "network",
+  scheme: "internal",
+  subnets: [subnet.ref],
+});
+const udpTg = new CfnTargetGroup(stack, "UdpTg", {
+  name: "cdkrd-0810v-udp-tg",
+  protocol: "UDP",
+  port: 53,
+  vpcId: vpc.ref,
+  targetType: "instance",
+});
+const tcpUdpTg = new CfnTargetGroup(stack, "TcpUdpTg", {
+  name: "cdkrd-0810v-tu-tg",
+  protocol: "TCP_UDP",
+  port: 54,
+  vpcId: vpc.ref,
+  targetType: "instance",
+});
+new CfnListener(stack, "UdpListener", {
+  loadBalancerArn: nlb.ref,
+  protocol: "UDP",
+  port: 53,
+  defaultActions: [{ type: "forward", targetGroupArn: udpTg.ref }],
+});
+new CfnListener(stack, "TcpUdpListener", {
+  loadBalancerArn: nlb.ref,
+  protocol: "TCP_UDP",
+  port: 54,
+  defaultActions: [{ type: "forward", targetGroupArn: tcpUdpTg.ref }],
+});
+
+app.synth();

--- a/tests/integration/variants6-hunt/cdk.json
+++ b/tests/integration/variants6-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/variants6-hunt/package.json
+++ b/tests/integration/variants6-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-variants6-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "2026-08-10 hunt: un-deployed variant branches — ECS DAEMON service, Batch EC2-SPOT compute environment, Glue Ray job, NLB UDP/TCP_UDP listeners. First-run FP probe via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/variants6-hunt/verify.sh
+++ b/tests/integration/variants6-hunt/verify.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# 2026-08-10 hunt: variant-branch first-run FP probe.
+# deploy -> first check must show ZERO [Potential Drift] -> record -> check --fail clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0810Var
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] first check MUST be CLEAN (variant FP probe) ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-variants6}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP (see /tmp/cdkrd-$STACK.pre.out)"
+
+echo "=== [$STACK] record -> check --fail MUST be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check"
+
+echo "=== [$STACK] DAEMON band FN/revert piggyback (#1740) ==="
+SVC_ARN="$(aws cloudformation describe-stack-resource --stack-name "$STACK" --region "$REGION" \
+  --logical-resource-id DaemonService --query 'StackResourceDetail.PhysicalResourceId' --output text)"
+if aws ecs update-service --cluster cdkrd-0810v-cluster --service "$SVC_ARN" --region "$REGION" \
+  --deployment-configuration "minimumHealthyPercent=50" >/dev/null 2>/tmp/cdkrd-ecs-mut.err; then
+  sleep 20
+  $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+  [ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected DAEMON band drift (exit 1)"
+  grep -q "DaemonService.DeploymentConfiguration" "/tmp/cdkrd-$STACK.detect.out" || fail "missed DAEMON band detection"
+  $CLI revert "$STACK" --region "$REGION" --yes --remove-unrecorded | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+  grep -Eq "NOT reverted|could not be confirmed|not revertable" "/tmp/cdkrd-$STACK.revert.out" \
+    && fail "DAEMON band revert did not converge"
+  sleep 20
+  $CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after DAEMON band revert"
+  V="$(aws ecs describe-services --cluster cdkrd-0810v-cluster --services "$SVC_ARN" --region "$REGION" \
+    --query 'services[0].deploymentConfiguration.minimumHealthyPercent' --output text)"
+  [ "$V" = "0" ] || fail "DAEMON minimumHealthyPercent not restored to 0: $V"
+else
+  # a service-side rejection is itself the determination: the DAEMON band is not
+  # OOB-mutable, so the derived revert arm is invariant-only (like DELIVERY retention)
+  echo "DETERMINATION: DAEMON band not OOB-mutable — $(cat /tmp/cdkrd-ecs-mut.err)"
+fi
+
+echo "INTEG OK ($STACK)"

--- a/tests/integration/wrtpack-hunt/app.ts
+++ b/tests/integration/wrtpack-hunt/app.ts
@@ -1,0 +1,167 @@
+// 2026-08-10 hunt: SDK-writer live-proof pack. The Round-0 audit found the READ
+// side almost fully live-exercised but ~10 SDK writers / prop writers / deleters
+// with a corpus-proven reader and a revert path that has NEVER run against real
+// AWS. One nearly-free stack; each resource gets an out-of-band mutation ->
+// detect -> revert -> live-value assert in verify-detect.sh:
+//  - ELBv2 TargetGroup attribute bag (modify-target-group-attributes writer)
+//  - ElastiCache ParameterGroup (declared param drift -> writer)
+//  - DAX ParameterGroup (undeclared param drift -> writer)
+//  - Budgets Budget (writeBudget, #1676 — never live-run)
+//  - CloudWatch CompositeAlarm ActionsEnabled (SDK_PROP_WRITERS via
+//    Enable/DisableAlarmActions — the batch-5 no-op fix, never live-run)
+//  - Cognito IdentityPool CognitoEvents (cognito-sync prop writer)
+//  - SES ConfigurationSetEventDestination (SESv2 update writer)
+//  - ServiceDiscovery Service (UpdateService writer — namespace writer is proven,
+//    the Service one is not)
+//  - KMS Grant (synthetic added-tier: out-of-band create-grant -> revert must
+//    RevokeGrant — deleter never live-run)
+//  - Logs LogGroup BearerTokenAuthenticationEnabled (dedicated-API prop writer)
+import { App, Fn, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnBudget } from "aws-cdk-lib/aws-budgets";
+import { CfnAlarm, CfnCompositeAlarm } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnIdentityPool } from "aws-cdk-lib/aws-cognito";
+import { CfnParameterGroup as CfnDaxParameterGroup } from "aws-cdk-lib/aws-dax";
+import { CfnSubnet, CfnVPC } from "aws-cdk-lib/aws-ec2";
+import { CfnParameterGroup as CfnEcParameterGroup } from "aws-cdk-lib/aws-elasticache";
+import { CfnTargetGroup } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnKey } from "aws-cdk-lib/aws-kms";
+import { CfnFunction } from "aws-cdk-lib/aws-lambda";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+import { CfnPrivateDnsNamespace, CfnService } from "aws-cdk-lib/aws-servicediscovery";
+import { CfnConfigurationSet, CfnConfigurationSetEventDestination } from "aws-cdk-lib/aws-ses";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const stack = new Stack(app, "CdkrdHunt0810Wrt");
+
+// --- ELBv2 TargetGroup (standalone, no LB needed for its attribute bag) ---
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.0.0.0/24" });
+new CfnSubnet(stack, "Subnet", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.0.0/25",
+  availabilityZone: Fn.select(0, Fn.getAzs()),
+});
+new CfnTargetGroup(stack, "Tg", {
+  name: "cdkrd-0810w-tg",
+  protocol: "TCP",
+  port: 80,
+  vpcId: vpc.ref,
+  targetType: "instance",
+});
+
+// --- ElastiCache ParameterGroup (declared params -> declared-drift revert) ---
+new CfnEcParameterGroup(stack, "EcPg", {
+  cacheParameterGroupFamily: "redis7",
+  description: "cdkrd 0810 writer hunt",
+  properties: {
+    "maxmemory-policy": "allkeys-lru",
+  },
+});
+
+// --- DAX ParameterGroup (barest: params undeclared -> undeclared-drift revert) ---
+new CfnDaxParameterGroup(stack, "DaxPg", {
+  parameterGroupName: "cdkrd-0810w-daxpg",
+  description: "cdkrd 0810 writer hunt",
+});
+
+// --- Budgets Budget (writeBudget) ---
+new CfnBudget(stack, "Budget", {
+  budget: {
+    budgetName: "cdkrd-0810w-budget",
+    budgetType: "COST",
+    timeUnit: "MONTHLY",
+    budgetLimit: { amount: 100, unit: "USD" },
+  },
+});
+
+// --- CloudWatch metric alarm + CompositeAlarm (ActionsEnabled prop writer) ---
+const cpu = new CfnAlarm(stack, "CpuAlarm", {
+  alarmName: "cdkrd-0810w-cpu",
+  namespace: "AWS/EC2",
+  metricName: "CPUUtilization",
+  statistic: "Average",
+  period: 300,
+  evaluationPeriods: 2,
+  threshold: 80,
+  comparisonOperator: "GreaterThanThreshold",
+});
+const composite = new CfnCompositeAlarm(stack, "Composite", {
+  alarmName: "cdkrd-0810w-composite",
+  alarmRule: `ALARM("${cpu.alarmName}")`,
+});
+// the composite validates its member alarms EXIST at create — force the ordering
+composite.addDependency(cpu);
+
+// --- Cognito IdentityPool + a minimal Lambda for the CognitoEvents SyncTrigger ---
+const lambdaRole = new CfnRole(stack, "FnRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      { Effect: "Allow", Principal: { Service: "lambda.amazonaws.com" }, Action: "sts:AssumeRole" },
+    ],
+  },
+});
+const fn = new CfnFunction(stack, "Fn", {
+  functionName: "cdkrd-0810w-fn",
+  runtime: "nodejs20.x",
+  handler: "index.handler",
+  role: lambdaRole.attrArn,
+  code: { zipFile: "exports.handler = async () => ({});" },
+});
+new CfnIdentityPool(stack, "IdPool", {
+  identityPoolName: "cdkrd0810wpool",
+  allowUnauthenticatedIdentities: false,
+});
+
+// --- SES ConfigurationSet + EventDestination (SESv2 update writer) ---
+const cs = new CfnConfigurationSet(stack, "SesCs", { name: "cdkrd-0810w-cs" });
+new CfnConfigurationSetEventDestination(stack, "SesDest", {
+  configurationSetName: cs.ref,
+  eventDestination: {
+    name: "cdkrd-0810w-dest",
+    enabled: true,
+    matchingEventTypes: ["SEND", "BOUNCE", "COMPLAINT"],
+    cloudWatchDestination: {
+      dimensionConfigurations: [
+        {
+          dimensionName: "ses-source",
+          dimensionValueSource: "messageTag",
+          defaultDimensionValue: "none",
+        },
+      ],
+    },
+  },
+});
+
+// --- Cloud Map private-DNS namespace + Service (UpdateService writer) ---
+// (a Service in an HTTP namespace is API-ONLY and CANNOT be updated —
+// "Service in API-only namespace cannot be updated", live 2026-08-10 — so the
+// UpdateService writer is provable only on a DNS-namespace service)
+const ns = new CfnPrivateDnsNamespace(stack, "Ns", {
+  name: "cdkrd0810w.local",
+  vpc: vpc.ref,
+  description: "cdkrd 0810 writer hunt ns",
+});
+new CfnService(stack, "Svc", {
+  name: "cdkrd-0810w-svc",
+  namespaceId: ns.attrId,
+  description: "cdkrd 0810 writer hunt svc",
+  dnsConfig: {
+    dnsRecords: [{ type: "A", ttl: 60 }],
+    routingPolicy: "MULTIVALUE",
+  },
+});
+
+// --- KMS key (out-of-band create-grant -> synthetic added AWS::KMS::Grant) ---
+const key = new CfnKey(stack, "Key", {
+  description: "cdkrd 0810 writer hunt",
+  pendingWindowInDays: 7,
+});
+key.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+// --- LogGroup (BearerTokenAuthenticationEnabled dedicated-API prop writer) ---
+const lg = new CfnLogGroup(stack, "Lg", { logGroupName: "cdkrd-0810w-lg" });
+lg.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+app.synth();

--- a/tests/integration/wrtpack-hunt/cdk.json
+++ b/tests/integration/wrtpack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wrtpack-hunt/package.json
+++ b/tests/integration/wrtpack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wrtpack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "2026-08-10 hunt: live-proof pack for never-exercised SDK writers/deleters (TG attributes, ElastiCache/DAX ParameterGroup, Budgets, CompositeAlarm ActionsEnabled, Cognito IdentityPool CognitoEvents, SES CSED, ServiceDiscovery Service, KMS Grant revoke, LogGroup bearer-token). Run via verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wrtpack-hunt/verify-detect.sh
+++ b/tests/integration/wrtpack-hunt/verify-detect.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# 2026-08-10 hunt: live-proof of never-exercised SDK writers/deleters.
+# deploy -> first check MUST be CLEAN (barest-pack FP probe) -> record ->
+# mutate all 10 targets out of band -> check MUST DETECT (exit 1) ->
+# revert --remove-unrecorded -> check MUST be CLEAN -> live values MUST be back.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0810Wrt
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ACCT="$(aws sts get-caller-identity --query Account --output text)"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  # the out-of-band grant blocks nothing, but revoke it if the run died mid-way
+  if [ -n "${KEY_ID:-}" ]; then
+    GID="$(aws kms list-grants --key-id "$KEY_ID" --region "$REGION" \
+      --query "Grants[?Name=='cdkrd-0810w-grant'].GrantId" --output text 2>/dev/null || true)"
+    [ -n "$GID" ] && aws kms revoke-grant --key-id "$KEY_ID" --grant-id "$GID" --region "$REGION" 2>/dev/null || true
+  fi
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+phys() {
+  aws cloudformation describe-stack-resource --stack-name "$STACK" --region "$REGION" \
+    --logical-resource-id "$1" --query 'StackResourceDetail.PhysicalResourceId' --output text
+}
+EC_PG="$(phys EcPg)"
+SVC_ID="$(phys Svc)"
+KEY_ID="$(phys Key)"
+ROLE_NAME="$(phys FnRole)"
+TG_ARN="$(aws elbv2 describe-target-groups --names cdkrd-0810w-tg --region "$REGION" \
+  --query 'TargetGroups[0].TargetGroupArn' --output text)"
+
+echo "=== [$STACK] first check MUST be CLEAN (barest-pack FP probe), then record ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-wrtpack}" $CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK.pre.out"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && fail "first-run FP (see /tmp/cdkrd-$STACK.pre.out)"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] mutate all targets out of band ==="
+aws elbv2 modify-target-group-attributes --target-group-arn "$TG_ARN" --region "$REGION" \
+  --attributes Key=deregistration_delay.timeout_seconds,Value=45 >/dev/null || fail "mutate tg"
+aws elasticache modify-cache-parameter-group --cache-parameter-group-name "$EC_PG" --region "$REGION" \
+  --parameter-name-values "ParameterName=maxmemory-policy,ParameterValue=noeviction" >/dev/null || fail "mutate ec pg"
+aws dax update-parameter-group --parameter-group-name cdkrd-0810w-daxpg --region "$REGION" \
+  --parameter-name-values "ParameterName=query-ttl-millis,ParameterValue=60000" >/dev/null || fail "mutate dax pg"
+aws budgets update-budget --account-id "$ACCT" --new-budget \
+  '{"BudgetName":"cdkrd-0810w-budget","BudgetType":"COST","TimeUnit":"MONTHLY","BudgetLimit":{"Amount":"50","Unit":"USD"}}' \
+  >/dev/null || fail "mutate budget"
+aws cloudwatch disable-alarm-actions --alarm-names cdkrd-0810w-composite --region "$REGION" \
+  >/dev/null || fail "mutate composite alarm"
+# CognitoEvents leg RULED OUT live (2026-08-10): "Amazon Cognito Sync is no longer
+# accepting new customers" (NotAuthorizedException) — the SDK_PROP_WRITERS
+# CognitoEvents writer cannot be live-proven from a new account; the OOB mutation
+# itself is service-refused, so the drift is unreachable here too.
+aws sesv2 update-configuration-set-event-destination --region "$REGION" \
+  --configuration-set-name cdkrd-0810w-cs --event-destination-name cdkrd-0810w-dest \
+  --event-destination '{"Enabled":true,"MatchingEventTypes":["SEND"],"CloudWatchDestination":{"DimensionConfigurations":[{"DimensionName":"ses-source","DimensionValueSource":"MESSAGE_TAG","DefaultDimensionValue":"none"}]}}' \
+  >/dev/null || fail "mutate ses csed"
+aws servicediscovery update-service --id "$SVC_ID" --region "$REGION" \
+  --service '{"Description":"cdkrd 0810 drifted","DnsConfig":{"DnsRecords":[{"Type":"A","TTL":60}]}}' \
+  >/dev/null || fail "mutate cloudmap svc"
+aws kms create-grant --key-id "$KEY_ID" --region "$REGION" \
+  --grantee-principal "arn:aws:iam::$ACCT:role/$ROLE_NAME" \
+  --operations Decrypt --name cdkrd-0810w-grant >/dev/null || fail "mutate kms grant"
+aws logs put-bearer-token-authentication --log-group-identifier cdkrd-0810w-lg --region "$REGION" \
+  --bearer-token-authentication-enabled >/dev/null || fail "mutate loggroup bearer"
+sleep 30
+
+echo "=== [$STACK] check MUST DETECT all 10 ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift (exit 1), got $rc"
+for needle in deregistration_delay "maxmemory-policy" "query-ttl-millis" BudgetLimit ActionsEnabled \
+  MatchingEventTypes "AWS::KMS::Grant" BearerTokenAuthenticationEnabled; do
+  grep -q "$needle" "/tmp/cdkrd-$STACK.detect.out" || fail "missed detection: $needle"
+done
+# the Cloud Map Service description drift (declared tier)
+grep -Eq "Description" "/tmp/cdkrd-$STACK.detect.out" || fail "missed detection: cloudmap Description"
+
+echo "=== [$STACK] revert (all via SDK writers / deleters) ==="
+$CLI revert "$STACK" --region "$REGION" --yes --remove-unrecorded | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+grep -Eq "NOT reverted|could not be confirmed|not revertable" "/tmp/cdkrd-$STACK.revert.out" \
+  && fail "revert reported a non-converged / not-revertable path (see /tmp/cdkrd-$STACK.revert.out)"
+sleep 30
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.post.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after revert — a revert did not converge"
+
+echo "=== [$STACK] live values MUST be back ==="
+V="$(aws elbv2 describe-target-group-attributes --target-group-arn "$TG_ARN" --region "$REGION" \
+  --query "Attributes[?Key=='deregistration_delay.timeout_seconds'].Value" --output text)"
+[ "$V" = "300" ] || fail "tg deregistration_delay not restored: $V"
+V="$(aws elasticache describe-cache-parameters --cache-parameter-group-name "$EC_PG" --region "$REGION" \
+  --query "Parameters[?ParameterName=='maxmemory-policy'].ParameterValue" --output text)"
+[ "$V" = "allkeys-lru" ] || fail "ec maxmemory-policy not restored: $V"
+V="$(aws dax describe-parameters --parameter-group-name cdkrd-0810w-daxpg --region "$REGION" \
+  --query "Parameters[?ParameterName=='query-ttl-millis'].ParameterValue" --output text)"
+[ "$V" = "300000" ] || fail "dax query-ttl-millis not restored: $V"
+V="$(aws budgets describe-budget --account-id "$ACCT" --budget-name cdkrd-0810w-budget \
+  --query 'Budget.BudgetLimit.Amount' --output text)"
+[ "${V%%.*}" = "100" ] || fail "budget limit not restored: $V"
+V="$(aws cloudwatch describe-alarms --alarm-names cdkrd-0810w-composite --alarm-types CompositeAlarm \
+  --region "$REGION" --query 'CompositeAlarms[0].ActionsEnabled' --output text)"
+[ "$V" = "True" ] || fail "composite ActionsEnabled not restored: $V"
+V="$(aws sesv2 get-configuration-set-event-destinations --configuration-set-name cdkrd-0810w-cs \
+  --region "$REGION" --query 'EventDestinations[0].MatchingEventTypes | length(@)' --output text)"
+[ "$V" = "3" ] || fail "ses matching event types not restored (len=$V)"
+V="$(aws servicediscovery get-service --id "$SVC_ID" --region "$REGION" \
+  --query 'Service.Description' --output text)"
+[ "$V" = "cdkrd 0810 writer hunt svc" ] || fail "cloudmap description not restored: $V"
+V="$(aws kms list-grants --key-id "$KEY_ID" --region "$REGION" \
+  --query "Grants[?Name=='cdkrd-0810w-grant'] | length(@)" --output text)"
+[ "$V" = "0" ] || fail "kms grant not revoked"
+V="$(aws cloudcontrol get-resource --type-name AWS::Logs::LogGroup --identifier cdkrd-0810w-lg \
+  --region "$REGION" --query 'ResourceDescription.Properties' --output text | python3 -c \
+  "import json,sys; print(json.load(sys.stdin).get('BearerTokenAuthenticationEnabled', False))")"
+[ "$V" = "False" ] || fail "loggroup bearer token not disabled: $V"
+
+echo "INTEG OK ($STACK): 10 SDK writer/deleter paths live-proven"

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -4553,6 +4553,55 @@ describe('Budgets Budget writer (UpdateBudget full-object reconstruction, #1676)
     expect(nb.CostFilters).toEqual({ Service: ['Amazon Elastic Compute Cloud - Compute'] });
   });
 
+  it('#1744: stringifies a numeric declared BudgetLimit.Amount before UpdateBudget', async () => {
+    // The CFn schema allows a NUMERIC Spend.Amount (a template declares `Amount: 100`), but
+    // the Budgets API models Amount as a STRING — the raw number failed the live revert with
+    // "SerializationException: NUMBER_VALUE can not be converted to a String" (wrtpack-hunt
+    // 2026-08-10). The declared-drift op therefore carries the number; the writer must
+    // stringify it (and any PlannedBudgetLimits spends).
+    budgets.on(DescribeBudgetCommand).resolves({
+      Budget: {
+        BudgetName: 'my-budget',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        BudgetLimit: { Amount: '50.0', Unit: 'USD' },
+      },
+    } as never);
+    budgets.on(UpdateBudgetCommand).resolves({});
+    await SDK_WRITERS['AWS::Budgets::Budget'](budgetCtx(), [
+      {
+        op: 'add',
+        path: '/Budget/BudgetLimit/Amount',
+        value: 100,
+        human: 'Budget.BudgetLimit.Amount -> deployed-template value',
+      },
+    ]);
+    const nb = budgets.commandCalls(UpdateBudgetCommand)[0]!.args[0].input.NewBudget!;
+    expect(nb.BudgetLimit).toEqual({ Amount: '100', Unit: 'USD' });
+  });
+
+  it('#1744: stringifies numeric PlannedBudgetLimits amounts too', async () => {
+    budgets.on(DescribeBudgetCommand).resolves({
+      Budget: {
+        BudgetName: 'my-budget',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        PlannedBudgetLimits: { '1750000000': { Amount: '10.0', Unit: 'USD' } },
+      },
+    } as never);
+    budgets.on(UpdateBudgetCommand).resolves({});
+    await SDK_WRITERS['AWS::Budgets::Budget'](budgetCtx(), [
+      {
+        op: 'add',
+        path: '/Budget/PlannedBudgetLimits/1750000000/Amount',
+        value: 20,
+        human: 'Budget.PlannedBudgetLimits.1750000000.Amount -> deployed-template value',
+      },
+    ]);
+    const nb = budgets.commandCalls(UpdateBudgetCommand)[0]!.args[0].input.NewBudget!;
+    expect(nb.PlannedBudgetLimits).toEqual({ '1750000000': { Amount: '20', Unit: 'USD' } });
+  });
+
   it('drops the computed BudgetLimit for an auto-adjusting budget so revert keeps it auto-adjusting', async () => {
     budgets.on(DescribeBudgetCommand).resolves({
       Budget: {


### PR DESCRIPTION
## 2026-08-10 bug-hunt sweep

Five rounds (offline audits + 5 live fixture packs + stackless CC probes). Six bugs found, all live-confirmed, fixed, and re-proven live with the fixed binary — every fixture ends INTEG OK.

Closes #1740, closes #1741, closes #1742, closes #1744, closes #1745, closes #1746.

### Bugs fixed

- **#1740 — ECS DAEMON first-run FPs.** A barest `SchedulingStrategy: DAEMON` service FP'd on `DeploymentConfiguration` (the DAEMON rollout band is 100/0, not the REPLICA 200/100 the pins encode) and `DesiredCount` (ECS-managed for DAEMON). Fixed as a tier-2 derived overlay (`ecsDaemonDerivedMaximumPercent`/`MinimumHealthyPercent` in `normalize/derived-defaults.ts`, wired into classify AND `derivedRevertDefaultFor` per the #1709 single-source rule) + a DAEMON-gated value-independent fold for `DesiredCount`. Live-proven both directions (clean first run + OOB band change detected → reverted → live 0 restored) by `variants6-hunt`.
- **#1741 — RDS mixed-case Engine/Family declared FPs.** The CFn/CC handlers ACCEPT `EngineName: "MySQL"` / `Family: "MySQL8.4"` / `"Aurora-MySQL8.0"` and store lowercase (stackless CC probes) — permanent declared FPs. Added `CASE_INSENSITIVE_PATHS` entries: OptionGroup `EngineName`, DBParameterGroup/DBClusterParameterGroup `Family`, DBInstance/DBCluster `Engine` (store-lowercases evidence carries per #1712; `describe-db-engine-versions --engine MySQL` → `mysql`). E2E-witnessed via CloudFormation in `allowpack-hunt`. Ruled out: `ElastiCache::User.Engine` (CC model enum REJECTS mixed case — unreachable).
- **#1742 — Route53 RecordSetGroup members false-flagged `added`.** The zone child-enumerator collected declared records only from standalone `AWS::Route53::RecordSet` resources; every `RecordSetGroup` member surfaced as an out-of-band added record — and a `revert --remove-unrecorded` would have DELETED the user's own records. Fixed by walking group members (group-level zone ref, per-member fallback) in the extracted `collectDeclaredRoute53Records`. Live-proven clean by `allowpack-hunt` (mixed-case + no-trailing-dot + multi-value members also prove the canonical matching). Follow-up #1743 (group members' declared drift needs a reader) filed separately.
- **#1744 — Budgets revert crash.** First live run of the #1676 `writeBudget` writer failed: a template-declared numeric `BudgetLimit.Amount` was sent as a JSON number where the UpdateBudget API wants a string (`SerializationException`). Writer now stringifies every Spend.Amount (BudgetLimit + PlannedBudgetLimits). Live-proven converged (OOB 50 → revert → live 100).
- **#1746 — EB LoadBalanced env first-run FP.** A live classic-LB environment echoes `aws:elb:loadbalancer|SecurityGroups` as the RAW sg-id of its own generated LB security group, which the anchored #893/#1264 generated-name gate cannot match. Fixed three-legged: gather collects the ids from live EB env option settings and resolves them via one `DescribeSecurityGroups` → `ebSgNamesById` classify opt; the gate resolves an id to its GroupName and applies the SAME anchored shapes (unresolvable id SURFACES — fail-closed, never re-opening #1264's rogue-SG hiding); the corpus recorder carries the map. Live-proven clean by `eb-lb-hunt` (116 option settings folded, zero potential drift).
- **#1745 — undeclared ELB attribute-bag element not revertable.** An OOB `modify-target-group-attributes` on an undeclared attribute was detected but refused by the generic nested-array-element bar, so the never-live-run `TargetGroupAttributes` writer never received it. Bag elements now bypass the bar when the per-key prop writer AND a value source (baseline value, else the curated per-key default via the now-exported `elbAttributeDefaultsFor`) exist; `ListenerAttributes` (no writer) and unknown keys stay honestly barred. Live-proven converged (45 → revert → live 300).

### Writer/deleter live-proofs (`wrtpack-hunt` — Round-0 audit found the READ side fully corpus-exercised; these write paths had never run live)

Mutate → detect → revert → live-value-restored, all converged: ELBv2 TargetGroupAttributes, ElastiCache ParameterGroup, DAX ParameterGroup, Budgets Budget, CloudWatch CompositeAlarm `ActionsEnabled` (the batch-5 Enable/DisableAlarmActions prop writer), SES ConfigurationSetEventDestination, ServiceDiscovery Service (DNS namespace), Logs LogGroup `BearerTokenAuthenticationEnabled`, and the synthetic `AWS::KMS::Grant` added-tier delete (out-of-band `create-grant` → surfaced → `RevokeGrant`).

### Determinations (recorded in fixture/source comments)

- Glue Ray jobs are deprecated and CFn-unreachable ("Account not allowed to submit Glue Ray job Post Deprecation") — the glueetl-scoped `Command.PythonVersion: '2'` pin can never FP on a Ray job.
- Cognito Sync is closed to new customers — the `CognitoEvents` prop writer (and its drift) is unreachable from a new account; leg removed from the pack with the evidence in the script comment.
- A Cloud Map Service in an HTTP namespace is API-only and CANNOT be updated — the UpdateService writer is provable only on a DNS-namespace service (fixture switched to PrivateDnsNamespace).
- RabbitMQ rejects `mq.t3.micro` (m5+ only) — engine-axis validation difference; and the mirrored `engineStorageDefault.RABBITMQ: 'EBS'` row is now LIVE-CITED (barest RabbitMQ broker first run CLEAN, corpus case promoted).
- Ruled out live by `allowpack-hunt` (predicted allowlist gaps that did NOT reproduce): WAFv2 `FieldToMatch.SingleHeader/SingleQueryArgument` name case (echoed verbatim), S3 lifecycle DATE rules (round-trip exactly), SNS partial `DeliveryPolicy` (echoed as declared, no default expansion), S3 `NotificationConfiguration` EventBridge form.
- Batch EC2-SPOT CE + NLB UDP/TCP_UDP listeners: clean first run (no new echoes).
- A SIXTH revert-no-op flavor rode along (#1740's revert leg): the DAEMON `DeploymentConfiguration` patch is REJECTED while the CC model carries the ECS-managed `DesiredCount` echo — fixed as a derived whole-object explicit `add` + a `REVERT_COMPANION_REMOVES` entry, and the companion is a #967 CONTRACT op (an ECS-managed echo persists by design; a non-contract companion false-flagged "NOT reverted" in the convergence report, so the no-op detector now skips contract ops).

### Corpus & fixtures

New committed fixtures: `wrtpack-hunt`, `variants6-hunt`, `mq-rabbit-hunt`, `allowpack-hunt`, `eb-lb-hunt` (all end INTEG OK). 14 corpus promotions: RabbitMQ broker, ECS DAEMON service, Batch SPOT CE, NLB UDP + TCP_UDP listeners, EB LoadBalanced environment, mixed-case RDS OptionGroup/DBParameterGroup, RecordSetGroup zone, S3 date-lifecycle bucket, SNS partial-DeliveryPolicy topic, WAFv2 mixed-case-header WebACL/RuleGroup, Cloud Map DNS service (1008 replay cases pass). Unit regressions in `tests/hunt-2026-08-10-folds.test.ts` + `tests/writers.test.ts`; durable lessons folded into the hunt skill (batch-13 writer-proof pattern + 5 new gotchas).

### Cleanup

All stacks deleted via `delstack` (verify traps) + `/sweep-resources` SWEEP CLEAN; bughunt sentinel cleared.
