### PR TITLE
feat(read): Route53 RecordSetGroup member-level read + revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,7 +902,8 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `lambda:GetPolicy`, `budgets:ViewBudget`, `ec2:DescribeAddresses`,
   `ec2:DescribeLaunchTemplateVersions`, `ec2:DescribeNetworkAcls`,
   `route53:ListResourceRecordSets`, `route53:ListHostedZonesByName` (resolves a
-  RecordSet declared via `HostedZoneName` instead of `HostedZoneId` to its zone
+  RecordSet — or a RecordSetGroup, which is read member-by-member via the same
+  listing — declared via `HostedZoneName` instead of `HostedZoneId` to its zone
   id),
   `ses:DescribeReceiptRuleSet`, `ses:DescribeReceiptRule`, `ses:ListReceiptFilters`
   (the SES inbound receipt-rule family — `ReceiptRuleSet` / `ReceiptRule` /

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -5250,6 +5250,13 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // still differs after case-fold). The sibling `AliasTarget.DNSName` on this same
   // type was case-folded for the identical reason.
   'AWS::Route53::RecordSet': new Set(['Name', 'AliasTarget.DNSName']),
+  // #1743: the RecordSetGroup members are the SAME records one level down — the group
+  // reader mirrors the standalone reader's projection (dot-aligned, case as stored), so
+  // the identical case tolerance applies at the member paths (indices normalize to `.*`).
+  'AWS::Route53::RecordSetGroup': new Set([
+    'RecordSets.*.Name',
+    'RecordSets.*.AliasTarget.DNSName',
+  ]),
   // Batch ComputeEnvironment `Type` — CDK's `FargateComputeEnvironment` /
   // `ManagedComputeEnvironment` emits the value LOWERCASE (`managed`) in the
   // template, but the Batch API accepts it case-insensitively and the live read
@@ -6608,6 +6615,9 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   // add/remove still changes the multiset. (Weighted/latency routing uses separate
   // RecordSets with SetIdentifier, not ordered ResourceRecords, so this is FP-safe.)
   'AWS::Route53::RecordSet': new Set(['ResourceRecords']),
+  // #1743: the group-member twin of the entry above — the same Route53 canonical-order
+  // echo one level down (`RecordSets.*.ResourceRecords`, the CidrCollection nested shape).
+  'AWS::Route53::RecordSetGroup': new Set(['RecordSets.*.ResourceRecords']),
   // Live-observed on a fresh codedeploy-deploymentgroup-readgap deploy: a deployment
   // group's AutoRollbackConfiguration.Events is a SET of rollback-trigger enums that
   // CodeDeploy echoes SORTED alphabetically, not in template order (declared

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -192,7 +192,7 @@ import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { ResourceGoneError } from '../aws-errors.js';
 import { partitionForRegion } from '../desired/template-adapter.js';
-import { unescapeRoute53Name } from './child-enumerators.js';
+import { pageResourceRecordSets, unescapeRoute53Name } from './child-enumerators.js';
 import { CLIENT_REQUEST_HANDLER, READ_RETRY } from './client-config.js';
 import { isDefinitiveDenial } from './kms-aliases.js';
 import { hashCaBundle, sha256Hex } from './pem.js';
@@ -1758,7 +1758,7 @@ const alignTrailingDot = (live: string | undefined, declared: unknown): string |
 // one apex name can host both a PUBLIC and a PRIVATE hosted zone, and picking the wrong one would
 // compare the record against the wrong zone. Only an unambiguous single match is used.
 const canonZone = (s: string): string => unescapeRoute53Name(s).replace(/\.$/, '').toLowerCase();
-const resolveHostedZoneIdByName = async (
+export const resolveHostedZoneIdByName = async (
   c: Route53Client,
   zoneName: string
 ): Promise<string | undefined> => {
@@ -1840,19 +1840,37 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
     throw new ResourceGoneError(
       `Route53 RecordSet ${name} ${type} absent from zone ${hostedZoneId}`
     );
+  // Mirror the DECLARED zone identifier. A record declared via HostedZoneName has no declared
+  // HostedZoneId, so emitting the resolved id would surface it as undeclared drift on a clean
+  // deploy (and the declared HostedZoneName would readGap, never returned by the live read).
+  // Echo the declared name instead — it is an immutable identity input (changing it replaces the
+  // record), so echoing loses no meaningful detection. A record declared by id emits the id as
+  // before (including the physical-id fallback, where zoneName is absent).
+  return projectRoute53RecordModel(
+    rec,
+    declared,
+    byName ? { HostedZoneName: zoneName } : { HostedZoneId: hostedZoneId }
+  );
+};
+
+// Project one live ResourceRecordSet into the CFn RecordSet model shape, compared against
+// the record's own DECLARED props (dot alignment on Name / AliasTarget.DNSName). `zoneField`
+// carries the zone-identity key(s) the caller wants mirrored into the model — the standalone
+// RecordSet reader passes its declared zone ref; the RecordSetGroup reader (#1743) mirrors
+// each MEMBER's own declared ref (usually none — the group-level ref governs). Shared so the
+// two readers can never diverge on the projection.
+function projectRoute53RecordModel(
+  rec: ResourceRecordSet,
+  declared: Record<string, unknown>,
+  zoneField: Record<string, unknown>
+): Record<string, unknown> {
   const model: Record<string, unknown> = {
     Name: alignTrailingDot(
       rec.Name === undefined ? undefined : unescapeRoute53Name(rec.Name),
       declared.Name
     ),
     Type: rec.Type,
-    // Mirror the DECLARED zone identifier. A record declared via HostedZoneName has no declared
-    // HostedZoneId, so emitting the resolved id would surface it as undeclared drift on a clean
-    // deploy (and the declared HostedZoneName would readGap, never returned by the live read).
-    // Echo the declared name instead — it is an immutable identity input (changing it replaces the
-    // record), so echoing loses no meaningful detection. A record declared by id emits the id as
-    // before (including the physical-id fallback, where zoneName is absent).
-    ...(byName ? { HostedZoneName: zoneName } : { HostedZoneId: hostedZoneId }),
+    ...zoneField,
   };
   if (rec.TTL !== undefined) model.TTL = String(rec.TTL); // CFn TTL is a string
   const records = rec.ResourceRecords?.map((rr) => rr.Value).filter((v): v is string => !!v);
@@ -1912,6 +1930,60 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
       ...(cidr.LocationName !== undefined && { LocationName: cidr.LocationName }),
     };
   return model;
+}
+
+// AWS::Route53::RecordSetGroup (#1743) — no Cloud Control handlers at all
+// (UnsupportedActionException → the whole group was `skipped`, so an out-of-band change to a
+// group member's TTL / values / alias was INVISIBLE, and the RecordSet fold family never
+// applied to group-declared records). Read the zone's records once and project each DECLARED
+// member (matched canonically by name+type+SetIdentifier, exactly like the standalone
+// reader) through the shared projection, in DECLARED order so the element-wise declared
+// compare lines up. A declared member ABSENT from the live zone is omitted from the
+// projected array — the declared-vs-live array diff then surfaces the deletion (a whole-group
+// ResourceGoneError would falsely mark the entire group deleted). Live records that are NOT
+// declared members are never included — the zone child-enumerator owns the `added` dimension.
+const readRoute53RecordSetGroup: OverrideReader = async ({ declared, region }) => {
+  const c = new Route53Client({ region, ...READ_RETRY });
+  const declaredZoneId = str(declared.HostedZoneId);
+  const zoneName = str(declared.HostedZoneName);
+  const byName = !declaredZoneId && !!zoneName;
+  const hostedZoneId =
+    declaredZoneId ?? (zoneName ? await resolveHostedZoneIdByName(c, zoneName) : undefined);
+  const declSets = Array.isArray(declared.RecordSets)
+    ? (declared.RecordSets as Record<string, unknown>[])
+    : undefined;
+  if (!hostedZoneId || !declSets) return undefined; // unresolvable → skipped (fail open)
+  const live = await pageResourceRecordSets(c, hostedZoneId);
+  const canon = (s: string): string => unescapeRoute53Name(s).replace(/\.$/, '').toLowerCase();
+  const projected: Record<string, unknown>[] = [];
+  for (const d of declSets) {
+    if (!d || typeof d !== 'object') continue;
+    const name = str(d.Name);
+    const type = str(d.Type);
+    if (!name || !type) continue;
+    const declSetId = str(d.SetIdentifier);
+    const rec = live.find(
+      (x) =>
+        x.Type === type &&
+        !!x.Name &&
+        canon(x.Name) === canon(name) &&
+        (x.SetIdentifier ?? undefined) === declSetId
+    );
+    if (!rec) continue; // member deleted out of band → surfaces via the array diff
+    // Mirror the MEMBER's own declared zone ref when present (legal but uncommon —
+    // normally the GROUP-level ref governs and the member carries none, so none is emitted).
+    projected.push(
+      projectRoute53RecordModel(rec, d, {
+        ...(str(d.HostedZoneId) !== undefined && { HostedZoneId: d.HostedZoneId }),
+        ...(str(d.HostedZoneName) !== undefined && { HostedZoneName: d.HostedZoneName }),
+      })
+    );
+  }
+  return {
+    ...(declaredZoneId !== undefined && { HostedZoneId: declaredZoneId }),
+    ...(byName && { HostedZoneName: zoneName }),
+    RecordSets: projected,
+  };
 };
 
 // AWS::Glue::Table — CC API GetResource throws UnsupportedActionException. Read via
@@ -3609,6 +3681,7 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::MediaConvert::Queue': readMediaConvertQueue,
   'AWS::MediaConvert::JobTemplate': readMediaConvertJobTemplate,
   'AWS::Route53::RecordSet': readRoute53RecordSet,
+  'AWS::Route53::RecordSetGroup': readRoute53RecordSetGroup,
   'AWS::Glue::Table': readGlueTable,
   'AWS::Glue::Classifier': readGlueClassifier,
   'AWS::Glue::Workflow': readGlueWorkflow,

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -253,6 +253,7 @@ import { CLIENT_TIMEOUTS } from '../read/client-config.js';
 import {
   DLM_DEFAULT_POLICY_SHORTHAND,
   type OverrideCtx,
+  resolveHostedZoneIdByName,
   SDK_OVERRIDES,
 } from '../read/overrides.js';
 import { applyOps } from './apply-ops.js';
@@ -1440,22 +1441,77 @@ const RR_ROUTING_FIELDS = [
   'GeoProximityLocation',
   'CidrRoutingConfig',
 ] as const;
-const writeRoute53RecordSet: SdkWriter = async (ctx, ops) => {
-  const m = await desiredModel('AWS::Route53::RecordSet', ctx, ops);
-  const zone = str(m.HostedZoneId) ?? str(ctx.declared['HostedZoneId']);
-  const name = str(m.Name) ?? str(ctx.declared['Name']);
-  const type = str(m.Type) ?? str(ctx.declared['Type']);
-  if (!zone || !name || !type) throw new Error('cannot resolve Route53 record target for revert');
+// Build the ChangeResourceRecordSets rrset payload from one CFn-shaped record model.
+// Shared by the standalone RecordSet writer and the RecordSetGroup per-member writer
+// (#1743) so the two can never diverge. Returns undefined when the model lacks its
+// Name/Type identity.
+function buildRoute53RrSet(m: Record<string, unknown>): Record<string, unknown> | undefined {
+  const name = str(m.Name);
+  const type = str(m.Type);
+  if (!name || !type) return undefined;
   const rrset: Record<string, unknown> = { Name: name, Type: type };
   if (m.TTL !== undefined) rrset.TTL = Number(m.TTL); // CFn TTL is a string; the API wants a number
   if (Array.isArray(m.ResourceRecords))
     rrset.ResourceRecords = (m.ResourceRecords as string[]).map((v) => ({ Value: v }));
   if (m.AliasTarget !== undefined) rrset.AliasTarget = m.AliasTarget;
   for (const k of RR_ROUTING_FIELDS) if (m[k] !== undefined) rrset[k] = m[k];
+  return rrset;
+}
+const writeRoute53RecordSet: SdkWriter = async (ctx, ops) => {
+  const m = await desiredModel('AWS::Route53::RecordSet', ctx, ops);
+  const zone = str(m.HostedZoneId) ?? str(ctx.declared['HostedZoneId']);
+  const rrset = buildRoute53RrSet({
+    ...m,
+    Name: str(m.Name) ?? str(ctx.declared['Name']),
+    Type: str(m.Type) ?? str(ctx.declared['Type']),
+  });
+  if (!zone || !rrset) throw new Error('cannot resolve Route53 record target for revert');
   await new Route53Client({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
     new ChangeResourceRecordSetsCommand({
       HostedZoneId: zone,
       ChangeBatch: { Changes: [{ Action: 'UPSERT', ResourceRecordSet: rrset as never }] },
+    })
+  );
+};
+
+// AWS::Route53::RecordSetGroup (#1743) — no Cloud Control handlers, read via the
+// readRoute53RecordSetGroup override, so revert routes here. Apply the revert ops to the
+// projected group model, then UPSERT ONLY the members the ops touched (parsed from the
+// `/RecordSets/<i>/...` pointers; a whole-array op — a member deleted out of band being
+// restored — UPSERTs every declared member). One ChangeBatch carries all the changes
+// atomically, the same call the standalone RecordSet writer makes per record.
+const writeRoute53RecordSetGroup: SdkWriter = async (ctx, ops) => {
+  const m = await desiredModel('AWS::Route53::RecordSetGroup', ctx, ops);
+  let zone = str(m.HostedZoneId) ?? str(ctx.declared['HostedZoneId']);
+  if (!zone) {
+    const zoneName = str(m.HostedZoneName) ?? str(ctx.declared['HostedZoneName']);
+    if (zoneName) {
+      zone = await resolveHostedZoneIdByName(
+        new Route53Client({ region: ctx.region, ...CLIENT_TIMEOUTS }),
+        zoneName
+      );
+    }
+  }
+  const sets = Array.isArray(m.RecordSets) ? (m.RecordSets as Record<string, unknown>[]) : [];
+  if (!zone || sets.length === 0)
+    throw new Error('cannot resolve Route53 record-set-group target for revert');
+  const wholeArray = ops.some((o) => o.path === '/RecordSets');
+  const touched = new Set<number>();
+  for (const o of ops) {
+    const i = /^\/RecordSets\/(\d+)(\/|$)/.exec(o.path)?.[1];
+    if (i !== undefined) touched.add(Number(i));
+  }
+  const members = wholeArray ? sets : [...touched].map((i) => sets[i]).filter((s) => !!s);
+  const changes = members
+    .map((member) => buildRoute53RrSet(member as Record<string, unknown>))
+    .filter((r): r is Record<string, unknown> => r !== undefined)
+    .map((rrset) => ({ Action: 'UPSERT' as const, ResourceRecordSet: rrset as never }));
+  if (changes.length === 0)
+    throw new Error('Route53 record-set-group revert: no member resolved from the revert ops');
+  await new Route53Client({ region: ctx.region, ...CLIENT_TIMEOUTS }).send(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: zone,
+      ChangeBatch: { Changes: changes },
     })
   );
 };
@@ -3333,6 +3389,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::DLM::LifecyclePolicy': writeDlmLifecyclePolicy,
   'AWS::Logs::MetricFilter': writeMetricFilter,
   'AWS::Route53::RecordSet': writeRoute53RecordSet,
+  'AWS::Route53::RecordSetGroup': writeRoute53RecordSetGroup,
   'AWS::DocDB::DBCluster': writeDocDbCluster,
   'AWS::DocDB::DBInstance': writeDocDbInstance,
   'AWS::ServiceDiscovery::HttpNamespace': writeServiceDiscoveryHttpNamespace,

--- a/tests/corpus/AWS__Route53__RecordSetGroup.Records.json
+++ b/tests/corpus/AWS__Route53__RecordSetGroup.Records.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Records",
+    "resourceType": "AWS::Route53::RecordSetGroup",
+    "physicalId": "CdkrdHunt0810Allow-Records-3ZIHE6L1MPZF",
+    "constructPath": "CdkrdHunt0810Allow/Records",
+    "declared": {
+      "HostedZoneId": "Z03071861ZEOY3LILKOPX",
+      "RecordSets": [
+        {
+          "Name": "MiXeD-Case.cdkrd-fphunt-a0810.com",
+          "ResourceRecords": ["192.0.2.1"],
+          "TTL": "300",
+          "Type": "A"
+        },
+        {
+          "Name": "txt.cdkrd-fphunt-a0810.com.",
+          "ResourceRecords": ["\"zulu\"", "\"alpha\"", "\"mike\""],
+          "TTL": "300",
+          "Type": "TXT"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "HostedZoneId": "Z03071861ZEOY3LILKOPX",
+    "RecordSets": [
+      {
+        "Name": "mixed-case.cdkrd-fphunt-a0810.com",
+        "Type": "A",
+        "TTL": "300",
+        "ResourceRecords": ["192.0.2.1"]
+      },
+      {
+        "Name": "txt.cdkrd-fphunt-a0810.com.",
+        "Type": "TXT",
+        "TTL": "300",
+        "ResourceRecords": ["\"alpha\"", "\"mike\"", "\"zulu\""]
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["HostedZoneId", "HostedZoneName"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HostedZoneId", "HostedZoneName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/allowpack-hunt/verify.sh
+++ b/tests/integration/allowpack-hunt/verify.sh
@@ -28,4 +28,27 @@ echo "=== [$STACK] record -> check --fail MUST be CLEAN ==="
 $CLI record "$STACK" --region "$REGION" --yes || fail "record"
 $CLI check "$STACK" --region "$REGION" --fail || fail "post-record check"
 
+echo "=== [$STACK] RecordSetGroup member detect/revert (#1743) ==="
+# pre-#1743 the group was wholly `skipped` (no CC read handler) — an OOB member change
+# was invisible. Mutate the mixed-case member's TTL out of band -> the group reader
+# must DETECT it as declared drift -> revert (per-member ChangeResourceRecordSets
+# UPSERT) -> clean -> live TTL restored.
+ZONE_ID="$(aws cloudformation describe-stack-resource --stack-name "$STACK" --region "$REGION" \
+  --logical-resource-id Zone --query 'StackResourceDetail.PhysicalResourceId' --output text)"
+aws route53 change-resource-record-sets --hosted-zone-id "$ZONE_ID" --change-batch \
+  '{"Changes":[{"Action":"UPSERT","ResourceRecordSet":{"Name":"mixed-case.cdkrd-fphunt-a0810.com.","Type":"A","TTL":60,"ResourceRecords":[{"Value":"192.0.2.1"}]}}]}' \
+  >/dev/null || fail "mutate rsg member TTL"
+sleep 15
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.detect.out"
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected RSG member drift (exit 1)"
+grep -q "Records.RecordSets" "/tmp/cdkrd-$STACK.detect.out" || fail "missed RSG member detection"
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK.revert.out" || fail "revert"
+grep -Eq "NOT reverted|could not be confirmed|not revertable" "/tmp/cdkrd-$STACK.revert.out" \
+  && fail "RSG revert did not converge (see /tmp/cdkrd-$STACK.revert.out)"
+sleep 15
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after RSG revert"
+V="$(aws route53 list-resource-record-sets --hosted-zone-id "$ZONE_ID" \
+  --query "ResourceRecordSets[?Name=='mixed-case.cdkrd-fphunt-a0810.com.' && Type=='A'].TTL" --output text)"
+[ "$V" = "300" ] || fail "RSG member TTL not restored: $V"
+
 echo "INTEG OK ($STACK)"

--- a/tests/route53-recordsetgroup-1743.test.ts
+++ b/tests/route53-recordsetgroup-1743.test.ts
@@ -1,0 +1,236 @@
+// #1743: AWS::Route53::RecordSetGroup — no Cloud Control handlers, so the group was
+// wholly `skipped` and its members' DECLARED drift was invisible. These pin the new
+// SDK reader projection, the classify behavior on the projected model, and the
+// per-member ChangeResourceRecordSets writer.
+import {
+  ChangeResourceRecordSetsCommand,
+  ListResourceRecordSetsCommand,
+  Route53Client,
+} from '@aws-sdk/client-route-53';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import { SDK_WRITERS } from '../src/revert/writers.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const r53 = mockClient(Route53Client);
+beforeEach(() => r53.reset());
+
+const ZONE = 'Z0AAAAEXAMPLE';
+const DECLARED_GROUP = {
+  HostedZoneId: ZONE,
+  RecordSets: [
+    {
+      // mixed case + no trailing dot — Route53 stores lowercased + dotted
+      Name: 'MiXeD-Case.cdkrd-test.com',
+      Type: 'A',
+      TTL: '300',
+      ResourceRecords: ['192.0.2.1'],
+    },
+    {
+      Name: 'txt.cdkrd-test.com.',
+      Type: 'TXT',
+      TTL: '300',
+      // declared non-sorted; Route53 echoes its canonical order
+      ResourceRecords: ['"zulu"', '"alpha"', '"mike"'],
+    },
+  ],
+};
+const LIVE_LISTING = {
+  ResourceRecordSets: [
+    {
+      Name: 'mixed-case.cdkrd-test.com.',
+      Type: 'A',
+      TTL: 300,
+      ResourceRecords: [{ Value: '192.0.2.1' }],
+    },
+    {
+      Name: 'txt.cdkrd-test.com.',
+      Type: 'TXT',
+      TTL: 300,
+      ResourceRecords: [{ Value: '"alpha"' }, { Value: '"mike"' }, { Value: '"zulu"' }],
+    },
+    // zone plumbing + a record that is NOT a group member — never projected
+    { Name: 'cdkrd-test.com.', Type: 'NS', TTL: 172800, ResourceRecords: [{ Value: 'ns1.' }] },
+    { Name: 'cdkrd-test.com.', Type: 'SOA', TTL: 900, ResourceRecords: [{ Value: 'soa' }] },
+    {
+      Name: 'other.cdkrd-test.com.',
+      Type: 'A',
+      TTL: 60,
+      ResourceRecords: [{ Value: '192.0.2.9' }],
+    },
+  ],
+  IsTruncated: false,
+};
+
+const groupResource = (): DesiredResource => ({
+  logicalId: 'Records',
+  resourceType: 'AWS::Route53::RecordSetGroup',
+  physicalId: 'Records-abc',
+  declared: structuredClone(DECLARED_GROUP),
+});
+
+const read = () =>
+  SDK_OVERRIDES['AWS::Route53::RecordSetGroup']({
+    physicalId: 'Records-abc',
+    declared: structuredClone(DECLARED_GROUP) as Record<string, unknown>,
+    region: 'us-east-1',
+  } as never);
+
+describe('#1743 RecordSetGroup reader projection', () => {
+  it('projects each declared member in declared order, dot-aligned, live values', async () => {
+    r53.on(ListResourceRecordSetsCommand).resolves(LIVE_LISTING as never);
+    const m = (await read()) as Record<string, unknown>;
+    expect(m.HostedZoneId).toBe(ZONE);
+    const sets = m.RecordSets as Record<string, unknown>[];
+    expect(sets).toHaveLength(2);
+    // dot ALIGNED to the declared form (no trailing dot); case is the STORED lowercase —
+    // folded by the CASE_INSENSITIVE_PATHS member entry, exactly like a standalone record
+    expect(sets[0]).toEqual({
+      Name: 'mixed-case.cdkrd-test.com',
+      Type: 'A',
+      TTL: '300',
+      ResourceRecords: ['192.0.2.1'],
+    });
+    expect(sets[1]!.ResourceRecords).toEqual(['"alpha"', '"mike"', '"zulu"']);
+    // the non-member live record is never projected
+    expect(JSON.stringify(m)).not.toContain('other.cdkrd-test');
+  });
+
+  it('omits a member deleted out of band (the array diff surfaces it)', async () => {
+    const listing = structuredClone(LIVE_LISTING);
+    listing.ResourceRecordSets = listing.ResourceRecordSets.filter(
+      (r) => r.Type !== 'TXT'
+    ) as never;
+    r53.on(ListResourceRecordSetsCommand).resolves(listing as never);
+    const m = (await read()) as Record<string, unknown>;
+    expect(m.RecordSets as unknown[]).toHaveLength(1);
+  });
+});
+
+describe('#1743 classify on the projected group model', () => {
+  const classified = (live: Record<string, unknown>): Finding[] =>
+    classifyResource(groupResource(), live, emptySchema);
+  const cleanLive = () => ({
+    HostedZoneId: ZONE,
+    RecordSets: [
+      {
+        Name: 'mixed-case.cdkrd-test.com',
+        Type: 'A',
+        TTL: '300',
+        ResourceRecords: ['192.0.2.1'],
+      },
+      {
+        Name: 'txt.cdkrd-test.com.',
+        Type: 'TXT',
+        TTL: '300',
+        ResourceRecords: ['"alpha"', '"mike"', '"zulu"'],
+      },
+    ],
+  });
+
+  it('a clean deploy classifies with ZERO findings (case + reorder fold at member paths)', () => {
+    expect(classified(cleanLive())).toEqual([]);
+  });
+
+  it('an out-of-band member TTL change surfaces as declared drift', () => {
+    const live = cleanLive();
+    (live.RecordSets[0] as Record<string, unknown>).TTL = '60';
+    const declaredFindings = classified(live).filter((f) => f.tier === 'declared');
+    expect(declaredFindings.length).toBeGreaterThan(0);
+    expect(JSON.stringify(declaredFindings)).toContain('60');
+  });
+
+  it('an out-of-band VALUE change surfaces (multiset gate, not blanket-unordered)', () => {
+    const live = cleanLive();
+    (live.RecordSets[1] as Record<string, unknown>).ResourceRecords = [
+      '"alpha"',
+      '"mike"',
+      '"rogue"',
+    ];
+    expect(classified(live).filter((f) => f.tier === 'declared').length).toBeGreaterThan(0);
+  });
+
+  it('a member deleted out of band surfaces as declared drift', () => {
+    const live = cleanLive();
+    live.RecordSets = [live.RecordSets[0]] as never;
+    expect(classified(live).filter((f) => f.tier === 'declared').length).toBeGreaterThan(0);
+  });
+});
+
+describe('#1743 RecordSetGroup writer', () => {
+  it('UPSERTs only the touched member via one ChangeBatch', async () => {
+    r53.on(ListResourceRecordSetsCommand).resolves(LIVE_LISTING as never);
+    r53.on(ChangeResourceRecordSetsCommand).resolves({} as never);
+    await SDK_WRITERS['AWS::Route53::RecordSetGroup'](
+      {
+        physicalId: 'Records-abc',
+        declared: structuredClone(DECLARED_GROUP) as Record<string, unknown>,
+        region: 'us-east-1',
+        accountId: '123456789012',
+      } as never,
+      [
+        {
+          op: 'add',
+          path: '/RecordSets/0/TTL',
+          value: '300',
+          human: 'RecordSets.0.TTL -> deployed-template value',
+        },
+      ]
+    );
+    const calls = r53.commandCalls(ChangeResourceRecordSetsCommand);
+    expect(calls).toHaveLength(1);
+    const batch = calls[0]!.args[0].input as {
+      HostedZoneId?: string;
+      ChangeBatch?: {
+        Changes?: { Action?: string; ResourceRecordSet?: Record<string, unknown> }[];
+      };
+    };
+    expect(batch.HostedZoneId).toBe(ZONE);
+    const changes = batch.ChangeBatch!.Changes!;
+    expect(changes).toHaveLength(1);
+    expect(changes[0]!.Action).toBe('UPSERT');
+    expect(changes[0]!.ResourceRecordSet!.Name).toBe('mixed-case.cdkrd-test.com');
+    expect(changes[0]!.ResourceRecordSet!.TTL).toBe(300);
+    expect(changes[0]!.ResourceRecordSet!.ResourceRecords).toEqual([{ Value: '192.0.2.1' }]);
+  });
+
+  it('a whole-array op UPSERTs every member (restores a deleted member)', async () => {
+    r53.on(ListResourceRecordSetsCommand).resolves(LIVE_LISTING as never);
+    r53.on(ChangeResourceRecordSetsCommand).resolves({} as never);
+    await SDK_WRITERS['AWS::Route53::RecordSetGroup'](
+      {
+        physicalId: 'Records-abc',
+        declared: structuredClone(DECLARED_GROUP) as Record<string, unknown>,
+        region: 'us-east-1',
+        accountId: '123456789012',
+      } as never,
+      [
+        {
+          op: 'add',
+          path: '/RecordSets',
+          value: DECLARED_GROUP.RecordSets,
+          human: 'RecordSets -> deployed-template value',
+        },
+      ]
+    );
+    const changes = (
+      r53.commandCalls(ChangeResourceRecordSetsCommand)[0]!.args[0].input as {
+        ChangeBatch?: { Changes?: unknown[] };
+      }
+    ).ChangeBatch!.Changes!;
+    expect(changes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Route53 RecordSetGroup member-level read + revert

Closes #1743 (the follow-up filed by the 2026-08-10 hunt's #1742 fix).

`AWS::Route53::RecordSetGroup` has no Cloud Control handlers (`UnsupportedActionException`), so the whole group was `skipped` — an out-of-band change to a group member's TTL / ResourceRecords / AliasTarget was **invisible**, and the RecordSet fold family (case, trailing dot, value reorder) never applied to group-declared records.

### What changed

- **Reader** (`SDK_OVERRIDES`): lists the zone's records once and projects each DECLARED member (matched canonically by name+type+SetIdentifier, exactly like the standalone reader) through the now-shared `projectRoute53RecordModel`, in declared order. A member deleted out of band is omitted → the array diff surfaces it (never a whole-group `ResourceGoneError`). Non-member live records are never included — the zone child-enumerator owns the `added` dimension. Same IAM actions as the standalone reader (`route53:ListResourceRecordSets`, `ListHostedZonesByName` for the by-name form).
- **Writer** (`SDK_WRITERS`): applies the revert ops to the projected model and UPSERTs ONLY the touched members (`/RecordSets/<i>/...` pointers; a whole-array op restores every member) in one `ChangeResourceRecordSets` batch, sharing `buildRoute53RrSet` with the standalone writer.
- **Folds**: member-path twins of the standalone entries — `CASE_INSENSITIVE_PATHS` `RecordSets.*.Name` / `RecordSets.*.AliasTarget.DNSName`, `UNORDERED_ARRAY_PROPS` `RecordSets.*.ResourceRecords`; trailing-dot alignment happens in the shared projection.

### Evidence

- Unit: `tests/route53-recordsetgroup-1743.test.ts` (8 tests — projection, clean-zero classify, TTL/value/deleted-member detection, per-member + whole-array writer) + corpus replay 1009 pass (new `AWS__Route53__RecordSetGroup.Records.json` case).
- **Live E2E** (`allowpack-hunt` verify extension, 2026-08-10): first check CLEAN with the group now READ (the `skipped=1` gone; mixed-case + no-trailing-dot + multi-value members all fold) → `record` → OOB `change-resource-record-sets` TTL 300→60 → `check --fail` detects `Records.RecordSets.0.TTL` (declared) → `revert` converges → live TTL back to 300 → INTEG OK. Stack deleted, SWEEP CLEAN, gate released.

Core shared suite deferred (offline + corpus + live-proven in this PR's own run — same deferral rule as #1747).
