### PR TITLE
chore(work-issues): one session lands a flow lesson in all three repos, and two mirrored traps it exposed

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -139,11 +139,32 @@ reading lane was itself about to edit. A false collision on one file and silence
 the two real ones, from the step whose entire job is to find them. It read correctly
 only once that lane committed, which is exactly when it had stopped mattering.
 
-Read any "working on this" comments on candidate issues too, but treat them as the
-WEAKEST signal: a claim is written once, before the work, and goes stale as the lane's
-scope grows — the go-to-k/cdk-real-drift#1771 claim above named a new `tests/`
-file and never named `docs/ARCHITECTURE.md`. Where a dirty tree and a claim
-disagree, the dirty tree wins.
+Read the "working on this" comments on candidate issues too — to the END of each
+thread, and then on every issue that thread NAMES (`gh issue view <n> --comments`
+prints the whole thread in one call). A lane that works an issue and cannot close
+it files the REMAINDER as a child issue, says so in its closing comment, and leaves
+the parent open on purpose, so the parent's live work can be owned by a claim that
+never appears on the parent. Measured in cdkd on 2026-08-19 (go-to-k/cdkd#2035):
+go-to-k/cdkd#2018's 08:14:47Z closing comment named go-to-k/cdkd#2026 as one of its
+two conditions for closing; that child was claimed at 08:30:39Z, a second run
+claimed the PARENT at 08:32:33Z, and two of the parent's three admissible remedies
+land in exactly the files the child's claim declared — so that run stood down at
+08:46Z and re-picked the work inside the child's lane. Treat the claim itself as
+the WEAKEST signal for WHICH FILES a lane owns: it is written once, before the
+work, and goes stale as the lane's scope grows — the go-to-k/cdk-real-drift#1771
+claim above named a new `tests/` file and never named `docs/ARCHITECTURE.md`.
+Where a dirty tree and a claim disagree, the dirty tree wins.
+
+That ranking answers which FILES a live lane owns, and it has one bounded blind
+spot: whether a lane exists AT ALL. Between `git worktree add` and the lane's first
+write, every probe above reads clean — no pushed branch, no PR, a worktree sitting
+at `main`'s exact tip with no commits, and a working tree with nothing in it — and
+the claim comment is the only artifact that exists. The cdkd child lane above had
+exactly that profile at 80 seconds old. So an EMPTY dirty tree is not the absence
+of a lane: it is either no lane or one younger than its first write, and only the
+claim tells those apart (§9 states the general form — every ownership signal
+establishes LIFE, never absence). After that first write the ranking above applies
+unchanged.
 
 **A file another agent is editing is OFF-LIMITS.** In practice the contested files are
 the central tables:
@@ -221,7 +242,9 @@ signal. Use the cheap conservative one and accept its false positives:
 lane filing a deferral and coming back to it, and comfortably longer than the window
 in which nothing LINKS a live lane to the issue it just filed: `git worktree list` /
 `git branch -a` show the lane but not its deferral, `gh pr list` shows nothing until
-it pushes, and §4's claim comment is never posted for an issue merely FILED.
+it pushes, and §4 posts a claim at filing time only for a deferral the filing run
+means to take ITSELF — never for one it hands off, which is the case this window
+protects.
 
 ```bash
 CUT=$(date -u -v-60M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '60 min ago' +%Y-%m-%dT%H:%M:%SZ)
@@ -515,13 +538,23 @@ Three things make that check misreport, and all three read as LOST CONTENT:
   its marker read back out of what is now the tip, so two hits are one confirmation
   plus one freebie. The load-bearing arm is the EARLIER-merged lane's — if you only
   have budget to think about one, think about that one.
-- **Use `grep -cF`, and do not chain the two greps with `&&`.** Prose markers are
-  full of regex metacharacters, so an unanchored `grep -c` silently fails to match
-  and produces exactly the false alarm this check exists to prevent — measured here
-  2026-08-19: a marker containing `[` and `.` scored 0 without `-F` and 1 with it.
-  `grep -c` also exits 1 on zero matches, which is the very case being hunted, so a
-  chained second grep never runs. (Double quotes, not `-F`, are what survive an
-  apostrophe.)
+- **Use `grep -cF`, keep the marker on ONE LINE of the merged file, and do not
+  chain the two greps with `&&`.** Prose markers are full of regex metacharacters,
+  so an unanchored `grep -c` silently fails to match and produces exactly the false
+  alarm this check exists to prevent — measured here 2026-08-19: a marker
+  containing `[` and `.` scored 0 without `-F` and 1 with it. `grep` is LINE-based
+  while these files are hard-wrapped, so a perfectly verbatim phrase that spans the
+  wrap scores 0 the same way: measured here 2026-08-19 against
+  go-to-k/cdk-real-drift#1790's merge commit, `Two lanes editing the SAME file`
+  scored 0 / rc=1 while the very next words on one line,
+  `the SAME file merge without a conflict`, scored 1 / rc=0. Pick the phrase from
+  the merged file you are about to grep rather than reusing a sibling repo's —
+  the wrap column moves with the wording, so go-to-k/cdk-local#532's marker for
+  this same rule is not the phrase that wraps here — and settle a 0 with
+  `git show origin/main:<file> | grep -n "<one short word of it>"`, which prints
+  the whole line and shows where it breaks. `grep -c` also exits 1 on zero matches,
+  which is the very case being hunted, so a chained second grep never runs. (Double
+  quotes, not `-F`, are what survive an apostrophe.)
 
 When a marker genuinely does come back 0, settle it from your lane worktree with
 `diff <(git show origin/main:<file>) <file>`: the lines YOUR commit removed should
@@ -856,15 +889,37 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   growth is not.
 - Do not restate a rule that already lives in `CLAUDE.md` or in another step — point
   at it instead.
-- If the lesson is about the FLOW rather than about cdk-real-drift, mirror it into
-  the same-named `work-issues` skill in the sibling repos (`../cdkd`,
-  `../cdk-local`). They run this flow with different gates and different ship steps,
-  so adapt the wording per repo rather than copying the section verbatim, and it is
-  one PR per repo under that repo's own worktree + gate flow (cdkd blocks
-  tracked-file edits in its main worktree, so it cannot be edited in place). Do them
-  in this session when it can pay for two more gate runs; otherwise file one issue
-  per repo carrying the `Session-fit` line. What is not an option is landing the fix
-  in only one of the three — that is how the three drift apart.
+- If the lesson is about the FLOW rather than about cdk-real-drift, ONE session
+  lands it in all three repos — this file plus the same-named `work-issues` skill
+  in the sibling repos, checked out beside this one as `../cdkd` and `../cdk-local`
+  RELATIVE TO THE REPO ROOT (from a `.worktrees/<lane>` cwd — where this flow puts
+  you — neither resolves; measured 2026-08-19). They run this flow with
+  different gates and different ship steps, so adapt the wording per repo rather
+  than copying the section verbatim: three worktrees, three PRs, three gate cycles,
+  each under its own repo's rules (cdkd blocks tracked-file edits in its main
+  worktree, so it cannot be edited in place). Landing all three is the DEFAULT, not
+  the affordable option, because the alternative makes this bullet a duplicate
+  GENERATOR: a lesson that hops one repo at a time has every landing session run
+  its own §10 retro, which files again into the other two. Measured 2026-08-19:
+  twelve open `chore(work-issues)` issues across the three repos were one change,
+  and two of them — go-to-k/cdkd#2011 and go-to-k/cdkd#2016, filed twenty minutes
+  apart by two different hops, neither seeing the other — were the SAME three
+  cdk-local lessons.
+  **Filing instead is a WHOLE-REMAINDER exception.** When the session genuinely
+  cannot pay for the remaining gate cycles, it files into EVERY repo it has not
+  landed in, in ONE turn, and each filed issue names the other filings plus the repo
+  the lesson already landed in — so a reader sees the set is complete instead of
+  re-deriving it. Partial filing is what produced the pair above. Carry §4's
+  `Session-fit` line in every one of them, in English.
+  **A lane WORKING a mirror issue does not mirror onward.** The originating session
+  already owns all three landings, so re-filing the received lesson into the
+  siblings only adds a second and a third copy of it. What IS new is whatever the
+  ADAPTATION itself teaches — a gate name that differs, a probe that reads
+  differently here — and that is subject to this bullet in turn.
+  **Batch a run's lessons into ONE PR per repo**, not one PR per lesson: the gate
+  cycle is the per-PR cost, so a run that learned five things ships three PRs. The
+  batch that shipped this bullet is that shape — go-to-k/cdk-real-drift#1791 and
+  go-to-k/cdk-real-drift#1792 landed in one lane, one PR.
   **Verify the copy against the TARGET repo, claim by claim, before shipping it.**
   Their gates, hooks and ship steps differ, so a sentence that is true here reads as
   authoritative there while being false, and nothing lints instruction prose — the


### PR DESCRIPTION
## Summary

Three edits to `.claude/skills/work-issues/SKILL.md`, shipped as one PR because
they land in one file — which is itself one of the clauses below.

Closes #1791
Closes #1792

### Section 10-c — one session lands a flow lesson in all three repos

The mirror bullet was a duplicate GENERATOR: a lesson that hops one repo at a
time makes every landing session run its own section 10 retro, which files
again into the other two. The bullet now makes landing all three the DEFAULT
(three worktrees, three PRs, three gate cycles), with three clauses written as
bold lead-in paragraphs in the bullet's existing style rather than as new
sub-bullets:

1. **Filing instead is a WHOLE-REMAINDER exception** — file into EVERY repo not
   yet landed in, in ONE turn, each issue naming the other filings plus the repo
   the lesson already landed in. Partial filing is what produced the duplicate
   pair.
2. **A lane WORKING a mirror issue does not mirror onward** — the originating
   session already owns all three landings; only what the ADAPTATION teaches is
   new, and that is subject to the bullet in turn.
3. **Batch a run's lessons into ONE PR per repo**, not one PR per lesson — the
   gate cycle is the per-PR cost.

Cut to pay for it: the old disposition sentence ("Do them in this session when
it can pay for two more gate runs; otherwise file one issue per repo ... What is
not an option is landing the fix in only one of the three").

Evidence measured for this PR, not carried over:

```
$ for R in cdkd cdk-local cdk-real-drift; do gh -R go-to-k/$R issue list --state open \
    --limit 100 --json number,title --jq '.[]|select(.title|test("work-issues"))|.number'; done
cdkd:            2017 2016 2011 2008 2003 1996 1993 1992 1990
cdk-local:       533
cdk-real-drift:  1792 1791
                 -> twelve open chore(work-issues) issues, all one change

$ gh -R go-to-k/cdkd issue list --state all --json number,createdAt,title --jq ...
2016  2026-08-19T06:37:52Z  mirror three flow lessons from cdk-local's 2026-08-19 run, and audit ...
2011  2026-08-19T06:17:34Z  mirror three flow lessons from cdk-local's 2026-08-19 run (flake-fix ...)
                 -> the same three cdk-local lessons, filed 20m18s apart by two hops
```

Also corrected in the same sentence, and measured here: the siblings were cited
as `../cdkd` / `../cdk-local`, which resolve from the REPO ROOT only.

```
$ cd /Users/goto/github/cdk-real-drift && ls -d ../cdkd ../cdk-local
../cdk-local
../cdkd
$ cd .worktrees/work-issues-cross-repo-batch && ls -d ../cdkd ../cdk-local
lsd: ../cdkd: No such file or directory (os error 2).
lsd: ../cdk-local: No such file or directory (os error 2).
```

Since section 10-c's own flow puts the agent in `.worktrees/<lane>`, the bare
relative path was a trap; the sentence now says which cwd it is relative to.

### Section 7 (#1791) — a same-file marker must sit on ONE LINE of the merged file

Folded into the existing `grep -cF` bullet (not added beside it), which is the
bullet about grep mechanics defeating the check. `grep` is line-based and these
files are hard-wrapped, so a perfectly verbatim phrase spanning the wrap scores
0 and reads as lost content — the exact alarm the check exists to prevent.

The wrap column moves per repo, so the shipped clause carries a LOCAL
measurement against this repo's own copy, taken from the merge commit of https://github.com/go-to-k/cdk-real-drift/issues/1790
(`1e719a209f6c554d05053ef8b43bb6a9596eb974`):

```
$ git show "$M:.claude/skills/work-issues/SKILL.md" | grep -cF "Two lanes editing the SAME file"
0
rc=1
$ git show "$M:.claude/skills/work-issues/SKILL.md" | grep -cF "the SAME file merge without a conflict"
1
rc=0
$ git show origin/main:.claude/skills/work-issues/SKILL.md | grep -n "Two lanes editing"
495:**A CLEAN merge is not evidence that there was no collision.** Two lanes editing
```

Same two phrases, same sentence — the first spans the wrap after "editing", the
second does not. The settling command named in the new text is the third one
above: it prints the whole line and shows where it breaks.

### Section 2 (#1792) — spawned-child claims, and the ranking's bounded blind spot

Two halves, both folded into section 2's existing claim paragraph rather than
bolted on:

- **Triage side.** Read each candidate's thread to the END, then the claim STATE
  of every issue that thread names. A lane that cannot close an issue files the
  remainder as a child, says so in its closing comment, and leaves the parent
  open on purpose. Verified against the cited records rather than the issue's
  summary of them: https://github.com/go-to-k/cdkd/issues/2018's closing comment is `2026-08-19T08:14:47Z`
  and names https://github.com/go-to-k/cdkd/issues/2026; https://github.com/go-to-k/cdkd/issues/2026 was claimed at
  `2026-08-19T08:30:39Z`; a second run claimed the PARENT at `08:32:33Z` and
  stood down at `08:46:15Z`, re-picking the work in the child's lane at
  `08:52:25Z`. (The issue body credited the cdkd lesson to
  https://github.com/go-to-k/cdkd/issues/2023 — that is the one-line-marker issue; the parent/child lesson
  came from that run's own retro and shipped in https://github.com/go-to-k/cdkd/issues/2035, merged
  `2026-08-19T09:14:57Z`. The PR cites the records, not the body.)
- **Owner-probe side (acceptance item 2).** Folded into the EXISTING dirty-tree
  ranking as its bounded blind spot, in a new paragraph directly after it. The
  existing wording survives verbatim — "The third probe is the only one that sees
  a LIVE lane, and it outranks both the other two and the claim comment" and
  "Where a dirty tree and a claim disagree, the dirty tree wins" are both
  unchanged. What is added is the window: between `git worktree add` and a lane's
  first write, the dirty tree is EMPTY too and only the claim comment records the
  lane, so an empty tree is "no lane OR a lane younger than its first write".
  After the first write the ranking applies unchanged.

The command the new text sends the next agent to run was run:
`gh issue view 1791 --comments` printed both comments in one call, including the
maintainer's re-measurement note — which is precisely why this PR ships a local
measurement instead of cdk-local's phrase.

### Also paid for

Section 3-a claimed "§4's claim comment is never posted for an issue merely
FILED". Section 4 has required exactly that since it gained "Claim what you
FILE, too" for a deferral the filing run means to take itself. The sentence now
distinguishes a self-retained deferral (claimed at filing time) from a handoff
(not claimed), which is the case the 60-minute window protects.

## Verification

Prose-only diff, no `src/**` — section 8's prose arm applies: resolve every
gate / hook / skill / path / command the new text names against this repo's own
files, and RUN each command it sends the next agent to run (all shown above).
`verify-pr-gate` exempts a diff with no `src/**` path; `check` + `docs` markers
were set from the worktree.

| Check | Result |
| --- | --- |
| `vp run typecheck` | pass |
| `vp check --fix` | pass — 0 errors, 125 warnings (pre-existing) in 403 files |
| `vp pack` | pass — dist built (fresh worktree had none) |
| `vp test run` | pass — 345 files / 6510 tests, rc=0 (re-run after the final edit: same) |
| `tests/skill-doc-paths.test.ts` + `markdown-fmt-corruption-1771` + `gate-cd-form-parity-1786` | pass — 3 files / 44 tests, rc=0 |
| `markgate verify check` / `verify docs` (from the worktree) | rc=0 / rc=0 |

Every issue reference in the edited file is fully qualified
(`go-to-k/<repo>#N`); `tests/skill-doc-paths.test.ts` is what enforces it and it
passes on this diff.

Not verified: nothing in the sibling repos was touched or re-read beyond the
GitHub records cited above — the cdkd and cdk-local landings of these same
lessons are peer lanes of this batch.

## Retrospective (verify-pr step 8)

Two things this lane hit, surfaced rather than silently absorbed:

1. **`vp check --fix` re-parents paragraphs that follow a new sub-bullet.** The
   three clauses were first written as `  - **Clause**` sub-bullets inside the
   10-c bullet; the formatter then re-indented the three verification paragraphs
   that follow them (`Verify the copy against the TARGET repo...`, and the two
   after it) from 2 spaces to 4, silently making them read as part of the LAST
   clause instead of the bullet. Caught by reading the post-format diff, not by
   any test. Rewritten as bold lead-in paragraphs — the style the bullet already
   used — after which the diff is stable across two `vp check --fix` runs. This
   is a flow lesson, so under the very clause this PR ships it belongs in all
   three repos in one session; it is reported to this batch's orchestrator
   instead of being appended here unilaterally, since the sibling lanes own
   their copies of the file.
2. **The `verify-pr` gate that fired is not this repo's.** This repo's own
   `.claude/hooks/verify-pr-gate.sh` exempts a diff with no `src/**`, and this
   diff has none. The block came from the driving session's foreign hook (its
   message lacks this repo's "Not heavyweight for a doc-like src change"
   paragraph), as did the `pr-body-item-number-gate` block that rejected the
   `owner/repo#N` form section 10-c mandates (known as
   https://github.com/go-to-k/cdkd/issues/1992). Per CLAUDE.md's sibling-repo
   rule the route taken was to satisfy the checklist, not to route around it:
   this repo's `/verify-pr` checklist was walked step by step (steps 0-6 and 8;
   step 7's shared-name core AWS suite is N/A — no `src/**` change, no hot path,
   no deploy), and the qualified refs in this body were rewritten as full URLs.
