### PR TITLE
fix(hunt): 2026-08-11 sweep — Glue link/SNS inline added-FPs, GuardDuty revert patch shape, GlobalCluster case fold, barest5/linkpack folds

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -487,6 +487,30 @@ companion-removes flavor, fixed with a derived whole-object explicit `add` + an
 `AWS::ECS::Service\0DeploymentConfiguration` companion entry (#1740). The audit
 shape ("which writers have zero live evidence?") is repeatable and cheap — re-run it
 whenever a few new writers have accumulated.
+Batch 14 (2026-08-11 hunt): a SIXTH revert-no-op flavor — **GuardDuty Detector
+rejects EVERY CC patch** on a current-era detector: the model echo carries BOTH the
+deprecated `EKS_RUNTIME_MONITORING` and successor `RUNTIME_MONITORING` features
+("cannot be provided in the same request"), and separately DataSources+Features may
+not coexist in one update ("provide only one") — so even a patch touching NEITHER
+fails. Fix shape (#1752, all legs live-proven stackless): TRANSLATE any
+`/DataSources/*` op to the successor-API side (`/Features/<idx>/Status`), companion-
+remove `/DataSources` (a derived projection — dropping it from the WRITE model is
+not a state change), companion-remove the deprecated feature element LAST (index
+stability). When a type carries a deprecated/successor API-alias pair in one model,
+expect this class. Same batch: ServerlessCache `Description` bare-remove silently
+no-ops (RSDP `' '` one-space placeholder converges, #1753); Transfer `Protocols` is
+OOB-UNREACHABLE on the barest form (UpdateServer rejects FTP/FTPS "unsupported for
+IdentityProviderType SERVICE_MANAGED", 2026-08-11 — a barest server can never drift
+its protocols, so that pin's revert convergence is moot; an API_GATEWAY-idp server
+could, left unproven). A stackless Transfer probe artifact worth knowing: CC
+UpdateResource on a tagless Transfer Server fails model validation ("#/Tags:
+expected minimum item count: 1") — tag the probe resource or expect the reject. Deferred convergence candidates (unproven, from the plan.ts
+audit — probe when their infra is cheap to stand up): ELBv2 Listener
+`MutualAuthentication.AdvertiseTrustStoreCaNames` (#1698, needs mTLS listener),
+ImageBuilder `ImageTestsConfiguration.*` (#1702, needs recipe+infra chain), ASG
+`MixedInstancesPolicy.InstancesDistribution` (#1695, needs MIP ASG), CloudFront
+VpcOrigin `OriginSSLProtocols` (#1734, needs VPC-origin infra), AppSync DataSource
+`MetricsConfig` + SourceApiAssociation config (#1751, needs API+schema+DS chain).
 Piggyback the convergence
 probe on every NEW KNOWN_DEFAULTS fold a hunt ships (mutate → revert → re-read) —
 it is ~1-in-3 to need an RSDP entry, and the probe is nearly free while the stack
@@ -1015,6 +1039,34 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   new deploy hits `DELETE_IN_PROGRESS state and can not be updated`. Both hit on
   2026-08-10; wait for the old PROCESS to exit AND `describe-stacks` to 404 before
   relaunching.
+- **CloudTrail Lake is closed to new customers** ("CloudTrail Lake is no longer
+  accepting new customers", live CREATE_FAILED on a barest EventDataStore 2026-08-11)
+  — `AWS::CloudTrail::EventDataStore` joins the dead-service exclusion list
+  (QLDB / CodeCommit / S3ObjectLambda / Cognito Sync class); don't re-probe.
+- **A parent whose declared shape is a LINK/PROXY to another container enumerates the
+  TARGET's children — skip enumeration for link shapes and drop proxy echoes.** Glue
+  `GetTables` on a resource-link database transparently returns the linked TARGET's
+  tables (each echoed with the target's DatabaseName), so a declared link false-added
+  every target table WITH a destructive delete offer (#1749). Fix pattern: early-return
+  for the declared link/federated shape + a generic owning-container-mismatch filter in
+  the pure diff. When adding an enumerator, ask whether the parent type has a
+  link/alias/federated variant whose child-inventory API proxies elsewhere.
+- **The #1729 twin-declaration class includes the parent's OWN inline property, not just
+  new sibling TYPES.** An SNS Topic's canonical inline `Subscription: [{Protocol,
+Endpoint}]` (raw CFn / L1) creates live subscriptions with no AWS::SNS::Subscription
+  resource, and the enumerator's declared-set missed them → false `added` + delete
+  offer on a clean deploy (#1754, live barest5-hunt). When building/auditing an
+  enumerator's declared-set, enumerate EVERY declaration shape for the child surface:
+  sibling resource type(s), \*InlinePolicy twins, AND inline properties on the parent
+  resource itself (match by natural key, conservatively on unresolved refs).
+- **2026-08-11 stackless declared-FP determinations (do not re-probe):** RDS
+  GlobalCluster mixed-case identifier IS accepted + stored lowercased (#1750, fixed);
+  Route53 HealthCheck `FullyQualifiedDomainName` PRESERVES case; Backup BackupPlan
+  `ScheduleExpression` REJECTS `rate()` outright ("Cron expression is not valid" — the
+  rate-canonicalization FP is CFn-unreachable); MemoryDB ACL `UserNames` echoes in
+  DECLARED order (no reorder FP); RDS EventSubscription `SourceIds` rejects mixed case
+  with a 404 ("Could not find source" — lookup is case-sensitive against the lowercase
+  store, so the consumer-case FP is unreachable) and echoes declared order.
 - **Cognito Sync is closed to new customers** (`SetCognitoEvents` →
   NotAuthorizedException "no longer accepting new customers"), so the IdentityPool
   `CognitoEvents` prop writer AND its drift are unreachable from current accounts —

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -128,6 +128,11 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
   // DEFAULT_SG_LIST_PATHS, so the prefetch must fire when a VPC endpoint is present or the
   // OOB-swap gate loses its default-SG ids.
   'AWS::EC2::VPCEndpoint',
+  // #1753: a barest ElastiCache ServerlessCache (engine+name only) is placed into the
+  // default VPC's default SG (live, barest5-hunt 2026-08-11) — registered in classify
+  // DEFAULT_SG_LIST_PATHS, so the prefetch must fire when a serverless cache is present
+  // or the OOB-swap gate loses its default-SG ids.
+  'AWS::ElastiCache::ServerlessCache',
 ]);
 
 // #1269: types whose undeclared SubnetIds default to ALL of the account's DEFAULT-VPC subnets —
@@ -135,6 +140,9 @@ export const DEFAULT_SG_LIST_TYPES: ReadonlySet<string> = new Set([
 // non-default subnet surfaces. Distinct from DEFAULT_SG_LIST_TYPES (that is a single-SG gate).
 const DEFAULT_SUBNET_LIST_TYPES: ReadonlySet<string> = new Set([
   'AWS::RedshiftServerless::Workgroup',
+  // #1753: a barest ServerlessCache also reads back the default-VPC subnets it was
+  // auto-placed into (a 3-subnet subset, still all default-VPC members).
+  'AWS::ElastiCache::ServerlessCache',
 ]);
 
 // #889: fetch the account/region VPC-default security-group ids — one `DescribeSecurityGroups`

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -216,6 +216,9 @@ const notRestored =
 const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) => boolean>> = {
   // A KMS key is always created enabled; `disable-key` (Enabled=false) is always meaningful.
   'AWS::KMS::Key': { Enabled: () => true },
+  // #1754: the replica twin — a ReplicaKey is created enabled and an out-of-band
+  // `disable-key` on it is always meaningful.
+  'AWS::KMS::ReplicaKey': { Enabled: () => true },
   // A TagOption is always created active (the KNOWN_DEFAULTS true pin, barest4/ccpi hunt
   // 2026-07-14); an undeclared `false` is an out-of-band deactivate that blocks the option
   // from new provisioning — a bare false isTrivialEmpty would otherwise swallow.
@@ -691,6 +694,11 @@ export const DEFAULT_SG_LIST_PATHS: Record<string, string> = {
   // the derived gate folds the single default and surfaces an append/swap. Keep in sync
   // with gather.ts DEFAULT_SG_LIST_TYPES.
   'AWS::EC2::VPCEndpoint': 'SecurityGroupIds',
+  // #1753: a barest ElastiCache ServerlessCache (engine+name only) is placed into the
+  // default VPC's default SG (live, barest5-hunt 2026-08-11). OOB-mutable
+  // (`elasticache modify-serverless-cache --security-group-ids`), so the derived gate
+  // folds the single default and surfaces a swap/append.
+  'AWS::ElastiCache::ServerlessCache': 'SecurityGroupIds',
 };
 /** #1269 fold decision for an UNDECLARED default-SUBNET list (RedshiftServerless Workgroup
  *  SubnetIds). Unlike the SG gate (which folds only a SINGLE default SG), a workgroup placed into
@@ -715,6 +723,10 @@ export function shouldFoldDefaultSubnetList(
 }
 const DEFAULT_SUBNET_LIST_PATHS: Record<string, string> = {
   'AWS::RedshiftServerless::Workgroup': 'SubnetIds',
+  // #1753: a barest ServerlessCache reads back the default-VPC subnets AWS auto-placed
+  // it into (live, barest5-hunt 2026-08-11) — fold only while every member is a
+  // default-VPC subnet; an OOB re-placement surfaces.
+  'AWS::ElastiCache::ServerlessCache': 'SubnetIds',
 };
 // #1272: the AWS default effective ConfigParameters a RedshiftServerless Workgroup reads back when
 // it declares none (harvested live from a fresh us-east-1 workgroup, 2026-07-11). Keyed by

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -989,6 +989,19 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ResolverCountLimit: 0,
     XrayEnabled: false,
   },
+  // #1751: a DataSource that declares no metrics config reads back the service default
+  // `MetricsConfig: "DISABLED"` (live-observed first-run on a fresh NONE data source,
+  // linkpack-hunt 2026-08-11). Equality-gated: an out-of-band ENABLED still surfaces.
+  'AWS::AppSync::DataSource': {
+    MetricsConfig: 'DISABLED',
+  },
+  // #1751: a SourceApiAssociation that declares no config materializes
+  // `{MergeType: "MANUAL_MERGE"}` (live-observed first-run, linkpack-hunt 2026-08-11 —
+  // AUTO_MERGE requires an explicit opt-in). Whole-object equality gate: an out-of-band
+  // switch to AUTO_MERGE still surfaces.
+  'AWS::AppSync::SourceApiAssociation': {
+    SourceApiAssociationConfig: { MergeType: 'MANUAL_MERGE' },
+  },
   // AppSync Resolvers / Functions default MaxBatchSize to 0 (no batch invocation)
   // when the template declares no batching — observed live on a fresh
   // appsync-resolver-rich deploy across UNIT + PIPELINE resolvers and the Function.
@@ -1010,6 +1023,20 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     KeySpec: 'SYMMETRIC_DEFAULT',
     KeyUsage: 'ENCRYPT_DECRYPT',
     Origin: 'AWS_KMS',
+  },
+  // #1754: a ReplicaKey is created enabled like its primary (live-observed first-run,
+  // barest5-hunt 2026-08-11); the KeySpec/KeyUsage/Origin trio is INHERITED from the
+  // primary (read-only on a replica) so only Enabled materializes undeclared. Paired
+  // with the MEANINGFUL_WHEN_OFF gate in classify.ts — an out-of-band `disable-key` on
+  // a replica must surface, exactly like the AWS::KMS::Key entry above.
+  'AWS::KMS::ReplicaKey': {
+    Enabled: true,
+  },
+  // #1754: an AccessPoint that declares no RootDirectory materializes the filesystem
+  // root `{Path: "/"}` (live-observed first-run, barest5-hunt 2026-08-11).
+  // Whole-object equality gate: an out-of-band re-point still surfaces.
+  'AWS::EFS::AccessPoint': {
+    RootDirectory: { Path: '/' },
   },
   // A default-policy shorthand DLM policy (`DefaultPolicy: VOLUME|INSTANCE`) that leaves
   // RetainInterval unset reads back the documented default of 7 days (#1663; CreateInterval's
@@ -1205,6 +1232,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::ElastiCache::ServerlessCache': {
     SnapshotRetentionLimit: 0,
+    // #1753: a barest redis serverless cache (engine+name only) reads back a literal
+    // ONE-SPACE Description (" ") — the service's undeclared-description placeholder
+    // (live-observed first-run, barest5-hunt 2026-08-11). Equality-gated; a real
+    // description set out of band still surfaces.
+    Description: ' ',
   },
   'AWS::OpenSearchService::Domain': {
     IPAddressType: 'ipv4',
@@ -1889,6 +1921,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::Transfer::Server': {
     IpAddressType: 'IPV4',
+    // #1753: a ZERO-property server (every prop undeclared — live-observed first-run,
+    // barest5-hunt 2026-08-11) reads back the classic SFTP/public/service-managed
+    // trio. All three are equality-gated (array pinned in its exact live shape), so an
+    // out-of-band protocol add / endpoint change / auth-provider change still surfaces.
+    Protocols: ['SFTP'],
+    EndpointType: 'PUBLIC',
+    IdentityProviderType: 'SERVICE_MANAGED',
     ProtocolDetails: {
       PassiveIp: 'AUTO',
       SetStatOption: 'DEFAULT',
@@ -4124,8 +4163,11 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   // so it folds value-independent too. Live-observed first-run on a fresh headless GlobalCluster
   // (`open-source-rds-extended-support`, #1406). A DECLARED enrollment is compared in the
   // declared loop (detected). GlobalCluster has no KmsKeyId / AZ / window props of its own
-  // (those live on the member cluster), so this is the only value-independent entry it needs.
-  'AWS::RDS::GlobalCluster': new Set(['EngineLifecycleSupport']),
+  // (those live on the member cluster). #1751: undeclared `EngineVersion` joins (the current
+  // GA version, "17.7" on a fresh headless aurora-postgresql GlobalCluster, linkpack-hunt
+  // 2026-08-11) — the same moves-per-GA-release rationale as the DBCluster/DBInstance
+  // entries above; a DECLARED version is still compared in the declared loop.
+  'AWS::RDS::GlobalCluster': new Set(['EngineLifecycleSupport', 'EngineVersion']),
   //   AWS::EKS::AccessEntry.Username is NO LONGER value-independent (#890): the undeclared
   //   default is a DETERMINISTIC transform of the declared PrincipalArn, so it is folded by a
   //   tier-2 derived equality gate in classify.ts (which STILL surfaces an out-of-band RBAC
@@ -4278,7 +4320,11 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'SnapshotWindow',
     'EngineVersion',
   ]),
-  'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime']),
+  //   AWS::ElastiCache::ServerlessCache.MajorEngineVersion — #1753: a cache that declares
+  //   no version reads back the engine's current GA major ("7" for redis today, moving as
+  //   AWS promotes new majors) — the MemoryDB/RDS undeclared-EngineVersion class one row
+  //   below; a user who pins a major DECLARES it and is compared in the declared loop.
+  'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime', 'MajorEngineVersion']),
   //   AWS::MemoryDB::Cluster.EngineVersion — #1503: a cluster that declares no EngineVersion
   //   reads back the current GA patch AWS auto-selected for the engine track (valkey "7.3"
   //   today), which AWS moves over time as it ships new GA versions — not a constant we can
@@ -4625,6 +4671,19 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
 //   (#1501, live-repro'd 2026-07-12 on tests/integration/s3kms-ddb-batch-min).
 export const VALUE_INDEPENDENT_DEFAULT_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Batch::ComputeEnvironment': new Set(['ComputeResources.DesiredvCpus']),
+  // #1753: a SAML identity provider ENRICHES its declared ProviderDetails with values
+  // COMPUTED from the metadata document (live-observed first-run, barest5-hunt
+  // 2026-08-11): SSORedirectBindingURI (extracted from the metadata's
+  // SingleSignOnService element; SLO is the same extraction for SingleLogoutService)
+  // and ActiveEncryptionCertificate (a Cognito-GENERATED per-pool certificate). None
+  // is user intent — the user declared the metadata itself, which stays compared —
+  // and the cert is AWS-assigned per resource, so the enrichments fold
+  // value-independent.
+  'AWS::Cognito::UserPoolIdentityProvider': new Set([
+    'ProviderDetails.SSORedirectBindingURI',
+    'ProviderDetails.SLORedirectBindingURI',
+    'ProviderDetails.ActiveEncryptionCertificate',
+  ]),
   // #1663: an interval-based schedule CreateRule that declares no Times reads back a
   // creation-time-assigned start time (e.g. `Times: ["03:06"]` — DLM picks a time within a
   // window after policy creation, different per resource). Not a constant and not derivable
@@ -5313,7 +5372,17 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
     'DBClusterParameterGroupName',
     'DBSubnetGroupName',
     'Engine',
+    // #1750: consumer of the GlobalCluster entry below — a member cluster's
+    // GlobalClusterIdentifier echoes the STORED (lowercased) global cluster name.
+    'GlobalClusterIdentifier',
   ]),
+  // #1750: live CC probe 2026-08-11 — create-resource passes a mixed-case
+  // `GlobalClusterIdentifier: CdkrdHunt-Mixed-GC` through and the stored echo reads
+  // back `cdkrdhunt-mixed-gc` (the CC physical identifier keeps the declared case;
+  // only the properties echo lowercases — exactly the DBCluster shape). `Engine`
+  // carries over from #1741: RDS engine-name matching is case-insensitive with a
+  // lowercase store service-wide, and a GlobalCluster declares the same engine names.
+  'AWS::RDS::GlobalCluster': new Set(['GlobalClusterIdentifier', 'Engine']),
   // The "stored as a lowercase string" identifier family — ElastiCache, DocumentDB,
   // Neptune, and DMS all lowercase their resource identifier on creation (AWS CLI help:
   // "This parameter is stored as a lowercase string"), so a template that declares a
@@ -6576,6 +6645,10 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   // changes the multiset. DefaultCapacityProviderStrategy order was live-proven PRESERVED
   // in the same probe and is deliberately NOT folded.
   'AWS::ECS::Cluster': new Set(['CapacityProviders']),
+  // #1751: the association-resource twin of the entry above — the SAME ECS attachment API
+  // echoes the provider set sorted (declared [FARGATE_SPOT, FARGATE] read back
+  // [FARGATE, FARGATE_SPOT], live-proven first-run on linkpack-hunt 2026-08-11).
+  'AWS::ECS::ClusterCapacityProviderAssociations': new Set(['CapacityProviders']),
   'AWS::Cognito::UserPoolClient': new Set([
     'AllowedOAuthFlows',
     'AllowedOAuthScopes',

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -1540,9 +1540,20 @@ const CHATBOT_SUBSCRIPTION_ENDPOINT = 'https://global.sns-api.chatbot.amazonaws.
 // Pure diff: declared subscription arns + live inventory -> the added subscriptions.
 export interface SnsTopicChildInput {
   declaredSubscriptionArns: string[]; // physical ids of AWS::SNS::Subscription in the template
+  // #1754: the topic's own INLINE `Subscription` property (raw CFn / L1) declares the
+  // same live subscriptions WITHOUT an AWS::SNS::Subscription sibling — each entry is
+  // matched by (Protocol, Endpoint). An entry whose endpoint the resolver could not
+  // collapse is conservatively protocol-only (a false `added` with a destructive delete
+  // offer is worse than a missed rogue — the TopicPolicy precedent).
+  declaredInlineSubscriptions?: {
+    protocol?: string | undefined;
+    endpoint?: string | undefined;
+    endpointUnresolved?: boolean | undefined;
+  }[];
   liveSubscriptions: {
     arn: string;
     label?: string | undefined;
+    protocol?: string | undefined;
     endpoint?: string | undefined;
     owner?: string | undefined; // the subscription's owning account (SNS `Owner`)
   }[];
@@ -1550,9 +1561,18 @@ export interface SnsTopicChildInput {
 
 export function diffSnsTopicChildren(input: SnsTopicChildInput): AddedChild[] {
   const declared = new Set(input.declaredSubscriptionArns);
+  const inline = input.declaredInlineSubscriptions ?? [];
+  const matchesInline = (s: SnsTopicChildInput['liveSubscriptions'][number]): boolean =>
+    inline.some(
+      (d) =>
+        (d.protocol === undefined ||
+          d.protocol.toLowerCase() === (s.protocol ?? '').toLowerCase()) &&
+        (d.endpointUnresolved || d.endpoint === s.endpoint)
+    );
   const added: AddedChild[] = [];
   for (const s of input.liveSubscriptions) {
     if (declared.has(s.arn)) continue;
+    if (matchesInline(s)) continue; // #1754: declared inline on the Topic itself
     if (s.endpoint === CHATBOT_SUBSCRIPTION_ENDPOINT) continue; // AWS Chatbot auto-managed
     added.push({
       resourceType: 'AWS::SNS::Subscription',
@@ -1602,6 +1622,28 @@ export async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise
     }
   }
 
+  // #1754: the topic's own INLINE `Subscription` property (raw CFn / L1 `CfnTopic`) is
+  // the second declaration shape for the same live subscriptions — a live subscription
+  // created by it is template-declared, not out of band. Matched by (Protocol,
+  // Endpoint); an unresolved endpoint conservatively suppresses by protocol alone.
+  const declaredInlineSubscriptions: {
+    protocol?: string | undefined;
+    endpoint?: string | undefined;
+    endpointUnresolved?: boolean | undefined;
+  }[] = [];
+  const inlineDecl = parent.declared?.Subscription;
+  if (Array.isArray(inlineDecl)) {
+    for (const e of inlineDecl) {
+      if (!e || typeof e !== 'object') continue;
+      const { Protocol, Endpoint } = e as { Protocol?: unknown; Endpoint?: unknown };
+      declaredInlineSubscriptions.push({
+        protocol: typeof Protocol === 'string' ? Protocol : undefined,
+        endpoint: typeof Endpoint === 'string' ? Endpoint : undefined,
+        endpointUnresolved: Endpoint !== undefined && hasUnresolved(Endpoint),
+      });
+    }
+  }
+
   // A declared AWS::SNS::TopicPolicy covers this topic iff one of its (gather-resolved) `Topics`
   // equals this topic's ARN (the declared override reader `readSnsTopicPolicy` handles it). A
   // declared TopicPolicy whose `Topics` is UNRESOLVED is conservatively treated as covering this
@@ -1638,6 +1680,7 @@ export async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise
     .map((s) => ({
       arn: s.SubscriptionArn,
       label: s.Protocol ? `${s.Protocol} ${s.Endpoint ?? ''}`.trim() : s.SubscriptionArn,
+      protocol: s.Protocol,
       endpoint: s.Endpoint,
       owner: s.Owner, // owning account — foreign-scope signal for the sibling-stack check (#1322)
     }));
@@ -1648,9 +1691,11 @@ export async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise
   // default and only surfaces a divergent one.
   const livePolicy = await readSnsTopicPolicyDocument(client, topicArn);
 
-  return diffSnsTopicChildren({ declaredSubscriptionArns, liveSubscriptions }).concat(
-    diffSnsTopicPolicy({ topicArn, hasDeclaredPolicy, livePolicy })
-  );
+  return diffSnsTopicChildren({
+    declaredSubscriptionArns,
+    declaredInlineSubscriptions,
+    liveSubscriptions,
+  }).concat(diffSnsTopicPolicy({ topicArn, hasDeclaredPolicy, livePolicy }));
 }
 
 // The AWS-default SNS topic access policy — every topic ALWAYS carries one at creation, so
@@ -5923,7 +5968,13 @@ async function enumerateAutoScalingGroupChildren(ctx: EnumeratorContext): Promis
 export interface GlueDatabaseChildInput {
   databaseName: string;
   declaredTableNames: string[]; // TableInput.Name values (or Ref/physical id) of AWS::Glue::Table on this database
-  liveTables: { name: string; label?: string | undefined }[];
+  // GetTables echoes each table's OWNING DatabaseName — for a resource-link database the
+  // echo names the linked TARGET, not the queried link (#1749).
+  liveTables: {
+    name: string;
+    label?: string | undefined;
+    sourceDatabaseName?: string | undefined;
+  }[];
 }
 
 export function diffGlueDatabaseChildren(input: GlueDatabaseChildInput): AddedChild[] {
@@ -5932,6 +5983,11 @@ export function diffGlueDatabaseChildren(input: GlueDatabaseChildInput): AddedCh
   const added: AddedChild[] = [];
   for (const t of liveTables) {
     if (declared.has(t.name)) continue;
+    // #1749: a table whose owning DatabaseName differs from the queried database is a
+    // resource-link PROXY echo of the linked target's table — it does not live "in" this
+    // database, the template does not govern it, and flagging it added would offer a
+    // destructive delete of the shared real table. Only a link can produce the mismatch.
+    if (t.sourceDatabaseName !== undefined && t.sourceDatabaseName !== databaseName) continue;
     added.push({
       resourceType: 'AWS::Glue::Table',
       identifier: `${databaseName}|${t.name}`, // DatabaseName|TableName — the composite readGlueTable consumes
@@ -5968,6 +6024,18 @@ async function enumerateGlueDatabaseChildren(ctx: EnumeratorContext): Promise<Ad
   const databaseName = parent.physicalId; // a Glue Database's physical id IS its name
   if (!databaseName) return [];
 
+  // #1749: a declared RESOURCE LINK (`DatabaseInput.TargetDatabase`) has no tables of its
+  // own — GetTables on it transparently proxies to the linked target database (live-proven
+  // 2026-08-11), so enumerating would false-flag every target table as `added` (and offer
+  // a destructive delete of the linked real table). Children cannot exist "in" a link.
+  // A FEDERATED database (`DatabaseInput.FederatedDatabase`) is the same shape one step
+  // further out — its tables live in the remote federation source, never as in-catalog
+  // children the template could govern — so it skips enumeration identically.
+  const dbInput = parent.declared.DatabaseInput as
+    | { TargetDatabase?: unknown; FederatedDatabase?: unknown }
+    | undefined;
+  if (dbInput?.TargetDatabase !== undefined || dbInput?.FederatedDatabase !== undefined) return [];
+
   // Declared tables of THIS database (Ref DatabaseName already resolved to the physical id
   // by gather). A table's identity is its TableInput.Name; fall back to the CFn physical id
   // (Ref = the bare table name — defensively take the last `|` segment in case a composite
@@ -5995,7 +6063,13 @@ async function enumerateGlueDatabaseChildren(ctx: EnumeratorContext): Promise<Ad
   const tables = await pageGlueTables(client, databaseName, catalogId);
   const liveTables = tables
     .filter((t): t is GlueTable & { Name: string } => typeof t.Name === 'string')
-    .map((t) => ({ name: t.Name, label: t.TableType ? `${t.Name} (${t.TableType})` : t.Name }));
+    .map((t) => ({
+      name: t.Name,
+      label: t.TableType ? `${t.Name} (${t.TableType})` : t.Name,
+      // Owning database per the live echo — differs from `databaseName` only for a
+      // resource-link proxy echo (#1749), which the pure diff drops.
+      sourceDatabaseName: t.DatabaseName,
+    }));
 
   return diffGlueDatabaseChildren({ databaseName, declaredTableNames, liveTables });
 }

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -140,6 +140,11 @@ const CC_REVERTABLE_DESPITE_READ_OVERRIDE = new Set<string>([
 // entry here (#702): UpdateUserPool ignores an omitted property, so a fold WITHOUT an RSDP
 // entry silently reverts as a no-op `remove`. Keyed `${resourceType}\0${path}`.
 export const REVERT_SET_DEFAULT_PATHS = new Set<string>([
+  // #1753: ElastiCache ModifyServerlessCache leaves an OMITTED Description unchanged — a
+  // bare `remove` of an out-of-band description reports SUCCESS yet the value persists
+  // (silent no-op, proven via explicit CC patches on a CC-created cache, 2026-08-11);
+  // the explicit `add` of the one-space KNOWN_DEFAULTS placeholder converges.
+  'AWS::ElastiCache::ServerlessCache\0Description',
   // EC2 ModifyCapacityReservation leaves an OMITTED property unchanged — a bare `remove`
   // of an out-of-band InstanceMatchCriteria=targeted or EndDateType=limited reports
   // SUCCESS yet the live value persists (silent no-op, proven via explicit Cloud Control
@@ -955,6 +960,107 @@ function nullHuskRemovalOps(model: Record<string, unknown>): PatchOp[] {
   return ops;
 }
 
+// #1752: GuardDuty Detector patch shape — the UpdateDetector CC handler rejects EVERY
+// patch on a current-era detector unless the write model satisfies two exclusivity rules
+// (all three legs live-proven by stackless CC probes, 2026-08-11):
+//   1. the Features echo carries BOTH the deprecated EKS_RUNTIME_MONITORING and its
+//      successor RUNTIME_MONITORING → "cannot be provided in the same request" — the
+//      deprecated element must be REMOVED from the model;
+//   2. the model carries BOTH the (derived-view) DataSources echo and Features → "both
+//      data sources and features were provided. You can provide only one" — the
+//      DataSources block must be REMOVED from the model (it is a projection of Features;
+//      dropping it from the WRITE model changes no live state);
+//   3. consequently a revert op targeting /DataSources/... can never be written on that
+//      side — it must be TRANSLATED to the equivalent Features Status write
+//      (S3Logs→S3_DATA_EVENTS, Kubernetes.AuditLogs→EKS_AUDIT_LOGS,
+//      MalwareProtection→EBS_MALWARE_PROTECTION), after which the live DataSources view
+//      follows the feature (probe: S3Logs read back ENABLED).
+const GUARDDUTY_DS_FEATURE_BLOCKS: readonly { block: string; feature: string }[] = [
+  { block: 'S3Logs', feature: 'S3_DATA_EVENTS' },
+  { block: 'Kubernetes', feature: 'EKS_AUDIT_LOGS' },
+  { block: 'MalwareProtection', feature: 'EBS_MALWARE_PROTECTION' },
+];
+
+// First boolean leaf of a DataSources sub-block ({Enable: b} / {AuditLogs: {Enable: b}} /
+// {ScanEc2InstanceWithFindings: {EbsVolumes: b}}) — each block carries exactly one toggle.
+function firstBooleanLeaf(v: unknown): boolean | undefined {
+  if (typeof v === 'boolean') return v;
+  if (v && typeof v === 'object' && !Array.isArray(v)) {
+    for (const x of Object.values(v as Record<string, unknown>)) {
+      const b = firstBooleanLeaf(x);
+      if (b !== undefined) return b;
+    }
+  }
+  return undefined;
+}
+
+export function applyGuardDutyDetectorPatchShape(
+  item: RevertItem,
+  live: Record<string, unknown>
+): void {
+  const features = Array.isArray(live.Features)
+    ? (live.Features as { Name?: unknown; Status?: unknown }[])
+    : [];
+  const featureIdx = (name: string) => features.findIndex((f) => f && f.Name === name);
+
+  // Leg 3: translate /DataSources ops to Features Status writes (original op kept only
+  // when no translation is possible — an unobserved shape should fail loudly, not no-op).
+  const ops: PatchOp[] = [];
+  for (const op of item.ops) {
+    if (!op.path.startsWith('/DataSources')) {
+      ops.push(op);
+      continue;
+    }
+    const seg = op.path.split('/')[2];
+    const blocks = seg
+      ? GUARDDUTY_DS_FEATURE_BLOCKS.filter((b) => b.block === seg)
+      : GUARDDUTY_DS_FEATURE_BLOCKS;
+    const translated: PatchOp[] = [];
+    for (const b of blocks) {
+      const sub = seg ? op.value : (op.value as Record<string, unknown> | undefined)?.[b.block];
+      // A bare `remove` means return-to-default, and the #1700 creation defaults are
+      // all-enabled; an add/replace carries the target toggle inside its value.
+      const enabled = op.op === 'remove' ? true : firstBooleanLeaf(sub);
+      const idx = featureIdx(b.feature);
+      if (enabled === undefined || idx < 0) continue;
+      translated.push({
+        op: 'add',
+        path: `/Features/${idx}/Status`,
+        value: enabled ? 'ENABLED' : 'DISABLED',
+        prior: op.prior,
+        human: `${b.feature} -> ${enabled ? 'ENABLED' : 'DISABLED'} (translated from ${op.path}, #1752)`,
+      });
+    }
+    ops.push(...(translated.length > 0 ? translated : [op]));
+  }
+
+  // Leg 2: strip the DataSources projection from the write model. Runs after the
+  // translated Status writes (ops apply in order; its removal cannot shift /Features
+  // indices).
+  if (live.DataSources !== undefined && !ops.some((o) => o.path === '/DataSources')) {
+    ops.push({
+      op: 'remove',
+      path: '/DataSources',
+      contract: true,
+      human: 'DataSources -> remove from the write model (Features projection, #1752)',
+    });
+  }
+
+  // Leg 1: strip the deprecated-alias feature element — LAST, so no earlier
+  // /Features/<i> op sees a shifted index.
+  const eksIdx = featureIdx('EKS_RUNTIME_MONITORING');
+  if (eksIdx >= 0 && featureIdx('RUNTIME_MONITORING') >= 0) {
+    ops.push({
+      op: 'remove',
+      path: `/Features/${eksIdx}`,
+      contract: true,
+      human: 'EKS_RUNTIME_MONITORING -> remove (deprecated alias of RUNTIME_MONITORING, #1752)',
+    });
+  }
+
+  item.ops = ops;
+}
+
 // Total-order comparator putting two JSON pointers into DESCENDING document order: at the
 // first differing segment, larger index / lexically-greater key first (a numeric-vs-numeric
 // pair compares numerically so `/Rules/10` sorts before `/Rules/2`); if one pointer is a
@@ -1674,6 +1780,11 @@ export function buildRevertPlan(
       item.liveRaw = live;
       const huskOps = nullHuskRemovalOps(live);
       if (huskOps.length > 0) item.ops.unshift(...huskOps);
+      // #1752: GuardDuty Detector patches need the DataSources→Features translation +
+      // the two exclusivity companion removes or the handler rejects the whole patch.
+      if (item.resourceType === 'AWS::GuardDuty::Detector') {
+        applyGuardDutyDetectorPatchShape(item, live);
+      }
     }
   }
 

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1054,6 +1054,39 @@ describe('diffSnsTopicChildren (SNS Topic subscriptions)', () => {
     ).toEqual([]);
   });
 
+  // #1754: the topic's own INLINE `Subscription` property (raw CFn / L1 CfnTopic) is the
+  // second declaration shape for the same live subscriptions — a live subscription created
+  // by it is template-declared, not out of band (the QueueInlinePolicy / TopicInlinePolicy
+  // #1729 class one resource up). Matched by (Protocol, Endpoint); an unresolved endpoint
+  // conservatively suppresses by protocol alone.
+  it('suppresses a subscription declared INLINE on the Topic (#1754) but still flags a rogue', () => {
+    const added = diffSnsTopicChildren({
+      declaredSubscriptionArns: [],
+      declaredInlineSubscriptions: [
+        { protocol: 'sqs', endpoint: 'arn:aws:sqs:us-east-1:111122223333:inlineq' },
+        { protocol: 'lambda', endpointUnresolved: true },
+      ],
+      liveSubscriptions: [
+        {
+          arn: SUB('inline'),
+          label: 'sqs arn:aws:sqs:us-east-1:111122223333:inlineq',
+          protocol: 'sqs',
+          endpoint: 'arn:aws:sqs:us-east-1:111122223333:inlineq',
+        },
+        // unresolved-endpoint inline entry suppresses by protocol alone (conservative)
+        { arn: SUB('inline2'), label: 'lambda fn', protocol: 'lambda', endpoint: 'arn:fn' },
+        // same protocol, DIFFERENT endpoint than any inline entry → still a real added
+        {
+          arn: SUB('rogue'),
+          label: 'sqs arn:aws:sqs:us-east-1:111122223333:rogueq',
+          protocol: 'sqs',
+          endpoint: 'arn:aws:sqs:us-east-1:111122223333:rogueq',
+        },
+      ],
+    });
+    expect(added.map((a) => a.identifier)).toEqual([SUB('rogue')]);
+  });
+
   // AWS Chatbot (SlackChannelConfiguration / Teams / Amazon Q console) auto-subscribes its
   // fixed global endpoint to every topic a channel config points at. That subscription is
   // never in the template, so without a fold it surfaces as a false `added` out-of-band

--- a/tests/corpus/AWS__AppSync__DataSource.SrcDs.json
+++ b/tests/corpus/AWS__AppSync__DataSource.SrcDs.json
@@ -1,0 +1,51 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SrcDs",
+    "resourceType": "AWS::AppSync::DataSource",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/4j3suerumfetpgnqlyaa5kaf7e/datasources/NoneDs",
+    "constructPath": "CdkrdHunt0811LinkPack/SrcDs",
+    "declared": {
+      "ApiId": "4j3suerumfetpgnqlyaa5kaf7e",
+      "Name": "NoneDs",
+      "Type": "NONE"
+    }
+  },
+  "liveRaw": {
+    "DataSourceArn": "arn:aws:appsync:us-east-1:111111111111:apis/4j3suerumfetpgnqlyaa5kaf7e/datasources/NoneDs",
+    "Type": "NONE",
+    "ApiId": "4j3suerumfetpgnqlyaa5kaf7e",
+    "MetricsConfig": "DISABLED",
+    "Name": "NoneDs"
+  },
+  "schema": {
+    "readOnly": ["DataSourceArn"],
+    "writeOnly": [],
+    "createOnly": ["ApiId", "Name"],
+    "readOnlyPaths": ["DataSourceArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcDs",
+      "resourceType": "AWS::AppSync::DataSource",
+      "path": "MetricsConfig",
+      "actual": "DISABLED",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/4j3suerumfetpgnqlyaa5kaf7e/datasources/NoneDs",
+      "constructPath": "CdkrdHunt0811LinkPack/SrcDs"
+    }
+  ]
+}

--- a/tests/corpus/AWS__AppSync__GraphQLApi.MergedApi.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.MergedApi.json
@@ -1,0 +1,131 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MergedApi",
+    "resourceType": "AWS::AppSync::GraphQLApi",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+    "constructPath": "CdkrdHunt0811LinkPack/MergedApi",
+    "declared": {
+      "ApiType": "MERGED",
+      "AuthenticationType": "API_KEY",
+      "MergedApiExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0811LinkPack-MergeRoleC1AB97BF-LQE1G4UQKG3j",
+      "Name": "cdkrd-hunt-0811-merged",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "QueryDepthLimit": 0,
+    "IntrospectionConfig": "ENABLED",
+    "MergedApiExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0811LinkPack-MergeRoleC1AB97BF-LQE1G4UQKG3j",
+    "RealtimeDns": "lt67dmsc25ga5cask37j34zspm.appsync-realtime-api.us-east-1.amazonaws.com",
+    "ResolverCountLimit": 0,
+    "Name": "cdkrd-hunt-0811-merged",
+    "RealtimeUrl": "wss://lt67dmsc25ga5cask37j34zspm.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+    "EnvironmentVariables": {},
+    "GraphQLUrl": "https://lt67dmsc25ga5cask37j34zspm.appsync-api.us-east-1.amazonaws.com/graphql",
+    "GraphQLDns": "lt67dmsc25ga5cask37j34zspm.appsync-api.us-east-1.amazonaws.com",
+    "ApiType": "MERGED",
+    "XrayEnabled": false,
+    "Visibility": "GLOBAL",
+    "Arn": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+    "ApiId": "wqmk6hy7evdmhlebmp5z46rkmi",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "AuthenticationType": "API_KEY",
+    "GraphQLEndpointArn": "arn:aws:appsync:us-east-1:111111111111:endpoints/graphql-api/lt67dmsc25ga5cask37j34zspm"
+  },
+  "schema": {
+    "readOnly": [
+      "ApiId",
+      "Arn",
+      "GraphQLDns",
+      "GraphQLEndpointArn",
+      "GraphQLUrl",
+      "RealtimeDns",
+      "RealtimeUrl"
+    ],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "ApiId",
+      "Arn",
+      "GraphQLDns",
+      "GraphQLEndpointArn",
+      "GraphQLUrl",
+      "RealtimeDns",
+      "RealtimeUrl"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["EnvironmentVariables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MergedApi",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "QueryDepthLimit",
+      "actual": 0,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+      "constructPath": "CdkrdHunt0811LinkPack/MergedApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MergedApi",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "IntrospectionConfig",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+      "constructPath": "CdkrdHunt0811LinkPack/MergedApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MergedApi",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "ResolverCountLimit",
+      "actual": 0,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+      "constructPath": "CdkrdHunt0811LinkPack/MergedApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MergedApi",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "XrayEnabled",
+      "actual": false,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+      "constructPath": "CdkrdHunt0811LinkPack/MergedApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MergedApi",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "Visibility",
+      "actual": "GLOBAL",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+      "constructPath": "CdkrdHunt0811LinkPack/MergedApi"
+    }
+  ]
+}

