### PR TITLE
docs: the repo is public and on npm, not private and unpublished

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,13 @@ node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to
 
 ## State of the Repo
 
-- **Pre-release / experimental.** Private until Phase 4; not yet published. Remote:
-  <https://github.com/go-to-k/cdk-real-drift> (developed solo, PR-based).
+- **Pre-release / experimental** (pre-1.0), but public and shipping: the repo is
+  public at <https://github.com/go-to-k/cdk-real-drift> (developed solo, PR-based)
+  and ships to npm as
+  [`cdk-real-drift`](https://www.npmjs.com/package/cdk-real-drift) — semantic-release
+  cuts a version on every `feat` / `fix` / `perf` / `revert` merge to `main`
+  (`docs` / `chore` merges do not release). Changes reach real users, so weigh
+  breaking ones accordingly.
 - Baseline files live at `.cdkrd/baselines/<stack>.<accountId>.<region>.json` — git-committed.
   A PR that changes a baseline is a visible, reviewable change to "what real state
   we record".

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -131,10 +131,16 @@ NEW (cdkd does NOT have these):
   real drift); it only names the likely source in a readable trailing line.
 - **golden corpus** — recorded real pipeline inputs+findings, replayed offline in CI (R63)
 
-## Roadmap (private until Phase 4)
+## Roadmap
 
-- Phase 2: build MVP here (private repo). DONE.
+> The repo is already public and on npm — see the Phase 4 entry for what the
+> "single public launch" still refers to.
+
+- Phase 2: build MVP here (the repo was private then). DONE.
 - Phase 3 (current): dogfood broadly on varied real stacks; tune normalizers;
   land revert. See [redesign-notes.md](redesign-notes.md) for the
   check/record/ignore/revert model adopted before publication.
-- Phase 4: publish + blog announce (the single public launch).
+- Phase 4: publish + blog announce (the single public launch). The publish half
+  has HAPPENED — the repo is public and `cdk-real-drift` has been on npm since
+  `0.0.1` (2026-07-06). The blog announce is the part still outstanding; whether
+  that makes Phase 4 "reached" is a call this doc does not make.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1024,9 +1024,12 @@ a correctly-named file always matches, so it now only catches a file hand-copied
 renamed to the wrong account's path (exit 2). A pre-release file with no `accountId`
 field only warns and is stamped on the next `record`.
 
-> No legacy-path fallback: cdkrd is pre-release (unpublished), so the only old-style
-> `<stack>.<region>.json` files are local dogfood artifacts. They are simply not found
-> under the new path (→ "no baseline", run `record`); delete them after re-recording.
+> No legacy-path fallback: the accountId-in-filename layout (R21) landed 2026-06-11,
+> almost a month BEFORE the first npm release (`0.0.1`, 2026-07-06), so no published
+> version of cdkrd ever wrote an old-style `<stack>.<region>.json` file — the only
+> ones that exist are local dogfood artifacts from before that commit. They are
+> simply not found under the new path (→ "no baseline", run `record`); delete them
+> after re-recording.
 
 When a baseline already exists, the interactive `record` multiselect shows only the
 **delta** from it (`splitRecordedByBaseline`) — new/changed undeclared values, where
@@ -1449,10 +1452,13 @@ declared-only `--pre-deploy`, and selective `record`.
 
 Repo hygiene (CLAUDE.md, CONTRIBUTING.md, check-gate hook, CI) is in place too.
 
-REMAINING before the single public launch (GitHub + npm + blog), none of which is a
-code-correctness blocker:
+DONE since this section was written: the public GitHub repo exists and is pushed,
+and publishing is automated — semantic-release runs `npm publish` on every
+release-triggering merge to `main` (`cdk-real-drift` has been on npm since
+`0.0.1`, 2026-07-06).
+
+REMAINING, neither of which is a code-correctness blocker:
 
 - the design-review re-review of this fix pass → address any blocking findings.
-- create the public GitHub repo + push, then `npm publish`, then the blog announce.
-  These three are the deliberate, irreversible "single launch" event and are done
-  last, on explicit go.
+- the blog announce — the last of the three "single launch" steps, done on
+  explicit go.

--- a/docs/redesign-notes.md
+++ b/docs/redesign-notes.md
@@ -1,7 +1,12 @@
 # Pre-publication redesign decisions (2026-06-11)
 
-The repo is not published yet, so breaking changes the final tool needs are made
-now. Target = "detect drift INCLUDING undeclared CloudFormation properties, AND
+> Historical record of decisions taken on 2026-06-11, kept for their rationale.
+> The window it describes is CLOSED: cdkrd has been published on npm since
+> `0.0.1` (2026-07-06), so breaking changes now affect real users and no longer
+> get made freely.
+
+At the time, the repo was not published yet, so breaking changes the final tool
+needed were made then. Target = "detect drift INCLUDING undeclared CloudFormation properties, AND
 revert it, as an effortless / friendly CLI."
 
 ## Decision 1 — three-verb model: check / record / revert


