### PR TITLE
chore(hooks): make the Stop hook see the lane it is running inside

### DIFF
--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # stop-unmerged-lane-warn.sh
 #
-# Stop hook. `stop-warn.sh` next to it catches UNCOMMITTED work in the main
-# tree. This catches the other, quieter half: a feature worktree whose branch
-# is COMMITTED but still ahead of `origin/main` -- a lane that is finished as
-# far as the editor is concerned and unfinished as far as the repo is.
+# Stop hook. It catches the quiet half of unfinished work: a feature worktree
+# whose branch is COMMITTED but still ahead of `origin/main` -- a lane that is
+# finished as far as the editor is concerned and unfinished as far as the repo
+# is. (The sibling cdkd repo pairs this with a `stop-warn.sh` covering the
+# UNCOMMITTED half in the main tree. This repo has no such hook, so do not read
+# the pair as coverage here; an earlier revision of this comment named it as if
+# it sat next to this file.)
 #
 # Why this is a hook rather than another sentence. CLAUDE.md already says a
 # NOT-CLOSEABLE verdict is a to-do list and not a stopping point, and already
@@ -22,6 +25,14 @@
 # alone separates "there is unmerged work here" from "there is not".
 set -u
 
+# BASH_SOURCE resolves to whichever checkout this copy of the hook lives in --
+# in a linked worktree that is the LANE, not the main tree. That is fine as a
+# place to run `git` from (every worktree shares one object store and one
+# `origin/main`), but it must NOT be used to decide which worktree to skip: the
+# session ending inside its own lane is the case this hook exists for, and an
+# earlier revision skipped exactly that one. Measured from a lane 5 commits
+# ahead: the hook printed nothing. The main tree is excluded by BRANCH below
+# (`main`/`master`), which is the property that actually identifies it.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO" 2>/dev/null || exit 0
 
@@ -33,7 +44,6 @@ git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 lanes=""
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
-  [ "$wt" = "$REPO" ] && continue
   br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
   [ -n "$br" ] || continue
   case "$br" in main | master) continue ;; esac
@@ -49,7 +59,10 @@ msg="WARNING: unmerged lane(s) still open -- a NOT-CLOSEABLE verdict is a TO-DO 
 Each branch below is committed but not on origin/main. If any is YOURS, you are not done: rebase, run the
 gates, open the PR, merge. If one belongs to another session, say which and why, rather than leaving it
 unexplained. And if you are ending the turn with nothing that will re-invoke you, the honest label is
-STOPPED, not WAITING."
+STOPPED, not WAITING.
+One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
+becomes an ancestor of origin/main and keeps reading as ahead. If a lane below is already merged, the
+remaining work is to remove its worktree and delete the branch -- not to open another PR."
 
 payload=$(printf '%s\n%s' "$msg" "$lanes" |
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -42,7 +42,17 @@ print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
 '
 }
 
-SANDBOX="$(mktemp -d)"
+# `pwd -P` is load-bearing, not tidiness. On macOS `mktemp -d` hands back a
+# path under `/var/folders/...` whose real location is `/private/var/...`, and
+# the hook derives its own root with `cd ... && pwd`, which canonicalises. Git,
+# meanwhile, records a worktree under whatever path it was CREATED with. So an
+# uncanonicalised sandbox makes the hook's root and git's listing two spellings
+# of one directory that never compare equal -- and any case whose subject is an
+# equality between those two paths passes no matter what the hook does. That is
+# how the self-lane case below was measured VACUOUS on its first attempt: the
+# defect it was written for (a skip keyed on the hook's own checkout) could be
+# reintroduced and the suite stayed green.
+SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
 REPO="$SANDBOX/repo"
@@ -79,6 +89,44 @@ git -C "$REPO" worktree add -q "$REPO/wt-two" -b feat/two HEAD
 git -C "$REPO/wt-two" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
 out=$(cd "$REPO" && bash "$RUN")
 check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
