### PR TITLE
chore(work-issues): warn that vp fmt re-parents a paragraph trailing a sub-bullet

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -977,6 +977,29 @@ pnpm install                  # worktrees have no node_modules
   that never happened.
 - English only in every committed line (`non-english-text-gate` enforces it at PR
   time).
+- **`vp fmt` REWRITES this file's indentation, and that can change what a
+  paragraph belongs to.** This repo's formatter covers markdown (the siblings' does
+  not -- measured 2026-08-19: the same probe file is rewritten here and reported as
+  "excluded by ignore rules" in cdkd and cdk-local), and it re-indents a paragraph
+  that follows a nested list item from 2 spaces to 4, which re-parents it under that
+  sub-bullet:
+
+  ```text
+  before                                    after `vp fmt`
+  - A bullet.                               - A bullet.
+    - A sub bullet that is new.               - A sub bullet that is new.
+    **A bold lead paragraph.**                  **A bold lead paragraph.**
+  ```
+
+  Nothing fails and no gate objects -- the file still renders, just saying something
+  else. It bit the go-to-k/cdk-real-drift#1793 lane, whose three verification
+  paragraphs in section 10-c were silently absorbed into the last clause above them.
+  The fix that survives the formatter is to write such a paragraph as a **bold lead
+  paragraph at the parent bullet's own indent** rather than as prose trailing a
+  sub-bullet, then run `vp fmt` TWICE and confirm the second run is a no-op. Read
+  the reformatted diff before committing; the damage is invisible in the source you
+  typed.
+
 - A `work-issues`-only edit is outside BOTH the `check` and `docs` gate scopes, but
   `check-gate` verifies both markers on every commit without computing scope, and a
   fresh worktree starts with NONE — so run `/check` + `/check-docs` there before the


### PR DESCRIPTION
Follow-on to https://github.com/go-to-k/cdk-real-drift/pull/1793, from the same
cross-repo batch run. That lane hit this trap while writing its own section 10-c
change and reported it rather than landing it alone; this PR records it.

## The trap

This repo's `vp fmt` covers markdown, and it re-indents a paragraph that follows a
nested list item from two spaces to four — which re-parents that paragraph under
the sub-bullet instead of the bullet it was written against.

```text
before                                    after `vp fmt`
- A bullet.                               - A bullet.
  - A sub bullet that is new.               - A sub bullet that is new.
  **A bold lead paragraph.**                  **A bold lead paragraph.**
```

Nothing fails and no gate objects. The file still renders; it just says something
else. It bit https://github.com/go-to-k/cdk-real-drift/pull/1793, whose three
verification paragraphs in section 10-c were silently absorbed into the last
clause above them — the lane restructured them as bold lead paragraphs to get back
the meaning it had written.

## Why this is recorded here only, and not mirrored

Section 10-c's new clause says one session lands a flow lesson in all three repos.
This is not a flow lesson — it is a property of THIS repo's toolchain. Probed the
identical file in all three on 2026-08-19:

| repo | `vp fmt <probe>.md` | file changed |
|---|---|---|
| cdk-real-drift | `Finished in 150ms on 1 files` | **yes** — 2-space paragraph became 4-space |
| cdkd | `Expected at least one target file. All matched files may have been excluded by ignore rules.` | no (sha identical) |
| cdk-local | same exclusion message | no (sha identical) |

So mirroring it would ship a false claim into two repos whose formatter never
touches markdown — exactly the failure the "verify the copy against the TARGET
repo, claim by claim" rule exists to prevent.

## Verification

The added text is written in the shape it prescribes, and was checked against the
formatter rather than assumed:

- `vp fmt` over the edited file, twice. First run normalized a blank line; **the
  second run is a byte-for-byte no-op** (`bb78eaa6…` both times), and the bold lead
  paragraph keeps its parent-bullet indent.
- `vp check` — `Found 0 errors and 125 warnings in 403 files` (warnings pre-exist
  on `main`).
- `vp run typecheck` — clean.
- `vp pack` — build complete.
- `vp run test` — **345 files / 6510 tests passed**, rc=0.
- `tests/skill-doc-paths.test.ts` — 15/15, so the new text's
  `go-to-k/cdk-real-drift#1793` reference satisfies the fully-qualified-refs rule.

One honest note on the run: the first `vp run test` reported 13 failures in
`tests/json-empty-on-error.test.ts`. That was a missing `dist/` in a fresh
worktree, not a regression — `/check` step 3 already documents that `vp pack` must
precede the test step for exactly this reason, and the suite is green once built.
Recording it because the failure looks alarming and unrelated to a markdown-only
diff.
