### PR TITLE
chore(hooks): register every hook via ${CLAUDE_PROJECT_DIR:-.} so a foreign cwd cannot swap or fail-open the gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,140 +7,140 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/check-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/check-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking /check + /check-docs markers..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/branch-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/branch-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking target branch is not main..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/branch-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/branch-gate.sh",
             "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking target branch is not main..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/bughunt-clean-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/bughunt-clean-gate.sh",
             "if": "Bash(*git*commit*)",
             "timeout": 10,
             "statusMessage": "Checking for un-deleted bug-hunt resources..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/bughunt-clean-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/bughunt-clean-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 10,
             "statusMessage": "Checking for un-deleted bug-hunt resources..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/bughunt-clean-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/bughunt-clean-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 10,
             "statusMessage": "Checking for un-deleted bug-hunt resources..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/stale-base-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stale-base-gate.sh",
             "if": "Bash(*git*push*)",
             "timeout": 10,
             "statusMessage": "Checking branch does not stale-base-clobber main..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/verify-pr-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/verify-pr-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 15,
             "statusMessage": "Checking /verify-pr marker is fresh..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/verify-pr-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/verify-pr-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 15,
             "statusMessage": "Checking /verify-pr marker is fresh..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/ci-green-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ci-green-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 30,
             "statusMessage": "Checking the PR's CI is all-green before merge..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-classification-label-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-classification-label-gate.sh",
             "if": "Bash(*gh*issue*create*)",
             "timeout": 15,
             "statusMessage": "Checking the issue's Severity / Effort labels match its body..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-classification-label-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-classification-label-gate.sh",
             "if": "Bash(*gh*issue*edit*)",
             "timeout": 15,
             "statusMessage": "Checking the issue's Severity / Effort labels match its body..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/non-english-text-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/non-english-text-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/non-english-text-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/non-english-text-gate.sh",
             "if": "Bash(*gh*pr*edit*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/non-english-text-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/non-english-text-gate.sh",
             "if": "Bash(*gh*pr*merge*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-dup-check-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-dup-check-gate.sh",
             "if": "Bash(*gh*issue*create*)",
             "timeout": 10,
             "statusMessage": "Checking the issue body records an open-issue dup check..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/issue-dup-check-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-dup-check-gate.sh",
             "if": "Bash(*gh*api*issues*)",
             "timeout": 10,
             "statusMessage": "Checking the issue body records an open-issue dup check..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/deploy-autoarm-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/deploy-autoarm-gate.sh",
             "if": "Bash(*deploy*)",
             "timeout": 10,
             "statusMessage": "Auto-arming the cleanup gate on deploy..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/deploy-autoarm-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/deploy-autoarm-gate.sh",
             "if": "Bash(*create-stack*)",
             "timeout": 10,
             "statusMessage": "Auto-arming the cleanup gate on deploy..."
           },
           {
             "type": "command",
-            "command": ".claude/hooks/deploy-autoarm-gate.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/deploy-autoarm-gate.sh",
             "if": "Bash(*update-stack*)",
             "timeout": 10,
             "statusMessage": "Auto-arming the cleanup gate on deploy..."
@@ -152,7 +152,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/worktree-guard.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/worktree-guard.sh",
             "timeout": 10,
             "statusMessage": "Checking edit targets a worktree, not the main checkout..."
           }
@@ -164,12 +164,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/stop-cleanup-warn.sh",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stop-cleanup-warn.sh",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": ".claude/hooks/stop-unmerged-lane-warn.sh"
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/stop-unmerged-lane-warn.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Closes #1835. All 23 hook commands in `.claude/settings.json` were registered repo-relative (`.claude/hooks/<name>.sh`); a hook process resolves that against the session shell's CURRENT cwd, so from a sibling repo's tree (the documented cross-repo workflow) cdk-real-drift's gate policy silently stopped being cdk-real-drift's: same-named hooks executed the SIBLING's implementation, and cdk-real-drift-only hooks (`deploy-autoarm-gate`, `stale-base-gate`, `stop-cleanup-warn`, `worktree-guard`) failed to spawn and the call proceeded — fail-open. The mechanism was measured live in cdkd on 2026-08-28 (go-to-k/cdkd#2379); this repo carries the identical registration pattern.

The fix prefixes every command with `${CLAUDE_PROJECT_DIR:-.}/` — the documented hook env var pins resolution to the session's project root, and the `:-.` fallback degrades to today's exact behavior if the variable is ever unset, so the change cannot be WORSE than the status quo in any environment. Hook internals are untouched; only the spawn path moves. Mirrors the merged cdkd fix go-to-k/cdkd#2380.

## Test plan

- `python json.loads` on the rewritten file: valid; zero relative `"command": ".claude/hooks/"` forms remain; 23 rewritten.
- `tests/gate-if-matchers-1801.test.ts` (the settings-reading suite: gate selection is derived from `settings.json` hook commands): 16 tests pass — `includes('.claude/hooks/')` and the `basename` extraction both tolerate the new prefix.
- Full suite: 347 files / 6591 tests pass; `vp run typecheck`, `vp check --fix`, `vp pack` all green.
- sh-level live-fire probes of the exact command form: from a foreign cwd with the var set, the RIGHT repo's `branch-gate.sh` spawns and blocks a main-tree commit (exit 2) and passes a feature-branch commit (exit 0); with the var unset, behavior is byte-identical to today (fallback `.`).
- Live-fire caveat, stated rather than skipped: a running session keeps the hook commands it registered at start, so the end-to-end proof (a cdk-real-drift gate blocking from a sibling cwd) is only observable in the NEXT session. The next session's verification command is in the issue (#1835).
