### PR TITLE
chore(work-issues): run lanes as per-issue subagents, with integ and merge serialized by the parent

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -28,23 +28,49 @@ optional** — each file carries hard rules and measured failure modes without
 which the stage summary below is not executable. A bare `§N` anywhere in this
 skill points into the file that holds that section (map in the table).
 
-**Delegate the read-heavy stages to subagents to keep this session's context for
-the lanes.** Two stages are shaped for it:
+**Delegate for context; keep the locks and the serialization in the parent.**
+The placements below are live-proven, not aspirational: on 2026-08-28 this
+repo's own skill-split PR (go-to-k/cdk-real-drift#1831), like its sibling
+go-to-k/cdk-local#621, was built END-TO-END by a lane subagent — worktree,
+implementation, gates, CI — with the parent doing only claims, serialized
+merges and cleanup, and every hook and markgate gate fired inside the lane's
+calls exactly as in the parent.
 
-- **Triage (stages 0–3)**: dispatch a read-only subagent (general-purpose or
-  Explore) whose prompt is: read `references/triage.md` in full, execute it
-  against this repo, and return ONLY the candidate table — per issue: number,
-  title, target files, rank + the rule that decided it, collision evidence
-  (worktrees / branches / claims found), and any premise-check findings. The raw
-  backlog listing and issue bodies stay out of the parent context. The PARENT
-  then claims (stage 4) — never the subagent, so the claim names the session
-  that will actually do the work.
-- **Retro (stage 10)**: after the last merge, dispatch a subagent with
+- **Triage (stages 0–3): a read-only subagent** (general-purpose or Explore)
+  whose prompt is: read `references/triage.md` in full, execute it against
+  this repo, and return ONLY the candidate table — per issue: number, title,
+  target files, rank + the rule that decided it, collision evidence
+  (worktrees / branches / claims found), and any premise-check findings. The
+  raw backlog listing and issue bodies stay out of the parent context.
+- **Claim (stage 4): the PARENT, never a subagent** — the claim is the lock,
+  so it names the session accountable for the lane; it also names the lane
+  branch/worktree the dispatched subagent will create, and the parent runs
+  §4's competing-claim re-check right before dispatching (§4).
+- **Lanes (stages 5–8): one general-purpose subagent per claimed issue.**
+  Dispatch each with the issue number(s), the posted claim, and the stage
+  files to read at stage entry (`references/implement.md`,
+  `references/gates-and-pr.md`, `references/verify.md`). The lane creates its
+  own worktree per §5, implements, runs `/check` + `/check-docs`, opens the
+  PR, dispatches read-only reviewers when the diff warrants them (§8),
+  addresses findings, and drives CI to green — then STOPS at merge-ready and
+  reports back: PR number, HEAD sha, markers set, review verdicts, the
+  live-test tier it owes (§8), anything deferred. Its diffs, test logs and
+  review round-trips never enter the parent context. A lane must NOT run a
+  real-AWS live test (a deploy → mutate → revert fixture) or merge on its
+  own — that is the serialization invariant below, not a capability gap.
+- **Finishing (stage 9): the parent, one lane at a time.** Grant each
+  merge-ready lane its turn — resume the lane agent (SendMessage) to run its
+  owed live test + `/sweep-resources` and merge while it holds the turn, or
+  run them yourself FROM THAT LANE'S WORKTREE (gate verdicts are computed
+  against the tree the command runs from — §9). Post-merge (pull → release →
+  install → worktree cleanup) follows §9.
+- **Retro (stage 10): a subagent**, dispatched after the last merge with
   `references/retro.md` plus this run's key evidence (what you re-read, what
   the text sent you into, corrections the user made) to measure the backlog
   effect, draft the skill edits, and ship them as the retro PR.
 
-Stages 4–9 run in the parent: they hold the locks, the worktrees, and the gates.
+Running a lane in the parent instead stays legal (a single-lane run, or a lane
+the user wants to watch); the stage files apply unchanged either way.
 
 ## Stages
 
