### PR TITLE
docs(governance): correct the stale no-remote / no-PR-flow claims

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -3,8 +3,8 @@
 #
 # PreToolUse hook. Blocks `git commit` and `git push` when the working
 # tree the command will actually act on is on `main` / `master`. All
-# changes to cdkd must land via PR from a feature branch — direct
-# commits/pushes to main are not allowed.
+# changes to cdk-real-drift must land via PR from a feature branch —
+# direct commits/pushes to main are not allowed.
 #
 # WHY the cwd-aware resolution matters: this repo is regularly worked
 # in via `git worktree`. The previous implementation derived the repo

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -7,10 +7,13 @@
 # and edits to docs-only invalidate only `docs`. The error message names the
 # skill to re-run.
 #
-# cdk-real-drift is a smaller, solo, local-only repo (no GitHub remote yet),
-# so this is the ONLY commit/merge gate wired up. Branch-protection,
-# verify-pr-merge, pr-review, and integ-* gates are deferred until Phase 4
-# (when the repo gets a remote). Adapted from cdkd's check-gate.sh; the
+# cdk-real-drift is a smaller repo than cdkd, so only a subset of cdkd's
+# gate suite is wired: this hook plus branch-gate, verify-pr-gate,
+# ci-green-gate, stale-base-gate, and non-english-text-gate (R83). The
+# pr-review and integ-* gates stay UNPORTED on purpose — pr-review needs the
+# multi-agent reviewers in `.claude/agents` cdkrd lacks, and integ-* depends
+# on cdkd's deploy/destroy paths cdkrd does not have (see .markgate.yml).
+# Adapted from cdkd's check-gate.sh; the
 # cwd-aware target-dir resolution is kept because work happens via
 # `git worktree` and markgate stores marker state per-worktree.
 

--- a/.claude/skills/check-docs/SKILL.md
+++ b/.claude/skills/check-docs/SKILL.md
@@ -13,8 +13,10 @@ docs describe.
 
 ## Steps
 
-1. **Identify what changed**: Run `git diff HEAD~5 --name-only` (solo repo, no PR
-   base) to see recently changed files.
+1. **Identify what changed**: on a `wt-*` branch, diff against the base to see
+   everything this PR changes, committed or not:
+   `git diff --name-only "$(git merge-base origin/main HEAD)"`. On `main`, fall
+   back to `git diff HEAD~5 --name-only`.
 
 2. **Decide whether a deep review is needed (short-circuit)**. Skip the LLM-judged
    review and set the marker directly when the diff **only** touches files the

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -7,10 +7,12 @@ description: Run local quality checks (typecheck, lint, build, tests). Quick che
 
 Run all local quality checks. Use during development to verify the current state quickly.
 
-cdk-real-drift (cdkrd) is a solo, local-only repo: there is no GitHub remote, no
-PR workflow, and no real-AWS deploy/destroy in this gate. This skill mirrors the
-CI workflow (`.github/workflows/ci.yml`), which runs typecheck / lint+format /
-build / unit tests on every push.
+cdk-real-drift (cdkrd) is developed solo, but on a GitHub remote and through
+PRs: work lands via `wt-*` worktree branches, and `.claude/hooks/verify-pr-gate.sh`
+gates `gh pr create` / `gh pr merge`. This skill is the LOCAL half of that flow —
+it runs no real-AWS deploy/destroy — and mirrors the CI workflow
+(`.github/workflows/ci.yml`), which runs typecheck / lint+format / build / unit
+tests on every push.
 
 ## Steps
 

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: verify-pr
-description: Comprehensive pre-release verification. Run quality checks, docs consistency, a live-test of changed behavior, and a short retrospective before tagging a release.
+description: Comprehensive PR-readiness verification. Run quality checks, docs consistency, a live-test of changed behavior, and a short retrospective before opening or merging a PR.
 ---
 
-# Pre-Release Verification
+# PR-Readiness Verification
 
-Heavy verification gate — a **pre-release** readiness check, not a per-PR gate
-(per-PR verification is `/check` + `/check-docs` + CI on the pull request). Run
-it before cutting a release. This skill is a superset of `/check` +
+Heavy verification gate, and a **pre-PR** one:
+`.claude/hooks/verify-pr-gate.sh` blocks `gh pr create` and `gh pr merge` until
+this skill has set the `verify-pr` marker. This skill is a superset of `/check` +
 `/check-docs` plus the real-AWS integration fixtures, a live-test, and a
 retrospective.
+
+**Exemption:** a PR whose diff touches no `src/**` (docs / tooling only) carries
+no runtime behavior to live-test, and the gate lets it through on the `check` +
+`docs` markers alone — so `/check` + `/check-docs` + CI is the whole per-PR
+requirement there. The hook computes this from the branch's diff against
+`origin/main` and fails CLOSED — it exempts only when it can prove the diff is
+src-free, so run this skill whenever it does ask for it.
 
 ## Checklist
 
