### PR TITLE
fix(hooks): stop the segment matcher losing quoted paths, and see the spellings it still missed

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -2,145 +2,200 @@
 # _command-match.sh — shared command matching for the PreToolUse gate hooks.
 # SOURCED, never executed: `. "$(dirname "${BASH_SOURCE[0]}")/_command-match.sh"`.
 #
-# WHY this exists (go-to-k/cdk-real-drift#1803): every gate used to decide whether
-# it applied with a LINE-START-anchored regex, optionally tolerating one leading
-# `cd <path> &&`. So a gated verb in any other position was invisible:
+# WHY (go-to-k/cdk-real-drift#1803): every gate used to decide whether it applied
+# with a LINE-START-anchored regex tolerating at most one leading `cd <path> &&`,
+# so a gated verb anywhere else was invisible and the command ran UNGATED —
+# `git add -A && git commit`, `cd <wt>; git commit`, `(cd <wt> && git commit)`,
+# `GIT_EDITOR=true git commit`, all measured reaching git.
 #
-#   git add -A && git commit -m "…"     <- the commonest commit spelling there is
-#   cd <wt>; git commit -m "…"          <- semicolon instead of &&
-#   (cd <wt> && git commit -m "…")      <- subshell
-#   GIT_EDITOR=true git commit -m "…"   <- leading env assignment
+# The model: a Bash tool call is a COMMAND LIST. Segment it, then ask whether any
+# SEGMENT is the gated command.
 #
-# all reached git ungated, and an ungated command looks exactly like one that
-# passed. Measured on 2026-08-20 right after the matcher fix
-# (go-to-k/cdk-real-drift#1802) made the hooks run at all.
-#
-# The model: a Bash tool call is a COMMAND LIST. Split it into segments and ask
-# whether ANY segment is the gated command. Quoted spans are blanked first, so a
-# separator or a command name inside a string cannot create a phantom segment —
-# `echo "run git commit later"` is still not a commit.
+# Quoting is handled by NEUTRALISING separators inside quoted spans rather than
+# blanking the span. The first version blanked them, which also erased the PATH in
+# `cd "<worktree>" && git commit` and `git -C "<path>" commit`, so target-dir
+# resolution silently fell back to the payload cwd and the gate passed a commit it
+# should have blocked — a regression against the pre-refactor gates, caught in
+# review of go-to-k/cdk-local#542. Segments therefore carry their original text;
+# only the separator CHARACTERS inside quotes are swapped for placeholders while
+# splitting, and swapped back afterwards. A verb inside a string still does not
+# match, because the per-verb regexes are anchored at the segment START.
 