--- a/tests/corpus/AWS__AppSync__SourceApiAssociation.SrcAssoc.json
+++ b/tests/corpus/AWS__AppSync__SourceApiAssociation.SrcAssoc.json
@@ -1,0 +1,99 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SrcAssoc",
+    "resourceType": "AWS::AppSync::SourceApiAssociation",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi/sourceApiAssociations/2b26d4c7-1e97-4a03-8fad-5712d581383e",
+    "constructPath": "CdkrdHunt0811LinkPack/SrcAssoc",
+    "declared": {
+      "MergedApiIdentifier": "wqmk6hy7evdmhlebmp5z46rkmi",
+      "SourceApiIdentifier": "4j3suerumfetpgnqlyaa5kaf7e"
+    }
+  },
+  "liveRaw": {
+    "AssociationArn": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi/sourceApiAssociations/2b26d4c7-1e97-4a03-8fad-5712d581383e",
+    "MergedApiId": "wqmk6hy7evdmhlebmp5z46rkmi",
+    "SourceApiArn": "arn:aws:appsync:us-east-1:111111111111:apis/4j3suerumfetpgnqlyaa5kaf7e",
+    "LastSuccessfulMergeDate": "2026-08-10T18:26:06.339Z",
+    "SourceApiAssociationConfig": {
+      "MergeType": "MANUAL_MERGE"
+    },
+    "SourceApiAssociationStatusDetail": "Successfully merged source GraphQL API (API Id: 4j3suerumfetpgnqlyaa5kaf7e, Association Id: 2b26d4c7-1e97-4a03-8fad-5712d581383e)",
+    "MergedApiArn": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi",
+    "AssociationId": "2b26d4c7-1e97-4a03-8fad-5712d581383e",
+    "SourceApiAssociationStatus": "MERGE_SUCCESS",
+    "SourceApiId": "4j3suerumfetpgnqlyaa5kaf7e"
+  },
+  "schema": {
+    "readOnly": [
+      "AssociationArn",
+      "AssociationId",
+      "LastSuccessfulMergeDate",
+      "MergedApiArn",
+      "MergedApiId",
+      "SourceApiArn",
+      "SourceApiAssociationStatus",
+      "SourceApiAssociationStatusDetail",
+      "SourceApiId"
+    ],
+    "writeOnly": ["MergedApiIdentifier", "SourceApiIdentifier"],
+    "createOnly": ["MergedApiIdentifier", "SourceApiIdentifier"],
+    "readOnlyPaths": [
+      "AssociationArn",
+      "AssociationId",
+      "LastSuccessfulMergeDate",
+      "MergedApiArn",
+      "MergedApiId",
+      "SourceApiArn",
+      "SourceApiAssociationStatus",
+      "SourceApiAssociationStatusDetail",
+      "SourceApiId"
+    ],
+    "writeOnlyPaths": ["MergedApiIdentifier", "SourceApiIdentifier"],
+    "createOnlyPaths": ["MergedApiIdentifier", "SourceApiIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "SrcAssoc",
+      "resourceType": "AWS::AppSync::SourceApiAssociation",
+      "path": "MergedApiIdentifier",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi/sourceApiAssociations/2b26d4c7-1e97-4a03-8fad-5712d581383e",
+      "constructPath": "CdkrdHunt0811LinkPack/SrcAssoc"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "SrcAssoc",
+      "resourceType": "AWS::AppSync::SourceApiAssociation",
+      "path": "SourceApiIdentifier",
+      "note": "write-only — cannot be read back",
+      "writeOnly": true,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi/sourceApiAssociations/2b26d4c7-1e97-4a03-8fad-5712d581383e",
+      "constructPath": "CdkrdHunt0811LinkPack/SrcAssoc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcAssoc",
+      "resourceType": "AWS::AppSync::SourceApiAssociation",
+      "path": "SourceApiAssociationConfig",
+      "actual": {
+        "MergeType": "MANUAL_MERGE"
+      },
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/wqmk6hy7evdmhlebmp5z46rkmi/sourceApiAssociations/2b26d4c7-1e97-4a03-8fad-5712d581383e",
+      "constructPath": "CdkrdHunt0811LinkPack/SrcAssoc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Batch__JobDefinition.MultinodeJd.json
+++ b/tests/corpus/AWS__Batch__JobDefinition.MultinodeJd.json
@@ -1,0 +1,130 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MultinodeJd",
+    "resourceType": "AWS::Batch::JobDefinition",
+    "physicalId": "arn:aws:batch:us-east-1:111111111111:job-definition/cdkrd-hunt-0811-multinode:4",
+    "constructPath": "CdkrdHunt0811BarestA/MultinodeJd",
+    "declared": {
+      "JobDefinitionName": "cdkrd-hunt-0811-multinode",
+      "NodeProperties": {
+        "MainNode": 0,
+        "NodeRangeProperties": [
+          {
+            "Container": {
+              "Image": "public.ecr.aws/amazonlinux/amazonlinux:latest",
+              "ResourceRequirements": [
+                {
+                  "Type": "VCPU",
+                  "Value": "1"
+                },
+                {
+                  "Type": "MEMORY",
+                  "Value": "1024"
+                }
+              ]
+            },
+            "TargetNodes": "0:"
+          }
+        ],
+        "NumNodes": 2
+      },
+      "Tags": {
+        "cdkrd:ephemeral": "1"
+      },
+      "Type": "multinode"
+    }
+  },
+  "liveRaw": {
+    "Type": "multinode",
+    "Parameters": {},
+    "NodeProperties": {
+      "MainNode": 0,
+      "NodeRangeProperties": [
+        {
+          "Container": {
+            "MountPoints": [],
+            "Volumes": [],
+            "Secrets": [],
+            "Command": [],
+            "Environment": [],
+            "Ulimits": [],
+            "Image": "public.ecr.aws/amazonlinux/amazonlinux:latest",
+            "ResourceRequirements": [
+              {
+                "Type": "VCPU",
+                "Value": "1"
+              },
+              {
+                "Type": "MEMORY",
+                "Value": "1024"
+              }
+            ]
+          },
+          "TargetNodes": "0:",
+          "InstanceTypes": []
+        }
+      ],
+      "NumNodes": 2
+    },
+    "JobDefinitionArn": "arn:aws:batch:us-east-1:111111111111:job-definition/cdkrd-hunt-0811-multinode:4",
+    "JobDefinitionName": "cdkrd-hunt-0811-multinode",
+    "PropagateTags": false,
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdHunt0811BarestA",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0811BarestA/1b689460-94eb-11f1-87ae-0affdb7e7f31",
+      "cdkrd:ephemeral": "1",
+      "aws:cloudformation:logical-id": "MultinodeJd"
+    }
+  },
+  "schema": {
+    "readOnly": ["JobDefinitionArn"],
+    "writeOnly": ["ResourceRetentionPolicy"],
+    "createOnly": ["JobDefinitionName"],
+    "readOnlyPaths": ["JobDefinitionArn"],
+    "writeOnlyPaths": ["ResourceRetentionPolicy", "ResourceRetentionPolicy.SkipDeregisterOnUpdate"],
+    "createOnlyPaths": ["JobDefinitionName"],
+    "defaults": {},
+    "defaultPaths": {
+      "ResourceRetentionPolicy.SkipDeregisterOnUpdate": false
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [
+      "ContainerProperties.LinuxParameters.Devices",
+      "ContainerProperties.LinuxParameters.Tmpfs",
+      "ContainerProperties.MountPoints",
+      "ContainerProperties.ResourceRequirements",
+      "EcsProperties.TaskProperties",
+      "NodeProperties.NodeRangeProperties",
+      "RetryStrategy.EvaluateOnExit"
+    ],
+    "freeFormMapPaths": [
+      "ContainerProperties.LogConfiguration.Options",
+      "EcsProperties.TaskProperties.*.Containers.*.FirelensConfiguration.Options",
+      "EcsProperties.TaskProperties.*.Containers.*.LogConfiguration.Options",
+      "EksProperties.PodProperties.Containers.*.Resources.Limits",
+      "EksProperties.PodProperties.Containers.*.Resources.Requests",
+      "EksProperties.PodProperties.InitContainers.*.Resources.Limits",
+      "EksProperties.PodProperties.InitContainers.*.Resources.Requests",
+      "EksProperties.PodProperties.Metadata.Annotations",
+      "EksProperties.PodProperties.Metadata.Labels",
+      "NodeProperties.NodeRangeProperties.*.Container.LogConfiguration.Options",
+      "NodeProperties.NodeRangeProperties.*.EcsProperties.TaskProperties.*.Containers.*.FirelensConfiguration.Options",
+      "NodeProperties.NodeRangeProperties.*.EcsProperties.TaskProperties.*.Containers.*.LogConfiguration.Options",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Containers.*.Resources.Limits",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Containers.*.Resources.Requests",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.InitContainers.*.Resources.Limits",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.InitContainers.*.Resources.Requests",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Metadata.Annotations",
+      "NodeProperties.NodeRangeProperties.*.EksProperties.PodProperties.Metadata.Labels",
+      "Parameters"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPoolIdentityProvider.SamlIdp.json
+++ b/tests/corpus/AWS__Cognito__UserPoolIdentityProvider.SamlIdp.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SamlIdp",
+    "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
+    "physicalId": "cdkrd-hunt-saml",
+    "constructPath": "CdkrdHunt0811BarestA/SamlIdp",
+    "declared": {
+      "ProviderDetails": {
+        "MetadataFile": "<?xml version=\"1.0\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"urn:cdkrd-hunt-0811-idp\"><md:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>MIIDEzCCAfugAwIBAgIUd23PixfCQqbN8bNqptEqE+9GNsMwDQYJKoZIhvcNAQELBQAwGTEXMBUGA1UEAwwOY2RrcmQtaHVudC1pZHAwHhcNMjYwODEwMTc1ODI0WhcNMjYwOTA5MTc1ODI0WjAZMRcwFQYDVQQDDA5jZGtyZC1odW50LWlkcDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMIRGjNNMo4aLwcGxCPEbN2GOpNel9TyHo1BsRax9FIZApdSa22mXs9o2UObdqYuVfvSMC83sxTDLxqTiYTy672yS7JLaVhOHUdi8dONyCMf2W9CPmg49iLEq5285It4LzYoKVgAWkk4qF6BHTHn2WU9j1pVJb+nte078L3CPqwC0208RSbsVSTrn3QSVcloaZNOKP+p045444mWKt9hc4Kn0nM73BZRhqNL/Mkgy6zptY4FFKtw2593rvnmOoM2O5dXrL2hG/DGSPAIWRjAFNZYctikC2ldPloxR7sfe5E3L2ELl5NXLbnpShSBThsuIpD7FHerqwq6LF7ptEPY1xMCAwEAAaNTMFEwHQYDVR0OBBYEFHWmzjhTgKum0G+1bvI57hKw5I/sMB8GA1UdIwQYMBaAFHWmzjhTgKum0G+1bvI57hKw5I/sMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBABoJmw5e2ptW0s3jjLJbr4VnIrbFQ5ieSemHC8VhujphYv7vPr5iLnqkM1QZrjRGWXDAB9PSIAZVPTw3S67AAIK6KRJxFdYr8xnKChsjzdjhqW3fkxRVefMP3Nxn8fx6rO9Hf50hXsU8Gbmzrh77uLECH+DI/KpiSui8wvZikNsbQ1WyEneP0yakj/C7VDmHHFP5FKHeHGh04eVygxPf89ctWHe9okm3KDbSkRmQMnwpLKF2Tvk1J5KIZFvkR6y+w8nh81N702lh1in/BSbXFp8aiGO1liQJTy4Duf3X6PrZOMwF30HrvYeACALjtwxt8tZL4epW2KsHVsozEJxrm38=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat><md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://example.com/sso\"/></md:IDPSSODescriptor></md:EntityDescriptor>"
+      },
+      "ProviderName": "cdkrd-hunt-saml",
+      "ProviderType": "SAML",
+      "UserPoolId": "us-east-1_cjQKm0iga"
+    }
+  },
+  "liveRaw": {
+    "ProviderName": "cdkrd-hunt-saml",
+    "UserPoolId": "us-east-1_cjQKm0iga",
+    "AttributeMapping": {},
+    "ProviderDetails": {
+      "MetadataFile": "<?xml version=\"1.0\"?><md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"urn:cdkrd-hunt-0811-idp\"><md:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\"><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>MIIDEzCCAfugAwIBAgIUd23PixfCQqbN8bNqptEqE+9GNsMwDQYJKoZIhvcNAQELBQAwGTEXMBUGA1UEAwwOY2RrcmQtaHVudC1pZHAwHhcNMjYwODEwMTc1ODI0WhcNMjYwOTA5MTc1ODI0WjAZMRcwFQYDVQQDDA5jZGtyZC1odW50LWlkcDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMIRGjNNMo4aLwcGxCPEbN2GOpNel9TyHo1BsRax9FIZApdSa22mXs9o2UObdqYuVfvSMC83sxTDLxqTiYTy672yS7JLaVhOHUdi8dONyCMf2W9CPmg49iLEq5285It4LzYoKVgAWkk4qF6BHTHn2WU9j1pVJb+nte078L3CPqwC0208RSbsVSTrn3QSVcloaZNOKP+p045444mWKt9hc4Kn0nM73BZRhqNL/Mkgy6zptY4FFKtw2593rvnmOoM2O5dXrL2hG/DGSPAIWRjAFNZYctikC2ldPloxR7sfe5E3L2ELl5NXLbnpShSBThsuIpD7FHerqwq6LF7ptEPY1xMCAwEAAaNTMFEwHQYDVR0OBBYEFHWmzjhTgKum0G+1bvI57hKw5I/sMB8GA1UdIwQYMBaAFHWmzjhTgKum0G+1bvI57hKw5I/sMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBABoJmw5e2ptW0s3jjLJbr4VnIrbFQ5ieSemHC8VhujphYv7vPr5iLnqkM1QZrjRGWXDAB9PSIAZVPTw3S67AAIK6KRJxFdYr8xnKChsjzdjhqW3fkxRVefMP3Nxn8fx6rO9Hf50hXsU8Gbmzrh77uLECH+DI/KpiSui8wvZikNsbQ1WyEneP0yakj/C7VDmHHFP5FKHeHGh04eVygxPf89ctWHe9okm3KDbSkRmQMnwpLKF2Tvk1J5KIZFvkR6y+w8nh81N702lh1in/BSbXFp8aiGO1liQJTy4Duf3X6PrZOMwF30HrvYeACALjtwxt8tZL4epW2KsHVsozEJxrm38=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor><md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat><md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://example.com/sso\"/></md:IDPSSODescriptor></md:EntityDescriptor>",
+      "SSORedirectBindingURI": "https://example.com/sso",
+      "ActiveEncryptionCertificate": "MIICvDCCAaSgAwIBAgIIRMJHbK9FFy4wDQYJKoZIhvcNAQELBQAwHjEcMBoGA1UEAwwTdXMtZWFzdC0xX2NqUUttMGlnYTAeFw0yNjA4MTAxODQxNDhaFw0zNjA4MTAwNDUzNDhaMB4xHDAaBgNVBAMME3VzLWVhc3QtMV9jalFLbTBpZ2EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDWYMkyGkhXS4SxENMYlf2RTMWZuNNF3DnHpjnf6OeLrYu9bBjdLp7VugHOLZWZfmpJSGKYzIkRSX1jrtbv26jvHuWbyK+i87pRKGjY+vAi7zwBPEApuoO41lpUJWjB7VPpvHIxuhKy7TIS0ei6iyEm75AiOcnJxY8FjW0uZ/B84O/04sDJrjbffudW6scyAuTteJVcLlzI81WsOItEd1WNzSzawHm1CKHEcIYJhXTIPJQQQpp/3MUAXwMDAXqAuXio18T0YPssdl7EOzg/+CXUwYBYpSc2Gc9exRfeBQtjq6s+9NZoa/zc5kh9Y4CXYuIWmJ3SlRX2ZnYB2j0pw89BAgMBAAEwDQYJKoZIhvcNAQELBQADggEBALUR+ntqCzETCVMVJmmEppxW9+HgCVBG1Nz7uoen5KwhdYXVRfoKpMsusU24YF5OlyN10zAW7blyil1yYQ6DTWh1k8EYKRmb/86JxG+xlHa7T8fwxn0BNl5gJwmsbji6TCj9tyqevkNoPPgQIGqXkUs/TU5n/C9ptSVlI6NxS9T7mSX5Z/aQ/pdKWEgF4bTr2ouzC8gzlqSmkSe4GW85S2l3zdOkXpsxR6gyvewj3XNHeO3jX0OaUx4hjSnHGAe983Wmahla5GtBVDdbTR3I7VjJcaOLrkJYqyPYZR0iuHSsulLjAvEgaE/CWKj39keQCZESFn5csdXENGji0cKyHKE="
+    },
+    "ProviderType": "SAML",
+    "IdpIdentifiers": []
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ProviderName", "ProviderType", "UserPoolId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ProviderName", "ProviderType", "UserPoolId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["AttributeMapping", "ProviderDetails"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SamlIdp",
+      "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
+      "path": "ProviderDetails.SSORedirectBindingURI",
+      "actual": "https://example.com/sso",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-saml",
+      "constructPath": "CdkrdHunt0811BarestA/SamlIdp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SamlIdp",
+      "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
+      "path": "ProviderDetails.ActiveEncryptionCertificate",
+      "actual": "MIICvDCCAaSgAwIBAgIIRMJHbK9FFy4wDQYJKoZIhvcNAQELBQAwHjEcMBoGA1UEAwwTdXMtZWFzdC0xX2NqUUttMGlnYTAeFw0yNjA4MTAxODQxNDhaFw0zNjA4MTAwNDUzNDhaMB4xHDAaBgNVBAMME3VzLWVhc3QtMV9jalFLbTBpZ2EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDWYMkyGkhXS4SxENMYlf2RTMWZuNNF3DnHpjnf6OeLrYu9bBjdLp7VugHOLZWZfmpJSGKYzIkRSX1jrtbv26jvHuWbyK+i87pRKGjY+vAi7zwBPEApuoO41lpUJWjB7VPpvHIxuhKy7TIS0ei6iyEm75AiOcnJxY8FjW0uZ/B84O/04sDJrjbffudW6scyAuTteJVcLlzI81WsOItEd1WNzSzawHm1CKHEcIYJhXTIPJQQQpp/3MUAXwMDAXqAuXio18T0YPssdl7EOzg/+CXUwYBYpSc2Gc9exRfeBQtjq6s+9NZoa/zc5kh9Y4CXYuIWmJ3SlRX2ZnYB2j0pw89BAgMBAAEwDQYJKoZIhvcNAQELBQADggEBALUR+ntqCzETCVMVJmmEppxW9+HgCVBG1Nz7uoen5KwhdYXVRfoKpMsusU24YF5OlyN10zAW7blyil1yYQ6DTWh1k8EYKRmb/86JxG+xlHa7T8fwxn0BNl5gJwmsbji6TCj9tyqevkNoPPgQIGqXkUs/TU5n/C9ptSVlI6NxS9T7mSX5Z/aQ/pdKWEgF4bTr2ouzC8gzlqSmkSe4GW85S2l3zdOkXpsxR6gyvewj3XNHeO3jX0OaUx4hjSnHGAe983Wmahla5GtBVDdbTR3I7VjJcaOLrkJYqyPYZR0iuHSsulLjAvEgaE/CWKj39keQCZESFn5csdXENGji0cKyHKE=",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-saml",
+      "constructPath": "CdkrdHunt0811BarestA/SamlIdp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__ClusterCapacityProviderAssociations.CcpaReorder.json
+++ b/tests/corpus/AWS__ECS__ClusterCapacityProviderAssociations.CcpaReorder.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Ccpa",
+    "resourceType": "AWS::ECS::ClusterCapacityProviderAssociations",
+    "physicalId": "cdkrd-hunt-0811-ccpa",
+    "constructPath": "CdkrdHunt0811LinkPack/Ccpa",
+    "declared": {
+      "CapacityProviders": ["FARGATE_SPOT", "FARGATE"],
+      "Cluster": "cdkrd-hunt-0811-ccpa",
+      "DefaultCapacityProviderStrategy": []
+    }
+  },
+  "liveRaw": {
+    "DefaultCapacityProviderStrategy": [],
+    "CapacityProviders": ["FARGATE", "FARGATE_SPOT"],
+    "Cluster": "cdkrd-hunt-0811-ccpa"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Cluster"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Cluster"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EFS__AccessPoint.Ap.json
+++ b/tests/corpus/AWS__EFS__AccessPoint.Ap.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Ap",
+    "resourceType": "AWS::EFS::AccessPoint",
+    "physicalId": "fsap-06f206e224a019d01",
+    "constructPath": "CdkrdHunt0811BarestB/Ap",
+    "declared": {
+      "AccessPointTags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "FileSystemId": "fs-0095a4e88992de345"
+    }
+  },
+  "liveRaw": {
+    "AccessPointId": "fsap-06f206e224a019d01",
+    "FileSystemId": "fs-0095a4e88992de345",
+    "RootDirectory": {
+      "Path": "/"
+    },
+    "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:access-point/fsap-06f206e224a019d01",
+    "ClientToken": "Ap-fOyykpY6zBUz",
+    "AccessPointTags": [
+      {
+        "Value": "CdkrdHunt0811BarestB",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0811BarestB/dbe593b0-94ea-11f1-a0e1-0eefa0f25c89",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Ap",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AccessPointId", "Arn"],
+    "writeOnly": [],
+    "createOnly": ["ClientToken", "CreationInfo", "FileSystemId", "PosixUser", "RootDirectory"],
+    "readOnlyPaths": ["AccessPointId", "Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ClientToken",
+      "CreationInfo",
+      "CreationInfo.OwnerGid",
+      "CreationInfo.OwnerUid",
+      "CreationInfo.Permissions",
+      "FileSystemId",
+      "PosixUser",
+      "PosixUser.Gid",
+      "PosixUser.SecondaryGids",
+      "PosixUser.Uid",
+      "RootDirectory",
+      "RootDirectory.CreationInfo",
+      "RootDirectory.Path"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Ap",
+      "resourceType": "AWS::EFS::AccessPoint",
+      "path": "RootDirectory",
+      "actual": {
+        "Path": "/"
+      },
+      "physicalId": "fsap-06f206e224a019d01",
+      "constructPath": "CdkrdHunt0811BarestB/Ap"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Ap",
+      "resourceType": "AWS::EFS::AccessPoint",
+      "path": "ClientToken",
+      "actual": "Ap-fOyykpY6zBUz",
+      "physicalId": "fsap-06f206e224a019d01",
+      "constructPath": "CdkrdHunt0811BarestB/Ap"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElastiCache__ServerlessCache.RedisServerless.json
+++ b/tests/corpus/AWS__ElastiCache__ServerlessCache.RedisServerless.json
@@ -1,0 +1,142 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RedisServerless",
+    "resourceType": "AWS::ElastiCache::ServerlessCache",
+    "physicalId": "cdkrd-hunt-0811-redis",
+    "constructPath": "CdkrdHunt0811BarestA/RedisServerless",
+    "declared": {
+      "Engine": "redis",
+      "ServerlessCacheName": "cdkrd-hunt-0811-redis",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Status": "available",
+    "Description": " ",
+    "CreateTime": "2026-08-10T18:41:44.368Z",
+    "SecurityGroupIds": ["sg-0a26e23e2310ee0c9"],
+    "SubnetIds": [
+      "subnet-0839f35959eaf9126",
+      "subnet-0db5f5bc4e364ba95",
+      "subnet-0ddbb00e7c1d5b679"
+    ],
+    "DailySnapshotTime": "10:00",
+    "ReaderEndpoint": {
+      "Address": "cdkrd-hunt-0811-redis-jzgy0l.serverless.use1.cache.amazonaws.com",
+      "Port": "6380"
+    },
+    "SnapshotRetentionLimit": 0,
+    "FullEngineVersion": "7.1",
+    "Endpoint": {
+      "Address": "cdkrd-hunt-0811-redis-jzgy0l.serverless.use1.cache.amazonaws.com",
+      "Port": "6379"
+    },
+    "ServerlessCacheName": "cdkrd-hunt-0811-redis",
+    "MajorEngineVersion": "7",
+    "ARN": "arn:aws:elasticache:us-east-1:111111111111:serverlesscache:cdkrd-hunt-0811-redis",
+    "Engine": "redis",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ARN", "CreateTime", "FullEngineVersion", "Status"],
+    "writeOnly": ["FinalSnapshotName", "SnapshotArnsToRestore"],
+    "createOnly": ["KmsKeyId", "ServerlessCacheName", "SnapshotArnsToRestore", "SubnetIds"],
+    "readOnlyPaths": [
+      "ARN",
+      "CreateTime",
+      "Endpoint.Address",
+      "Endpoint.Port",
+      "FullEngineVersion",
+      "ReaderEndpoint.Address",
+      "ReaderEndpoint.Port",
+      "Status"
+    ],
+    "writeOnlyPaths": ["FinalSnapshotName", "SnapshotArnsToRestore"],
+    "createOnlyPaths": ["KmsKeyId", "ServerlessCacheName", "SnapshotArnsToRestore", "SubnetIds"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SecurityGroupIds", "SnapshotArnsToRestore", "SubnetIds"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RedisServerless",
+      "resourceType": "AWS::ElastiCache::ServerlessCache",
+      "path": "Description",
+      "actual": " ",
+      "physicalId": "cdkrd-hunt-0811-redis",
+      "constructPath": "CdkrdHunt0811BarestA/RedisServerless"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RedisServerless",
+      "resourceType": "AWS::ElastiCache::ServerlessCache",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "cdkrd-hunt-0811-redis",
+      "constructPath": "CdkrdHunt0811BarestA/RedisServerless"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RedisServerless",
+      "resourceType": "AWS::ElastiCache::ServerlessCache",
+      "path": "SubnetIds",
+      "actual": [
+        "subnet-0839f35959eaf9126",
+        "subnet-0db5f5bc4e364ba95",
+        "subnet-0ddbb00e7c1d5b679"
+      ],
+      "physicalId": "cdkrd-hunt-0811-redis",
+      "constructPath": "CdkrdHunt0811BarestA/RedisServerless"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RedisServerless",
+      "resourceType": "AWS::ElastiCache::ServerlessCache",
+      "path": "DailySnapshotTime",
+      "actual": "10:00",
+      "physicalId": "cdkrd-hunt-0811-redis",
+      "constructPath": "CdkrdHunt0811BarestA/RedisServerless"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RedisServerless",
+      "resourceType": "AWS::ElastiCache::ServerlessCache",
+      "path": "SnapshotRetentionLimit",
+      "actual": 0,
+      "physicalId": "cdkrd-hunt-0811-redis",
+      "constructPath": "CdkrdHunt0811BarestA/RedisServerless"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RedisServerless",
+      "resourceType": "AWS::ElastiCache::ServerlessCache",
+      "path": "MajorEngineVersion",
+      "actual": "7",
+      "physicalId": "cdkrd-hunt-0811-redis",
+      "constructPath": "CdkrdHunt0811BarestA/RedisServerless"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Database.LinkDb.json
+++ b/tests/corpus/AWS__Glue__Database.LinkDb.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LinkDb",
+    "resourceType": "AWS::Glue::Database",
+    "physicalId": "cdkrd_hunt_0811_link",
+    "constructPath": "CdkrdHunt0811LinkPack/LinkDb",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseInput": {
+        "Name": "cdkrd_hunt_0811_link",
+        "TargetDatabase": {
+          "CatalogId": "111111111111",
+          "DatabaseName": "cdkrd_hunt_0811_link_target"
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_hunt_0811_link",
+    "DatabaseInput": {
+      "CreateTableDefaultPermissions": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "Parameters": {},
+      "TargetDatabase": {
+        "DatabaseName": "cdkrd_hunt_0811_link_target",
+        "CatalogId": "111111111111"
+      },
+      "Name": "cdkrd_hunt_0811_link"
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DatabaseName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DatabaseName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["DatabaseInput.CreateTableDefaultPermissions"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "LinkDb",
+      "resourceType": "AWS::Glue::Database",
+      "path": "DatabaseInput.CreateTableDefaultPermissions",
+      "actual": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "nested": true,
+      "physicalId": "cdkrd_hunt_0811_link",
+      "constructPath": "CdkrdHunt0811LinkPack/LinkDb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KMS__ReplicaKey.ReplicaKey.json
+++ b/tests/corpus/AWS__KMS__ReplicaKey.ReplicaKey.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ReplicaKey",
+    "resourceType": "AWS::KMS::ReplicaKey",
+    "physicalId": "mrk-c13b7e251eec4ac19f6e8fbc3bf1ecaa",
+    "constructPath": "CdkrdHunt0811BarestB/ReplicaKey",
+    "declared": {
+      "KeyPolicy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "root",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+          }
+        ]
+      },
+      "PrimaryKeyArn": "arn:aws:kms:us-west-2:111111111111:key/mrk-c13b7e251eec4ac19f6e8fbc3bf1ecaa",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "KeyPolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "kms:*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "root"
+        }
+      ]
+    },
+    "PrimaryKeyArn": "arn:aws:kms:us-west-2:111111111111:key/mrk-c13b7e251eec4ac19f6e8fbc3bf1ecaa",
+    "Enabled": true,
+    "KeyId": "mrk-c13b7e251eec4ac19f6e8fbc3bf1ecaa",
+    "Arn": "arn:aws:kms:us-east-1:111111111111:key/mrk-c13b7e251eec4ac19f6e8fbc3bf1ecaa",
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "KeyId"],
+    "writeOnly": ["PendingWindowInDays"],
+    "createOnly": ["PrimaryKeyArn"],
+    "readOnlyPaths": ["Arn", "KeyId"],
+    "writeOnlyPaths": ["PendingWindowInDays"],
+    "createOnlyPaths": ["PrimaryKeyArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ReplicaKey",
+      "resourceType": "AWS::KMS::ReplicaKey",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "mrk-c13b7e251eec4ac19f6e8fbc3bf1ecaa",
+      "constructPath": "CdkrdHunt0811BarestB/ReplicaKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__GlobalCluster.HeadlessGc.json
+++ b/tests/corpus/AWS__RDS__GlobalCluster.HeadlessGc.json
@@ -1,0 +1,97 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HeadlessGc",
+    "resourceType": "AWS::RDS::GlobalCluster",
+    "physicalId": "cdkrd-hunt-0811-gc",
+    "constructPath": "CdkrdHunt0811LinkPack/HeadlessGc",
+    "declared": {
+      "Engine": "aurora-postgresql",
+      "GlobalClusterIdentifier": "cdkrd-hunt-0811-gc",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "StorageEncrypted": false,
+    "EngineVersion": "17.7",
+    "DeletionProtection": false,
+    "GlobalClusterIdentifier": "cdkrd-hunt-0811-gc",
+    "Engine": "aurora-postgresql",
+    "Tags": [
+      {
+        "Value": "HeadlessGc",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      },
+      {
+        "Value": "CdkrdHunt0811LinkPack",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0811LinkPack/de3b0750-94e8-11f1-b451-0affeb9d18e3",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["GlobalEndpoint"],
+    "writeOnly": [],
+    "createOnly": [
+      "Engine",
+      "GlobalClusterIdentifier",
+      "SourceDBClusterIdentifier",
+      "StorageEncrypted"
+    ],
+    "readOnlyPaths": ["GlobalEndpoint"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "Engine",
+      "GlobalClusterIdentifier",
+      "SourceDBClusterIdentifier",
+      "StorageEncrypted"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HeadlessGc",
+      "resourceType": "AWS::RDS::GlobalCluster",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrd-hunt-0811-gc",
+      "constructPath": "CdkrdHunt0811LinkPack/HeadlessGc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HeadlessGc",
+      "resourceType": "AWS::RDS::GlobalCluster",
+      "path": "EngineVersion",
+      "actual": "17.7",
+      "physicalId": "cdkrd-hunt-0811-gc",
+      "constructPath": "CdkrdHunt0811LinkPack/HeadlessGc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Subscription.FhSub.json
+++ b/tests/corpus/AWS__SNS__Subscription.FhSub.json
@@ -1,0 +1,43 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FhSub",
+    "resourceType": "AWS::SNS::Subscription",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0811-topic:f108fd27-55d5-466a-a5c6-6fac7988687d",
+    "constructPath": "CdkrdHunt0811BarestB/FhSub",
+    "declared": {
+      "Endpoint": "arn:aws:firehose:us-east-1:111111111111:deliverystream/cdkrd-hunt-0811-fh",
+      "Protocol": "firehose",
+      "SubscriptionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0811BarestB-SnsSubRoleF54CF7B8-AsiDXjM3ScYW",
+      "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0811-topic"
+    }
+  },
+  "liveRaw": {
+    "RawMessageDelivery": false,
+    "Endpoint": "arn:aws:firehose:us-east-1:111111111111:deliverystream/cdkrd-hunt-0811-fh",
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0811-topic",
+    "SubscriptionRoleArn": "arn:aws:iam::111111111111:role/CdkrdHunt0811BarestB-SnsSubRoleF54CF7B8-AsiDXjM3ScYW",
+    "Arn": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0811-topic:f108fd27-55d5-466a-a5c6-6fac7988687d",
+    "Protocol": "firehose"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["Region"],
+    "createOnly": ["Endpoint", "Protocol", "TopicArn"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["Region"],
+    "createOnlyPaths": ["Endpoint", "Protocol", "TopicArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SNS__Topic.InlineSubTopic.json
+++ b/tests/corpus/AWS__SNS__Topic.InlineSubTopic.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "InlineSubTopic",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0811-inline",
+    "constructPath": "CdkrdHunt0811BarestB/InlineSubTopic",
+    "declared": {
+      "Subscription": [
+        {
+          "Endpoint": "arn:aws:sqs:us-east-1:111111111111:cdkrd-hunt-0811-inlineq",
+          "Protocol": "sqs"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ],
+      "TopicName": "cdkrd-hunt-0811-inline"
+    }
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-0811-inline",
+    "FifoTopic": false,
+    "Subscription": [
+      {
+        "Endpoint": "arn:aws:sqs:us-east-1:111111111111:cdkrd-hunt-0811-inlineq",
+        "Protocol": "sqs"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0811BarestB",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "InlineSubTopic",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0811BarestB/dbe593b0-94ea-11f1-a0e1-0eefa0f25c89",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "cdkrd-hunt-0811-inline"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["DeliveryStatusLogging", "Subscription"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__Document.AutomationDoc.json
+++ b/tests/corpus/AWS__SSM__Document.AutomationDoc.json
@@ -1,0 +1,83 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AutomationDoc",
+    "resourceType": "AWS::SSM::Document",
+    "physicalId": "CdkrdHunt0811BarestA-AutomationDoc-569eWauPQFf4",
+    "constructPath": "CdkrdHunt0811BarestA/AutomationDoc",
+    "declared": {
+      "Content": {
+        "schemaVersion": "0.3",
+        "mainSteps": [
+          {
+            "name": "sleep",
+            "action": "aws:sleep",
+            "inputs": {
+              "Duration": "PT5S"
+            }
+          }
+        ]
+      },
+      "DocumentType": "Automation",
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DocumentFormat": "JSON",
+    "Content": "{\n  \"schemaVersion\" : \"0.3\",\n  \"mainSteps\" : [ {\n    \"inputs\" : {\n      \"Duration\" : \"PT5S\"\n    },\n    \"name\" : \"sleep\",\n    \"action\" : \"aws:sleep\"\n  } ]\n}",
+    "DocumentType": "Automation",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0811BarestA",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "AutomationDoc",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0811BarestA/1b689460-94eb-11f1-87ae-0affdb7e7f31",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ],
+    "Name": "CdkrdHunt0811BarestA-AutomationDoc-569eWauPQFf4"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["Attachments", "UpdateMethod"],
+    "createOnly": ["DocumentType", "Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["Attachments", "UpdateMethod"],
+    "createOnlyPaths": ["DocumentType", "Name"],
+    "defaults": {
+      "DocumentFormat": "JSON",
+      "UpdateMethod": "Replace"
+    },
+    "defaultPaths": {
+      "DocumentFormat": "JSON",
+      "UpdateMethod": "Replace"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Transfer__Server.TransferBarest.json
+++ b/tests/corpus/AWS__Transfer__Server.TransferBarest.json
@@ -1,0 +1,164 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TransferBarest",
+    "resourceType": "AWS::Transfer::Server",
+    "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+    "constructPath": "CdkrdHunt0811BarestA/TransferBarest",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "cdkrd:ephemeral",
+          "Value": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "IPV4",
+    "Protocols": ["SFTP"],
+    "StructuredLogDestinations": [],
+    "ServerId": "s-b44deb54dcc541998",
+    "As2ServiceManagedEgressIpAddresses": [],
+    "State": "ONLINE",
+    "EndpointType": "PUBLIC",
+    "SecurityPolicyName": "TransferSecurityPolicy-2018-11",
+    "ProtocolDetails": {
+      "PassiveIp": "AUTO",
+      "SetStatOption": "DEFAULT",
+      "TlsSessionResumptionMode": "ENFORCED"
+    },
+    "S3StorageOptions": {
+      "DirectoryListingOptimization": "DISABLED"
+    },
+    "Arn": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+    "Domain": "S3",
+    "IdentityProviderType": "SERVICE_MANAGED",
+    "Tags": [
+      {
+        "Value": "CdkrdHunt0811BarestA",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TransferBarest",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdHunt0811BarestA/1b689460-94eb-11f1-87ae-0affdb7e7f31",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "1",
+        "Key": "cdkrd:ephemeral"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "As2ServiceManagedEgressIpAddresses", "ServerId", "State"],
+    "writeOnly": [],
+    "createOnly": ["Domain"],
+    "readOnlyPaths": ["Arn", "As2ServiceManagedEgressIpAddresses", "ServerId", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Domain"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "As2ServiceManagedEgressIpAddresses",
+      "EndpointDetails.SecurityGroupIds",
+      "ProtocolDetails.As2Transports",
+      "Protocols",
+      "StructuredLogDestinations"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "stackTags": {
+      "cdkrd:ephemeral": "1"
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "IpAddressType",
+      "actual": "IPV4",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "Protocols",
+      "actual": ["SFTP"],
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "EndpointType",
+      "actual": "PUBLIC",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "SecurityPolicyName",
+      "actual": "TransferSecurityPolicy-2018-11",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "ProtocolDetails",
+      "actual": {
+        "PassiveIp": "AUTO",
+        "SetStatOption": "DEFAULT",
+        "TlsSessionResumptionMode": "ENFORCED"
+      },
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "S3StorageOptions",
+      "actual": {
+        "DirectoryListingOptimization": "DISABLED"
+      },
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "Domain",
+      "actual": "S3",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TransferBarest",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "IdentityProviderType",
+      "actual": "SERVICE_MANAGED",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-b44deb54dcc541998",
+      "constructPath": "CdkrdHunt0811BarestA/TransferBarest"
+    }
+  ]
+}

--- a/tests/enumerators-1540.test.ts
+++ b/tests/enumerators-1540.test.ts
@@ -9,6 +9,7 @@
 // table excluded.
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  CHILD_ENUMERATORS,
   diffAsgLifecycleHookChildren,
   diffAsgScheduledActionChildren,
   diffGlueDatabaseChildren,
@@ -115,6 +116,50 @@ describe('#1540 Glue database table children', () => {
     });
     expect(added.map((a) => a.identifier)).toEqual(['hunt_db|oob_table']);
     expect(added[0]!.resourceType).toBe('AWS::Glue::Table');
+  });
+
+  // #1749: GetTables on a resource-link database proxies to the linked TARGET's tables
+  // (each echoed with the TARGET's DatabaseName) — a proxy echo is not a child of the
+  // link and must never surface as added (the offered delete would destroy the shared
+  // real table). A genuine out-of-band table still surfaces: its owning DatabaseName
+  // matches the queried database (or is absent on an older echo shape).
+  it('drops resource-link proxy echoes (owning DatabaseName differs) but keeps real OOB tables (#1749)', () => {
+    const added = diffGlueDatabaseChildren({
+      databaseName: 'link_db',
+      declaredTableNames: [],
+      liveTables: [
+        { name: 'proxied_target_table', sourceDatabaseName: 'target_db' },
+        { name: 'real_oob_table', sourceDatabaseName: 'link_db' },
+        { name: 'legacy_echo_no_owner' },
+      ],
+    });
+    expect(added.map((a) => a.identifier)).toEqual([
+      'link_db|real_oob_table',
+      'link_db|legacy_echo_no_owner',
+    ]);
+  });
+
+  it('declared resource link (DatabaseInput.TargetDatabase) short-circuits enumeration with no API call (#1749)', async () => {
+    const enumerate = CHILD_ENUMERATORS['AWS::Glue::Database']!;
+    const added = await enumerate({
+      parent: {
+        logicalId: 'LinkDb',
+        resourceType: 'AWS::Glue::Database',
+        physicalId: 'link_db',
+        declared: {
+          CatalogId: '111111111111',
+          DatabaseInput: {
+            Name: 'link_db',
+            TargetDatabase: { CatalogId: '111111111111', DatabaseName: 'target_db' },
+          },
+        },
+      } as never,
+      desired: { resources: [] } as never,
+      // An invalid region guarantees the test fails loudly if the enumerator ever
+      // reaches the Glue client instead of short-circuiting.
+      region: 'invalid-region-never-called',
+    });
+    expect(added).toEqual([]);
   });
 });
 

--- a/tests/hunt-2026-08-11-folds.test.ts
+++ b/tests/hunt-2026-08-11-folds.test.ts
@@ -1,0 +1,501 @@
+// 2026-08-11 hunt regressions:
+//  - #1750: RDS GlobalCluster stores GlobalClusterIdentifier lowercased while the CC
+//    handler accepts mixed case (live CC probe: `CdkrdHunt-Mixed-GC` stored as
+//    `cdkrdhunt-mixed-gc`) — declared-side case tolerance on the owning prop, plus the
+//    #1712-class consumer echo on a member DBCluster's GlobalClusterIdentifier.
+//  - #1751: linkpack-hunt first-run FPs — ECS ClusterCapacityProviderAssociations echoes
+//    CapacityProviders sorted; AppSync DataSource materializes MetricsConfig "DISABLED"
+//    and SourceApiAssociation {MergeType: MANUAL_MERGE} undeclared; a headless RDS
+//    GlobalCluster reads back the current GA EngineVersion undeclared.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import { buildRevertPlan } from '../src/revert/plan.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const tierPaths = (findings: Finding[]) => findings.map((f) => `${f.tier}:${f.path}`).sort();
+
+describe('#1750 RDS GlobalCluster mixed-case identifier folds', () => {
+  it('owning GlobalClusterIdentifier + Engine: case-only echoes fold', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'GC',
+        resourceType: 'AWS::RDS::GlobalCluster',
+        physicalId: 'CdkrdHunt-Mixed-GC',
+        declared: { GlobalClusterIdentifier: 'CdkrdHunt-Mixed-GC', Engine: 'Aurora-PostgreSQL' },
+      },
+      { GlobalClusterIdentifier: 'cdkrdhunt-mixed-gc', Engine: 'aurora-postgresql' },
+      emptySchema
+    );
+    expect(findings.filter((f: Finding) => f.tier === 'declared')).toEqual([]);
+  });
+
+  it('consumer DBCluster.GlobalClusterIdentifier: stored-lowercase echo folds', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'Member',
+        resourceType: 'AWS::RDS::DBCluster',
+        physicalId: 'member-cl',
+        declared: {
+          DBClusterIdentifier: 'member-cl',
+          Engine: 'aurora-postgresql',
+          GlobalClusterIdentifier: 'CdkrdHunt-Mixed-GC',
+        },
+      },
+      {
+        DBClusterIdentifier: 'member-cl',
+        Engine: 'aurora-postgresql',
+        GlobalClusterIdentifier: 'cdkrdhunt-mixed-gc',
+      },
+      emptySchema
+    );
+    expect(findings.filter((f: Finding) => f.tier === 'declared')).toEqual([]);
+  });
+
+  it('undeclared GA EngineVersion on a headless GlobalCluster folds value-independent, declared stays compared (#1751)', () => {
+    const clean = classifyResource(
+      {
+        logicalId: 'GC',
+        resourceType: 'AWS::RDS::GlobalCluster',
+        physicalId: 'gc',
+        declared: { GlobalClusterIdentifier: 'gc', Engine: 'aurora-postgresql' },
+      },
+      { GlobalClusterIdentifier: 'gc', Engine: 'aurora-postgresql', EngineVersion: '17.7' },
+      emptySchema
+    );
+    expect(tierPaths(clean)).toEqual(['atDefault:EngineVersion']);
+
+    const declaredMismatch = classifyResource(
+      {
+        logicalId: 'GC',
+        resourceType: 'AWS::RDS::GlobalCluster',
+        physicalId: 'gc',
+        declared: {
+          GlobalClusterIdentifier: 'gc',
+          Engine: 'aurora-postgresql',
+          EngineVersion: '16.4',
+        },
+      },
+      { GlobalClusterIdentifier: 'gc', Engine: 'aurora-postgresql', EngineVersion: '17.7' },
+      emptySchema
+    );
+    expect(tierPaths(declaredMismatch)).toEqual(['declared:EngineVersion']);
+  });
+
+  it('a real global-cluster reassignment (beyond case) still surfaces', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'GC',
+        resourceType: 'AWS::RDS::GlobalCluster',
+        physicalId: 'gc-a',
+        declared: { GlobalClusterIdentifier: 'gc-a', Engine: 'aurora-postgresql' },
+      },
+      { GlobalClusterIdentifier: 'gc-b', Engine: 'aurora-postgresql' },
+      emptySchema
+    );
+    expect(findings.filter((f: Finding) => f.tier === 'declared').map((f) => f.path)).toEqual([
+      'GlobalClusterIdentifier',
+    ]);
+  });
+});
+
+describe('#1751 ECS ClusterCapacityProviderAssociations CapacityProviders reorder', () => {
+  const base = {
+    logicalId: 'Ccpa',
+    resourceType: 'AWS::ECS::ClusterCapacityProviderAssociations',
+    physicalId: 'cdkrd-hunt-ccpa',
+  };
+  it('the sorted live echo of the declared set folds', () => {
+    const findings = classifyResource(
+      {
+        ...base,
+        declared: {
+          Cluster: 'cdkrd-hunt-ccpa',
+          CapacityProviders: ['FARGATE_SPOT', 'FARGATE'],
+          DefaultCapacityProviderStrategy: [],
+        },
+      },
+      {
+        Cluster: 'cdkrd-hunt-ccpa',
+        CapacityProviders: ['FARGATE', 'FARGATE_SPOT'],
+        DefaultCapacityProviderStrategy: [],
+      },
+      emptySchema
+    );
+    expect(tierPaths(findings)).toEqual([]);
+  });
+  it('a multiset change (provider removed out of band) still surfaces', () => {
+    const findings = classifyResource(
+      {
+        ...base,
+        declared: {
+          Cluster: 'cdkrd-hunt-ccpa',
+          CapacityProviders: ['FARGATE_SPOT', 'FARGATE'],
+          DefaultCapacityProviderStrategy: [],
+        },
+      },
+      {
+        Cluster: 'cdkrd-hunt-ccpa',
+        CapacityProviders: ['FARGATE'],
+        DefaultCapacityProviderStrategy: [],
+      },
+      emptySchema
+    );
+    expect(tierPaths(findings)).toEqual(['declared:CapacityProviders']);
+  });
+});
+
+describe('#1753 barest5 first-run folds', () => {
+  it('ServerlessCache barest: space-Description / GA major / default SG+subnets fold; swaps surface', () => {
+    const resource = {
+      logicalId: 'RedisServerless',
+      resourceType: 'AWS::ElastiCache::ServerlessCache',
+      physicalId: 'cdkrd-hunt-0811-redis',
+      declared: { Engine: 'redis', ServerlessCacheName: 'cdkrd-hunt-0811-redis' },
+    };
+    const opts = {
+      defaultSgIds: new Set(['sg-0a26e23e2310ee0c9']),
+      defaultSubnetIds: new Set(['subnet-a', 'subnet-b', 'subnet-c']),
+    };
+    const clean = classifyResource(
+      resource,
+      {
+        Engine: 'redis',
+        ServerlessCacheName: 'cdkrd-hunt-0811-redis',
+        Description: ' ',
+        MajorEngineVersion: '7',
+        SecurityGroupIds: ['sg-0a26e23e2310ee0c9'],
+        SubnetIds: ['subnet-a', 'subnet-b', 'subnet-c'],
+      },
+      emptySchema,
+      opts
+    );
+    expect(tierPaths(clean)).toEqual([
+      'atDefault:Description',
+      'atDefault:MajorEngineVersion',
+      'atDefault:SecurityGroupIds',
+      'atDefault:SubnetIds',
+    ]);
+
+    const swapped = classifyResource(
+      resource,
+      {
+        Engine: 'redis',
+        ServerlessCacheName: 'cdkrd-hunt-0811-redis',
+        Description: 'set out of band',
+        MajorEngineVersion: '7',
+        SecurityGroupIds: ['sg-rogue'],
+        SubnetIds: ['subnet-a', 'subnet-rogue'],
+      },
+      emptySchema,
+      opts
+    );
+    expect(tierPaths(swapped)).toEqual([
+      'atDefault:MajorEngineVersion',
+      'undeclared:Description',
+      'undeclared:SecurityGroupIds',
+      'undeclared:SubnetIds',
+    ]);
+  });
+
+  it('Transfer Server zero-prop trio folds; an OOB protocol append surfaces', () => {
+    const resource = {
+      logicalId: 'TransferBarest',
+      resourceType: 'AWS::Transfer::Server',
+      physicalId: 's-123',
+      declared: {},
+    };
+    const clean = classifyResource(
+      resource,
+      { Protocols: ['SFTP'], EndpointType: 'PUBLIC', IdentityProviderType: 'SERVICE_MANAGED' },
+      emptySchema
+    );
+    expect(tierPaths(clean)).toEqual([
+      'atDefault:EndpointType',
+      'atDefault:IdentityProviderType',
+      'atDefault:Protocols',
+    ]);
+
+    const appended = classifyResource(
+      resource,
+      {
+        Protocols: ['SFTP', 'FTPS'],
+        EndpointType: 'PUBLIC',
+        IdentityProviderType: 'SERVICE_MANAGED',
+      },
+      emptySchema
+    );
+    expect(tierPaths(appended)).toEqual([
+      'atDefault:EndpointType',
+      'atDefault:IdentityProviderType',
+      'undeclared:Protocols',
+    ]);
+  });
+
+  it('Cognito SAML IdP metadata-computed enrichments fold value-independent', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'SamlIdp',
+        resourceType: 'AWS::Cognito::UserPoolIdentityProvider',
+        physicalId: 'pool|cdkrd-hunt-saml',
+        declared: {
+          UserPoolId: 'pool',
+          ProviderName: 'cdkrd-hunt-saml',
+          ProviderType: 'SAML',
+          ProviderDetails: { MetadataFile: '<EntityDescriptor .../>' },
+        },
+      },
+      {
+        UserPoolId: 'pool',
+        ProviderName: 'cdkrd-hunt-saml',
+        ProviderType: 'SAML',
+        ProviderDetails: {
+          MetadataFile: '<EntityDescriptor .../>',
+          SSORedirectBindingURI: 'https://example.com/sso',
+          SLORedirectBindingURI: 'https://example.com/slo',
+          ActiveEncryptionCertificate: 'MIICvDCC…',
+        },
+      },
+      emptySchema
+    );
+    expect(tierPaths(findings)).toEqual([
+      'atDefault:ProviderDetails.ActiveEncryptionCertificate',
+      'atDefault:ProviderDetails.SLORedirectBindingURI',
+      'atDefault:ProviderDetails.SSORedirectBindingURI',
+    ]);
+  });
+});
+
+describe('#1751 AppSync undeclared creation defaults fold', () => {
+  it('DataSource MetricsConfig "DISABLED" folds atDefault; an OOB "ENABLED" surfaces', () => {
+    const base = {
+      logicalId: 'SrcDs',
+      resourceType: 'AWS::AppSync::DataSource',
+      physicalId: 'ds',
+      declared: { ApiId: 'api', Name: 'NoneDs', Type: 'NONE' },
+    };
+    const clean = classifyResource(
+      base,
+      { ApiId: 'api', Name: 'NoneDs', Type: 'NONE', MetricsConfig: 'DISABLED' },
+      emptySchema
+    );
+    expect(tierPaths(clean)).toEqual(['atDefault:MetricsConfig']);
+
+    const flipped = classifyResource(
+      base,
+      { ApiId: 'api', Name: 'NoneDs', Type: 'NONE', MetricsConfig: 'ENABLED' },
+      emptySchema
+    );
+    expect(tierPaths(flipped)).toEqual(['undeclared:MetricsConfig']);
+  });
+
+  it('SourceApiAssociation {MergeType: MANUAL_MERGE} folds; an OOB AUTO_MERGE switch surfaces', () => {
+    const base = {
+      logicalId: 'SrcAssoc',
+      resourceType: 'AWS::AppSync::SourceApiAssociation',
+      physicalId: 'assoc',
+      declared: { MergedApiIdentifier: 'm', SourceApiIdentifier: 's' },
+    };
+    const clean = classifyResource(
+      base,
+      {
+        MergedApiIdentifier: 'm',
+        SourceApiIdentifier: 's',
+        SourceApiAssociationConfig: { MergeType: 'MANUAL_MERGE' },
+      },
+      emptySchema
+    );
+    expect(tierPaths(clean)).toEqual(['atDefault:SourceApiAssociationConfig']);
+
+    const flipped = classifyResource(
+      base,
+      {
+        MergedApiIdentifier: 'm',
+        SourceApiIdentifier: 's',
+        SourceApiAssociationConfig: { MergeType: 'AUTO_MERGE' },
+      },
+      emptySchema
+    );
+    expect(tierPaths(flipped)).toEqual(['undeclared:SourceApiAssociationConfig']);
+  });
+});
+
+// The real live Features echo shape from the 2026-08-11 stackless probe detector —
+// EKS_RUNTIME_MONITORING (deprecated alias) at index 6, RUNTIME_MONITORING at index 8.
+const GD_FEATURES = [
+  { Name: 'S3_DATA_EVENTS', Status: 'DISABLED' },
+  { Name: 'EKS_AUDIT_LOGS', Status: 'ENABLED' },
+  { Name: 'EBS_MALWARE_PROTECTION', Status: 'ENABLED' },
+  { Name: 'RDS_LOGIN_EVENTS', Status: 'ENABLED' },
+  { Name: 'AI_PROTECTION', Status: 'DISABLED' },
+  { Name: 'AI_ANALYST', Status: 'DISABLED' },
+  { Name: 'EKS_RUNTIME_MONITORING', Status: 'DISABLED' },
+  { Name: 'LAMBDA_NETWORK_LOGS', Status: 'ENABLED' },
+  { Name: 'RUNTIME_MONITORING', Status: 'DISABLED' },
+];
+
+describe('#1752 GuardDuty Detector patch shape', () => {
+  const live = {
+    Enable: true,
+    FindingPublishingFrequency: 'SIX_HOURS',
+    DataSources: {
+      S3Logs: { Enable: false },
+      Kubernetes: { AuditLogs: { Enable: true } },
+      MalwareProtection: { ScanEc2InstanceWithFindings: { EbsVolumes: true } },
+    },
+    Features: GD_FEATURES,
+  };
+
+  it('translates a DataSources revert to the Features Status write + both exclusivity companions', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Detector',
+      resourceType: 'AWS::GuardDuty::Detector',
+      physicalId: 'd-123',
+      path: 'DataSources.S3Logs',
+      actual: { Enable: false },
+      desired: { Enable: true },
+    };
+    const plan = buildRevertPlan([f], undefined, {
+      liveByLogical: new Map([['Detector', live]]) as never,
+    });
+    expect(plan.notRevertable).toEqual([]);
+    const ops = plan.items[0]!.ops;
+    // the real op: the S3Logs toggle written on the Features side (S3_DATA_EVENTS, idx 0)
+    const statusWrite = ops.find((o) => o.path === '/Features/0/Status');
+    expect(statusWrite).toBeDefined();
+    expect(statusWrite!.op).toBe('add');
+    expect(statusWrite!.value).toBe('ENABLED');
+    expect(statusWrite!.contract).toBeUndefined();
+    // no op may still target the DataSources side (the handler rejects any such write)
+    expect(ops.some((o) => o.path.startsWith('/DataSources/'))).toBe(false);
+    // leg 2: the DataSources projection is stripped from the write model (contract)
+    const dsRemove = ops.find((o) => o.op === 'remove' && o.path === '/DataSources');
+    expect(dsRemove?.contract).toBe(true);
+    // leg 1: the deprecated alias element is stripped LAST (contract, index intact)
+    expect(ops[ops.length - 1]).toMatchObject({
+      op: 'remove',
+      path: '/Features/6',
+      contract: true,
+    });
+  });
+
+  it('a non-DataSources revert still carries both companions (any patch is rejected without them)', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Detector',
+      resourceType: 'AWS::GuardDuty::Detector',
+      physicalId: 'd-123',
+      path: 'FindingPublishingFrequency',
+      actual: 'SIX_HOURS',
+      desired: 'FIFTEEN_MINUTES',
+    };
+    const plan = buildRevertPlan([f], undefined, {
+      liveByLogical: new Map([['Detector', live]]) as never,
+    });
+    const ops = plan.items[0]!.ops;
+    expect(ops.some((o) => o.path === '/FindingPublishingFrequency')).toBe(true);
+    expect(ops.some((o) => o.op === 'remove' && o.path === '/DataSources' && o.contract)).toBe(
+      true
+    );
+    expect(ops.some((o) => o.op === 'remove' && o.path === '/Features/6' && o.contract)).toBe(true);
+  });
+
+  it('no deprecated-alias companion when the echo carries only RUNTIME_MONITORING', () => {
+    const modern = {
+      ...live,
+      Features: GD_FEATURES.filter((f) => f.Name !== 'EKS_RUNTIME_MONITORING'),
+    };
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Detector',
+      resourceType: 'AWS::GuardDuty::Detector',
+      physicalId: 'd-123',
+      path: 'FindingPublishingFrequency',
+      actual: 'SIX_HOURS',
+      desired: 'FIFTEEN_MINUTES',
+    };
+    const plan = buildRevertPlan([f], undefined, {
+      liveByLogical: new Map([['Detector', modern]]) as never,
+    });
+    const ops = plan.items[0]!.ops;
+    expect(ops.some((o) => o.path.startsWith('/Features/') && o.op === 'remove')).toBe(false);
+    expect(ops.some((o) => o.op === 'remove' && o.path === '/DataSources' && o.contract)).toBe(
+      true
+    );
+  });
+});
+
+describe('#1754 barest5 stack-B first-run folds', () => {
+  it('EFS AccessPoint materialized RootDirectory {Path:"/"} folds; a re-point surfaces', () => {
+    const resource = {
+      logicalId: 'Ap',
+      resourceType: 'AWS::EFS::AccessPoint',
+      physicalId: 'fsap-1',
+      declared: { FileSystemId: 'fs-1' },
+    };
+    const clean = classifyResource(
+      resource,
+      { FileSystemId: 'fs-1', RootDirectory: { Path: '/' } },
+      emptySchema
+    );
+    expect(tierPaths(clean)).toEqual(['atDefault:RootDirectory']);
+
+    const repointed = classifyResource(
+      resource,
+      { FileSystemId: 'fs-1', RootDirectory: { Path: '/data' } },
+      emptySchema
+    );
+    expect(tierPaths(repointed)).toEqual(['undeclared:RootDirectory']);
+  });
+
+  it('KMS ReplicaKey Enabled=true folds; an out-of-band disable STILL surfaces (off-flip gate)', () => {
+    const resource = {
+      logicalId: 'ReplicaKey',
+      resourceType: 'AWS::KMS::ReplicaKey',
+      physicalId: 'mrk-1',
+      declared: { PrimaryKeyArn: 'arn:aws:kms:us-west-2:111111111111:key/mrk-1' },
+    };
+    const clean = classifyResource(
+      resource,
+      { PrimaryKeyArn: 'arn:aws:kms:us-west-2:111111111111:key/mrk-1', Enabled: true },
+      emptySchema
+    );
+    expect(tierPaths(clean)).toEqual(['atDefault:Enabled']);
+
+    const disabled = classifyResource(
+      resource,
+      { PrimaryKeyArn: 'arn:aws:kms:us-west-2:111111111111:key/mrk-1', Enabled: false },
+      emptySchema
+    );
+    expect(tierPaths(disabled)).toEqual(['undeclared:Enabled']);
+  });
+});
+
+describe('#1753 ServerlessCache Description revert set-default', () => {
+  it('reverts an out-of-band description via an explicit add of the one-space default (bare remove no-ops live)', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'RedisServerless',
+      resourceType: 'AWS::ElastiCache::ServerlessCache',
+      physicalId: 'cdkrd-hunt-0811-redis',
+      path: 'Description',
+      actual: 'oob description',
+    };
+    const plan = buildRevertPlan([f], undefined, {});
+    expect(plan.notRevertable).toEqual([]);
+    const op = plan.items[0]!.ops.find((o) => o.path === '/Description')!;
+    expect(op.op).toBe('add');
+    expect(op.value).toBe(' ');
+  });
+});

