### PR TITLE
chore(markgate): adopt hash: diff for the integ gate

### DIFF
--- a/.markgate.yml
+++ b/.markgate.yml
@@ -41,10 +41,19 @@
 #               explicitly: markgate has no `origin/HEAD` fallback, and that ref is
 #               commonly unset in CI clones, which would make the same gate mean
 #               different things locally and in CI. Accepted cost: cross-FILE
-#               interaction goes unseen (branch changes A, `main` changes B, the
-#               deltas never overlap) — 14 of the 83 cases; the 14d TTL still
-#               forces a periodic real run. On a clean `main` the delta is empty
-#               and markgate ERRORS (exit 2) rather than silently passing.
+#               interaction goes unseen — a caller uses A and B, this branch
+#               changes A, `main` changes B. By definition those two changes sit in
+#               DIFFERENT files, so this class lives inside the 69 ZERO-OVERLAP
+#               cases, NOT the 14 overlapping ones: an overlapping change lands
+#               inside this branch's own delta and is still caught. The residual
+#               risk is therefore bounded above by 69, and how much of that 69 is
+#               genuine semantic coupling rather than genuinely independent work is
+#               UNMEASURED — the measurement distinguishes file overlap, not
+#               coupling. The trade is still worth making, but on those terms: the
+#               invalidations removed are provably uninformative, while the risk
+#               accepted is bounded but not quantified. The 14d TTL still forces a
+#               periodic real run. On a clean `main` the delta is empty and
+#               markgate ERRORS (exit 2) rather than silently passing.
 #
 #               `check` / `docs` deliberately STAY on `hash: files`: it is the
 #               stricter mode, and strictness is only worth trading away where the

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -29,6 +29,29 @@
 #               remains, and it has no companion /run-integ skill yet. 14d TTL
 #               (AWS-side wire-format + Cloud Control behavior drift over time).
 #
+#               This is the ONE gate on `hash: diff` (markgate 0.4+, #1756). Its
+#               digest is the working-tree delta against `merge-base(origin/main,
+#               HEAD)` restricted to the include set, so a merge arriving from
+#               `main` that moves an UNRELATED in-scope file no longer invalidates
+#               the marker — while a change to a file this branch also touched, and
+#               any in-scope edit on this branch (committed or not), still do. On
+#               the last 250 merged PRs here, 69 of the 83 cross-PR invalidations
+#               (83%) carried no information about the branch being gated. `base:`
+#               is mandatory for a diff gate and is pinned to `origin/main`
+#               explicitly: markgate has no `origin/HEAD` fallback, and that ref is
+#               commonly unset in CI clones, which would make the same gate mean
+#               different things locally and in CI. Accepted cost: cross-FILE
+#               interaction goes unseen (branch changes A, `main` changes B, the
+#               deltas never overlap) — 14 of the 83 cases; the 14d TTL still
+#               forces a periodic real run. On a clean `main` the delta is empty
+#               and markgate ERRORS (exit 2) rather than silently passing.
+#
+#               `check` / `docs` deliberately STAY on `hash: files`: it is the
+#               stricter mode, and strictness is only worth trading away where the
+#               re-verification it forces is expensive — re-running typecheck /
+#               lint / build / unit tests is not. `pr-review` is bound to a
+#               sentinel file, so a pull cannot invalidate it either way.
+#
 # Bug-hunt cleanup is NOT a markgate gate — it is a sentinel-file gate
 # (.markgate-bughunt-pending + .claude/hooks/bughunt-clean-gate.sh), armed by
 # /hunt-bugs's bughunt-track.sh BEFORE any deploy and released only after every
@@ -71,7 +94,8 @@ gates:
       - '.markgate-pr-review-sha'
 
   integ:
-    hash: files
+    hash: diff
+    base: origin/main
     ttl: 14d
     include:
       - 'src/**'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"ubi:go-to-k/markgate" = "0.3.3"
+"ubi:go-to-k/markgate" = "0.4.0"
 # Force-delete CloudFormation stacks (incl. DELETE_FAILED / retained / protected
 # resources) so test & integ teardown never leaves orphans — see CLAUDE.md.
 "ubi:go-to-k/delstack" = "2.11.1"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"ubi:go-to-k/markgate" = "0.4.0"
+"ubi:go-to-k/markgate" = "0.4.1"
 # Force-delete CloudFormation stacks (incl. DELETE_FAILED / retained / protected
 # resources) so test & integ teardown never leaves orphans — see CLAUDE.md.
 "ubi:go-to-k/delstack" = "2.11.1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,14 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     live-test + retrospective; named `verify-pr` for layout parity with cdkd).
   - A `check-gate` PreToolUse hook blocks `git commit` unless both the `check` and
     `docs` markers are fresh. Run the relevant skill before committing.
