### PR TITLE
chore(work-issues): rank security issues first, and require a per-repo claim check when mirroring

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -378,6 +378,18 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   in this session when it can pay for two more gate runs; otherwise file one issue
   per repo carrying the `Session-fit` line. What is not an option is landing the fix
   in only one of the three — that is how the three drift apart.
+  **Verify the copy against the TARGET repo, claim by claim, before shipping it.**
+  Their gates, hooks and ship steps differ, so a sentence that is true here reads as
+  authoritative there while being false, and nothing lints instruction prose — the
+  next agent simply acts on it. On 2026-08-18 the first mirror of this section
+  carried four such claims: a `verify-pr` gate that exempts a non-`src/**` diff, a
+  review heuristic that still down-biases `.claude/**`, a `CLAUDE.md` rule the
+  sibling does not carry, and a hook it does not ship. A read-only reviewer per
+  target repo — its only job being to check each gate name, hook behavior, skill
+  name, path convention and cross-reference against that repo's own files — is what
+  caught them. Checking in the rule here rather than in agent memory is deliberate:
+  memory is per-project-path and per-machine, so it would not load in the very repos
+  this bullet sends you to.
 
 ### 10-d. Ship it like any other change
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -106,6 +106,16 @@ parallelized — bundle them into ONE lane (one worktree, one PR) or defer one.
 **At most one lane per central table.** Map each candidate to its target file
 (grep the relevant table name; read the issue's "Fix direction") before choosing.
 
+- **Security issues come FIRST**, ahead of every other preference on this list. A
+  security defect is the one class whose cost grows while it waits: the vulnerable
+  behavior is already shipped and running, and the report may be public. It counts
+  as security when the issue reports credential / secret handling, redaction or
+  masking, a sensitive value persisted or logged (state, journal, events, reports),
+  IAM / role-assumption scope, auth or token verification, command injection, or
+  anything tied to a GHSA advisory. When in doubt, treat it as security — ranking a
+  normal bug first costs one position in a queue. Urgency changes ORDER only: a
+  security lane gets the same verification depth as any other, plus a deliberate
+  read of every place the sensitive value flows.
 - Same file, related class → **bundle** into a single lane/PR (e.g. two
   `revert/plan.ts` fixes → one PR "Subnet set-default + Lambda husk (#651, #650)").
 - Different files → separate parallel lanes.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -110,8 +110,10 @@ parallelized — bundle them into ONE lane (one worktree, one PR) or defer one.
   security defect is the one class whose cost grows while it waits: the vulnerable
   behavior is already shipped and running, and the report may be public. It counts
   as security when the issue reports credential / secret handling, redaction or
-  masking, a sensitive value persisted or logged (state, journal, events, reports),
-  IAM / role-assumption scope, auth or token verification, command injection, or
+  masking, a sensitive value persisted or logged (the baseline file
+  `src/baseline/baseline-file.ts` or report output — `src/report/redact.ts` is the
+  file this rule is most often about), IAM / role-assumption scope, command
+  injection, or
   anything tied to a GHSA advisory. When in doubt, treat it as security — ranking a
   normal bug first costs one position in a queue. Urgency changes ORDER only: a
   security lane gets the same verification depth as any other, plus a deliberate


### PR DESCRIPTION
## Summary

The section-10 mirror bullet told the next agent to "adapt the wording per repo",
which reads as an editing note. What actually happened when this section was first
mirrored across the three repos is stronger than that: four claims travelled as
authoritative statements that are FALSE in the target repo —

- a `verify-pr` gate that exempts a diff with no `src/**` path (true in one repo, not the others),
- a review-tier heuristic that still down-biases `.claude/**`,
- a `CLAUDE.md` rule the sibling repo does not carry (a dangling pointer),
- a hook named as the reason for a step that the sibling does not ship.

Nothing type-checks instruction prose and the markdown lints clean, so the failure
is silent: the next agent reads the claim and acts on it.

## What changes

One clause in 10-c's mirror bullet: verify the copy against the TARGET repo claim
by claim before shipping it, with the check that actually caught these — a
read-only reviewer per target repo whose only job is to walk each gate name, hook
behavior, skill name, path convention and cross-reference against that repo's own
files.

It also records WHY the rule is checked in rather than kept in agent memory: memory
is per-project-path and per-machine, so a note written in one repo's memory does not
load in the repos this bullet sends you to. Git is the only carrier that crosses
both.

## Test plan

- Tooling-only change, no `src/**`.
- Local quality checks green in the worktree.
- Review: inline read (1 file, 12 added lines).

Landing the same clause in all three repos (cdkd, cdk-local, cdk-real-drift), per
the bullet it amends.


## Also in this PR: security issues rank first

The pick step ordered candidates by how much value a fix adds (type, then area,
then file isolation, then age). A security defect does not sit on that axis — the
vulnerable behavior is already shipped and running in users' accounts and the
report may be public, so its cost grows while it waits instead of staying flat. It
now sorts ahead of every other rule, with its own detection list (credential /
secret handling, redaction or masking, a sensitive value persisted or logged, IAM /
role-assumption scope, auth or token verification, command injection, GHSA-tied
reports, plus the paths the security reviewer covers) and an instruction to treat
ambiguous cases as security.

Two interactions are spelled out because they read the other way otherwise: a
security issue that is ALSO an umbrella gets split and started, not deferred by the
umbrella-last rule; and urgency never buys a shortcut — the lane keeps the review
tier its size gives, adds the security reviewer, and runs the same verification as
any other lane.

The same change lands in all three repos' copies of this skill.