@@ -75,6 +101,15 @@ Stages 4–9 run in the parent: they hold the locks, the worktrees, and the gate
   (`noise.ts` / `classify.ts` / `revert/plan.ts`). (§2, §3)
 - **Never work in the main checkout** — one worktree per lane under
   `.worktrees/`, `mise trust` + `pnpm install` in each. (§5)
+- **Real-AWS live tests and merges are SERIALIZED across lanes** — the parent
+  grants the turn, one lane at a time; a lane subagent never starts either on
+  its own. Everything else (edits, unit tests, markers, PR create, reviews,
+  CI) runs concurrently, with two repo-local caveats: the markgate store is
+  SHARED across worktrees with hashes from the setter's cwd, so a peer's
+  `markgate set` landing between your set and your commit fails closed (a
+  re-run, not a wrong pass); and the deploy-autoarm sentinel is per-SESSION,
+  so one lane's live deploy blocks EVERY lane's commit and PR until the
+  sweep clears it. (§9)
 - **English only in every published artifact** — issue bodies/comments, PR
   titles/bodies, commits, code. (CLAUDE.md)
 - **The run ends with the retro (stage 10) and the standard wrap report**

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -2,6 +2,13 @@
 
 ## 4. CLAIM the chosen issues BEFORE editing
 