--- a/tests/integration/barest5-hunt/app.ts
+++ b/tests/integration/barest5-hunt/app.ts
@@ -1,0 +1,221 @@
+// Barest-form first-run FP probe (2026-08-11 hunt): common CC-readable types whose
+// undeclared-default surface has never been deployed barest — every existing
+// corpus case DECLARES the axis props these leave open (audit evidence per type):
+// Stack A (no cross-resource deps):
+// - ElastiCache::ServerlessCache engine=redis, name only (the one corpus case is
+//   valkey with MajorEngineVersion declared; MajorEngineVersion/FullEngineVersion/
+//   CacheUsageLimits/default-VPC subnet+SG echoes all unprobed)
+// - Transfer::Server with ZERO properties (corpus declares EndpointType/
+//   IdentityProviderType/Protocols — the undeclared SFTP/SERVICE_MANAGED/PUBLIC
+//   defaults are unprobed)
+// - CloudTrail::EventDataStore was in the pack but is CLOSED to new customers
+//   ("CloudTrail Lake is no longer accepting new customers", live CREATE_FAILED
+//   2026-08-11) — it joins the dead-service exclusion list (QLDB / CodeCommit /
+//   S3ObjectLambda / Cognito Sync class), not the fixture.
+// - Batch::JobDefinition Type=multinode (both corpus cases are Type=container —
+//   the NodeProperties union branch is unread)
+// - SSM::Document DocumentType=Automation (both corpus cases are Command)
+// - Cognito::UserPoolIdentityProvider ProviderType=SAML with inline metadata
+//   (corpus has only Google; SAML enriches ProviderDetails with computed
+//   SSORedirectBindingURI/SLORedirectBindingURI/ActiveEncryptionCertificate)
+// Stack B (dependency types):
+// - EFS::AccessPoint barest, FileSystemId only (corpus case declares
+//   RootDirectory; the materialized RootDirectory {Path:"/"} default is unprobed)
+// - SNS::Subscription Protocol=firehose (corpus protocols: email/sqs/lambda only)
+// - KMS::ReplicaKey (zero coverage; primary MRK is CLI-created in us-west-2 by
+//   verify.sh and threaded in via -c primaryKeyArn=...; the resource is skipped
+//   when the context is absent so a bare synth still works)
+// - SNS::Topic with an INLINE `Subscription` property (raw-CFn/L1 shape): the
+//   SNS child enumerator builds its declared-set from AWS::SNS::Subscription
+//   resources only, so an inline-declared subscription is suspected to false-flag
+//   as `added` (the #1729 twin-declaration-shape class) — live probe.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { CfnJobDefinition } from "aws-cdk-lib/aws-batch";
+import { CfnUserPool, CfnUserPoolIdentityProvider } from "aws-cdk-lib/aws-cognito";
+import { CfnAccessPoint, CfnFileSystem } from "aws-cdk-lib/aws-efs";
+import { CfnServerlessCache } from "aws-cdk-lib/aws-elasticache";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { CfnReplicaKey } from "aws-cdk-lib/aws-kms";
+import { PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnSubscription, CfnTopic } from "aws-cdk-lib/aws-sns";
+import { CfnQueue, CfnQueuePolicy } from "aws-cdk-lib/aws-sqs";
+import { CfnDocument } from "aws-cdk-lib/aws-ssm";
+import { CfnServer } from "aws-cdk-lib/aws-transfer";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+// `-c rev=2` threads a neutral tag update through every resource — the
+// post-update echo probe (redeploy with rev=2, re-check; see hunt-bugs skill).
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+// ---------------------------------------------------------------- stack A
+const a = new Stack(app, "CdkrdHunt0811BarestA");
+
+new CfnServerlessCache(a, "RedisServerless", {
+  engine: "redis",
+  serverlessCacheName: "cdkrd-hunt-0811-redis",
+  // SubnetIds/SecurityGroupIds deliberately undeclared → default VPC + default SG
+  // echoes probe the DEFAULT_SG/SUBNET_LIST gates on this type.
+});
+
+new CfnServer(a, "TransferBarest", {});
+
+new CfnJobDefinition(a, "MultinodeJd", {
+  type: "multinode",
+  jobDefinitionName: "cdkrd-hunt-0811-multinode",
+  nodeProperties: {
+    mainNode: 0,
+    numNodes: 2,
+    nodeRangeProperties: [
+      {
+        targetNodes: "0:",
+        container: {
+          image: "public.ecr.aws/amazonlinux/amazonlinux:latest",
+          resourceRequirements: [
+            { type: "VCPU", value: "1" },
+            { type: "MEMORY", value: "1024" },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+new CfnDocument(a, "AutomationDoc", {
+  documentType: "Automation",
+  content: {
+    schemaVersion: "0.3",
+    mainSteps: [{ name: "sleep", action: "aws:sleep", inputs: { Duration: "PT5S" } }],
+  },
+});
+
+const pool = new CfnUserPool(a, "IdpPool", {
+  userPoolName: "cdkrd-hunt-0811-idp-pool",
+});
+// Throwaway self-signed cert (public half only; key discarded at generation) —
+// Cognito requires valid IDPSSODescriptor metadata with a signing cert.
+const samlCert =
+  "MIIDEzCCAfugAwIBAgIUd23PixfCQqbN8bNqptEqE+9GNsMwDQYJKoZIhvcNAQELBQAwGTEXMBUGA1UEAwwOY2RrcmQtaHVudC1pZHAwHhcNMjYwODEwMTc1ODI0WhcNMjYwOTA5MTc1ODI0WjAZMRcwFQYDVQQDDA5jZGtyZC1odW50LWlkcDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMIRGjNNMo4aLwcGxCPEbN2GOpNel9TyHo1BsRax9FIZApdSa22mXs9o2UObdqYuVfvSMC83sxTDLxqTiYTy672yS7JLaVhOHUdi8dONyCMf2W9CPmg49iLEq5285It4LzYoKVgAWkk4qF6BHTHn2WU9j1pVJb+nte078L3CPqwC0208RSbsVSTrn3QSVcloaZNOKP+p045444mWKt9hc4Kn0nM73BZRhqNL/Mkgy6zptY4FFKtw2593rvnmOoM2O5dXrL2hG/DGSPAIWRjAFNZYctikC2ldPloxR7sfe5E3L2ELl5NXLbnpShSBThsuIpD7FHerqwq6LF7ptEPY1xMCAwEAAaNTMFEwHQYDVR0OBBYEFHWmzjhTgKum0G+1bvI57hKw5I/sMB8GA1UdIwQYMBaAFHWmzjhTgKum0G+1bvI57hKw5I/sMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBABoJmw5e2ptW0s3jjLJbr4VnIrbFQ5ieSemHC8VhujphYv7vPr5iLnqkM1QZrjRGWXDAB9PSIAZVPTw3S67AAIK6KRJxFdYr8xnKChsjzdjhqW3fkxRVefMP3Nxn8fx6rO9Hf50hXsU8Gbmzrh77uLECH+DI/KpiSui8wvZikNsbQ1WyEneP0yakj/C7VDmHHFP5FKHeHGh04eVygxPf89ctWHe9okm3KDbSkRmQMnwpLKF2Tvk1J5KIZFvkR6y+w8nh81N702lh1in/BSbXFp8aiGO1liQJTy4Duf3X6PrZOMwF30HrvYeACALjtwxt8tZL4epW2KsHVsozEJxrm38=";
+const samlMetadata = [
+  '<?xml version="1.0"?>',
+  '<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="urn:cdkrd-hunt-0811-idp">',
+  '<md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">',
+  '<md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">',
+  `<ds:X509Data><ds:X509Certificate>${samlCert}</ds:X509Certificate></ds:X509Data>`,
+  "</ds:KeyInfo></md:KeyDescriptor>",
+  '<md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>',
+  '<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.com/sso"/>',
+  "</md:IDPSSODescriptor></md:EntityDescriptor>",
+].join("");
+
+new CfnUserPoolIdentityProvider(a, "SamlIdp", {
+  userPoolId: pool.ref,
+  providerName: "cdkrd-hunt-saml",
+  providerType: "SAML",
+  providerDetails: { MetadataFile: samlMetadata },
+});
+
+// ---------------------------------------------------------------- stack B
+const b = new Stack(app, "CdkrdHunt0811BarestB");
+
+const efsFs = new CfnFileSystem(b, "Fs", {});
+efsFs.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+// EFS AccessPoint barest: FileSystemId only — probes the materialized
+// RootDirectory {Path:"/"} (and any PosixUser/ClientToken echoes) undeclared.
+new CfnAccessPoint(b, "Ap", { fileSystemId: efsFs.ref });
+
+const topic = new CfnTopic(b, "Topic", { topicName: "cdkrd-hunt-0811-topic" });
+
+// Inline-subscription topic (the #1729-class probe): the subscription is declared
+// INSIDE the Topic resource, not as an AWS::SNS::Subscription sibling.
+const inlineQ = new CfnQueue(b, "InlineQ", { queueName: "cdkrd-hunt-0811-inlineq" });
+const inlineTopic = new CfnTopic(b, "InlineSubTopic", {
+  topicName: "cdkrd-hunt-0811-inline",
+  subscription: [{ protocol: "sqs", endpoint: inlineQ.attrArn }],
+});
+new CfnQueuePolicy(b, "InlineQPolicy", {
+  queues: [inlineQ.ref],
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "sns.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: inlineQ.attrArn,
+        Condition: { ArnEquals: { "aws:SourceArn": inlineTopic.ref } },
+      },
+    ],
+  },
+});
+
+const fhBucket = new Bucket(b, "FhBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const fhRole = new Role(b, "FhRole", {
+  assumedBy: new ServicePrincipal("firehose.amazonaws.com"),
+  inlinePolicies: {
+    s3: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          actions: ["s3:AbortMultipartUpload", "s3:GetBucketLocation", "s3:GetObject", "s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:PutObject"],
+          resources: [fhBucket.bucketArn, `${fhBucket.bucketArn}/*`],
+        }),
+      ],
+    }),
+  },
+});
+
+const fh = new CfnDeliveryStream(b, "Firehose", {
+  deliveryStreamName: "cdkrd-hunt-0811-fh",
+  s3DestinationConfiguration: {
+    bucketArn: fhBucket.bucketArn,
+    roleArn: fhRole.roleArn,
+  },
+});
+fh.node.addDependency(fhRole);
+
+const snsSubRole = new Role(b, "SnsSubRole", {
+  assumedBy: new ServicePrincipal("sns.amazonaws.com"),
+  inlinePolicies: {
+    fh: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          actions: ["firehose:DescribeDeliveryStream", "firehose:ListDeliveryStreams", "firehose:ListTagsForDeliveryStream", "firehose:PutRecord", "firehose:PutRecordBatch"],
+          resources: [fh.attrArn],
+        }),
+      ],
+    }),
+  },
+});
+
+new CfnSubscription(b, "FhSub", {
+  topicArn: topic.ref,
+  protocol: "firehose",
+  endpoint: fh.attrArn,
+  subscriptionRoleArn: snsSubRole.roleArn,
+});
+
+const primaryKeyArn = app.node.tryGetContext("primaryKeyArn");
+if (primaryKeyArn) {
+  const rk = new CfnReplicaKey(b, "ReplicaKey", {
+    primaryKeyArn,
+    keyPolicy: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Sid: "root",
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${b.account}:root` },
+          Action: "kms:*",
+          Resource: "*",
+        },
+      ],
+    },
+  });
+  rk.applyRemovalPolicy(RemovalPolicy.DESTROY);
+}

--- a/tests/integration/barest5-hunt/cdk.json
+++ b/tests/integration/barest5-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/barest5-hunt/package.json
+++ b/tests/integration/barest5-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-barest5-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Barest first-run FP probe (2026-08-11): ElastiCache ServerlessCache redis, Transfer Server zero-prop, CloudTrail EventDataStore, Batch multinode JobDefinition, SSM Automation Document, Cognito SAML IdP, EFS AccessPoint barest, SNS firehose subscription + inline-subscription topic, KMS ReplicaKey. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/barest5-hunt/verify.sh
+++ b/tests/integration/barest5-hunt/verify.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Barest first-run FP probe on the 2026-08-11 hunt pack (two stacks): deploy,
+# assert the FIRST check (before record) is CLEAN — every [Potential Drift] /
+# false `added` entry it prints is a fold/suppression gap to triage — then
+# record and assert check --fail stays clean. Finally the post-update echo
+# probe: redeploy with -c rev=2 (neutral tag update) and re-check.
+#
+# The KMS ReplicaKey leg needs a multi-Region PRIMARY key in another region:
+# created here via CLI (us-west-2), threaded in with -c primaryKeyArn=..., and
+# scheduled for deletion (7-day pending) in the cleanup trap.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACKS=(CdkrdHunt0811BarestA CdkrdHunt0811BarestB)
+REGION="${AWS_REGION:-us-east-1}"
+KMS_PRIMARY_REGION="us-west-2"
+CLI="node $ROOT/dist/cli.js"
+
+PRIMARY_KEY_ARN=""
+
+cleanup() {
+  echo "--- cleanup (${STACKS[*]}) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  if [ -n "$PRIMARY_KEY_ARN" ]; then
+    aws kms schedule-key-deletion --key-id "$PRIMARY_KEY_ARN" \
+      --pending-window-in-days 7 --region "$KMS_PRIMARY_REGION" >/dev/null 2>&1 || true
+  fi
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (barest5-hunt): $*"; exit 1; }
+
+echo "=== create multi-Region primary key ($KMS_PRIMARY_REGION) ==="
+PRIMARY_KEY_ARN=$(aws kms create-key --multi-region \
+  --description "cdkrd barest5-hunt primary (ephemeral)" \
+  --tags TagKey=cdkrd:ephemeral,TagValue=1 \
+  --region "$KMS_PRIMARY_REGION" --query 'KeyMetadata.Arn' --output text) || fail "create primary key"
+echo "primary: $PRIMARY_KEY_ARN"
+
+echo "=== deploy (both stacks) ==="
+npx cdk deploy -f --all --require-approval never -c "primaryKeyArn=$PRIMARY_KEY_ARN" || fail "deploy"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] FIRST check (no baseline) MUST be CLEAN ==="
+  CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-barest5}" $CLI check "$STACK" --region "$REGION" --fail \
+    -c "primaryKeyArn=$PRIMARY_KEY_ARN" | tee "/tmp/cdkrd-$STACK.pre.out"
+  RC=${PIPESTATUS[0]}
+  # `--fail` exits 0 on baseline-less potential drift — the invariant is ZERO, so grep too.
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+  # A false `added` on the inline-subscription topic is the #1729-class bug this
+  # fixture probes — count added-tier entries too.
+  grep -qE "created out of band|\[Added\]" "/tmp/cdkrd-$STACK.pre.out" && RC=11
+  [ "$RC" -eq 0 ] || fail "[$STACK] first check not clean (rc=$RC)"
+
+  echo "=== [$STACK] record + check --fail ==="
+  $CLI record "$STACK" --region "$REGION" --yes -c "primaryKeyArn=$PRIMARY_KEY_ARN" || fail "[$STACK] record"
+  $CLI check "$STACK" --region "$REGION" --fail -c "primaryKeyArn=$PRIMARY_KEY_ARN" || fail "[$STACK] post-record check not clean"
+done
+
+echo "=== redeploy with -c rev=2 (post-update echo probe) ==="
+npx cdk deploy -f --all --require-approval never -c rev=2 -c "primaryKeyArn=$PRIMARY_KEY_ARN" || fail "redeploy rev=2"
+
+for STACK in "${STACKS[@]}"; do
+  echo "=== [$STACK] post-update check MUST be CLEAN ==="
+  $CLI check "$STACK" --region "$REGION" --fail -c "primaryKeyArn=$PRIMARY_KEY_ARN" | tee "/tmp/cdkrd-$STACK.rev2.out"
+  RC=${PIPESTATUS[0]}
+  grep -q "Potential Drift" "/tmp/cdkrd-$STACK.rev2.out" && RC=10
+  [ "$RC" -eq 0 ] || fail "[$STACK] post-update check not clean (rc=$RC)"
+done
+
+echo "INTEG OK (barest5-hunt)"

--- a/tests/integration/linkpack-hunt/app.ts
+++ b/tests/integration/linkpack-hunt/app.ts
@@ -1,0 +1,116 @@
+// 2026-08-11 hunt wave 2 — cheap association/link-shaped probes in one stack:
+// - Glue resource link (#1749 live witness): a declared TARGET database + table and a
+//   declared RESOURCE-LINK database pointing at it. GetTables on the link proxies to
+//   the target's tables, so pre-fix the link's child enumeration false-flags t1 as
+//   `added` (with a destructive delete offer); post-fix the check must be clean.
+// - ECS ClusterCapacityProviderAssociations declaring [FARGATE_SPOT, FARGATE]
+//   (deliberately unsorted): the sibling Cluster.CapacityProviders was live-proven
+//   sorted-echo (#1491) against the same attachment API, and this type is absent from
+//   UNORDERED_ARRAY_PROPS — reorder-FP probe.
+// - AppSync MERGED API + SourceApiAssociation: the GraphQLApi child enumerator has no
+//   ApiType branch — probes whether a merged API's live child inventory (data sources
+//   merged in from the source) false-flags as `added`.
+// - RDS GlobalCluster HEADLESS barest (no member clusters — free, fast): first-run FP
+//   probe of the undeclared defaults observed on the #1750 CC probe echo
+//   (EngineVersion, StorageEncrypted, DeletionProtection, EngineLifecycleSupport).
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import {
+  CfnDataSource,
+  CfnGraphQLApi,
+  CfnGraphQLSchema,
+  CfnSourceApiAssociation,
+} from "aws-cdk-lib/aws-appsync";
+import { CfnCluster, CfnClusterCapacityProviderAssociations } from "aws-cdk-lib/aws-ecs";
+import { CfnDatabase, CfnTable } from "aws-cdk-lib/aws-glue";
+import { PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnGlobalCluster } from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+Tags.of(app).add("cdkrd:ephemeral", "1");
+const rev = app.node.tryGetContext("rev");
+if (rev) Tags.of(app).add("cdkrd:rev", String(rev));
+
+const s = new Stack(app, "CdkrdHunt0811LinkPack");
+
+// --- Glue resource link (#1749 witness) ---
+const targetDb = new CfnDatabase(s, "TargetDb", {
+  catalogId: s.account,
+  databaseInput: { name: "cdkrd_hunt_0811_link_target" },
+});
+const targetTable = new CfnTable(s, "TargetTable", {
+  catalogId: s.account,
+  databaseName: "cdkrd_hunt_0811_link_target",
+  tableInput: {
+    name: "t1",
+    tableType: "EXTERNAL_TABLE",
+    storageDescriptor: {
+      columns: [{ name: "c1", type: "string" }],
+      location: "s3://example-nonexistent/x",
+    },
+  },
+});
+targetTable.addDependency(targetDb);
+const linkDb = new CfnDatabase(s, "LinkDb", {
+  catalogId: s.account,
+  databaseInput: {
+    name: "cdkrd_hunt_0811_link",
+    targetDatabase: { catalogId: s.account, databaseName: "cdkrd_hunt_0811_link_target" },
+  },
+});
+linkDb.addDependency(targetDb);
+
+// --- ECS ClusterCapacityProviderAssociations reorder probe ---
+const cluster = new CfnCluster(s, "EcsCluster", { clusterName: "cdkrd-hunt-0811-ccpa" });
+new CfnClusterCapacityProviderAssociations(s, "Ccpa", {
+  cluster: cluster.ref,
+  capacityProviders: ["FARGATE_SPOT", "FARGATE"], // deliberately unsorted
+  defaultCapacityProviderStrategy: [],
+});
+
+// --- AppSync merged API probe ---
+const srcApi = new CfnGraphQLApi(s, "SrcApi", {
+  name: "cdkrd-hunt-0811-src",
+  authenticationType: "API_KEY",
+});
+const srcSchema = new CfnGraphQLSchema(s, "SrcSchema", {
+  apiId: srcApi.attrApiId,
+  definition: "type Query { hello: String }",
+});
+const srcDs = new CfnDataSource(s, "SrcDs", {
+  apiId: srcApi.attrApiId,
+  name: "NoneDs",
+  type: "NONE",
+});
+srcDs.addDependency(srcSchema);
+
+const mergeRole = new Role(s, "MergeRole", {
+  assumedBy: new ServicePrincipal("appsync.amazonaws.com"),
+  inlinePolicies: {
+    merge: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          actions: ["appsync:SourceGraphQL", "appsync:StartSchemaMerge"],
+          resources: [`${srcApi.attrArn}/*`, srcApi.attrArn],
+        }),
+      ],
+    }),
+  },
+});
+const mergedApi = new CfnGraphQLApi(s, "MergedApi", {
+  name: "cdkrd-hunt-0811-merged",
+  authenticationType: "API_KEY",
+  apiType: "MERGED",
+  mergedApiExecutionRoleArn: mergeRole.roleArn,
+});
+const assoc = new CfnSourceApiAssociation(s, "SrcAssoc", {
+  mergedApiIdentifier: mergedApi.attrApiId,
+  sourceApiIdentifier: srcApi.attrApiId,
+});
+assoc.node.addDependency(srcSchema);
+
+// --- RDS GlobalCluster headless barest ---
+const gc = new CfnGlobalCluster(s, "HeadlessGc", {
+  globalClusterIdentifier: "cdkrd-hunt-0811-gc",
+  engine: "aurora-postgresql",
+});
+gc.applyRemovalPolicy(RemovalPolicy.DESTROY);

--- a/tests/integration/linkpack-hunt/cdk.json
+++ b/tests/integration/linkpack-hunt/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/linkpack-hunt/package.json
+++ b/tests/integration/linkpack-hunt/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-linkpack-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "2026-08-11 hunt wave 2: Glue resource-link added-FP witness (#1749), ECS ClusterCapacityProviderAssociations reorder probe, AppSync merged API enumerator probe, RDS GlobalCluster headless barest. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/linkpack-hunt/verify.sh
+++ b/tests/integration/linkpack-hunt/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Wave-2 probe (2026-08-11 hunt): deploy the link/association pack, assert the
+# FIRST check (before record) is CLEAN — a false `added` on the Glue link's
+# proxied tables (#1749) or the merged AppSync API's inherited children, or a
+# reorder [Potential Drift] on the ECS capacity-provider association, is the bug
+# being probed — then record and assert check --fail stays clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdHunt0811LinkPack
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL (linkpack-hunt): $*"; exit 1; }
+
+echo "=== deploy ==="
+npx cdk deploy -f --all --require-approval never || fail "deploy"
+
+echo "=== FIRST check (no baseline) MUST be CLEAN ==="
+CDKRD_CORPUS_DIR="${CDKRD_HUNT_CORPUS_DIR:-/tmp/corpus-linkpack}" $CLI check "$STACK" --region "$REGION" --fail \
+  | tee "/tmp/cdkrd-$STACK.pre.out"
+RC=${PIPESTATUS[0]}
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK.pre.out" && RC=10
+grep -qE "created out of band|\[Added\]" "/tmp/cdkrd-$STACK.pre.out" && RC=11
+[ "$RC" -eq 0 ] || fail "first check not clean (rc=$RC)"
+
+echo "=== record + check --fail ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-record check not clean"
+
+echo "INTEG OK (linkpack-hunt)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -1269,9 +1269,13 @@ describe('noise suppressors', () => {
       },
     });
     // A Transfer server assigns the stable default security policy, an S3 domain, and
-    // directory-listing optimization DISABLED when those are omitted.
+    // directory-listing optimization DISABLED when those are omitted — and (#1753) a
+    // ZERO-property server additionally reads back the SFTP/public/service-managed trio.
     expect(KNOWN_DEFAULTS['AWS::Transfer::Server']).toEqual({
       IpAddressType: 'IPV4',
+      Protocols: ['SFTP'],
+      EndpointType: 'PUBLIC',
+      IdentityProviderType: 'SERVICE_MANAGED',
       ProtocolDetails: {
         PassiveIp: 'AUTO',
         SetStatOption: 'DEFAULT',


### PR DESCRIPTION
## Summary

2026-08-11 bug-hunt sweep — six confirmed bugs found, fixed, unit-tested, and live-verified in one session. All probes ran stackless (Cloud Control / CLI) or on two cheap ephemeral fixture stacks; everything deployed was deleted and swept.

Closes #1749, Closes #1750, Closes #1751, Closes #1752, Closes #1753, Closes #1754.

### Added-tier FPs with destructive delete offers (the worst class)

- **#1749 Glue resource link**: `GetTables` on a resource-link database transparently proxies to the linked TARGET's tables, so a declared link false-added every target table and offered a delete of the shared real table. Fix: early-return for declared link/federated shapes + a generic owning-DatabaseName-mismatch filter in `diffGlueDatabaseChildren`. Live witness: `linkpack-hunt` (link + in-stack target) first check clean.
- **#1754 SNS inline `Subscription`**: the Topic's own canonical inline `Subscription` property (raw CFn / L1) was missing from the enumerator's declared-set — the #1729 twin-declaration class extended to the parent's own inline property. Fix: `declaredInlineSubscriptions` matched by (Protocol, Endpoint), conservative on unresolved refs. Live witness: `barest5-hunt` stack B (`created out of band` pre-fix → clean post-fix).

### Revert broken for a whole type

- **#1752 GuardDuty Detector**: EVERY CC patch was rejected on a current-era detector (deprecated `EKS_RUNTIME_MONITORING` + successor `RUNTIME_MONITORING` coexist in the model echo; DataSources+Features exclusivity). Fix: `applyGuardDutyDetectorPatchShape` — translate `/DataSources/*` ops to `/Features/<idx>/Status`, companion-remove `/DataSources` (a derived projection), companion-remove the deprecated feature element last. All three legs live-proven by stackless CC probes, including the exact op order the implementation emits (S3Logs OOB-disable → patch SUCCESS → live re-ENABLED).

### Declared-tier FPs

- **#1750 RDS GlobalCluster**: handler accepts a mixed-case `GlobalClusterIdentifier`, store lowercases → permanent declared FP. `CASE_INSENSITIVE_PATHS` owning entry (+`Engine`, the #1741 carry-over) + the `AWS::RDS::DBCluster.GlobalClusterIdentifier` consumer (#1712 class). Live CC probe evidence in the issue.
- **#1751 ECS `ClusterCapacityProviderAssociations.CapacityProviders`** sorted echo → `UNORDERED_ARRAY_PROPS` (the #1491 sibling's association twin).

### First-run undeclared FPs (fold gaps → zero)

- **#1751 AppSync**: DataSource `MetricsConfig: "DISABLED"`, SourceApiAssociation `{MergeType: "MANUAL_MERGE"}` (equality-gated pins); RDS GlobalCluster undeclared `EngineVersion` (moving GA → value-independent).
- **#1753 ElastiCache ServerlessCache barest redis**: literal one-space `Description` pin, default-VPC SG/subnet echoes via the derived `DEFAULT_SG_LIST_PATHS`/`DEFAULT_SUBNET_LIST_PATHS` gates (+ gather prefetch registrations — OOB swap/append detection preserved), `MajorEngineVersion` (moving GA major → value-independent). Transfer Server zero-prop trio (`Protocols=[SFTP]` / `EndpointType=PUBLIC` / `IdentityProviderType=SERVICE_MANAGED`, equality-gated). Cognito SAML IdP metadata-computed `ProviderDetails` enrichments (SSO/SLO RedirectBindingURI + Cognito-generated ActiveEncryptionCertificate → nested value-independent).
- **#1754**: EFS AccessPoint materialized `RootDirectory {Path:"/"}` (whole-object pin); KMS ReplicaKey `Enabled: true` pin WITH the `MEANINGFUL_WHEN_OFF` gate (an OOB `disable-key` still surfaces — the #1092 off-flip class).

### Revert-convergence piggyback (the ~1-in-3 rule held)

- ServerlessCache `Description` bare-remove is a silent no-op live → `REVERT_SET_DEFAULT_PATHS` entry (explicit one-space add converges, live-proven).

## Live verification

- `linkpack-hunt` (new fixture): deploy → first check CLEAN (was 4 findings pre-fix) → record → `check --fail` clean → INTEG OK.
- `barest5-hunt` (new fixture): stack A 9 FPs → zero; stack B 3 FPs → zero; record + post-update (`-c rev=2`) echo probe clean → INTEG OK.
- GuardDuty: stackless probe detector — implementation-shape patch SUCCESS + live value restored; detector deleted.

## Determinations (recorded in the skill; no code change needed)

- CloudTrail Lake (`EventDataStore`) is CLOSED to new customers → dead-service list.
- Route53 HealthCheck FQDN preserves case; Backup BackupPlan rejects `rate()`; MemoryDB ACL `UserNames` echoes declared order; RDS EventSubscription `SourceIds` rejects mixed case (404) and preserves order — four predicted declared-FP classes ruled out stackless.
- AppSync MERGED API enumerates clean (no inherited-children false added) — proven by the linkpack fixture.

## Corpus / regression assets

- 6 promoted corpus cases (SourceApiAssociation, GlobalCluster headless, DataSource MetricsConfig trigger, CCPA reorder trigger, Glue LinkDb declared-link shape, MERGED GraphQLApi) + barest5 harvest.
- Both fixtures committed as regression integs; skill file gains batch-14 history + 4 new gotchas + the stackless determinations list.

## Verification

`/check` (typecheck / lint+format / `vp pack` / 6462 unit tests) and `/check-docs` (no docs-visible surface touched — fold/enumerator/revert-table internals only) pass; `/verify-pr` run including diff self-review and the live-tests above. **Shared-name CORE suite deferred** — this diff is fully covered by unit tests + committed corpus replays AND was live-proven in its originating hunt (this PR's own fixtures ran INTEG OK end-to-end); the suite runs at the next clean-window release verification.

## Deferred (recorded in SKILL.md batch-14 note, no issues — unproven candidates, not bugs)

Convergence probes needing non-trivial infra: ELBv2 `AdvertiseTrustStoreCaNames` (#1698 fold), ImageBuilder `ImageTestsConfiguration` (#1702), ASG MIP `InstancesDistribution` (#1695), CloudFront VpcOrigin `OriginSSLProtocols` (#1734), AppSync `MetricsConfig`/association config (#1751).
