### PR TITLE
fix(build): make `test` depend on `build`, so a cold checkout is not red

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -143,7 +143,13 @@ export default defineConfig({
       build: { command: 'vp pack', cache: false },
       dev: { command: 'vp pack --watch', cache: false },
       check: { command: checkCommand },
-      test: { command: 'vp test run' },
+      // `dependsOn: ['build']` because several suites SPAWN `dist/cli.js`
+      // (`tests/json-empty-on-error.test.ts` among them). Without it a bare
+      // `vp test run`, and `vp run verify` on a clean checkout, execute a stale
+      // or absent binary -- 13 cases failed on a fresh clone for a reason that
+      // had nothing to do with the source. `runtime:smoke` already declares it
+      // for the same reason. See go-to-k/cdk-real-drift#1825.
+      test: { command: 'vp test run', dependsOn: ['build'] },
       'test:watch': { command: 'vp test watch', cache: false },
       'test:coverage': { command: 'vp test run --coverage', cache: false },
       lint: { command: 'vp lint' },
@@ -162,7 +168,11 @@ export default defineConfig({
       // typecheck` reported GREEN from cache, so the gate marker was set on a red
       // tree and the break reached main. Typecheck is ~1s; correctness > the cache.
       typecheck: { command: 'tsc --project tsconfig.json --noEmit', cache: false },
-      verify: { command: 'vp run check && vp run test && vp run test:hooks && vp run build' },
+      // `build` FIRST: `test` spawns `dist/cli.js`, so running it before the
+      // build measured the previous commit's binary. The `dependsOn` above makes
+      // this ordering redundant rather than load-bearing, and it is kept so the
+      // sequence reads in the order it actually happens.
+      verify: { command: 'vp run build && vp run check && vp run test && vp run test:hooks' },
       'runtime:smoke': {
         command: 'node dist/cli.js --version',
         dependsOn: ['build'],


### PR DESCRIPTION
## Summary

`vp run verify` failed 13 cases on a clean clone of `main`, and the failure had
nothing to do with the source.

`tests/json-empty-on-error.test.ts:26` SPAWNS `../dist/cli.js`, and the `test`
task declared no `dependsOn: ['build']` — while `runtime:smoke`, which runs the
same binary, already did. `verify` compounded it by ordering `build` **last**:

```
check && test && test:hooks && build
```

So on a checkout with no `dist/`, or one left from an older commit, the suite
measured a stale or absent binary.

## Proof, both directions

One session, no source change in between:

```text
rm -rf dist && vp run test    (before)  ->  13 failed | 6537 passed
rm -rf dist && vp run test    (after)   ->  6550 passed
rm -rf dist && vp run verify  (after)   ->  rc=0
```

## The CLI was always correct

Worth stating plainly, because the issue was first filed with the wrong
diagnosis:

```text
$ node dist/cli.js record --json --bogus
error: unknown option "--bogus" — see cdkrd --help
[]
ACTUAL EXIT=2
```

Exit 2 with `[]` on stdout is exactly what the suite asserts —
`src/cli.ts` already ends that path in `flushAndExit(2)`. There is no exit-code
regression. https://github.com/go-to-k/cdk-real-drift/issues/1825 was filed
before executing the CLI, and is corrected in place rather than edited, so the
mistake stays visible.

## Why this is worth more than one red file

`vp run verify` gates `check` and `verify-pr`, so every lane in this repo was
either unable to set its markers or setting them over a red suite. The second is
the dangerous one, and it is the default once an agent decides a failure is
"unrelated to my change" — which, this time, it genuinely was. That is precisely
the reasoning that would have shipped this.

Found while landing an unrelated cross-repo prose change; the gates would not go
green, and this is why.

## Test plan

- `rm -rf dist && vp run test`: 6550 passed (13 failed before the change).
- `rm -rf dist && vp run verify`: rc=0, 346 files / 6550 tests, 0 errors.
- The reverse direction measured too: reverting `vite.config.ts` alone and
  re-running cold reproduces exactly the 13.
- Config-only change; no `src/**` touch.

Closes #1825
