### PR TITLE
chore(work-issues): query for the precondition, not the remedy — and build a fresh worktree

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -483,6 +483,32 @@ instance: one command factory mishandling a flag, one resolver arm missing a cas
 one caller of a shared helper assuming the old contract. Once the root cause is
 named, grep for the same shape across `src/` before writing the fix.
 
+**Query for the PRECONDITION minus the REMEDY, never for the remedy alone.** When the
+defect is a MISSING thing, the obvious grep searches for the thing that is missing —
+and it can only ever return the sites that already HAVE it. The absent sites are
+invisible to it by construction, so the sweep reports itself complete while covering
+only the half that was never broken. Ask instead: what makes a site ELIGIBLE for this
+defect, and which eligible sites lack the fix?
+
+Measured in go-to-k/cdk-local on 2026-08-27, whose root cause was "a fixture leaks the
+Docker image it builds". The sweep was bounded by a grep for the REMEDY
+(`docker rmi|docker image rm|docker image prune`); it returned five sites, every one of
+them a fixture that already had cleanup, and the lane closed all five and declared the
+class done. The correct query is eligibility minus remedy — builds an image, does not
+remove one — and it returns six more, plus a seventh that neither query finds. The
+remedy-shaped query had seen 5 of 12 eligible sites.
+
+**The same run then repeated the mistake one level up, which is why this is a rule and
+not a footnote.** An agent that had just diagnosed the flaw in the orchestrator's query
+sized the residue from the ONE instance it had tripped over — "one site, ~30 min" —
+rather than asking which query would find the class. It was seven. **A count derived
+from the instance you happened to hit is not a count**, and sizing a deferral is exactly
+where that bites, because `Effort` and `Estimate` are what a future session budgets from.
+
+The shape recurs here wherever a fix is an ADDED guard rather than a changed line — a
+missing `handledProperties` entry, a provider without a validation arm, a resource type
+with no drift comparator. Grepping for the guard finds the types that have it.
+
 **N sites of one root cause is ONE issue and ONE PR, never N issues.** This is the
 single largest source of unbounded backlog growth: split into N, each site pays the
 full fixed cost — triage, claim, worktree, review tier, integ run, merge — for a fix
@@ -637,7 +663,21 @@ Never edit in the main checkout. Per lane:
 git worktree add .worktrees/<name> -b wt-<name> main
 mise trust .worktrees/<name>/.mise.toml
 ( cd .worktrees/<name> && pnpm install )     # worktrees have no node_modules
+( cd .worktrees/<name> && vp run build )     # ...and no dist/ -- see below
 ```
+
+**Build BEFORE the first test run, and read a fresh worktree's failures with that
+in mind.** A worktree starts with no `dist/`, and any test that spawns the built
+CLI then fails on the missing binary rather than on its subject — with an
+assertion message about the SUBJECT, which is what makes it costly. Measured on
+2026-08-27: a docs-only lane in a fresh worktree saw 13 failures in
+`tests/json-empty-on-error.test.ts` (`expected 1 to be 2`), reproduced them with
+its own edit stashed, and had begun writing them up as "a peer merge broke main"
+— the same file passed in the main checkout, which HAS a `dist/`, so every
+comparison pointed at main. `vp run build` in the worktree turned it green with
+no other change. **A fresh worktree failing where the main checkout passes is
+evidence about the WORKTREE first**, and one build costs seconds against a false
+broken-main report.
 
 Do the fix in the worktree (match the existing table/entry pattern exactly; ESM
 relative imports need the `.js` extension). **Always add a unit test that fails


### PR DESCRIPTION
## Summary

Two lessons carried from a `/work-issues` run in
https://github.com/go-to-k/cdk-local on 2026-08-27, adapted to this repo. Skill
text only — no `src/**` change.

### 1. A sweep that greps for the REMEDY can only find sites that already have it

When the defect is a MISSING thing, the obvious grep searches for the thing that is
missing. The absent sites are invisible to it by construction, so the sweep reports
itself complete while covering only the half that was never broken.

There, the root cause was "a fixture leaks the Docker image it builds". The sweep was
bounded by `grep 'docker rmi|docker image rm|docker image prune'` — a search for the
remedy. It returned five sites, every one of them a fixture that already had cleanup,
and the lane closed all five and declared the class done. Eligibility minus remedy
(builds an image, does not remove one) returns six more, plus a seventh that neither
query finds. The remedy-shaped query had seen 5 of 12 eligible sites.

**The same run then repeated the mistake one level up**, which is what makes it a rule
rather than a footnote: an agent that had just diagnosed the flaw in the orchestrator's
query sized the residue from the ONE instance it had tripped over rather than asking
which query would find the class. It was seven. That lands directly on the `Effort` and
`Estimate` lines a future session budgets from.

### 2. Build a fresh worktree before its first test run

A worktree starts with no `dist/`, so any test that spawns the built CLI fails on the
missing binary while REPORTING an assertion about its subject. That mismatch is what
makes it expensive.

Measured live while preparing this very PR: a docs-only lane in a fresh worktree saw 13
failures in a CLI exit-code suite (`expected 1 to be 2`), reproduced them with its own
edit stashed — correctly ruling out its own change — and had begun writing them up as
"a peer merge broke main". The same file passed in the main checkout, which HAS a
`dist/`, so every comparison pointed at main. One `vp run build` in the worktree turned
it green with no other change. A fresh worktree failing where the main checkout passes
is evidence about the WORKTREE first.

The bootstrap block in section 5 now includes the build, and says why.

## Test plan

Skill text only. `vp check` clean, full suite green, and the build that lesson 2 is
about was run in this worktree (which is how lesson 2 was found).

## Remaining work

Nothing remaining for this repo. The same two lessons are landing in all three repos
this session, per the skill's own cross-repo rule — see the sibling PRs in
https://github.com/go-to-k/cdk-local and the other repo of the trio.
