### PR TITLE
chore(work-issues): probe every fence for spelling and deletion, and fix the four that were dead

### DIFF
--- a/.claude/hooks/check-gate.test.sh
+++ b/.claude/hooks/check-gate.test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Smoke test for check-gate.sh.
+#
+# Stubs the markgate resolution (`mise exec -- markgate verify <gate>` and the
+# bare `markgate` fallback) so the marker verdicts are controlled, then asserts
+# the BLOCK (exit 2) vs ALLOW (exit 0) outcomes: which command spellings are
+# gated at all, which working tree the verdict is read from, and the fail-open
+# paths. Run from the repo root:
+#   bash .claude/hooks/check-gate.test.sh
+#
+# Why a shell script (not vitest): the hook IS a shell script; its contract is
+# the stdin JSON payload + exit code. A TS wrapper would test the wrapper.
+#
+# Written 2026-08-20 (go-to-k/cdk-real-drift#1797): `tests/skill-doc-paths.test.ts`
+# enumerated `.claude/hooks/*.test.sh` and asserted a COUNT, so it measured the
+# harnesses that exist rather than the hooks that owe one — and check-gate, the
+# hook every commit passes through, was the one with no harness at all.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-gate.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+repo="$TMPDIR/repo"
+git init -q -b main "$repo"
+git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+notrepo="$TMPDIR/plain"
+mkdir -p "$notrepo"
+
+# `mise exec -- markgate verify <gate>` exits with the per-gate mock rc.
+SHIM_DIR="$TMPDIR/bin"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/mise" <<'MISE_EOF'
+#!/usr/bin/env bash
+# mise exec -- markgate verify <gate>
+gate="${!#}"
+case "$gate" in
+  check) exit "${MARKGATE_CHECK_RC:-0}" ;;
+  docs) exit "${MARKGATE_DOCS_RC:-0}" ;;
+esac
+exit 0
+MISE_EOF
+cat > "$SHIM_DIR/markgate" <<'MG_EOF'
+#!/usr/bin/env bash
+# markgate verify <gate>  (the PATH fallback when mise is absent)
+gate="${!#}"
+case "$gate" in
+  check) exit "${MARKGATE_CHECK_RC:-0}" ;;
+  docs) exit "${MARKGATE_DOCS_RC:-0}" ;;
+esac
+exit 0
+MG_EOF
+chmod +x "$SHIM_DIR/mise" "$SHIM_DIR/markgate"
+
+# A PATH holding neither mise nor markgate, for the not-installed case.
+BARE_DIR="$TMPDIR/bare"
+mkdir -p "$BARE_DIR"
+for tool in bash git jq sed awk grep cat dirname printf; do
+  target=$(command -v "$tool" 2>/dev/null) && ln -sf "$target" "$BARE_DIR/$tool"
+done
+
+pass=0; fail=0
+
+# run_case <name> <expect_exit> <command> <cwd> [PATH_DIR] [check_rc] [docs_rc]
+run_case() {
+  local name="$1" want="$2" command="$3" cwd="$4"
+  local path_dir="${5:-$SHIM_DIR}" check_rc="${6:-0}" docs_rc="${7:-0}"
+  local payload got out
+  payload=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$cwd" "$command")
+  out=$(printf '%s' "$payload" | env PATH="$path_dir:/usr/bin:/bin" \
+    MARKGATE_CHECK_RC="$check_rc" MARKGATE_DOCS_RC="$docs_rc" "$HOOK" 2>&1)
+  got=$?
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1)); printf 'OK   %s (exit %s)\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL %s (want %s, got %s)\n  out: %s\n' "$name" "$want" "$got" "$out"
+  fi
+}
+
+# --- which commands are gated at all -----------------------------------------
+# Stale markers everywhere below, so an ALLOW means the hook never looked.
+run_case "non-commit command passes through" 0 "git status" "$repo" "$SHIM_DIR" 1 1
+run_case "git commit is gated" 2 "git commit -m x" "$repo" "$SHIM_DIR" 1 1
+run_case "git -C <path> commit is gated" 2 "git -C $repo commit -m x" "$repo" "$SHIM_DIR" 1 1
+run_case "cd <path> && git commit is gated" 2 "cd $repo && git commit -m x" "$repo" "$SHIM_DIR" 1 1
+run_case "git -c k=v commit is gated" 2 "git -c user.name=t commit -m x" "$repo" "$SHIM_DIR" 1 1
+# A quoted mention is not an invocation: the match is line-start anchored.
+run_case "quoted mention is not gated" 0 "echo \\\"run git commit next\\\"" "$repo" "$SHIM_DIR" 1 1
+
+# --- the verdict is read from the resolved working tree ----------------------
+run_case "both markers fresh allows the commit" 0 "git commit -m x" "$repo" "$SHIM_DIR" 0 0
+run_case "stale check marker blocks" 2 "git commit -m x" "$repo" "$SHIM_DIR" 1 0
+run_case "stale docs marker blocks" 2 "git commit -m x" "$repo" "$SHIM_DIR" 0 1
+run_case "cd <path> reads the target tree, not cwd" 2 "cd $repo && git commit -m x" \
+  "$notrepo" "$SHIM_DIR" 1 1
+
+# --- fail-open / fail-loud paths ---------------------------------------------
+run_case "non-git target fails open" 0 "git commit -m x" "$notrepo" "$SHIM_DIR" 1 1
+run_case "cd to a non-git path fails open" 0 "cd $notrepo && git commit -m x" \
+  "$repo" "$SHIM_DIR" 1 1
+run_case "missing markgate fails LOUD" 2 "git commit -m x" "$repo" "$BARE_DIR" 0 0
+
+# --- the messages name the skill to re-run -----------------------------------
+msg=$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m x"}}' "$repo" |
+  env PATH="$SHIM_DIR:/usr/bin:/bin" MARKGATE_CHECK_RC=1 MARKGATE_DOCS_RC=1 "$HOOK" 2>&1)
+for needle in "/check" "/check-docs"; do
+  if printf '%s' "$msg" | grep -qF -- "$needle"; then
+    pass=$((pass + 1)); printf 'OK   block message names %s\n' "$needle"
+  else
+    fail=$((fail + 1)); printf 'FAIL block message omits %s\n  out: %s\n' "$needle" "$msg"
+  fi
+done
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -31,10 +31,10 @@ Run these sequentially and report results:
    HAS caused a false-negative live-test is a `dist/` nobody rebuilt: a stale
    binary that lacked the change under test.
 4. `vp test run` (Vitest unit tests; `tests/integration/**` is excluded by
-   `vite.config.ts`). The run-task cache is a real foot-gun — PR #438's duplicate
+   `vite.config.ts`). The run-task cache is a real foot-gun — PR go-to-k/cdk-real-drift#438's duplicate
    object key passed a CACHED `vp run typecheck` and reached `main`, which is why
    `typecheck` is now `cache: false` — but `test` reported a cache MISS on every
