### PR TITLE
chore(work-issues): stop section 9 telling the run to remove a peer's live worktree

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -315,6 +315,14 @@ git log origin/main --oneline | grep -iE "<n>|<fix-keyword>"   # the peer's merg
 git show origin/main:<your-target-file> | grep -n "<marker>"   # main already carries the fix?
 ```
 
+**A CLEAN merge is not evidence that there was no collision.** Two lanes editing
+the SAME file merge without a conflict whenever they touch disjoint SECTIONS of it,
+so §3's one-lane-per-file rule fails SILENTLY rather than loudly — #1772 and #1773
+both rewrote `.claude/skills/work-issues/SKILL.md` within minutes of each other on
+2026-08-19 and both landed intact, which was luck, not design. After a merge that
+lands into a file another PR touched in the same window, `git pull` and grep `main`
+for a marker string from EACH side before believing both survived.
+
 If the issue is CLOSED (or main already carries an equivalent fix), **ABANDON the
 lane — do NOT resolve the conflict to re-apply a now-duplicate fix**: `git rebase
 --abort`, `gh pr close <pr> --delete-branch` (or never open one), comment the
@@ -465,8 +473,20 @@ residue of this flow):
 ```bash
 git worktree remove .worktrees/<name>        # --force if it refuses on artifacts
 git worktree prune
-git worktree list                            # only the main checkout should remain
+git worktree list                            # yours should be gone
 ```
+
+**Only the ones YOU created.** A worktree you did not create is a peer lane, and
+`git worktree list` cannot tell you whose it is — a leftover from a finished run
+and a session working right now look identical, including a branch whose last
+commit is already on `main`. On 2026-08-19 this run read
+`.worktrees/work-issues-fresh-issue-quarantine-20260819` as residue of the
+previous run; it was live, and it merged #1773 while this lane was still open. So
+the closing check is "every worktree I added is gone", never "only the main
+checkout remains". Before removing one you do not recognise, confirm it is
+finished — `git log --oneline -1` on its branch, then `gh pr list --state all
+--head <branch>` for an OPEN PR — and when in doubt leave it and say so in the
+wrap.
 
 Finally, comment the outcome on each issue if it was not auto-closed. Do NOT stop
 here: what the run taught you is still only in this session's context, so go on to
@@ -614,7 +634,7 @@ pnpm install                  # worktrees have no node_modules
   so the depth IS your own read of the whole diff plus `/verify-pr`'s self-review —
   a wrong rule here propagates into every future session.
 - **Merge it before the wrap report, then remove the worktree** — §9 ends with
-  "only the main checkout should remain" and §10 must not undo that, so finish with
+  every worktree this run added gone, and §10 must not undo that, so finish with
   `git worktree remove .worktrees/<name> && git worktree prune`. This is
   `Session-fit: now` on the criterion that deferring leaves main self-inconsistent:
   the skill would keep telling the next run to do the thing this run just proved it


### PR DESCRIPTION
§10 retrospective for the #1768 run (PR #1772). Two lessons, both measured in this
run, both about the flow rather than the code.

## 1. §9 told the run to remove a peer's LIVE worktree

§9's closing check was `git worktree list  # only the main checkout should remain`.

This run found `.worktrees/work-issues-fresh-issue-quarantine-20260819`, whose
branch tip was already on `main`, and read it as residue of the previous run — the
reading §9 invites. It was a live peer lane, and it **merged #1773 while this lane
was still open**. `git worktree list` cannot tell you whose a worktree is: a
finished lane and a session working right now look identical, including the
already-on-`main` tip.

The check becomes "every worktree I added is gone", never "only the main checkout
remains", with a two-command confirmation (`git log --oneline -1` on its branch,
then `gh pr list --state all --head <branch>`) before removing one you do not
recognise — and leave-it-and-say-so-in-the-wrap when in doubt. §10-d cross-
referenced the old phrase verbatim, so it is updated in the same commit; leaving
it would have been the same self-inconsistency #1768 was filed about.

## 2. §7: a CLEAN merge is not evidence that there was no collision

#1772 and #1773 both rewrote `.claude/skills/work-issues/SKILL.md` within minutes
of each other and both landed intact. Not because §3's one-lane-per-file rule held
— it did not — but because the two lanes happened to touch disjoint SECTIONS, so
git had nothing to conflict on. §3 fails **silently** in that case, unlike the
rebase-conflict signal §7 already documents.

Added: after a merge that lands into a file another PR touched in the same window,
`git pull` and grep `main` for a marker string from EACH side before believing both
survived. This run did exactly that (both markers present on `f5e5d37`), which is
the only reason the near-miss is legible at all.

## Verification

No `src/**` in the diff, so `verify-pr-gate` exempts it; `check` + `docs` markers
are set. `vp run typecheck` rc=0 · `vp check --fix` rc=0 (0 errors) · `vp pack`
pass · `vp test run` 343 files / 6469 tests pass.

Per §10-c "pay for what you add": both edits amend sentences that were wrong rather
than appending beside them, and the §9 one replaces the line it corrects.

## Mirroring

Both hazards exist **verbatim** in `cdkd` (its §9 line 602) and `cdk-local` (§9 line
409, plus the same §10-d cross-reference at line 559). Filed one issue per repo with
the `Session-fit` line rather than copied, since their worktree paths
(`.claude/worktrees/`) and gate sets differ and §10-c requires per-repo verification
of every claim.
