### PR TITLE
chore(work-issues): a deferral is a prediction, so name the check that would confirm it

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -325,6 +325,66 @@ filed at 03:14Z, claimed by its filing lane at 03:30Z, and that lane's branch re
 so every probe in §2 reported it free; for 52 minutes nothing but a time-based gate
 could have kept a second run off it.
 
+### 3-b. Before writing `next`, NAME the verification — in the ISSUE BODY
+
+`CLAUDE.md` ("The four TODO fields") forbids writing `Session-fit: next` until you
+can name the command the NEXT session will run to see the fix work, and can say a
+fresh session will be able to run it. Read the rule there; this section is where it
+lands in THIS flow, and the flow is where it has teeth: here a deferral does not
+stay in a chat report, it becomes an ISSUE, read later by a session holding none of
+this run's context. So the named command goes INTO the body, as the reason clause on
+the `Session-fit` line:
+
+```text
+Session-fit: next (not this session) — no corpus case covers this type yet, so
+one has to be recorded from a live read first; after that `vp test run
+corpus-replay` fails on the fold and passes with the fix, on any machine, no AWS.
+```
+
+What that answer looks like HERE, cheapest first. Walking the list is not a
+classification exercise — its value is that the SECOND entry, which looks like an
+ordinary `next`, is the one that is almost always `now`:
+
+- **Portable, so `next` is honest.** A committed unit test (`vp test run <file>`)
+  or a golden-corpus replay (`vp test run corpus-replay`, over
+  `tests/corpus/*.json`) runs offline on any machine with no AWS at all. This is
+  the common case in this repo, and naming it costs one line.
+- **Bound to THIS run's live AWS state, so `next` is a bad bet.** A drift this run
+  injected by hand, or a stack still standing. This is not merely unlikely to
+  survive the session: `/hunt-bugs`'s cleanup gate
+  (`.claude/hooks/bughunt-clean-gate.sh`) is armed before any deploy and refuses
+  every `git commit` / `gh pr create` / `gh pr merge` until each tracked stack is
+  deleted and the orphan sweep is clean — so this run cannot SHIP without
+  destroying its own verifier. The counter-move is
+  `/hunt-bugs` §5: while the stack is still up, harvest the live read into
+  `tests/corpus/` via `CDKRD_CORPUS_DIR`, which converts a session-bound verifier
+  into a portable one — after which the entry above applies and `next` is fine.
+- **Bound to the account, the region, or a window.** The shared-name core suite
+  (`tests/integration/basic/verify.sh` and its siblings) deploys FIXED stack names
+  (`CdkdriftIntegBasic`) into one account in `us-east-1` and must hold a GLOBAL
+  CLEAN WINDOW while it runs (`/verify-pr` step 7); and a fresh session may hold no
+  credentials at all, which `/verify-pr` step 6 already accepts as a legitimate
+  reason not to live-test. Naming it is still worth the line — it tells the next
+  session what it has to ACQUIRE before it can start.
+- **It does not exist yet.** No fixture under `tests/integration/` and no corpus
+  case covers the shape, and writing one is most of the work. The one case where
+  `next` is unambiguously right, and right BECAUSE you could name what is missing.
+- **You cannot name it at all.** Then nobody can confirm the fix later either —
+  that is an unbounded deferral, not a deferral. Do it now, or say in the body that
+  the fix would be unverifiable and why.
+
+The incident behind the rule is a sibling's, and its binding was a HOST rather than
+an account: go-to-k/cdk-local#560 was deferred on "a fixture / base-image change on
+a different axis" — a statement about the work's CATEGORY, never about who could
+check it. The defect is a Go RIE segfault under `linux/amd64` emulation on an arm64
+host, the machine that filed it was arm64, and the real verification was "run those
+fixtures on an arm64 host". The maintainer caught the misclassification; the flow
+did not. That exact shape cannot recur here — cdkrd has no Docker anywhere in its
+gates, and its `integ` gate (`.markgate.yml`) is read-only AWS and has no companion
+skill — so the binding that will bite in THIS repo is the account / region /
+live-resource one two bullets up. The error is identical either way: naming the KIND
+of work in place of naming the check.
+
 ## 4. CLAIM the chosen issues BEFORE editing
 
 For EACH issue you will start:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,6 +493,35 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   all review of a larger diff, which grows superlinearly because a reviewer reads
   the whole thing and cross-file interactions multiply. Defer on those.
 
+  **Before writing `Session-fit: next`, NAME the command that verifies the fix.**
+  A deferral is a PREDICTION — that a later session can finish this — and an
+  unstated prediction is never checked, so the field decays into naming the KIND
+  of work ("a fixture change", "a different subsystem"). That is classifying by
+  MEANS rather than by PURPOSE, and no list of `now` triggers can catch it,
+  because the next miss arrives in a shape the list does not contain. So you may
+  not write `next` until you can name, concretely, the command the NEXT session
+  will run to see the fix work — and can say a fresh session will be able to run
+  it. Not "run the tests": the test file. Not "check it live": the stack and the
+  region. The check is GENERATIVE rather than a lookup, which is the whole point,
+  and if naming it is HARD that difficulty IS the finding. It is one of four
+  things: the verifier is bound to THIS run's live AWS state (a stack this run
+  must delete before it can ship, a drift injected by hand, a clean window on the
+  shared-name suite) or to credentials a fresh session may not hold; it is
+  bound to THIS host (CPU architecture, an installed toolchain, a container image
+  already pulled); it does NOT EXIST yet and writing it is most of the work — the
+  one case where `next` is unambiguously right, and right BECAUSE you could name
+  what is missing; or you cannot name it at all, which is not a deferral but an
+  unbounded one. Measured 2026-08-26: go-to-k/cdk-local#560 was deferred on "a
+  fixture / base-image change on a different axis", a statement about the work's
+  CATEGORY. Its defect is a Go RIE segfault under `linux/amd64` emulation on an
+  arm64 host and the filing machine was arm64, so the real verification was "run
+  those fixtures on an arm64 host" — which nothing guarantees a fresh session
+  has. The maintainer caught the misclassification, not the flow. The converse is
+  the honest `next`: when you CAN name the check and any machine can run it, say
+  so in one line beside `Session-fit`, so the next session starts from the check
+  instead of re-deriving it. `/work-issues` §3-b applies this to a deferral that
+  becomes a filed ISSUE, with the repo-specific shapes the answer takes here.
+
   **`Session-fit: next` is NOT available for work discovered inside a scope the
   user framed as "do this across the repos in one session".** Three tells that
   force `now`: (a) you are about to file the SAME issue body in more than one