+
+# --- FIRES: run from INSIDE a lane worktree, that lane must still be named. ---
+# The case the hook exists for, and the one every case above misses: they all
+# `cd "$REPO"` (the main tree), so a skip keyed on the hook's OWN checkout was
+# invisible to all seven of them. An earlier revision derived the skip from
+# `BASH_SOURCE` and went silent for exactly this run. The main tree is excluded
+# by BRANCH, so removing that skip costs nothing here -- which this case pins
+# from the other side, by asserting the count is 2 rather than 3.
+mkdir -p "$REPO/wt-two/.claude/hooks"
+cp "$HOOK" "$REPO/wt-two/.claude/hooks/"
+out=$(cd "$REPO/wt-two" && bash "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
+check "names its OWN lane when run from inside it" "2" "$(lanes_in "$out")"
+if printf '%s' "$out" | grep -q 'feat/two'; then
+  pass=$((pass + 1)); printf 'OK   the self-lane is the one named\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the self-lane is not named\n"; printf 'FAIL the self-lane is named\n'
+fi
+
+# --- SILENT: the main tree ON `main`, ahead of origin/main, is NOT a lane.
+# Without this the `main`/`master` filter is unfenced: everywhere else in this
+# sandbox the main tree is LEVEL with origin/main, so the ahead-count check
+# already excludes it and deleting the branch filter changes nothing. Measured:
+# with this case absent, dropping `case "$br" in main|master) continue` left the
+# suite green. Direct commits on `main` are a different problem with its own
+# gate; this hook reports unmerged LANES.
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'on main'
+out=$(cd "$REPO" && bash "$RUN")
+check "the main tree on main is not a lane even when ahead" "2" "$(lanes_in "$out")"
+
+# --- The BRANCH filter, not the path, is what excludes the main tree. Put the
+# main tree on a feature branch that is ahead and it must be named like any
+# other lane; otherwise the two filters mask each other and neither is fenced.
+git -C "$REPO" checkout -q -b feat/main-tree-lane
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(cd "$REPO" && bash "$RUN")
+check "the main tree on a feature branch is a lane too" "3" "$(lanes_in "$out")"
+git -C "$REPO" checkout -q -
+git -C "$REPO" branch -q -D feat/main-tree-lane
 
 # --- The payload has to be valid JSON, or the harness swallows it silently. ---
 if printf '%s' "$out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then


### PR DESCRIPTION
Follow-up to go-to-k/cdk-real-drift#1822, which shipped this hook with a defect that made it inert for its own primary case.

## The defect

`stop-unmerged-lane-warn.sh` derived `REPO` from `BASH_SOURCE` and skipped the worktree it matched. The intent was to skip the main tree. The effect was the opposite: in a linked worktree `BASH_SOURCE` IS the lane, so the session ending inside its own unmerged lane -- exactly what the hook exists to catch -- got nothing.

Measured in the sibling cdk-local, whose copy is the same code, from a lane worktree five commits ahead: the hook printed EMPTY.

The main tree is identified by BRANCH (`main` / `master`), which the loop already checks, so the path skip was both redundant and the entire defect. It is gone.

## Why no case caught it

All seven cases ran the hook from the sandbox's MAIN tree, so a skip keyed on the hook's own checkout was invisible to every one of them. Three cases now cover it:

- the hook run from INSIDE a lane worktree, which must still name that lane;
- a main tree ON `main` and ahead of `origin/main`, which must stay SILENT (direct commits to main are a different problem with their own gate);
- a main tree put on a FEATURE branch, which must be named like any other lane -- pinning that the filter is by branch and not by path.

## The first attempt at that case passed while proving nothing

Worth recording, because a vacuous case is worse than none. On macOS `mktemp -d` returns a `/var/folders/...` path whose real location is `/private/var/...`. The hook canonicalises its own root with `cd && pwd`; git records a worktree under whatever path it was CREATED with. The two spellings never compare equal, so a case whose subject IS that equality cannot fail. Reintroducing the skip left the suite green. The sandbox root is now `cd "$(mktemp -d)" && pwd -P`.

The branch filter was unfenced for a second, independent reason: everywhere else in the sandbox the main tree is LEVEL with `origin/main`, so the ahead-count check already excluded it and deleting the filter changed nothing.

## Two smaller corrections

- The warning now says what to do about its one expected false positive. This repo squash-merges, so a merged branch never becomes an ancestor of `origin/main` and keeps reading as ahead; the remedy there is to remove the worktree and delete the branch, not to open another PR. Without that line the hook tells the reader to open a PR for work already on main.
- The header claimed a `stop-warn.sh` sits next to it covering the UNCOMMITTED half. That hook exists only in cdkd. Naming it here claimed coverage this repo does not have, so the note now says so explicitly.

## Verification

Probed rather than asserted, each probe restoring first and the restore verified:

| mutation | measured |
|---|---|
| reintroduce the `BASH_SOURCE` skip | 3 fail |
| drop the `main` / `master` filter | 1 fail |

11 pass / 0 fail under bash 5.x and macOS system bash 3.2.

`vp run check` rc 0, `vp run build` rc 0, full suite **346 files / 6550 tests** green.

One note on that suite: it fails 13 tests in `tests/json-empty-on-error.test.ts` in a fresh worktree with no `dist/`, because those cases spawn the built CLI and read its exit code. Building first makes them pass. Unrelated to this diff, which touches only `.claude/hooks/**`, but worth stating rather than leaving a reader to wonder why a first run was red.

The same fix is going to cdkd and cdk-local, whose copies carry the identical line.
