### PR TITLE
chore(hooks): match a gated verb in any command position, and stop `next` being available inside a cross-repo request

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# _command-match.sh — shared command matching for the PreToolUse gate hooks.
+# SOURCED, never executed: `. "$(dirname "${BASH_SOURCE[0]}")/_command-match.sh"`.
+#
+# WHY this exists (go-to-k/cdk-real-drift#1803): every gate used to decide whether
+# it applied with a LINE-START-anchored regex, optionally tolerating one leading
+# `cd <path> &&`. So a gated verb in any other position was invisible:
+#
+#   git add -A && git commit -m "…"     <- the commonest commit spelling there is
+#   cd <wt>; git commit -m "…"          <- semicolon instead of &&
+#   (cd <wt> && git commit -m "…")      <- subshell
+#   GIT_EDITOR=true git commit -m "…"   <- leading env assignment
+#
+# all reached git ungated, and an ungated command looks exactly like one that
+# passed. Measured on 2026-08-20 right after the matcher fix
+# (go-to-k/cdk-real-drift#1802) made the hooks run at all.
+#
+# The model: a Bash tool call is a COMMAND LIST. Split it into segments and ask
+# whether ANY segment is the gated command. Quoted spans are blanked first, so a
+# separator or a command name inside a string cannot create a phantom segment —
+# `echo "run git commit later"` is still not a commit.
+
+# Blank the CONTENT of quoted spans, preserving length so offsets and the
+# surrounding structure survive. Unterminated quotes blank to end of input, which
+# is the conservative reading (that text is not a command).
+gate_blank_quotes() {
+  awk '
+    {
+      line = $0; out = ""; q = ""
+      n = length(line)
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (q == "") {
+          if (c == "\"" || c == "'"'"'") { q = c; out = out c; continue }
+          out = out c
+        } else {
+          if (c == "\\" && q == "\"") { out = out "  "; i++; continue }
+          if (c == q) { q = ""; out = out c; continue }
+          out = out " "
+        }
+      }
+      print out
+    }
+  ' <<< "$1"
+}
+
+# Blank the BODY of every heredoc, keeping the line count. A heredoc body is data
+# the shell hands to a program, not a command list — and this repo's own flow
+# writes PR bodies with `gh pr create --body-file <<EOF ... git commit ... EOF`,
+# which would otherwise trip the commit gates on its own prose.
+gate_blank_heredocs() {
+  awk '
+    BEGIN { tag = "" }
+    {
+      if (tag != "") {
+        line = $0
+        gsub(/^[ \t]+|[ \t]+$/, "", line)
+        if (line == tag) { tag = "" ; print $0 ; next }
+        print ""
+        next
+      }
+      if (match($0, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*["'"'"']?/)) {
+        t = substr($0, RSTART, RLENGTH)
+        gsub(/^<<-?[ \t]*|["'"'"']/, "", t)
+        tag = t
+      }
+      print $0
+    }
+  ' <<< "$1"
+}
+
+# Print one command segment per line: split on && || ; | newline, and drop the
+# grouping punctuation ( ) { } that wraps a subshell or brace group.
+gate_segments() {
+  local blanked
+  blanked=$(gate_blank_quotes "$(gate_blank_heredocs "$1")")
+  printf '%s' "$blanked" |
+    sed -E 's/\|\||&&|;|\||\n/\n/g' |
+    sed -E 's/^[[:space:]]*[({][[:space:]]*//; s/[[:space:]]*[)}][[:space:]]*$//' |
+    sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' |
+    grep -v '^$'
+}
+
+# Strip leading `VAR=value` assignments and an `env`/`command`/`nohup` wrapper, so
+# `GIT_EDITOR=true git commit` and `env git commit` are seen as `git commit`.
+gate_strip_prefix() {
+  printf '%s' "$1" | sed -E 's/^(([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup)[[:space:]]+)*//'
+}
+
+# gate_matches <cmd> <extended-regex>
+# 0 when any segment matches the regex (anchored at the segment start, after the
+# prefix strip). The regex is the SAME per-verb shape each gate used to carry.
+gate_matches() {
+  local cmd="$1" re="$2" segment
+  while IFS= read -r segment; do
+    segment=$(gate_strip_prefix "$segment")
+    printf '%s' "$segment" | grep -qE "$re" && return 0
+  done < <(gate_segments "$cmd")
+  return 1
+}
+
+# The regexes, kept here so every gate spells its verb the same way. Each is
+# anchored at the START of a segment; `git -C <path>` / `git -c k=v` and
+# `gh -C <path>` are absorbed.
+GATE_RE_GIT_COMMIT='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'
+GATE_RE_GIT_PUSH='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+push([[:space:]]|$)'
+GATE_RE_GH_PR_CREATE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'
+GATE_RE_GH_PR_EDIT='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+edit([[:space:]]|$)'
+GATE_RE_GH_PR_MERGE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'
+
+# gate_target_dir <cmd> <fallback> <extended-regex>
+# The working tree the gated command will actually run in:
+#   1. a `-C <path>` inside the MATCHED segment wins (git -C / gh -C), else
+#   2. the last `cd <path>` segment BEFORE the matched one, else
+#   3. the fallback (the hook payload's cwd).
+# Relative paths resolve against the fallback, then against each other, which is
+# what a `cd a && cd b` chain does.
+gate_target_dir() {
+  local cmd="$1" fallback="$2" re="$3"
+  local target="$fallback" segment stripped cd_target c_target remaining
+  while IFS= read -r segment; do
+    stripped=$(gate_strip_prefix "$segment")
+    if [[ "$stripped" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+      cd_target="${BASH_REMATCH[1]}"
+      cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+      cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+      [[ "$cd_target" != /* ]] && cd_target="$target/$cd_target"
+      target="$cd_target"
+      continue
+    fi
+    printf '%s' "$stripped" | grep -qE "$re" || continue
+    # Last `-C <path>` in this segment wins over any earlier cd.
+    if [[ "$stripped" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+      c_target=""
+      remaining="$stripped"
+      while [[ "$remaining" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+        c_target="${BASH_REMATCH[2]}"
+        remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+      done
+      c_target="${c_target%\"}"; c_target="${c_target#\"}"
+      c_target="${c_target%\'}"; c_target="${c_target#\'}"
+      [[ "$c_target" != /* ]] && c_target="$target/$c_target"
+      target="$c_target"
+    fi
+    break
+  done < <(gate_segments "$cmd")
+  printf '%s' "$target"
+}

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Smoke test for _command-match.sh, the shared segment matcher every gate uses.
+# Run from the repo root: `bash .claude/hooks/_command-match.test.sh`
+#
+# The cases are the spellings go-to-k/cdk-real-drift#1803 measured running UNGATED
+# against the old line-start-anchored regexes, plus the negatives that must stay
+# out (a verb inside a string, a different verb, a lookalike).
+
+set -u
+
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
+pass=0; fail=0
+
+# want_match <expect 0|1> <label> <command> <regex>
+want_match() {
+  local want="$1" label="$2" cmd="$3" re="$4" got
+  if gate_matches "$cmd" "$re"; then got=0; else got=1; fi
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s got %s) :: %s\n' "$label" "$want" "$got" "$cmd"
+  fi
+}
+
+# want_dir <expected> <label> <command> <fallback> <regex>
+want_dir() {
+  local want="$1" label="$2" cmd="$3" fallback="$4" re="$5" got
+  got=$(gate_target_dir "$cmd" "$fallback" "$re")
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s\n  want: %s\n  got:  %s\n' "$label" "$want" "$got"
+  fi
+}
+
+C="$GATE_RE_GIT_COMMIT"
+P="$GATE_RE_GIT_PUSH"
+M="$GATE_RE_GH_PR_MERGE"
+
+# --- the spellings that used to bypass ---------------------------------------
+want_match 0 "bare git commit"              'git commit -m x' "$C"
+want_match 0 "git add -A && git commit"     'git add -A && git commit -m x' "$C"
+want_match 0 "cd && git commit"             'cd /w/t && git commit -m x' "$C"
+want_match 0 "cd ; git commit"              'cd /w/t; git commit -m x' "$C"
+want_match 0 "no spaces around &&"          'cd /w/t&&git commit -m x' "$C"
+want_match 0 "subshell"                     '(cd /w/t && git commit -m x)' "$C"
+want_match 0 "leading env assignment"       'GIT_EDITOR=true git commit -m x' "$C"
+want_match 0 "env wrapper"                  'env git commit -m x' "$C"
+want_match 0 "git -C <path> commit"         'git -C /w/t commit -m x' "$C"
+want_match 0 "git -c k=v commit"            'git -c user.name=t commit -m x' "$C"
+want_match 0 "three-segment chain"          'vp run check && git add -A && git commit -m x' "$C"
+want_match 0 "pipe into another command"    'git commit -m x | tee log' "$C"
+want_match 0 "gh pr merge after a push"     'git push && gh pr merge 1 --squash' "$M"
+want_match 0 "git push in second position"  'echo go && git push origin HEAD' "$P"
+
+# --- negatives ----------------------------------------------------------------
+want_match 1 "verb inside a double-quoted string" 'echo "next: git commit -m x"' "$C"
+want_match 1 "verb inside a single-quoted string" "echo 'run git commit later'" "$C"
+want_match 1 "heredoc body mentioning the verb"   'cat <<EOF
+git commit -m x
+EOF' "$C"
+want_match 1 "different verb"                     'git status --short' "$C"
+want_match 1 "commit as an argument, not a verb"  'git log --grep commit' "$C"
+want_match 1 "push is not commit"                 'git push origin HEAD' "$C"
+want_match 1 "gh pr create is not merge"          'gh pr create --fill' "$M"
+
+# --- target directory ---------------------------------------------------------
+want_dir "/fallback"  "no cd, no -C"           'git commit -m x' /fallback "$C"
+want_dir "/w/t"       "leading cd"             'cd /w/t && git commit -m x' /fallback "$C"
+want_dir "/w/t"       "cd in an earlier segment" 'cd /w/t && git add -A && git commit -m x' /fallback "$C"
+want_dir "/w/b"       "chained cd"             'cd /w && cd /w/b && git commit -m x' /fallback "$C"
+want_dir "/fallback/rel" "relative cd"         'cd rel && git commit -m x' /fallback "$C"
+want_dir "/w/t"       "git -C beats cd"        'cd /other && git -C /w/t commit -m x' /fallback "$C"
+want_dir "/w/t"       "gh -C on a merge"       'gh -C /w/t pr merge 1 --squash' /fallback "$M"
+want_dir "/fallback"  "cd AFTER the verb does not count" 'git commit -m x && cd /w/t' /fallback "$C"
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -75,50 +75,17 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 #                               forms are an accepted false-negative
 #                               of the line-start tightening (per the
 #                               memory rule's trade-off).
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(commit|push)([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
-# Start from the Bash session's persisted cwd; fall back to the hook
-# process's own cwd if the payload did not include a `cwd` field.
-target_dir="${hook_cwd:-$PWD}"
+# Which commands this gate applies to. The segment matcher sees a gated verb in
+# ANY position — `git add -A && git commit` used to run ungated
+# (go-to-k/cdk-real-drift#1803).
+GATE_RE_COMMIT_OR_PUSH='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+(commit|push)([[:space:]]|$)'
+gate_matches "$cmd" "$GATE_RE_COMMIT_OR_PUSH" || exit 0
 
-# `cd <path>` at the start of the command shifts the target dir. We
-# look at the FIRST `cd` and stop — chained `cd` patterns are rare
-# enough that handling only the leading one covers the realistic
-# foot-gun (the "cd into parent for tooling" case) without parsing
-# arbitrary shell.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  # Strip surrounding single or double quotes if present.
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  # Resolve relative paths against the inherited cwd.
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# `git -C <path>` is git's own "run as if from <path>" flag and beats
-# any earlier cd. Find the LAST occurrence so a chained
-# `git -C /a foo && git -C /b commit` resolves to /b.
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  # Use a pattern that captures the last occurrence by greedy-skipping.
-  # bash regex doesn't support lookbehind, so re-scan from the end.
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Resolve where the command will actually run: a `-C <path>` in the matched
+# segment wins, else the last `cd <path>` segment before it, else the payload cwd.
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_COMMIT_OR_PUSH")
 
 # Repo opt-in scope (cdkd#1259): this gate protects repos that follow
 # the feature-branch + PR + markgate convention. A session rooted in

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -153,21 +153,29 @@ run_case "cd <main> && git commit from feature-cwd blocked" 2 \
 run_case "git -C <main> commit blocked" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s commit -m oops"}}' "$feature_repo" "$main_repo")"
 
-# 11. Single-line `git -C <a> status; git -C <b> commit` — chained
-#     shape where the second `git` is NOT at line-start. With the
-#     line-start anchored matcher (per memory rule
-#     feedback_hook_command_match_line_start.md, issue #563), the
-#     matcher fires on the FIRST `git -C <feature> status` token
-#     (the line-start one), which is not a commit/push subcommand,
-#     so the hook short-circuits at the matcher (exit 0). This is
-#     an ACCEPTED FALSE-NEGATIVE of the line-start tightening — the
-#     trade-off we make to eliminate quoted-body false-positives
-#     (see Part C false-positive cases below). For the agent
-#     workflow this is fine: chained-on-one-line commits to main
-#     are rare; the dominant shape is `cd <repo> && git commit ...`,
-#     which IS line-start matched.
-run_case "single-line chained git -C status; git -C commit (accepted false-negative)" 0 \
+# 11. Single-line `git -C <a> status; git -C <b> commit` — the commit is NOT at
+#     line-start. This used to be an ACCEPTED FALSE-NEGATIVE: the matcher was
+#     anchored at line start, saw `git -C <feature> status` (not a commit), and
+#     short-circuited, so a commit to main in the second segment ran ungated.
+#     go-to-k/cdk-real-drift#1803 replaced the anchor with the shared segment
+#     matcher in `_command-match.sh`, which splits the command list and matches
+#     each segment — the quoted-body false positives that motivated the anchor
+#     are handled by blanking quoted spans instead. The case is now a true
+#     positive, and its target dir resolves to the SECOND `-C`.
+run_case "single-line chained git -C status; git -C commit is caught" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s status; git -C %s commit -m oops"}}' "$feature_repo" "$feature_repo" "$main_repo")"
+
+# 11a. The spellings go-to-k/cdk-real-drift#1803 measured running UNGATED against
+#      the old line-start anchor. Each must now block, and a mention inside a
+#      quoted argument must still not.
+run_case "git add -A && git commit on main is caught" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git add -A && git -C %s commit -m oops"}}' "$main_repo" "$main_repo")"
+run_case "leading env assignment is caught" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"GIT_EDITOR=true git -C %s commit -m oops"}}' "$main_repo" "$main_repo")"
+run_case "subshell is caught" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"(cd %s && git commit -m oops)"}}' "$main_repo" "$main_repo")"
+run_case "commit named inside a quoted argument is not a commit" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"echo \\"next: git commit -m x\\""}}' "$main_repo")"
 
 # 11b. `git -c <key>=<val> commit` — global `-c` flag before commit
 #      subcommand. The tightened regex must not get confused by the

--- a/.claude/hooks/bughunt-clean-gate.sh
+++ b/.claude/hooks/bughunt-clean-gate.sh
@@ -37,26 +37,18 @@ input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Gate only `git commit`, `gh pr create`, and `gh pr merge`. Line-start anchored
-# (tolerating an optional `cd <path> &&` prefix and `gh -C <path>`) so the command
-# words inside a quoted argument body do NOT false-positive.
-git_commit_re='^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+commit([[:space:]]|$)'
-gh_pr_re='^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$|[|;&`)])'
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
-if ! printf '%s' "$cmd" | grep -qE "$git_commit_re" \
-  && ! printf '%s' "$cmd" | grep -qE "$gh_pr_re"; then
-  exit 0
-fi
+# Gate only `git commit`, `gh pr create` and `gh pr merge`. The shared segment
+# matcher sees the verb in ANY position — `git add -A && git commit` used to run
+# ungated (go-to-k/cdk-real-drift#1803) — while a mention inside a quoted argument
+# body still does not count, because quoted spans are blanked before splitting.
+GATE_RE_COMMIT_OR_PR='^(git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+commit|gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge))([[:space:]]|$)'
+gate_matches "$cmd" "$GATE_RE_COMMIT_OR_PR" || exit 0
 
-# Resolve where the command runs (cwd-aware; mirrors the other gates).
-target_dir="${hook_cwd:-$PWD}"
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  [[ "$cd_target" != /* ]] && cd_target="$target_dir/$cd_target"
-  target_dir="$cd_target"
-fi
+# Resolve where the command will actually run: a `-C <path>` in the matched
+# segment wins, else the last `cd <path>` segment before it, else the payload cwd.
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_COMMIT_OR_PR")
 
 # Not a git repo (or git unavailable) → nothing to gate.
 git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1 || exit 0

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -30,39 +30,17 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # so a `git commit` substring inside a quoted argument body does not
 # false-positive. Tolerates `git -C <path> commit` / `git -c k=v commit` and
 # an optional leading `cd <path> &&` worktree prefix.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+commit([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
-# Resolve where the git command will actually run (cwd-aware).
-target_dir="${hook_cwd:-$PWD}"
+# Which commands this gate applies to. The segment matcher sees a gated verb
+# in ANY position — `git add -A && git commit` used to run ungated
+# (go-to-k/cdk-real-drift#1803).
+GATE_RE="$GATE_RE_GIT_COMMIT"
+gate_matches "$cmd" "$GATE_RE" || exit 0
 
-# `cd <path>` at the start of the command shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# `git -C <path>` beats any earlier cd; pick the LAST occurrence.
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Resolve where the command will actually run: a `-C <path>` in the matched
+# segment wins, else the last `cd <path>` segment before it, else the payload cwd.
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE")
 
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/check-gate.test.sh
+++ b/.claude/hooks/check-gate.test.sh
@@ -88,7 +88,14 @@ run_case "git commit is gated" 2 "git commit -m x" "$repo" "$SHIM_DIR" 1 1
 run_case "git -C <path> commit is gated" 2 "git -C $repo commit -m x" "$repo" "$SHIM_DIR" 1 1
 run_case "cd <path> && git commit is gated" 2 "cd $repo && git commit -m x" "$repo" "$SHIM_DIR" 1 1
 run_case "git -c k=v commit is gated" 2 "git -c user.name=t commit -m x" "$repo" "$SHIM_DIR" 1 1
-# A quoted mention is not an invocation: the match is line-start anchored.
+# The spellings go-to-k/cdk-real-drift#1803 measured running UNGATED against the
+# old line-start anchor. Each must now be gated.
+run_case "git add -A && git commit is gated" 2 "git add -A && git commit -m x" "$repo" "$SHIM_DIR" 1 1
+run_case "cd <path>; git commit is gated" 2 "cd $repo; git commit -m x" "$repo" "$SHIM_DIR" 1 1
+run_case "subshell is gated" 2 "(cd $repo && git commit -m x)" "$repo" "$SHIM_DIR" 1 1
+run_case "leading env assignment is gated" 2 "GIT_EDITOR=true git commit -m x" "$repo" "$SHIM_DIR" 1 1
+# A quoted mention is still not an invocation: quoted spans are blanked before
+# the command list is split.
 run_case "quoted mention is not gated" 0 "echo \\\"run git commit next\\\"" "$repo" "$SHIM_DIR" 1 1
 
 # --- the verdict is read from the resolved working tree ----------------------

--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -37,9 +37,13 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate `gh pr merge` (with optional leading `cd <path> &&` and optional
 # `gh -C <path>`). Anything else passes through.
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+
+# Which commands this gate applies to. The segment matcher sees a gated verb
+# in ANY position — `git add -A && git commit` used to run ungated
+# (go-to-k/cdk-real-drift#1803).
+GATE_RE="$GATE_RE_GH_PR_MERGE"
+gate_matches "$cmd" "$GATE_RE" || exit 0
 
 # Human emergency override.
 if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])--admin([[:space:]]|=|$)'; then
@@ -47,35 +51,10 @@ if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])--admin([[:space:]]|=|$)'; then
   exit 0
 fi
 
-# Resolve where the gh command will actually run (cwd + leading cd + gh -C).
-target_dir="${hook_cwd:-$PWD}"
+# Resolve where the command will actually run: a `-C <path>` in the matched
+# segment wins, else the last `cd <path>` segment before it, else the payload cwd.
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE")
 
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
-
-# Can't audit what we can't see — pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -69,38 +69,17 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || ec
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate gh pr create / edit / merge — anything else passes through.
-if ! printf '%s' "$cmd" | grep -qE '\bgh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|edit|merge)\b'; then
-  exit 0
-fi
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
-target_dir="${hook_cwd:-$PWD}"
+# Which commands this gate applies to. The segment matcher sees a gated verb in
+# ANY position — `git add -A && git commit` used to run ungated
+# (go-to-k/cdk-real-drift#1803).
+GATE_RE_PR_WRITE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|edit|merge)([[:space:]]|$)'
+gate_matches "$cmd" "$GATE_RE_PR_WRITE" || exit 0
 
-# Leading `cd <path> && ...` shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# Last `gh -C <path>` wins.
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Resolve where the command will actually run: a `-C <path>` in the matched
+# segment wins, else the last `cd <path>` segment before it, else the payload cwd.
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_PR_WRITE")
 
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/stale-base-gate.sh
+++ b/.claude/hooks/stale-base-gate.sh
@@ -37,30 +37,17 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate `git push` (subcommand position, line-start anchored — same shape
 # as branch-gate.sh so quoted "git push" substrings don't false-positive).
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+push([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
-# Resolve where the git command actually runs.
-target_dir="${hook_cwd:-$PWD}"
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  [[ "$cd_target" != /* ]] && cd_target="$target_dir/$cd_target"
-  target_dir="$cd_target"
-fi
-if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""; remaining="$cmd"
-  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  [[ "$c_target" != /* ]] && c_target="$target_dir/$c_target"
-  target_dir="$c_target"
-fi
+# Which commands this gate applies to. The segment matcher sees a gated verb
+# in ANY position — `git add -A && git commit` used to run ungated
+# (go-to-k/cdk-real-drift#1803).
+GATE_RE="$GATE_RE_GIT_PUSH"
+gate_matches "$cmd" "$GATE_RE" || exit 0
+
+# Resolve where the command will actually run: a `-C <path>` in the matched
+# segment wins, else the last `cd <path>` segment before it, else the payload cwd.
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE")
 
 g() { git -C "$target_dir" "$@" 2>/dev/null; }
 

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -46,40 +46,17 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # hard block. The optional leading `cd <path> &&` prefix preserves
 # the worktree-aware `cd <side> && gh pr create` chain shape,
 # mirroring check-gate.sh (PR #562 fix pattern).
-if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$|[|;&`)])'; then
-  exit 0
-fi
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 
-# Resolve where the gh command will actually run (cwd-aware; mirrors
-# non-english-text-gate.sh / integ-local-gate.sh).
-target_dir="${hook_cwd:-$PWD}"
+# Which commands this gate applies to. The segment matcher sees a gated verb in
+# ANY position — `git add -A && git commit` used to run ungated
+# (go-to-k/cdk-real-drift#1803).
+GATE_RE_PR_CREATE_OR_MERGE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$)'
+gate_matches "$cmd" "$GATE_RE_PR_CREATE_OR_MERGE" || exit 0
 
-# `cd <path>` at the start of the command shifts the target dir.
-if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-  cd_target="${BASH_REMATCH[1]}"
-  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
-  if [[ "$cd_target" != /* ]]; then
-    cd_target="$target_dir/$cd_target"
-  fi
-  target_dir="$cd_target"
-fi
-
-# Last `gh -C <path>` wins.
-if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
-  c_target=""
-  remaining="$cmd"
-  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
-    c_target="${BASH_REMATCH[1]}"
-    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
-  done
-  c_target="${c_target%\"}"; c_target="${c_target#\"}"
-  c_target="${c_target%\'}"; c_target="${c_target#\'}"
-  if [[ "$c_target" != /* ]]; then
-    c_target="$target_dir/$c_target"
-  fi
-  target_dir="$c_target"
-fi
+# Resolve where the command will actually run: a `-C <path>` in the matched
+# segment wins, else the last `cd <path>` segment before it, else the payload cwd.
+target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_PR_CREATE_OR_MERGE")
 
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see.

--- a/.claude/hooks/verify-pr-gate.test.sh
+++ b/.claude/hooks/verify-pr-gate.test.sh
@@ -126,6 +126,17 @@ run_case "gh pr view passes through" 0 stale "" \
 run_case "gh pr edit passes through" 0 stale "" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr edit 42"}}' "$side_repo")"
 
+# 3b. The spellings go-to-k/cdk-real-drift#1803 measured running UNGATED against
+#      the old line-start anchor: the verb after another command, in a subshell,
+#      or behind an env assignment. Each must now be gated (stale marker → block).
+run_case "git push && gh pr create is gated" 2 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git push && gh pr create --title x"}}' "$side_repo")"
+run_case "subshell gh pr merge is gated" 2 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"(cd %s && gh pr merge 42 --squash)"}}' "$side_repo" "$side_repo")"
+# A mention inside a quoted argument is still not an invocation.
+run_case "quoted mention passes through" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"echo \\"then gh pr create --title x\\""}}' "$side_repo")"
+
 # 4. Non-git target dir → silent pass.
 run_case "non-git target dir allowed" 0 stale "" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr create --title x"}}' "$TMPDIR")"

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -974,6 +974,22 @@ is where §9 and §10 live.
   cross-repo. Weakest enforcement — the landing spot when nothing above can hold the
   rule, not the default one.
 
+**A cross-repo request outranks your own triage.** When the ask was "handle this
+across the repos in one session", a discovery made INSIDE that scope cannot be
+classified `Session-fit: next` — three tells, any one of which forces `now`: you
+are about to file the SAME issue body in more than one repo (that is the split the
+request exists to end, not triage); the fix is mechanical and its evidence is live
+right now (repro built, files open, a gate cycle already running); or the user
+already said "finish it here" for the surrounding task, which a discovery inside it
+inherits rather than getting its own budget. The classification fields exist to
+make a deferral honest, not to make one available — writing a tidy `Effort` /
+`Estimate` for work the session is already positioned to do is the tell that the
+fields are being used as an excuse. On 2026-08-20 this run consolidated one lesson
+into cdkd, cdk-local and go-to-k/cdk-real-drift, found every PreToolUse gate in the
+siblings inert, fixed the matchers in all three — and then filed the remaining
+script-level gap as three separate issues, recreating the per-repo split the
+request existed to end. It went into the same three PRs after the user objected.
+
 ### 10-c. How to edit: amend, do not append
 
 Every run appending one more bullet is exactly how a long skill becomes an unread one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,6 +394,24 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   all review of a larger diff, which grows superlinearly because a reviewer reads
   the whole thing and cross-file interactions multiply. Defer on those.
 
+  **`Session-fit: next` is NOT available for work discovered inside a scope the
+  user framed as "do this across the repos in one session".** Three tells that
+  force `now`: (a) you are about to file the SAME issue body in more than one
+  repo — that is the split the framing exists to end, not triage; (b) the fix is
+  mechanical and its evidence is live right now (the repro is built, the files are
+  open, a gate cycle is already running); (c) the user already said "finish it
+  here" for the surrounding task, and a discovery inside that task inherits the
+  instruction rather than getting its own budget. The four fields exist to make a
+  deferral HONEST, not to make one available — a defensible-looking `Effort` /
+  `Estimate` written for work the session is already positioned to do is the tell
+  that the classification is being used as an excuse. On 2026-08-20 a session
+  asked to consolidate one `/work-issues` lesson across cdkd, cdk-local and this
+  repo discovered that every PreToolUse gate here was inert, fixed the matchers in
+  all three, and then filed the remaining script-level gap as three separate
+  issues — reproducing exactly the per-repo split the request existed to end. The
+  fix belonged in the same three PRs, which is where it landed after the user
+  objected.
+
   **A newly DISCOVERED bug is not a residual.** A residual (deferred polish, a
   nit, a parity gap) is fully describable, so writing it down loses nothing. A
   discovery's expensive part is the EVIDENCE behind it — the repro you built,

--- a/tests/skill-doc-paths.test.ts
+++ b/tests/skill-doc-paths.test.ts
@@ -244,8 +244,13 @@ describe('hook harnesses resolve their subject from their own script path', () =
   });
 
   it.each(harnesses)('%s derives its subject from its own path', (file) => {
-    const assignment = readFileSync(path.join(HOOKS_DIR, file), 'utf8').match(/^HOOK=.*$/m)?.[0];
-    expect(assignment, `${file} has no HOOK= assignment to check`).toBeDefined();
+    const text = readFileSync(path.join(HOOKS_DIR, file), 'utf8');
+    // Two shapes, both self-relative: a `HOOK=` assignment naming the gate under
+    // test, or a `.`-source of a sibling LIBRARY (`_command-match.sh` is exercised
+    // by sourcing it, so it has no single subject to assign).
+    const assignment =
+      text.match(/^HOOK=.*$/m)?.[0] ?? text.match(/^\.\s+"\$\(cd .*_[a-z-]+\.sh"$/m)?.[0];
+    expect(assignment, `${file} has no self-relative subject to check`).toBeDefined();
     // The two interchangeable spellings §5 names, and nothing else.
     expect(
       assignment,


### PR DESCRIPTION
## Summary

Closes go-to-k/cdk-real-drift#1803. Every gate decided whether it applied with a
LINE-START-anchored regex that tolerated at most one leading `cd <path> &&`, so a
gated verb in any other position was invisible and the command ran UNGATED.
Measured right after go-to-k/cdk-real-drift#1802 made the hooks fire at all:

```
$ echo x && git commit -m "compound probe"
nothing added to commit but untracked files present    # reached git, ungated
```

The hook WAS selected and ran; its own regex just could not see `git commit` in
the second position. Bypassing spellings, none exotic: `git add -A && git commit`,
`cd <wt>; git commit`, `(cd <wt> && git commit)`, `cd <wt>&&git commit`,
`GIT_EDITOR=true git commit`.

## What changed

`.claude/hooks/_command-match.sh` — the shared matcher every gate now sources:

1. blank heredoc BODIES (this repo's own flow writes PR bodies containing
   `git commit`, which would otherwise trip the commit gates on its own prose),
2. blank quoted spans (so a verb inside a string is still not a command),
3. split the command LIST on `&&` `||` `;` `|` and grouping punctuation,
4. drop a leading env assignment or `env`/`command`/`nohup` wrapper,
5. match each SEGMENT against the per-verb regex.

Target-dir resolution moves with it: a `-C <path>` in the MATCHED segment wins,
else the LAST `cd <path>` segment before it — so `cd a && cd b && git commit`
resolves to `b`, which no gate handled — else the payload cwd.

Converted: `check-gate`, `branch-gate`, `stale-base-gate`, `verify-pr-gate`,
`ci-green-gate`, `non-english-text-gate`, `bughunt-clean-gate`.
`deploy-autoarm-gate` already stripped quotes and matched unanchored; unchanged.

`branch-gate.test.sh` carried a case literally named **"accepted false-negative"**
asserting that `git -C <feature> status; git -C <main> commit` was NOT caught. It
is now a true positive resolving to the second `-C`; the case is inverted and its
comment rewritten. The quoted-body false positives that motivated the old anchor
are handled by blanking quoted spans instead.

## The rule this session broke

`CLAUDE.md` and `.claude/skills/work-issues/SKILL.md` also gain: work discovered
INSIDE a request framed as "do this across the repos in one session" cannot be
classified `Session-fit: next`. Filing the same issue body in three repos is the
split the request exists to end, not triage. This session did exactly that with
go-to-k/cdk-real-drift#1803 and its two siblings before the user objected; the fix
is in the same three PRs instead. The same amendment lands in cdk-local, cdkd, and
the global dotfiles `CLAUDE.md`.

## Test plan

- [x] `bash .claude/hooks/_command-match.test.sh` — 29 cases (every bypassing
      spelling matches; quoted mentions, heredoc bodies, and lookalike verbs do
      not; 8 target-dir cases including chained `cd` and `-C`-beats-`cd`)
- [x] `vp run test:hooks` — 10 harnesses, 0 failed (branch-gate 31, check-gate 19,
      verify-pr-gate 18, bughunt-clean-gate 24, …), each now carrying the compound
      spellings and a quoted-mention negative
- [x] `vp run check` — 0 errors
- [x] `vp run test` — 345 files / 6526 tests
- [x] `vp run build`

No `src/**` in the diff.