@@ -39,7 +46,8 @@ Run each check and report pass/fail:
 2. **Tests**
    - `vp test run` — all unit tests pass; report file + test counts. **Invoke
      `vp test run` DIRECTLY, not `vp run test`** (same cache-replay foot-gun).
-   - **Coverage of changes**: compare `git diff HEAD~5 --name-only` for `src/`
+   - **Coverage of changes**: compare
+     `git diff --name-only "$(git merge-base origin/main HEAD)"` for `src/`
      vs `tests/`. If logic was added/changed in `src/` with no corresponding test
      added/updated, flag as **fail** and add the missing tests before proceeding.
 
@@ -53,8 +61,8 @@ Run each check and report pass/fail:
      `SDK_WRITERS` map. Fix any discrepancy.
 
 5. **Code review**
-   - `git diff HEAD~5` — read the diff. For each change: is it correct? complete?
-     necessary?
+   - `git diff "$(git merge-base origin/main HEAD)"` — read the PR's whole diff.
+     For each change: is it correct? complete? necessary?
    - Check for logic errors / unhandled edge cases, unnecessary changes (dead
      code, unrelated edits), and inconsistencies between changed files.
    - If a shared helper changed, list its importers (`grep -rl` under `src`/
@@ -146,7 +154,7 @@ Present results as a table:
 | shared CORE suite (7)          | pass/deferred/skipped     |
 | retrospective + rule proposals | done/skipped              |
 
-If all pass, confirm "Ready to release."
+If all pass, confirm "Ready to open / merge the PR."
 If any fail, list the issues to fix.
 
 ## Final Step

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -9,9 +9,12 @@
 #               (set by /check and /verify-pr).
 #   docs      — README / DESIGN / docs consistency with src
 #               (set by /check-docs and /verify-pr).
-#   verify-pr — pre-release readiness checklist; AND of check + docs.
-#               (set by /verify-pr.) cdkrd is solo + local-only with no GitHub
-#               remote, so this is a pre-RELEASE gate, not a PR gate.
+#   verify-pr — PR readiness checklist; AND of check + docs. (set by
+#               /verify-pr.) This is a pre-PR gate: .claude/hooks/verify-pr-gate.sh
+#               blocks `gh pr create` / `gh pr merge` until the marker is fresh.
+#               Docs/tooling-only PRs (no `src/**` in the diff) are EXEMPT — the
+#               skill's heavy half is the live-test of changed runtime behavior,
+#               and check + docs already cover a PR that has none.
 #
 # The check / docs / verify-pr gates each have a companion skill under
 # .claude/skills/ that SETS their marker (/check, /check-docs, /verify-pr). Those
@@ -20,8 +23,10 @@
 # INERT gates (kept for layout parity with the sibling repos, but with NO
 # companion skill in cdkrd — do NOT wire a commit/merge hook to either until a
 # companion skill is ported, or it would become unsatisfiable and brick the flow):
-#   pr-review — `/review-pr` reviewer-dispatch verification (sha-bound). N/A:
-#               cdkrd has no GitHub remote / PR review flow. No companion skill.
+#   pr-review — `/review-pr` reviewer-dispatch verification (sha-bound). The repo
+#               does have a remote and a PR flow, but /review-pr dispatches
+#               multi-agent reviewers from `.claude/agents`, which cdkrd has not
+#               ported (CLAUDE.md R83). No companion skill.
 #   integ     — read-only real-AWS verification (gather/check/inject-drift). cdkrd
 #               is READ-ONLY against AWS (no deploy/destroy, no schema migration),
 #               so cdkd's destroy / broad / local / schema-migration integ gates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,10 +232,13 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   its marker:
   - `/check` → `check` marker (typecheck / lint+format / build / unit tests).
   - `/check-docs` → `docs` marker (README / DESIGN / docs consistency with src).
-  - `/verify-pr` → `verify-pr` marker (pre-RELEASE superset of check + docs plus a
-    live-test + retrospective; named `verify-pr` for layout parity with cdkd).
+  - `/verify-pr` → `verify-pr` marker (pre-PR superset of check + docs plus a
+    live-test + retrospective).
   - A `check-gate` PreToolUse hook blocks `git commit` unless both the `check` and
-    `docs` markers are fresh. Run the relevant skill before committing.
+    `docs` markers are fresh, and a `verify-pr-gate` hook blocks `gh pr create` /
+    `gh pr merge` unless `verify-pr` is fresh — except for a docs/tooling-only PR
+    (no `src/**` in the diff), which the gate lets through on `check` + `docs`.
+    Run the relevant skill before committing or opening the PR.
   - **Hash modes**: `check` / `docs` hash file CONTENT (`hash: files`) — the
     stricter mode, kept because re-running them is cheap. The inert `integ` gate is
     the ONE gate on `hash: diff` (markgate 0.4+, #1756): it digests this branch's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@ AWS CDK / CloudFormation — including the **undeclared** properties that `cdk d
 and CloudFormation drift detection miss. See [README.md](README.md) for an overview
 and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design.
 
-> **Status:** pre-release / experimental. Developed solo on `main` for now; a
-> public GitHub remote (and PR workflow) lands at Phase 4.
+> **Status:** pre-release / experimental. Developed solo, but every change lands
+> through a pull request on the GitHub remote — never committed directly to
+> `main`.
 
 ## Prerequisites
 
@@ -84,3 +85,14 @@ Run the markgate companion skills (they back the pre-commit gate):
 
 A `check-gate` hook blocks `git commit` unless both markers are fresh. Run the
 relevant skill, then commit.
+
+## Before you open a PR
+
+Work on a branch — `branch-gate` blocks commits and pushes on `main`.
+
+- `/verify-pr` — the PR readiness checklist; sets the `verify-pr` marker that
+  `verify-pr-gate` requires for `gh pr create` / `gh pr merge`. A PR whose diff
+  touches no `src/**` (docs / tooling only) is exempt: `check` + `docs` already
+  cover it.
+- CI (`.github/workflows/ci.yml`) must be green before merging — `ci-green-gate`
+  blocks `gh pr merge` on a red or still-pending run.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1420,11 +1420,14 @@ check` green). The earlier `TS2591 'process'` errors came from oxc's type-aware
 7. **Governance / repo hygiene (in place)**: CI (`.github/workflows/ci.yml` =
    `vp run check` + test + build; `release.yml` semantic-release; `pr-title-check.yml`),
    `.markgate.yml` (check/docs/verify-pr), `.claude/skills/{check,check-docs,verify-pr}`,
-   `.claude/hooks/check-gate.sh` (+ `.claude/settings.json`), `CLAUDE.md`,
-   `CONTRIBUTING.md`. Deliberately deferred until the repo has a remote (Phase 4):
-   branch/PR/merge gates and `.claude/rules` / `.claude/agents` — cdkd's heavy
-   50-hook / 10-rule suite is disproportionate for a new repo. _Open question: which
-   of those become worth adding once there are external contributors?_
+   the `.claude/hooks/` suite (+ `.claude/settings.json`) — `check-gate`,
+   `branch-gate`, `verify-pr-gate`, `ci-green-gate`, `stale-base-gate`,
+   `non-english-text-gate`, `worktree-guard`, and the bug-hunt cleanup gates —
+   plus `CLAUDE.md` and `CONTRIBUTING.md`. Still deliberately absent:
+   `.claude/rules` / `.claude/agents` (and with them the pr-review gate) —
+   cdkd's heavy 50-hook / 10-rule suite is disproportionate for a repo this size.
+   _Open question: which of those become worth adding once there are external
+   contributors?_
 8. **Ignore-rule management (R32)**: ignore rules live in `.cdkrd/ignore.yaml` and
    can be hand-edited or appended by the `cdkrd ignore` verb (comment-preserving,
    append-only). _Open question: add a `cdkrd ignore --list` view to inspect the


### PR DESCRIPTION
Closes #1758

## Problem

`.markgate.yml` and `.claude/skills/check/SKILL.md` still described cdkrd as a
solo, **local-only** repo with **no GitHub remote and no PR workflow**. Both are
false: the repo has a remote, work lands through PRs (#1757 is the latest), and
`.claude/hooks/verify-pr-gate.sh` gates `gh pr create` / `gh pr merge`.

The most misleading instance was `verify-pr` being described as a
pre-**RELEASE** gate while the hook enforcing it is a pre-**PR** hook — exactly
the sort of thing that sends a future session to the wrong step.

## Beyond the two files the issue named

The claim had been copied, so a repo-wide grep turned up six more sites plus one
adjacent copy-paste bug. All are fixed here:

| File | Stale claim |
| --- | --- |
| `.markgate.yml` | `verify-pr` = "pre-RELEASE gate, not a PR gate"; `pr-review` = "N/A: cdkrd has no GitHub remote / PR review flow" |
| `.claude/skills/check/SKILL.md` | "there is no GitHub remote, no PR workflow" |
| `.claude/hooks/check-gate.sh` | "no GitHub remote yet ... this is the ONLY commit/merge gate wired up ... deferred until Phase 4 (when the repo gets a remote)" |
| `.claude/skills/check-docs/SKILL.md` | "(solo repo, no PR base)" on the change-detection step |
| `.claude/skills/verify-pr/SKILL.md` | "a **pre-release** readiness check, not a per-PR gate"; `git diff HEAD~5` for both its change-detection steps |
| `CLAUDE.md` | "`/verify-pr` → `verify-pr` marker (pre-RELEASE superset ...)" |
| `CONTRIBUTING.md` | "Developed solo on `main` for now; a public GitHub remote (and PR workflow) lands at Phase 4" |
| `docs/ARCHITECTURE.md` §13.7 | "Deliberately deferred until the repo has a remote (Phase 4): branch/PR/merge gates" |
| `.claude/hooks/branch-gate.sh` | header says "All changes to **cdkd** must land via PR" — wrong repo, copied |

Each replacement states what is actually true today rather than just deleting the
sentence:

- **`verify-pr`** is a pre-PR gate, and docs/tooling-only PRs (no `src/**`) are
  exempt — matching `verify-pr-gate.sh`'s own non-src exemption.
- **`pr-review`** stays INERT for the real reason: `/review-pr` dispatches
  multi-agent reviewers from `.claude/agents`, which cdkrd has not ported
  (CLAUDE.md R83). Not because there is no PR flow.
- **`check-gate.sh`** now lists the gates that ARE wired (branch-gate,
  verify-pr-gate, ci-green-gate, stale-base-gate, non-english-text-gate) and why
  pr-review / integ-\* remain unported.
- **`check-docs`** and **`verify-pr`** step 1/2/5 now use
  `git diff --name-only "$(git merge-base origin/main HEAD)"`, which reports this
  PR's own files including uncommitted ones. (`origin/main...` was tried first
  and rejected — it silently misses uncommitted work.)
- **`CONTRIBUTING.md`** additionally gains a "Before you open a PR" section: the
  file documented the commit gate but nothing about the PR-side gates it now
  tells contributors to use.
- **`.claude/skills/verify-pr/SKILL.md`** is the one the issue predicted would
  matter most — it told the reader the skill is "not a per-PR gate" while the
  hook of the same name blocks `gh pr create` / `gh pr merge`. It was found
  precisely because that gate fired on this PR. It now describes the gate it
  backs, plus the docs/tooling-only exemption.

## Out of scope (a different claim, deliberately not fixed here)

`CLAUDE.md:106`, `DESIGN.md` "Roadmap (private until Phase 4)" and
`docs/ARCHITECTURE.md` §14 / §11 still say the repo is **private and
unpublished**. That is also stale — the repo is public and `cdk-real-drift@0.26.1`
is on npm — but it is a *different* claim, and resolving it means deciding
whether Phase 4 counts as reached (it is defined as "publish + blog announce").
Filed separately rather than half-fixed here, which would leave `CLAUDE.md` and
`DESIGN.md` contradicting each other.

## Verification

Docs / tooling only — no `src/**`, so no runtime behavior changes.

| Check | Result |
| --- | --- |
| `vp run typecheck` | pass |
| `vp check --fix` | pass — 0 errors, 117 pre-existing warnings |
| `vp pack` | pass |
| `vp test run` | pass — 341 files, 6462 tests |
| `.claude/hooks/branch-gate.test.sh` | pass — 27/27 |
| `bash -n` on both edited hooks | pass |
| `verify-pr-gate.sh` exemption, 3 payload shapes | fires as documented |
| `markgate status` | `.markgate.yml` still parses; check + docs + verify-pr set |

Live-test, for a change whose "runtime" is the hook + skill + markgate layer:
`markgate status` confirms `.markgate.yml` still parses and the markers set;
`branch-gate.test.sh` passes 27/27; `bash -n` passes on both edited hooks; and
the `git diff --name-only "$(git merge-base origin/main HEAD)"` command this PR
puts into two skills was run and lists exactly this PR's files. The
docs/tooling-only exemption newly documented in `.markgate.yml`, `CLAUDE.md`,
`CONTRIBUTING.md` and the verify-pr skill was verified by feeding
`verify-pr-gate.sh` three payload shapes directly — it exempts this diff, and
fails closed when it cannot resolve the target worktree.

Real-AWS core integration suite: **deferred** — the diff touches no `src/**` and
nothing in the check/revert hot path, so there is no runtime behavior for it to
exercise. No AWS credentials were used and no resources created.

Note: `vp run check` aborts locally with exit 134 (`Vite+ panicked ... failed
printing to stdout: Resource temporarily unavailable`) while printing its warning
list. It reproduces identically on unmodified `main`, so it is pre-existing and
environment-specific, not from this branch — formatting passes on all 1463 files
and lint reports warnings only. Filed separately.
