### PR TITLE
chore(work-issues): order the markgate call correctly, and calibrate scanner tests on the broken tree

### DIFF
--- a/.claude/skills/check-docs/SKILL.md
+++ b/.claude/skills/check-docs/SKILL.md
@@ -68,8 +68,15 @@ docs describe.
 ## Commit-gate marker (on success only)
 
 After documentation is verified consistent (no issues found, or all fixed),
-record the `docs` marker so the markgate `docs` gate is satisfied. Run from the
-repo root (use `mise exec` to avoid PATH issues when shims aren't active):
+record the `docs` marker so the markgate `docs` gate is satisfied. Run it from the
+root of the tree you are WORKING in — the worktree, not the main checkout, whenever
+the lane lives in one: the marker store (`.git/markgate`) is shared across
+worktrees, but the hashes come from the cwd's files, so setting it from the main
+checkout records `main`'s content and the gate then fails from your worktree (see
+`/check` for the measurement). Set it in its OWN command too, separate from the
+`git commit` — `check-gate` is a PreToolUse hook, so it judges a
+`markgate set … && git commit` one-liner before the `set` inside it ever runs. Use
+`mise exec` to avoid PATH issues when shims aren't active:
 
 ```bash
 mise exec -- markgate set docs

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -73,8 +73,19 @@ gate's scope (`src/**`, `tests/**`, `package.json`, `pnpm-lock.yaml`,
 `tsconfig*.json`, `vite.config.ts` — see `.markgate.yml`); any subsequent edit
 in that scope invalidates it and requires re-running `/check`.
 
-Run from the repo root (cdkrd pins markgate via mise, so use `mise exec` to
-avoid PATH issues when shims aren't active):
+Run from the root of the tree you are WORKING in — the worktree, not the main
+checkout, whenever the lane lives in one. The marker store is `.git/markgate`,
+shared by every worktree, but the hashes come from the cwd's files, so setting it
+from the main checkout records `main`'s content instead of yours: measured
+2026-08-19, with the worktree dirty and the marker set from the main checkout,
+`markgate verify check` returns rc=1 from the worktree and rc=0 from main. It fails
+CLOSED, so the cost is a wasted gate cycle plus a "run /check first" message right
+after you ran it. Also set it in its OWN command, separate from the `git commit` —
+`check-gate` is a PreToolUse hook and judges the call before anything in it runs, so
+a `markgate set … && git commit` one-liner is blocked in full.
+
+cdkrd pins markgate via mise, so use `mise exec` to avoid PATH issues when shims
+aren't active:
 
 ```bash
 mise exec -- markgate set check

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -276,6 +276,33 @@ behavior by standalone `.claude/hooks/*.test.sh` suites you run BY HAND (`bash
 invokes those, so a hook change resting on a green suite plus green CI is not
 verified at all. Extend the harness that exists before writing a new one beside it.
 
+**When the fix is a repo-wide SCANNER — a test that greps every committed file for
+a bad pattern — calibrate it against the PRE-FIX broken tree, and do not implement
+the issue's signature literally.** An issue describes the signature the way its
+author noticed it, which is a description of ONE instance, not a rule with a
+measured false-positive rate. Run the candidate rule over the unrepaired tree,
+classify every hit by hand, and let that split decide the rule. On 2026-08-19
+(go-to-k/cdk-real-drift#1771 -> go-to-k/cdk-real-drift#1782) the issue proposed "a code span immediately followed by an
+alphanumeric"; run literally it flagged ~30 spots, most of them idiomatic prose.
+Measuring split it cleanly by SIDE — a letter immediately BEFORE a code span gave
+5 hits and all 5 were genuine corruption, while the AFTER side gave 13 of which 6
+were the ordinary plural suffix (`` `remove`s ``) — so the shipped rule flags the
+before-side unconditionally and allows a short `s`/`es` after, catching all 12 real
+hits with zero false positives. Then drive the failure direction the same way the
+no-`src/**` tier in section 8 requires: `git stash push <the repaired file>`, watch
+the scan report the exact hits with their line numbers, and `git stash pop`.
+
+Two traps that cost most of the apparent false positives there, both worth checking
+in any markdown scanner: tokenize per PARAGRAPH, not per line, because a code span
+may WRAP a line break and a per-line scan pairs one span's closing backtick with the
+next one's opening backtick and invents findings in the prose between them; and
+report the line the HIT is on rather than the paragraph start, because a paragraph
+in `docs/ARCHITECTURE.md` can run 100+ lines and a start-of-paragraph number sends
+the reader hunting. When WRITING, keep each code span on one line for the same
+reason — a span that wraps a line break inside a list item also loses the
+continuation's indent to `vp fmt`, which is how this very paragraph's neighbour got
+re-flowed while being drafted.
+
 **When the issue reports a stale ENTRY in an enumerated list, audit the whole list,
 in BOTH directions, before fixing the named entry.** The defect class is "this list
 drifted from the repo", and drift almost never produces exactly the one instance
@@ -310,8 +337,32 @@ without it (they spawn the built CLI), so `vp pack` runs before the suite:
 vp run typecheck && vp check --fix && vp pack && vp test run
 ```
 
-All green, then commit (conventional-commit; `check`/`docs` markers must be fresh
-or the check-gate blocks the commit), push, and open the PR with `Closes #<n>`.
+All green, then commit (conventional-commit), push, and open the PR with
+`Closes #<n>`.
+
+**Set the `check` / `docs` markers in their OWN Bash call, from the WORKTREE, and
+after staging.** Three separate traps, all hit in one lane on 2026-08-19
+(go-to-k/cdk-real-drift#1782):
+
+- `check-gate` is a **PreToolUse** hook, so it judges the call BEFORE anything in
+  it runs. A single call of `markgate set check && markgate set docs && git commit`
+  is therefore blocked in FULL — including the `markgate set` that would have
+  satisfied it — and the message says "run /check first" when you just did. The
+  markers must already be recorded by the time the commit call is submitted.
+- Run `markgate set` from the **worktree**, not the main checkout. The marker store
+  is `.git/markgate`, which every worktree SHARES, but the hashes are taken from the
+  cwd's files — so setting from the main checkout records `main`'s content. Measured
+  2026-08-19: with the worktree dirty and the marker set from the main checkout,
+  a `markgate verify check` returns rc=1 from the worktree and rc=0 from main —
+  it fails CLOSED, so it costs a wasted cycle rather than a bad merge. But
+  `/check` and `/check-docs` both
+  say "run from the repo root", which in this flow's mandated worktree means the
+  WORKTREE root.
+- Stage new files first. A marker set while your new test is still untracked does not
+  cover it.
+
+This is the commit-time twin of the merge-time rule in Gotchas below; same hook
+mechanism, same fix.
 
 ## 7. If main advanced while you worked (parallel merges)
 
@@ -440,13 +491,14 @@ Run `/verify-pr`. Its live-test rules decide how each PR is verified:
     go-to-k/cdk-real-drift#1765 test above), or the standalone hook suite for a
     `.claude/hooks/` change — which §5 already notes you must run BY HAND.
 
-  Both arms end in writing, and `vp fmt` fights you there. A paragraph that uses
-  bold AND contains a double-star glob inside a code span comes back mangled —
-  spaces around later code spans eaten, continuation lines de-indented (reproduced
-  in isolation 2026-08-19; one-shot, stable after). It is what corrupted this very
-  passage when go-to-k/cdk-real-drift#1766 first added it. In a bold paragraph
-  write the plain directory (`src/`, `tests/`) instead of the glob, and re-read the
-  diff after `vp check --fix` (go-to-k/cdk-real-drift#1771).
+  Both arms end in writing, and `vp fmt` mangles a paragraph that uses bold AND
+  contains a double-star glob inside a code span — it is what corrupted this very
+  passage when go-to-k/cdk-real-drift#1766 first added it. That trap is now a GATE,
+  not a thing to remember: `tests/markdown-fmt-corruption-1771.test.ts` fails on
+  both the trigger construct and the damage it leaves, so write the plain directory
+  (`src/`, `tests/`) in a bold paragraph and let the test catch you otherwise. Root
+  cause and the toolchain bump that ends it: go-to-k/cdk-real-drift#1771 /
+  go-to-k/cdk-real-drift#1780.
 
 - **revert / read HOT-PATH fix** → live-verify with a MINIMAL, UNIQUE-named
   fixture: deploy → mutate out of band → `check` detects → `revert --yes`


### PR DESCRIPTION
Retrospective (§10) from the #1771 lane (#1782). Three lessons, each with a
measurement behind it, each placed in the step where it fires rather than appended
to a tail section.

## §6 — the marker call was in the wrong shape, not merely "not fresh"

`check-gate` is a **PreToolUse** hook: it judges a Bash call *before* anything in it
runs. So a single

```bash
markgate set check && markgate set docs && git add … && git commit …
```

is blocked in **full** — including the `markgate set` that would have satisfied it
— and the error reads "run /check first" immediately after you ran `/check`. Two
adjacent traps hit in the same lane:

- **Set the markers from the WORKTREE.** The store `.git/markgate` is *shared*
  across worktrees, but the hashes come from the **cwd's** files, so setting from
  the main checkout records `main`'s content. Measured: worktree dirty, marker set
  from the main checkout → `markgate verify check` returns **rc=1 from the
  worktree, rc=0 from main**. It fails CLOSED, so the cost is a wasted gate cycle
  rather than a bad merge.
- **Stage new files first** — a marker set while your new test is still untracked
  does not cover it.

The old sentence only said the markers "must be fresh". That was true, and useless:
it was already being followed at the moment the commit got blocked.

## §5 — calibrate a repo-wide scanner on the BROKEN tree

When the fix is a test that greps every committed file, the signature stated in the
issue is a description of **one noticed instance**, not a rule with a measured
false-positive rate.

Implemented literally, #1771's "a code span immediately followed by an
alphanumeric" flagged **~30** spots, most of them idiomatic prose. Running the
candidate rule over the **unrepaired** tree and hand-classifying every hit split it
cleanly by side:

| side | hits on the broken tree | genuine |
| --- | --- | --- |
| letter immediately **before** a code span | 5 | 5 |
| letter immediately **after** | 13 | 7 (6 were the ordinary plural `` `remove`s ``) |

→ flag the before-side unconditionally, allow a short `s`/`es` after. Zero false
positives, all 12 real hits caught. Also records the two markdown sub-traps: tokenize
per **paragraph**, since a code span may wrap a line break and a per-line scan pairs
one span's closing backtick with the next one's opening backtick and invents
findings in the prose between them; and report the **hit's** line, not the
paragraph start (a paragraph in `docs/ARCHITECTURE.md` runs 100+ lines).

## `/check` + `/check-docs` — amended the sentence that was wrong

Both told you to run `markgate set` "from the repo root", which in this repo's
mandated worktree flow names the wrong root. Fixed in place, with the measurement,
rather than adding a bullet somewhere else.

## Paying for the additions (§10-c)

§8's `vp fmt` warning shrinks from a paragraph asking the next author to *remember*
the trap to a pointer at `tests/markdown-fmt-corruption-1771.test.ts`, which now
fails on both the trigger construct and the damage it leaves. Per §10-b, a rule that
was already in the text and got violated anyway — #1766 shipped the corruption into
that very passage — belongs in a gate, not in another sentence.

## Mirrors

Filed rather than shipped blind, per §10-c's verify-against-the-target-repo rule
(their gates, hooks and ship steps differ, and nothing lints instruction prose):
go-to-k/cdkd#2003 and go-to-k/cdk-local#523.

## Verification

- typecheck / `vp check --fix` / `vp pack` / `vp test run` all rc=0 — **344 files,
  6492 tests**.
- The edited skill docs are `vp fmt`-stable across 3 passes. One draft paragraph was
  **not**, because a code span wrapped a line break and lost its continuation
  indent — caught by re-running `vp fmt` on my own edits, fixed, and the clause is
  now recorded in the §5 text.
- The peer's new qualified-reference test from #1776 caught four bare `#N` refs in
  my additions; all are now `go-to-k/cdk-real-drift#N`.

No `src/**` in the diff, so `verify-pr-gate` exempts this; `check` + `docs` markers
are set.
