### PR TITLE
chore(work-issues): hold back issues filed in the last hour, and claim what you file

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -105,6 +105,9 @@ edit DISJOINT files.** Two issues that both land in `noise.ts` cannot be
 parallelized — bundle them into ONE lane (one worktree, one PR) or defer one.
 **At most one lane per central table.** Map each candidate to its target file
 (grep the relevant table name; read the issue's "Fix direction") before choosing.
+§3-a at the end of this step is a second HARD gate and applies before any of the
+preferences below: it holds back issues filed within the last hour, subject to the
+three exemptions it names.
 
 - **Security issues come FIRST**, ahead of every other preference on this list. A
   security defect is the one class whose cost grows while it waits: the vulnerable
@@ -115,9 +118,10 @@ parallelized — bundle them into ONE lane (one worktree, one PR) or defer one.
   file this rule is most often about), IAM / role-assumption scope, command
   injection, or
   anything tied to a GHSA advisory. When in doubt, treat it as security — ranking a
-  normal bug first costs one position in a queue. Urgency changes ORDER only: a
-  security lane gets the same verification depth as any other, plus a deliberate
-  read of every place the sensitive value flows.
+  normal bug first costs one position in a queue. Urgency changes ORDER, and waives
+  §3-a's freshness gate; it never changes verification depth — a security lane gets
+  the same depth as any other, plus a deliberate read of every place the sensitive
+  value flows.
 - Same file, related class → **bundle** into a single lane/PR (e.g. two
   `revert/plan.ts` fixes → one PR "Subnet set-default + Lambda husk (#651, #650)").
 - Different files → separate parallel lanes.
@@ -128,6 +132,77 @@ parallelized — bundle them into ONE lane (one worktree, one PR) or defer one.
 Scale the count to the backlog and to how many central tables are free. 2–3 clean
 lanes is typical; do not force a lane into a contested file just to raise the count
 — report the deferred ones instead.
+
+### 3-a. A FRESH issue belongs to the lane that FILED it
+
+An issue you are cleared to act on is maintainer-authored (§0), so `.author.login`
+cannot tell you WHICH session filed it — and the session that did is usually a lane
+still running. It filed the issue as its own deferral, it still holds the context
+the issue was derived from, and it is therefore the cheapest agent alive to fix it:
+it may pick the issue up the moment its current lane merges. Taking it from under
+that lane pays for the same re-read twice, and risks two lanes on one fix even when
+the §2 probes look clear — a lane's own deferral names the files that lane is STILL
+editing, which is the worst case for the disjointness rule above rather than the
+best.
+
+Nothing identifies the filing session reliably, so do not try to build a reliable
+signal. Use the cheap conservative one and accept its false positives:
+
+**Skip every issue created less than 60 minutes ago.** Roughly the span between a
+lane filing a deferral and coming back to it, and comfortably longer than the window
+in which nothing LINKS a live lane to the issue it just filed: `git worktree list` /
+`git branch -a` show the lane but not its deferral, `gh pr list` shows nothing until
+it pushes, and §4's claim comment is never posted for an issue merely FILED.
+
+```bash
+CUT=$(date -u -v-60M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '60 min ago' +%Y-%m-%dT%H:%M:%SZ)
+# An empty $CUT matches nothing and reads as an empty backlog, so stop rather than warn.
+[ -n "$CUT" ] || { echo 'CUTOFF FAILED — do not treat the empty result as an empty backlog'; exit 1; }
+
+gh issue list --state open --limit 60 --json number,title,createdAt \
+  --jq ".[] | select(.createdAt < \"$CUT\") | [.number, .createdAt, .title] | @tsv"
+```
+
+(`createdAt` — camelCase, unlike `gh api`'s `created_at` — comes back as ISO-8601
+UTC, which compares correctly as a plain string, so no date parsing. Flip `<` to
+`>=` to list what you are holding back, and report those as HELD FOR THEIR FILER,
+never as backlog you declined.)
+
+**Recompute `CUT` as you pick each lane, not once at triage.** A run lasts hours, so
+an issue held at 09:00 is an ordinary candidate at 10:05. A cutoff computed once
+silently excludes a whole cohort for the rest of the run, and that is the common case
+rather than the edge: this backlog arrives in `/hunt-bugs`-shaped bursts filed
+minutes apart.
+
+Three exemptions, and only these three. Each lifts §3-a ALONE — §2's disjointness
+gate and §4's claim-then-re-check still apply unchanged:
+
+- **You filed it yourself this run, meaning to work it yourself.** `/hunt-bugs` files
+  an issue and then sends you here to fix it, and §4 has you claim exactly that kind.
+  The window protects OTHER lanes' deferrals, never your own, and your own claim
+  comment on it is the proof — which is also why the exemption stops there: §4 gives
+  an issue you filed FOR A LATER SESSION no claim, and taking one back minutes after
+  handing it off contradicts the handoff rather than being exempted by it.
+- **The maintainer named the issue in the invocation** (`/work-issues #<n>`) — an
+  explicit instruction outranks a heuristic about who else might want it.
+- **A security issue** (the security-first rule above) — an extra hour of a shipped
+  vulnerability costs more than a duplicated context. Take it, and say in the claim
+  (§4) that you took it inside the window and why.
+
+Once the window passes the issue is PRESUMED free, and that presumption is the whole
+test: no §2 probe, no open PR, no live claim referencing it. Do not try to establish
+that the filing session has ENDED — you cannot; a live session and a dead one look
+identical from outside. What may still hold the issue back is §2 or §4, on their own
+grounds rather than this one.
+
+What the gate accepts in exchange: an issue filed by a session that has since ended
+waits up to an hour. That is the cheap side — the backlog is not going anywhere,
+while the expensive side is two agents deriving one fix from scratch. Mirrored from
+cdkd on 2026-08-19, where the window was watched live the same morning: cdkd#1973 was
+filed at 03:14Z, claimed by its filing lane at 03:30Z, and that lane's branch reached
+`origin` only at 04:06Z. For 16 minutes the issue had no branch, no PR and no comment,
+so every probe in §2 reported it free; for 52 minutes nothing but a time-based gate
+could have kept a second run off it.
 
 ## 4. CLAIM the chosen issues BEFORE editing
 
