### PR TITLE
chore(work-issues): filing the structural fix does not stop the cascade

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1122,8 +1122,42 @@ than trickling them.
   tell everyone what they are chasing. Then do NOT take the structural fix late
   in the cascade — adding new code at round five is how round six happens. Take
   the narrow fix, file the structural one, and reference it from the narrow fix
-  so the next reader sees the choice was made rather than missed. Two shapes
-  recur, and they are distinguishable a round apart:
+  so the next reader sees the choice was made rather than missed.
+
+  **Filing the structural fix does not STOP the cascade, and the sentence above
+  used to imply it would.** Measured in go-to-k/cdk-local#596 on 2026-08-27: the
+  structural issue was filed at round five and the rounds ran to TWELVE,
+  producing eleven instances of one defect class in one PR, five of them
+  introduced by the fix for the previous one. What ended it was not a better
+  check — it was making the artifact **CLAIM LESS**.
+
+  The tell is that each round's fix is more SOPHISTICATED than the last. There a
+  `/run-integ` orphan sweep went name scan -> scoped filter -> guarded filter ->
+  stderr classification -> status filter, while the plain rc-only sweeps three
+  lines away were correct the whole time, under the exact conditions that
+  defeated the clever ones: `grep -q 'does not exist'` also matches botocore's
+  `The source_profile ... does not exist`, raised before any network call, so a
+  broken profile reported CLEAN having queried nothing. The sophistication WAS
+  the defect. That sweep now prints raw command output and names both outcomes
+  instead of emitting a verdict — a command that claims nothing cannot claim
+  something false. Expect it to feel like a retreat; it is one, and it converges.
+
+  Two corollaries, both paid for there:
+
+  - **Fence the REMEDIATION, not just the detection.** Five of eleven instances
+    arrived through a fix, and the last was in the remediation: a destroy built
+    from names missing a required suffix exits 0 SILENTLY, so the operator read
+    success with the resources still deployed. Every fence to that point pinned
+    the DETECTION, so restoring that line left the suite green. If a procedure
+    both detects and repairs, the repair is where the next instance goes.
+  - **Do not pre-commit to a remedy for a finding you have not seen.** Twice the
+    stated plan was "if instance nine appears, delete the whole thing",
+    announced before instance nine existed; when it arrived, deleting would have
+    left the flow with NO check at all — instance one made permanent. A rule
+    announced in advance is a way of not having to exercise judgement. Say what
+    the next finding would have to SHOW, not what you will do about it.
+
+  Two shapes recur, and they are distinguishable a round apart:
   - **TWO SPELLINGS OF ONE QUESTION** — the fix is to make both sites use ONE
     predicate verbatim, not to write a better second spelling. A better spelling
     looks like a fix and passes its own test, so this is the sub-case that keeps
@@ -1152,6 +1186,7 @@ than trickling them.
     from the template, a normalizer left it untouched) misses real drift AND
     manufactures false positives at the same time, which is why this repo's
     corpus is authoritative over any predicate reasoned about in isolation.
+
 - **WITHDRAWING the half that cannot be made right is a legitimate outcome, and
   the residual issue must carry the MEASUREMENTS, not just the diagnosis.** The
   rule above says where the fix goes; this says what to do with the code already


### PR DESCRIPTION
## Summary

Third of three landings for one flow lesson. The cascade rule in section 8 says:
after round two name the structural absence, take the narrow fix, file the
structural one. That is exactly what happened in
https://github.com/go-to-k/cdk-local/pull/596 — the structural issue
(https://github.com/go-to-k/cdk-local/issues/601) was filed at round FIVE — and
the rounds ran to **twelve**, producing **eleven instances of one defect class in
one PR, five of them introduced by the fix for the previous one**.

So the rule implied a convergence it does not deliver. This adds what actually
ended it.

## What ended it

Not a better check. Making the artifact **claim less**.

The tell is that each round's fix is more SOPHISTICATED than the last. That PR's
orphan sweep went name scan -> scoped filter -> guarded filter -> stderr
classification -> status filter, while the plain `rc`-only sweeps three lines
away were correct the whole time, under the exact conditions that defeated the
clever ones:

```text
AWS_PROFILE=broken   # source_profile references a missing profile
  the sophisticated stack scan  -> "AWS clean"
  the rc-only SSM sweep         -> "FAILED to query -- NOT a clean verdict"
```

`grep -q 'does not exist'` also matches botocore's
`The source_profile "x" ... does not exist`, raised BEFORE any network call. The
sophistication WAS the defect.

## Two corollaries

- **Fence the REMEDIATION, not just the detection.** Five of the eleven instances
  arrived through a fix, and the last one was in the remediation: a destroy built
  from names missing a required suffix exits 0 SILENTLY. Every fence up to that
  point pinned the detection, so restoring that line left the suite green.
- **Do not pre-commit to a remedy for a finding you have not seen.** Twice the
  stated plan was "if instance nine appears, delete the whole thing", announced
  before instance nine existed. When it arrived, deleting would have left the
  flow with NO check at all — instance one made permanent.

## A note on how this PR itself went

Landing it here was blocked: `vp run verify` was red on a clean `main`, because
`test` spawned `dist/cli.js` without depending on `build`. I nearly set the
markers anyway on the grounds that the failure was "unrelated to my change" —
which is the exact reasoning the bullet above warns about, and which I had just
written into an issue body. Fixed first, in
https://github.com/go-to-k/cdk-real-drift/pull/1826, so this lands on a green
tree rather than over a red one.

## Test plan

- `vp run verify`: rc=0, 346 files / 6550 tests, 0 errors — on the base that
  now includes the build-order fix.
- Prose-only change to one agent-instruction file; no `src/**` touch.
- `vp fmt` applied (this repo formats markdown under `.claude/**`, unlike its
  siblings).

## Cross-repo

cdk-local https://github.com/go-to-k/cdk-local/pull/606 (merged), cdkd
https://github.com/go-to-k/cdkd/pull/2331 (open). Per section 10-c, the session
that finds a flow lesson owns all three landings.