-   run measured on 2026-08-19 (#1768). Prefer the direct form; do not treat a
+   run measured on 2026-08-19 (go-to-k/cdk-real-drift#1768). Prefer the direct form; do not treat a
    `vp run test` result as suspect on cache grounds alone.
 
 When piping any of the above to `tail` / `head` / `grep`, **check the actual

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -126,7 +126,7 @@ collides with a parallel agent, or stops short of a fix the user wanted.
    that **DECLARES** the suspect property never exercises the undeclared-default fold,
    so a first-run FP on that property stays latent under apparent coverage (observed on
    `Events::ApiDestination` `InvocationRateLimitPerSecond` — the pre-existing corpus case
-   declared it, hiding the undeclared-300 FP; #615). Before skipping a "covered" type,
+   declared it, hiding the undeclared-300 FP; go-to-k/cdk-real-drift#615). Before skipping a "covered" type,
    check whether any existing case leaves the suspect property **UNDECLARED** — `grep`
    the fixture `app.ts` / the corpus case's `declared` block for it; if every case
    declares it, the undeclared-default path is still open hunting ground.
@@ -142,7 +142,7 @@ collides with a parallel agent, or stops short of a fix the user wanted.
    to zero → move to the next type.** Do not settle for one rich fixture per type.
    **And cover the type's COMMON VARIANTS in their minimal form, not just one** — a
    default is frequently a function of a mode / family / engine, so a variant you did not
-   deploy is an unguarded gap. Concretely (a live-found miss, #1477): the RDS folds were
+   deploy is an unguarded gap. Concretely (a live-found miss, go-to-k/cdk-real-drift#1477): the RDS folds were
    all built from an Aurora / `DBCluster`-centric corpus, so a minimal **non-Aurora
    provisioned `DBInstance`** still first-ran FPs on `StorageType` (`gp2` — folded only
    for `aurora`), `BackupRetentionPeriod` (`1` — added to `DBCluster` but not
@@ -177,7 +177,7 @@ collides with a parallel agent, or stops short of a fix the user wanted.
    The INVERSE is prime hunting ground: an `SDK_OVERRIDES` reader / `SDK_SUPPLEMENTS`
    entry that EXISTS but has **zero corpus cases and zero fixtures** was added from a
    live FN report without ever exercising the barest first-run path — deploy its
-   minimal form first (the 2026-07-12 hunt's RedshiftServerless Workgroup trio, #1489,
+   minimal form first (the 2026-07-12 hunt's RedshiftServerless Workgroup trio, go-to-k/cdk-real-drift#1489,
    came from exactly this audit; ACM Certificate / ELBv2 TrustStore / DAX /
    MediaConvert / SageMaker EndpointConfig / ClientVPN remain unexercised).
 
@@ -200,7 +200,7 @@ collides with a parallel agent, or stops short of a fix the user wanted.
    child segment → a likely declared-read gap worth a (cheap) deploy to confirm the
    exact composite order (the order is unreliable to guess — verify live, e.g. with
    `aws cloudcontrol get-resource`). Confirmed this way: Logs SubscriptionFilter
-   (`FilterName|LogGroupName`, PR #344). **But weight by GENERATION: registry-era
+   (`FilterName|LogGroupName`, PR go-to-k/cdk-real-drift#344). **But weight by GENERATION: registry-era
    types are overwhelmingly NATURAL composites** (their CFn physical id is already
    the `seg1|seg2` join, so CC reads them as-is — no adapter needed). The 2026-07-14
    ccpi-hunt deployed 7 uncovered composite-pi types in one cheap stack
@@ -235,7 +235,7 @@ collides with a parallel agent, or stops short of a fix the user wanted.
      only ONE value never tests multi-value reorder), or the service can't even produce
      the divergence (MSK rejects a partial version → declared==live, NO risk) → that
      determination is the deliverable. Only deploy the genuine, reproducible gaps. This
-     ruled out a whole class and ~10 wasteful deploys in the PR #303 hunt — fan out
+     ruled out a whole class and ~10 wasteful deploys in the PR go-to-k/cdk-real-drift#303 hunt — fan out
      parallel read-only agents (one per class) to do the audit. The fix for a confirmed
      gap is usually a one-line allowlist addition + the unit test + corpus case.
 6. **Parallelize, but cap at 3–4 stacks.** Independent stacks (unique names) can
@@ -251,8 +251,8 @@ Every hunt opens with the zero-cost sweeps; they regularly dissolve whole rounds
 zero deploys) or hand you a confirmed bug before the first deploy:
 
 - **New-pin off-flip audit over the diff window since the last hunt** — the step
-  that found the Budgets CostTypes FN (#1675). New truthy boolean pins arrive not
-  only from hunts but from READER-projection fixes (#1658 shipped a 9-leaf all-true
+  that found the Budgets CostTypes FN (go-to-k/cdk-real-drift#1675). New truthy boolean pins arrive not
+  only from hunts but from READER-projection fixes (go-to-k/cdk-real-drift#1658 shipped a 9-leaf all-true
   family with no off-state gate), so scan what LANDED, not just the historical
   tables:
   ```bash
@@ -328,7 +328,7 @@ prop to a NON-default (it must re-surface, proving the equality-gate still detec
 out-of-band change), then `revert` and confirm the live value actually returns to the
 default. Some providers IGNORE an omitted property on update, so the default `remove`
 revert is a SILENT no-op — Cloud Control reports SUCCESS yet the live value persists
-(observed on Transfer `UpdateServer` / `SecurityPolicyName` #597, IAM
+(observed on Transfer `UpdateServer` / `SecurityPolicyName` go-to-k/cdk-real-drift#597, IAM
 `MaxSessionDuration`, Lambda Alias `Description`, Cognito `AllowClassicFlow`). The fix
 is to add `${resourceType}\0${path}` to `REVERT_SET_DEFAULT_PATHS`
 (`src/revert/plan.ts`) so revert writes the `KNOWN_DEFAULTS` default EXPLICITLY and
@@ -341,7 +341,7 @@ to assume that a property changed only by a dedicated sub-API (Enable/DisableRul
 Increase/DecreaseStreamRetentionPeriod, PutBackupPolicy, SetQueueAttributes) must
 no-op on an omitted `remove` — but the Cloud Control HANDLER often RECONCILES the full
 desired state and resets the property to its default when omitted. Live-proven
-2026-07-13 (#1571): of four dedicated-toggle siblings, only **`Kinesis::Stream`
+2026-07-13 (go-to-k/cdk-real-drift#1571): of four dedicated-toggle siblings, only **`Kinesis::Stream`
 `RetentionPeriodHours`** actually no-oped (CC leaves it unchanged) and needed the RSDP
 entry; **`Events::Rule` State, `SQS::Queue` VisibilityTimeout, `EFS::FileSystem`
 BackupPolicy all CONVERGED via the bare `remove`** (the CC handler reset them). So a
@@ -350,7 +350,7 @@ band and asserts the LIVE value after revert is the only reliable test — the A
 is not a predictor. The `revert-toggle-converge` fixture is the reference (one fixed
 case + converge-via-remove controls). Batch 2 (2026-07-14, `revconv-hunt` fixture):
 **`ECR::Repository` `ImageTagMutability` no-oped** (independently found+fixed the
-same day as #1580/#1581 — check upstream before pushing a same-table fix); Lambda
+same day as go-to-k/cdk-real-drift#1580/#1581 — check upstream before pushing a same-table fix); Lambda
 `TracingConfig`, SQS `DelaySeconds`, KMS Key `Enabled` all converged via bare
 `remove` — again ~1-in-4, unpredictable from the API shape. Batch 3 (2026-07-14,
 `revconv2-hunt` fixture): **`ECR::Repository` `ImageScanningConfiguration` no-oped**
@@ -365,14 +365,14 @@ scan/mutability scalars — prove per-property, not per-type. Also excluded from
 in-run revert probe by AWS-side rate limits (not cdkrd bugs): DDB TTL (1 change/h),
 EFS ThroughputMode (1 change/24h); Kinesis stream-mode allows exactly 2 switches/24h
 — enough for one mutate + one revert, none left for a retry. Batch 4 (2026-07-14,
-`revconv3-hunt` fixture, #1613): **SQS `SqsManagedSseEnabled`** (its 4 scalar
+`revconv3-hunt` fixture, go-to-k/cdk-real-drift#1613): **SQS `SqsManagedSseEnabled`** (its 4 scalar
 siblings converge — non-uniform WITHIN SQS again), **SFN `LoggingConfiguration`**,
 **ApiGateway RestApi `DisableExecuteApiEndpoint`**, **Cognito UserPoolClient
 `RefreshTokenValidity`** all no-oped; Athena WorkGroup `State`, DDB
 `DeletionProtectionEnabled`, Scheduler Schedule `State` converged via the bare
 `remove` — ~1-in-2 this round. Excluded as SERVER-SIDE IRREVERSIBLE (not a
 convergence probe): SSM Parameter `Tier` (AWS cannot downgrade Advanced→Standard).
-Batch 5 (2026-07-14, `revconv4-hunt` fixture, #1619): **ECS Cluster
+Batch 5 (2026-07-14, `revconv4-hunt` fixture, go-to-k/cdk-real-drift#1619): **ECS Cluster
 `ClusterSettings`**, **ApiGateway RestApi `ApiKeySourceType`**, **Glue Crawler
 `SchemaChangePolicy`** no-oped (RSDP entries converge them); CW Alarm
 `TreatMissingData`, AppSync `IntrospectionConfig`, Scheduler
@@ -386,7 +386,7 @@ before writing the fix: `aws cloudcontrol update-resource --patch-document
 answers "does the explicit write converge?" with no stack.** Also found: CodeBuild
 Project + MediaConvert Queue detect fine but are read-only ("type not revertable
 yet") — when a probe target is such a type, restore it OUT OF BAND before `revert`
-or the fixture can never converge to zero (#1623). Batch 6 (2026-07-14, barest4/ccpi
+or the fixture can never converge to zero (go-to-k/cdk-real-drift#1623). Batch 6 (2026-07-14, barest4/ccpi
 hunt): **RUM AppMonitor `CustomEvents`** no-oped (silent keep), and **ServiceCatalog
 TagOption `Active`** surfaced a FOURTH flavor — the handler REJECTS the bare remove
 outright (`InvalidRequest: Active and new value cannot both be null`), a hard error
@@ -403,10 +403,10 @@ hunt's NEW folds rather than a dedicated fixture): **VpcLattice ResourceConfigur
 `StartWindowHours` AND `ScheduleExpressionTimezone`** (same handler, both proven
 individually), and **EC2 TransitGatewayAttachment `Options`** ALL no-oped — 4-in-4
 for this batch's new folds (streaks run hot too); every one converged via an explicit
-CC `add` patch → plain RSDP entries (#1639/#1640/#1642).
-Batch 9 (2026-07-22 hunt): **RUM `AppMonitorConfiguration`** (#1684, sibling of
-CustomEvents), **GuardDuty Filter `Action`** (#1687), and **Cognito UserPoolClient
-`EnableTokenRevocation` + `AuthSessionValidity`** (#1689 — the RefreshTokenValidity
+CC `add` patch → plain RSDP entries (go-to-k/cdk-real-drift#1639/#1640/#1642).
+Batch 9 (2026-07-22 hunt): **RUM `AppMonitorConfiguration`** (go-to-k/cdk-real-drift#1684, sibling of
+CustomEvents), **GuardDuty Filter `Action`** (go-to-k/cdk-real-drift#1687), and **Cognito UserPoolClient
+`EnableTokenRevocation` + `AuthSessionValidity`** (go-to-k/cdk-real-drift#1689 — the RefreshTokenValidity
 siblings, both proven by a STACKLESS CC probe: `cloudcontrol create-resource`
 pool+client, OOB-flip, bare `remove` no-ops, explicit `add` converges — the whole
 per-property proof for ~$0 and no fixture) all no-oped → RSDP entries; Backup RTP
@@ -419,13 +419,13 @@ INACTIVE set — an ACTIVE set validates against the real bucket owner and rejec
 with AccessDeniedException, so an E2E fixture leg must target an Activate:false set —
 the drift is real and security-typed) — and exposed a STRUCTURAL gap:
 the pin lives in `CONTEXT_ARN_DEFAULTS` (`{accountId}` placeholder), which
-plan.ts did not consult at all, so no plain RSDP entry could express the fix. #1694
+plan.ts did not consult at all, so no plain RSDP entry could express the fix. go-to-k/cdk-real-drift#1694
 adds RSDP entries + an `opts.identity`-resolved `contextArnDefaultFor` fallback in
 `revertOp` — any future CONTEXT_ARN_DEFAULTS pin gets revert convergence by adding
 the RSDP key alone. **Lambda ESM `TumblingWindowInSeconds` CONVERGED** via the bare
 `remove` (like PF) — but ONLY when the probe patch rides the
 `/DestinationConfig/OnFailure` husk removal (`CC_UPDATE_REJECTED_EMPTY_PATHS`,
-#1611): a raw stackless probe WITHOUT the husk op fails with "The Destination field
+go-to-k/cdk-real-drift#1611): a raw stackless probe WITHOUT the husk op fails with "The Destination field
 is required" and proves nothing — when a stackless CC probe errors, check the type's
 husk table entry before concluding anything. **VpcLattice ALS
 `ServiceNetworkLogType` closed offline** (update API takes only destination-arn —
@@ -434,11 +434,11 @@ not OOB-mutable, in-code note). **SES `ScalingMode` closed from docs**
 help; in-code note). **Remaining deferred candidates**: OpenSearch
 `ClusterConfig.DedicatedMasterCount` (HIGH cost, and NOTE: it is a NESTED
 KNOWN_DEFAULT_PATHS pin, so plan.ts already emits an explicit `add` — the residual
-risk is only the #763 explicit-write-ignored class, low), EC2 VPCEndpointService
+risk is only the go-to-k/cdk-real-drift#763 explicit-write-ignored class, low), EC2 VPCEndpointService
 `SupportedIpAddressTypes` (needs a dualstack NLB in IPv6 subnets), Synthetics Canary
 `Schedule.DurationInSeconds` + Firehose `HttpEndpointDestinationConfiguration.*`
 (nested pins — same auto-`add` note as OpenSearch, low residual).
-Batch 11 (2026-08-02 hunt, #1709/#1710) found the CLASS behind several of these:
+Batch 11 (2026-08-02 hunt, go-to-k/cdk-real-drift#1709/#1710) found the CLASS behind several of these:
 **DERIVED (tier-2) folds had NO revert-side value source at all** — classify builds
 them into its LOCAL knownDef/knownDefPaths, so the RSDP branch sourced the (wrong)
 static value and the nested explicit-`add` branch missed entirely. Live-proven:
@@ -458,33 +458,33 @@ gp2"). Fix = `REVERT_COMPANION_REMOVES` (plan.ts): sibling `remove`s ride the sa
 patch, gated on live-presence + not-declared; both combined patches live-converged.
 Cassandra Table `DefaultTimeToLive` CONVERGED via bare remove (no entry needed).
 Batch 12 (2026-08-03 hunt): **CodeDeploy DeploymentGroup `DeploymentConfigName`
-no-oped** (the #1723 fold's revert side; explicit CC `add` converged → RSDP entry,
-#1725) — probed by piggybacking on the enum-added2 stack the same day the fold
+no-oped** (the go-to-k/cdk-real-drift#1723 fold's revert side; explicit CC `add` converged → RSDP entry,
+go-to-k/cdk-real-drift#1725) — probed by piggybacking on the enum-added2 stack the same day the fold
 shipped, exactly the piggyback rule below. Its sibling `DeploymentStyle` whole-object
 pin stays revert-unproven: the off-default shape is UNREACHABLE on a barest Server
 DG (UpdateDeploymentGroup rejects WITH_TRAFFIC_CONTROL without LoadBalancerInfo) —
 an LB-attached fixture would be needed. And a REVERT-DELETE flavor: an `added`
 **AWS::Glue::Table** delete-kind item failed at apply with UnsupportedActionException
-(CC has no DELETE handler — the #1405 class, but with a trivial service API) → fixed
-as an `SDK_DELETERS` entry splitting the enumerator identifier `db|table` (#1724);
-when an added-child revert fails this way, prefer the #1431 SDK-deleter route over
+(CC has no DELETE handler — the go-to-k/cdk-real-drift#1405 class, but with a trivial service API) → fixed
+as an `SDK_DELETERS` entry splitting the enumerator identifier `db|table` (go-to-k/cdk-real-drift#1724);
+when an added-child revert fails this way, prefer the go-to-k/cdk-real-drift#1431 SDK-deleter route over
 the honest-notRevertable set whenever the service has a one-call delete.
 Batch 13 (2026-08-10 hunt, the "writer-proof pack"): the Round-0 offline audit found
 the READ side fully corpus-exercised but ~10 SDK writers/deleters that had NEVER run
 live — one nearly-free stack (`wrtpack-hunt`) mutate→detect→revert→live-assert'd all
 of them at once and found THREE revert bugs in one run: **Budgets `writeBudget`
 crashed on a template-declared NUMERIC `BudgetLimit.Amount`** (the CFn schema allows
-a number, the API models Spend.Amount as a STRING → SerializationException; #1744 —
+a number, the API models Spend.Amount as a STRING → SerializationException; go-to-k/cdk-real-drift#1744 —
 when writing a writer, check every CFn-numeric/API-string field, the Spend shape
 recurs); **an UNDECLARED ELB attribute-bag element (`TargetGroupAttributes[key]`)
 was pre-barred by the generic nested-array-element gate** before the per-key prop
-writer could take it (#1745 — when a "not revertable" reason fires on a path a
+writer could take it (go-to-k/cdk-real-drift#1745 — when a "not revertable" reason fires on a path a
 writer COULD serve, check the bar's ordering before accepting it); and **ECS DAEMON
 `DeploymentConfiguration` remove was REJECTED outright** because the CC
 read-modify-write model still carried the ECS-managed `DesiredCount` echo ("daemon
-scheduling strategy does not support a desired count") — the #1710
+scheduling strategy does not support a desired count") — the go-to-k/cdk-real-drift#1710
 companion-removes flavor, fixed with a derived whole-object explicit `add` + an
-`AWS::ECS::Service\0DeploymentConfiguration` companion entry (#1740). The audit
+`AWS::ECS::Service\0DeploymentConfiguration` companion entry (go-to-k/cdk-real-drift#1740). The audit
 shape ("which writers have zero live evidence?") is repeatable and cheap — re-run it
 whenever a few new writers have accumulated.
 Batch 14 (2026-08-11 hunt): a SIXTH revert-no-op flavor — **GuardDuty Detector
@@ -492,13 +492,13 @@ rejects EVERY CC patch** on a current-era detector: the model echo carries BOTH 
 deprecated `EKS_RUNTIME_MONITORING` and successor `RUNTIME_MONITORING` features
 ("cannot be provided in the same request"), and separately DataSources+Features may
 not coexist in one update ("provide only one") — so even a patch touching NEITHER
-fails. Fix shape (#1752, all legs live-proven stackless): TRANSLATE any
+fails. Fix shape (go-to-k/cdk-real-drift#1752, all legs live-proven stackless): TRANSLATE any
 `/DataSources/*` op to the successor-API side (`/Features/<idx>/Status`), companion-
 remove `/DataSources` (a derived projection — dropping it from the WRITE model is
 not a state change), companion-remove the deprecated feature element LAST (index
 stability). When a type carries a deprecated/successor API-alias pair in one model,
 expect this class. Same batch: ServerlessCache `Description` bare-remove silently
-no-ops (RSDP `' '` one-space placeholder converges, #1753); Transfer `Protocols` is
+no-ops (RSDP `' '` one-space placeholder converges, go-to-k/cdk-real-drift#1753); Transfer `Protocols` is
 OOB-UNREACHABLE on the barest form (UpdateServer rejects FTP/FTPS "unsupported for
 IdentityProviderType SERVICE_MANAGED", 2026-08-11 — a barest server can never drift
 its protocols, so that pin's revert convergence is moot; an API_GATEWAY-idp server
@@ -506,11 +506,11 @@ could, left unproven). A stackless Transfer probe artifact worth knowing: CC
 UpdateResource on a tagless Transfer Server fails model validation ("#/Tags:
 expected minimum item count: 1") — tag the probe resource or expect the reject. Deferred convergence candidates (unproven, from the plan.ts
 audit — probe when their infra is cheap to stand up): ELBv2 Listener
-`MutualAuthentication.AdvertiseTrustStoreCaNames` (#1698, needs mTLS listener),
-ImageBuilder `ImageTestsConfiguration.*` (#1702, needs recipe+infra chain), ASG
-`MixedInstancesPolicy.InstancesDistribution` (#1695, needs MIP ASG), CloudFront
-VpcOrigin `OriginSSLProtocols` (#1734, needs VPC-origin infra), AppSync DataSource
-`MetricsConfig` + SourceApiAssociation config (#1751, needs API+schema+DS chain).
+`MutualAuthentication.AdvertiseTrustStoreCaNames` (go-to-k/cdk-real-drift#1698, needs mTLS listener),
+ImageBuilder `ImageTestsConfiguration.*` (go-to-k/cdk-real-drift#1702, needs recipe+infra chain), ASG
+`MixedInstancesPolicy.InstancesDistribution` (go-to-k/cdk-real-drift#1695, needs MIP ASG), CloudFront
+VpcOrigin `OriginSSLProtocols` (go-to-k/cdk-real-drift#1734, needs VPC-origin infra), AppSync DataSource
+`MetricsConfig` + SourceApiAssociation config (go-to-k/cdk-real-drift#1751, needs API+schema+DS chain).
 Piggyback the convergence
 probe on every NEW KNOWN_DEFAULTS fold a hunt ships (mutate → revert → re-read) —
 it is ~1-in-3 to need an RSDP entry, and the probe is nearly free while the stack
@@ -639,7 +639,7 @@ Then fix it:
 6. **If the bug is a CLASS, prove it's closed for EVERY affected type — don't stop
    at the one resource you happened to hit.** Most real bugs here are not specific
    to the type that surfaced them: they live in shared code keyed on a schema flag
-   or a normalizer applied to many types (e.g. #252 — a property that is BOTH
+   or a normalizer applied to many types (e.g. go-to-k/cdk-real-drift#252 — a property that is BOTH
    write-only and create-only was re-included into a Cloud Control patch and
    rejected; found on ElastiCache, but RDS / DynamoDB / EC2 / Redshift / S3 / EFS …
    all have such properties). When the root cause generalizes:
@@ -715,7 +715,7 @@ enforced structurally rather than by discipline:
 - **Owner scoping — set `CDKRD_BUGHUNT_OWNER="session-$CLAUDE_CODE_SESSION_ID"`.**
   When `CDKRD_BUGHUNT_OWNER` is UNSET, the tracker derives the owner from the
   main-tree root (`--git-common-dir`), so two sessions both running `add` from the
-  main checkout write into ONE shared owner file (#1409). Then a `clear` — which
+  main checkout write into ONE shared owner file (go-to-k/cdk-real-drift#1409). Then a `clear` — which
   empties the WHOLE owner file — would drop a PEER's still-pending stacks, releasing
   the gate while their live AWS resources remain. Setting a per-session owner gives
   each session its own `.d/session-<id>` file, so your `clear` can never touch a
@@ -738,7 +738,7 @@ the sentinel by hand to bypass the gate.
 - **An added-direction probe must create its OOB children AFTER `record` — children
   that pre-date the record are ENDORSED as recorded-added and never surface.** A
   resumed/reordered run that records while probe children exist silently converts
-  them into baseline-endorsed recorded-added entries (by design, #764), and the
+  them into baseline-endorsed recorded-added entries (by design, go-to-k/cdk-real-drift#764), and the
   subsequent "must surface as added" assert false-fails — it reads exactly like an
   enumerator FN when it is a sequencing mistake (hit on enum-added2, 2026-08-03).
   When an added assert misses, FIRST check whether the child pre-dates the baseline;
@@ -746,13 +746,13 @@ the sentinel by hand to bypass the gate.
 - **Non-Standard-class parents can REJECT a child-inventory API — an enumerator scan
   failure demotes the whole resource to `skipped` on every check.** Logs
   DescribeMetricFilters throws ValidationException "only supported on the Standard
-  log class" for INFREQUENT_ACCESS and DELIVERY groups (#1726, live 2026-08-03), so
+  log class" for INFREQUENT_ACCESS and DELIVERY groups (go-to-k/cdk-real-drift#1726, live 2026-08-03), so
   every IA/DELIVERY log group carried a permanent skipped= since the LogGroup
   enumerator landed. The class rejection means "this child kind cannot exist here" =
   empty inventory, not a failure. When adding an enumerator, ask which parent
   VARIANTS reject the List/Describe calls and tolerate exactly that rejection; a
   DELIVERY-class group also materializes the fixed `RetentionInDays: 2` (a derived
-  fold off the declared LogGroupClass, #1727 — the class axis carries its own
+  fold off the declared LogGroupClass, go-to-k/cdk-real-drift#1727 — the class axis carries its own
   defaults, the LogGroupClass twin of the EFS One Zone lesson).
 - **A stale "unreachable id shape" claim dissolves on a fresh deploy — probe before
   guarding.** The audit-predicted SNS email-subscription literal physical id
@@ -772,7 +772,7 @@ Recorded]` breakdown with `--verbose`.
   out-of-band mutation.** Without a baseline, the mutated value surfaces only as
   `[Potential Drift]` and `check --fail` still exits 0 — the test false-fails on the
   exit-code assert even though detection worked (hit live on the MediaConvert Queue
-  pause, #1526). Sequence: deploy → first check CLEAN → `record --yes` → mutate →
+  pause, go-to-k/cdk-real-drift#1526). Sequence: deploy → first check CLEAN → `record --yes` → mutate →
   `check --fail` MUST exit 1 (confirmed drift) → restore → CLEAN.
 - **An UNDECLARED-atDefault prop's OOB change is only caught via "appeared since record",
   which needs the resource `complete` — and a DECLARED write-only prop (secret/password/key)
@@ -790,27 +790,27 @@ Recorded]` breakdown with `--verbose`.
   ONLINE modify (RDS CopyTagsToSnapshot/MonitoringInterval, no reboot) keeps the instance
   `available`, so `aws … wait …-available` returns before the change propagates — poll
   `describe` (AND `cloudcontrol get-resource`, a different surface) until the value flips
-  before asserting. The write-only-readGap→incomplete FN was live-found this way (#1582).
+  before asserting. The write-only-readGap→incomplete FN was live-found this way (go-to-k/cdk-real-drift#1582).
 - **A harvested corpus case can embed a credential-shaped physical id that
   git-secrets rightly blocks at commit.** An `AWS::IAM::AccessKey` case's physicalId
   IS a real `AKIA…` id (the corpus recorder strips account ids, not access-key ids).
   Sanitize before committing: replace every occurrence with AWS's documented example
   id `AKIAIOSFODNN7EXAMPLE` (consistent replace keeps the case self-consistent;
-  corpus-replay only needs internal equality) and re-run `corpus-replay` (#1526 PR).
+  corpus-replay only needs internal equality) and re-run `corpus-replay` (go-to-k/cdk-real-drift#1526 PR).
 - **An off-flip FN candidate is real for a STANDALONE-boolean pin OR an
   ALL-BOOLEAN-object pin — mixed object/array pins are not swallowed.** `isTrivialEmpty`
   drops a bare `false`/`""`/`[]`/`{}` AND an object whose every leaf is trivial; a
   `true` pinned INSIDE an object whose siblings are non-trivial (`ReadWriteType:
 "All"`, `SSEAlgorithm:"AES256"`, `VersionNumber:1`) survives the flip — the flipped
   shape breaks the pin equality and surfaces normally. An offline audit of "unpaired
-  true-pins" (the #1530 hunt) overcounted 9→4 for exactly this reason: before filing,
+  true-pins" (the go-to-k/cdk-real-drift#1530 hunt) overcounted 9→4 for exactly this reason: before filing,
   check the pinned `true` stands ALONE at its path, and drop pins on immutable-revision
   resources (ECS TaskDefinition) that cannot drift out of band. But the INVERSE trap
   (hunt 2026-07-14): a whole-object pin with ONLY boolean leaves (`SendingOptions:
 {SendingEnabled: true}`, the 4-flag S3 `PublicAccessBlockConfiguration`) flips
   ALL-FALSE when every toggle is disabled, and the all-false object IS trivially empty —
   swallowed before the pin gate exactly like a standalone bool (the GuardDuty
-  `DataSources` shape, #1092). The class is mechanically enumerable: scan
+  `DataSources` shape, go-to-k/cdk-real-drift#1092). The class is mechanically enumerable: scan
   `KNOWN_DEFAULTS` for object pins whose leaves are all booleans, then live-probe each
   for (a) OOB mutability (AmazonMQ `EncryptionOptions` = create-only, S3 AccessPoint
   PABC = no mutate API, VpcLattice `SharingConfig` = update API can't flip it,
@@ -823,27 +823,27 @@ Recorded]` breakdown with `--verbose`.
   SendingOptions/ReputationOptions (live end-to-end), and SES EmailIdentity
   DkimAttributes/FeedbackAttributes (CC-read-shape proven).
 - **A corpus promotion can PIN a live FP as `expected` — eyeball declared-tier findings
-  before promoting.** The #1507 hunt promoted three RDS cases whose `expected` carried
+  before promoting.** The go-to-k/cdk-real-drift#1507 hunt promoted three RDS cases whose `expected` carried
   the mixed-case-name declared FP (`CdkrdHunt-Mixed-CPG` vs `cdkrdhunt-mixed-cpg`), so
-  `corpus-replay` asserted the WRONG behavior until #1531. A declared finding on a
+  `corpus-replay` asserted the WRONG behavior until go-to-k/cdk-real-drift#1531. A declared finding on a
   name/identifier path where declared and live differ only by case (or another pure
   normalization) is a red flag: that is a bug to file, not an expectation to record.
 - **A `KNOWN_DEFAULTS` pin containing an ARRAY must carry the exact live element
   shape.** `matchesKnownDefault` is subset-tolerant for OBJECT keys but strict
   deep-equality for arrays — trivially-empty element sub-keys (`CidrListAliases: []`,
   `CommonName: ""`) must be IN the pin or it never matches (hit on the Lightsail
-  `Networking` default-firewall pin, #1533). Copy the array verbatim from the live read.
+  `Networking` default-firewall pin, go-to-k/cdk-real-drift#1533). Copy the array verbatim from the live read.
 - **When a reader's physical-id-shape assumption breaks (name vs ARN), grep the
   SAME service family's sibling readers for the identical assumption — in both
   directions.** readSageMakerEndpointConfig passed the ARN physical id as the bare
-  name and ValidationExceptioned on every read (#1527) while its sibling
-  readSageMakerMonitoringSchedule had already fixed exactly that (#1523) — the fix
+  name and ValidationExceptioned on every read (go-to-k/cdk-real-drift#1527) while its sibling
+  readSageMakerMonitoringSchedule had already fixed exactly that (go-to-k/cdk-real-drift#1523) — the fix
   existed one function away. A physical-id shape is per-type but the MISTAKE is
   per-family; audit siblings before shipping a one-type fix.
 - **A revert bug's fix belongs in the route the plan ACTUALLY takes — check
   `SDK_WRITERS[type]` FIRST.** A type with an SDK writer never sends the CC patch, so
   a fix in the CC augmentation path (`augmentCcItemOps` strips) is dead code for it.
-  The #1568 Glue capacity-echo failure was first "fixed" in the CC layer before
+  The go-to-k/cdk-real-drift#1568 Glue capacity-echo failure was first "fixed" in the CC layer before
   discovering `writeGlueJob` existed — the real bug was the writer's non-WorkerType
   branch re-sending BOTH GetJob capacity echoes. Corollary: a writer's unit-test mock
   must mirror the REAL read echo shape (the old test's GetJob mock omitted the dual
@@ -853,7 +853,7 @@ Recorded]` breakdown with `--verbose`.
   update.** A clean FIRST-run check proves nothing about the post-update echo
   surface: Glue normalizes sizing on EVERY UpdateJob (including a CFn stack update),
   so undeclared `WorkerType`/`NumberOfWorkers` materialized out of nowhere after an
-  update that never mentioned them (#1569) — and the pair is irremovable (a `remove`
+  update that never mentioned them (go-to-k/cdk-real-drift#1569) — and the pair is irremovable (a `remove`
   revert is a structural no-op). After the first-run check, run ANY update against
   the resource (a service update API call or a trivial template change) and re-check:
   every newly materialized undeclared field is a latent FP a real user hits on their
@@ -871,7 +871,7 @@ Drift"` the output — trusting the exit code let a real FP print INTEG OK.**
 - **A barest PROVISIONED variant hides behind its richer/other-mode siblings.** The
   2026-07-14 hunt's only first-run FP: a Kinesis stream declaring ONLY `ShardCount`
   reads back `StreamModeDetails={"StreamMode":"PROVISIONED"}` undeclared — every
-  existing fixture either declared StreamModeDetails or was ON_DEMAND (#1487's fold
+  existing fixture either declared StreamModeDetails or was ON_DEMAND (go-to-k/cdk-real-drift#1487's fold
   is the exact inverse: ON_DEMAND materializes ShardCount). When a type has a mode
   axis, deploy the barest form of EACH mode and check which sibling props the OTHER
   mode's fold assumed declared.
@@ -923,7 +923,7 @@ Drift"` the output — trusting the exit code let a real FP print INTEG OK.**
   `ClientVpnEndpoint` (the existing `clientvpn-barest` fixture) reads back neither
   `VpcId` nor `SecurityGroupIds`, but the moment an in-stack
   `ClientVpnTargetNetworkAssociation` lands, BOTH materialize (the subnet's VPC + its
-  default SG) → 2 first-run FPs invisible under apparent coverage (#1574,
+  default SG) → 2 first-run FPs invisible under apparent coverage (go-to-k/cdk-real-drift#1574,
   2026-07-13). When a type has attachment-style siblings (association / attachment /
   registration / membership resources), deploy the parent WITH one attached and
   first-check that shape too. Fold with the decision order — the association echo is
@@ -957,7 +957,7 @@ UnsupportedImageLayerDetected` (the stack rolls back). The failure is NON-DETERM
   `Role`, leaving the Image-variant defaults (Architectures, EphemeralStorage,
   RecursiveLoop, LoggingConfig, RuntimeManagementConfig) undeclared to probe the fold
   (`lambda-container-barest` is the reference; container Lambdas were a whole uncovered
-  variant axis until #1572).
+  variant axis until go-to-k/cdk-real-drift#1572).
 - **Deploy-time API validation differences across engine/mode variants are
   FINDINGS, not mere fixture bugs.** A minimal variant deploy that FAILS validation
   is telling you the variant's defaults differ (valkey RGs default
@@ -971,7 +971,7 @@ UnsupportedImageLayerDetected` (the stack rolls back). The failure is NON-DETERM
 create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercased —
   the FP trigger), yet the CFn/CC handlers REJECT the same input
   (`InvalidRequest: must contain only lowercase…`), making the FP unreachable via
-  CloudFormation — no allowlist entry needed (2026-07-13, #1539 determinations). The
+  CloudFormation — no allowlist entry needed (2026-07-13, go-to-k/cdk-real-drift#1539 determinations). The
   cheap sequence: probe the raw API by CLI create+delete first (it answers "does the
   service lowercase?"), but only a CFn DEPLOY proves reachability; a handler rejection
   is itself the determination (record it in the fixture comment). The inverse also
@@ -983,14 +983,14 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   (SubnetGroup/User/ACL all reject: "must contain only lowercase") and Cassandra
   Keyspace (accepts AND preserves case — no FP either way) for zero deploys; reserve
   the paid CFn fixture for the types the handler lets THROUGH (Redshift::Cluster
-  ClusterIdentifier, #1589). Tag the probe resource `cdkrd:ephemeral=1` in its desired
+  ClusterIdentifier, go-to-k/cdk-real-drift#1589). Tag the probe resource `cdkrd:ephemeral=1` in its desired
   state and delete it immediately.
 - **A case-insensitive fold on the OWNING name prop implies the same FP on every
   CONSUMER property that references it — audit the referencing props when adding one.**
   RDS stores group names lowercased and the owning entries were folded one by one, but a
   raw-CFn consumer referencing `CdkrdHunt-Mixed-DPG` reads back the lowercased STORED
   name on `DBInstance.DBParameterGroupName` — a permanent declared FP the owning fold
-  never touches (#1712, classify-proven offline + live E2E on rds-replica-hunt
+  never touches (go-to-k/cdk-real-drift#1712, classify-proven offline + live E2E on rds-replica-hunt
   2026-08-02; the whole RDS/DocDB/Neptune/ElastiCache/DMS/Redshift family had the gap).
   The store-lowercases evidence carries over from the owning probe, so the consumer
   entries are a same-PR one-liner — no new deploy needed beyond one E2E witness.
@@ -1009,13 +1009,13 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   never plans it and the "proof" proves nothing — the fixture-side twin of the
   "corpus that declares the target leaf can't stand in" lesson. Live-proof each
   REVERT_SET_DEFAULT sibling individually with a template that genuinely omits it
-  (#1541: BackupRetentionPeriod proven; CopyTagsToSnapshot stays unproven for exactly
+  (go-to-k/cdk-real-drift#1541: BackupRetentionPeriod proven; CopyTagsToSnapshot stays unproven for exactly
   this reason).
 - **An in-stack scalable target is a cheap real-drift generator.** A ScalableTarget
   scheduled action (min/max below the declared capacity) makes App Auto Scaling clamp
   the resource within minutes of deploy — producing a REAL capacity divergence with no
   out-of-band CLI call. That accident exposed the WarmThroughput creation-echo FP
-  (#1538: warm throughput echoes CREATION capacity and never follows a scale-in, so a
+  (go-to-k/cdk-real-drift#1538: warm throughput echoes CREATION capacity and never follows a scale-in, so a
   derived fold gated only on the CURRENT live sibling FPs after any scale-in). Pattern
   to reuse: derived folds for creation-echo values must ALSO gate against the
   DECLARED-derived value, and autoscaling-governed fixtures probe that class for free.
@@ -1034,9 +1034,9 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   undeclared), so the audited "Require\* off-flip FN" did not exist and the attempted
   true-pins + MEANINGFUL_WHEN_OFF_NESTED gates CREATED a first-run FP — caught by
   corpus-replay on a REAL partial-declared case (Users0A0EEA89), exactly the guard the
-  corpus exists to be (#1701 determination). GuardDuty's DataSources fills the SAME
+  corpus exists to be (go-to-k/cdk-real-drift#1701 determination). GuardDuty's DataSources fills the SAME
   all-true in both shapes (CC-probed 2026-08-01), so its partial-dimension pins+gates
-  are correct (#1700). The cheap discriminator: `cloudcontrol create-resource` with
+  are correct (go-to-k/cdk-real-drift#1700). The cheap discriminator: `cloudcontrol create-resource` with
   the partial shape, read back the fill, delete — one minute, no stack. And BEFORE
   filing a nested off-flip FN, grep the corpus for a partial-declared case of that
   block: a false-filled sibling in a CLEAN case is the disproof.
@@ -1064,20 +1064,20 @@ create-parameter-group` both ACCEPT a mixed-case identifier (storing it lowercas
   TARGET's children — skip enumeration for link shapes and drop proxy echoes.** Glue
   `GetTables` on a resource-link database transparently returns the linked TARGET's
   tables (each echoed with the target's DatabaseName), so a declared link false-added
-  every target table WITH a destructive delete offer (#1749). Fix pattern: early-return
+  every target table WITH a destructive delete offer (go-to-k/cdk-real-drift#1749). Fix pattern: early-return
   for the declared link/federated shape + a generic owning-container-mismatch filter in
   the pure diff. When adding an enumerator, ask whether the parent type has a
   link/alias/federated variant whose child-inventory API proxies elsewhere.
-- **The #1729 twin-declaration class includes the parent's OWN inline property, not just
+- **The go-to-k/cdk-real-drift#1729 twin-declaration class includes the parent's OWN inline property, not just
   new sibling TYPES.** An SNS Topic's canonical inline `Subscription: [{Protocol,
 Endpoint}]` (raw CFn / L1) creates live subscriptions with no AWS::SNS::Subscription
   resource, and the enumerator's declared-set missed them → false `added` + delete
-  offer on a clean deploy (#1754, live barest5-hunt). When building/auditing an
+  offer on a clean deploy (go-to-k/cdk-real-drift#1754, live barest5-hunt). When building/auditing an
   enumerator's declared-set, enumerate EVERY declaration shape for the child surface:
   sibling resource type(s), \*InlinePolicy twins, AND inline properties on the parent
   resource itself (match by natural key, conservatively on unresolved refs).
 - **2026-08-11 stackless declared-FP determinations (do not re-probe):** RDS
-  GlobalCluster mixed-case identifier IS accepted + stored lowercased (#1750, fixed);
+  GlobalCluster mixed-case identifier IS accepted + stored lowercased (go-to-k/cdk-real-drift#1750, fixed);
   Route53 HealthCheck `FullyQualifiedDomainName` PRESERVES case; Backup BackupPlan
   `ScheduleExpression` REJECTS `rate()` outright ("Cron expression is not valid" — the
   rate-canonicalization FP is CFn-unreachable); MemoryDB ACL `UserNames` echoes in
@@ -1094,9 +1094,9 @@ Endpoint}]` (raw CFn / L1) creates live subscriptions with no AWS::SNS::Subscrip
   probe needs a DNS-namespace service (PrivateDnsNamespace + DnsConfig), and the
   update JSON must re-include DnsConfig or it is deleted (wrtpack-hunt 2026-08-10).
 - **A NEW all-boolean pin family can arrive via a READER-projection fix — re-run the
-  off-flip audit over the diff window, not just the historical tables.** The #1658
+  off-flip audit over the diff window, not just the historical tables.** The go-to-k/cdk-real-drift#1658
   Budgets reader fix (projecting the full 11-boolean `CostTypes`) necessarily added a
-  whole-object + per-leaf all-`true` pin family, silently re-opening the #1092/#1635
+  whole-object + per-leaf all-`true` pin family, silently re-opening the go-to-k/cdk-real-drift#1092/#1635
   all-boolean-object class: an out-of-band `update-budget` disabling ALL nine
   `Include*` cost types read back an all-false object that `isTrivialEmpty` swallowed
   — check stayed CLEAN while the budget was gutted (live-proven + fixed with a
@@ -1109,11 +1109,11 @@ grep ': true'` and pair every new truthy pin with its off-state gate. A SINGLE
   into a harvested corpus case's liveRaw, flip, assert) proves the FN for free before
   any deploy, and `DescribeBudget` RETURNS the all-false object (not vanished), so
   the fix is the isTrivialEmpty gate, not the vanished-default baseline family.
-  AND the inverse interaction (#1702, 2026-08-02): **adding a per-leaf pin for a
+  AND the inverse interaction (go-to-k/cdk-real-drift#1702, 2026-08-02): **adding a per-leaf pin for a
   SIBLING leaf can silently re-fold a WHOLLY-undeclared off-flipped object** — the
-  #624 `allLeavesAtSchemaDefault` whole-object rule counts a false leaf as
+  go-to-k/cdk-real-drift#624 `allLeavesAtSchemaDefault` whole-object rule counts a false leaf as
   trivially-empty and the newly-pinned sibling as at-default, so the flipped object
-  folds whole (the #911 ImageTestsConfiguration test caught it). Fixed generally
+  folds whole (the go-to-k/cdk-real-drift#911 ImageTestsConfiguration test caught it). Fixed generally
   (a trivially-empty leaf with a firing MEANINGFUL_WHEN_OFF_NESTED gate refuses the
   fold), but when adding per-leaf pins under a whole-object-pinned parent, re-run
   the parent's off-flip test explicitly.
@@ -1149,11 +1149,11 @@ grep ': true'` and pair every new truthy pin with its off-state gate. A SINGLE
   a regression. TWO STALENESS TRAPS in this determination (both hit 2026-07-20): (a)
   the gap may have been CLOSED since the note you're reading was written — Route53
   RecordSet was this gotcha's original example and has been fully revertable since
-  #1312/#1431 — so grep `SDK_WRITERS[type]` before planning around "not revertable";
+  go-to-k/cdk-real-drift#1312/#1431 — so grep `SDK_WRITERS[type]` before planning around "not revertable";
   (b) the not-revertable RATIONALE can go stale in the other direction: writers.ts
   justified Budgets by "the reader returns only the scalar identity subset", but
-  #1647/#1658 later grew the reader to the full NewBudget surface, making a writer
-  feasible (#1676) — when a reader gains projection, re-read the not-revertable list
+  go-to-k/cdk-real-drift#1647/#1658 later grew the reader to the full NewBudget surface, making a writer
+  feasible (go-to-k/cdk-real-drift#1676) — when a reader gains projection, re-read the not-revertable list
   for entries whose justification was that reader's thinness.
 - **Read the revert's convergence REPORT text, not just the live value — the report
   layer has its own bug class.** A revert whose target converges perfectly can still
@@ -1161,7 +1161,7 @@ grep ': true'` and pair every new truthy pin with its off-state gate. A SINGLE
 no-op` for the write-only RE-INCLUDE op every password-declaring resource carries
   (the CC read-modify-write contract): a write-only path re-reads as `readGap` with no
   live value on either side, so a persistence check built on `deepEqual(pre, post)` is
-  vacuously true (#1594, live-hit on an aurora-pg Sv2 revert 2026-07-14). When a revert
+  vacuously true (go-to-k/cdk-real-drift#1594, live-hit on an aurora-pg Sv2 revert 2026-07-14). When a revert
   probe passes on the live value, ALSO grep its output for `NOT reverted:` /
   `could not be confirmed` on paths you never drifted — an unverifiable (readGap) path
   must never drive a "value persists" verdict, and fixtures that only assert
@@ -1171,7 +1171,7 @@ no-op` for the write-only RE-INCLUDE op every password-declaring resource carrie
   Control.** GuardDuty stores a Filter's short condition keys as their long twins
   (declared `Criterion.severity.Gte: 4` reads back `GreaterThanOrEqual: 4`), so one
   declared short key produced BOTH a declared "removed" finding and an undeclared
-  "appeared" finding with equal values (#1612). The tell is that value-equal pair.
+  "appeared" finding with equal values (go-to-k/cdk-real-drift#1612). The tell is that value-equal pair.
   Probe the echo shape for free before fixing: `aws cloudcontrol create-resource`
   with the short keys, `get-resource` back — the CC read echoed ONLY the long forms
   (the raw `GetFilter` returns both, but cdkrd reads via CC). Fix = a declared-side
@@ -1180,10 +1180,10 @@ no-op` for the write-only RE-INCLUDE op every password-declaring resource carrie
   OFF-by-default feature — that is its designed failure mode; the fix is one line.**
   GuardDuty Detector `Features` folds via `GUARDDUTY_FEATURE_CREATION_STATUS`
   (classify.ts), which errs toward VISIBILITY: a new opt-in protection AWS ships
-  DISABLED (AI_PROTECTION, 2026 — #1612, after #1485's AI_ANALYST) surfaces the whole
+  DISABLED (AI_PROTECTION, 2026 — go-to-k/cdk-real-drift#1612, after go-to-k/cdk-real-drift#1485's AI_ANALYST) surfaces the whole
   array as a first-run FP until its name is added. When a barest detector FPs on
   `Features`, check that map FIRST — do not reach for value-independent (that was
-  reverted once already, #1092: it hid out-of-band disables forever).
+  reverted once already, go-to-k/cdk-real-drift#1092: it hid out-of-band disables forever).
 - **`CDKRD_CORPUS_DIR` exported around a whole verify-detect.sh records EVERY check
   — the LAST (post-mutation) read wins.** A detect/revert script runs 3-4 checks;
   the corpus case for a mutated resource then pins the MUTATED read, and a later
@@ -1219,7 +1219,7 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   sink in the same account" — cross-account only, unprobeable solo), and a
   lowercase-only-name service (VPC Lattice) mints its CFn generated name LOWERCASED
   (`cdkrdhunt0715lattice-sn-<random>`), which the exact-case isCfnGeneratedName
-  branches missed until #1639.
+  branches missed until go-to-k/cdk-real-drift#1639.
 - **A per-variant fold TABLE row that was MIRRORED from a live-proven sibling is itself
   unproven — audit the split tables for never-deployed rows.** The BY_PROTOCOL /
   BY_LB_TYPE / BY_TARGET_TYPE-style variant tables are built one live variant at a
@@ -1227,7 +1227,7 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   "for symmetry" — which bakes the do-NOT-copy-sibling-constants trap INTO the fold
   table (ELB_TG_ATTRIBUTE_DEFAULTS_BY_PROTOCOL's UDP/TCP_UDP rows carried TCP's
   `deregistration_delay.connection_termination.enabled: 'false'`; AWS's UDP-family
-  default is `'true'` → first-run FP, #1664). A barest deploy of each mirrored-row
+  default is `'true'` → first-run FP, go-to-k/cdk-real-drift#1664). A barest deploy of each mirrored-row
   variant is cheap (a TargetGroup needs no LB); grep the split tables for rows whose
   comment cites a DIFFERENT variant's deploy as evidence.
 - **Two split tables proven per-axis are still unproven per-COMBINATION — and the
@@ -1251,14 +1251,14 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   late-rollout regions like ap-northeast-3) but the broad axis is mined — don't
   re-burn a wide region pack; reserve region probes for a specific suspected
   rollout-lag value.
-- **Determination (2026-07-21): the #904 Processed-template path is live-proven.** A
+- **Determination (2026-07-21): the go-to-k/cdk-real-drift#904 Processed-template path is live-proven.** A
   raw-CFn `Transform: AWS::LanguageExtensions` stack (Fn::ForEach-expanded log groups
   - an Fn::ToJsonString SSM parameter) checked CLEAN end-to-end via a hand-built
     cdk.out pointing at the ORIGINAL unexpanded template (langext-hunt) — the deployed
     Processed fallback resolved the expansion. No SAM/LanguageExtensions live gap
     remains for the check path.
 - **An EC2-style `TagSpecifications` INPUT wrapper can be echoed back on read with
-  the CFN-propagated STACK tags inside — the #683 FP class one level down.** A barest
+  the CFN-propagated STACK tags inside — the go-to-k/cdk-real-drift#683 FP class one level down.** A barest
   CapacityReservation echoed `TagSpecifications[{ResourceType, Tags:[cdkrd:ephemeral…]}]`
   as undeclared Potential Drift (every hunt fixture stack-tags itself, so this FPs on
   EVERY deploy of such a type; the `aws:*` members were already deep-stripped —
@@ -1278,25 +1278,25 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   silently disables appeared-since-record for the WHOLE resource, and the report
   masks it as "No baseline yet".** The R62 mechanism only fires on snapshot-COMPLETE
   resources; a declared prop the reader never projects (DLM's shorthand
-  `DefaultPolicy`, #1665) keeps the resource incomplete forever, so every undeclared
+  `DefaultPolicy`, go-to-k/cdk-real-drift#1665) keeps the resource incomplete forever, so every undeclared
   OOB change stays [Potential Drift] and `check --fail` exits 0 — and (pre-#1665) the
   preamble printed "No baseline yet" right after a successful `record`, sending you
   to re-record instead of at the readGap. When a detect probe unexpectedly misses:
   check the target resource's `readGap=` in the info: footer FIRST, and either close
   the gap (project the declared-shaped value from what the API does return, gated so
-  it never emits on other shapes — the #1660 lesson) or probe a readGap-free sibling
+  it never emits on other shapes — the go-to-k/cdk-real-drift#1660 lesson) or probe a readGap-free sibling
   resource. The readGap-closing fix then needs the SAME live proof pair as any reader
   fix: clean first run + detection restored.
 - **A CONTROLLER-ATTACHED feature rewrites SIBLING resources — deploy the attached
   shape and expect drift on resources the feature never names.** ECS blue/green
   (2026-08-09 hunt, modes-hunt) rewrote its production LISTENER RULE's forward action
   to a weighted ForwardConfig (scalar `TargetGroupArn` disappears; weights swing every
-  deployment — permanent declared FP, #1730), registered tasks into the ALTERNATE
+  deployment — permanent declared FP, go-to-k/cdk-real-drift#1730), registered tasks into the ALTERNATE
   target group (`Targets` FP because the registrar builder only knew
-  `LoadBalancers[].TargetGroupArn`, #1732), and partial-declared
-  `DeploymentConfiguration` filled the Max/Min band (#1733) — three distinct FP classes
+  `LoadBalancers[].TargetGroupArn`, go-to-k/cdk-real-drift#1732), and partial-declared
+  `DeploymentConfiguration` filled the Max/Min band (go-to-k/cdk-real-drift#1733) — three distinct FP classes
   from ONE feature, none on the resource that declares it. The fix family for the
-  rule takeover is the #688 governed pattern: gather builds the governed-rule → allowed
+  rule takeover is the go-to-k/cdk-real-drift#688 governed pattern: gather builds the governed-rule → allowed
   TG-pair map, classify folds within-pair and marks outside-pair non-revertable, corpus
   recorder carries the per-rule entry. When probing any feature whose docs say a
   service "manages" a sibling (BG deployments, autoscalers, service discovery), first-check
@@ -1310,7 +1310,7 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
 - **AWS services also tag their auto-created resources in the unreserved `aws.` DOT
   namespace — an `aws:`-prefix filter misses them.** CloudFront's VpcOrigin service SG
   (`CloudFront-VPCOrigins-Service-SG`) carries `aws.cloudfront.vpcorigin=enabled`, not an
-  `aws:*` tag, so the rogue-SG enumerator flagged it as added (#1731). When a
+  `aws:*` tag, so the rogue-SG enumerator flagged it as added (go-to-k/cdk-real-drift#1731). When a
   service-created child FPs despite "AWS-managed" filtering, dump its real tags before
   assuming it is untagged — and add the exact dot-namespace key (never the whole `aws.`
   prefix: it is user-forgeable and unreserved).
@@ -1318,20 +1318,20 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   older one, every declared-sibling suppression keyed on the old type silently misses
   it.** `AWS::SQS::QueueInlinePolicy` / `AWS::SNS::TopicInlinePolicy` (scalar-ref twins
   of QueuePolicy/TopicPolicy) first-ran an added-tier "created out of band" FP on the
-  very policy the template declared (#1729). When AWS ships an alternative declaration
+  very policy the template declared (go-to-k/cdk-real-drift#1729). When AWS ships an alternative declaration
   shape for an existing surface (inline twins, *InlinePolicy, *Attachment vs embedded
   list), grep the enumerators' `hasDeclared*` sibling loops for the old type name — each
   is a latent FP for the new type's users. Related fixture trap: a verify.sh
   `drift_entries` grep must match ADDED-tier entry lines too (`<id> ▸ <label> (AWS::…)`,
   multi-token before the type) — a `^\s+\S+ \(AWS::` pattern silently passes them.
-- **Added-after-record is CONFIRMED drift since #1737 — assert exit 1 on an OOB-added
-  probe, and expect plain `revert --yes` to delete it.** Before #1737, an OOB child
+- **Added-after-record is CONFIRMED drift since go-to-k/cdk-real-drift#1737 — assert exit 1 on an OOB-added
+  probe, and expect plain `revert --yes` to delete it.** Before go-to-k/cdk-real-drift#1737, an OOB child
   created AFTER `record` surfaced only as `[Potential Drift]` (`check --fail` exit 0 —
   the 2026-08-09 enumrev2-hunt's live find), so older verify scripts never asserted the
   exit code on the added step. A post-#1737 probe MUST assert `check --fail` exits 1
   and the output carries `appeared since record`; the delete then plans WITHOUT
   `--remove-unrecorded` (the flag still gates unrecorded/pre-record inventory and the
-  #764 recorded-changed state). Note the marker is stamped at `record` time — a
+  go-to-k/cdk-real-drift#764 recorded-changed state). Note the marker is stamped at `record` time — a
   baseline recorded by an older binary keeps the potential-only behavior.
 - **A backgrounded `verify.sh 2>&1 | tail` reports the PIPELINE's exit (tail's 0) — an
   INTEG FAIL reads as success.** The 2026-08-09 hunt's first enumrev2 run "completed
@@ -1382,8 +1382,8 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   hostile actor watches new issues/PRs to reply within minutes with a "helpful fix"
   that is really a way to make you run unvetted code (the maintainer holds AWS
   credentials — a prime target). The vector varies but the play is identical — seen
-  live from ONE campaign: issue #648 got a `*_fix.zip` attachment 4 min after filing;
-  PR #655 (the very PR adding this rule) got `pip install vulnledger && vulnledger
+  live from ONE campaign: issue go-to-k/cdk-real-drift#648 got a `*_fix.zip` attachment 4 min after filing;
+  PR go-to-k/cdk-real-drift#655 (the very PR adding this rule) got `pip install vulnledger && vulnledger
 scan .` seconds after merge — a fabricated package (no such real tool). Both from
   `author_association: NONE` throwaway accounts, with body text parroting the
   thread's wording and no real root cause. Do NOT download / unpack / `pip install` /

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -415,6 +415,48 @@ hits with zero false positives. Then drive the failure direction the same way th
 no-`src/**` tier in section 8 requires: `git stash push <the repaired file>`, watch
 the scan report the exact hits with their line numbers, and `git stash pop`.
 
+**Calibration and that stash-pop drive read the SAME instances, so between them
+they never show the rule catching a defect written a DIFFERENT way.** Running the
+candidate over the unrepaired tree buys PRECISION (are the hits real?) plus recall
+over the instances that HAPPEN TO EXIST; stashing the repaired file back in then
+replays exactly those. Neither touches the SHAPE — the spellings the tree does not
+use today, and the contexts that defeat the exemption logic. Follow them with two
+more probes, both run against the real tree rather than reasoned about. Every
+fence in this repo was put through them on 2026-08-20
+(go-to-k/cdk-real-drift#1797) and four of the eight were dead:
+
+- **Write the defect in EVERY spelling the language allows, and confirm each one
+  is flagged.** `tests/no-direct-tty.test.ts` asserted `not.toContain('stdin.isTTY')`,
+  so `process.stdin['isTTY']`, a destructured `const { isTTY } = process.stdin`
+  and `isatty(0)` from `node:tty` all read the same state past a green fence. In
+  source the same shape is go-to-k/cdkd#2111: a scanner calibrated at 19 hits /
+  zero false positives matched `||` only while the tree already used `??` at four
+  sites, and widening it surfaced a real bug nobody had filed.
+- **Delete the thing the fence REQUIRES, and watch it fail.** This is the probe
+  that finds a wrong POPULATION, and a population derived from the DEFECT is the
+  worst kind: `tests/gate-cd-form-parity-1786.test.ts` selected its gates with
+  `filter(h => h.condition.includes('Bash(git commit*)'))`, so deleting the bare
+  form dropped a gate OUT of the population instead of failing it — and disarming
+  `stale-base-gate` and `ci-green-gate` outright (`if` replaced by a pattern that
+  matches nothing) left it green at 7/7. The same day, three more here: the TTY
+  fence listed 4 of the 14 files in `src/commands/` and so never looked at
+  `ignore.ts`; `tests/skill-doc-paths.test.ts` enumerated `.claude/hooks/*.test.sh`
+  and asserted a COUNT, which measures the harnesses that exist and can never
+  report the hook that has none (`check-gate.sh`, the one every commit passes
+  through); and `tests/releaserc-header-pattern.test.ts` looked ONE plugin up by
+  name while `@semantic-release/release-notes-generator` sat there with no
+  `parserOpts` at all — which is why all 13 `type!:` merges in this repo's history
+  released a version and left no CHANGELOG entry behind.
+
+And ask the dumbest question last: **is anything RUNNING it?** The nine
+`.claude/hooks/*.test.sh` harnesses had no `vp run` task and no CI step — they are
+shell, so `vp test run` never saw them — and had been exercised only by hand since
+the day each was written (`vp run test:hooks` now runs them, in CI too).
+
+The general shape: **a fence is not evidence until you have watched it go red on
+something you had not already counted.** Calibration says it is not noisy; only
+the spelling and deletion probes say it is load-bearing.
+
 Two traps that cost most of the apparent false positives there, both worth checking
 in any markdown scanner: tokenize per PARAGRAPH, not per line, because a code span
 may WRAP a line break and a per-line scan pairs one span's closing backtick with the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       # this always rebuilds — no stale-dist replay.
       - run: vp run build
       - run: vp run test
+      # The gate harnesses are shell, so `vp run test` (vitest) never sees them.
+      # They went unrun by anything until go-to-k/cdk-real-drift#1797.
+      - run: vp run test:hooks
 
       # go-to-k/cdk-local#402 diagnostics (upstream Vite+ forks-pool crash, NOT a
       # cdk-real-drift issue): if a forks worker crashed ("Worker exited

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -19,7 +19,17 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "headerPattern": "^(\\w*)(?:\\((.+?)\\))?(!)?: (.+)$",
+          "headerCorrespondence": ["type", "scope", "breaking", "subject"],
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        }
+      }
+    ],
     "@semantic-release/changelog",
     [
       "@semantic-release/npm",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ same as `cdk-local`. `vp` and `markgate` are pinned by `.mise.toml` (run
 vp run build       # vp pack — tsdown ESM bundle to dist/ (bin: cdkrd)
 vp run dev         # vp pack --watch
 vp run test        # vp test run — Vitest unit tests (tests/integration/** excluded)
+vp run test:hooks  # the .claude/hooks/*.test.sh gate harnesses (shell; vitest never sees them)
 vp run typecheck   # tsc --project tsconfig.json --noEmit
 vp check --fix     # lint + format (oxc), with auto-fix
 vp run check       # lint + format check (what CI runs)

--- a/scripts/run-hook-tests.sh
+++ b/scripts/run-hook-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run every PreToolUse / Stop hook harness under .claude/hooks/.
+#
+# The harnesses existed for months with nothing invoking them: no `vp run` task
+# and no CI step, so a hook could rot and its own smoke test would never say so
+# (found 2026-08-20, go-to-k/cdk-real-drift#1797). A fence nobody runs is not a
+# fence. Wired as `vp run test:hooks` and into the CI check job.
+#
+# Each harness resolves its subject from its OWN path (asserted by
+# tests/skill-doc-paths.test.ts), so they run in place, from the repo root.
+
+set -u
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root" || exit 2
+
+failed=0
+ran=0
+for harness in .claude/hooks/*.test.sh; do
+  [ -e "$harness" ] || continue
+  ran=$((ran + 1))
+  printf '\n=== %s\n' "$harness"
+  if ! bash "$harness"; then
+    failed=$((failed + 1))
+    printf 'FAILED: %s\n' "$harness"
+  fi
+done
+
+if [ "$ran" -eq 0 ]; then
+  echo "run-hook-tests: no harness found under .claude/hooks/ — the glob is wrong" >&2
+  exit 2
+fi
+
+printf '\nharnesses run: %s  failed: %s\n' "$ran" "$failed"
+[ "$failed" -eq 0 ]

--- a/tests/gate-cd-form-parity-1786.test.ts
+++ b/tests/gate-cd-form-parity-1786.test.ts
@@ -4,29 +4,63 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vite-plus/test';
 
 // Every PreToolUse gate must catch a gated command written in ALL the invocation
-// forms this repo's flow actually produces — including `cd <worktree> && <cmd>`.
+// forms this repo's flow actually produces — the bare one, the `git -C <path>` /
+// `gh -C <path>` one, and `cd <worktree> && <cmd>`.
 //
 // `.claude/skills/work-issues/SKILL.md` section 5 mandates working from a worktree,
-// and section 6 now tells the agent to prefix commands with an explicit
-// `cd <worktree> &&` because shell cwd does not persist across tool calls. That
-// guidance is only safe if the gates SEE that form. On 2026-08-19
-// (go-to-k/cdk-real-drift#1786) they did not: `branch-gate`, `bughunt-clean-gate`,
-// `stale-base-gate` and `ci-green-gate` each carried a `Bash(cd * && …)`
-// alternative, while `check-gate`, `verify-pr-gate` and `non-english-text-gate` did
-// not — so `cd <wt> && git commit` bypassed check-gate outright, and
-// `cd <wt> && gh pr create` bypassed BOTH verify-pr-gate and the English-only gate.
-// The bypass is silent: the command simply succeeds ungated.
+// and section 6 tells the agent to prefix commands with an explicit `cd <worktree> &&`
+// because shell cwd does not persist across tool calls. That guidance is only safe if
+// the gates SEE those forms. On 2026-08-19 (go-to-k/cdk-real-drift#1786) they did not:
+// `branch-gate`, `bughunt-clean-gate`, `stale-base-gate` and `ci-green-gate` each
+// carried a `Bash(cd * && …)` alternative, while `check-gate`, `verify-pr-gate` and
+// `non-english-text-gate` did not — so `cd <wt> && git commit` bypassed check-gate
+// outright, and `cd <wt> && gh pr create` bypassed BOTH verify-pr-gate and the
+// English-only gate. The bypass is silent: the command simply succeeds ungated.
 //
-// A hook `if` clause is plain configuration that nothing else re-reads, and the
-// drift was invisible precisely because each clause looks reasonable on its own.
-// This test compares them against each other instead.
+// A hook `if` clause is plain configuration that nothing else re-reads, and the drift
+// was invisible precisely because each clause looks reasonable on its own.
+//
+// The first version of this test derived its POPULATION from the defect it hunts —
+// `hooks.filter(h => h.condition.includes('Bash(git commit*)'))` — so DELETING the
+// bare form dropped the gate out of the population instead of failing, and a gate
+// neutered wholesale (its `if` replaced by a pattern that matches nothing) was not
+// looked at by any case. Both probes were green on 2026-08-20 with `stale-base-gate`
+// and `ci-green-gate` fully disarmed. The population below is therefore DECLARED —
+// which gate owes which verb — and a completeness case fails when a hook exists in
+// `settings.json` that the table does not mention, so a new gate cannot be added
+// silently either.
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SETTINGS = path.join(ROOT, '.claude', 'settings.json');
 
-// The command forms the gates guard. A gate that matches the bare form of one of
-// these owes the `cd * && ` form too.
-const GATED_COMMANDS = ['git commit', 'git push', 'gh pr create', 'gh pr edit', 'gh pr merge'];
+/** Every gated verb a gate can owe, with the three spellings each one has. */
+const FORMS: Record<string, (verb: string) => string[]> = {
+  git: (verb) => [`Bash(git ${verb}*)`, `Bash(git -C * ${verb}*)`, `Bash(cd * && git ${verb}*)`],
+  gh: (verb) => [
+    `Bash(gh pr ${verb}*)`,
+    `Bash(gh -C * pr ${verb}*)`,
+    `Bash(cd * && gh pr ${verb}*)`,
+  ],
+};
+
+const gitVerb = (verb: string) => ({ label: `git ${verb}`, patterns: FORMS['git']!(verb) });
+const ghVerb = (verb: string) => ({ label: `gh pr ${verb}`, patterns: FORMS['gh']!(verb) });
+
+/**
+ * What each gate MUST guard. Declared, not derived from the conditions being
+ * tested — see the header. `deploy-autoarm-gate` is deliberately listed with no
+ * verbs: it matches on a command SHAPE (`Bash(*deploy*)`), not on these verbs.
+ */
+const REQUIRED: Record<string, { label: string; patterns: string[] }[]> = {
+  'check-gate.sh': [gitVerb('commit')],
+  'branch-gate.sh': [gitVerb('commit'), gitVerb('push')],
+  'bughunt-clean-gate.sh': [gitVerb('commit'), ghVerb('create'), ghVerb('merge')],
+  'stale-base-gate.sh': [gitVerb('push')],
+  'verify-pr-gate.sh': [ghVerb('create'), ghVerb('merge')],
+  'ci-green-gate.sh': [ghVerb('merge')],
+  'non-english-text-gate.sh': [ghVerb('create'), ghVerb('edit'), ghVerb('merge')],
+  'deploy-autoarm-gate.sh': [],
+};
 
 interface GateHook {
   name: string;
@@ -53,13 +87,9 @@ function gateHooks(): GateHook[] {
   return out;
 }
 
-// `Bash(git commit*)` is ANCHORED, so it does not match `cd x && git commit`.
-// `Bash(cd * && git commit*)` is the separate alternative that does.
-const bareForm = (cmd: string) => `Bash(${cmd}`;
-const cdForm = (cmd: string) => `Bash(cd * && ${cmd}`;
-
 describe('PreToolUse gate coverage parity across invocation forms (go-to-k/cdk-real-drift#1786)', () => {
   const hooks = gateHooks();
+  const byName = new Map(hooks.map((h) => [h.name, h.condition]));
 
   it('finds the repo gate hooks', () => {
     expect(hooks.length).toBeGreaterThanOrEqual(8);
@@ -69,21 +99,44 @@ describe('PreToolUse gate coverage parity across invocation forms (go-to-k/cdk-r
     expect(names).toContain('non-english-text-gate.sh');
   });
 
-  for (const cmd of GATED_COMMANDS) {
-    it(`every gate guarding "${cmd}" also guards "cd … && ${cmd}"`, () => {
-      const gaps = hooks
-        .filter((h) => h.condition.includes(bareForm(cmd)))
-        .filter((h) => !h.condition.includes(cdForm(cmd)))
-        .map((h) => h.name);
-      expect(gaps).toEqual([]);
-    });
+  // The population is the DECLARED table, so a gate cannot leave it by losing a
+  // pattern; and it cannot enter unnoticed either.
+  it('every gate hook in settings.json is accounted for in the required table', () => {
+    const undeclared = hooks.map((h) => h.name).filter((n) => !(n in REQUIRED));
+    expect(
+      undeclared,
+      'a new PreToolUse gate must declare which verbs it guards in REQUIRED'
+    ).toEqual([]);
+    const missing = Object.keys(REQUIRED).filter((n) => !byName.has(n));
+    expect(missing, 'REQUIRED names a gate that settings.json no longer wires').toEqual([]);
+  });
+
+  for (const [gate, verbs] of Object.entries(REQUIRED)) {
+    for (const verb of verbs) {
+      it(`${gate} guards "${verb.label}" in every invocation form`, () => {
+        const condition = byName.get(gate) ?? '';
+        const gaps = verb.patterns.filter((p) => !condition.includes(p));
+        expect(gaps, `${gate} is missing ${gaps.join(', ')}`).toEqual([]);
+      });
+    }
   }
 
-  it('the three gates that carried the gap now cover the cd form', () => {
-    const byName = new Map(hooks.map((h) => [h.name, h.condition]));
-    expect(byName.get('check-gate.sh')).toContain('Bash(cd * && git commit*)');
-    expect(byName.get('verify-pr-gate.sh')).toContain('Bash(cd * && gh pr create*)');
-    expect(byName.get('verify-pr-gate.sh')).toContain('Bash(cd * && gh pr merge*)');
-    expect(byName.get('non-english-text-gate.sh')).toContain('Bash(cd * && gh pr edit*)');
+  it('a gate that guards a verb in ANY form owes it in ALL forms', () => {
+    // Backstop for a verb reached by a gate the table does not require it for —
+    // the drift go-to-k/cdk-real-drift#1786 actually was.
+    const gaps: string[] = [];
+    for (const { name, condition } of hooks) {
+      for (const family of ['git', 'gh'] as const) {
+        const verbs = family === 'git' ? ['commit', 'push'] : ['create', 'edit', 'merge'];
+        for (const verb of verbs) {
+          const patterns = FORMS[family]!(verb);
+          if (!patterns.some((p) => condition.includes(p))) continue;
+          for (const missing of patterns.filter((p) => !condition.includes(p))) {
+            gaps.push(`${name}: ${missing}`);
+          }
+        }
+      }
+    }
+    expect(gaps).toEqual([]);
   });
 });

--- a/tests/no-direct-tty.test.ts
+++ b/tests/no-direct-tty.test.ts
@@ -1,28 +1,87 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vite-plus/test';
 
 // R38: interactivity flows through the single `isInteractive()` helper in
-// cli-args.ts. Command code must NOT read `process.stdin.isTTY` directly — only
+// cli-args.ts. Everything else must NOT read the stdin TTY state directly — only
 // cli-args.ts may. This keeps the TTY check in ONE place (non-interactive simply
 // means non-TTY since R58) so its semantics can never fork per command.
-const COMMAND_FILES = [
-  '../src/commands/check.ts',
-  '../src/commands/record.ts',
-  '../src/commands/revert.ts',
-  '../src/commands/stack-actions.ts',
+//
+// Both halves of this fence were probed on 2026-08-20 and both were wrong:
+//
+// - POPULATION. It listed FOUR files by hand while `src/commands/` holds 14,
+//   so `ignore.ts` — one of the four verbs — could read `stdin.isTTY` with the
+//   fence green. It is now the whole of `src/**`, minus the one owner, which is
+//   also the population the rule states.
+// - SPELLING. It matched the literal `stdin.isTTY` only, so `process.stdin['isTTY']`,
+//   a destructured `const { isTTY } = process.stdin`, and `isatty(0)` from
+//   `node:tty` all passed. Each is now a signature of its own.
+const OWNER = path.join('src', 'cli-args.ts');
+
+/** Every way to reach the stdin TTY state that does not go through the helper. */
+const SIGNATURES: { label: string; test: (src: string) => boolean }[] = [
+  { label: 'stdin.isTTY', test: (s) => s.includes('stdin.isTTY') },
+  { label: "stdin['isTTY']", test: (s) => /stdin\s*\[\s*['"]isTTY['"]\s*\]/.test(s) },
+  {
+    label: 'destructured isTTY from process.stdin',
+    test: (s) => /\{[^}]*\bisTTY\b[^}]*\}\s*=\s*process\.stdin/.test(s),
+  },
+  { label: 'node:tty isatty()', test: (s) => /from\s+['"]node:tty['"]|\bisatty\s*\(/.test(s) },
 ];
 
-describe('no direct process.stdin.isTTY in command code (R38)', () => {
-  for (const rel of COMMAND_FILES) {
-    it(`${rel} does not read stdin.isTTY directly`, () => {
-      const src = readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
-      expect(src).not.toContain('stdin.isTTY');
-    });
+const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.name.endsWith('.ts')) out.push(full);
   }
+  return out;
+}
+
+describe('no direct stdin TTY reads outside cli-args.ts (R38)', () => {
+  const files = sourceFiles(SRC);
+
+  it('walks the whole src tree, not a hand-kept list', () => {
+    const rels = files.map((f) => path.relative(path.join(SRC, '..'), f));
+    expect(rels).toContain(path.join('src', 'commands', 'check.ts'));
+    expect(rels).toContain(path.join('src', 'commands', 'ignore.ts'));
+    expect(rels.length).toBeGreaterThan(20);
+  });
+
+  it('no file but cli-args.ts reaches the stdin TTY state, in any spelling', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = path.relative(path.join(SRC, '..'), file);
+      if (rel === OWNER) continue;
+      const src = readFileSync(file, 'utf8');
+      for (const sig of SIGNATURES) {
+        if (sig.test(src)) offenders.push(`${rel}: ${sig.label}`);
+      }
+    }
+    expect(offenders, 'route the check through isInteractive() in src/cli-args.ts instead').toEqual(
+      []
+    );
+  });
+
+  it('every signature flags its own spelling (spelling probe)', () => {
+    const samples = [
+      'const i = process.stdin.isTTY === true;',
+      "const i = process.stdin['isTTY'] === true;",
+      'const { isTTY } = process.stdin;',
+      "import { isatty } from 'node:tty';",
+    ];
+    for (const sample of samples) {
+      expect(SIGNATURES.filter((s) => s.test(sample)).length, sample).toBeGreaterThanOrEqual(1);
+    }
+    expect(SIGNATURES.filter((s) => s.test('const tty = renderTable(rows);')).length).toBe(0);
+  });
 
   it('the helper lives in cli-args.ts', () => {
-    const src = readFileSync(fileURLToPath(new URL('../src/cli-args.ts', import.meta.url)), 'utf8');
+    const src = readFileSync(path.join(SRC, 'cli-args.ts'), 'utf8');
     expect(src).toContain('stdin.isTTY');
     expect(src).toContain('export function isInteractive');
   });

--- a/tests/releaserc-header-pattern.test.ts
+++ b/tests/releaserc-header-pattern.test.ts
@@ -1,4 +1,4 @@
-// The semantic-release commit-analyzer `headerPattern` in `.releaserc.json` must parse a
+// The semantic-release `headerPattern` in `.releaserc.json` must parse a
 // COMPOUND conventional-commit type like `fix(read)+fix(revert): …` as a releasing `fix`.
 // The original pattern's scope class `[^)]+` forbade a `)`, so a compound title (which has a
 // `)` mid-header before the colon) failed to match ENTIRELY → the commit parsed as no type →
@@ -16,21 +16,62 @@ const releaserc = JSON.parse(
   plugins: unknown[];
 };
 
-// Pull the commit-analyzer plugin's headerPattern out of the actual config so the test
-// exercises the SHIPPED regex, not a copy.
-const analyzer = releaserc.plugins.find(
-  (p): p is [string, { parserOpts: { headerPattern: string } }] =>
-    Array.isArray(p) && p[0] === '@semantic-release/commit-analyzer'
-);
-const headerPattern = analyzer![1].parserOpts.headerPattern;
+// EVERY plugin that PARSES commits needs the pattern, not just the one that decides the
+// bump. This test used to look `@semantic-release/commit-analyzer` up by name, so
+// `@semantic-release/release-notes-generator` — configured as a bare string, and therefore
+// falling back to conventional-changelog-angular's default `^(\w*)(?:\((.*)\))?: (.*)$`,
+// which has no `!` — was outside its population entirely. The consequence shipped: all 13
+// `type!:` / `type(scope)!:` merges in this repo's history released a version and left NO
+// entry in `CHANGELOG.md` (checked 2026-08-20 for go-to-k/cdk-real-drift#432, #105, #93,
+// #73 and #57 — zero hits each, and the file has no BREAKING section at all).
+// go-to-k/cdk-real-drift#1797.
+const COMMIT_PARSING_PLUGINS = [
+  '@semantic-release/commit-analyzer',
+  '@semantic-release/release-notes-generator',
+];
+
+function parserOptsOf(name: string): { headerPattern: string; headerCorrespondence: string[] } {
+  const plugin = releaserc.plugins.find(
+    (p): p is [string, { parserOpts: { headerPattern: string; headerCorrespondence: string[] } }] =>
+      Array.isArray(p) && p[0] === name
+  );
+  expect(
+    plugin,
+    `${name} must carry its own parserOpts, not fall back to the preset`
+  ).toBeDefined();
+  return plugin![1].parserOpts;
+}
+
+const headerPattern = parserOptsOf('@semantic-release/commit-analyzer').headerPattern;
 const re = new RegExp(headerPattern);
 
-const parse = (header: string): { type?: string; scope?: string } => {
+const parse = (header: string): { type?: string; scope?: string; breaking?: string } => {
   const m = re.exec(header);
-  return m ? { type: m[1], scope: m[2] } : {};
+  return m ? { type: m[1], scope: m[2], breaking: m[3] } : {};
 };
 
-describe('.releaserc.json commit-analyzer headerPattern', () => {
+describe('.releaserc.json headerPattern', () => {
+  it('every commit-parsing plugin carries the SAME parserOpts', () => {
+    for (const name of COMMIT_PARSING_PLUGINS) {
+      const opts = parserOptsOf(name);
+      expect(opts.headerPattern, `${name} headerPattern drifted`).toBe(headerPattern);
+      expect(opts.headerCorrespondence).toContain('breaking');
+    }
+  });
+
+  it('parses a BREAKING `type!:` title, so the entry reaches the release notes', () => {
+    expect(parse('feat!: drop the legacy flag')).toEqual({
+      type: 'feat',
+      scope: undefined,
+      breaking: '!',
+    });
+    expect(parse('feat(api)!: drop the legacy flag')).toEqual({
+      type: 'feat',
+      scope: 'api',
+      breaking: '!',
+    });
+  });
+
   it('parses a COMPOUND `fix(x)+fix(y):` title as a releasing `fix` (the #1431 no-release bug)', () => {
     const p = parse('fix(read)+fix(revert): record-endorse + real delete (#1431) (#1446)');
     expect(p.type).toBe('fix'); // NOT undefined → semantic-release applies the `fix` → patch rule

--- a/tests/skill-doc-paths.test.ts
+++ b/tests/skill-doc-paths.test.ts
@@ -22,22 +22,36 @@ import { describe, expect, it } from 'vite-plus/test';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
 
-// Only these roots make a backticked token a PATH citation rather than prose.
-const PATH_ROOTS = ['src', 'tests', 'docs', '.claude', '.github'];
+// A backticked token is a PATH citation when its first segment is a real
+// top-level entry of this repo. DERIVED, not listed: the hand-kept list said
+// `src tests docs .claude .github` while `scripts/` and `demo/` are equally real
+// top-level directories, so a stale `scripts/…` citation was invisible to the
+// scan (measured 2026-08-20, go-to-k/cdk-real-drift#1797). Build outputs and
+// dependency trees are excluded — nothing in a skill doc should cite them.
+const NON_CITABLE_ROOTS = new Set(['node_modules', 'dist', 'coverage', '.git', '.worktrees']);
+const PATH_ROOTS = readdirSync(ROOT, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && !NON_CITABLE_ROOTS.has(e.name))
+  .map((e) => e.name);
 
 const PATH_LIKE = /^[A-Za-z0-9_.@-]+(\/[A-Za-z0-9_.*@-]+)+$/;
 
-// Skill docs that §10-c of `.claude/skills/work-issues/SKILL.md` mirrors into the
-// sibling repos (`../cdkd`, `../cdk-local`). Only these owe fully-qualified issue
-// references: a bare `#N` renders against whichever repo is READING it, so the
-// mirror silently rewrites a correct citation into a wrong one. Both failure
-// shapes were live on 2026-08-19 (go-to-k/cdk-real-drift#1774) — this repo's
-// `#1761` resolves in cdkd to an unrelated EC2 security-group-rule issue, and its
-// `#1765` does not exist in cdk-local at all, which already shipped a bare `#1765`
-// meaning this repo's. `hunt-bugs` is deliberately NOT listed: §10-b records that
-// this flow never mirrors it, and it carries ~99 bare refs that are correct where
-// they are.
-const MIRRORED_DOCS = [path.join('.claude', 'skills', 'work-issues', 'SKILL.md')];
+// EVERY skill doc owes fully-qualified issue references: a bare `#N` renders
+// against whichever repo is READING it, so mirroring a sentence into a sibling
+// repo silently rewrites a correct citation into a wrong one. Both failure shapes
+// were live on 2026-08-19 (go-to-k/cdk-real-drift#1774) — this repo's `#1761`
+// resolves in cdkd to an unrelated EC2 security-group-rule issue, and its `#1765`
+// does not exist in cdk-local at all, which already shipped a bare `#1765` meaning
+// this repo's.
+//
+// The population used to be the ONE file this flow mirrors wholesale, on the
+// reasoning that `hunt-bugs` never travels. That stopped being true the day
+// go-to-k/cdk-real-drift#1796 and its cdk-local twin landed the same `hunt-bugs`
+// change in both repos, and the exclusion was hiding 98 bare refs in exactly the
+// file the rule had stopped covering. A doc is in scope because a SENTENCE of it
+// can travel, which is true of all of them — so the population is derived, not
+// listed (2026-08-20, go-to-k/cdk-real-drift#1797).
+// (assigned after skillDocs is declared — see below)
+let MIRRORED_DOCS: string[] = [];
 
 // A reference is qualified when `owner/repo` immediately precedes the `#`. Matches
 // deliberately skip inline-code spans and fenced blocks, so a paragraph can still
@@ -61,6 +75,8 @@ function skillDocs(): string[] {
     .map((e) => path.join('.claude', 'skills', e.name, 'SKILL.md'))
     .filter((rel) => existsSync(path.join(ROOT, rel)));
 }
+
+MIRRORED_DOCS = skillDocs();
 
 function citations(rel: string): string[] {
   const text = readFileSync(path.join(ROOT, rel), 'utf8');
@@ -131,15 +147,18 @@ describe('mirrored skill docs cite issues by fully-qualified reference', () => {
     ).toEqual([]);
   });
 
+  // Anti-no-op guard on the TOTAL, not per doc: a skill that cites nothing is
+  // legitimate (`check-docs` has no refs at all), so a per-doc floor would only
+  // measure how chatty each file is. What must never happen is the extractor
+  // matching nothing anywhere.
   it('the qualified references it should be finding are actually there', () => {
-    for (const rel of MIRRORED_DOCS) {
+    const qualified = MIRRORED_DOCS.reduce((n, rel) => {
       const text = prose(readFileSync(path.join(ROOT, rel), 'utf8'));
-      const qualified = [...text.matchAll(/[\w-]+\/[\w-]+#\d+/g)];
-      expect(
-        qualified.length,
-        `${rel} has no qualified refs — extractor is a no-op`
-      ).toBeGreaterThanOrEqual(10);
-    }
+      return n + [...text.matchAll(/[\w-]+\/[\w-]+#\d+/g)].length;
+    }, 0);
+    expect(qualified, 'no qualified refs anywhere — extractor is a no-op').toBeGreaterThanOrEqual(
+      50
+    );
   });
 });
 
@@ -157,14 +176,27 @@ describe('mirrored skill docs cite issues by fully-qualified reference', () => {
 // change caused.
 describe('hook harnesses resolve their subject from their own script path', () => {
   const HOOKS_DIR = path.join(ROOT, '.claude', 'hooks');
-  const harnesses = existsSync(HOOKS_DIR)
-    ? readdirSync(HOOKS_DIR)
-        .filter((f) => f.endsWith('.test.sh'))
-        .sort()
-    : [];
+  const entries = existsSync(HOOKS_DIR) ? readdirSync(HOOKS_DIR).sort() : [];
+  // The population is the HOOKS, not the harnesses. Deriving it from
+  // `*.test.sh` counted the harnesses that exist and so could never report the
+  // one that does not: on 2026-08-20 `check-gate.sh` — the hook every commit
+  // passes through — was the only hook in the directory with no harness beside
+  // it, and this block was green at 9/9 (go-to-k/cdk-real-drift#1797).
+  const hooks = entries.filter((f) => f.endsWith('.sh') && !f.endsWith('.test.sh'));
+  const harnesses = entries.filter((f) => f.endsWith('.test.sh'));
 
-  it('finds the harnesses to check (the extractor is not a no-op)', () => {
-    expect(harnesses.length).toBeGreaterThanOrEqual(9);
+  it('finds the hooks to check (the extractor is not a no-op)', () => {
+    expect(hooks.length).toBeGreaterThanOrEqual(9);
+    expect(hooks).toContain('check-gate.sh');
+  });
+
+  it('every hook has a harness beside it', () => {
+    const unharnessed = hooks.filter((f) => !harnesses.includes(f.replace(/\.sh$/, '.test.sh')));
+    expect(
+      unharnessed,
+      `hook(s) with no .test.sh beside them — a gate nothing exercises is a gate ` +
+        `nobody has watched go red:\n${unharnessed.join('\n')}`
+    ).toEqual([]);
   });
 
   it.each(harnesses)('%s derives its subject from its own path', (file) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,13 +150,19 @@ export default defineConfig({
       'lint:fix': { command: 'vp lint --fix', cache: false },
       format: { command: 'vp fmt', cache: false },
       'format:check': { command: 'vp fmt --check' },
+      // The `.claude/hooks/*.test.sh` harnesses assert the gates' BLOCK / ALLOW
+      // contracts. Nothing ran them until 2026-08-20
+      // (go-to-k/cdk-real-drift#1797) — they are shell, so `vp test run` never
+      // saw them, and CI had no step. cache:false: their subjects are hook
+      // scripts and settings.json, which the task hash does not cover.
+      'test:hooks': { command: 'bash scripts/run-hook-tests.sh', cache: false },
       // cache:false — the run-task cache can REPLAY a stale pass even though the
       // current tree has a real type error, masking it. This bit us live: PR #438
       // introduced a duplicate object-literal key (tsgo TS1117) that `vp run
       // typecheck` reported GREEN from cache, so the gate marker was set on a red
       // tree and the break reached main. Typecheck is ~1s; correctness > the cache.
       typecheck: { command: 'tsc --project tsconfig.json --noEmit', cache: false },
-      verify: { command: 'vp run check && vp run test && vp run build' },
+      verify: { command: 'vp run check && vp run test && vp run test:hooks && vp run build' },
       'runtime:smoke': {
         command: 'node dist/cli.js --version',
         dependsOn: ['build'],


### PR DESCRIPTION
## Summary

Closes go-to-k/cdk-real-drift#1797 — the mirror of go-to-k/cdkd#2112's section 5
lesson, adapted to this repo's wording rather than pasted, plus the repairs that
adapting it turned up. They ship together on purpose: the lesson says a fence is
not evidence until you have watched it go red, and the only way to write that
sentence honestly here was to run the probes over this repo's own fences first.

## The amendment

This repo's section 5 already says to calibrate a scanner against the PRE-FIX
tree and then drive the failure direction with `git stash push`. Both read the
instances that ALREADY EXIST, so neither says anything about the SHAPE — the
spellings the tree does not use today, and the contexts that defeat the exemption
logic. The amendment adds the two probes (every spelling; delete what the fence
requires) and one more question: is anything RUNNING it?

## What the probes found

All eight fences were probed. Four were dead:

| fence | verdict | probe that used to pass |
| --- | --- | --- |
| `tests/gate-cd-form-parity-1786.test.ts` | inert | `stale-base-gate` + `ci-green-gate` disarmed outright → 7/7 green |
| `tests/no-direct-tty.test.ts` | blind + stale population | `process.stdin['isTTY']` in `src/commands/ignore.ts` → 5/5 green |
| `tests/skill-doc-paths.test.ts` | wrong population | it counts harnesses, so the hook with none (`check-gate.sh`) was unreportable |
| `tests/releaserc-header-pattern.test.ts` | wrong population | `release-notes-generator` had no `parserOpts` → 6/6 green |

The gate-parity one is the sharpest shape: its population came from the DEFECT
(`hooks.filter(h => h.condition.includes('Bash(git commit*)'))`), so deleting the
bare form dropped the gate OUT of the population instead of failing.

The releaserc one had already shipped: `@semantic-release/release-notes-generator`
was a bare string, falling back to conventional-changelog-angular's default
header pattern, which has no `!`. Every `type!:` merge therefore released a
version and left no changelog entry — checked against go-to-k/cdk-real-drift#432,
go-to-k/cdk-real-drift#105, go-to-k/cdk-real-drift#93, go-to-k/cdk-real-drift#73
and go-to-k/cdk-real-drift#57: zero hits each in `CHANGELOG.md`, which has no
BREAKING section at all. 13 such merges exist in this repo's history.

## What changed

- `.claude/skills/work-issues/SKILL.md` — the amendment, in this repo's wording.
- `tests/gate-cd-form-parity-1786.test.ts` — DECLARED gate → verb table plus a
  completeness case, so a gate can neither leave the population by losing a
  pattern nor enter it unnoticed.
- `tests/no-direct-tty.test.ts` — walks all of `src/**` (minus the one owner) and
  carries four signatures instead of one substring.
- `tests/skill-doc-paths.test.ts` — population derived from the HOOKS (every hook
  owes a harness), `PATH_ROOTS` derived from the real top-level entries
  (`scripts/` and `demo/` were missing), and the mirrored-doc set is every skill
  doc: `hunt-bugs` travels too (go-to-k/cdk-real-drift#1796 landed the same change
  here and in cdk-local), and it carried 98 bare refs.
- `.claude/hooks/check-gate.test.sh` — new, 15 cases: which spellings are gated,
  that the verdict is read from the RESOLVED tree, the fail-open paths, and that
  the block message names the skill to re-run.
- `.releaserc.json` — `release-notes-generator` gets the same `parserOpts`.
- `scripts/run-hook-tests.sh` + `vp run test:hooks` + a CI step — the harnesses
  were run by hand only; nothing invoked them.
- `.claude/skills/{hunt-bugs,check}/SKILL.md` — 100 refs qualified. All 88
  distinct numbers were checked to resolve in this repo before rewriting.

## Test plan

- [x] `vp run check` — 0 errors
- [x] `vp run test` — 345 files / 6527 tests
- [x] `vp run test:hooks` — 10 harnesses, 0 failed
- [x] `vp run build`
- [x] every rewritten fence re-probed after the fix — each goes RED under the
      probe that used to pass it (gate parity: drop a form → 2 failed, disarm a
      gate → 1 failed, remove a gate → 3 failed; TTY: all four spellings flagged;
      skill-doc-paths: bare ref → red, missing harness → red, stale `scripts/`
      citation → red; releaserc: drop the parserOpts → red)

This is a docs/tooling-only PR — no `src/**` in the diff — so `verify-pr-gate`'s
non-src exemption applies and `check` + `docs` cover it.
