### PR TITLE
fix(hooks): see a gated verb behind if/while/sudo/xargs/case and process substitution, and stop corrupting a path containing `&`

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -50,6 +50,8 @@ gate_segments_raw() {
         if (q == "") {
           if ((c == "\"" || c == "'"'"'") && c != ignore_q) { q = c; out = out c; continue }
           if (c == "$" && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
+          # Process substitution runs its body too: `diff <(git commit) …`.
+          if ((c == "<" || c == ">") && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
           if (c == "`") { out = out "\n"; continue }
           if (c == "&" || c == ";" || c == "|") { out = out "\n"; continue }
           out = out c
@@ -68,11 +70,17 @@ gate_segments_raw() {
     # The line with every QUOTED span blanked, for the heredoc-opener test only:
     # `echo "use <<EOF here"` is a mention, and honouring it blanked the rest of
     # the command (go-to-k/cdkd#2130).
-    function unquoted_part(line,   i, n, c, out, inq) {
+    function unquoted_part(line,   i, n, c, out, inq, prev2) {
       out = ""; inq = ""; n = length(line)
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
+        prev2 = (i > 2) ? substr(line, i - 2, 2) : ""
         if (inq == "") {
+          # A quote right after `<<` (or `<<-`) is part of a heredoc TAG, not a
+          # span: `cat <<'"'"'EOF'"'"'` is an ordinary opener. Blanking it lost the tag,
+          # so the body was treated as commands and this repo blocked its own
+          # scripts (go-to-k/cdkd#2130 review).
+          if ((c == "\"" || c == "'"'"'") && (prev2 == "<<" || substr(line, i - 1, 1) == "-" && substr(line, i - 3, 2) == "<<")) { out = out c; continue }
           if ((c == "\"" || c == "'"'"'") && c != ignore_q) { inq = c; out = out " "; continue }
           out = out c
         } else {
@@ -117,10 +125,19 @@ gate_segments_raw() {
         gsub(/^<<-?[ \t]*|["'"'"']/, "", t)
         if (terminated(t, i + 1)) tag = t
       }
-      outbuf[++outn] = neutral
+      # A quoted span that continues past the newline is ONE argument, so its
+      # lines must not become separate segments: a `--body "…"` whose second
+      # line STARTS with a gated verb was matched and blocked (go-to-k/cdkd#2130
+      # review). Join the continuation onto the segment that opened the span.
+      if (open_span != "") {
+        outbuf[outn] = outbuf[outn] " " neutral
+      } else {
+        outbuf[++outn] = neutral
+      }
+      open_span = q
     }
     function run_pass(   i) {
-      q = ""; tag = ""; pending = ""; outn = 0
+      q = ""; tag = ""; pending = ""; outn = 0; open_span = ""
       for (i = 1; i <= total; i++) emit(i)
       if (pending != "") outbuf[++outn] = flush_line(pending)
     }
@@ -138,17 +155,31 @@ gate_segments_raw() {
 # Leading words that introduce a command without being one: env assignments,
 # wrappers, and the keywords that open a compound statement.
 gate_strip_prefix() {
-  local s="$1"
-  # Trim first: a segment split off after a separator starts with a space, and
-  # every verb regex is anchored at the segment start.
+  local s="$1" prev=""
   s="${s#"${s%%[![:space:]]*}"}"
   # `bash -c "<cmd>"` RUNS its argument, so a gated verb inside it is a gated
   # command (go-to-k/cdk-local#542 review).
   if [[ "$s" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+[\"\'](.*)[\"\'][[:space:]]*$ ]]; then
     s="${BASH_REMATCH[2]}"
   fi
-  while [[ "$s" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup|time|timeout[[:space:]]+[^[:space:]]+|exec|then|do|else|elif|\{|\()[[:space:]]+(.*)$ ]]; do
-    s="${BASH_REMATCH[2]}"
+  # Strip leaders until stable: a `case <word> in` opener, a `<pattern>)` arm
+  # label, compound-statement keywords, wrappers, and env assignments can nest
+  # (`case a in a) sudo git commit`). `if|while|until|!|sudo|xargs` were missing,
+  # so `if <verb>; then …`, `! <verb>` and `sudo <verb>` ran UNGATED — a
+  # regression for every gate that traded an unanchored grep for this matcher
+  # (go-to-k/cdkd#2130 review).
+  while [ "$s" != "$prev" ]; do
+    prev="$s"
+    if [[ "$s" =~ ^[[:space:]]*case[[:space:]]+[^[:space:]]+[[:space:]]+in[[:space:]]+(.*)$ ]]; then
+      s="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$s" =~ ^[[:space:]]*[^\(\)\|\;\&[:space:]]+\)[[:space:]]*(.*)$ ]]; then
+      s="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$s" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*|env|command|nohup|time|timeout[[:space:]]+[^[:space:]]+|exec|then|do|else|elif|if|while|until|!|sudo|xargs|-[A-Za-z][^[:space:]]*|\{|\()[[:space:]]+(.*)$ ]]; then
+      s="${BASH_REMATCH[2]}"
+    fi
+    s="${s#"${s%%[![:space:]]*}"}"
   done
   # Any remaining grouping punctuation at either end (nested subshells).
   while [[ "$s" =~ ^[[:space:]]*[\(\{][[:space:]]*(.*)$ ]]; do s="${BASH_REMATCH[1]}"; done
@@ -162,7 +193,14 @@ gate_strip_prefix() {
 gate_segments() {
   local segment
   while IFS= read -r segment; do
-    segment="${segment//"$GATE_SEP_AMP"/&}"
+    # NOT `${segment//"$GATE_SEP_AMP"/&}`: since bash 5.2 an `&` in the
+    # replacement means the MATCHED TEXT, so the placeholder survived and a
+    # quoted path containing `&` came back corrupted — the gate then failed to
+    # resolve the tree and exited 0 (go-to-k/cdkd#2130 review). Version-dependent:
+    # macOS bash 3.2 masks it.
+    while [[ "$segment" == *"$GATE_SEP_AMP"* ]]; do
+      segment="${segment%%"$GATE_SEP_AMP"*}&${segment#*"$GATE_SEP_AMP"}"
+    done
     segment="${segment//"$GATE_SEP_SEMI"/;}"
     segment="${segment//"$GATE_SEP_PIPE"/|}"
     segment="${segment//"$GATE_SEP_SUBST"/$}"

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -263,6 +263,12 @@ gate_target_dir() {
   while IFS= read -r segment; do
     if [[ "$segment" =~ ^cd[[:space:]]+$GATE_PATH_TOKEN ]]; then
       cd_target=$(gate_unquote "${BASH_REMATCH[1]}")
+      # An UNEXPANDED path is not a path. `cd "$WT" && …` is the spelling this
+      # flow mandates, and resolving it literally produced `<cwd>/$WT`, which no
+      # `git -C` can read — so the gate could not resolve a tree and exited 0.
+      # Skipping it falls back to the payload cwd, which fails CLOSED
+      # (go-to-k/cdkd#2130 review).
+      case "$cd_target" in *'$'*|*'`'*) continue ;; esac
       [ -z "$cd_target" ] && continue
       [[ "$cd_target" != /* ]] && cd_target="$target/$cd_target"
       target="$cd_target"
@@ -278,6 +284,7 @@ gate_target_dir() {
         remaining="${remaining#*"${BASH_REMATCH[0]}"}"
       done
       c_target=$(gate_unquote "$c_target")
+      case "$c_target" in *'$'*|*'`'*) c_target="" ;; esac
       if [ -n "$c_target" ]; then
         [[ "$c_target" != /* ]] && c_target="$target/$c_target"
         target="$c_target"

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -168,5 +168,17 @@ EOF" "$C"
 want_dir "/tmp/a&b" "quoted path containing an ampersand" \
   'cd "/tmp/a&b" && git commit -m x' /fb "$C"
 
+# --- unexpanded paths (go-to-k/cdkd#2130 spec review) -------------------------
+# `cd "$WT" && …` is the spelling this flow MANDATES. Resolving it literally gave
+# `<cwd>/$WT`, which no `git -C` can read, so the gate could not resolve a tree
+# and exited 0. Falling back to the payload cwd fails CLOSED instead.
+want_dir "/base" "cd with an unexpanded variable falls back" 'cd "$WT" && git commit -m x' /base "$C"
+want_dir "/base" "cd with a command substitution falls back" 'cd "$(pwd)" && git commit -m x' /base "$C"
+want_dir "/base" "-C with an unexpanded variable falls back" 'git -C "$WT" commit -m x' /base "$C"
+want_dir "/real/path" "a real quoted path still resolves" 'cd "/real/path" && git commit -m x' /base "$C"
+# The verb is still SEEN in all of those — only the directory falls back.
+want_match 0 "unexpanded cd still matches the verb" 'cd "$WT" && git commit -m x' "$C"
+want_match 0 "xargs behind a pipe" 'echo f | xargs git commit -m x' "$C"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -142,5 +142,31 @@ EOF' "$C"
 want_match 1 "balanced quotes still hide a separator" 'echo "step && git commit -m x"' "$C"
 want_match 1 "balanced single quotes still hide one" "echo 'step ; git commit -m x'" "$C"
 
+# --- compound statements, wrappers, process substitution (go-to-k/cdkd#2130) ---
+# Every one of these ran UNGATED before, and each is a regression against the
+# unanchored greps some gates used to carry.
+want_match 0 "if ... then <verb>"        'if true; then git commit -m x; fi' "$C"
+want_match 0 "while ... do <verb>"       'while :; do git commit -m x; done' "$C"
+want_match 0 "until ... do <verb>"       'until false; do git commit -m x; done' "$C"
+want_match 0 "negation"                  '! git commit -m x' "$C"
+want_match 0 "sudo wrapper"              'sudo git commit -m x' "$C"
+want_match 0 "xargs wrapper"             'xargs -I{} git commit -m {}' "$C"
+want_match 0 "case arm"                  'case a in a) git commit -m x;; esac' "$C"
+want_match 0 "process substitution"      'diff <(git commit -m x) /dev/null' "$C"
+want_match 0 "output process substitution" 'tee >(git commit -m x) < f' "$C"
+
+# A quoted span that CONTINUES past the newline is one argument: its lines are
+# not separate commands, even when one of them starts with a gated verb.
+want_match 1 "multi-line quoted body line starting with the verb" 'gh pr create --body "intro
+git commit -m x was the step
+end"' "$C"
+# ... and a QUOTED heredoc tag is an ordinary opener, so its body is still data.
+want_match 1 "quoted heredoc tag still hides its body" "cat <<'EOF'
+git commit -m x
+EOF" "$C"
+
+want_dir "/tmp/a&b" "quoted path containing an ampersand" \
+  'cd "/tmp/a&b" && git commit -m x' /fb "$C"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -75,11 +75,23 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 #                               forms are an accepted false-negative
 #                               of the line-start tightening (per the
 #                               memory rule's trade-off).
-# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
-# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
+# first shape here, and it silently disabled the gate whenever the library was
+# unreadable or truncated — with the sibling gates' own comments claiming the
+# opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
+# source, where `.` succeeds but the function is missing.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
-[ -r "$_gate_lib" ] || exit 0
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
 . "$_gate_lib"
+if ! declare -F gate_matches >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
 
 # Which commands this gate applies to. The segment matcher sees a gated verb in
 # ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/bughunt-clean-gate.sh
+++ b/.claude/hooks/bughunt-clean-gate.sh
@@ -37,11 +37,23 @@ input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
-# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
-# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
+# first shape here, and it silently disabled the gate whenever the library was
+# unreadable or truncated — with the sibling gates' own comments claiming the
+# opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
+# source, where `.` succeeds but the function is missing.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
-[ -r "$_gate_lib" ] || exit 0
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
 . "$_gate_lib"
+if ! declare -F gate_matches >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
 
 # Gate only `git commit`, `gh pr create` and `gh pr merge`. The shared segment
 # matcher sees the verb in ANY position — `git add -A && git commit` used to run

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -30,11 +30,23 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # so a `git commit` substring inside a quoted argument body does not
 # false-positive. Tolerates `git -C <path> commit` / `git -c k=v commit` and
 # an optional leading `cd <path> &&` worktree prefix.
-# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
-# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
+# first shape here, and it silently disabled the gate whenever the library was
+# unreadable or truncated — with the sibling gates' own comments claiming the
+# opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
+# source, where `.` succeeds but the function is missing.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
-[ -r "$_gate_lib" ] || exit 0
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
 . "$_gate_lib"
+if ! declare -F gate_matches >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
 
 # Which commands this gate applies to. The segment matcher sees a gated verb
 # in ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -37,11 +37,23 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate `gh pr merge` (with optional leading `cd <path> &&` and optional
 # `gh -C <path>`). Anything else passes through.
-# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
-# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
+# first shape here, and it silently disabled the gate whenever the library was
+# unreadable or truncated — with the sibling gates' own comments claiming the
+# opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
+# source, where `.` succeeds but the function is missing.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
-[ -r "$_gate_lib" ] || exit 0
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
 . "$_gate_lib"
+if ! declare -F gate_matches >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
 
 # Which commands this gate applies to. The segment matcher sees a gated verb
 # in ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -69,11 +69,23 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || ec
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate gh pr create / edit / merge — anything else passes through.
-# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
-# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
+# first shape here, and it silently disabled the gate whenever the library was
+# unreadable or truncated — with the sibling gates' own comments claiming the
+# opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
+# source, where `.` succeeds but the function is missing.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
-[ -r "$_gate_lib" ] || exit 0
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
 . "$_gate_lib"
+if ! declare -F gate_matches >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
 
 # Which commands this gate applies to. The segment matcher sees a gated verb in
 # ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/stale-base-gate.sh
+++ b/.claude/hooks/stale-base-gate.sh
@@ -37,11 +37,23 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate `git push` (subcommand position, line-start anchored — same shape
 # as branch-gate.sh so quoted "git push" substrings don't false-positive).
-# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
-# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
+# first shape here, and it silently disabled the gate whenever the library was
+# unreadable or truncated — with the sibling gates' own comments claiming the
+# opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
+# source, where `.` succeeds but the function is missing.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
-[ -r "$_gate_lib" ] || exit 0
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
 . "$_gate_lib"
+if ! declare -F gate_matches >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
 
 # Which commands this gate applies to. The segment matcher sees a gated verb
 # in ANY position — `git add -A && git commit` used to run ungated

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -46,11 +46,23 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # hard block. The optional leading `cd <path> &&` prefix preserves
 # the worktree-aware `cd <side> && gh pr create` chain shape,
 # mirroring check-gate.sh (PR #562 fix pattern).
-# Fail OPEN if the shared matcher is missing: a hook that cannot decide must not
-# break every Bash call with a `command not found` (go-to-k/cdk-local#542 review).
+# Fail CLOSED if the shared matcher is missing or does not load: a gate that
+# cannot decide must not wave the command through. `[ -r … ] || exit 0` was the
+# first shape here, and it silently disabled the gate whenever the library was
+# unreadable or truncated — with the sibling gates' own comments claiming the
+# opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
+# source, where `.` succeeds but the function is missing.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
-[ -r "$_gate_lib" ] || exit 0
+if [ ! -r "$_gate_lib" ]; then
+  echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
+  exit 2
+fi
+# shellcheck source=/dev/null
 . "$_gate_lib"
+if ! declare -F gate_matches >/dev/null 2>&1; then
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+  exit 2
+fi
 
 # Which commands this gate applies to. The segment matcher sees a gated verb in
 # ANY position — `git add -A && git commit` used to run ungated


### PR DESCRIPTION
## Summary

Six defects in the shared gate matcher, all surfaced by the three-axis review of
the cdkd convergence (go-to-k/cdkd#2130) and all reproduced on this repo's merged
`main` before fixing. Three are FAIL OPEN, two are FALSE BLOCKS, one is both
(version-dependent).

## Fail open — the gate stopped firing where it used to

| spelling | before |
| --- | --- |
| `if true; then <verb>; fi` | ungated |
| `while :; do <verb>; done`, `until …` | ungated |
| `! <verb>` | ungated |
| `sudo <verb>`, `xargs -I{} <verb>` | ungated |
| `case a in a) <verb>;; esac` | ungated |
| `diff <(<verb>) /dev/null`, `tee >(<verb>) < f` | ungated |
| `cd "/tmp/a&b" && <verb>` | target dir resolved to `/tmp/ab`, `git -C` failed, gate exited 0 |

The leader list was only `then|do|else|elif`. This is a **regression** for the
gates that traded an unanchored grep for this matcher — their old grep caught
`if <verb>`. The stripper is a stable loop now, so nested forms
(`case a in a) sudo <verb>`) resolve too.

The `&` one is the nastiest: `${segment//"$SEP"/&}` — since **bash 5.2** an `&`
in the replacement means the MATCHED TEXT, so the placeholder survived and the
path came back corrupted. macOS `/bin/bash` 3.2 masks it, so the failure depended
on which bash ran the hook.

## False block — the gate fired where it must not

- A quoted span continuing past a newline is ONE argument, but its lines were
  segmented separately, so `gh pr create --body "…"` whose second line STARTS with
  a gated verb was blocked. Continuations now join the segment that opened the span.
- A QUOTED heredoc tag (`cat <<'EOF'`) was read as a quoted span, losing the tag,
  so the body became commands. **This repo blocked its own probe script while that
  probe was being written** — the fix is that a quote directly after `<<` / `<<-`
  belongs to the tag.

## Test plan

- [x] `bash .claude/hooks/_command-match.test.sh` — 70 cases, 0 failed; 12 new
      ones cover every row above
- [x] Mutation probes: dropping the new leaders fails **12** cases, removing
      process substitution **2**, breaking the `&` restore **2**, splitting
      multi-line spans **1**
- [x] `vp run test:hooks` — 11 harnesses, 0 failed
- [x] `vp run check` — 0 errors; `vp run build`; `vp run test` — 6526 tests

No `src/**` in the diff. The same fixes go to cdk-local and to cdkd's converged
`lib/command-match.sh` in go-to-k/cdkd#2130 before it merges.
