### PR TITLE
chore(work-issues): re-derive review depth and counts at the final sha; probe the state axis

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -67,6 +67,35 @@ Run each check and report pass/fail:
      code, unrelated edits), and inconsistencies between changed files.
    - If a shared helper changed, list its importers (`grep -rl` under `src`/
      `tests`) and confirm the new behavior is correct for each.
+   - **Re-derive the review DEPTH at the FINAL sha, not at the first commit.**
+     Depth is a function of the diff, and the diff GROWS across fix-back rounds
+     while the depth decision, made once, does not. There is no reviewer tier
+     here to recompute — this repo ships no multi-agent reviewer set and no
+     `/review-pr` skill (CLAUDE.md keeps `pr-review` UNPORTED because cdkrd is
+     solo), and `.markgate.yml` keeps that gate INERT and UNWIRED — so what gets
+     frozen is your own call: how closely to read, and whether to
+     dispatch read-only reviewers at all for a diff big enough to warrant them
+     (`/work-issues` §8 covers what to do when two of them contradict each
+     other). Nothing re-opens that call mechanically, and on a prose / tooling PR
+     nothing even stales the marker that would force a re-run: `check` and `docs`
+     — the two gates this one is an AND of — include `src/**`, `tests/**`,
+     `docs/**`, `README.md` and `DESIGN.md`, none of which a `.claude/**` fix
+     round touches. Measured in cdk-local on 2026-08-27
+     (go-to-k/cdk-local#609): tiered from its first commit at 819 LOC / 5 files
+     and given ONE reviewer, its fix round took it to 1342 LOC, and it merged at
+     1466 added lines across 5 files (`gh pr view 609 -R go-to-k/cdk-local
+--json additions,changedFiles`, re-derived 2026-08-28). The spec and test
+     reviewers added only after re-computing found a live order-blind fail-open
+     in the new code plus two wrong counts in the PR body — neither inside the
+     single code reviewer's remit. So re-measure with
+     `git diff --stat "$(git merge-base origin/main HEAD)"` after the LAST fix
+     round and re-decide, rather than carrying the first round's call forward.
+   - Then say the tree is FINAL when it is, and batch the remaining findings into
+     ONE round — an agent handed findings will otherwise fix, verify and hand
+     back, which re-runs whatever the next step costs (here step 7's shared-name
+     suite, and the `integ` gate's `hash: diff` marker, which a comment-only
+     change to an in-scope file still stales). `/work-issues` §8 records what
+     skipping that cost.
 
 6. **Live-test changed behavior (per-PR, collision-safe)**
    - Unit tests verify code correctness; this verifies _feature_ correctness

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -546,8 +546,22 @@ The tell is grammatical rather than technical: a number arriving as a WORD
 ("nine sites", "a third copy") was counted by a person or an agent, while one
 arriving as command output was counted by a machine. Before a relayed count goes
 anywhere durable — an issue body, a PR body, this file — run the query yourself
-and put it in the text. It is one command. What worked on that run was the
-implementing agent deriving its next count with `awk` and catching its own
+and put it in the text. It is one command. **Run it at the sha that artifact will
+describe**, because WHEN is the other half of the rule and the half that actually
+fails: a count is correct for the round that reported it and stale by the time it
+reaches the PR body, because the body is written once and the branch keeps
+moving. Measured in cdk-local on 2026-08-27 (go-to-k/cdk-local#614): one run
+published four counts, every one accurate for its round and wrong against the
+merged branch — 90 cases (94 by merge); `52 -> 93` for a file that was NEW, so
+`0 -> 118` against `main`; `354 -> 368`, where 354 was a mid-PR peak and the real
+delta is `337 -> 358` for a feature later deleted; and "6 sites closed" against an
+enumeration that omitted one the totals included (7). Three of the four reached PR
+bodies and were patched after review caught them. So re-derive every number in a
+body after the LAST fix round, not once when you first wrote it — and note that a
+count already committed to a durable artifact goes stale the same way: this file
+said "nine" `.claude/hooks/*.test.sh` harnesses in two places until 2026-08-28,
+when `ls .claude/hooks/*.test.sh | wc -l` returned 15. What worked on that run
+was the implementing agent deriving its next count with `awk` and catching its own
 correction mid-flight, and declining to relay a path from the orchestrator's
 message after grepping and finding no such file.
 
@@ -690,7 +704,7 @@ behavior by standalone `.claude/hooks/*.test.sh` suites you run BY HAND (`bash
 .claude/hooks/<name>.test.sh` from the repo root) — nothing in `vp test run` or CI
 invokes those, so a hook change resting on a green suite plus green CI is not
 verified at all. Run that harness FROM `.claude/hooks/`, never from a copy parked
-elsewhere: all nine suites resolve their subject from their OWN script path —
+elsewhere: every suite resolves its subject from its OWN script path —
 `$(dirname "$0")` or the interchangeable `$(dirname "${BASH_SOURCE[0]}")` — with no
 env override for it (`BUGHUNT_TRACKER_OVERRIDE` overrides the TRACKER script, not the
 hook). A copy under a scratch directory therefore points at a sibling that is not
@@ -756,7 +770,7 @@ fence in this repo was put through them on 2026-08-20
   `parserOpts` at all — which is why all 13 `type!:` merges in this repo's history
   released a version and left no CHANGELOG entry behind.
 
-And ask the dumbest question last: **is anything RUNNING it?** The nine
+And ask the dumbest question last: **is anything RUNNING it?** The
 `.claude/hooks/*.test.sh` harnesses had no `vp run` task and no CI step — they are
 shell, so `vp test run` never saw them — and had been exercised only by hand since
 the day each was written (`vp run test:hooks` now runs them, in CI too).
@@ -765,8 +779,29 @@ The general shape: **a fence is not evidence until you have watched it go red on
 something you had not already counted.** Calibration says it is not noisy; only
 the spelling and deletion probes say it is load-bearing.
 
-**Those two probes test the RULE; a third is needed when the subject is a
-CLASSIFIER, because there the weak part is the POPULATION.** A classifier is any
+**Both probes above vary the INPUT. The second axis is the STATE the subject is in
+when the input arrives, and that one gets enumerated by ACCIDENT** — every case
+reuses whatever fixture setup the first case needed, so the suite covers one row
+of a table it never drew, and goes green over every defect in the other rows.
+Measured twice in one cdk-local PR on 2026-08-27 (go-to-k/cdk-local#609): a commit
+gate shipped 52 green cases with two live fail-opens, was fixed, and shipped 93
+green cases with four more. Both times the misses were a file STATE the fixture
+never entered — untracked, tracked-but-modified, deleted on disk — not a command
+shape nobody imagined, and one of those branches let a NUL byte reach a commit.
+DRAW THE GRID: enumerate the states on one axis and the input shapes on the other
+and write the cells out. Six states by four command shapes ended it there, made
+the deliberately-uncovered cells NAMEABLE rather than merely absent, and surfaced
+three FALSE blocks that a one-dimensional suite cannot produce at all. The state
+axis is repo-specific, so name it from what the subject actually reads: a
+`.claude/hooks/*.test.sh` case reads the TREE (clean, staged-only, dirty,
+untracked-only, on `main`, on a branch, inside a worktree), while a fold or
+classify fence reads the TIER a property lands in (`declared`, `undeclared`,
+`atDefault`, `readGap`) plus the empty-husk shape `isTrivialEmpty` pre-empts —
+which is the row a hand-picked case most often skips, and the row
+go-to-k/cdk-real-drift#1647 turned out to live in.
+
+**The spelling and deletion probes test the RULE; a third is needed when the
+subject is a CLASSIFIER, because there the weak part is the POPULATION.** A classifier is any
 function deciding which of several shapes an input is — `classifyTransient` and
 `isDependencyViolation` (`src/revert/transient.ts`, `src/revert/apply.ts`),
 `classifyStackStatus` and `isResourceNotFoundError` (`src/aws-errors.ts`),
@@ -1113,8 +1148,9 @@ than trickling them.
   sweep, run the fixture end to end against stubs first — two seconds of a dry run
   catches it.
 - **When a fix round produces the NEXT round's blocker twice, stop reviewing the
-  patch and question its SHAPE.** `/verify-pr` already says to re-review the fix
-  delta; this is what to do when that keeps paying out. Each fix is locally
+  patch and question its SHAPE.** `/verify-pr` step 5 re-reads the WHOLE diff on
+  every run, fix-round deltas included, and re-decides review depth at the final
+  sha; this is what to do when that keeps paying out. Each fix is locally
   correct and moves the failure one layer out rather than removing it, and the
   blockers are found by executing a probe or tracing a window — never by
   re-reading the diff. After round two, ask what the rounds have in COMMON: it is


### PR DESCRIPTION
## Summary

Mirrors the three `/work-issues` flow lessons filed in #1828 (landed in
go-to-k/cdk-local#614; companion filing go-to-k/cdkd#2341, so the mirror set is
complete). Each is amended into the step where it fires, and adapted to this
repo's gates rather than copied — all three landing spots differ from
cdk-local's.

**1. `/verify-pr` step 5 — re-derive the review DEPTH at the FINAL sha.** Depth
is a function of the diff, and the diff grows across fix-back rounds while the
decision, made once, does not. cdk-local's version is about recomputing a
sha-bound `pr-review` TIER; there is no tier here to recompute — this repo ships
no multi-agent reviewer set and no `/review-pr` skill, and `.markgate.yml` keeps
`pr-review` INERT and UNWIRED — so what freezes is the agent's own call. Worse
here than there: on a prose / tooling PR nothing even stales the marker that
would force a re-run, because `check` and `docs` (the two gates `verify-pr` is an
AND of) do not include `.claude/**`.

**2. `/work-issues` §5 — re-derive counts at the FINAL sha.** The existing count
paragraph already says a relayed number must be re-run; the half it omitted is
WHEN. Folded into that paragraph rather than added beside it, so it stays one
rule.

**3. `/work-issues` §5 — a suite enumerated along ONE dimension goes green over
defects in the other.** Added beside the "a fence is not evidence until you have
watched it go red" paragraph. The state axis is named from what cdkrd subjects
actually read: a `.claude/hooks/*.test.sh` case reads the TREE, while a fold or
classify fence reads the TIER (`declared` / `undeclared` / `atDefault` /
`readGap`) plus the empty-husk shape `isTrivialEmpty` pre-empts — the row #1647
turned out to live in.

## Two defects the per-repo claim check surfaced

The issue asks that each claim be verified against THIS repo's files before
shipping. Doing that found two things wrong in the existing text, both fixed
here:

- §8 asserted "`/verify-pr` already says to re-review the fix delta". It said
  nothing of the kind: `grep -ni "re-review\|fix delta\|depth\|reviewer\|recommendation\|tier"`
  over `.claude/skills/verify-pr/SKILL.md` returned rc=1, zero hits. Repointed at
  what step 5 actually does — and step 5 now genuinely covers review depth, so
  the pointer is true rather than merely narrowed.
- The file said "nine" `.claude/hooks/*.test.sh` harnesses in two places.
  `ls .claude/hooks/*.test.sh | wc -l` returns **15**, and `vp run test:hooks`
  prints `harnesses run: 15`. Both occurrences rewritten to carry no count, and
  the drift is cited inside lesson 2's own paragraph as a live instance of the
  rule being added.

## Evidence check

Every cited record was opened rather than relayed (§10-c):

- go-to-k/cdk-local#609 — MERGED, **1466 additions / 5 files**
  (`gh pr view 609 -R go-to-k/cdk-local --json additions,changedFiles`),
  consistent with a PR tiered at 819 LOC growing past its first-round call.
- go-to-k/cdk-local#614 — MERGED; its body carries the four-count table quoted
  in lesson 2 (90→94; 52→93 vs 0→118; 354→368 vs 337→358; 6 vs 7).
- go-to-k/cdkd#2341 — OPEN, the companion filing. Per §10-c a lane WORKING a
  mirror issue does not mirror onward, so nothing was re-filed into the siblings.
- #1647 — CLOSED, and its body does describe the `isTrivialEmpty`-swallowed
  all-false-leaf row cited in lesson 3.

## Test plan

Prose-only diff (no `src/**`), so `verify-pr-gate` exempts it from the live-test
tier. The verification owed is §8's prose arm — resolve every gate, path, skill
and command the new text names, and run each command it sends the next agent to
run:

- `vp run typecheck` rc=0; `vp check --fix` rc=0 (0 errors, no files modified);
  `vp pack` rc=0; `vp test run` rc=0 (346 files, 6550 tests).
- `vp run test:hooks` rc=0, `harnesses run: 15  failed: 0`.
- `tests/skill-doc-paths.test.ts` **went RED on this diff first** — the draft
  cited `.claude/agents` (as a path that deliberately does not exist), and the
  fence has no negation exemption. Rewritten to name the absence in prose rather
  than blunting the fence; 50/50 green after. That is the "watched it go red on
  something you had not already counted" evidence §5 asks for, produced by this
  change rather than asserted about it.
- `tests/markdown-fmt-corruption-1771.test.ts` green.
- `vp fmt` run to a fixed point and confirmed IDEMPOTENT by hash across two runs
  (§10-d's re-parenting trap): no paragraph changed owner.
- Commands the new text names were run, not assumed:
  `git diff --stat "$(git merge-base origin/main HEAD)"`,
  `ls .claude/hooks/*.test.sh | wc -l`, and the `gh pr view` above.
- Gate liveness proved before the first commit: `git commit --dry-run` as a tool
  call returned `Blocked by check-gate`, so the hooks fire.

Closes #1828
