### PR TITLE
chore(work-issues): mirror the both-directions list audit + existing-harness check into §5

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -157,6 +157,30 @@ Do the fix in the worktree (match the existing table/entry pattern exactly; ESM
 relative imports need the `.js` extension). **Always add a unit test that fails
 without the fix and passes with it** — for a fold/FP fix use the issue's exact
 harvested live model; for revert, assert the update document / patch op.
+**Check first whether the artifact already has a harness**, because the obvious
+place is usually the wrong one: fold-table entries are already covered generically
+(`tests/classify.test.ts`, "EVERY entry FOLDS its exact default value"), and hook
+behavior by standalone `.claude/hooks/*.test.sh` suites you run BY HAND (`bash
+.claude/hooks/<name>.test.sh` from the repo root) — nothing in `vp test run` or CI
+invokes those, so a hook change resting on a green suite plus green CI is not
+verified at all. Extend the harness that exists before writing a new one beside it.
+
+**When the issue reports a stale ENTRY in an enumerated list, audit the whole list,
+in BOTH directions, before fixing the named entry.** The defect class is "this list
+drifted from the repo", and drift almost never produces exactly the one instance
+someone happened to notice. Check both that every entry still resolves to something
+real AND that everything that belongs is present — the second half is the one that
+gets skipped, because the issue only names the first. The evidence is cross-repo:
+on 2026-08-19 cdkd#1972 reported one dead path in a security-surface path list; the
+audit found a second dead path (stale since an unrelated directory rename) plus four
+live authn / credential / exec surfaces never added, so the list under-protected
+considerably more than it over-claimed. Then ask what makes the recurrence
+mechanical: a list that must stay in sync with the repo is a TEST, not a sentence
+asking the next reader to remember. Both audits above are that shape, and #1767 —
+the mirror of this very lesson, whose source wording pointed at a unit-test
+directory this repo does not have — added `tests/skill-doc-paths.test.ts`, which
+asserts every repo path a SKILL.md cites still resolves. It caught that class on
+its first run, against this paragraph's own draft.
 
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an

