### PR TITLE
fix(hooks): re-segment a `bash -c` body, and stop splitting on an escaped separator

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -48,6 +48,10 @@ gate_segments_raw() {
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
         if (q == "") {
+          # An escaped character outside quotes is LITERAL: `echo a\; git commit`
+          # is ONE echo, and splitting on that `;` blocked it (go-to-k/cdkd#2130
+          # test review).
+          if (c == "\\") { out = out c substr(line, i + 1, 1); i++; continue }
           if ((c == "\"" || c == "'"'"'") && c != ignore_q) { q = c; out = out c; continue }
           if (c == "$" && substr(line, i + 1, 1) == "(") { out = out "\n"; i++; continue }
           # Process substitution runs its body too: `diff <(git commit) …`.
@@ -157,11 +161,6 @@ gate_segments_raw() {
 gate_strip_prefix() {
   local s="$1" prev=""
   s="${s#"${s%%[![:space:]]*}"}"
-  # `bash -c "<cmd>"` RUNS its argument, so a gated verb inside it is a gated
-  # command (go-to-k/cdk-local#542 review).
-  if [[ "$s" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+[\"\'](.*)[\"\'][[:space:]]*$ ]]; then
-    s="${BASH_REMATCH[2]}"
-  fi
   # Strip leaders until stable: a `case <word> in` opener, a `<pattern>)` arm
   # label, compound-statement keywords, wrappers, and env assignments can nest
   # (`case a in a) sudo git commit`). `if|while|until|!|sudo|xargs` were missing,
@@ -189,6 +188,18 @@ gate_strip_prefix() {
   printf '%s' "$s"
 }
 
+# Strip one surrounding quote pair from a whole argument (the `bash -c` body).
+gate_unquote_span() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  case "$v" in
+    \"*\") v="${v#\"}"; v="${v%\"}" ;;
+    \'*\') v="${v#\'}"; v="${v%\'}" ;;
+  esac
+  printf '%s' "$v"
+}
+
 # Print one command segment per line, in the ORIGINAL text (placeholders restored).
 gate_segments() {
   local segment
@@ -205,6 +216,14 @@ gate_segments() {
     segment="${segment//"$GATE_SEP_PIPE"/|}"
     segment="${segment//"$GATE_SEP_SUBST"/$}"
     segment=$(gate_strip_prefix "$segment")
+    # `bash -c "<cmd>"` RUNS its argument, and that argument is a command LIST:
+    # matching it as ONE segment missed `bash -c "cd /w && git commit"`
+    # (go-to-k/cdkd#2130 test review). Recurse ONLY here — re-segmenting every
+    # segment would split a quoted `--body` whose prose contains `&&`.
+    if [[ "$segment" =~ ^(bash|zsh|ksh|sh)[[:space:]]+-[a-z]*c[[:space:]]+(.*)$ ]]; then
+      gate_segments "$(gate_unquote_span "${BASH_REMATCH[2]}")"
+      continue
+    fi
     # An `if`, not `[ … ] && printf`: under a caller's `set -e` the trailing
     # false test aborts the whole function, and the segments after it are never
     # emitted — a silent fail-open that depends on which gate sources this.

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -180,5 +180,21 @@ want_dir "/real/path" "a real quoted path still resolves" 'cd "/real/path" && gi
 want_match 0 "unexpanded cd still matches the verb" 'cd "$WT" && git commit -m x' "$C"
 want_match 0 "xargs behind a pipe" 'echo f | xargs git commit -m x' "$C"
 
+# --- go-to-k/cdkd#2130 test review: two real defects, and the unpinned rest ----
+want_match 0 "bash -c with an inner chain" 'bash -c "cd /w && git commit -m x"' "$C"
+want_match 0 "process substitution"        'diff <(git commit -m x) b' "$C"
+# An escaped separator outside quotes is LITERAL — one `echo`, not two commands.
+want_match 1 "escaped semicolon is literal" 'echo a\; git commit -m x' "$C"
+# Behaviour that was already right but pinned by nothing.
+want_match 1 "ANSI-C quoting hides its contents" "echo \$'x; git commit'" "$C"
+want_match 0 "parameter expansion default runs"  'echo ${V:-a; git commit -m x}' "$C"
+want_match 1 "# comment holding the verb"        'echo hi # git commit -m x' "$C"
+want_match 1 "grep pattern is not a verb"        'git log --grep commit' "$C"
+want_match 1 "grep=pattern is not a verb"        'git log --grep=commit' "$C"
+want_match 1 "an ordinary task run"              'vp run test' "$C"
+# The quoted-span protection is what stops a gate firing on prose: pin it with a
+# separator INSIDE the quotes, which is the only shape that can distinguish it.
+want_match 1 "separator inside a quoted body" 'gh issue create --body "run vp check && git commit -m x"' "$C"
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Two real defects from the cdkd test review (go-to-k/cdkd#2130), plus the cases it
showed were unpinned. Both reproduced on this repo's merged `main` first.

## Fail open

```
bash -c "cd /w && git commit -m x"     -> no match
```

The unwrap happened in the prefix stripper, so the body — itself a command LIST —
was matched as ONE segment and its chain was invisible. Unwrapping moves into the
segmenter, which recurses on the body. **Only there**: re-segmenting every segment
splits a quoted `--body` whose prose contains `&&`, which is the false block an
earlier round fixed — the first attempt at this did exactly that and turned three
sibling cases red, which is how the placement was settled.

## False block

```
echo a\; git commit -m x               -> matched
```

An escaped separator outside quotes is LITERAL: that is one `echo`, not two
commands.

## The suite's own gap

The review's mutation matrix showed the **quoted-span protection** — the only
thing keeping a gate off prose — was pinned by cases whose quoted bodies contained
no separator, so deleting it left them green. Nine cases now pin it and the
behaviours that were right but unasserted: `$'…'` quoting, `${V:-a; verb}`, a `#`
comment holding the verb, `--grep commit`, `--grep=commit`, `vp run test`, and a
separator inside a quoted `--body`.

## Test plan

- [x] `bash .claude/hooks/_command-match.test.sh` — 86 cases, 0 failed
- [x] Mutation probes: dropping the escape branch fails **1** case, disabling the
      `bash -c` recursion **1**, disabling quote protection **9**
- [x] `vp run test:hooks` — 11 harnesses, 0 failed
- [x] `vp run check` — 0 errors; `vp run build`; `vp run test` — 6526 tests

No `src/**` in the diff. Siblings: go-to-k/cdk-local#547 and go-to-k/cdkd#2130.
