### PR TITLE
chore(work-issues): name the killed/refused-call cwd trigger beside the failed-cd incident

### DIFF
--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -69,7 +69,16 @@ after staging.** Three separate traps, all hit in one lane on 2026-08-19
   calls, which makes the wrong-cwd set the DEFAULT outcome rather than a slip; it
   fired again while this very lane was written, when a relative `cd .worktrees/…`
   failed because the cwd was ALREADY inside that worktree and the chained edit
-  silently did not run. The marker store is `.git/markgate`, which every worktree
+  silently did not run. A KILLED or REFUSED call is a further named trigger: a
+  tool-call timeout that kills a call mid-run can bring the persistent shell
+  back at the session cwd, and a PreToolUse refusal aborts the WHOLE call, so a
+  directory it was going to create never exists for a later call's relative
+  `cd` — and while a failed `cd` stops an `&&` chain (the incident above), it
+  does NOT stop the later lines of a multi-line call, which then write into
+  whatever cwd was current. Both measured in a cdkd `/work-issues` run on
+  2026-08-28 (retro go-to-k/cdkd#2370). After any timeout or refusal, run `pwd`
+  and re-verify what the aborted call was supposed to create, before the next
+  relative-path command. The marker store is `.git/markgate`, which every worktree
   SHARES, but the hashes are taken from the cwd's files — so setting from the main
   checkout records `main`'s content. Measured 2026-08-19: with the worktree dirty
   and the marker set from the main checkout, a `markgate verify check` returns rc=1


### PR DESCRIPTION
Mirror of a `/work-issues` flow lesson found in cdkd on 2026-08-28 (retro go-to-k/cdkd#2370), landed here by the originating session per the three-repo mirror rule in `references/retro.md` section 10-c.

**The lesson**: the marker-cwd bullet already records one instance (a relative `cd` failing and the chained edit silently not running) but names no TRIGGER, so each occurrence still arrives as a surprise. Two triggers were measured in one run: a tool-call timeout killing a call mid-run brings the persistent shell back at the session cwd, and a PreToolUse refusal aborts the WHOLE call, so a directory it was going to create never exists for a later call's relative `cd`. The amendment also completes the failed-`cd` fact the bullet's own incident shows only half of: a failed `cd` stops an `&&` chain, but NOT the later lines of a multi-line call, which then write into whatever cwd was current.

**Adapted per this repo** (verified claim by claim): the amendment lands inside the existing bullet and ties to its own recorded incident; it does not import cdkd-only hook names (this repo has no main-tree edit gate, and none is claimed), and this repo's shared `.git/markgate` store semantics in the surrounding text are left untouched.

Landed in all three repos by this session: cdkd (go-to-k/cdkd#2370), cdk-local (go-to-k/cdk-local#625), and this PR. No mirror issues filed — the same-session landing covers the set.

**Verification** (prose-only diff): `vp run typecheck` rc=0, `vp check --fix` rc=0, `vp pack` rc=0, `vp test run` 6591/6591 rc=0 — including this repo's skill-file-payload and skill-doc-paths fences over the edited file.
