### PR TITLE
chore(work-issues): add the no-src verification tier, and record the `vite-plus/test` import convention

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -221,6 +221,17 @@ Run `/verify-pr`. Its live-test rules decide how each PR is verified:
   live data. If it is pinned by `vp test run corpus-replay` AND was live-proven in
   its originating hunt (the issue carries the real repro), that IS the live
   evidence — no fresh deploy. State the deferral explicitly.
+- **toolchain / CI / skill fix (no `src/**`in the diff)** → there is no live-test
+tier and no corpus, so the verification IS the broken command itself: run it
+REPEATEDLY (3–5×) both BEFORE and AFTER, and drive the FAILURE direction too by
+injecting a real error (e.g. an unused variable for a`no-unused-vars`gate) to
+prove the fix did not turn a red tree green. One run is not evidence — on #1761
+the`check`gate flipped rc=0/rc=1 across identical runs (the tsgolint
+budget-cascade artifact), so a single green would have "proved" either verdict.
+Then guard the SHAPE of the fix with a unit test on the config object, since
+nothing else re-checks a build-config line.`verify-pr-gate`exempts a diff with
+no`src/\*\*`, so `/verify-pr` is not required — that is an exemption from the LIVE
+  test, not from verifying.
 - **revert / read HOT-PATH fix** → live-verify with a MINIMAL, UNIQUE-named
   fixture: deploy → mutate out of band → `check` detects → `revert --yes`
   converges → confirm the live value. A throwaway CDK app works:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,18 @@ source changes before telling the user to test.
   invoked via `vp run <task>` — prefer this over ad-hoc `node` invocations or
   `package.json` "scripts".
 
+- **Test files import from `vite-plus/test`, not `vitest`** — all 342 of them do.
+  `vitest` is not a dependency and is not present in `node_modules` at all (Vite+
+  aliases it at test RUNTIME, so the suite still passes), but the type-aware oxc
+  lint resolves it against `tests/tsconfig.json` and fails the `check` gate with
+  `TS2307: Cannot find module 'vitest'`. A new test written the habitual way looks
+  green under `vp test run` and only breaks a gate cycle later (PR #1765):
+
+  ```typescript
+  import { describe, expect, it, vi } from 'vite-plus/test'; // correct
+  import { describe, expect, it, vi } from 'vitest'; // wrong — TS2307 at lint time
+  ```
+
 ## Architecture (src layout)
 
 Terse per-dir map — defer to [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the


### PR DESCRIPTION
`/work-issues` §10 retrospective for the #1761 / #1765 run. Two evidence-backed
amendments, no net-new sections.

## 1. `.claude/skills/work-issues/SKILL.md` §8 — the missing verification tier

§8 listed only the live-test tiers (fold/FP → corpus; revert/read → live fixture),
so an issue whose fix has **no `src/**` in the diff** fell through it entirely.
`verify-pr-gate` *exempts* that diff shape, which reads as "nothing to verify" —
but that is an exemption from the LIVE test, not from verifying.

Evidence (#1761): the fix is one line of build config. "It works now" from a single
run would have been the natural verification and would have been wrong twice over:

- the `check` gate flipped **rc=0 / rc=1 across identical runs on the same tree**
  (the tsgolint budget-cascade artifact) — a single green proves nothing;
- a config change that swallows the exit code turns a red tree green, which only
  the FAILURE direction catches (injecting a real `no-unused-vars` error).

So the new bullet asks for: 3–5× before and after, the failure direction driven
deliberately, and a unit test on the config object — because nothing else in the
repo re-checks a build-config line.

## 2. `CLAUDE.md` — test files import from `vite-plus/test`, not `vitest`

All 342 test files do, and `vitest` is absent from `node_modules` entirely. Vite+
aliases it at test RUNTIME, so a `vitest` import **passes `vp test run`** and only
fails later in the type-aware lint with `TS2307: Cannot find module 'vitest'`.
That is a trap shaped to be found late: it cost a full `vp check --fix` cycle in
#1765, and nothing in the repo stated the convention.

## Mirroring (§10-c)

Not mirrored to `../cdkd` / `../cdk-local` in this session. The new §8 bullet
carries repo-specific claims (gate names, the tsgolint artifact, the lint rule used
to inject the failure) that §10-c requires verifying against each target repo
first — the failure mode that section itself records from 2026-08-18. Filed as one
issue per repo instead, each carrying the `Session-fit` line:
go-to-k/cdkd#1973 and go-to-k/cdk-local#504.

## Gates

`vp run typecheck` pass · `vp check --fix` pass (0 errors, 117 warnings) ·
`vp pack` pass · `vp test run` 342 files / 6466 tests pass. No `src/**` in the
diff, so `verify-pr-gate` exempts it and there is nothing to live-test.
