### PR TITLE
fix(hooks): a flag between the command and its verb no longer skips the gate, and the liveness probe says who runs it

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,91 +8,91 @@
           {
             "type": "command",
             "command": ".claude/hooks/check-gate.sh",
-            "if": "Bash(*git commit*)",
+            "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking /check + /check-docs markers..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(*git commit*)",
+            "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking target branch is not main..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(*git push*)",
+            "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking target branch is not main..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/bughunt-clean-gate.sh",
-            "if": "Bash(*git commit*)",
+            "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking for un-deleted bug-hunt resources..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/bughunt-clean-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 10,
             "statusMessage": "Checking for un-deleted bug-hunt resources..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/bughunt-clean-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 10,
             "statusMessage": "Checking for un-deleted bug-hunt resources..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/stale-base-gate.sh",
-            "if": "Bash(*git push*)",
+            "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking branch does not stale-base-clobber main..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Checking /verify-pr marker is fresh..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Checking /verify-pr marker is fresh..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/ci-green-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Checking the PR's CI is all-green before merge..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(*gh pr create*)",
+            "if": "Bash(*gh*pr*create*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(*gh pr edit*)",
+            "if": "Bash(*gh*pr*edit*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(*gh pr merge*)",
+            "if": "Bash(*gh*pr*merge*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
           },

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -507,6 +507,11 @@ it cannot see this. One command does:
 git commit --dry-run -m "gate liveness probe"   # from the repo root, on main
 ```
 
+Run it as YOUR OWN Bash tool call. PreToolUse hooks gate the agent's tool calls
+and nothing else — the identical line typed by a human into a terminal bypasses
+the hook system entirely, so it always looks "unblocked" and proves nothing. That
+mistake was made while writing this rule.
+
 `--dry-run` commits nothing whatever the tree looks like. Expected: `Blocked by
 branch-gate` (the root is on `main`) or `Blocked by check-gate` (markers stale).
 **Git's own output instead — `On branch main`, `nothing to commit` — means the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,8 +285,10 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     end if the sentinel is still armed. Run **`/sweep-resources`** to do the
     cleanup + release the gate.
 - **Registration is not execution — prove the gates are ALIVE before the first
-  commit of a session**: `git commit --dry-run -m "gate liveness probe"` from the
-  repo root. `--dry-run` commits nothing regardless of the tree; a `Blocked by
+  commit of a session**: run `git commit --dry-run -m "gate liveness probe"` from
+  the repo root **as a Bash TOOL CALL**. PreToolUse hooks gate the AGENT's tool
+  calls only: the same line typed by a human into a terminal never passes through
+  them, so it proves nothing and will always look "unblocked". `--dry-run` commits nothing regardless of the tree; a `Blocked by
 branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   output means they do NOT, and every gate below is then unenforced. On
   2026-08-20 all eight were registered and inert for a day (go-to-k/cdk-real-drift#1801:

--- a/tests/gate-if-matchers-1801.test.ts
+++ b/tests/gate-if-matchers-1801.test.ts
@@ -35,13 +35,13 @@ const SETTINGS = path.join(ROOT, '.claude', 'settings.json');
 
 /** What each gate must be selected for. `deploy-autoarm` matches a command SHAPE. */
 const REQUIRED: Record<string, string[]> = {
-  'check-gate.sh': ['Bash(*git commit*)'],
-  'branch-gate.sh': ['Bash(*git commit*)', 'Bash(*git push*)'],
-  'bughunt-clean-gate.sh': ['Bash(*git commit*)', 'Bash(*gh pr create*)', 'Bash(*gh pr merge*)'],
-  'stale-base-gate.sh': ['Bash(*git push*)'],
-  'verify-pr-gate.sh': ['Bash(*gh pr create*)', 'Bash(*gh pr merge*)'],
-  'ci-green-gate.sh': ['Bash(*gh pr merge*)'],
-  'non-english-text-gate.sh': ['Bash(*gh pr create*)', 'Bash(*gh pr edit*)', 'Bash(*gh pr merge*)'],
+  'check-gate.sh': ['Bash(*git*commit*)'],
+  'branch-gate.sh': ['Bash(*git*commit*)', 'Bash(*git*push*)'],
+  'bughunt-clean-gate.sh': ['Bash(*git*commit*)', 'Bash(*gh*pr*create*)', 'Bash(*gh*pr*merge*)'],
+  'stale-base-gate.sh': ['Bash(*git*push*)'],
+  'verify-pr-gate.sh': ['Bash(*gh*pr*create*)', 'Bash(*gh*pr*merge*)'],
+  'ci-green-gate.sh': ['Bash(*gh*pr*merge*)'],
+  'non-english-text-gate.sh': ['Bash(*gh*pr*create*)', 'Bash(*gh*pr*edit*)', 'Bash(*gh*pr*merge*)'],
   'deploy-autoarm-gate.sh': ['Bash(*deploy*)', 'Bash(*create-stack*)', 'Bash(*update-stack*)'],
 };
 
@@ -121,6 +121,45 @@ describe('PreToolUse gate matchers (go-to-k/cdk-real-drift#1786, go-to-k/cdk-rea
 
   // The matcher is a glob over the WHOLE command string, so an anchored pattern
   // cannot see a gated verb that follows another command. Keep them unanchored.
+  // `git -C <path> commit` and `gh -R <owner/repo> pr create` put a FLAG between
+  // the command and its verb, so a pattern demanding them adjacent
+  // (`Bash(*git commit*)`) never selects those spellings — and this repo's own
+  // memory rule tells an agent to use `git -C` in multi-repo sessions, so the
+  // gap was being actively steered into (found 2026-08-21, the same class as
+  // go-to-k/cdk-real-drift#1801). Simulate the glob to keep it closed.
+  it('a flag between the command and its verb still selects the gate', () => {
+    const globToRe = (pattern: string) =>
+      new RegExp(
+        `^${pattern
+          .replace(/^Bash\(/, '')
+          .replace(/\)$/, '')
+          .split('*')
+          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('.*')}$`
+      );
+    const spellings = [
+      'git commit -m x',
+      'git -C /w/t commit -m x',
+      'git -c user.name=t commit -m x',
+      'cd /w/t && git commit -m x',
+      'git add -A && git commit -m x',
+    ];
+    const commitPatterns = hooks.filter((h) => h.name === 'check-gate.sh').map((h) => h.condition);
+    for (const spelling of spellings) {
+      expect(
+        commitPatterns.some((p) => globToRe(p).test(spelling)),
+        `no check-gate pattern selects: ${spelling}`
+      ).toBe(true);
+    }
+    const ghPatterns = hooks.filter((h) => h.name === 'verify-pr-gate.sh').map((h) => h.condition);
+    for (const spelling of ['gh pr create --fill', 'gh -R go-to-k/x pr create --fill']) {
+      expect(
+        ghPatterns.some((p) => globToRe(p).test(spelling)),
+        `no verify-pr-gate pattern selects: ${spelling}`
+      ).toBe(true);
+    }
+  });
+
   it('the guarded-verb patterns are unanchored, so a compound command still selects', () => {
     const anchored = hooks
       .filter((h) => /^Bash\((git|gh)\b/.test(h.condition))


### PR DESCRIPTION
## Summary

Two defects, both surfaced by actually running the liveness probe the last merge
added — which is the point of that rule.

## 1. Fail open: a flag between the command and its verb skipped the gate

`Bash(*git commit*)` needs `git commit` as a **contiguous** string, so these were
never selected and the gate simply did not run:

```
git -C <path> commit …
git -c user.name=t commit …
gh -R <owner/repo> pr create …
```

Measured A/B in one session, one cwd:

| command | result |
| --- | --- |
| `git commit --dry-run -m …` | `Blocked by check-gate` |
| `git -C <path> commit --dry-run -m …` | **passed** — git's ordinary output |

Same class as go-to-k/cdk-real-drift#1801, and worse than a plain gap: this repo's
memory rule tells an agent to prefer `git -C <path>` in multi-repo sessions, so
the guidance steered straight into the hole. Most commits in the session that
wrote these gates went through ungated for exactly that reason.

Every verb pattern is now `Bash(*git*commit*)`-shaped, tolerating anything between
the command and its verb. The gate scripts already re-match precisely, so the
matcher's only job is to hand them every candidate.

## 2. The liveness rule did not say WHO runs the probe

A human typed it into a terminal, saw `nothing to commit, working tree clean`, and
reasonably read that as "the gates are dead". But a PreToolUse hook gates the
**agent's tool calls** only — a line typed into a shell never enters the hook
system, always looks unblocked, and proves nothing. `CLAUDE.md` and `/work-issues`
section 6 now say it is the agent's own Bash tool call and name that failure mode.

## Test plan

- [x] `vp test run tests/gate-if-matchers-1801.test.ts` — 14 cases, 0 failed. The
      new one simulates the glob against the real spellings (`git -C … commit`,
      `git -c k=v commit`, `git add -A && git commit`, `gh -R … pr create`);
      reverting to the adjacent-only pattern fails **4** of its cases.
- [x] `vp run check` — 0 errors; `vp run build`; `vp run test` — 6527 tests
- [x] `vp run test:hooks` — 11 harnesses, 0 failed

No `src/**` in the diff. Siblings: go-to-k/cdk-local#549 (same two fixes) and
go-to-k/cdkd#2140 (wording only — cdkd wires its hooks with no `if`, so the
matcher hole cannot occur there).
