### PR TITLE
chore(work-issues): make the reference fence see half-qualified refs, and stop it calling a real mid-path glob stale

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -350,7 +350,7 @@ band and asserts the LIVE value after revert is the only reliable test — the A
 is not a predictor. The `revert-toggle-converge` fixture is the reference (one fixed
 case + converge-via-remove controls). Batch 2 (2026-07-14, `revconv-hunt` fixture):
 **`ECR::Repository` `ImageTagMutability` no-oped** (independently found+fixed the
-same day as go-to-k/cdk-real-drift#1580/#1581 — check upstream before pushing a same-table fix); Lambda
+same day as go-to-k/cdk-real-drift#1580 / go-to-k/cdk-real-drift#1581 — check upstream before pushing a same-table fix); Lambda
 `TracingConfig`, SQS `DelaySeconds`, KMS Key `Enabled` all converged via bare
 `remove` — again ~1-in-4, unpredictable from the API shape. Batch 3 (2026-07-14,
 `revconv2-hunt` fixture): **`ECR::Repository` `ImageScanningConfiguration` no-oped**
@@ -403,7 +403,7 @@ hunt's NEW folds rather than a dedicated fixture): **VpcLattice ResourceConfigur
 `StartWindowHours` AND `ScheduleExpressionTimezone`** (same handler, both proven
 individually), and **EC2 TransitGatewayAttachment `Options`** ALL no-oped — 4-in-4
 for this batch's new folds (streaks run hot too); every one converged via an explicit
-CC `add` patch → plain RSDP entries (go-to-k/cdk-real-drift#1639/#1640/#1642).
+CC `add` patch → plain RSDP entries (go-to-k/cdk-real-drift#1639 / go-to-k/cdk-real-drift#1640 / go-to-k/cdk-real-drift#1642).
 Batch 9 (2026-07-22 hunt): **RUM `AppMonitorConfiguration`** (go-to-k/cdk-real-drift#1684, sibling of
 CustomEvents), **GuardDuty Filter `Action`** (go-to-k/cdk-real-drift#1687), and **Cognito UserPoolClient
 `EnableTokenRevocation` + `AuthSessionValidity`** (go-to-k/cdk-real-drift#1689 — the RefreshTokenValidity
@@ -438,7 +438,7 @@ risk is only the go-to-k/cdk-real-drift#763 explicit-write-ignored class, low), 
 `SupportedIpAddressTypes` (needs a dualstack NLB in IPv6 subnets), Synthetics Canary
 `Schedule.DurationInSeconds` + Firehose `HttpEndpointDestinationConfiguration.*`
 (nested pins — same auto-`add` note as OpenSearch, low residual).
-Batch 11 (2026-08-02 hunt, go-to-k/cdk-real-drift#1709/#1710) found the CLASS behind several of these:
+Batch 11 (2026-08-02 hunt, go-to-k/cdk-real-drift#1709 / go-to-k/cdk-real-drift#1710) found the CLASS behind several of these:
 **DERIVED (tier-2) folds had NO revert-side value source at all** — classify builds
 them into its LOCAL knownDef/knownDefPaths, so the RSDP branch sourced the (wrong)
 static value and the nested explicit-`add` branch missed entirely. Live-proven:
@@ -780,7 +780,7 @@ Recorded]` breakdown with `--verbose`.
   AWS default folds `atDefault` and is NOT recorded, so a later OOB change to it is caught
   ONLY by the R62 "appeared since record" mechanism — which fires ONLY when the resource is
   `complete`. A resource that DECLARES a write-only property (RDS `MasterUserPassword`, any
-  secret/token/key) surfaced a write-only `readGap` that (pre-#1582) marked it NOT complete,
+  secret/token/key) surfaced a write-only `readGap` that (before go-to-k/cdk-real-drift#1582) marked it NOT complete,
   silently disabling that detection — so mutating an undeclared-atDefault prop on it read
   `[Not Recorded]`, `check --fail` exited 0, and it looked like a fold bug when it was a
   completeness gap. When an undeclared-prop FN detect-test on a resource that declares a
@@ -1096,7 +1096,7 @@ Endpoint}]` (raw CFn / L1) creates live subscriptions with no AWS::SNS::Subscrip
 - **A NEW all-boolean pin family can arrive via a READER-projection fix — re-run the
   off-flip audit over the diff window, not just the historical tables.** The go-to-k/cdk-real-drift#1658
   Budgets reader fix (projecting the full 11-boolean `CostTypes`) necessarily added a
-  whole-object + per-leaf all-`true` pin family, silently re-opening the go-to-k/cdk-real-drift#1092/#1635
+  whole-object + per-leaf all-`true` pin family, silently re-opening the go-to-k/cdk-real-drift#1092 / go-to-k/cdk-real-drift#1635
   all-boolean-object class: an out-of-band `update-budget` disabling ALL nine
   `Include*` cost types read back an all-false object that `isTrivialEmpty` swallowed
   — check stayed CLEAN while the budget was gutted (live-proven + fixed with a
@@ -1149,10 +1149,10 @@ grep ': true'` and pair every new truthy pin with its off-state gate. A SINGLE
   a regression. TWO STALENESS TRAPS in this determination (both hit 2026-07-20): (a)
   the gap may have been CLOSED since the note you're reading was written — Route53
   RecordSet was this gotcha's original example and has been fully revertable since
-  go-to-k/cdk-real-drift#1312/#1431 — so grep `SDK_WRITERS[type]` before planning around "not revertable";
+  go-to-k/cdk-real-drift#1312 / go-to-k/cdk-real-drift#1431 — so grep `SDK_WRITERS[type]` before planning around "not revertable";
   (b) the not-revertable RATIONALE can go stale in the other direction: writers.ts
   justified Budgets by "the reader returns only the scalar identity subset", but
-  go-to-k/cdk-real-drift#1647/#1658 later grew the reader to the full NewBudget surface, making a writer
+  go-to-k/cdk-real-drift#1647 / go-to-k/cdk-real-drift#1658 later grew the reader to the full NewBudget surface, making a writer
   feasible (go-to-k/cdk-real-drift#1676) — when a reader gains projection, re-read the not-revertable list
   for entries whose justification was that reader's thinness.
 - **Read the revert's convergence REPORT text, not just the live value — the report
@@ -1279,7 +1279,7 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   masks it as "No baseline yet".** The R62 mechanism only fires on snapshot-COMPLETE
   resources; a declared prop the reader never projects (DLM's shorthand
   `DefaultPolicy`, go-to-k/cdk-real-drift#1665) keeps the resource incomplete forever, so every undeclared
-  OOB change stays [Potential Drift] and `check --fail` exits 0 — and (pre-#1665) the
+  OOB change stays [Potential Drift] and `check --fail` exits 0 — and (before go-to-k/cdk-real-drift#1665) the
   preamble printed "No baseline yet" right after a successful `record`, sending you
   to re-record instead of at the readGap. When a detect probe unexpectedly misses:
   check the target resource's `readGap=` in the info: footer FIRST, and either close
@@ -1328,7 +1328,7 @@ tests/integration/sweep-orphans.sh` to restore main to HEAD — the committed
   probe, and expect plain `revert --yes` to delete it.** Before go-to-k/cdk-real-drift#1737, an OOB child
   created AFTER `record` surfaced only as `[Potential Drift]` (`check --fail` exit 0 —
   the 2026-08-09 enumrev2-hunt's live find), so older verify scripts never asserted the
-  exit code on the added step. A post-#1737 probe MUST assert `check --fail` exits 1
+  exit code on the added step. A probe written after go-to-k/cdk-real-drift#1737 MUST assert `check --fail` exits 1
   and the output carries `appeared since record`; the delete then plans WITHOUT
   `--remove-unrecorded` (the flag still gates unrecorded/pre-record inventory and the
   go-to-k/cdk-real-drift#764 recorded-changed state). Note the marker is stamped at `record` time — a

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -293,7 +293,7 @@ grounds rather than this one.
 What the gate accepts in exchange: an issue filed by a session that has since ended
 waits up to an hour. That is the cheap side — the backlog is not going anywhere,
 while the expensive side is two agents deriving one fix from scratch. Mirrored from
-cdkd on 2026-08-19, where the window was watched live the same morning: cdkd#1973 was
+cdkd on 2026-08-19, where the window was watched live the same morning: go-to-k/cdkd#1973 was
 filed at 03:14Z, claimed by its filing lane at 03:30Z, and that lane's branch reached
 `origin` only at 04:06Z. For 16 minutes the issue had no branch, no PR and no comment,
 so every probe in §2 reported it free; for 52 minutes nothing but a time-based gate
@@ -474,7 +474,7 @@ drifted from the repo", and drift almost never produces exactly the one instance
 someone happened to notice. Check both that every entry still resolves to something
 real AND that everything that belongs is present — the second half is the one that
 gets skipped, because the issue only names the first. The evidence is cross-repo:
-on 2026-08-19 cdkd#1972 reported one dead path in a security-surface path list; the
+on 2026-08-19 go-to-k/cdkd#1972 reported one dead path in a security-surface path list; the
 audit found a second dead path (stale since an unrelated directory rename) plus four
 live authn / credential / exec surfaces never added, so the list under-protected
 considerably more than it over-claimed. Then ask what makes the recurrence
@@ -1036,7 +1036,8 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   quoted verbatim, before a reviewer asked to check the records caught it
   (go-to-k/cdk-real-drift#1768). Reading the two records cost one command each.
   **Write every issue / PR reference FULLY QUALIFIED — the `owner/repo#N` form,
-  never a bare `#N` — everywhere in this file, this section's own refs included.**
+  never a bare `#N` and never a half-qualified `cdkd#N` — everywhere in every
+  skill doc, this section's own refs included.**
   A bare `#N` renders against whichever repo is READING it, so mirroring silently
   rewrites a correct citation into a wrong one, in both of the shapes available:
   an unqualified `#1761` here lands on go-to-k/cdkd#1761, a real but unrelated EC2
@@ -1045,8 +1046,11 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   both were resolved on 2026-08-19, and cdk-local's already-mirrored copy carried a
   bare `#1765` that meant this repo's. The rule is mechanically detectable, so per
   §10-b it is a TEST rather than a sentence: `tests/skill-doc-paths.test.ts` fails
-  on any unqualified reference in this file. It reads plain prose only, which is
-  why the counter-examples in this paragraph can stay written as code spans.
+  on any unqualified reference in ANY `.claude/skills/*/SKILL.md` — not just this
+  one, because a sentence can travel out of any of them, and `hunt-bugs` already does
+  (go-to-k/cdk-real-drift#1796 landed the same change here and in cdk-local). It
+  reads plain prose only, which is why the counter-examples in this paragraph can
+  stay written as code spans.
 
 ### 10-d. Ship it like any other change
 

--- a/tests/skill-doc-paths.test.ts
+++ b/tests/skill-doc-paths.test.ts
@@ -53,19 +53,37 @@ const PATH_LIKE = /^[A-Za-z0-9_.@-]+(\/[A-Za-z0-9_.*@-]+)+$/;
 // (assigned after skillDocs is declared — see below)
 let MIRRORED_DOCS: string[] = [];
 
-// A reference is qualified when `owner/repo` immediately precedes the `#`. Matches
-// deliberately skip inline-code spans and fenced blocks, so a paragraph can still
-// SHOW a bare `#N` as its own counter-example, and skip YAML frontmatter, where
-// `argument-hint` demonstrates what a user types rather than citing anything.
-const BARE_REF = /(?<![\w/-])#\d+/g;
+// A reference is qualified only when a WHOLE `owner/repo` immediately precedes
+// the `#`. The first version asked for "not a word, slash or dash character
+// before the `#`", which accepts both HALF-qualified spellings — `cdk-real-drift#5`
+// (owner dropped) and `go-to-k#5` (repo dropped) — and GitHub autolinks neither,
+// so the likeliest typo in a file full of `go-to-k/cdk-real-drift#…` was the one
+// the fence could not see (probed 2026-08-20, go-to-k/cdk-real-drift#1797).
+// Matches deliberately skip inline-code spans and fenced blocks, so a paragraph
+// can still SHOW a bare `#N` as its own counter-example, and skip YAML
+// frontmatter, where `argument-hint` demonstrates what a user types.
+const ANY_REF = /([A-Za-z0-9._/-]*)#(\d+)/g;
+const QUALIFIER = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+function unqualifiedRefs(text: string): string[] {
+  return [...text.matchAll(ANY_REF)]
+    .filter((m) => !QUALIFIER.test(m[1]!))
+    .map((m) => `${m[1]}#${m[2]}`);
+}
 
 function prose(text: string): string {
   const withoutFrontmatter = text.startsWith('---\n')
     ? text.slice(text.indexOf('\n---\n', 3) + 5)
     : text;
-  return withoutFrontmatter
-    .replace(/^```[\s\S]*?^```/gm, '') // fenced code blocks
-    .replace(/`[^`\n]*`/g, ''); // inline code spans
+  return (
+    withoutFrontmatter
+      .replace(/^```[\s\S]*?^```/gm, '') // fenced code blocks
+      // DOUBLE-backtick spans first: that is how a counter-example containing a
+      // backtick is written, and a single-span-only strip leaves its contents
+      // exposed as prose, which the fence then reports as a violation.
+      .replace(/``.*?``/g, '')
+      .replace(/`[^`\n]*`/g, '') // inline code spans
+  );
 }
 
 function skillDocs(): string[] {
@@ -92,25 +110,38 @@ function citations(rel: string): string[] {
 }
 
 /**
- * Resolve a citation against the repo. Globs are satisfied by ONE match:
- * a trailing `**` only requires its prefix directory, and a `*`-bearing final
- * segment requires at least one sibling entry matching it.
+ * Resolve a citation against the repo. Globs are satisfied by ONE match: a
+ * trailing `**` only requires its prefix directory, and a `*`-bearing segment
+ * requires at least one entry matching it — in ANY position, not only the last
+ * one. The first version handled a wildcard in the final segment only, so a
+ * perfectly real `.claude/skills/*\/SKILL.md` citation was reported as stale
+ * (go-to-k/cdk-real-drift#1797).
  */
 function resolves(citation: string): boolean {
-  if (!citation.includes('*')) return existsSync(path.join(ROOT, citation));
+  const segmentRe = (segment: string) =>
+    new RegExp(`^${segment.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
 
-  const segments = citation.split('/');
-  const wildcardAt = segments.findIndex((s) => s.includes('*'));
-  const prefix = path.join(ROOT, ...segments.slice(0, wildcardAt));
-  if (!existsSync(prefix) || !statSync(prefix).isDirectory()) return false;
+  const walk = (dir: string, segments: string[]): boolean => {
+    if (segments.length === 0) return true;
+    const [head, ...rest] = segments as [string, ...string[]];
+    if (head === '**') return true; // `dir/**` and `dir/**/*.sh`: the prefix is the assertion
+    const here = path.join(dir, head);
+    if (!head.includes('*')) {
+      if (!existsSync(here)) return false;
+      if (rest.length === 0) return true;
+      return statSync(here).isDirectory() && walk(here, rest);
+    }
+    if (!existsSync(dir) || !statSync(dir).isDirectory()) return false;
+    const re = segmentRe(head);
+    return readdirSync(dir).some((entry) => {
+      if (!re.test(entry)) return false;
+      if (rest.length === 0) return true;
+      const next = path.join(dir, entry);
+      return statSync(next).isDirectory() && walk(next, rest);
+    });
+  };
 
-  const segment = segments[wildcardAt];
-  // `dir/**` (and `dir/**/*.sh`): the prefix directory existing is the assertion.
-  if (segment === '**') return true;
-  // `dir/*.json`: at least one entry must match, and nothing may follow it.
-  if (wildcardAt !== segments.length - 1) return false;
-  const re = new RegExp(`^${segment.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
-  return readdirSync(prefix).some((entry) => re.test(entry));
+  return walk(ROOT, citation.split('/'));
 }
 
 describe('skill docs cite real repo paths', () => {
@@ -139,12 +170,25 @@ describe('skill docs cite real repo paths', () => {
 describe('mirrored skill docs cite issues by fully-qualified reference', () => {
   it.each(MIRRORED_DOCS)('%s uses owner/repo#N, never a bare #N', (rel) => {
     const text = prose(readFileSync(path.join(ROOT, rel), 'utf8'));
-    const bare = [...text.matchAll(BARE_REF)].map((m) => m[0]);
+    const bare = unqualifiedRefs(text);
     expect(
       bare,
       `unqualified issue reference(s) in ${rel} — write go-to-k/<repo>#N so the ` +
-        `reference survives being mirrored into a sibling repo:\n${bare.join(', ')}`
+        `reference survives being mirrored into a sibling repo (a half-qualified ` +
+        `cdk-real-drift#N or go-to-k#N autolinks nowhere):\n${bare.join(', ')}`
     ).toEqual([]);
+  });
+
+  it('flags every unqualified spelling and exempts the backtick forms (spelling probe)', () => {
+    expect(unqualifiedRefs(prose('A bare #601 ref.'))).toEqual(['#601']);
+    expect(unqualifiedRefs(prose('A repo-only cdk-real-drift#602 ref.'))).toEqual([
+      'cdk-real-drift#602',
+    ]);
+    expect(unqualifiedRefs(prose('An owner-only go-to-k#603 ref.'))).toEqual(['go-to-k#603']);
+    expect(unqualifiedRefs(prose('A parenthesised (PR #604) ref.'))).toEqual(['#604']);
+    expect(unqualifiedRefs(prose('A qualified go-to-k/cdk-real-drift#605 ref.'))).toEqual([]);
+    expect(unqualifiedRefs(prose('A span `#606` is exempt.'))).toEqual([]);
+    expect(unqualifiedRefs(prose('A span ``#607 with `ticks` `` is exempt too.'))).toEqual([]);
   });
 
   // Anti-no-op guard on the TOTAL, not per doc: a skill that cites nothing is


### PR DESCRIPTION
## Summary

Follow-up to go-to-k/cdk-real-drift#1798. Reviewing its cdk-local twin
(go-to-k/cdk-local#538) surfaced two defects in that repo's reference scanner;
both were live in this repo's `tests/skill-doc-paths.test.ts` too, and fixing
them turned up a third.

## What was wrong

- **Half-qualified references passed.** The rule was "no word, slash or dash
  character before the `#`", which flags a bare `#5` and accepts BOTH
  `cdk-real-drift#5` (owner dropped) and `go-to-k#5` (repo dropped). GitHub
  autolinks neither, so the likeliest typo in a file full of
  `go-to-k/cdk-real-drift#…` was the one shape the fence could not see. Requiring
  the whole `owner/repo` prefix went red on 12 real ones: `cdkd#1972` and
  `cdkd#1973`, the trailing half of seven `#1580/#1581`-style pairs, and three
  `pre-#N` / `post-#N` forms. All are written out now.
- **A double-backtick span was read as prose.** ``` ``#607 with `ticks` `` ``` is
  how a counter-example containing a backtick is written; the single-span strip
  left its contents exposed, so the fence reported the counter-example as the
  violation.
- **`resolves()` only understood a wildcard in the LAST segment.** So the real
  citation `.claude/skills/*/SKILL.md` — which section 10-c now needs, since
  go-to-k/cdk-real-drift#1798 widened the fence to every skill doc — was reported
  as a stale path. It walks a glob in any position now.

Section 10-c still said the fence covers "this file"; it covers every skill doc,
and `hunt-bugs` travels too (go-to-k/cdk-real-drift#1796 landed the same change
here and in cdk-local).

## Test plan

- [x] `vp run check` — 0 errors
- [x] `vp run build`, `vp run test` — 345 files / 6528 tests
- [x] `vp run test:hooks` — 10 harnesses, 0 failed
- [x] probes: a stale mid-glob path, a stale leaf under a real mid-glob, a stale
      plain path, and a half-qualified `cdkd#4242` each turn the fence RED; the
      real `.claude/skills/*/SKILL.md` citation stays green

Docs/tooling-only — no `src/**` in the diff.
