### PR TITLE
chore(work-issues): make the section 7 marker check trustworthy, and stop section 9 reading absence as death

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -501,6 +501,32 @@ go-to-k/cdk-real-drift#1772 and go-to-k/cdk-real-drift#1773 both rewrote
 lands into a file another PR touched in the same window, `git pull` and grep `main`
 for a marker string from EACH side before believing both survived.
 
+Three things make that check misreport, and all three read as LOST CONTENT:
+
+- **Source each marker from the MERGED text, never from a draft you read earlier.**
+  A lane routinely rewords a sentence between the draft you saw and the commit it
+  merges, so a draft-sourced marker returns 0 and looks like a clobber. Take THEIR
+  marker out of THEIR merge commit —
+  `git show "$(gh pr view <n> --json mergeCommit -q .mergeCommit.oid):<file>"`. In
+  cdkd on 2026-08-19 a bullet drafted as "A mirror issue can duplicate an open PR"
+  merged as "A mirror issue is a duplicate more often than it looks"
+  (go-to-k/cdkd#2000): nothing was lost, the marker was stale.
+- **One arm of the check is always tautological.** Whichever lane merged LAST has
+  its marker read back out of what is now the tip, so two hits are one confirmation
+  plus one freebie. The load-bearing arm is the EARLIER-merged lane's — if you only
+  have budget to think about one, think about that one.
+- **Use `grep -cF`, and do not chain the two greps with `&&`.** Prose markers are
+  full of regex metacharacters, so an unanchored `grep -c` silently fails to match
+  and produces exactly the false alarm this check exists to prevent — measured here
+  2026-08-19: a marker containing `[` and `.` scored 0 without `-F` and 1 with it.
+  `grep -c` also exits 1 on zero matches, which is the very case being hunted, so a
+  chained second grep never runs. (Double quotes, not `-F`, are what survive an
+  apostrophe.)
+
+When a marker genuinely does come back 0, settle it from your lane worktree with
+`diff <(git show origin/main:<file>) <file>`: the lines YOUR commit removed should
+be exactly the ones you meant to replace.
+
 **And the two lanes need not touch one file at all: a peer that adds a REPO-WIDE
 check gains jurisdiction over YOUR content.** File-disjointness says nothing here,
 because the collision is their TEST against your CONTENT, and neither PR's CI
@@ -734,9 +760,18 @@ commit is already on `main`. On 2026-08-19 this run read
 previous run; it was live, and it merged go-to-k/cdk-real-drift#1773 while this
 lane was still open. So the closing check is "every worktree I added is gone",
 never "only the main
-checkout remains". Before removing one you do not recognise, confirm it is
-finished — `git log --oneline -1` on its branch, then `gh pr list --state all
---head <branch>` for an OPEN PR — and when in doubt leave it and say so in the
+checkout remains". Before removing one you do not recognise, know what the probes
+can and cannot say: **every ownership signal establishes LIFE, never absence.** A
+dirty tree or an open PR proves a lane is live; the ABSENCE of either proves
+nothing at all. A branch tip already on `main` is not death — its owner may still
+be inside the ship or retro steps — and a claim comment carries CLAIM time, not
+last activity, so an old stamp is equally what a long-running live session looks
+like. This run measured both "finished" signals failing at once: at triage
+`.worktrees/vp-bump-1780` sat on `f6e0373`, which was `main`'s own tip, and
+`gh pr list --state open` returned nothing — yet it was live, and it merged
+go-to-k/cdk-real-drift#1787 twenty minutes later. So run `git log --oneline -1`
+and `gh pr list --state all --head <branch>` to find a reason to LEAVE a worktree;
+they can never license removing one. When in doubt leave it and say so in the
 wrap.
 
 Finally, comment the outcome on each issue if it was not auto-closed. Do NOT stop


### PR DESCRIPTION
## Summary

Mirrors three lessons from cdkd's 2026-08-19 run (go-to-k/cdkd#2009,
go-to-k/cdkd#2015) into this repo's `work-issues` skill, adapted and verified
claim-by-claim per section 10-c rather than copied.

Both edits land on text that already existed, so both are amendments rather than
new bullets.

### Section 7 — the marker check existed, but not the way to run it honestly

Section 7 already told the run to `grep` `main` for a marker from EACH side after a
same-file merge. It did not say how that check misreports, and every failure mode
reads as **lost content** — the single alarm most likely to make a run "restore" a
peer's text over its own:

- **Source each marker from the MERGED text, not from a draft read earlier.** Lanes
  reword between draft and merge, so a draft-sourced marker scores 0 and looks like
  a clobber. Verified against go-to-k/cdkd#2000's merge commit: drafted as
  "A mirror issue can duplicate an open PR", merged as "A mirror issue is a
  duplicate more often than it looks".
- **One arm is always tautological** — the last-merged lane reads its own marker
  back out of what is now the tip, so two hits are one confirmation plus one
  freebie. The earlier lane's arm is the load-bearing one.
- **`grep -cF`, and never chain the two greps.** Prose markers carry regex
  metacharacters, and `grep -c` exits 1 on zero matches — precisely the case being
  hunted — so an `&&` chain swallows the second check.

### Section 9 — the ownership advice was wrong, not just incomplete

The existing text said to "confirm it is finished" using `git log --oneline -1` and
an open-PR check. Those probes cannot do that: **every ownership signal establishes
LIFE, never absence.** A branch tip already on `main` is not death (the owner may
still be in the ship or retro steps), and a claim comment records claim time, not
last activity.

**This run falsified the old advice first-hand, with both signals failing at once.**
At triage, `.worktrees/vp-bump-1780` sat on `f6e0373` — which was `main`'s own tip —
and `gh pr list --state open` returned nothing. Both "finished" readings. It was
live, and it merged go-to-k/cdk-real-drift#1787 twenty minutes later. The passage
now says to run those probes to find a reason to LEAVE a worktree, never a licence
to remove one.

Adapted, not copied: cdkd states this against its `worktree-owner-gate.sh`
`session-owner` sentinel, which this repo does not have (`.claude/hooks/` here
carries `worktree-guard.sh`). The principle is restated against the signals this
repo actually carries — dirty tree, open PR, claim comment.

## Verification (section 8's prose arm — no `src/**` in the diff)

The claims are the artifact, so every one was resolved against real records rather
than a command re-run 5x:

- All cited cdkd refs opened and confirmed to say what the lesson claims
  (go-to-k/cdkd#2009, go-to-k/cdkd#2015, go-to-k/cdkd#2000), including reading the
  reworded bullet out of go-to-k/cdkd#2000's actual merge commit.
- The `grep -cF` claim reproduced locally: a marker containing `[` and `.` scored
  **0 / rc=1** without `-F` and **1 / rc=0** with it; a zero-match `grep -cF` exits
  **rc=1**.
- Both commands the new text sends the next agent to run were executed as literally
  written. `git show "$(gh pr view <n> --json mergeCommit -q .mergeCommit.oid):<file>"`
  piped to `grep -cF` returned 1/rc=0 against this run's own merged
  go-to-k/cdk-real-drift#1788, and the `diff <(git show origin/main:<file>) <file>`
  form showed this diff is purely additive plus the intended section 9 replacement.
- Re-derived against the **new** `main`: this issue's file check predates
  go-to-k/cdk-real-drift#1788, which rewrote sections 6 and 9 of this same file.
  Re-checked after that merge — lessons 1 and 2 still absent, lesson 3's principle
  partly present at the section 9 passage, hence amended there.
- Full suite green: **345 files / 6510 tests**, typecheck 0 errors,
  `vp check --fix` clean, no `vp fmt` reflow of the new prose.

## Won't-do (recorded here)

**No new test.** `tests/skill-doc-paths.test.ts` already mechanizes the path and
fully-qualified-ref claims in this file and passes, and
`tests/markdown-fmt-corruption-1771.test.ts` covers the formatting hazard. The three
lessons govern how an agent runs ad-hoc greps during a merge check; asserting the
skill's own prose phrasing would over-fit without catching a real defect class.

**The sibling repos are not updated here.** These lessons originate in cdkd and
already ship there. cdk-local lacks all three (checked: 0 hits for each marker) and
is tracked in go-to-k/cdk-local#531, filed by this lane; the separate cdk-local
lesson set that go-to-k/cdk-real-drift#1788 mirrored is tracked for cdkd in
go-to-k/cdkd#2016. Each needs its own repo's worktree + gate cycle and its own
per-claim verification pass, so neither is bundled into this PR.

Closes #1789
