### PR TITLE
chore(work-issues): mirror three cdk-local flow lessons, and close the cd-form gate bypass they exposed

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
           {
             "type": "command",
             "command": ".claude/hooks/check-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*)",
             "timeout": 10,
             "statusMessage": "Checking /check + /check-docs markers..."
           },
@@ -36,7 +36,7 @@
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*)",
+            "if": "Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr merge*)",
             "timeout": 15,
             "statusMessage": "Checking /verify-pr marker is fresh..."
           },
@@ -50,7 +50,7 @@
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*)",
+            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr edit*) or Bash(cd * && gh pr merge*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
           },

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -419,25 +419,51 @@ All green, then commit (conventional-commit), push, and open the PR with
 after staging.** Three separate traps, all hit in one lane on 2026-08-19
 (go-to-k/cdk-real-drift#1782):
 
-- `check-gate` is a **PreToolUse** hook, so it judges the call BEFORE anything in
-  it runs. A single call of `markgate set check && markgate set docs && git commit`
-  is therefore blocked in FULL — including the `markgate set` that would have
-  satisfied it — and the message says "run /check first" when you just did. The
-  markers must already be recorded by the time the commit call is submitted.
-- Run `markgate set` from the **worktree**, not the main checkout. The marker store
-  is `.git/markgate`, which every worktree SHARES, but the hashes are taken from the
-  cwd's files — so setting from the main checkout records `main`'s content. Measured
-  2026-08-19: with the worktree dirty and the marker set from the main checkout,
-  a `markgate verify check` returns rc=1 from the worktree and rc=0 from main —
-  it fails CLOSED, so it costs a wasted cycle rather than a bad merge. But
-  `/check` and `/check-docs` both
-  say "run from the repo root", which in this flow's mandated worktree means the
-  WORKTREE root.
+- **A gated command must be the ONLY thing in its Bash call.** `check-gate` is a
+  **PreToolUse** hook, so it judges the call BEFORE anything in it runs: a single
+  call of `markgate set check && markgate set docs && git commit` is blocked in
+  FULL — including the `markgate set` that would have satisfied it — and the message
+  says "run /check first" when you just did. The trap is not confined to markers,
+  because a denial also discards every PREAMBLE SIDE EFFECT you assumed had already
+  happened. On 2026-08-19 in the sibling repo a heredoc body-file write chained onto
+  `gh pr create --body-file` was denied by its verify-pr gate, so the body file was
+  never written; the retry appended with `>>`, which CREATED the file as a fragment,
+  and go-to-k/cdk-local#525 opened carrying only its review section — no summary and
+  no `Closes` line. That silently cost the auto-close: its body had to be patched
+  after the merge and go-to-k/cdk-local#509 closed by hand. Every gated command here
+  is reachable the same way — `git commit` (`check-gate`, `branch-gate`,
+  `bughunt-clean-gate`), `git push` (`branch-gate`, `stale-base-gate`), and
+  `gh pr create` / `gh pr edit` / `gh pr merge` (`verify-pr-gate`, `ci-green-gate`,
+  `non-english-text-gate`). Write the body file in its own call, set markers in
+  theirs, then submit the gated command alone.
+- Run `markgate set` from the **worktree**, not the main checkout — and say so
+  EXPLICITLY, starting the call with `cd <worktree> &&` rather than relying on a
+  `cd` from an earlier call. The shell cwd does not reliably persist across tool
+  calls, which makes the wrong-cwd set the DEFAULT outcome rather than a slip; it
+  fired again while this very lane was written, when a relative `cd .worktrees/…`
+  failed because the cwd was ALREADY inside that worktree and the chained edit
+  silently did not run. The marker store is `.git/markgate`, which every worktree
+  SHARES, but the hashes are taken from the cwd's files — so setting from the main
+  checkout records `main`'s content. Measured 2026-08-19: with the worktree dirty
+  and the marker set from the main checkout, a `markgate verify check` returns rc=1
+  from the worktree and rc=0 from main — it fails CLOSED, so it costs a wasted cycle
+  rather than a bad merge. But `/check` and `/check-docs` both say "run from the
+  repo root", which in this flow's mandated worktree means the WORKTREE root. The
+  sibling repo shows the same symptom from a DIFFERENT mechanism (its stores are
+  per-worktree, so the marker reads as missing rather than wrong) — import the
+  advice, not its explanation.
+- That `cd <worktree> &&` form is safe on a GATED command only because this repo's
+  hook conditions now match it, and they did not until
+  go-to-k/cdk-real-drift#1786: `branch-gate`, `bughunt-clean-gate`,
+  `stale-base-gate` and `ci-green-gate` each carried a `Bash(cd * && …)`
+  alternative while `check-gate`, `verify-pr-gate` and `non-english-text-gate` did
+  not — so `cd <wt> && git commit` ran UNGATED, and `cd <wt> && gh pr create`
+  skipped both the verify-pr and the English-only gate. The bypass is silent: an
+  ungated command looks exactly like one that passed.
+  `tests/gate-cd-form-parity-1786.test.ts` now fails on any gate guarding a bare
+  command form without its `cd` twin, so it cannot quietly reopen.
 - Stage new files first. A marker set while your new test is still untracked does not
   cover it.
-
-This is the commit-time twin of the merge-time rule in Gotchas below; same hook
-mechanism, same fix.
 
 ## 7. If main advanced while you worked (parallel merges)
 
@@ -642,6 +668,27 @@ removal below clears it.) Merge each verified PR. If a later PR is behind, GitHu
 still merges it when the files are disjoint — but disjoint files are not the whole
 test: if the PR that landed first added a repo-wide check, rebase and run it over
 your diff first (§7).