### PR DESCRIPTION
Closes #1760

Follow-on to (#1759), which fixed the "no GitHub remote / no PR flow" claim
class. This one fixes the adjacent class: docs still describing the repo as
**private and unpublished**.

## The facts this is measured against

- `gh repo view --json isPrivate,visibility` -> `PUBLIC`, `isPrivate=false`
- `npm view cdk-real-drift` -> first publish `0.0.1` on **2026-07-06**, latest
  `0.26.1`, `repository.url` pointing at this repo
- `.releaserc.json` -> `@semantic-release/npm` with `npmPublish: true`, on pushes
  to `main`

## Scope: the factual half only

Where a sentence fused a verifiable fact with a roadmap judgment, it is **split**
— the factual half corrected, the judgment left visibly open. In particular this
PR does **not** decide whether Phase 4 (defined as "publish + blog announce") has
been *reached*: publishing demonstrably has happened, the blog announce is not
something I can verify, and that call is the maintainer's.

## Fixed

| Site | Was | Now |
| --- | --- | --- |
| `CLAUDE.md` "State of the Repo" | "Private until Phase 4; not yet published" | public + on npm, and which merge types actually release |
| `DESIGN.md` heading | "## Roadmap (private until Phase 4)" — asserts private *now* | "## Roadmap" + a note that the repo is already public and on npm |
| `DESIGN.md` Phase 4 entry | "publish + blog announce" as wholly future | publish half recorded as DONE with the date; blog announce still open; phase status explicitly not decided |
| `docs/ARCHITECTURE.md` §11 | "cdkrd is pre-release (unpublished), so the only old-style files are local dogfood artifacts" | same conclusion, true premise (below) |
| `docs/ARCHITECTURE.md` §14 | "REMAINING ... create the public GitHub repo + push, then `npm publish`, then the blog announce" | those two moved to DONE; only the blog announce remains |
| `docs/redesign-notes.md` | "The repo is not published yet, so breaking changes ... are made now" | tensed to its 2026-06-11 context + a note that the window is CLOSED |

**§11 is the one worth reading closely.** Its conclusion ("the only old-style
`<stack>.<region>.json` baselines are local dogfood artifacts") was resting on a
premise that is now false. Rather than delete the claim or wave at it, I checked
whether the conclusion survives: the accountId-in-filename layout (R21,
`ecdc87a`) landed **2026-06-11**, roughly four weeks BEFORE the first npm release
(`0.0.1`, 2026-07-06). So no published version of cdkrd ever wrote an old-style
baseline, and the "no legacy-path fallback" decision is still sound — for a
reason that stays true as the repo ages. The rewrite states that reason.

`docs/redesign-notes.md` was beyond the three files the issue named. It matters
more than its size suggests: read today, "the repo is not published yet, so
breaking changes ... are made now" is a standing licence to break compatibility
for real npm users.

## Deliberately left alone

- `DESIGN.md` "Phase 3 (current)", and `docs/ARCHITECTURE.md` §1 / §13's "before
  the Phase 4 public launch" framing — roadmap judgments, not factual claims
  about the repo's current visibility.
- `DESIGN.md` "Phase 2: build MVP here (the repo was private then). DONE." — a
  historical statement, now explicitly tensed.
- `CONTRIBUTING.md` "pre-release / experimental" — accurate at `0.26.1` (pre-1.0).
- `docs/ARCHITECTURE.md` §11's "A **pre-release file** with no `accountId` field"
  and the matching comment in `src/baseline/baseline-file.ts` — these describe a
  baseline FILE written by an early version, not the repo's publish status.
  Different subject; no change.

Nothing was found that I could not settle from evidence.

## Verification

Docs only — no `src/**`, no runtime behavior change.

| Check | Result |
| --- | --- |
| `vp run typecheck` | pass |
| `vp check --fix` | pass — 0 errors, 117 pre-existing warnings |
| `vp pack` | pass |
| `vp test run` | pass — 341 files, 6462 tests |

Every factual assertion added by this PR was verified against its source rather
than asserted: repo visibility via `gh repo view`, publish date and version via
`npm view`, the release trigger via `.releaserc.json`, and the R21 landing date
via `git log`. That last check caught an overstatement in my own first draft — I
had written that *every* merge auto-publishes, but `releaseRules` only cuts a
version for `feat` / `fix` / `perf` / `revert`, so a `docs` merge (this one
included) publishes nothing. Corrected in both places it appeared.
