### PR TITLE
chore(work-issues): port cdkd's fix-cascade shape rule, and add the PROXY shape

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -787,6 +787,56 @@ Run `/verify-pr`. Its live-test rules decide how each PR is verified:
   pre-run call, which is why it has not bitten here; the moment one adds a pre-run
   sweep, run the fixture end to end against stubs first — two seconds of a dry run
   catches it.
+- **When a fix round produces the NEXT round's blocker twice, stop reviewing the
+  patch and question its SHAPE.** `/verify-pr` already says to re-review the fix
+  delta; this is what to do when that keeps paying out. Each fix is locally
+  correct and moves the failure one layer out rather than removing it, and the
+  blockers are found by executing a probe or tracing a window — never by
+  re-reading the diff. After round two, ask what the rounds have in COMMON: it is
+  usually one structural absence, and naming it does not skip the rounds but does
+  tell everyone what they are chasing. Then do NOT take the structural fix late
+  in the cascade — adding new code at round five is how round six happens. Take
+  the narrow fix, file the structural one, and reference it from the narrow fix
+  so the next reader sees the choice was made rather than missed. Two shapes
+  recur, and they are distinguishable a round apart:
+  - **TWO SPELLINGS OF ONE QUESTION** — the fix is to make both sites use ONE
+    predicate verbatim, not to write a better second spelling. A better spelling
+    looks like a fix and passes its own test, so this is the sub-case that keeps
+    regenerating. Name the SITE THAT OWNS the question and make every other site
+    call or copy it exactly; a paraphrase is another round waiting to happen.
+    Measured in cdkd (go-to-k/cdkd#2134) over three rounds, ending only when the
+    authority's test was copied character for character — the round before, the
+    two spellings still disagreed on the empty string, on the fail-OPEN side.
+  - **A PROXY FOR A QUESTION ONLY ANOTHER COMPONENT CAN ANSWER** — the fix is to
+    make that component REPORT, and the tell is that each proxy is wrong in BOTH
+    directions at once. Two spellings DISAGREE at an edge; a proxy has no access
+    to the fact at all, so every candidate both misses real cases and fires on
+    unreal ones. When a round's fix lands on a new OBSERVABLE rather than a new
+    spelling — "it threw", "the text survived", "a marker exists" — ask whether
+    the thing you want to know is even derivable from outside the component that
+    decides it. If it is not, the rounds are unbounded. Measured in cdkd
+    (go-to-k/cdkd#2157 / go-to-k/cdkd#2166) over three rounds asking "did this
+    reference go unresolved?" from outside the resolver: keying on "it THREW"
+    missed the path that warns and continues without throwing, and over-reported
+    an unrelated failure that merely shared the same bag; keying on "the raw text
+    SURVIVED" missed input a downstream step rewrote without resolving, broke on
+    JSON escaping, and fired permanently on PROSE that merely mentioned the
+    syntax. The drift analogue is any question only AWS's own readback can
+    answer — "is this property genuinely drifted, or did the provider never
+    return it?" — where an outside proxy (the field is absent, the value differs
+    from the template, a normalizer left it untouched) misses real drift AND
+    manufactures false positives at the same time, which is why this repo's
+    corpus is authoritative over any predicate reasoned about in isolation.
+- **WITHDRAWING the half that cannot be made right is a legitimate outcome, and
+  the residual issue must carry the MEASUREMENTS, not just the diagnosis.** The
+  rule above says where the fix goes; this says what to do with the code already
+  written for the wrong one. Cut it, ship the part the issues actually scoped,
+  and file the rest — the filing is cheap only if it carries what the session
+  PAID for: each proxy tried, the input that broke it, and the number it
+  produced. A diagnosis alone makes the next session re-run every probe. cdkd's
+  go-to-k/cdkd#2166 is the worked example: three rounds of measurements plus a
+  live arm that was written, passed, mutation-probed and then reverted, so none
+  of it is rebuilt.
 - **When two reviewers CONTRADICT each other, settle it in the code YOURSELF
   before forwarding either.** Forwarding both hands the implementing agent a
   contradiction to adjudicate with LESS context than you have; forwarding only the


### PR DESCRIPTION
Mirrored from cdkd, where a scrub relaxation (go-to-k/cdkd#2157 / go-to-k/cdkd#2150, PR go-to-k/cdkd#2164) spent **four** review rounds and withdrew half of itself.

Two pieces travel together, because the second builds on the first and this skill carried neither.

## 1. The cascade rule (ported)

cdkd added it earlier and it was never mirrored here: when a fix round produces the NEXT round's blocker twice, stop reviewing the patch and question its SHAPE. Every such blocker is found by executing a probe or tracing a window — never by re-reading the diff — and the structural fix must **not** be taken late in the cascade, because adding new code at round five is how round six happens.

## 2. The second shape (new — this run found it)

**A PROXY FOR A QUESTION ONLY ANOTHER COMPONENT CAN ANSWER**, adjacent to the TWO SPELLINGS shape cdkd already names and diagnosable a round earlier:

| shape | how it fails | tell |
| --- | --- | --- |
| two spellings of one question | the two DISAGREE at an edge | a round's fix is a *better spelling* of the same test |
| a proxy for a question only another component can answer | the proxy has no access to the fact, so every candidate misses real cases **and** fires on unreal ones at once | a round's fix lands on a new **observable** |

Measured across three rounds asking *"did this reference go unresolved?"* from outside the resolver that decides it: keying on "it THREW" missed the path that warns and continues without throwing, and over-reported an unrelated failure sharing the same bag; keying on "the raw text SURVIVED" missed input a downstream step rewrote without resolving, broke on JSON escaping, and fired permanently on prose that merely mentioned the syntax.

**Adapted, not copied.** The drift analogue named here is any question only AWS's own readback can answer — *is this property genuinely drifted, or did the provider never return it?* — where an outside proxy (the field is absent, the value differs from the template, a normalizer left it untouched) misses real drift **and** manufactures false positives at once. That is the same argument this repo already makes for the harvested corpus being authoritative, so the new shape names it rather than restating it.

## 3. Withdrawal (new — no repo had this)

Withdrawing the half that cannot be made right is a legitimate outcome, and the residual issue must carry the **measurements**, not just the diagnosis — each proxy tried, the input that broke it, the number it produced. Otherwise the next session re-runs every probe.

## Verification

Prose-only change to a skill, so §8's no-`src/**` arm applies: the claims are the artifact. Every cross-repo reference is fully qualified and resolves; both shapes are checked against the cdkd run they came from; the local analogue is stated in this repo's own vocabulary rather than cdkd's.

`vp check`, `vp run check` and `vp run build` pass; full suite green (345 files / 6527 tests).

One note on the local run: a fresh worktree has no `dist/`, and `tests/json-empty-on-error.test.ts` shells out to the built CLI — so 13 cases failed with exit 1 instead of 2 until `vp run build` ran. Recorded because the failure names the CLI's exit code and reads like a product regression rather than a missing build.
