### PR TITLE
chore(hunt-bugs): require the four classification lines on every issue the hunt files

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -56,10 +56,10 @@ which they want** — do not assume. Typical options to offer:
 - **Fix + PR** — additionally root-cause, fix in `src/`, add the unit test, keep the
   fixture, and carry it through PR (per "On a confirmed bug" + the merge steps).
 
-Only skip the question when the user already said which (e.g. "issueを立てるまでを
-ゴールに" = issue-only, or "直して" / "fix and PR" = fix). When in doubt, ASK — a wrong
-assumption here either wastes a fix that collides with a parallel agent, or stops
-short of a fix the user wanted.
+Only skip the question when the user already named one — "stop at filing the
+issues" / "just report what you find" means issue-only, "fix it" / "fix and PR"
+means fix. When in doubt, ASK — a wrong assumption here either wastes a fix that
+collides with a parallel agent, or stops short of a fix the user wanted.
 
 ## Core principles
 
@@ -596,6 +596,23 @@ issue-only hunt round files the issue and stops there (the fix comes later); a
 fix-in-session round still files the issue, then closes it from the PR (`Closes
 #<n>`). The issue body carries the real repro (live model / commands) so the later
 fixer has the evidence.
+
+**Every issue this hunt files also carries the four classification lines**
+(`CLAUDE.md` -> "The four TODO fields"), in English, one field per line:
+
+```text
+Session-fit: now (do it in this session) | next (not this session) - <reason>
+Severity: high | medium | low - <what stays broken while it is undone>
+Effort: small (S) | medium (M) | large (L) - <which verification cycle it drags>
+Estimate: <duration, e.g. ~1-3 h -- never a bare letter> - <what eats the time>
+```
+
+A hunt is the single best moment to write them: you have just reproduced the bug,
+so `Severity` is measured rather than guessed, and you already know which fixture
+the fix will drag. Deferring them to whoever picks the issue up throws that
+evidence away -- the same reason `CLAUDE.md` puts the decision at the moment of
+deferral. `/work-issues` reads these lines back when it ranks candidates, so an
+unclassified body is one this hunt made harder to triage.
 
 When you then WORK an issue — this hunt's own or one already filed — **run
 `/work-issues` and follow it** for the collision-safe start: its §0 screens the


### PR DESCRIPTION
## Summary

Follow-up to the wrap-report field split (this repo's companion PR). That PR
made `CLAUDE.md` require four classification lines on every TODO issue, but
`/hunt-bugs` -- which files issues as a normal step -- was never told, so main
was left self-inconsistent: the rule demanded the lines and the skill that
produces most of the issue bodies did not write them.

`/hunt-bugs` now carries the same four-line block the other skills do:

```text
Session-fit / Severity / Effort / Estimate
```

A hunt is the single best moment to write them -- the bug has just been
reproduced, so `Severity` is measured rather than guessed and the fixture the fix
will drag is already known. Deferring them to whoever picks the issue up throws
that evidence away, which is the same argument `CLAUDE.md` makes for deciding at
the moment of deferral. `/work-issues` reads these lines back when it ranks
candidates, so an unclassified body is one the hunt made harder to triage.

Mirrors the equivalent change already merged in go-to-k/cdkd (see
https://github.com/go-to-k/cdkd/pull/2101 ).

## Test plan

- `vp run check` / `vp run build` / `vp run test` -- all pass
- Docs-only change to a skill; no source surface touched