--- a/tests/skill-doc-paths.test.ts
+++ b/tests/skill-doc-paths.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+// Guard against a skill doc citing a repo path that does not exist.
+//
+// `.claude/skills/**/SKILL.md` is instruction prose an agent ACTS on, and nothing
+// lints it: a stale `src/…` path or a `tests/unit/**` that this repo never had
+// sends the next session to a directory that is not there, and the mistake is only
+// found by a human reading the run afterwards. #1767 mirrored a lesson from the
+// sibling repo whose wording named `tests/unit/**` — a real path THERE, absent
+// here — which is exactly this failure and exactly what this test now catches.
+//
+// SCOPE (deliberately narrow, zero false positives on the current tree): only
+// inline-code spans whose FIRST segment is a real top-level entry of this repo are
+// treated as path citations, so `npm i <pkg>`, `key=value`, URLs and prose in
+// backticks are left alone. Placeholder-bearing spans (`<name>`) are skipped —
+// they resolve per invocation, not statically.
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
+
+// Only these roots make a backticked token a PATH citation rather than prose.
+const PATH_ROOTS = ['src', 'tests', 'docs', '.claude', '.github'];
+
+const PATH_LIKE = /^[A-Za-z0-9_.@-]+(\/[A-Za-z0-9_.*@-]+)+$/;
+
+function skillDocs(): string[] {
+  if (!existsSync(SKILLS_DIR)) return [];
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join('.claude', 'skills', e.name, 'SKILL.md'))
+    .filter((rel) => existsSync(path.join(ROOT, rel)));
+}
+
+function citations(rel: string): string[] {
+  const text = readFileSync(path.join(ROOT, rel), 'utf8');
+  const found = new Set<string>();
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) {
+    const token = m[1].trim();
+    if (token.includes('<') || token.includes('>')) continue; // <placeholder>
+    if (!PATH_LIKE.test(token)) continue;
+    if (!PATH_ROOTS.includes(token.split('/')[0])) continue;
+    found.add(token);
+  }
+  return [...found].sort();
+}
+
+/**
+ * Resolve a citation against the repo. Globs are satisfied by ONE match:
+ * a trailing `**` only requires its prefix directory, and a `*`-bearing final
+ * segment requires at least one sibling entry matching it.
+ */
+function resolves(citation: string): boolean {
+  if (!citation.includes('*')) return existsSync(path.join(ROOT, citation));
+
+  const segments = citation.split('/');
+  const wildcardAt = segments.findIndex((s) => s.includes('*'));
+  const prefix = path.join(ROOT, ...segments.slice(0, wildcardAt));
+  if (!existsSync(prefix) || !statSync(prefix).isDirectory()) return false;
+
+  const segment = segments[wildcardAt];
+  // `dir/**` (and `dir/**/*.sh`): the prefix directory existing is the assertion.
+  if (segment === '**') return true;
+  // `dir/*.json`: at least one entry must match, and nothing may follow it.
+  if (wildcardAt !== segments.length - 1) return false;
+  const re = new RegExp(`^${segment.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
+  return readdirSync(prefix).some((entry) => re.test(entry));
+}
+
+describe('skill docs cite real repo paths', () => {
+  const docs = skillDocs();
+
+  it('finds the skill docs to check', () => {
+    expect(docs.length).toBeGreaterThan(0);
+  });
+
+  it('every repo path cited in a SKILL.md resolves', () => {
+    const missing: string[] = [];
+    for (const rel of docs) {
+      for (const citation of citations(rel)) {
+        if (!resolves(citation)) missing.push(`${rel} -> ${citation}`);
+      }
+    }
+    expect(missing, `stale path citation(s) in skill docs:\n${missing.join('\n')}`).toEqual([]);
+  });
+
+  it('actually inspects a meaningful number of citations (the extractor is not a no-op)', () => {
+    const total = docs.reduce((n, rel) => n + citations(rel).length, 0);
+    expect(total).toBeGreaterThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
## What

Mirrors two `/work-issues` retrospective lessons from cdkd (issue go-to-k/cdkd#1972,
PR go-to-k/cdkd#1976) into this repo's `.claude/skills/work-issues/SKILL.md` §5:

1. **When an issue reports a stale ENTRY in an enumerated list, audit the whole list
   in both directions before fixing the named entry.** The defect class is "this list
   drifted from the repo", and the "is everything that belongs present?" half is the
   one that gets skipped, because the issue only names the first half.
2. **Check whether the artifact already has a test harness** before writing a new one.

## Per-repo verification (§10-c), not a copy

The issue flagged that cdkd's phrasing of lesson 2 contrasts `tests/unit/**` against
the hook suites, and that this repo has no `tests/unit/`. Auditing the rest of that
sentence against this checkout found **two further false claims**: this repo has no
`.claude/hooks/run-tests.sh` runner and no `hooks.yml` workflow. The nine
`.claude/hooks/*.test.sh` suites here are standalone — nothing in `vp test run` or CI
invokes them — which is a stronger warning than cdkd's version, so the mirrored text
says that, and anchors the "harness already exists" point to what does exist here:
the generic EVERY-entry fold audit in `tests/classify.test.ts`.

cdkd's gate names and ship steps are not copied.

## Mechanical recurrence control

Lesson 1 ends with "a list that must stay in sync with the repo is a TEST, not a
sentence asking the next reader to remember" — so this PR does that rather than only
saying it. `tests/skill-doc-paths.test.ts` asserts every repo path cited in a
`.claude/skills/**/SKILL.md` still resolves.

Nothing lints instruction prose: a stale citation sends the next session to a
directory that is not there, and is only caught by a human reading the run
afterwards. `tests/unit/**` in the source wording is exactly that class.

Scope is deliberately narrow, zero false positives on the current tree: only
inline-code spans whose first segment is a real top-level entry (`src`, `tests`,
`docs`, `.claude`, `.github`) count as citations, and `<placeholder>` spans are
skipped. It checks 31 citations across 6 skill docs today.

## Verification

- `vp run typecheck`, `vp check --fix`, `vp pack`, `vp test run` — all pass
  (343 files / 6469 tests).
- **Both directions driven on the new test**, not just the green one:
  - True positive, unplanned: the first run **failed on this PR's own draft
    paragraph**, which cited `` `tests/unit/**` `` as a code span. Reworded.
  - Injected failure: a temporary `src/does-not-exist.ts` (plain path) and
    `tests/nope/*.json` (glob) in another skill doc — both flagged; tree restored
    and re-run green.
- No `src/**` in the diff, so `verify-pr-gate` exempts it and there is no live-test
  tier; `check` + `docs` markers are set. No deploy, nothing to sweep.

Closes #1767
