### PR TITLE
chore(hooks): probe that the gates are ALIVE before the session's first commit

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -496,6 +496,23 @@ enforce quality yourself; you (the orchestrator) still gate the MERGE.
 
 ## 6. Gates + PR (per lane)
 
+**Before the session's FIRST commit, prove the gates are ALIVE.** Registration is
+not execution: on 2026-08-20 every PreToolUse gate in this repo was registered and
+INERT for a day (go-to-k/cdk-real-drift#1801 — an `if` holding `A or B` matches
+nothing), and the failure is silent in the worst direction, because an ungated
+commit looks exactly like one that passed. `/hooks` shows what is REGISTERED, so
+it cannot see this. One command does:
+
+```bash
+git commit --dry-run -m "gate liveness probe"   # from the repo root, on main
+```
+
+`--dry-run` commits nothing whatever the tree looks like. Expected: `Blocked by
+branch-gate` (the root is on `main`) or `Blocked by check-gate` (markers stale).
+**Git's own output instead — `On branch main`, `nothing to commit` — means the
+gates are not firing at all**, and everything below is then self-enforced: run
+each gate's own check by hand and say so in the report, because nothing else will.
+
 From inside the worktree — a fresh worktree has no `dist/`, and 13 tests fail
 without it (they spawn the built CLI), so `vp pack` runs before the suite:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,14 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     deploy-shaped command, and the `stop-cleanup-warn` Stop hook warns at session
     end if the sentinel is still armed. Run **`/sweep-resources`** to do the
     cleanup + release the gate.
+- **Registration is not execution — prove the gates are ALIVE before the first
+  commit of a session**: `git commit --dry-run -m "gate liveness probe"` from the
+  repo root. `--dry-run` commits nothing regardless of the tree; a `Blocked by
+branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
+  output means they do NOT, and every gate below is then unenforced. On
+  2026-08-20 all eight were registered and inert for a day (go-to-k/cdk-real-drift#1801:
+  an `if` holding `A or B` matches nothing), which `/hooks` cannot show because it
+  lists registration, not firing.
 - **ALWAYS develop in a git worktree — never edit or branch in the main
   checkout, even for a single "sequential" session.** Sessions that believed
   they were alone have collided twice: a README clobber, and a branch created in


### PR DESCRIPTION
## Summary

Registration is not execution, and nothing in this repo could tell the difference.
On 2026-08-20 all eight PreToolUse gates were registered and **inert for a day**
(go-to-k/cdk-real-drift#1801: an `if` holding `A or B` matches nothing). The
failure is silent in the worst direction — an ungated commit looks exactly like
one that passed — and none of the existing fences can see it:

- `/hooks` lists what is REGISTERED, not what fires.
- The hook harnesses run the scripts DIRECTLY, so they pass either way.
- `tests/gate-if-matchers-1801.test.ts` reads `settings.json`, so it checks the
  configuration, not the client's use of it.

Only a real tool call routed through the client exercises the wiring. So the flow
takes one, once per session, before the first commit:

```bash
git commit --dry-run -m "gate liveness probe"
```

`--dry-run` commits nothing whatever the tree looks like. `Blocked by
branch-gate` / `Blocked by check-gate` means the hooks fire. **Git's ordinary
output means they do not**, and every gate is then self-enforced: run each check
by hand and say so in the report, because nothing else will.

Recorded in `CLAUDE.md` beside the worktree rule, and in `/work-issues` section 6
where a lane's first commit happens.

## Test plan

- [x] The probe itself, run in this repo: `Blocked by check-gate: run /check
      first …` — the expected output when markers are stale, which is the state a
      fresh worktree starts in
- [x] `vp run check` — 0 errors; `vp run build`; `vp run test` — 6526 tests
- [x] `vp run test:hooks` — 11 harnesses, 0 failed

No `src/**` in the diff. Same rule in go-to-k/cdk-local#548 and go-to-k/cdkd#2131.
