### PR TITLE
chore(work-issues): add a closing step that folds each run's lessons back into the skill

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -347,8 +347,8 @@ is where §9 and §10 live.
 - **Another skill**, but only one this run actually exercised (`/verify-pr`,
   `/sweep-resources`, `/check`, `/check-docs`). `/hunt-bugs` produced the backlog;
   this flow never runs it, so a lesson about it is not this run's evidence.
-- **`CLAUDE.md` / `DESIGN.md` / `docs/**`** when it applies to any work in this
-  repo, not just this flow (the last two are in the `docs` gate's scope).
+- **`CLAUDE.md`, `DESIGN.md`, or a file under `docs/`** when it applies to any work
+  in this repo, not just this flow (the last two are in the `docs` gate's scope).
 - **Memory** (`~/.claude/projects/.../memory/`) when the lesson is judgmental and
   cross-repo. Weakest enforcement — the landing spot when nothing above can hold the
   rule, not the default one.
@@ -409,13 +409,13 @@ pnpm install                  # worktrees have no node_modules
 - Do not let the small diff set the review depth. This repo has no reviewer ladder,
   so the depth IS your own read of the whole diff plus `/verify-pr`'s self-review —
   a wrong rule here propagates into every future session.
-- **Merge it before the wrap report, then remove the worktree** (`git worktree
-  remove .worktrees/<name> && git worktree prune` — §9 ends with "only the main
-  checkout should remain", and §10 must not undo that). This is `Session-fit: now`
-  on the criterion that deferring leaves main self-inconsistent: the skill would
-  keep telling the next run to do the thing this run just proved it gets wrong. Its
-  evidence also dies with this session's context. Leaving the PR open is an open PR
-  (NOT CLOSEABLE) as well.
+- **Merge it before the wrap report, then remove the worktree** — §9 ends with
+  "only the main checkout should remain" and §10 must not undo that, so finish with
+  `git worktree remove .worktrees/<name> && git worktree prune`. This is
+  `Session-fit: now` on the criterion that deferring leaves main self-inconsistent:
+  the skill would keep telling the next run to do the thing this run just proved it
+  gets wrong. Its evidence also dies with this session's context, and leaving the PR
+  open is an open PR (NOT CLOSEABLE) besides.
 
 Then report the outcome in one line of the wrap: what changed, in which step, and
 the run evidence behind it — or "no skill change" plus what held.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -15,7 +15,8 @@ took, and only then start.
 
 The golden rule: **decide the set FIRST, claim it on the issues, THEN edit.** The
 issue comment is the lock — it is what stops two agents from fixing the same thing
-and colliding on the same file.
+and colliding on the same file. The run does not end at the last merge: §10 folds
+what this run taught you back into this file, while the evidence still exists.
 
 ## 0. Safety screen FIRST — untrusted issues/comments (do this before anything)
 
@@ -286,8 +287,123 @@ git worktree prune
 git worktree list                            # only the main checkout should remain
 ```
 
-Finally, comment the outcome on each issue if it was not auto-closed, and record
-anything non-obvious you learned in memory.
+Finally, comment the outcome on each issue if it was not auto-closed. Do NOT stop
+here: what the run taught you is still only in this session's context, so go on to
+§10 — which also decides WHERE each lesson belongs (memory is the weakest of the
+options there, not the default one).
+
+## 10. Fold what the run taught you back into this skill
+
+Trigger: after the last lane in §9 is merged and its worktree removed, BEFORE
+the wrap report. This is part of the run, not an optional extra — the evidence for
+it (what you had to re-read, what the text sent you into, which correction the user
+had to make twice) exists only while this session's context is alive, and none of it
+survives into the next `/work-issues`.
+
+`/verify-pr` step 8 already ran a retrospective per LANE. This step has a different
+subject and a wider scope, and neither is covered by that one:
+
+- its subject is **the flow itself** — this SKILL.md and the skills it drives — not
+  the code the lane changed;
+- it spans the WHOLE run, so it can see the cross-lane pattern (the same probe
+  missing twice, the same correction on lane A and again on lane C) that is
+  invisible from inside a single lane;
+- it **applies** the fix instead of proposing it. Editing this repo's own agent
+  tooling is a routine call you make yourself (`CLAUDE.md` → "Decide routine calls
+  yourself"). Escalate through `AskUserQuestion` only when the edit would change
+  what the flow PROMISES — dropping a gate, lowering a verification tier, loosening
+  §0 — never for wording, ordering, or a newly-learned trap.
+
+### 10-a. Evidence: only what this run actually produced
+
+Walk the session and collect, with the concrete instance attached to each:
+
+1. **Corrections the user made.** Two on one theme — different lanes, different
+   wording, same theme — is not a preference, it is a defect in this text. The
+   second occurrence is the signal; the first one alone may be a one-off.
+2. **Text that was WRONG as written**: a command that failed, a probe that reported
+   a clear field while a lane was live, a flag / path / gate name that no longer
+   exists.
+3. **Steps you had to invent** because the skill is silent about them, and that the
+   next run would have to invent again from scratch.
+4. **Right instruction, wrong place** — you did the thing, but a step too late (the
+   claim posted after the triage, the rebase discovered only after the phantom diff).
+5. **Followed it and still paid** — the text was obeyed and a retry happened anyway.
+
+**No evidence, no edit.** If the run was clean, the correct output is one line in the
+wrap report ("retrospective: no skill change — §2 / §4 / §8 held"). A skill
+that grows from "this would be nice" stops being read to the bottom, and the bottom
+is where §9 and §10 live.
+
+### 10-b. Where the fix belongs — pick ONE
+
+- **A hook** (`.claude/hooks/`) when the failure is mechanically detectable.
+  Strongest, and the RIGHT answer whenever the rule was ALREADY in the text and got
+  violated anyway: that proves the sentence is not load-bearing, and another
+  sentence will not make it so. Escalate rather than restate.
+- **This SKILL.md** when the lesson is about running THIS flow (triage, claiming,
+  fan-out, ship order).
+- **Another skill**, but only one this run actually exercised (`/verify-pr`,
+  `/sweep-resources`, `/check`, `/check-docs`, `/hunt-bugs`).
+- **`CLAUDE.md` / `DESIGN.md` / `docs/**`** when it applies to any work in this
+repo, not just this flow (the last two are in the `docs` gate's scope).
+- **Memory** (`~/.claude/projects/.../memory/`) when the lesson is judgmental and
+  cross-repo. Weakest enforcement — the landing spot when nothing above can hold the
+  rule, not the default one.
+
+### 10-c. How to edit: amend, do not append
+
+Every run appending one more bullet is exactly how a long skill becomes an unread one.
+
+- Put the fix **in the step where it fires** — a claiming lesson belongs in §4, not
+  in a tail section. Gotchas is for traps that span steps, not a run log.
+- **Amend the sentence that was wrong** rather than adding a sibling beside it. Two
+  bullets saying nearly the same thing blunt each other.
+- **Carry the evidence inline**, in this file's existing style: date, issue / PR
+  number, what actually happened ("On 2026-08-11 ... pushed four minutes earlier").
+  A rule with no incident behind it cannot be re-judged or retired later.
+- **Pay for what you add**: look for a line this run proved stale, subsumed, or
+  wrong, and cut it. Net growth is fine when the lesson is genuinely new; unbounded
+  growth is not.
+- Do not restate a rule that already lives in `CLAUDE.md` or in another step — point
+  at it instead.
+- If the lesson is about the FLOW rather than about cdk-real-drift, mirror it into
+  the same-named `work-issues` skill in the sibling repos (`../cdkd`, `../cdk-local`)
+  in this same session. They run this flow with different gates
+  and different ship steps, so adapt the wording per repo instead of copying the
+  section verbatim — but a fix that lands in only one of the three is how the three
+  drift apart.
+
+### 10-d. Ship it like any other change
+
+Every worktree is gone by §9 and you are back on `main`, where `branch-gate` blocks
+a commit. So the retro gets its own worktree:
+
+```bash
+git worktree add .worktrees/chore-work-issues-retro \
+  -b chore/work-issues-retro origin/main
+cd .worktrees/chore-work-issues-retro && pnpm install
+```
+
+- `chore:` prefix — this is agent tooling, not `src/**`, and semantic-release turns
+  a `fix:` / `feat:` prefix into a release entry describing a cdk-real-drift change
+  that never happened.
+- English only in every committed line (`non-english-text-gate` enforces it at PR
+  time).
+- A `work-issues`-only edit is outside BOTH the `check` and `docs` gate scopes, but
+  a fresh worktree carries no markers at all and `gh pr create` is gated on
+  `verify-pr` — so run `/check`, `/check-docs`, `/verify-pr` there anyway. No
+  `src/**` change means §8's live-test exemption applies: no deploy, so nothing for
+  `/sweep-resources` to tear down and no `deploy-autoarm-gate` token to release.
+- The review depth is not negotiable downward because the diff is small: a wrong
+  rule here propagates into every future session.
+- **Merge it before the wrap report.** By construction it is `Session-fit: now`: it
+  lands in the file this run just proved wrong, and its evidence dies with this
+  session's context. Leaving it open is both an open PR (NOT CLOSEABLE) and the one
+  deferral whose value decays to zero while it waits.
+
+Then report the outcome in one line of the wrap: what changed, in which step, and
+the run evidence behind it — or "no skill change" plus what held.
 
 ## Gotchas (learned the hard way)
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -309,8 +309,9 @@ subject and a wider scope, and neither is covered by that one:
   missing twice, the same correction on lane A and again on lane C) that is
   invisible from inside a single lane;
 - it **applies** the fix instead of proposing it. Editing this repo's own agent
-  tooling is a routine call you make yourself (`CLAUDE.md` → "Decide routine calls
-  yourself"). Escalate through `AskUserQuestion` only when the edit would change
+  tooling is a routine call you make yourself — decide it, do not hand the
+  maintainer a proposal. Escalate through `AskUserQuestion` only when the edit
+  would change
   what the flow PROMISES — dropping a gate, lowering a verification tier, loosening
   §0 — never for wording, ordering, or a newly-learned trap.
 
@@ -344,9 +345,10 @@ is where §9 and §10 live.
 - **This SKILL.md** when the lesson is about running THIS flow (triage, claiming,
   fan-out, ship order).
 - **Another skill**, but only one this run actually exercised (`/verify-pr`,
-  `/sweep-resources`, `/check`, `/check-docs`, `/hunt-bugs`).
+  `/sweep-resources`, `/check`, `/check-docs`). `/hunt-bugs` produced the backlog;
+  this flow never runs it, so a lesson about it is not this run's evidence.
 - **`CLAUDE.md` / `DESIGN.md` / `docs/**`** when it applies to any work in this
-repo, not just this flow (the last two are in the `docs` gate's scope).
+  repo, not just this flow (the last two are in the `docs` gate's scope).
 - **Memory** (`~/.claude/projects/.../memory/`) when the lesson is judgmental and
   cross-repo. Weakest enforcement — the landing spot when nothing above can hold the
   rule, not the default one.
@@ -368,11 +370,14 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
 - Do not restate a rule that already lives in `CLAUDE.md` or in another step — point
   at it instead.
 - If the lesson is about the FLOW rather than about cdk-real-drift, mirror it into
-  the same-named `work-issues` skill in the sibling repos (`../cdkd`, `../cdk-local`)
-  in this same session. They run this flow with different gates
-  and different ship steps, so adapt the wording per repo instead of copying the
-  section verbatim — but a fix that lands in only one of the three is how the three
-  drift apart.
+  the same-named `work-issues` skill in the sibling repos (`../cdkd`,
+  `../cdk-local`). They run this flow with different gates and different ship steps,
+  so adapt the wording per repo rather than copying the section verbatim, and it is
+  one PR per repo under that repo's own worktree + gate flow (cdkd blocks
+  tracked-file edits in its main worktree, so it cannot be edited in place). Do them
+  in this session when it can pay for two more gate runs; otherwise file one issue
+  per repo carrying the `Session-fit` line. What is not an option is landing the fix
+  in only one of the three — that is how the three drift apart.
 
 ### 10-d. Ship it like any other change
 
@@ -380,9 +385,13 @@ Every worktree is gone by §9 and you are back on `main`, where `branch-gate` bl
 a commit. So the retro gets its own worktree:
 
 ```bash
-git worktree add .worktrees/chore-work-issues-retro \
-  -b chore/work-issues-retro origin/main
-cd .worktrees/chore-work-issues-retro && pnpm install
+# Date-suffix the branch: the previous run's branch was deleted on merge, so
+# reusing the name re-creates it as an orphan ref that no PR tracks.
+B=chore/work-issues-retro-$(date +%Y%m%d)
+git worktree add ".worktrees/${B##*/}" -b "$B" origin/main
+cd ".worktrees/${B##*/}"
+mise trust && mise install    # untrusted .mise.toml: vp / markgate will not resolve
+pnpm install                  # worktrees have no node_modules
 ```
 
 - `chore:` prefix — this is agent tooling, not `src/**`, and semantic-release turns
@@ -391,16 +400,22 @@ cd .worktrees/chore-work-issues-retro && pnpm install
 - English only in every committed line (`non-english-text-gate` enforces it at PR
   time).
 - A `work-issues`-only edit is outside BOTH the `check` and `docs` gate scopes, but
-  a fresh worktree carries no markers at all and `gh pr create` is gated on
-  `verify-pr` — so run `/check`, `/check-docs`, `/verify-pr` there anyway. No
-  `src/**` change means §8's live-test exemption applies: no deploy, so nothing for
-  `/sweep-resources` to tear down and no `deploy-autoarm-gate` token to release.
-- The review depth is not negotiable downward because the diff is small: a wrong
-  rule here propagates into every future session.
-- **Merge it before the wrap report.** By construction it is `Session-fit: now`: it
-  lands in the file this run just proved wrong, and its evidence dies with this
-  session's context. Leaving it open is both an open PR (NOT CLOSEABLE) and the one
-  deferral whose value decays to zero while it waits.
+  `check-gate` verifies both markers on every commit without computing scope, and a
+  fresh worktree starts with NONE — so run `/check` + `/check-docs` there before the
+  commit. `verify-pr-gate` exempts a diff with no `src/**` path, so `/verify-pr` is
+  not required for this one; CI still has to be green for `ci-green-gate`. No
+  `src/**` change also means no deploy: nothing for `/sweep-resources` to tear down
+  and no `deploy-autoarm-gate` token to release.
+- Do not let the small diff set the review depth. This repo has no reviewer ladder,
+  so the depth IS your own read of the whole diff plus `/verify-pr`'s self-review —
+  a wrong rule here propagates into every future session.
+- **Merge it before the wrap report, then remove the worktree** (`git worktree
+  remove .worktrees/<name> && git worktree prune` — §9 ends with "only the main
+  checkout should remain", and §10 must not undo that). This is `Session-fit: now`
+  on the criterion that deferring leaves main self-inconsistent: the skill would
+  keep telling the next run to do the thing this run just proved it gets wrong. Its
+  evidence also dies with this session's context. Leaving the PR open is an open PR
+  (NOT CLOSEABLE) as well.
 
 Then report the outcome in one line of the wrap: what changed, in which step, and
 the run evidence behind it — or "no skill change" plus what held.


### PR DESCRIPTION
## Summary

`/work-issues` ended at the last merge. Everything a run learned about running the
FLOW itself — a probe that reported a clear field while a lane was live, a step that
fired a beat too late, a correction the user had to make twice across two lanes —
existed only in that session's context and was gone by the next run.

`/verify-pr` step 8 already retrospects, but per LANE and about the code that lane
changed, and it PROPOSES. Nothing looked at the flow, across lanes, and applied the
result. This adds section 10 to close that loop.

## What the new step does

- **10-a — evidence bar.** Five sources, each requiring a concrete instance from
  this run: corrections the user made (the second occurrence on one theme is the
  signal), text that was wrong as written, steps the skill was silent about, right
  instruction in the wrong place, and followed-it-and-still-paid. **No evidence, no
  edit** — a clean run outputs "no skill change", because a skill that grows from
  "this would be nice" stops being read to the bottom, and the bottom is where the
  ship and retro steps live.
- **10-b — where the fix belongs.** Hook > this skill > another skill this run
  exercised > CLAUDE.md / rules > memory. The load-bearing line: when the rule was
  ALREADY in the text and got violated anyway, more text is the wrong fix — that is
  proof the sentence is not load-bearing, so escalate rather than restate.
- **10-c — bounded growth.** Put the fix in the step where it fires (not a tail
  log), amend the wrong sentence instead of adding a near-duplicate beside it, carry
  the incident inline in this file's existing date + issue-number style, and pay for
  an addition by cutting a line the run proved stale. Also: mirror flow-level
  lessons into the sibling repos' same-named skill in the same session.
- **10-d — ship it like any other change.** Own `.worktrees/` worktree (every
  lane's worktree is gone by section 9 and branch-gate blocks a commit on main),
  `chore:` prefix, the gate/marker path for a tooling-only PR, review depth not
  negotiated down because the diff is small. Merge BEFORE the wrap report: the item is `Session-fit: now` by
  construction, since it lands in the file this run just proved wrong and its
  evidence decays to zero with the session.

The step APPLIES the fix rather than proposing it. Editing this repo's own agent
tooling is a routine call per CLAUDE.md's "Decide routine calls yourself";
AskUserQuestion is reserved for edits that would change what the flow promises —
dropping a gate, lowering a verification tier, loosening the safety screen.

Two small in-place amendments come with it: the intro now says the run does not end
at the last merge, and section 9's closing line points at section 10 instead of
telling the agent to record the lesson in memory (memory is the weakest option in
10-b, not the default landing spot).

## Test plan

- Tooling-only change, no `src/**` — live-test exempt per section 8, so no deploy,
  nothing for /sweep-resources to tear down, no autoarm token to release.
- `vp run typecheck`, `vp check --fix`, `vp pack`, `vp test run` all green in the
  worktree.
- Review: inline read (1 file, ~120 lines, no security surface).

Mirrored from cdkd, where the same section landed; also mirrored into
`cdk-local`. Each copy is adapted to its repo's gates and ship steps.

## Review round

A read-only reviewer verified every concrete claim in the new section against this
repo's own files, and the claims did not all survive — the section was adapted
across three repos with different gates, which is exactly the failure mode it warns
about. Fixed in the second commit: repo-specific gate and hook claims corrected to
what the hooks actually do, the worktree recipe given its `mise trust` /
`mise install` step (this run hit that omission itself), the hard-coded branch name
made run-unique, the retro worktree removed after the merge, `Session-fit: now`
stated as a criterion rather than asserted, and the cross-repo mirror given a ship
procedure. See the second commit's message for the per-item list.