-# Blank the CONTENT of quoted spans, preserving length so offsets and the
-# surrounding structure survive. Unterminated quotes blank to end of input, which
-# is the conservative reading (that text is not a command).
-gate_blank_quotes() {
+# Placeholders for separators that live inside quoted spans (never in real input).
+GATE_SEP_AMP=$'\001'
+GATE_SEP_SEMI=$'\002'
+GATE_SEP_PIPE=$'\003'
+GATE_SEP_SUBST=$'\004'
+
+# One awk pass: join `\`-continuations, blank heredoc BODIES, neutralise
+# separators inside quotes, and turn every real separator into a newline. Command
+# substitutions (`$(...)` and backticks) become separators too — the text inside
+# one RUNS, so `echo "$(git commit -m x)"` is a commit.
+gate_segments_raw() {
   awk '
-    {
-      line = $0; out = ""; q = ""
-      n = length(line)
+    # `q` is deliberately GLOBAL: a quoted span survives a newline, and a
+    # `--body "…multi-line…"` argument is ONE span. Resetting it per line split a
+    # PR body into segments and matched a `&& git commit` inside the prose
+    # (caught in review of go-to-k/cdk-local#542).
+    function flush_line(line,   i, n, c, out, prev) {
+      out = ""; n = length(line)
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
+        prev = (i > 1) ? substr(line, i - 1, 1) : ""
         if (q == "") {
           if (c == "\"" || c == "'"'"'") { q = c; out = out c; continue }
+          if (c == "$" && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
+          if (c == "`") { out = out "\n"; continue }
+          if (c == "&" || c == ";" || c == "|") { out = out "\n"; continue }
           out = out c
-        } else {
-          if (c == "\\" && q == "\"") { out = out "  "; i++; continue }
-          if (c == q) { q = ""; out = out c; continue }
-          out = out " "
+          continue
         }
+        # inside a quoted span
+        if (c == "\\" && q == "\"") { out = out c substr(line, i + 1, 1); i++; continue }
+        if (c == q) { q = ""; out = out c; continue }
+        if (c == "&") { out = out SEP_AMP; continue }
+        if (c == ";") { out = out SEP_SEMI; continue }
+        if (c == "|") { out = out SEP_PIPE; continue }
+        if (c == "$" && substr(line, i + 1, 1) == "(") { out = out SEP_SUBST "("; i++; continue }
+        out = out c
       }
-      print out
+      return out
     }
-  ' <<< "$1"
-}
-
-# Blank the BODY of every heredoc, keeping the line count. A heredoc body is data
-# the shell hands to a program, not a command list — and this repo's own flow
-# writes PR bodies with `gh pr create --body-file <<EOF ... git commit ... EOF`,
-# which would otherwise trip the commit gates on its own prose.
-gate_blank_heredocs() {
-  awk '
-    BEGIN { tag = "" }
+    BEGIN { tag = ""; pending = ""; q = "" }
     {
-      if (tag != "") {
-        line = $0
-        gsub(/^[ \t]+|[ \t]+$/, "", line)
-        if (line == tag) { tag = "" ; print $0 ; next }
+      line = $0
+      sub(/\r$/, "", line)
+      if (tag != "") {                      # inside a heredoc body: data, not commands
+        t = line
+        gsub(/^[ \t]+|[ \t]+$/, "", t)
+        if (t == tag) tag = ""
         print ""
         next
       }
-      if (match($0, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*["'"'"']?/)) {
-        t = substr($0, RSTART, RLENGTH)
+      if (pending != "") { line = pending line; pending = "" }
+      if (line ~ /\\$/) {                   # `\`-continuation: join with the next line
+        sub(/\\$/, "", line)
+        pending = line
+        next
+      }
+      if (match(line, /<<-?[ \t]*["'"'"']?[A-Za-z_][A-Za-z0-9_]*["'"'"']?/)) {
+        t = substr(line, RSTART, RLENGTH)
         gsub(/^<<-?[ \t]*|["'"'"']/, "", t)
         tag = t
       }
-      print $0
+      print flush_line(line)
     }
-  ' <<< "$1"
+    END { if (pending != "") print flush_line(pending) }
+  ' SEP_AMP="$GATE_SEP_AMP" SEP_SEMI="$GATE_SEP_SEMI" SEP_PIPE="$GATE_SEP_PIPE" \
+    SEP_SUBST="$GATE_SEP_SUBST" <<< "$1"
 }
 
-# Print one command segment per line: split on && || ; | newline, and drop the
-# grouping punctuation ( ) { } that wraps a subshell or brace group.
-gate_segments() {
-  local blanked
-  blanked=$(gate_blank_quotes "$(gate_blank_heredocs "$1")")
-  printf '%s' "$blanked" |
-    sed -E 's/\|\||&&|;|\||\n/\n/g' |
-    sed -E 's/^[[:space:]]*[({][[:space:]]*//; s/[[:space:]]*[)}][[:space:]]*$//' |
-    sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' |
-    grep -v '^$'
-}
-
-# Strip leading `VAR=value` assignments and an `env`/`command`/`nohup` wrapper, so
-# `GIT_EDITOR=true git commit` and `env git commit` are seen as `git commit`.
+# Leading words that introduce a command without being one: env assignments,
+# wrappers, and the keywords that open a compound statement.
 gate_strip_prefix() {
-  printf '%s' "$1" | sed -E 's/^(([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup)[[:space:]]+)*//'
+  local s="$1"
+  # Trim first: a segment split off after a separator starts with a space, and
+  # every verb regex is anchored at the segment start.
+  s="${s#"${s%%[![:space:]]*}"}"
+  # `bash -c "<cmd>"` RUNS its argument, so a gated verb inside it is a gated
+  # command (go-to-k/cdk-local#542 review).
+  if [[ "$s" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+[\"\'](.*)[\"\'][[:space:]]*$ ]]; then
+    s="${BASH_REMATCH[2]}"
+  fi
+  while [[ "$s" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup|time|timeout[[:space:]]+[^[:space:]]+|exec|then|do|else|elif|\{|\()[[:space:]]+(.*)$ ]]; do
+    s="${BASH_REMATCH[2]}"
+  done
+  # Any remaining grouping punctuation at either end (nested subshells).
+  while [[ "$s" =~ ^[[:space:]]*[\(\{][[:space:]]*(.*)$ ]]; do s="${BASH_REMATCH[1]}"; done
+  while [[ "$s" =~ ^(.*[^[:space:]])[[:space:]]*[\)\}][[:space:]]*$ ]]; do s="${BASH_REMATCH[1]}"; done
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# Print one command segment per line, in the ORIGINAL text (placeholders restored).
+gate_segments() {
+  local segment
+  while IFS= read -r segment; do
+    segment="${segment//"$GATE_SEP_AMP"/&}"
+    segment="${segment//"$GATE_SEP_SEMI"/;}"
+    segment="${segment//"$GATE_SEP_PIPE"/|}"
+    segment="${segment//"$GATE_SEP_SUBST"/$}"
+    segment=$(gate_strip_prefix "$segment")
+    [ -n "$segment" ] && printf '%s\n' "$segment"
+  done < <(gate_segments_raw "$1")
 }
 
 # gate_matches <cmd> <extended-regex>
-# 0 when any segment matches the regex (anchored at the segment start, after the
-# prefix strip). The regex is the SAME per-verb shape each gate used to carry.
+# 0 when any segment matches. Bash-native `=~` rather than a `grep` per segment:
+# these hooks run on every matching Bash tool call, and the fork per segment per
+# gate was measured at ~5x the whole gate suite's latency in review of
+# go-to-k/cdk-local#542.
 gate_matches() {
   local cmd="$1" re="$2" segment
   while IFS= read -r segment; do
-    segment=$(gate_strip_prefix "$segment")
-    printf '%s' "$segment" | grep -qE "$re" && return 0
+    [[ "$segment" =~ $re ]] && return 0
   done < <(gate_segments "$cmd")
   return 1
 }
 
+# A path token: a quoted span (either quote character) or a bare run of
+# non-space. Held in a variable because a literal `[[ =~ ]]` pattern cannot carry
+# both quote characters inside one bracket expression.
+GATE_PATH_TOKEN='("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+)'
+
 # The regexes, kept here so every gate spells its verb the same way. Each is
 # anchored at the START of a segment; `git -C <path>` / `git -c k=v` and
-# `gh -C <path>` are absorbed.
-GATE_RE_GIT_COMMIT='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'
-GATE_RE_GIT_PUSH='^git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+push([[:space:]]|$)'
-GATE_RE_GH_PR_CREATE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'
-GATE_RE_GH_PR_EDIT='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+edit([[:space:]]|$)'
-GATE_RE_GH_PR_MERGE='^gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)'
+# `gh -C <path>` are absorbed — including a QUOTED path containing spaces, which
+# an earlier version could not parse, so `git -C "/a b" commit` matched nothing
+# and ran ungated (go-to-k/cdk-local#542 review).
+GATE_FLAGS='([[:space:]]+-[^[:space:]]+([[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]-][^[:space:]]*))?)*'
+GATE_GH_C='([[:space:]]+-C[[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]]+))?'
+GATE_RE_GIT_COMMIT="^git${GATE_FLAGS}[[:space:]]+commit([[:space:]]|$)"
+GATE_RE_GIT_PUSH="^git${GATE_FLAGS}[[:space:]]+push([[:space:]]|$)"
+GATE_RE_GH_PR_CREATE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+create([[:space:]]|$)"
+GATE_RE_GH_PR_EDIT="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+edit([[:space:]]|$)"
+GATE_RE_GH_PR_MERGE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+merge([[:space:]]|$)"
+
+# Strip one layer of surrounding quotes from a path token.
+gate_unquote() {
+  local p="$1"
+  p="${p%\"}"; p="${p#\"}"
+  p="${p%\'}"; p="${p#\'}"
+  printf '%s' "$p"
+}
 
 # gate_target_dir <cmd> <fallback> <extended-regex>
 # The working tree the gated command will actually run in:
 #   1. a `-C <path>` inside the MATCHED segment wins (git -C / gh -C), else
 #   2. the last `cd <path>` segment BEFORE the matched one, else
 #   3. the fallback (the hook payload's cwd).
-# Relative paths resolve against the fallback, then against each other, which is
-# what a `cd a && cd b` chain does.
+# Quoted paths survive: segments carry their original text (see the header).
 gate_target_dir() {
   local cmd="$1" fallback="$2" re="$3"
-  local target="$fallback" segment stripped cd_target c_target remaining
+  local target="$fallback" segment cd_target c_target remaining
   while IFS= read -r segment; do
-    stripped=$(gate_strip_prefix "$segment")
-    if [[ "$stripped" =~ ^cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
-      cd_target="${BASH_REMATCH[1]}"
-      cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
-      cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+    if [[ "$segment" =~ ^cd[[:space:]]+$GATE_PATH_TOKEN ]]; then
+      cd_target=$(gate_unquote "${BASH_REMATCH[1]}")
+      [ -z "$cd_target" ] && continue
       [[ "$cd_target" != /* ]] && cd_target="$target/$cd_target"
       target="$cd_target"
       continue
     fi
-    printf '%s' "$stripped" | grep -qE "$re" || continue
+    [[ "$segment" =~ $re ]] || continue
     # Last `-C <path>` in this segment wins over any earlier cd.
-    if [[ "$stripped" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+    if [[ "$segment" =~ (git|gh)[[:space:]]+-C[[:space:]]+$GATE_PATH_TOKEN ]]; then
       c_target=""
-      remaining="$stripped"
-      while [[ "$remaining" =~ (git|gh)[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+      remaining="$segment"
+      while [[ "$remaining" =~ (git|gh)[[:space:]]+-C[[:space:]]+$GATE_PATH_TOKEN ]]; do
         c_target="${BASH_REMATCH[2]}"
         remaining="${remaining#*"${BASH_REMATCH[0]}"}"
       done
-      c_target="${c_target%\"}"; c_target="${c_target#\"}"
-      c_target="${c_target%\'}"; c_target="${c_target#\'}"
-      [[ "$c_target" != /* ]] && c_target="$target/$c_target"
-      target="$c_target"
+      c_target=$(gate_unquote "$c_target")
+      if [ -n "$c_target" ]; then
+        [[ "$c_target" != /* ]] && c_target="$target/$c_target"
+        target="$c_target"
+      fi
     fi
     break
   done < <(gate_segments "$cmd")

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -75,5 +75,41 @@ want_dir "/w/t"       "git -C beats cd"        'cd /other && git -C /w/t commit 
 want_dir "/w/t"       "gh -C on a merge"       'gh -C /w/t pr merge 1 --squash' /fallback "$M"
 want_dir "/fallback"  "cd AFTER the verb does not count" 'git commit -m x && cd /w/t' /fallback "$C"
 
+# --- the review findings from go-to-k/cdk-local#542 --------------------------
+# Every one of these was measured WRONG in the first version of this helper.
+want_match 0 "bare & separator"              'sleep 0 & git commit -m x' "$C"
+want_match 0 "command substitution"          'echo $(git commit -m x)' "$C"
+want_match 0 "substitution into a variable"  'SHA=$(git commit -m x)' "$C"
+want_match 0 "backtick substitution"         'echo `git commit -m x`' "$C"
+want_match 0 "bash -c wrapper"               'bash -c "git commit -m x"' "$C"
+want_match 0 "if/then compound"              'if true; then git commit -m x; fi' "$C"
+want_match 0 "for/do compound"               'for f in a; do git commit -m x; done' "$C"
+want_match 0 "timeout wrapper"               'timeout 60 git commit -m x' "$C"
+want_match 0 "time wrapper"                  'time git commit -m x' "$C"
+want_match 0 "nested subshells"              '( ( git commit -m x ) )' "$C"
+want_match 0 "backslash continuation"        'git \
+  commit -m x' "$C"
+want_match 0 "quoted -C path with a space"   'git -C "/w t" commit -m x' "$C"
+
+# The quote machinery only earns its keep on a separator INSIDE a string: without
+# it these match, and the gates start blocking ordinary `echo`s.
+want_match 1 "&& inside a quoted string"     'echo "step && git commit -m x"' "$C"
+want_match 1 "; inside a quoted string"      "echo 'step ; git commit -m x'" "$C"
+want_match 1 "| inside a quoted string"      'echo "step | git commit -m x"' "$C"
+# A quoted span survives a NEWLINE: a `--body "…"` argument is one span, and this
+# repo writes PR bodies that quote shell examples.
+want_match 1 "multi-line quoted body" 'gh pr create --body "line one
+line two && git commit -m x
+line three"' "$C"
+want_match 1 "CRLF heredoc terminator" 'cat <<EOF
+body
+EOF
+echo done' "$C"
+
+want_dir "/w t"   "quoted cd path"   'cd "/w t" && git commit -m x' /fb "$C"
+want_dir "/w t"   "quoted -C path"   'git -C "/w t" commit -m x' /fb "$C"
+want_dir "/fb"    "-C in a NON-matched segment is ignored" \
+  'git -C /elsewhere status && git commit -m x' /fb "$C"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -75,7 +75,11 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 #                               forms are an accepted false-negative
 #                               of the line-start tightening (per the
 #                               memory rule's trade-off).
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Which commands this gate applies to. The segment matcher sees a gated verb in
 # ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/bughunt-clean-gate.sh
+++ b/.claude/hooks/bughunt-clean-gate.sh
@@ -37,7 +37,11 @@ input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Gate only `git commit`, `gh pr create` and `gh pr merge`. The shared segment
 # matcher sees the verb in ANY position — `git add -A && git commit` used to run

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -30,7 +30,11 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # so a `git commit` substring inside a quoted argument body does not
 # false-positive. Tolerates `git -C <path> commit` / `git -c k=v commit` and
 # an optional leading `cd <path> &&` worktree prefix.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Which commands this gate applies to. The segment matcher sees a gated verb
 # in ANY position — `git add -A && git commit` used to run ungated
@@ -41,6 +45,19 @@ gate_matches "$cmd" "$GATE_RE" || exit 0
 # Resolve where the command will actually run: a `-C <path>` in the matched
 # segment wins, else the last `cd <path>` segment before it, else the payload cwd.
 target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE")
+
+# Repo opt-in scope, mirroring branch-gate (go-to-k/cdkd#1259): this gate belongs
+# to repos that follow the markgate convention. A session rooted in one of them
+# still runs git against OTHER repos — a dotfiles checkout, a scratch clone —
+# where committing to main is the normal workflow and no marker exists to be
+# fresh. Without this the gate blocked those commits with a message naming skills
+# that repo does not have (hit on 2026-08-20 committing to `dotfiles` from a
+# cdk-real-drift session). Opt-in signal: a `.markgate.yml` at the target repo's
+# top level.
+target_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -z "$target_top" ] || [ ! -f "$target_top/.markgate.yml" ]; then
+  exit 0
+fi
 
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/check-gate.test.sh
+++ b/.claude/hooks/check-gate.test.sh
@@ -26,6 +26,14 @@ trap 'rm -rf "$TMPDIR"' EXIT
 repo="$TMPDIR/repo"
 git init -q -b main "$repo"
 git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+# Opt-in marker: the gate only guards repos that follow the markgate convention.
+: > "$repo/.markgate.yml"
+
+# A git repo that does NOT opt in — someone else's workflow (a dotfiles
+# checkout), where committing to main is normal and no marker exists.
+noopt="$TMPDIR/noopt"
+git init -q -b main "$noopt"
+git -C "$noopt" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 
 notrepo="$TMPDIR/plain"
 mkdir -p "$notrepo"
@@ -107,6 +115,8 @@ run_case "cd <path> reads the target tree, not cwd" 2 "cd $repo && git commit -m
 
 # --- fail-open / fail-loud paths ---------------------------------------------
 run_case "non-git target fails open" 0 "git commit -m x" "$notrepo" "$SHIM_DIR" 1 1
+# A git repo that does not opt in (no .markgate.yml) is someone else's workflow.
+run_case "repo without .markgate.yml passes through" 0 "git commit -m x" "$noopt" "$SHIM_DIR" 1 1
 run_case "cd to a non-git path fails open" 0 "cd $notrepo && git commit -m x" \
   "$repo" "$SHIM_DIR" 1 1
 run_case "missing markgate fails LOUD" 2 "git commit -m x" "$repo" "$BARE_DIR" 0 0

--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -37,7 +37,11 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate `gh pr merge` (with optional leading `cd <path> &&` and optional
 # `gh -C <path>`). Anything else passes through.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Which commands this gate applies to. The segment matcher sees a gated verb
 # in ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -69,7 +69,11 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || ec
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate gh pr create / edit / merge — anything else passes through.
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Which commands this gate applies to. The segment matcher sees a gated verb in
 # ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/stale-base-gate.sh
+++ b/.claude/hooks/stale-base-gate.sh
@@ -37,7 +37,11 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate `git push` (subcommand position, line-start anchored — same shape
 # as branch-gate.sh so quoted "git push" substrings don't false-positive).
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Which commands this gate applies to. The segment matcher sees a gated verb
 # in ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -62,6 +62,33 @@ gate_matches "$cmd" "$GATE_RE_PR_CREATE_OR_MERGE" || exit 0
 # segment wins, else the last `cd <path>` segment before it, else the payload cwd.
 target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_PR_CREATE_OR_MERGE")
 
+# Fails CLOSED (keeps gating) if the changed-file set can't be computed — we
+# only skip the gate when we can PROVE the diff is src-free.
+#
+# Read the diff from the RESOLVED TARGET DIR, never the hook's own cwd. The hook
+# process runs wherever the client launched it (usually the main checkout), where
+# HEAD == origin/main and the diff is EMPTY, so the exemption could not fire and
+# a docs-only PR was told to run /verify-pr. The mirror case is worse: a cwd
+# sitting in some OTHER tree with a non-src diff would have EXEMPTED a PR that
+# does touch `src/**` — a fail-open. Measured 2026-08-21 while merging
+# go-to-k/cdk-real-drift#1805.
+base=""
+for ref in origin/main origin/master main master; do
+  if git -C "$target_dir" rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then base="$ref"; break; fi
+done
+if [ -n "$base" ]; then
+  mb=$(git -C "$target_dir" merge-base "$base" HEAD 2>/dev/null || echo "")
+  if [ -n "$mb" ]; then
+    changed=$(git -C "$target_dir" diff --name-only "$mb" HEAD 2>/dev/null || echo "__ERR__")
+    if [ "$changed" != "__ERR__" ] && [ -n "$changed" ] \
+       && ! printf '%s\n' "$changed" | grep -qE '^src/'; then
+      echo "verify-pr-gate: PR diff touches no src/** (docs/tooling-only) — exempt from /verify-pr (check + docs cover it)." >&2
+      exit 0
+    fi
+  fi
+fi
+
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
@@ -79,24 +106,6 @@ cd "$target_dir" 2>/dev/null || exit 0
 # (which needs AWS credentials it doesn't exercise) is pure friction. So: if the
 # PR's diff vs the base contains NO `src/**` path, let it through.
 #
-# Fails CLOSED (keeps gating) if the changed-file set can't be computed — we
-# only skip the gate when we can PROVE the diff is src-free.
-base=""
-for ref in origin/main origin/master main master; do
-  if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then base="$ref"; break; fi
-done
-if [ -n "$base" ]; then
-  mb=$(git merge-base "$base" HEAD 2>/dev/null || echo "")
-  if [ -n "$mb" ]; then
-    changed=$(git diff --name-only "$mb" HEAD 2>/dev/null || echo "__ERR__")
-    if [ "$changed" != "__ERR__" ] && [ -n "$changed" ] \
-       && ! printf '%s\n' "$changed" | grep -qE '^src/'; then
-      echo "verify-pr-gate: PR diff touches no src/** (docs/tooling-only) — exempt from /verify-pr (check + docs cover it)." >&2
-      exit 0
-    fi
-  fi
-fi
-
 # Prefer the `.mise.toml`-pinned version via `mise exec --` so the repo's
 # canonical markgate wins over an older PATH binary; see check-gate.sh for
 # the schema-bump rationale (0.3.0 markers are silently invisible to 0.3.1).

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -46,7 +46,11 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # hard block. The optional leading `cd <path> &&` prefix preserves
 # the worktree-aware `cd <side> && gh pr create` chain shape,
 # mirroring check-gate.sh (PR #562 fix pattern).
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
+# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+. "$_gate_lib"
 
 # Which commands this gate applies to. The segment matcher sees a gated verb in
 # ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/verify-pr-gate.test.sh
+++ b/.claude/hooks/verify-pr-gate.test.sh
@@ -202,6 +202,16 @@ gx checkout -q feature/docs
 run_case "non-src (docs-only) PR exempt from verify-pr" 0 stale "" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr create --title docs"}}' "$exempt_repo")"
 
+# 14b. The exemption must read the RESOLVED TARGET DIR, not the hook's own cwd.
+#      Payload cwd is a tree whose HEAD == origin/main (empty diff, so the
+#      exemption cannot fire there); the command `cd`s to the docs-only branch,
+#      which is what the PR actually is. Before go-to-k/cdk-real-drift#1805 the
+#      hook read its own cwd: docs-only PRs were told to run /verify-pr, and a
+#      cwd in an unrelated tree with a non-src diff would have EXEMPTED a src PR.
+gx checkout -q feature/docs
+run_case "exemption reads the cd target, not the hook cwd" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"cd %s && gh pr merge 42 --squash"}}' "$main_repo" "$exempt_repo")"
+
 # 15. feature/src (src/ diff vs origin/main) → still gated, exit 2 when stale.
 gx checkout -q feature/src
 run_case "src-touching PR still gated" 2 stale "$exempt_repo" \

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -988,7 +988,9 @@ fields are being used as an excuse. On 2026-08-20 this run consolidated one less
 into cdkd, cdk-local and go-to-k/cdk-real-drift, found every PreToolUse gate in the
 siblings inert, fixed the matchers in all three — and then filed the remaining
 script-level gap as three separate issues, recreating the per-repo split the
-request existed to end. It went into the same three PRs after the user objected.
+request existed to end. It took the user objecting to get it done in the same
+SESSION, as a follow-up PR per repo — "same session" is the bar, "same PR" only
+when the work is small enough to review together.
 
 ### 10-c. How to edit: amend, do not append
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,9 +408,10 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   asked to consolidate one `/work-issues` lesson across cdkd, cdk-local and this
   repo discovered that every PreToolUse gate here was inert, fixed the matchers in
   all three, and then filed the remaining script-level gap as three separate
-  issues — reproducing exactly the per-repo split the request existed to end. The
-  fix belonged in the same three PRs, which is where it landed after the user
-  objected.
+  issues — reproducing exactly the per-repo split the request existed to end. It
+  took the user objecting to get the fix done in the same SESSION, as a follow-up
+  PR per repo. "Same session" is the bar; "same PR" is only the bar when the work
+  is small enough to review together.
 
   **A newly DISCOVERED bug is not a residual.** A residual (deferred polish, a
   nit, a parity gap) is fully describable, so writing it down loses nothing. A


### PR DESCRIPTION
## Summary

Follow-up to go-to-k/cdk-real-drift#1804, driven by the three-axis review of its
cdk-local twin (go-to-k/cdk-local#542). The first finding is a **regression that
#1804 introduced**; the rest are spellings it still missed, one false positive it
created, and two things this session hit directly.

## The regression

Blanking quoted spans also erased the PATH, so target-dir resolution fell back to
the payload cwd:

```
cd /Users/goto/pc/github/cdk-local && git commit -m x        -> exit 2 (blocked)
cd "/Users/goto/pc/github/cdk-local" && git commit -m x      -> exit 0 FAIL OPEN
git -C "/Users/goto/pc/github/cdk-local" commit -m x         -> exit 0 FAIL OPEN
```

The pre-refactor gates read the RAW command and stripped quotes, so they got this
right. Quoting is now handled by neutralising only the separator CHARACTERS inside
a quoted span (placeholders, restored after splitting), so segments keep their
original text and paths survive.

A second fail-open lived in the verb regexes: a quoted flag argument containing a
space broke the flag loop, so `git -C "/a b" commit` matched **nothing at all**.
They are built from a shared quoted-or-bare path token now.

## Everything else

| finding | was | now |
| --- | --- | --- |
| bare `&` separator | `sleep 0 & git commit` ungated | matched |
| `$(…)` / backticks | `echo $(git commit)` ungated | matched |
| `bash -c "…"` | ungated | unwrapped, matched |
| `if/then`, `for/do`, `time`, `timeout <n>`, `( ( … ) )`, `\`-continuation | ungated | matched |
| CRLF heredoc terminator | heredoc never closed, rest of command blanked | closed |
| multi-line `--body "…"` containing `&& git commit` | **matched** (false positive; it blocked one of this session's own commands) | not matched — `q` is global across awk records |
| latency | `sed`+`grep` fork per segment per gate, ~5x the suite | bash-native `[[ =~ ]]`, one awk pass |
| missing helper | every Bash call died with `command not found` | `[ -r "$_gate_lib" ] || exit 0` |

## Two more, from using the gates today

- **`check-gate` had no repo opt-in scope**, so it blocked a commit in an
  unrelated repo (a `dotfiles` checkout this session also edits) with a message
  naming `/check` and `/check-docs`, skills that repo does not have. It now
  mirrors `branch-gate`'s `.markgate.yml` opt-in, with a fixture repo that does
  not opt in as its own case.
- **The rule amendment misstated its own incident.** It said the deferral ended
  "in the same three PRs"; it ended in the same SESSION, as a follow-up PR per
  repo. Corrected in `CLAUDE.md`, the work-issues skill, and the global dotfiles
  `CLAUDE.md`.

## Test plan

- [x] `bash .claude/hooks/_command-match.test.sh` — 49 cases, 0 failed. Every row
      of the table above has a case, including the three "separator inside a
      quoted string" negatives that the review showed were unpinned (the whole
      quote machinery survived being replaced with the identity function).
- [x] `vp run test:hooks` — 11 harnesses, 0 failed
- [x] Mutation probes on `check-gate`: pointing it at the wrong `GATE_RE_*` and
      replacing its `gate_matches … || exit 0` with a bare `exit 0` each kill 14
      of its 20 cases — the harness is load-bearing, not decorative
- [x] `vp run check` — 0 errors; `vp run test` — 345 files / 6526 tests;
      `vp run build`

No `src/**` in the diff.