### PR DESCRIPTION
## Problem

`Session-fit: next` is an unstated PREDICTION that a later session can finish the work. Because it is never stated, it is never checked — and the classification degrades into naming the KIND of work ("a fixture change", "a different subsystem"), i.e. classifying by MEANS rather than by PURPOSE. No list of `now` triggers can catch that, because the next miss arrives in a shape the list does not contain.

## Fix

A GENERATIVE forcing question rather than another lookup table: **you may not write `Session-fit: next` until you can name, concretely, the command the NEXT session will run to see the fix work — and can say a fresh session will be able to run it.** If naming it is hard, that difficulty IS the finding.

Placed in two files, non-duplicating, per `/work-issues` 10-b ("pick ONE" home):

- **`CLAUDE.md`** carries the RULE, inside "The four TODO fields" where `Session-fit` is defined. Every session that writes the field reads it there, not only this flow — which 10-b routes to `CLAUDE.md` rather than to a skill.
- **`.claude/skills/work-issues/SKILL.md` 3-b** carries the APPLIED version, following the same split the four fields already use (defined in `CLAUDE.md`, applied in section 4 for labels and English-only). This flow is where a deferral stops being a chat line and becomes a filed ISSUE, so the named command goes into the body as the `Session-fit` reason clause.

## What the answer looks like in THIS repo

Adapted rather than transplanted — cdkrd's bindings are not the sibling's:

| Shape | Verdict |
| --- | --- |
| Committed unit test / `vp test run corpus-replay` over `tests/corpus/*.json` | portable, so `next` is honest |
| A drift injected by hand, or a stack still standing | `bughunt-clean-gate.sh` refuses every commit / PR until it is deleted, so the run cannot SHIP without destroying its own verifier — harvest into `tests/corpus/` via `CDKRD_CORPUS_DIR` while the stack is up |
| The shared-name core suite (`tests/integration/basic/verify.sh`, `CdkdriftIntegBasic`, `us-east-1`) | needs one account plus a GLOBAL CLEAN WINDOW; a fresh session may hold no credentials |
| No fixture and no corpus case exists yet | the one honest `next`, and honest BECAUSE you could name what is missing |
| Cannot name it at all | not a deferral, an unbounded one |

## Evidence

go-to-k/cdk-local#560 was classified `next` on "a fixture / base-image change on a different axis" — a statement about the work's CATEGORY. Its defect is a Go RIE segfault under `linux/amd64` emulation on an arm64 host, and the filing machine was arm64, so the real verification is "run those fixtures on an arm64 host", which nothing guarantees a fresh session has. The maintainer caught it, not the flow.

That binding was a HOST. cdkrd has no Docker in any gate and its `integ` gate is read-only AWS with no companion skill, so the shape that will bite here is the account / region / live-resource one — the text says so explicitly rather than importing the arm64 framing.

## Verification

Prose-only diff, so the CLAIMS are the artifact. Every path, hook, skill section and command the new text names was resolved against this repo, and every command it sends a future agent to run was RUN:

- `vp test run corpus-replay` — 1024 passed, 1.42 s, no AWS. Confirms the "portable, needs no AWS" claim.
- `tests/integration/basic/verify.sh` — `STACK=CdkdriftIntegBasic` (line 13), `REGION="${AWS_REGION:-us-east-1}"` (line 14).
- `.claude/hooks/bughunt-clean-gate.sh` — blocks `git commit` / `gh pr create` / `gh pr merge` while tracked stacks are pending; armed by `bughunt-track.sh add` before deploy, released by `verify` then `clear` on SWEEP CLEAN.
- `/hunt-bugs` section 5 + `CDKRD_CORPUS_DIR` — the harvest-while-deployed path exists as described.
- `/verify-pr` steps 6 and 7 — the numbering cited is correct (live-test; shared-name core suite plus clean window).
- `.markgate.yml` — `integ` is read-only AWS, `hash: diff`, 14d TTL, no companion skill. No `docker` anywhere in `.claude/hooks/`, `.markgate.yml` or `.claude/settings.json`.
- Gate liveness proved BEFORE the first commit: `git commit --dry-run` as a tool call returned `Blocked by check-gate`, not ordinary git output. `gate-if-matchers-1801` also passes.
- Mutation probe on the new section: injecting a bare `#560` and a fake `tests/integration/basic/nope.sh` into it makes `skill-doc-paths` fail on BOTH counts, so the fence discriminates on this text rather than passing vacuously. Restored, and the diff is insertions only.
- Full suite: typecheck pass, `vp check --fix` pass (formatter left the new prose byte-identical), `vp pack` pass, `vp test run` 346 files / 6549 tests pass.
- English-only: no CJK in the diff or the commit body; all issue references fully qualified as `go-to-k/<repo>#N`.
