### PR TITLE
chore(work-issues): run your own review round after the lane's, and stop the spelling treadmill at round three

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -73,10 +73,12 @@ Run each check and report pass/fail:
      here to recompute — this repo ships no multi-agent reviewer set and no
      `/review-pr` skill (CLAUDE.md keeps `pr-review` UNPORTED because cdkrd is
      solo), and `.markgate.yml` keeps that gate INERT and UNWIRED — so what gets
-     frozen is your own call: how closely to read, and whether to
-     dispatch read-only reviewers at all for a diff big enough to warrant them
-     (`/work-issues` §8 covers what to do when two of them contradict each
-     other). Nothing re-opens that call mechanically. A stale marker is not that
+     frozen is your own call: how closely to read, and which read-only
+     reviewers to dispatch — not WHETHER to, which `/work-issues` §8 settles:
+     an independent round is owed even when the lane already ran one, because a
+     lane's reviewers inherit the premise the lane handed them (§8 also covers
+     what to do when two of them contradict each other). Nothing re-opens the
+     depth call mechanically. A stale marker is not that
      forcing function either, and it is easy to mistake for one: a `.claude/**`
      fix round DOES stale `check`, which covers `.claude/skills/**` and — since
      go-to-k/cdk-real-drift#1837 — `.claude/settings.json`, `.claude/hooks/**`,

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -200,17 +200,17 @@ with two more probes against the real tree; every fence here got them on
   tree already used `??`; widening it surfaced an unfiled real bug.
 
   **But when round three is still ADDING spellings, the instrument is wrong —
-  change it rather than write a better pattern.** Measured 2026-08-29 across
-  go-to-k/cdk-real-drift#1837, go-to-k/cdkd#2381 and go-to-k/cdk-local#630: one
-  defect class in five escalating spellings of a fence reading `.markgate.yml`
-  by hand. Block items only, so a FLOW list passed — this repo's own instance,
-  and it left the fence's "no exclude declared" tripwire GREEN while markgate
-  really did subtract from the scope. Then unquoted keys only, so `"exclude":`
-  passed; then a block scan terminating on `/^ {2}\S/`, which a two-space
-  COMMENT ended early with every case still green; then a merge key
-  (`<<: *anchor`) splicing an `exclude` declared on a SIBLING gate. Each round
-  added one more regex. **Three spellings in three rounds is the signal to stop
-  patterning.** Two shapes end it, and neither is a sixth pattern: parse the
+  change it rather than write a better pattern.** Measured 2026-08-29 in three
+  repos at once, one defect class in a hand-rolled `.markgate.yml` reader. This
+  repo's own instance (go-to-k/cdk-real-drift#1838): the fence learned to read
+  `exclude` as 6-space BLOCK items, so the FLOW spelling still parsed to
+  `exclude: []` and the "no exclude declared" tripwire stayed GREEN a second
+  time while markgate really did subtract from the scope. The sibling
+  go-to-k/cdkd#2383 tallies its own run as **four spellings across four rounds,
+  each patch moving the hole rather than closing it**, ending on a merge key
+  (`<<: *anchor`) splicing an `exclude` declared on a SIBLING gate — which the
+  raw-text tripwire added as that very backstop did not fire on. **Three
+  spellings in three rounds is the signal to stop patterning.** Two shapes end it, and neither is a sixth pattern: parse the
   config with a REAL parser — `yaml` is already a production dependency here,
   and a third-party, versioned library is not the fence checking its own work —
   then ALLOW-LIST the tool's own keys, fail CLOSED on anything outside them,

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -198,6 +198,27 @@ with two more probes against the real tree; every fence here got them on
   `const { isTTY } = process.stdin` and `isatty(0)` from `node:tty` all passed.
   Source-side sibling go-to-k/cdkd#2111: a scanner matched `||` only while the
   tree already used `??`; widening it surfaced an unfiled real bug.
