### PR TITLE
chore(dx): make `vp run check` survive the Vite+ stdout panic (exit 134)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
       # I/O, so the EAGAIN that triggers the panic never happens; the warnings are captured
       # but only surfaced when the check actually fails. `vp check` still exits non-zero on a
       # real lint/format ERROR, which we propagate. (Upstream Vite+ stdout-panic bug — the
-      # tool itself prints "This is a bug in Vite+, not your code".)
+      # tool itself prints "This is a bug in Vite+, not your code".) The same panic hit
+      # `vp run check` LOCALLY (exit 134 on a clean tree, #1761), so the `check` run-task in
+      # vite.config.ts now applies this identical redirect — keep the two in sync.
       - run: vp check >vpcheck.log 2>&1 || { cat vpcheck.log; exit 1; }
       # Build BEFORE test: tests/json-empty-on-error.test.ts (#943/#988/#989) spawns the
       # built `dist/cli.js` end to end, so `dist/` must exist when `vp run test` runs. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,13 @@ vp check --fix     # lint + format (oxc), with auto-fix
 vp run check       # lint + format check (what CI runs)
 ```
 
+`vp run check` captures the checker's output to `node_modules/.cache/vpcheck.log`
+and prints it only when the check FAILS, so a quiet run means **0 errors** — run
+`vp check` directly to read the advisory warning list. The redirect works around an
+upstream Vite+ panic that otherwise aborted the task with exit 134 on a clean tree
+([#1761](https://github.com/go-to-k/cdk-real-drift/issues/1761)); CI applies the same
+workaround.
+
 `node dist/cli.js` runs the built CLI, so **run `vp run build` after source
 changes** before testing manually. Integration tests (real AWS, self-cleaning)
 live under `tests/integration/` — see

--- a/tests/vp-run-check-redirect-1761.test.ts
+++ b/tests/vp-run-check-redirect-1761.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vite-plus/test';
+import config from '../vite.config.js';
+
+/**
+ * #1761 — `vp run check` aborted with exit 134 ("Vite+ panicked … failed printing to
+ * stdout: Resource temporarily unavailable") on a tree with 0 lint/format ERRORS,
+ * because the Rust oxc binary cannot write its large output to the NON-BLOCKING pipe
+ * `vp run` gives a task. The fix redirects that output to a file and prints it only on
+ * failure — the same workaround `.github/workflows/ci.yml` already applies.
+ *
+ * This guards the shape of the workaround: a "simplification" back to a bare
+ * `vp check` re-introduces the abort, and dropping the unconditional `exit 1` would
+ * make a REAL lint/format error exit 0 (a green gate on a red tree).
+ */
+describe('vite.config.ts: the `check` run-task avoids the Vite+ stdout panic (#1761)', () => {
+  const command = (config as { run: { tasks: Record<string, { command: string }> } }).run.tasks
+    .check.command;
+
+  it('redirects `vp check` output to a file instead of the run-task pipe', () => {
+    expect(command).toMatch(/vp check\s+>\S*vpcheck\.log\s+2>&1/);
+    expect(command).not.toMatch(/^\s*vp check\s*$/);
+  });
+
+  it('keeps the log out of the working tree so `git add -A` cannot sweep it up', () => {
+    expect(command).toContain('node_modules/');
+  });
+
+  it('still fails the task on a real lint/format error, printing the captured output', () => {
+    expect(command).toContain('cat ');
+    expect(command).toContain('exit 1');
+  });
+
+  it('creates the log directory first (a fresh worktree has no node_modules/.cache)', () => {
+    expect(command).toMatch(/^mkdir -p node_modules\/\.cache &&/);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,30 @@ const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8'))
 };
 const sourceOnlyIgnorePatterns = ['**/*', '!src', '!src/**'];
 
+// `vp run check` sends `vp check`'s output to a redirect FILE instead of letting it
+// write straight to the run-task pipe, and prints it only when the check FAILS.
+// The Rust oxc binary PANICS mid-write once its output gets large — "failed printing
+// to stdout: Resource temporarily unavailable" (os error 11 on Linux, 35 on macOS) —
+// aborting the task with exit 134 even though the check itself finds 0 ERRORS. `vp run`
+// hands a task a NON-BLOCKING stdout pipe, so a large write hits EAGAIN; a regular file
+// is blocking I/O and never does. #1761: reproduced 3/3 on a clean `main` at ~117
+// warnings, while `vp run lint` (longer output, but not the combined lint+format path)
+// did NOT panic — hence the workaround is scoped to `check`.
+// `.github/workflows/ci.yml` applies the same trick for the same reason; keep the two in
+// sync. The `exit 1` is unconditional, so a real lint/format ERROR still surfaces (with
+// the full captured output) and still exits non-zero. On success nothing is printed —
+// run `vp check` directly to read the advisory warning list.
+// The log lives under `node_modules/` so it can never be swept into a commit by
+// `git add -A`; the task does not cache either way (vite's own
+// `node_modules/.vite-temp/vite.config.ts.timestamp-*.mjs` already makes every `vp run`
+// task here a cache miss).
+const checkLogDir = 'node_modules/.cache';
+const checkLog = `${checkLogDir}/vpcheck.log`;
+const checkCommand = [
+  `mkdir -p ${checkLogDir}`,
+  `vp check >${checkLog} 2>&1 || { cat ${checkLog}; exit 1; }`,
+].join(' && ');
+
 export default defineConfig({
   staged: {
     '*': 'vp check --fix',
@@ -118,7 +142,7 @@ export default defineConfig({
     tasks: {
       build: { command: 'vp pack', cache: false },
       dev: { command: 'vp pack --watch', cache: false },
-      check: { command: 'vp check' },
+      check: { command: checkCommand },
       test: { command: 'vp test run' },
       'test:watch': { command: 'vp test watch', cache: false },
       'test:coverage': { command: 'vp test run --coverage', cache: false },


### PR DESCRIPTION
Closes #1761.

## Problem

`vp run check` — the command `CONTRIBUTING.md` and the `check` skill point
contributors at — aborts on a clean `main`:

```
$ vp run check
pass: All 1463 files are correctly formatted (550ms, 15 threads)
warn: Lint or type warnings found
Vite+ panicked. This is a bug in Vite+, not your code.
thread '<unnamed>' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Resource temporarily unavailable (os error 35)
[rc=134]
```

The Rust oxc binary cannot write its ~1000-line output to the **non-blocking**
stdout pipe `vp run` hands a task, so a large write hits `EAGAIN` and panics —
even though the check itself finds **0 errors** (117 advisory warnings).
`.github/workflows/ci.yml` already documents and works around exactly this
(`os error 11` on Linux; macOS reports the same condition as `os error 35`), but
the run-task did not — so the documented local command trained everyone to ignore
a non-zero exit from a lint command, which is the habit that lets a real failure
through.

## Fix

Issue direction **(1)**: apply CI's redirect to the `check` run-task itself, so the
docs stay true instead of documenting an exception.

- **`vite.config.ts`** — `check` now runs
  `mkdir -p node_modules/.cache && vp check >node_modules/.cache/vpcheck.log 2>&1 || { cat <log>; exit 1; }`.
  A regular file is blocking I/O, so the `EAGAIN` never happens. The log lives under
  `node_modules/` so `git add -A` can never sweep it up, and the `mkdir -p` covers a
  fresh worktree. The `exit 1` is **unconditional**, so a real lint/format ERROR still
  surfaces (with the full captured output) and still exits non-zero.
- **`.github/workflows/ci.yml`** — cross-reference the two copies of the workaround so
  they stay in sync.
- **`CONTRIBUTING.md`** — a quiet run means 0 errors; run `vp check` directly to read
  the advisory warning list.
- **`tests/vp-run-check-redirect-1761.test.ts`** — guards the shape of the workaround.
  A "simplification" back to a bare `vp check` re-introduces the abort, and dropping the
  `exit 1` would make a real error exit 0 (a green gate on a red tree).

Scoped to `check` deliberately: `vp run lint`, whose output is even longer (1090 lines),
does **not** panic — only the combined lint+format path does.

## Verification (both directions)

| | before | after |
| --- | --- | --- |
| `vp run check` on a clean tree | exit **134**, 3/3 | exit **0**, 3/3 |
| `vp run check` with a deliberate `no-unused-vars` error in `src/` | exit 134 | exit **1**, all 1106 lines of captured output printed |
| `tests/vp-run-check-redirect-1761.test.ts` | 4/4 **fail** | 4/4 **pass** |

Gates: `vp run typecheck` pass · `vp check --fix` pass (0 errors, 117 warnings) ·
`vp pack` pass · `vp test run` 342 files / 6466 tests pass.

No `src/**` in the diff, so `verify-pr-gate` exempts this one (`check` + `docs`
markers cover it) and there is nothing to live-test.
