### PR TITLE
chore(work-issues): a relayed count is unearned, and "integ last" does not hold still across review rounds

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -381,6 +381,36 @@ Two boundaries, so this does not become a licence for unbounded lanes:
   are two issues; one wrong assumption at five call sites is one. The test is
   whether a single sentence describes the fix at every site.
 
+**A COUNT is a claim, and one RELAYED from a subagent is unearned.** A sweep
+reporting "N sites" in its commit message, its issue body and its PR body has
+asserted that number three times, and a reader can only re-derive it if the query
+is there — so paste the command beside the number. The harder half is the count
+you never derived: in this flow the published numbers usually arrive inside a
+fan-out agent's summary or a reviewer's finding, already phrased as fact, and get
+copied onward without anyone re-running anything.
+
+Measured in cdkd on 2026-08-26 (go-to-k/cdkd#2261), whose run published FOUR such
+counts, every one wrong and every one relayed — "all nine sibling sites" (a grep
+found 78 across 14 files), "nine mutation probes" (fourteen), "ten unit shapes"
+(thirteen), and a "if a third copy ever appears" trigger for a predicate that
+already had nine copies. Two went into GitHub artifacts, where they outlive the
+session, and the first was the load-bearing argument for deferring that work to
+an umbrella — so being wrong by ~9x under-scoped the deferral it justified.
+
+The tell is grammatical rather than technical: a number arriving as a WORD
+("nine sites", "a third copy") was counted by a person or an agent, while one
+arriving as command output was counted by a machine. Before a relayed count goes
+anywhere durable — an issue body, a PR body, this file — run the query yourself
+and put it in the text. It is one command. What worked on that run was the
+implementing agent deriving its next count with `awk` and catching its own
+correction mid-flight, and declining to relay a path from the orchestrator's
+message after grepping and finding no such file.
+
+This repo has no automated fence on that class: its own §8 prose arm ("the CLAIMS
+are the artifact") is the only thing standing between a relayed number and a
+merged one, and a number is exactly the kind of claim that reads as already
+verified.
+
 **And whatever you do file, resolve it against the issues ALREADY OPEN first.** The
 sweep above looks for sibling sites in the CODE. This looks for a sibling ISSUE, and
 it is a different search with a different answer: the issue that covers your finding
@@ -844,6 +874,24 @@ your last, authoritative signal to stop and check before spending more.
 ## 8. Verify before merge (`/verify-pr`)
 
 Run `/verify-pr`. Its live-test rules decide how each PR is verified:
+
+**Run the integ LAST, and note that "last" does not hold still across review
+rounds — so DECLARE the tree final, in words, to whoever is still editing it.**
+This repo's `integ` gate is `hash: diff` over `src/**` and
+`tests/integration/**`, so it digests the branch's DELTA rather than the working
+tree's behaviour. The consequence is worth stating outright: a round of review
+fixes whose change to an in-scope file is **comment-only** still stales the
+marker, and still costs a full fixture run. Measured in cdkd on 2026-08-26
+(go-to-k/cdkd#2261), where a lane paid THREE real-AWS runs of one fixture, the
+third for a round whose provider change was verified to carry zero non-comment
+lines. What ended it was telling the implementing agent, before its last pass, to
+batch every remaining finding into ONE commit and report when the tree is FINAL
+with no second pass — after which the integ ran once. Say that explicitly rather
+than assuming it: an agent handed a list of findings will otherwise fix, verify
+and hand back, which is the right instinct everywhere except in front of a gate
+that costs a real run. The reviewer-side corollary is the reverse — dispatch a
+round SCOPED to the delta and ask for the whole round's findings at once, rather
+than trickling them.
 
 - **fold / FP / classify fix** → the harvested **corpus** case is authoritative
   live data. If it is pinned by `vp test run corpus-replay` AND was live-proven in


### PR DESCRIPTION
## Summary

Mirrors two `/work-issues` lessons measured in cdkd on 2026-08-26
(go-to-k/cdkd#2261), completing the three-repo landing that section 10-c makes
the default. The cdk-local half is go-to-k/cdk-local#562.

Neither rule existed here, so these land as **new text rather than amendments**,
and every claim was re-verified against this repo instead of copied.

## 1. A relayed count is unearned (section 5)

The counts published in this flow usually did not come from a sweep the author
ran — they arrive inside a fan-out agent's summary or a reviewer's finding,
already phrased as fact, and get copied onward without anyone re-running
anything.

That cdkd run published four such counts, every one wrong and every one relayed:

| published | actual |
|---|---|
| "all **nine** sibling sites" | **78** call sites across 14 files |
| "**nine** mutation probes" | **fourteen** |
| "**ten** unit shapes" | **thirteen** |
| "if a **third** copy ever appears" | already **nine** copies |

Two went into GitHub artifacts, where they outlive the session, and the first was
the load-bearing argument for deferring that work to an umbrella — so being wrong
by ~9x under-scoped the deferral it was justifying.

The new text names the grammatical tell (a number arriving as a WORD was counted
by a person or an agent; one arriving as command output was counted by a machine)
and records what ended it.

**One clause is specific to this repo.** Unlike cdkd and cdk-local, there is no
skill-refs-style reference test here, so nothing mechanically checks a claim in
this file — section 8's prose arm is the only thing between a relayed number and
a merged one, and a number is exactly the kind of claim that reads as already
verified. The text says so rather than implying the sibling repos' fence exists
here.

## 2. "Integ last" does not hold still across review rounds (section 8)

Verified against **this repo's** `.markgate.yml`: the `integ` gate is `hash: diff`
over `src/**` and `tests/integration/**`. It therefore digests the branch's
DELTA, not the working tree's behaviour — so a review round whose in-scope change
is **comment-only** still stales the marker and still costs a full fixture run.

The cdkd lane paid three real-AWS runs of one fixture, the third for a round
whose provider change was verified to carry zero non-comment lines. What ended it
was telling the implementing agent, before its last pass, to batch every
remaining finding into ONE commit and report when the tree is FINAL with no
second pass. The reviewer-side corollary is the reverse: dispatch a round scoped
to the delta and ask for the whole round's findings at once.

## Verification

Prose-only change to an agent-instruction file, so per this repo's own section 8
the CLAIMS are the artifact — each resolved against this repo, not the sibling's
wording:

- `integ` gate mode and include set read from this repo's `.markgate.yml`
  (`hash: diff`; `src/**` + `tests/integration/**`).
- Confirmed this repo has **no** skill-refs / reference fence, which is why that
  clause is stated here and not in the cdk-local copy.
- All issue references are fully qualified (`go-to-k/cdkd#2261`), so the text
  stays correct if it is ever read from another repo.
- `vp check --fix` 0 · `vp run check` 0 · `build` 0 · full suite **346 files /
  6549 tests, rc=0**.