+
+**When one lane fixes a full-suite flake, merge THAT lane first.** Every other
+lane's §6 gate run and its `/verify-pr` execute the same suite, so until the fix is
+on `main` each of them rolls the same dice — and the REBASE is what delivers it,
+since a lane branched before the merge keeps flaking on its own stale base. This
+repo has a standing instance, so the case is not hypothetical: the
+`json-empty-on-error` suite flakes even with `dist/` packed (§8 — three of its 13
+failed once, the identical re-run went 343/343), so a lane fixing it outranks the
+rest of the ship order. The sibling measured what skipping this costs: on 2026-08-19
+the go-to-k/cdk-local#509 lane hit the go-to-k/cdk-local#515 timeout 2/2 in its own
+worktree while the fix sat unmerged in a parallel lane, and the first run after
+merging go-to-k/cdk-local#522 and rebasing was green.
+
+**A PR's CI runs on the MERGE ref, not on your branch** — `.github/workflows/ci.yml`
+triggers on `pull_request`, so GitHub tests your branch combined with current
+`main`. A red check can therefore be caused by a PEER's just-merged content that
+your local green never saw, and here that red also blocks `ci-green-gate` on
+`gh pr merge`. The fix is fetch + rebase + re-run; do NOT start distrusting the
+peer's new test. On 2026-08-19 go-to-k/cdk-local#524's new reference harness failed
+CI on a line go-to-k/cdk-local#520 had merged in parallel. This is the CI-side face
+of §7's repo-wide-check collision — same cause, and the same rebase answers both.
 
 ```bash
 git checkout main && git pull origin main    # bring the merges local

--- a/tests/gate-cd-form-parity-1786.test.ts
+++ b/tests/gate-cd-form-parity-1786.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+// Every PreToolUse gate must catch a gated command written in ALL the invocation
+// forms this repo's flow actually produces — including `cd <worktree> && <cmd>`.
+//
+// `.claude/skills/work-issues/SKILL.md` section 5 mandates working from a worktree,
+// and section 6 now tells the agent to prefix commands with an explicit
+// `cd <worktree> &&` because shell cwd does not persist across tool calls. That
+// guidance is only safe if the gates SEE that form. On 2026-08-19
+// (go-to-k/cdk-real-drift#1786) they did not: `branch-gate`, `bughunt-clean-gate`,
+// `stale-base-gate` and `ci-green-gate` each carried a `Bash(cd * && …)`
+// alternative, while `check-gate`, `verify-pr-gate` and `non-english-text-gate` did
+// not — so `cd <wt> && git commit` bypassed check-gate outright, and
+// `cd <wt> && gh pr create` bypassed BOTH verify-pr-gate and the English-only gate.
+// The bypass is silent: the command simply succeeds ungated.
+//
+// A hook `if` clause is plain configuration that nothing else re-reads, and the
+// drift was invisible precisely because each clause looks reasonable on its own.
+// This test compares them against each other instead.
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SETTINGS = path.join(ROOT, '.claude', 'settings.json');
+
+// The command forms the gates guard. A gate that matches the bare form of one of
+// these owes the `cd * && ` form too.
+const GATED_COMMANDS = ['git commit', 'git push', 'gh pr create', 'gh pr edit', 'gh pr merge'];
+
+interface GateHook {
+  name: string;
+  condition: string;
+}
+
+function gateHooks(): GateHook[] {
+  const settings = JSON.parse(readFileSync(SETTINGS, 'utf8')) as {
+    hooks?: {
+      PreToolUse?: { if?: string; hooks?: { command?: string; if?: string }[] }[];
+    };
+  };
+  const matchers = settings.hooks?.PreToolUse ?? [];
+  const out: GateHook[] = [];
+  for (const matcher of matchers) {
+    for (const hook of matcher.hooks ?? []) {
+      const command = hook.command ?? '';
+      if (!command.includes('.claude/hooks/')) continue;
+      const name = path.basename(command.split(/\s+/)[0] ?? command);
+      const condition = matcher.if ?? hook.if ?? '';
+      if (condition) out.push({ name, condition });
+    }
+  }
+  return out;
+}
+
+// `Bash(git commit*)` is ANCHORED, so it does not match `cd x && git commit`.
+// `Bash(cd * && git commit*)` is the separate alternative that does.
+const bareForm = (cmd: string) => `Bash(${cmd}`;
+const cdForm = (cmd: string) => `Bash(cd * && ${cmd}`;
+
+describe('PreToolUse gate coverage parity across invocation forms (go-to-k/cdk-real-drift#1786)', () => {
+  const hooks = gateHooks();
+
+  it('finds the repo gate hooks', () => {
+    expect(hooks.length).toBeGreaterThanOrEqual(8);
+    const names = hooks.map((h) => h.name);
+    expect(names).toContain('check-gate.sh');
+    expect(names).toContain('verify-pr-gate.sh');
+    expect(names).toContain('non-english-text-gate.sh');
+  });
+
+  for (const cmd of GATED_COMMANDS) {
+    it(`every gate guarding "${cmd}" also guards "cd … && ${cmd}"`, () => {
+      const gaps = hooks
+        .filter((h) => h.condition.includes(bareForm(cmd)))
+        .filter((h) => !h.condition.includes(cdForm(cmd)))
+        .map((h) => h.name);
+      expect(gaps).toEqual([]);
+    });
+  }
+
+  it('the three gates that carried the gap now cover the cd form', () => {
+    const byName = new Map(hooks.map((h) => [h.name, h.condition]));
+    expect(byName.get('check-gate.sh')).toContain('Bash(cd * && git commit*)');
+    expect(byName.get('verify-pr-gate.sh')).toContain('Bash(cd * && gh pr create*)');
+    expect(byName.get('verify-pr-gate.sh')).toContain('Bash(cd * && gh pr merge*)');
+    expect(byName.get('non-english-text-gate.sh')).toContain('Bash(cd * && gh pr edit*)');
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the three flow lessons from cdk-local's 2026-08-19 run (shipped there as
go-to-k/cdk-local#527) into this repo's `work-issues` skill. Per section 10-c these
were adapted and verified claim-by-claim against this repo, not copied — and one of
them was **false as written here**, which is what the verification pass is for.

### 1. Ship-order for flake-fix lanes, plus the CI merge-ref corollary (section 9)

A lane fixing a full-suite flake merges FIRST; every other lane's gate run rolls the
same dice until it lands, and the *rebase* is what delivers the fix. Adapted with
this repo's own standing instance (the `json-empty-on-error` flake already recorded
in section 8) rather than only the sibling's evidence.

The corollary — a PR's CI runs on the MERGE ref, so a red check can come from a
peer's just-merged content — is coupled here to `ci-green-gate`, which blocks
`gh pr merge` on that red. Cited evidence verified: go-to-k/cdk-local#509 /
go-to-k/cdk-local#515 / go-to-k/cdk-local#522 and go-to-k/cdk-local#524 vs
go-to-k/cdk-local#520 all open and say what the lesson claims.

### 2. Explicit `cd <worktree> &&` on marker commands (section 6)

Amends the existing worktree bullet rather than adding a sibling beside it.

**The source's explanation does not hold here and was dropped.** cdk-local has
per-worktree markgate stores, so its failure is a *missing* marker. This repo shares
one `.git/markgate` across worktrees and derives hashes from the cwd's files, so the
same mistake records the *wrong content* instead — which is why the existing measured
note (rc=1 from the worktree, rc=0 from main) is a fail-closed, not a fail-open. The
bullet now says to import the advice, not the explanation.

### 3. A gated command must be the ONLY thing in its Bash call (section 6)

Generalizes the existing PreToolUse bullet from markers to any **preamble side
effect**: a denial aborts the whole command string, so a chained heredoc body-file
write never happens, and a `>>` retry then creates a fragment. That is how
go-to-k/cdk-local#525 opened with only its review section and no `Closes` line,
costing the auto-close (verified: its body carries a manual
"closed by hand" note). The bullet now enumerates this repo's actual gated commands.

## The gate bypass this verification uncovered

Checking whether lesson 2's advice was safe here found that it **was not**. The
`cd * && …` invocation form was covered by only four of the seven relevant gates:

| Gate | `cd * &&` form covered (before) |
| --- | --- |
| `branch-gate`, `bughunt-clean-gate`, `stale-base-gate`, `ci-green-gate` | yes |
| `check-gate`, `verify-pr-gate`, `non-english-text-gate` | **no** |

So `cd <wt> && git commit` ran **ungated**, and `cd <wt> && gh pr create` skipped
**both** the verify-pr and English-only gates. The bypass is silent — an ungated
command is indistinguishable from one that passed. Shipping lesson 2 without this
fix would have actively instructed future agents to write commands in the bypassing
form.

- `.claude/settings.json` — adds the missing `cd * &&` alternatives. Tightening
  only: it widens what the gates catch and loosens nothing.
- `tests/gate-cd-form-parity-1786.test.ts` — asserts every gate guarding a bare
  command form also guards its `cd` twin, so the asymmetry cannot silently reopen.

## Test plan

- **Failure direction driven** (section 8's no-`src` command arm): reverted
  `.claude/settings.json` and re-ran — 5 failed / 2 passed, the failure naming the
  exact gate (`expected [ 'check-gate.sh' ] to deeply equal []`). Restored: 7/7.
  `git push` stayed green in both states, correctly — two gates already covered it,
  so the test is not a blanket assertion.
- Full suite green on the rebased base: **345 files / 6510 tests**, typecheck clean,
  `vp check --fix` 0 errors.
- Rebased onto go-to-k/cdk-real-drift#1787 (the vite-plus 0.2.9 bump that changes
  markdown formatting) and re-ran everything, since this diff is ~100 lines of new
  markdown and that peer PR also touched the fmt-corruption harness. `vp fmt` under
  0.2.9 left the new prose untouched.
- Paid for the addition per section 10-c: cut one sentence now subsumed by the
  generalized bullet.

## Won't-do (recorded here)

The sibling repos are not updated in this PR. Lessons 1 and 3 originate in
cdk-local and already ship there; the cd-form gate parity is specific to this
repo's `.claude/settings.json` wiring and does not transfer as-is. Whether cdkd
carries the same asymmetry is a separate audit against its own hook set — filed
rather than guessed at from here.

Closes #1786