+  - **Hash modes**: `check` / `docs` hash file CONTENT (`hash: files`) — the
+    stricter mode, kept because re-running them is cheap. The inert `integ` gate is
+    the ONE gate on `hash: diff` (markgate 0.4+, #1756): it digests this branch's
+    delta against `merge-base(origin/main, HEAD)` restricted to its include set, so
+    a merge from `main` touching an UNRELATED in-scope file no longer forces a
+    re-run of an expensive real-AWS verification, while a same-file change and any
+    local in-scope edit still stale it. A diff gate ERRORS (exit 2) when run from a
+    clean base branch. Rationale + accepted cost are in `.markgate.yml`.
   - `/hunt-bugs` is the (non-marker) skill that drives a periodic real-AWS bug-hunt:
     deploy UNCOVERED, high-frequency resource types / configs / CFn notations, then
     catch false positives (clean `record`→`check` must be CLEAN) and missed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,10 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     a merge from `main` touching an UNRELATED in-scope file no longer forces a
     re-run of an expensive real-AWS verification, while a same-file change and any
     local in-scope edit still stale it. A diff gate ERRORS (exit 2) when run from a
-    clean base branch. Rationale + accepted cost are in `.markgate.yml`.
+    clean base branch. The invalidations it removes are provably uninformative; the
+    risk it accepts — undetected cross-FILE interaction, which by definition sits in
+    the zero-overlap cases — is bounded but NOT quantified. Full rationale in
+    `.markgate.yml`.
   - `/hunt-bugs` is the (non-marker) skill that drives a periodic real-AWS bug-hunt:
     deploy UNCOVERED, high-frequency resource types / configs / CFn notations, then
     catch false positives (clean `record`→`check` must be CLEAN) and missed


### PR DESCRIPTION

`/verify-pr` was walked anyway (a sibling repo's copy of `verify-pr-gate.sh`, which lacks the non-src exemption, gates this session): typecheck / lint / build / tests pass, no `src/**` change so no unit-test delta is owed, working tree clean, docs consistent, diff reviewed. The **shared-name CORE integration suite (step 7) was NOT run and is logged as deferred** — it is required for a change to the `check` / `revert` hot path, and this diff touches no runtime code at all. Nothing was deployed; no AWS cost, no orphans, no sweep needed.

## Correction (second commit)

The first commit's accepted-cost note attributed undetected cross-file interaction to the **14 overlapping** cases. That is backwards, and is corrected in `d3f0408`:

- An overlapping change (base branch moves a file this branch also touched) lands **inside this branch's own delta**, so `hash: diff` still catches it — those 14 are not the residual risk.
- Cross-file interaction (a caller uses A and B, this branch changes A, `main` changes B) requires the two changes to be in **different** files, so it lives inside the **69 zero-overlap** cases.

So the residual risk is bounded above by **69, not 14**, and the portion of those 69 that is genuine semantic coupling rather than genuinely independent work is **unmeasured** — the measurement distinguishes file overlap, not semantic coupling. The trade is still worth making, on honest terms: the invalidations removed are provably uninformative, while the risk accepted is bounded but not quantified. `.markgate.yml` and the `CLAUDE.md` bullet both now say that.

## markgate version: pinned at 0.4.1

`0.4.1` released after the first commit (golangci-lint pin, main-branch guard fix, `fix(cli): let clear work without a valid config`) — none of it touches `hash: diff` semantics. Pin bumped in `addae42`; `mise exec -- markgate version` -> `0.4.1` (the bare PATH binary is an unrelated stale `v0.1.0`, which is why every invocation here goes through `mise exec`).

`v0.4.2` also exists, but it is a **re-tag of the identical tree** — both tags resolve to commit `47ee2ff`, and `compare/v0.4.1...v0.4.2` returns zero commits and zero changed files — so pinning `0.4.1` loses nothing.

**The four behavior checks were re-run against the 0.4.1 binary, not carried over.** `.mise.toml` sits outside every gate's include scope, so swapping the binary leaves `check` / `docs` / `verify-pr` *reported* fresh while the thing they attest to has changed (go-to-k/cdkd#1954). All four reproduce identically on 0.4.1: unrelated base-branch change -> `verify exit=0`; same-file change -> `verify exit=1`; uncommitted in-scope edit -> `verify exit=1` (and back to 0 on revert); clean base branch -> `set` / `verify exit=2` with the empty-delta refusal. The nine hook test suites, `markgate config lint` (same single pre-existing sentinel warning), the `verify-pr-gate.sh` `state:`-line awk, and readback of markers written by an older binary were all re-checked on 0.4.1 too.