+
+  **But when round three is still ADDING spellings, the instrument is wrong —
+  change it rather than write a better pattern.** Measured 2026-08-29 across
+  go-to-k/cdk-real-drift#1837, go-to-k/cdkd#2381 and go-to-k/cdk-local#630: one
+  defect class in five escalating spellings of a fence reading `.markgate.yml`
+  by hand. Block items only, so a FLOW list passed — this repo's own instance,
+  and it left the fence's "no exclude declared" tripwire GREEN while markgate
+  really did subtract from the scope. Then unquoted keys only, so `"exclude":`
+  passed; then a block scan terminating on `/^ {2}\S/`, which a two-space
+  COMMENT ended early with every case still green; then a merge key
+  (`<<: *anchor`) splicing an `exclude` declared on a SIBLING gate. Each round
+  added one more regex. **Three spellings in three rounds is the signal to stop
+  patterning.** Two shapes end it, and neither is a sixth pattern: parse the
+  config with a REAL parser — `yaml` is already a production dependency here,
+  and a third-party, versioned library is not the fence checking its own work —
+  then ALLOW-LIST the tool's own keys, fail CLOSED on anything outside them,
+  and raw-scan the whole map; or, where no parser is available, REFUSE every
+  shape the reader cannot model, which is the STRICTER option, not the weaker
+  one. `tests/check-scope-checker-inputs-1837.test.ts` is this repo's worked
+  example.
+
 - **Delete the thing the fence REQUIRES, and watch it fail.** This finds a
   wrong POPULATION, and one derived from the DEFECT is the worst kind:
   `tests/gate-if-matchers-1801.test.ts` (then named for

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -296,8 +296,9 @@ pnpm install                  # worktrees have no node_modules
   `ci-green-gate`. No `src/**` change also means no deploy: nothing for
   `/sweep-resources` to tear down, no `deploy-autoarm-gate` token to release.
 - Do not let the small diff set the review depth. This repo has no reviewer
-  ladder, so the depth IS your own read of the whole diff plus `/verify-pr`'s
-  self-review — a wrong rule here propagates into every future session.
+  ladder, so the depth is your own read of the whole diff plus the independent
+  round §8 says you owe even after a lane's own — a wrong rule here propagates
+  into every future session.
 - **Merge it before the wrap report, then remove the worktree**
   (`git worktree remove .worktrees/<name> && git worktree prune`) — §9 ends
   with every worktree gone and §10 must not undo that. This is

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -125,8 +125,8 @@ at once, not trickled.
   before forwarding either** — forwarding both hands the implementer a
   contradiction with LESS context than you have; forwarding only the reassuring
   one is how a blocker ships. Read the disputed lines; say which reviewer was
-  right and why. No standing reviewer ladder here — this fires when a lane
-  dispatches read-only reviewers of its own.
+  right and why — routine whenever a lane, or you, dispatch read-only reviewers
+  (see the round below, which this repo has no ladder to run for you).
 
   What to measure in the command arm (all confirmed here 2026-08-19,
   go-to-k/cdk-real-drift#1768):
@@ -211,6 +211,39 @@ worktree cwd (the merge gate scopes by committing worktree owner + your
 `/verify-pr` sets the `check` + `docs` + `verify-pr` markers, which unblock
 `gh pr merge`. Docs/tooling-only PRs (no `src/**`) are EXEMPT from the
 live-test — `check` + `docs` suffice.
+
+**Your own review round is not optional because the lane already ran one, and
+this repo has no ladder to fall back on.** A lane's reviewers are its children
+— same brief, same framing — so they clear what the lane already believes, and
+here nothing mechanical catches that: there is no multi-agent reviewer set and
+no review-tier skill, and the `pr-review` entry in `.markgate.yml` is wired to
+no hook. Measured 2 for 2 on 2026-08-29: go-to-k/cdk-real-drift#1838's lane ran
+its own 3-axis round, reported clean, and an independent 3-axis pass then found
+a HIGH blocker — a flow-style `exclude:` invisible to a hand-rolled YAML
+scanner, leaving its "no exclude declared" tripwire green while markgate really
+did subtract; the sibling go-to-k/cdkd#2383 repeated it one spelling deeper
+with a merge key anchored on another gate. So the depth is your own read of the
+whole diff plus a round you dispatch yourself, and a lane's clean round is not
+a measurement that lowers it.
+
+**A reviewer's scratch COPY of a worktree is not detached from git, so its
+`git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
+holding `gitdir: <repo>/.git/worktrees/<name>`, and `cp -R` carries the
+pointer: every git command inside the copy reads and WRITES the real worktree's
+index and HEAD. Measured 2026-08-29 in the sibling cdkd, where a read-only code
+reviewer copied a lane's worktree, ran `git add -A` there, and staged three
+tracked DELETIONS in the live tree that the lane's next commit would have
+shipped — nothing announced it, because the reviewer believed it was on a copy.
+Two lines therefore belong in every read-only reviewer's brief: **run no
+WRITING git verb** (`add` / `commit` / `restore` / `checkout` / `stash` /
+`clean`) anywhere, copy included, severing the pointer with `rm .git` if you
+must copy at all; and **report the TARGET worktree's `git status --porcelain`
+before AND after the round.** The pair is what makes damage attributable rather
+than a mystery a later agent finds: that incident surfaced only because the
+NEXT reviewer volunteered "the tree went dirty mid-review, not mine", after
+which the responsible one repaired the index with `git restore --staged` (index
+only, never the working tree). This repo's lanes live under a `.worktrees/`
+directory, so the hazard is identical here.
 
 ### 8-z. When a mutation probe reports NO discrimination
 

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -217,14 +217,16 @@ this repo has no ladder to fall back on.** A lane's reviewers are its children
 — same brief, same framing — so they clear what the lane already believes, and
 here nothing mechanical catches that: there is no multi-agent reviewer set and
 no review-tier skill, and the `pr-review` entry in `.markgate.yml` is wired to
-no hook. Measured 2 for 2 on 2026-08-29: go-to-k/cdk-real-drift#1838's lane ran
-its own 3-axis round, reported clean, and an independent 3-axis pass then found
-a HIGH blocker — a flow-style `exclude:` invisible to a hand-rolled YAML
-scanner, leaving its "no exclude declared" tripwire green while markgate really
-did subtract; the sibling go-to-k/cdkd#2383 repeated it one spelling deeper
-with a merge key anchored on another gate. So the depth is your own read of the
-whole diff plus a round you dispatch yourself, and a lane's clean round is not
-a measurement that lowers it.
+no hook. Measured on the sibling go-to-k/cdkd#2383 (2026-08-29), which runs a reviewer
+ladder this repo does not: three rounds of the LANE's own reviewers each found
+the next spelling of one defect, and it took an independent
+orchestrator-level round to find the last one — a YAML merge key, the spelling
+the lane's own raw-text tripwire had been added specifically to backstop and
+did not fire on. This repo's go-to-k/cdk-real-drift#1838 spent its own rounds
+on the same class, its flow-style `exclude:` staying green through the first
+fix for it. So the depth is your own read of the whole diff plus a round you
+dispatch yourself, and a lane's clean round is evidence about the lane's
+assumptions, not about the diff.
 
 **A reviewer's scratch COPY of a worktree is not detached from git, so its
 `git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
@@ -236,9 +238,10 @@ tracked DELETIONS in the live tree that the lane's next commit would have
 shipped — nothing announced it, because the reviewer believed it was on a copy.
 Two lines therefore belong in every read-only reviewer's brief: **run no
 WRITING git verb** (`add` / `commit` / `restore` / `checkout` / `stash` /
-`clean`) anywhere, copy included, severing the pointer with `rm .git` if you
-must copy at all; and **report the TARGET worktree's `git status --porcelain`
-before AND after the round.** The pair is what makes damage attributable rather
+`clean`) anywhere, copy included — and if you must copy, copy OUTSIDE every
+repository, since deleting the `.git` file does not detach the copy, it only
+makes discovery walk UPWARD into whatever encloses it; and **report the TARGET
+worktree's `git status --porcelain` before AND after the round.** The pair is what makes damage attributable rather
 than a mystery a later agent finds: that incident surfaced only because the
 NEXT reviewer volunteered "the tree went dirty mid-review, not mine", after
 which the responsible one repaired the index with `git restore --staged` (index


### PR DESCRIPTION
## Summary

Stage-10 retrospective for the `/work-issues` run that landed go-to-k/cdk-real-drift#1838, go-to-k/cdkd#2383 and go-to-k/cdk-local#631 — one root cause fixed in all three repos ("every file the unit suite reads as INPUT must be inside the markgate `check` gate's include, else an edit leaves a recorded marker reporting FRESH while the suite is red").

Prose only. One PR per repo; the sibling PRs carry the same lessons adapted to their own gates.

## What changed, and where it fires

**`references/verify.md`** (section 8):

- **Your own review round is not optional because the lane already ran one — and this repo has no ladder to fall back on.** The contradiction bullet closed with "no standing reviewer ladder here", which reads as a reason to skip a round rather than as a reason to run one yourself; it now points at the new paragraph that states the rule. A lane's reviewers are its children — same brief, same framing — so the thing they are least able to doubt is the premise the lane handed them, and nothing mechanical catches that here: no multi-agent reviewer set, no review-tier skill, and the `pr-review` entry in `.markgate.yml` is wired to no hook.

  The measurement is the sibling go-to-k/cdkd#2383's own record, since it runs a reviewer ladder this repo does not: three rounds of the LANE's reviewers each found the next spelling of one defect, and it took an independent orchestrator-level round to find the last — a YAML merge key, the spelling the lane's own raw-text tripwire had been added specifically to backstop and did not fire on. This repo's go-to-k/cdk-real-drift#1838 spent its own rounds on the same class, its flow-style `exclude:` staying green through the first fix for it.

- **A reviewer's scratch COPY of a worktree is not detached from git.** A linked worktree's `.git` is a FILE holding `gitdir: <repo>/.git/worktrees/<name>`, so `cp -R` carries the pointer and every git command inside the copy reads and WRITES the real worktree's index and HEAD. Measured in the sibling cdkd this run: a read-only reviewer copied a lane worktree, ran `git add -A` there, and staged three tracked DELETIONS in the live tree that the lane's next commit would have shipped. Nothing announced it; a LATER reviewer noticed the tree had gone dirty and said it was not theirs, after which the responsible one repaired the index with `git restore --staged` (index only, no working-tree write).

  Two lines therefore belong in every read-only reviewer's brief: no WRITING git verb anywhere (copying outside every repository if you must copy at all — deleting the `.git` file does not detach a copy, it only makes discovery walk UPWARD), and a before/after `git status --porcelain` of the target worktree. This repo's lanes live under a `.worktrees/` directory, so the hazard is identical here.

**`.claude/skills/verify-pr/SKILL.md`** — a contradiction the review round caught. It still framed the frozen call as "whether to dispatch read-only reviewers at all", which is the opposite of the rule above. Two ship-path docs must not carry opposite rules, so it now names the call as WHICH reviewers, with WHETHER settled in section 8.

**`references/implement.md`** (section 5):

- The spelling probe told you to write the defect in every spelling and said nothing about **when to stop**. This repo's own instance (go-to-k/cdk-real-drift#1838): the fence learned to read `exclude` as 6-space BLOCK items, so the FLOW spelling still parsed to `exclude: []` and the "no exclude declared" tripwire stayed GREEN a second time while markgate really did subtract from the scope. The sibling go-to-k/cdkd#2383 tallies its own run as four spellings across four rounds, ending on a `<<: *anchor` merge key splicing an `exclude` declared on a sibling gate. Three spellings in three rounds is the signal to change instrument.

  Two shapes end it and neither is another pattern: parse with a REAL parser — `yaml` is already a production dependency here, and a third-party, versioned library is not the fence checking its own work — then allow-list the tool's own keys, fail CLOSED outside them, and raw-scan the whole map; or, where no parser is available, refuse every shape the reader cannot model. `tests/check-scope-checker-inputs-1837.test.ts` is this repo's worked example.

**`references/retro.md`** — its "the depth IS your own read of the whole diff plus `/verify-pr`'s self-review" bullet was left weaker than the new rule; it now points at it rather than sitting beside it as a near-duplicate.

## Deliberately NOT mirrored here

The run's fourth lesson — that the `pr-review` marker belongs to the orchestrator and a lane must never set it — is not in this diff. This repo ships no review-tier skill and no hook reads that marker, so the rule would name a mechanism that does not exist; per the skill's own claim-by-claim rule, a sentence true in a sibling is not automatically true here. It landed in cdkd and cdk-local only. The part of it that DOES apply here — run your own round even after the lane's — is the first bullet above.

## What was cut to pay for it

The contradiction bullet's closing clause, which asserted the absence of a reviewer ladder without saying what to do about it, and the retro bullet's weaker restatement of the same thing.

## Test plan

- `vp run typecheck`: pass. `vp check --fix`: 0 errors. `vp pack`: pass.
- `vp test run`: rc 0, 348 files / 6,605 tests pass — including `tests/skill-doc-paths.test.ts` (every path-shaped code span resolves here, every issue reference fully qualified as `go-to-k/<repo>#N`) and `tests/markdown-fmt-corruption-1771.test.ts`.
- `vp fmt` run twice, second run a no-op, and the reformatted diff read — this repo's formatter rewrites markdown and can re-parent a paragraph that follows a nested list item.
- `check` and `docs` markers recorded from this worktree, after the review-fix round rather than before it.
- Live-test tier: prose-only diff with no `src/**` path, so this is the PROSE arm of the tooling tier — every gate, hook, path, dependency and issue reference the new text names was resolved against **this** repo's own files by an independent read-only reviewer, claim by claim (the text was adapted from cdkd, where several of those claims differ). It returned one blocker, three minors and two nits; all are fixed in the second commit, and each incident cited was re-read from its own PR/issue body rather than from the number — which is how the original "2 for 2" claim was found to be unsupported by go-to-k/cdk-real-drift#1838's body and rewritten.

## Backlog effect for the whole run

`closed 4 / filed 4 (new 4 / folded 0)` — zero left open, zero `Session-fit: next` deferrals. Closed: go-to-k/cdk-real-drift#1837, go-to-k/cdkd#2381, go-to-k/cdk-local#630, go-to-k/cdkd#2384. Filed = the same four; every one was filed and fixed inside the run, which is why `filed` equals `closed` rather than exceeding it.