@@ -142,6 +217,18 @@ Claiming to avoid collision with parallel agents."
 comes BEFORE the first edit. It is the issue-level twin of the worktree
 DISJOINT-FILE rule. Re-check for a competing claim/PR right before you start; if
 one appeared, pick a different issue.
+
+**Claim what you FILE, too — filing is not claiming.** An issue this run files as
+its own deferral is invisible to every ownership probe: no branch, no PR, no comment,
+and only §3-a's hour covers it. So when the issue is one THIS run means to pick up
+itself (a `Session-fit: now` line in the body, where you write one), post the claim
+comment in the same turn you file it. Name the LANE and what it defers from, not just
+your current branch: a merged branch is deleted, so a claim naming the branch you are
+on now reads stale at exactly the moment you come back for the issue — re-post the
+claim with the real branch when you open that lane. An issue you are handing off to a
+later session gets NO claim at filing time — that would park a released issue under a
+session that has decided not to do it — but this says nothing about the LATER run
+that takes it: that run claims it normally, per the mandatory rule above.
 
 ## 5. One worktree per lane, then implement
 
@@ -491,6 +578,9 @@ the run evidence behind it — or "no skill change" plus what held.
 
 - **Claim before editing, always** — the whole point. An unclaimed lane races a
   parallel agent onto the same central table.
+- **A fresh issue is someone's deferral, not free backlog** (§3-a). The author field
+  proves nothing about which session filed it, so the 60-minute window is the whole
+  defence — and §4 is its other half: claim what you FILE, not only what you take.
 - **One lane per central table.** `noise.ts` / `classify.ts` / `revert/plan.ts`
   each absorb most fixes; you cannot parallelize two issues that both land there.
 - **A collision-driven local fallback beats touching a contested file.** If your


### PR DESCRIPTION
## Summary

Mirror of cdkd#1985 (`/work-issues` is one flow across the three repos; §10-c
requires the fix to land in all of them or not at all).

`/work-issues` had no way to leave an issue alone for the agent that filed it.
An issue filed minutes ago is almost always a still-running lane's own deferral:
that lane holds the context the issue was derived from and is the cheapest agent
alive to fix it, so taking it pays for the same re-read twice — and a lane's own
deferral names the files it is STILL editing, which is the worst case for §3's
disjointness rule rather than the best.

Nothing identifies the filing session, so this is a deliberate heuristic rather
than a reliable signal, at the maintainer's request.

- **§3-a (new)** — a hard gate alongside file-disjointness: skip every issue
  created less than 60 minutes ago, recomputing the cutoff **as each lane is
  picked** rather than once at triage. Three exemptions, each lifting §3-a alone:
  an issue you filed yourself this run meaning to work it, one the maintainer
  named in the invocation, and a security issue (whose urgency now waives this
  gate explicitly, where §3 previously said urgency changes ORDER only).
- **§4** — claim what you FILE, not only what you take. A deferral this run files
  has no branch, no PR and no comment, so once the window lapses every ownership
  probe reports it free. The claim names the LANE rather than the branch you are
  on now: a merged branch is deleted, so a branch-named claim reads stale at
  exactly the moment the filer comes back for the issue.

## Adapted for this repo, not copied

- The 60-minute window is justified on its own terms here; the sibling's "same
  window as its §2 ref-recency probe" does not apply, because §2 here has no such
  probe. What it IS longer than is the window in which nothing LINKS a live lane
  to the issue it just filed.
- `gh issue list`'s `createdAt` is camelCase, unlike `gh api`'s `created_at`.
- No §3-a ranking table here, so the gate hangs off §3's own preferences and is
  named `3-a` to match this file's `10-a`…`10-d` lettering.
- The `Session-fit` trigger in §4 is keyed on the DECISION ("one this run means to
  pick up itself"), with the field named only as the way it is written when it is
  written — this repo's instruction files do not define it.

## Evidence

The window was watched live while this was being written: cdkd#1973 was filed at
03:14Z, claimed by its filing lane at 03:30Z, and that lane's branch reached
`origin` only at 04:06Z. For 16 minutes the issue had no branch, no PR and no
comment; for 52 minutes nothing but a time-based gate could have kept a second
run off it.

## Test plan

- Full local quality run on this branch after rebasing onto `origin/main`: green.
- Live-tested the documented block verbatim in THIS repo, both arms: the happy
  path filters correctly against this repo's real open issues, and the
  empty-`$CUT` arm stops with rc=1 before the `gh issue list` call instead of
  printing an empty list that reads as an empty backlog.
- A read-only reviewer ran against this repo's copy specifically (§10-c's
  per-repo verification rule), checking every cross-reference, gate name, path
  convention and command against this repo's own files rather than the sibling's.
  Its findings are folded in.
