### PR TITLE
chore(work-issues): a skill doc cannot cite a repo path to say it is absent

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1795,6 +1795,30 @@ pnpm install                  # worktrees have no node_modules
   the reformatted diff before committing; the damage is invisible in the source you
   typed.
 
+- **A skill doc cannot cite a repo path in order to say it is ABSENT.**
+  `tests/skill-doc-paths.test.ts` resolves every path-shaped code span in every
+  `.claude/skills/*/SKILL.md`, and it has no negation exemption on purpose: a
+  genuinely stale path would otherwise hide behind a "no longer exists" phrasing,
+  which is the class the fence exists to catch. Adding an exemption is therefore
+  the wrong repair — reword instead. Measured 2026-08-28
+  (go-to-k/cdk-real-drift#1829): a draft explaining that this repo has no reviewer
+  tier put the dot-claude agents directory in a code span to say it does not
+  exist, and went red; naming the absence in PROSE ("this repo ships no
+  multi-agent reviewer set and no `/review-pr` skill") passes and reads better.
+  Note that this very bullet cannot quote that example in a code span either — it
+  went red a second time for exactly that, which is the rule demonstrating itself.
+  This bites MIRROR lanes hardest, because adapting a sibling's lesson so often
+  means stating that the mechanism it assumes is missing here. Two details of the
+  fence make the reword easy once you know them: a span is only checked when its
+  FIRST segment is an existing top-level directory, so an invented root is not
+  checked at all while anything under the real `.claude` tree is; and `PATH_LIKE`
+  requires a leading word character, so a skill name like `/review-pr` is never
+  treated as a path. A gate that DOES exist, such
+  as the INERT `pr-review` entry in `.markgate.yml`, can still be cited by name.
+  Run `vp test run tests/skill-doc-paths.test.ts` before the commit rather than
+  after a full gate cycle: on a prose-only diff it is the one fence that can
+  actually go red.
+
 - A `work-issues`-only edit is outside BOTH the `check` and `docs` gate scopes, but
   `check-gate` verifies both markers on every commit without computing scope, and a
   fresh worktree starts with NONE — so run `/check` + `/check-docs` there before the


### PR DESCRIPTION
## Summary

§10 retrospective for the `/work-issues` run that landed #1829 (closing #1828).
One lesson, and it was found by RUNNING the flow rather than reasoned about.

`tests/skill-doc-paths.test.ts` resolves every path-shaped code span in every
`.claude/skills/*/SKILL.md`, and it has no negation exemption. That is correct —
a genuinely stale path would otherwise hide behind a "no longer exists"
phrasing, which is the class the fence exists to catch — but it means a skill doc
cannot cite a repo path in order to say the path is ABSENT, and the repair is to
reword rather than to add an exemption.

This bites MIRROR lanes hardest, which is why it belongs in the skill: adapting a
sibling repo's lesson so often means stating that the mechanism it assumes is
missing here. #1829 was exactly that shape — explaining that this repo has no
reviewer tier — and it went red on the draft.

The bullet then went red a SECOND time for quoting its own example in a code
span, so the text now says so; the rule demonstrates itself.

## What the bullet records beyond the rule

Two mechanics of the fence, both read out of the test rather than guessed, which
turn the reword from guesswork into a mechanical fix:

- a span is only checked when its FIRST segment is an existing top-level
  directory (`PATH_ROOTS` is `readdirSync(ROOT)` minus a non-citable set), so an
  invented root is not checked at all while anything under the real `.claude`
  tree is;
- `PATH_LIKE` requires a leading word character, so a skill name like
  `/review-pr` is never treated as a path and needs no rewording.

Placed in §10-d beside the `vp fmt` re-parenting trap — the other thing that only
bites a prose-only diff in this same file. §10-c's "pay for what you add" was
settled in #1829, which cut two stale counts and one false cross-reference.

## Test plan

Prose-only diff (no `src/**`), so `verify-pr-gate` exempts it from the live-test
tier; the verification owed is §8's prose arm.

- `vp run typecheck` rc=0; `vp check --fix` rc=0; `vp pack` rc=0;
  `vp test run` rc=0 (346 files, 6550 tests).
- `vp run test:hooks` rc=0, `harnesses run: 15  failed: 0`.
- `tests/skill-doc-paths.test.ts` — watched go RED twice on this diff and green
  after each reword; 50/50 with `tests/markdown-fmt-corruption-1771.test.ts`.
- `vp fmt` confirmed IDEMPOTENT by hash across two runs after every edit, and the
  reformatted diff read before committing (§10-d).
