### PR TITLE
chore(work-issues): give the wrap-report TODO record five fields, and stop deferring work on an unmeasured integ cost

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -326,8 +326,10 @@ session that has decided not to do it — but this says nothing about the LATER 
 that takes it: that run claims it normally, per the mandatory rule above.
 
 **English-only covers the issue BODIES this flow files, not just the comment above.**
-Write the `Session-fit` gloss in English too — `Session-fit: next (not this session)`
-/ `Effort: ~1-3 h` — never in the session's chat language. Nothing enforces this
+Write the classification lines in English too — `Session-fit` / `Severity` /
+`Effort` / `Estimate`, one field per line (see `CLAUDE.md` → "The four TODO
+fields"), glosses included: `Session-fit: next (not this session)`,
+`Estimate: ~1-3 h — one live run` — never in the session's chat language. Nothing enforces this
 half: `non-english-text-gate` fires only on `gh pr create` / `gh pr edit` /
 `gh pr merge` (its `"if"` clause in `.claude/settings.json`), and it identifies its
 target by resolving a PR NUMBER and scanning `gh pr diff`, so it structurally cannot
@@ -338,6 +340,29 @@ go-to-k/cdk-local filed its follow-up on 2026-08-19 with both halves of the
 after creation (go-to-k/cdk-real-drift#1777).
 
 ## 5. One worktree per lane, then implement
+
+**Before fixing, ask whether the defect has SIBLING SITES — and if it does, sweep
+them in THIS lane rather than filing them.** Most defects here are a CLASS, not an
+instance: one command factory mishandling a flag, one resolver arm missing a case,
+one caller of a shared helper assuming the old contract. Once the root cause is
+named, grep for the same shape across `src/` before writing the fix.
+
+**N sites of one root cause is ONE issue and ONE PR, never N issues.** This is the
+single largest source of unbounded backlog growth: split into N, each site pays the
+full fixed cost — triage, claim, worktree, review tier, integ run, merge — for a fix
+that is the same edit N times. Swept together, that cost is paid once, and the
+reviewer sees the whole class instead of one instance whose generality is invisible.
+It also removes the failure mode where sites 2..N sit open long enough for the fix
+at site 1 to drift away from them.
+
+Two boundaries, so this does not become a licence for unbounded lanes:
+
+- **A sweep that would make the PR unreviewable is a genuine `next`** — file it as
+  an explicit umbrella naming every site, and say which sites this lane DID close,
+  so the residue is unambiguous rather than "the rest, somewhere".
+- **Sweep the same ROOT CAUSE, not the same AREA.** Two unrelated bugs in one file
+  are two issues; one wrong assumption at five call sites is one. The test is
+  whether a single sentence describes the fix at every site.
 
 Never edit in the main checkout. Per lane:
 
@@ -834,6 +859,30 @@ subject and a wider scope, and neither is covered by that one:
   would change
   what the flow PROMISES — dropping a gate, lowering a verification tier, loosening
   §0 — never for wording, ordering, or a newly-learned trap.
+
+### 10-0. Measure the run's net effect on the backlog
+
+Before anything else in this step, count what the run did to the issue list and put
+both numbers in the wrap report — `closed N / filed M` — and **when M > N, give the
+reason in one more line**. It is almost always one of three, and only the first is
+healthy:
+
+- **the code really does have that many independent defects** — the run walked into
+  an untested area. Fine; say which area, so the next hunt aims there.
+- **one root cause was split into many issues** — §5's sweep rule should have folded
+  them. This is the failure mode to catch; fold what is still open into an umbrella
+  now rather than next time.
+- **discoveries were deferred that had session-only evidence** — re-read the `now`
+  criteria in `CLAUDE.md`; a discovery whose repro dies with this session is not a
+  residual, and deferring it means the next session re-derives it.
+
+**M <= N is NOT a target, and must never become one.** The purpose of the system is
+a correct codebase, not a short list: an unfiled finding is strictly worse than a
+filed one, because it removes the defect from the record while leaving it in the
+product. This count exists to make growth VISIBLE and route it to the right cause —
+never to justify not writing a finding down, softening one, or merging two genuinely
+independent defects into one vague issue to make the number smaller. If you ever
+find yourself weighing whether to file, file.
 
 ### 10-a. Evidence: only what this run actually produced
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,7 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   issues elsewhere. **Remaining work** — exactly one of: **TODO (issue #N)**
   (work that still needs doing later; the ONLY bucket meaning follow-ups
   exist — every entry MUST have a GitHub issue number, filed BEFORE
-  reporting);
+  reporting, AND the four classification fields described below);
   **Won't-do (decided + recorded)** (things consciously decided AGAINST doing,
   with a one-line reason and where the decision is recorded — PR body, in-code
   comment, issue comment; no action needed); **Nothing remaining** (an explicit
@@ -331,6 +331,95 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   tree clean; no open PRs owned by this session; no running background tasks /
   hunts / subagents; no AWS resources pending cleanup (bughunt sentinel clear);
   every TODO filed as an issue.
+
+  **The four TODO fields — decide them WHEN THE ITEM ARISES, not at wrap time.**
+  By wrap time the evidence for the call (which files were open, which
+  verification cycle was already being paid for) is gone, and a retrospective
+  guess is worth little. Record them **in the issue body** so they outlive the
+  session. The issue body and the report use the SAME four lines, one field per
+  line:
+
+  ```text
+  Session-fit: now (do it in this session) | next (not this session) — <reason>
+  Severity: high | medium | low — <what stays broken while it is undone>
+  Effort: small (S) | medium (M) | large (L) — <which verification cycle it drags>
+  Estimate: <duration, e.g. ~1-3 h> — <what eats the time>
+  ```
+
+  A report adds a fifth line, **`Notes`**, for session-specific context (`none`
+  when there is nothing); the issue body stays at four, because what belongs
+  there is only the part that outlives the session.
+
+  **The four answer four DIFFERENT questions and none derives from another**:
+  `Session-fit` is the decision, `Severity` the cost of leaving it undone,
+  `Effort` which verification cycle the fix drags, `Estimate` the hours. In
+  particular do not collapse `Severity` into `Session-fit` — a `Severity: high`
+  item can still be `next` (a new fixture has to be written for it) and a `low` one
+  can be `now` (it lands in a file this session already has open). The moment
+  the two track each other, `Severity` is a second spelling of the decision and
+  the field is wasted. Likewise `Effort` is not `Estimate`: "one live run" is a
+  kind of cost, and how many hours it takes depends on which fixture.
+
+  **The keys are spelled identically everywhere** — issue body, English report,
+  Japanese report; never translated or renamed per context. **No bare tokens**,
+  because a value must be readable without knowing the internal scale: write
+  `Session-fit: next (not this session)` and never a lone `next`;
+  `Effort: large (L)` and never a lone `L`; `Severity` as a word and **never as
+  an initial** (the initials collide with `Effort`'s both ways — `M` is
+  `medium` on either scale, and `L` would be _low_, the least urgent thing there
+  is, against _large_, the biggest); and always BOTH `Effort` and `Estimate` —
+  dropping the duration and keeping the letter is exactly the failure this split
+  exists to end.
+
+  **Scales.** `Severity`: `high` = a wrong result, data loss, a security
+  surface, or something a user hits in normal operation; `medium` = a capability
+  is missing but there is a workaround, or it only shows up under a specific
+  condition; `low` = internal tidiness, invisible to users. **Rate what a user
+  experiences, never why this session should do it** — "leaving main
+  self-inconsistent" is a `Session-fit: now` trigger, not a Severity level, and
+  copying it here makes that flavour of `high` permanently un-`next`-able.
+  `Effort` measures the verification tail rather
+  than the edit: `small` = edit plus unit tests, riding verification this
+  session already pays for; `medium` = one re-review round, or a live run this
+  session was not otherwise going to make; `large` = a NEW fixture has to be
+  WRITTEN, or a behavior change needing its own PR plus review.
+
+  **Calibration: RUNNING an existing integ is not a reason to defer.** Measured
+  over the 268 rows of cdkd's `docs/_generated/integ-last-run.tsv` on 2026-08-20:
+  median run 85 s, mean 4.6 min, p90 8.8 min. A passing run costs a few hundred
+  tokens. If the session is running one for its current lane anyway, a fix riding
+  the same fixture costs zero — the same run refreshes the same gate. What is
+  genuinely expensive is WRITING a new fixture, an integ that FAILS, and above
+  all review of a larger diff, which grows superlinearly because a reviewer reads
+  the whole thing and cross-file interactions multiply. Defer on those.
+
+  **A newly DISCOVERED bug is not a residual.** A residual (deferred polish, a
+  nit, a parity gap) is fully describable, so writing it down loses nothing. A
+  discovery's expensive part is the EVIDENCE behind it — the repro you built,
+  what you watched actually happen, the number you measured — and that is exactly
+  what an issue body cannot carry cheaply. When a bug surfaces mid-session, ask
+  which it is: if the evidence is session-only, finish it now unless a genuine
+  defer criterion fires, and if you must defer it anyway, put the EVIDENCE in the
+  issue body, not just the diagnosis.
+
+  **One field per line — never pack two onto one**, and keep the field names and
+  their order identical every time. A field with nothing to say gets an explicit
+  `none`, never omission:
+
+  ```text
+  ## Remaining work
+  - TODO #<N> — <what it is>
+    - Session-fit: now (do it in this session) | next (not this session) — <one line>
+    - Severity: high | medium | low — <what stays broken while it is undone>
+    - Effort: small (S) | medium (M) | large (L) — <which verification cycle it drags>
+    - Estimate: <duration> — <what eats the time>
+    - Notes: <session-specific context | none>
+  - Won't-do — <what>
+    - Why: <one line>
+    - Recorded: <PR body | in-code comment | issue>
+  (or the single line: Nothing remaining)
+  ```
+
 - **Claim a filed issue before working it — post a `gh issue comment` the moment
   you START (or commit to start) work, so parallel agents and sessions don't
   collide.** Multiple agents pick up open issues concurrently; two of them fixing


### PR DESCRIPTION
## Summary

Mirrors https://github.com/go-to-k/cdkd/pull/2101 . Two things: the session-wrap TODO record gains a
proper shape (this repo's Remaining-work rule named the TODO bucket but never
said what an entry must carry, so entries shipped with no classification at
all), and three rules that pushed work out of sessions are corrected.

### 1. The TODO record is four fields in the issue body, one per line

```text
Session-fit: now | next — <reason>            the decision
Severity: high | medium | low — <what stays broken while it is undone>
Effort: small (S) | medium (M) | large (L) — <which verification cycle it drags>
Estimate: <duration> — <what eats the time>
```

plus a report-only `Notes` line. The four answer four different questions and
none derives from another; in particular `Severity` rates what a USER
experiences, never why this session should do it, so it cannot decay into a
second spelling of `Session-fit`. No bare tokens: `Effort: large (L)` never a
lone `L`; `Severity` always as a word (the initials collide with `Effort`'s both
ways — `L` would be *low*, the least urgent thing there is, against *large*, the
biggest); `Effort` never without `Estimate`.

### 2. `needs its own integ cycle` was mis-calibrated

Measured over the 268 rows of cdkd's `docs/_generated/integ-last-run.tsv`:
median run **85 s**, mean 4.6 min, p90 8.8 min. A passing run costs a few
hundred tokens, and if the session is running one for its current lane anyway, a
fix riding the same fixture costs zero. What is genuinely expensive is *writing*
a new fixture, a run that FAILS, and above all review of a larger diff, which
grows superlinearly. The `Effort` scale is recalibrated to match.

### 3. A newly discovered bug is not a residual

A residual is fully describable, so writing it down loses nothing. A discovery's
expensive part is the EVIDENCE (the repro built, what was watched happening, the
number measured) — exactly what an issue body cannot carry cheaply. Session-only
evidence is now a reason to finish it now, and a deferred discovery must carry
its evidence, not just its diagnosis.

### 4. One root cause is one issue, and the run measures its own net effect

`/work-issues` §5: N sites of one root cause is ONE issue and ONE PR, never N
issues — the largest source of unbounded backlog growth, since split into N every
site pays the full fixed cost for the same edit N times. Bounded: a sweep that
would make the PR unreviewable is a genuine `next` (file an umbrella naming every
site and which this lane closed), and the unit is the ROOT CAUSE, not the area.

`/work-issues` §10-0: report `closed N / filed M`, and when `M > N` name which of
three causes it was. **`M <= N` is explicitly NOT a target** — an unfiled finding
removes a defect from the record while leaving it in the product. The count makes
growth visible and routes it; it never justifies not writing a finding down.

`/work-issues` §4's English-only note now names all four lines rather than only
the `Session-fit` gloss, since every one of them ships in the issue body.

## Test plan

- `vp run check` / `vp run build` / `vp run test` — all pass, counts in the
  commit trailer
- Docs consistency: no other copy of the wrap-report format exists in this repo
  (grepped `Session-fit` / `Remaining work` / `Effort:` across `docs/`,
  `README.md`, `.claude/rules/`)
