### PR TITLE
chore(work-issues): condition §9's release + install on a releasing commit type

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -311,9 +311,10 @@ still merges it when the files are disjoint.
 git checkout main && git pull origin main    # bring the merges local
 ```
 
-**Release** is automated (`.github/workflows/release.yml`) — merging to `main`
-produces a `chore(release): <ver> [skip ci]` bump commit on `main` a minute or two
-later. Poll for it before installing:
+**Release** is automated (`.github/workflows/release.yml`) — merging a `feat:` /
+`fix:` / `perf:` / `revert:` commit to `main` produces a `chore(release): <ver>
+[skip ci]` bump commit on `main` a minute or two later. Poll for it before
+installing:
 
 ```bash
 git fetch origin && git log origin/main --oneline -3   # look for chore(release)
@@ -324,6 +325,13 @@ Once released, **global install by NAME** (published npm package):
 ```bash
 vp i -g cdk-real-drift
 ```
+
+**A run whose lanes are all `chore:` / `docs:` releases NOTHING** (CLAUDE.md → State
+of the Repo), so skip both steps above rather than polling: the bump you are waiting
+for is never coming, and the installed binary is already current. Say so in the wrap
+instead of reporting a release. This is the ordinary case for a §10 retro lane and
+for a tooling-only backlog — on 2026-08-19 the #1767 lane (a skill edit plus a test)
+merged as `chore:` and this text still sent the run looking for a bump commit.
 
 **Remove every worktree you created** (a left-behind worktree is the silent
 residue of this flow):


### PR DESCRIPTION
## What

`/work-issues` §10 retrospective for the #1767 run (PR #1769).

§9 stated flatly that "merging to `main` produces a `chore(release): <ver>` bump
commit" and instructed the run to **poll for it before installing**. semantic-release
only cuts a version on `feat:` / `fix:` / `perf:` / `revert:` (CLAUDE.md → State of
the Repo), so a run whose lanes are all `chore:` / `docs:` waits on a bump that never
lands.

## Evidence

The #1767 lane was a skill edit plus a test, merged as `chore:` — §9 as written sent
the run looking for a release commit, and the skip had to be worked out against
CLAUDE.md instead. This is not an edge case for this flow: the §10 retro lane that
§10-d mandates is `chore:` **by construction**, so every complete run of this skill
ends with at least one non-releasing lane.

## Change

One amended sentence (release conditioned on commit type) plus the explicit skip,
pointing at CLAUDE.md rather than restating the rule — §10-c.

## Not mirrored, and why

Verified claim by claim against both sibling checkouts:

- **cdkd** §9 already reads "merging a `fix:` / `feat:` commit to `main` produces …" —
  no gap.
- **cdk-local** §9 (`merge → pull → cleanup`, all via `/merge-pr`) has no release or
  install step at all — nothing to condition.

So this is a cdk-real-drift-only correction, not a three-repo lesson.

## What held (no change made)

§0 safety screen, §2 collision map, §4 claim-before-edit, §5 worktree setup, §6
gates, §8's no-`src/**` verification tier, and §9's documented
`'main' is already used by worktree` merge gotcha all matched reality on this run.
§10-c's "verify a mirror claim by claim against the target repo" is what turned up
the two extra false claims fixed in #1769.

## Verification

`vp run typecheck`, `vp check --fix`, `vp pack`, `vp test run` — all pass
(343 files / 6469 tests), including `tests/skill-doc-paths.test.ts` from #1769
against this file's edited citations. No `src/**` in the diff, so `verify-pr-gate`
exempts it; `check` + `docs` markers set. No deploy, nothing to sweep.