+When lanes run as SUBAGENTS (the orchestrator's default for stages 5-8), the
+PARENT posts every claim in this section — the claim is the lock and must name
+the session accountable for the lane — and the claim's `<ref>` names the branch
+/ worktree the dispatched lane agent will create, not a branch the parent
+holds. The competing-claim/PR re-check below also runs in the parent, right
+before dispatch. Everything else in this section is unchanged.
+
 For EACH issue you will start:
 
 ```bash

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -2,6 +2,17 @@
 
 ## 5. One worktree per lane, then implement
 
+This stage (and stages 6-8) normally runs INSIDE a lane subagent the
+orchestrator dispatched — one general-purpose agent per claimed issue, so the
+lane's diffs, test output and review round-trips never land in the parent
+context. Every rule below applies unchanged inside the lane: hooks fire on the
+lane's tool calls (measured on go-to-k/cdk-real-drift#1831, built end-to-end by
+a lane subagent on 2026-08-28), and markgate markers land in the lane's own
+worktree. Two actions are reserved to the parent's serialization turn and are
+NOT the lane's to start: a real-AWS live test (deploy → mutate → revert) and
+the merge (the orchestrator's serialization invariant; §9). A lane stops at
+merge-ready and reports.
+
 **Before fixing, ask whether the defect has SIBLING SITES — and if it does, sweep
 them in THIS lane rather than filing them.** Most defects here are a CLASS, not an
 instance: one command factory mishandling a flag, one resolver arm missing a case,
@@ -389,6 +400,8 @@ its first run, against this paragraph's own draft.
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an
 explicit "do NOT touch <the other lanes' / other agents' files>; STOP and report
-if the fix needs a forbidden file" guardrail. Note: a subagent's Bash **bypasses
-the PreToolUse gate hooks**, so it can `gh pr create` past `verify-pr-gate` —
-enforce quality yourself; you (the orchestrator) still gate the MERGE.
+if the fix needs a forbidden file" guardrail. This file used to warn that a
+subagent's Bash bypasses the PreToolUse gate hooks; that is measured FALSE —
+on 2026-08-28 the go-to-k/cdk-real-drift#1831 lane subagent had every gate hook
+fire on its own calls exactly as in the parent. The gates are a backstop, not
+the plan, either way: the orchestrator still holds the MERGE turn (§9).

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -2,6 +2,24 @@
 
 ## 9. Ship: merge → pull → release → global install → cleanup
 
+With subagent lanes, this stage is the PARENT's serialization point: grant one
+merge-ready lane at a time its turn — resume that lane agent (SendMessage) to
+run its owed §8 live test + `/sweep-resources` and merge while it holds the
+turn, or run them yourself FROM THAT LANE'S WORKTREE. The worktree matters
+mechanically, not stylistically: gate verdicts are computed against the tree
+the command runs from — this repo's markgate store is shared across worktrees
+but the HASHES come from the cwd's files (the `/check` skill's 2026-08-19
+measurement), and the bughunt-clean gate keys the committing WORKTREE owner —
+so a marker set or a merge issued from the main tree attests to MAIN's
+content, not the lane's. cdkd measured the merge-time failure live on
+2026-08-28 (go-to-k/cdkd#2363 records the cwd-race side of it).
+Live-AWS runs have a second, repo-specific reason to stay inside the granted
+turn: the deploy-autoarm sentinel is per-SESSION, and a lane subagent's calls
+carry this same session, so one lane's deploy arms the token that blocks EVERY
+lane's commit / PR create / merge until `/sweep-resources` clears it. Never
+two lanes' live tests or merges concurrently; everything after the merge in
+this section (pull → release → install → cleanup) stays with the parent.
+
 ```bash
 gh pr merge <n> --squash --delete-branch     # squash is the repo's only method
 ```


### PR DESCRIPTION
## Summary

The skill split (go-to-k/cdk-real-drift#1831) delegated triage and retro to subagents; this PR extends the model to the LANES themselves — the dominant parent-context cost (tens of thousands of tokens per lane of diffs, test output and review round-trips). It mirrors go-to-k/cdkd#2372, adapted to this repo's stage files and gates.

- **Orchestrator**: stages 5-8 run as one general-purpose subagent per claimed issue (worktree-isolated under `.worktrees/`). A lane implements, runs `/check` + `/check-docs`, opens its PR, dispatches read-only reviewers when the diff warrants them (this repo has no standing reviewer ladder — verify.md's own rule), drives CI to green, then STOPS at merge-ready and returns a compact report. The parent claims (stage 4 — the lock names the accountable session, and runs the competing-claim re-check before dispatch), grants real-AWS live-test and merge turns one lane at a time (stage 9), and runs post-merge + retro. Running a lane in the parent stays legal.
- **New hard invariant**: real-AWS live tests (deploy -> mutate -> revert fixtures + `/sweep-resources`) and merges are SERIALIZED across lanes by the parent; everything else is concurrent — with two repo-local caveats spelled out: the markgate store is SHARED across worktrees with hashes from the setter's cwd (a peer's `markgate set` fails closed, not wrong-pass), and the deploy-autoarm sentinel is per-SESSION, so one lane's live deploy blocks every lane's commit/PR until the sweep clears it.
- **claim.md**: with subagent lanes, the parent posts every claim, naming the lane branch/worktree the dispatched agent will create; the competing-claim/PR re-check also runs in the parent.
- **implement.md**: stages 5-8 normally run inside the lane; every rule applies unchanged there. Also corrects the stale fan-out note that claimed a subagent's Bash bypasses the PreToolUse gate hooks — measured FALSE on 2026-08-28, when the go-to-k/cdk-real-drift#1831 lane subagent had every gate hook fire on its own calls.
- **ship.md**: stage 9 is the parent's serialization point; run the live test and merge from the LANE's worktree, because gate verdicts hash the cwd's files (the `/check` skill's 2026-08-19 measurement; go-to-k/cdkd#2363 records cdkd's merge-time cwd-race), and the bughunt-clean gate keys the committing worktree owner plus the session's autoarm token.

Live evidence for the pattern: go-to-k/cdk-real-drift#1831 itself (and go-to-k/cdk-local#621) was built end-to-end by a lane subagent on 2026-08-28 — worktree, gates, CI — with the parent doing only claims, serialized merges and cleanup.

## Test plan

- `vp run check`: rc=0 (typecheck / lint+format / build / unit tests)
- `vp run test`: 347 files / 6,591 tests pass (skill-file-payload cap: orchestrator 10,633 B <= 12,000 B; skill-doc-paths issue-ref + path fences green)
- Prose-only change to 4 skill docs; no `src/**`, no behavior outside the agent flow
