### PR TITLE
chore(work-issues): a peer's repo-wide check collides with your content, not your files

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -475,6 +475,20 @@ go-to-k/cdk-real-drift#1772 and go-to-k/cdk-real-drift#1773 both rewrote
 lands into a file another PR touched in the same window, `git pull` and grep `main`
 for a marker string from EACH side before believing both survived.
 
+**And the two lanes need not touch one file at all: a peer that adds a REPO-WIDE
+check gains jurisdiction over YOUR content.** File-disjointness says nothing here,
+because the collision is their TEST against your CONTENT, and neither PR's CI
+necessarily exercised the pair — yours ran before their check existed, theirs ran
+before your content did. So when a peer merges, look at WHAT it added, not only at
+which files it touched: a test that globs the tree (`git ls-files`, a `readdirSync`
+over a directory, a lint rule) applies to everything you are about to land. Rebase
+and RUN it over your own diff before merging. Measured here 2026-08-19
+(go-to-k/cdk-real-drift#1782 into go-to-k/cdk-real-drift#1783): the first added a
+scanner over every committed `.md` while the second was adding ~100 lines of new
+markdown to a file the first never touched. Rebasing and running that scanner scored
+21/21, so nothing broke — but the check cost one command, and the gate that would
+have caught a failure only existed once the two were combined.
+
 If the issue is CLOSED (or main already carries an equivalent fix), **ABANDON the
 lane — do NOT resolve the conflict to re-apply a now-duplicate fix**: `git rebase
 --abort`, `gh pr close <pr> --delete-branch` (or never open one), comment the
@@ -625,7 +639,9 @@ gh pr merge <n> --squash --delete-branch     # squash is the repo's only method
 
 (Local branch delete fails while its worktree exists — expected; the worktree
 removal below clears it.) Merge each verified PR. If a later PR is behind, GitHub
-still merges it when the files are disjoint.
+still merges it when the files are disjoint — but disjoint files are not the whole
+test: if the PR that landed first added a repo-wide check, rebase and run it over
+your diff first (§7).
 
 ```bash
 git checkout main && git pull origin main    # bring the merges local


### PR DESCRIPTION
§10 retrospective for this `/work-issues` run (lanes: #1777 / #1779 / #1781, all
merged in #1783).

## The gap

§7 and §9 both judge cross-lane safety by **which files** each side touches. §9
says outright that GitHub "still merges it when the files are disjoint", and §7's
collision paragraph is entirely about two lanes editing one file.

That misses the shape this run hit: a peer PR that adds a **repo-wide check** — a
test globbing the tree, a `readdirSync` over a directory, a new lint rule — gains
jurisdiction over content in files it never touched. File-disjointness says
nothing, because the collision is their **test** against your **content**.

Neither PR's CI necessarily exercises the pair: yours ran before their check
existed, theirs ran before your content did. So `main` can go red on a merge where
both sides were green and nothing conflicted.

## Evidence (this run)

#1782 added `tests/markdown-fmt-corruption-1771.test.ts`, which scans **every**
committed `.md` via `git ls-files "*.md"`. It merged while #1783 was open, adding
~100 lines of new markdown to `.claude/skills/work-issues/SKILL.md` — a file #1782
never touched. Rebase was clean; §7's existing "grep for a marker from each side"
check would have passed, because both sides' content did survive.

Rebasing and running that scanner over the new prose scored **21/21**, so nothing
broke. Recorded honestly as *a check that cost one command*, not as an averted
breakage — the point is that the gate which would have caught a failure only
existed once the two were combined.

## Changes

- §7 — the existing "**A CLEAN merge is not evidence**" paragraph is **extended**
  (not duplicated) to cover the test-vs-content shape beside the content-vs-content
  one, with the concrete instruction: when a peer merges, look at **what** it added,
  not only which files it touched; rebase and run it over your own diff.
- §9 — "still merges it when the files are disjoint" now carries the caveat and
  points at §7, rather than reading as sufficient on its own.

Per §10-c this **amends** the sentences that were incomplete rather than appending a
new bullet, and the evidence is carried inline in the file's existing style.

## Not colliding with #1784

#1784 (a peer's retro lane) is open on this same file. Its hunks are in §5, §6 and
§8; mine are in §7 and §9, and I left the anchors its hunks sit on untouched — which
is the technique §2 gained in #1783. If #1784 lands first this rebases cleanly; if
not, it rebases over this.

## Checks

| check | result |
| --- | --- |
| `vp run typecheck` | pass (rc=0) |
| `vp check` | pass — 0 errors, 118 pre-existing warnings |
| `vp pack` | pass |
| `vp test run` | pass — 344 files / 6502 tests, rc=0 |
| `tests/skill-doc-paths.test.ts` + `tests/markdown-fmt-corruption-1771.test.ts` | 36/36 |

Prose-only diff, no `src/**` — `verify-pr-gate` exempts it, and `check` + `docs`
markers are set. No deploy, so no `/sweep-resources` and no autoarm token.

`tests/skill-doc-paths.test.ts` earned its keep again here: the first draft cited
`#1782` / `#1783` bare inside the evidence sentence and it failed the
qualified-reference assertion, so the sentence was rewritten to name them once,
fully qualified.
