### PR TITLE
chore(hooks): give each Stop warning the channel its audience actually reads, and spend one nudge per subject

### DIFF
--- a/.claude/hooks/stop-cleanup-warn.sh
+++ b/.claude/hooks/stop-cleanup-warn.sh
@@ -186,13 +186,20 @@ subject="${subject%,}"
 # measured, and the second direction is the dangerous one HERE, since reading a
 # resumed pass as fresh emits `additionalContext` again and spins the turn. So:
 # null / false / 0 / an empty container are falsy, everything else is truthy, which
-# is Python's rule spelled in jq.
+# is Python's rule spelled in jq. There is deliberately NO `null` arm: the `//
+# false` above has already mapped a null (and an absent field) to `false`, so
+# `$t` can never be "null" and such an arm is a fence no case could trip --
+# which this file argues against a few lines down.
+#
+# One shape still diverges, in the safe direction: `1e-999` reads truthy here
+# (jq preserves the literal, so `$f == 0` is false) and falsy in Python, which
+# underflows it to 0.0. The cost is the money hook going QUIET to the model on a
+# value nothing produces, rather than spinning.
 active=$(printf '%s' "$input" | jq -r '
   (.stop_hook_active // false) as $f
   | ($f | type) as $t
   | if $t == "string"
     then (if ($f | ascii_downcase | gsub("^\\s+|\\s+$"; "") | . == "" or . == "false" or . == "0" or . == "no") then "0" else "1" end)
-    elif $t == "null" then "0"
     elif $t == "boolean" then (if $f then "1" else "0" end)
     elif $t == "number" then (if $f == 0 then "0" else "1" end)
     else (if ($f | length) == 0 then "0" else "1" end) end' 2>/dev/null || echo "0")

--- a/.claude/hooks/stop-cleanup-warn.sh
+++ b/.claude/hooks/stop-cleanup-warn.sh
@@ -191,10 +191,26 @@ subject="${subject%,}"
 # `$t` can never be "null" and such an arm is a fence no case could trip --
 # which this file argues against a few lines down.
 #
-# One shape still diverges, in the safe direction: `1e-999` reads truthy here
-# (jq preserves the literal, so `$f == 0` is false) and falsy in Python, which
-# underflows it to 0.0. The cost is the money hook going QUIET to the model on a
-# value nothing produces, rather than spinning.
+# One shape still diverges, and it has TWO sides -- which is the point, because
+# the reason this ladder exists at all is that the two Stop hooks must not
+# disagree about what a payload MEANS. `1e-999` reads truthy here (jq 1.8
+# preserves the literal, so `$f == 0` is false) and falsy in
+# `stop-unmerged-lane-warn.sh`, whose Python underflows it to 0.0. Measured on
+# jq-1.8.1 / CPython 3: this ladder answers `1` (resumed) and
+# `json.loads('1e-999')` is `0.0`, falsy (not resumed). So on ONE payload:
+#
+#   this hook   reads RESUMED     -> goes quiet to the model
+#   lane hook   reads NOT resumed -> spends its model nudge
+#
+# Naming only the first half understates it: the divergence is not "one hook is
+# conservative" but "the two hooks disagree", which is exactly the property the
+# rest of this ladder was written to guarantee. It is left as is because both
+# halves are bounded. Going quiet costs a nudge that a later ordinary turn will
+# emit anyway; the lane hook's nudge is bounded by its per-subject cadence
+# record, so it fires once rather than every turn -- neither side spins. And no
+# producer emits `1e-999`: the harness sends a JSON boolean. Special-casing it
+# would mean teaching jq to underflow, a rule with no other use, to make two
+# hooks agree about a value neither will ever see.
 active=$(printf '%s' "$input" | jq -r '
   (.stop_hook_active // false) as $f
   | ($f | type) as $t

--- a/.claude/hooks/stop-cleanup-warn.sh
+++ b/.claude/hooks/stop-cleanup-warn.sh
@@ -39,7 +39,11 @@
 #                         model, and only the model can act on it.
 #
 # CADENCE. `stop_hook_active` marks a turn the harness has already resumed on a hook's
-# account, so it stops a nudge SPINNING inside one turn -- and that is all it does.
+# account, so it drops the MODEL half -- and that is all it does. It is deliberately not
+# a full stand-down: the `systemMessage` above is promised on every fire, and the
+# condition can first become true DURING a continuation another hook forced (that
+# continuation runs a deploy, `deploy-autoarm-gate.sh` arms, and this pass is the first
+# time there is anything to say).
 # Across turns the armed sentinel persists until the resources are actually deleted, so
 # an unconditional `additionalContext` would fire at every turn-end for as long as they
 # live. That is not merely slow: a Stop hook's `additionalContext` travels in the same
@@ -84,11 +88,32 @@ input=$(cat 2>/dev/null || true)
 command -v jq >/dev/null 2>&1 || exit 0
 
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
-target_dir="${hook_cwd:-$PWD}"
+
+# Three candidates, tried in order, because a `cwd` that is merely WRONG is the
+# common failure and used to be indistinguishable from a correct one: the payload
+# names a directory that has since been removed (a worktree cleaned up mid-session),
+# `git -C` fails, and this hook exits 0 -- silent about resources that are still
+# billing. Only an EMPTY `cwd` fell back before, so the stale case went unnoticed.
+#
+#   1. the event payload's `cwd` -- authoritative when it resolves.
+#   2. `$PWD` -- the directory the harness launched the hook from.
+#   3. this hook copy's own checkout, via BASH_SOURCE -- the last resort, and the
+#      anchor stop-unmerged-lane-warn.sh next door already uses for the same reason.
+#
+# Only if none of the three is inside a git repository does the hook stand down.
+self_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)" || self_root=""
+target_dir=""
+for cand in "$hook_cwd" "$PWD" "$self_root"; do
+  [ -n "$cand" ] || continue
+  if git -C "$cand" rev-parse --git-dir >/dev/null 2>&1; then
+    target_dir="$cand"
+    break
+  fi
+done
+[ -n "$target_dir" ] || exit 0
 
 # Resolve the shared main-tree root (parent of the common .git dir) so the sentinel
 # path matches what bughunt-track.sh / bughunt-clean-gate.sh use.
-git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1 || exit 0
 git_common="$(git -C "$target_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
 if [ -n "$git_common" ]; then
   main_root="$(dirname "$git_common")"
@@ -111,32 +136,56 @@ owner_file="${pending_dir}/${owner_key}"
 sid="${CLAUDE_CODE_SESSION_ID:-}"
 [ -z "$sid" ] && sid=$(printf '%s' "$input" | jq -r '.session_id // ""' 2>/dev/null || echo "")
 sid_key="$(printf '%s' "$sid" | sed 's#[^A-Za-z0-9._-]#_#g')"
-autoarm_file="${pending_dir}/autoarm-${sid_key:-shared}"
+[ -n "$sid_key" ] || sid_key="shared"
+autoarm_file="${pending_dir}/autoarm-${sid_key}"
+
+# The sid goes into a TAB-separated record that is read back with `IFS=<TAB> read`,
+# and a tab is IFS *whitespace*: a run of them collapses and a LEADING empty field
+# is dropped outright. So an empty sid (no `CLAUDE_CODE_SESSION_ID`, no `session_id`
+# in the payload) wrote `<TAB>subject<TAB>...`, which read back one field to the
+# left -- `prev_sid` held the SUBJECT, never compared equal, and the cadence never
+# armed down. The nudge then fired on every single turn-end, spending the shared
+# `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` budget the cadence exists to protect. A sid
+# CONTAINING a tab did the same from the other direction. Normalised ONCE here, so
+# the comparison below and the record it is compared against cannot disagree; the
+# filename key above was already defaulted, this is the same defaulting for the
+# value itself. (`stop-unmerged-lane-warn.sh` defends both halves already.)
+sid=$(printf '%s' "$sid" | tr '\t\n' '  ')
+[ -n "$sid" ] || sid="shared"
 
 # The armed TOKENS, not just how many: the set of them is the cadence subject below,
 # so a stack deployed or cleaned re-arms the nudge while an ordinary turn does not.
 armed=$(cat "$owner_file" "$autoarm_file" "$legacy" 2>/dev/null | grep -vE '^[[:space:]]*$' || true)
 [ -n "$armed" ] || exit 0
-count=$(printf '%s\n' "$armed" | grep -c '' 2>/dev/null || echo 0)
 
 # Tabs are folded to spaces because the record below is tab-separated, and a token
-# carrying one would shift every later field.
-subject=$(printf '%s\n' "$armed" | tr '\t' ' ' | LC_ALL=C sort -u | tr '\n' ',')
+# carrying one would shift every later field. `LC_ALL=C sort -u` makes the subject
+# ORDER-independent (the three sentinel files are concatenated, so the same set can
+# arrive in different orders and must not read as a new subject) as well as
+# duplicate-free (the legacy flat file and the owner file legitimately name the same
+# stack).
+#
+# `count` is derived from the SAME deduped set the message lists, not from the raw
+# lines: counting raw while listing deduped made the text say "2 token(s)" and then
+# name one, which reads as a bug in the sentinel rather than in the counting.
+armed_set=$(printf '%s\n' "$armed" | tr '\t' ' ' | LC_ALL=C sort -u)
+count=$(printf '%s\n' "$armed_set" | grep -c '' 2>/dev/null || echo 0)
+subject=$(printf '%s\n' "$armed_set" | tr '\n' ',')
 subject="${subject%,}"
 
 # `stop_hook_active` is a required boolean on the Stop payload. A STRING "false" is
 # truthy to a naive read, so the textual spellings are folded down rather than trusted;
-# reading one as "already continued" would silence this hook permanently.
+# reading one as "already continued" would silence this hook's model half permanently.
+# The non-string arm is `$f == true` rather than jq truthiness, because jq and Python
+# disagree on exactly the values a malformed payload carries -- `0`, `[]` and `{}` are
+# all TRUTHY in jq and all falsy in Python. Left as truthiness, this hook read them as a
+# continuation while stop-unmerged-lane-warn.sh next door did not, and this is the one
+# that goes quiet about money.
 active=$(printf '%s' "$input" | jq -r '
   (.stop_hook_active // false) as $f
   | if ($f | type) == "string"
     then (if ($f | ascii_downcase | gsub("^\\s+|\\s+$"; "") | . == "" or . == "false" or . == "0" or . == "no") then "0" else "1" end)
-    else (if $f then "1" else "0" end) end' 2>/dev/null || echo "0")
-
-# Already surfaced once this turn and the model came back to Stop. Repeating it would
-# spin the turn instead of ending it, and the human has already seen the systemMessage
-# from the earlier pass of this same turn, so stand down entirely.
-[ "$active" = "1" ] && exit 0
+    else (if ($f == true) then "1" else "0" end) end' 2>/dev/null || echo "0")
 
 now=$(date +%s)
 armed_since="$now"
@@ -157,8 +206,21 @@ if [ -n "$git_dir" ]; then
   if [ "$prev_sid" = "$sid" ] && [ "$prev_subject" = "$subject" ]; then
     case "$prev_since" in '' | *[!0-9]*) prev_since="$prev_nudge" ;; esac
     case "$prev_since" in '' | *[!0-9]*) prev_since="$now" ;; esac
-    armed_since="$prev_since"
     case "$prev_nudge" in '' | *[!0-9]*) prev_nudge=0 ;; esac
+    # `10#` because the sanitisers above accept a LEADING ZERO -- it is a digit -- and
+    # bash then reads `08` as octal and aborts the arithmetic with "value too great for
+    # base", on the hook's real stderr, every turn.
+    prev_since=$((10#$prev_since))
+    prev_nudge=$((10#$prev_nudge))
+    # A stamp in the FUTURE is not hypothetical: a forward clock jump plus the NTP
+    # correction that follows it leaves one behind, and bash WRAPS an over-long value
+    # silently rather than refusing it. Unclamped, `now - prev_nudge` is negative, never
+    # reaches REARM_SECONDS, and the model is silent about live resources for as long as
+    # the stamp says -- the same unbounded-silence failure as a record that never
+    # compares equal, in the opposite direction. Treat anything not in [0, now] as 0.
+    if [ "$prev_nudge" -gt "$now" ] || [ "$prev_nudge" -lt 0 ]; then prev_nudge=0; fi
+    if [ "$prev_since" -gt "$now" ] || [ "$prev_since" -lt 0 ]; then prev_since="$now"; fi
+    armed_since="$prev_since"
     # Same tokens, same session: quiet, UNLESS the wall clock says these resources have
     # been billing for another REARM_SECONDS since the model was last told.
     if [ "$((now - prev_nudge))" -ge "$REARM_SECONDS" ]; then
@@ -169,7 +231,28 @@ if [ -n "$git_dir" ]; then
   fi
 fi
 
+# No clamp here, deliberately. "armed for ~-5256000 minute(s)" is the visible half of
+# the future-stamp bug, but the fix belongs at the SOURCE: `armed_since` is either
+# `now` or a `prev_since` already clamped into [0, now] above, so this difference
+# cannot be negative. A second clamp here would be a fence no test can trip -- probed
+# by deleting it, which left the suite green because the clamp above had already made
+# the case unreachable.
 armed_minutes=$(((now - armed_since) / 60))
+
+# `stop_hook_active` marks a pass the harness has ALREADY resumed on some hook's
+# account. Emitting `additionalContext` again would spin the turn instead of ending it,
+# so the MODEL half stands down -- and only that half. This used to `exit 0` outright,
+# which took the `systemMessage` with it and broke the promise this file's header makes
+# (the user hears about live resources on every turn it fires). The justification was
+# that the human saw it on the earlier pass, and that is FALSE whenever the tokens were
+# not armed then: the neighbouring Stop hook forces a continuation, the model runs a
+# deploy inside it, `deploy-autoarm-gate.sh` arms, and this pass is the FIRST time the
+# condition holds at all. A bare `systemMessage` does not continue a turn, so nothing
+# spins.
+if [ "$active" = "1" ]; then
+  arm=0
+  arm_reason="active"
+fi
 
 user_msg="cdkrd cleanup reminder: ${count} deploy/stack token(s) are still ARMED in the bughunt-clean
 sentinel -- real AWS resources were deployed this session and have NOT been verified gone. They are
@@ -190,14 +273,33 @@ are still billing. Nothing here goes away on its own -- clean up now, or say exp
 must stay live."
 fi
 
-if [ "$arm" = "1" ] && [ -n "$state_file" ]; then
-  # tmp + `mv` so a Stop racing another never leaves a half-written line behind.
-  tmp="${state_file}.$$"
-  if printf '%s\t%s\t%s\t%s\n' "$sid" "$subject" "$now" "$armed_since" >"$tmp" 2>/dev/null; then
-    mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
-  else
-    rm -f "$tmp" 2>/dev/null || true
+# The record is what BOUNDS the nudge, so failing to persist it is not a cosmetic
+# problem: an unwritable git dir (a read-only checkout, a full disk, a directory owned
+# by another user) leaves every later turn re-arming, which is the same unbounded
+# `additionalContext` the cadence exists to prevent. When the record cannot be kept,
+# the model half is dropped for THIS turn and the user still hears it -- one telling
+# lost is cheaper than a spin that the harness eventually overrides.
+#
+# `2>/dev/null >"$tmp"`, in that order: applied the other way round, bash has already
+# replaced fd 2 with the tmp file by the time it tries to open it, so the failure to
+# open is reported on the hook's REAL stderr -- a "Permission denied" line surfacing
+# from an advisory hook on every turn.
+if [ "$arm" = "1" ]; then
+  wrote=0
+  if [ -n "$state_file" ]; then
+    # tmp + `mv` so a Stop racing another never leaves a half-written line behind.
+    tmp="${state_file}.$$"
+    if printf '%s\t%s\t%s\t%s\n' "$sid" "$subject" "$now" "$armed_since" 2>/dev/null >"$tmp"; then
+      if mv -f "$tmp" "$state_file" 2>/dev/null; then
+        wrote=1
+      else
+        rm -f "$tmp" 2>/dev/null || true
+      fi
+    else
+      rm -f "$tmp" 2>/dev/null || true
+    fi
   fi
+  [ "$wrote" = "1" ] || arm=0
 fi
 
 if [ "$arm" = "1" ]; then

--- a/.claude/hooks/stop-cleanup-warn.sh
+++ b/.claude/hooks/stop-cleanup-warn.sh
@@ -176,16 +176,26 @@ subject="${subject%,}"
 # `stop_hook_active` is a required boolean on the Stop payload. A STRING "false" is
 # truthy to a naive read, so the textual spellings are folded down rather than trusted;
 # reading one as "already continued" would silence this hook's model half permanently.
-# The non-string arm is `$f == true` rather than jq truthiness, because jq and Python
-# disagree on exactly the values a malformed payload carries -- `0`, `[]` and `{}` are
-# all TRUTHY in jq and all falsy in Python. Left as truthiness, this hook read them as a
-# continuation while stop-unmerged-lane-warn.sh next door did not, and this is the one
-# that goes quiet about money.
+#
+# The non-string arms reproduce PYTHON's truthiness rather than jq's, because
+# `stop-unmerged-lane-warn.sh` next door parses the same field with `python3` and the
+# two must not disagree about what a malformed payload means. Neither the naive jq
+# read nor a plain `$f == true` gets there, and each fails in the opposite direction:
+# jq truthiness makes `0`, `[]` and `{}` continuations (Python says no), while
+# `$f == true` makes `1`, `[1]` and `{"a":1}` ordinary turns (Python says yes) --
+# measured, and the second direction is the dangerous one HERE, since reading a
+# resumed pass as fresh emits `additionalContext` again and spins the turn. So:
+# null / false / 0 / an empty container are falsy, everything else is truthy, which
+# is Python's rule spelled in jq.
 active=$(printf '%s' "$input" | jq -r '
   (.stop_hook_active // false) as $f
-  | if ($f | type) == "string"
+  | ($f | type) as $t
+  | if $t == "string"
     then (if ($f | ascii_downcase | gsub("^\\s+|\\s+$"; "") | . == "" or . == "false" or . == "0" or . == "no") then "0" else "1" end)
-    else (if ($f == true) then "1" else "0" end) end' 2>/dev/null || echo "0")
+    elif $t == "null" then "0"
+    elif $t == "boolean" then (if $f then "1" else "0" end)
+    elif $t == "number" then (if $f == 0 then "0" else "1" end)
+    else (if ($f | length) == 0 then "0" else "1" end) end' 2>/dev/null || echo "0")
 
 now=$(date +%s)
 armed_since="$now"
@@ -280,10 +290,11 @@ fi
 # the model half is dropped for THIS turn and the user still hears it -- one telling
 # lost is cheaper than a spin that the harness eventually overrides.
 #
-# `2>/dev/null >"$tmp"`, in that order: applied the other way round, bash has already
-# replaced fd 2 with the tmp file by the time it tries to open it, so the failure to
-# open is reported on the hook's REAL stderr -- a "Permission denied" line surfacing
-# from an advisory hook on every turn.
+# `2>/dev/null >"$tmp"`, in that order, and the order is the whole point. Redirections
+# are applied left to right, and the one that FAILS here is the fd-1 open of `$tmp`.
+# Written `>"$tmp" 2>/dev/null` that open is attempted while fd 2 is still the REAL
+# stderr, so "Permission denied" is reported there -- from an advisory hook, on every
+# turn. Putting `2>/dev/null` first silences fd 2 before the open that can fail.
 if [ "$arm" = "1" ]; then
   wrote=0
   if [ -n "$state_file" ]; then

--- a/.claude/hooks/stop-cleanup-warn.sh
+++ b/.claude/hooks/stop-cleanup-warn.sh
@@ -34,9 +34,14 @@
 #                         told. This is a different trade from stop-unmerged-lane-warn
 #                         next door, where the same wall of text every turn WAS the
 #                         complaint; an unmerged lane costs nothing while it sits.
-#   additionalContext  -- additionally, when the cadence below arms. The text names a
-#                         command to run (`/sweep-resources`), so it is written at the
-#                         model, and only the model can act on it.
+#   additionalContext  -- additionally, when the cadence below arms. What makes it the
+#                         MODEL's channel is not that it names `/sweep-resources` -- the
+#                         `systemMessage` names the same command, deliberately, so a
+#                         person can run it themselves. It is that only
+#                         `additionalContext` CONTINUES the turn, so it is the only way
+#                         to hand the work back to an agent that was about to stop; and
+#                         its text is phrased as an instruction ("you deployed ... do not
+#                         leave them billing") rather than as a report.
 #
 # CADENCE. `stop_hook_active` marks a turn the harness has already resumed on a hook's
 # account, so it drops the MODEL half -- and that is all it does. It is deliberately not
@@ -223,7 +228,29 @@ active=$(printf '%s' "$input" | jq -r '
 now=$(date +%s)
 armed_since="$now"
 arm=1
+# `arm_reason` has ONE value that is ever read: `clock`, tested far below to
+# decide whether the model text carries the escalated "this is a REPEAT" line.
+# `new` and `active` are the two ways of being not-`clock`; `new` also
+# initialises the variable under `set -u`. They are not dead, but neither is
+# read by name, so do not add a third value expecting it to do something.
 arm_reason="new"
+
+# DELIBERATELY NOT DELETED when the condition clears, unlike the record in
+# `stop-unmerged-lane-warn.sh` next door. That hook drops its record the moment
+# no worktree is ahead, because its stale record can SWALLOW a later first
+# sighting of the same subject -- a missed nudge, the unsafe direction.
+#
+# This one cannot go silent the same way, and the difference is the wall clock.
+# The subject here is the SET OF ARMED TOKENS: it changes whenever a token is
+# armed or cleared, so a stale record stops matching as soon as the situation
+# actually differs. When it does keep matching -- the same resources still
+# armed, the same session -- staying quiet on the MODEL channel is the intended
+# cadence, the `systemMessage` still fires on every turn so the human is never
+# unaware, and `REARM_SECONDS` re-arms the model channel anyway after 20
+# minutes. So the worst case is bounded at "the model is not re-told for up to
+# 20 minutes about resources the user is being told about every turn", against
+# the lane hook's unbounded "never told again". Reviewed and left as is rather
+# than left unstated.
 
 git_dir=$(git -C "$target_dir" rev-parse --absolute-git-dir 2>/dev/null || true)
 state_file=""
@@ -324,10 +351,21 @@ if [ "$arm" = "1" ]; then
     # tmp + `mv` so a Stop racing another never leaves a half-written line behind.
     tmp="${state_file}.$$"
     if printf '%s\t%s\t%s\t%s\n' "$sid" "$subject" "$now" "$armed_since" 2>/dev/null >"$tmp"; then
-      if mv -f "$tmp" "$state_file" 2>/dev/null; then
+      # `mv -f <file> <dir>` returns SUCCESS -- it moves the tmp INSIDE the
+      # directory -- so `mv` alone certified a record that was never written.
+      # The readback next turn then found nothing, `wrote` was 1 anyway, and
+      # every later turn re-armed: the UNBOUNDED `additionalContext` against
+      # CLAUDE_CODE_STOP_HOOK_BLOCK_CAP that this whole cadence exists to
+      # remove, arriving through the success check. Measured: `mv -f <file>
+      # <dir>` -> rc 0, file inside the directory, and with the record path a
+      # directory the hook emitted `both both both both` where the cadence
+      # promises `both sys sys sys`. So the destination is confirmed to be a
+      # regular FILE, and the tmp the non-move left inside it is swept --
+      # otherwise the git dir grows one orphan per turn.
+      if mv -f "$tmp" "$state_file" 2>/dev/null && [ -f "$state_file" ]; then
         wrote=1
       else
-        rm -f "$tmp" 2>/dev/null || true
+        rm -f "$tmp" "$state_file/${tmp##*/}" 2>/dev/null || true
       fi
     else
       rm -f "$tmp" 2>/dev/null || true

--- a/.claude/hooks/stop-cleanup-warn.sh
+++ b/.claude/hooks/stop-cleanup-warn.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # stop-cleanup-warn.sh
 #
-# Stop hook. Closes hole B — "deployed real AWS resources, then ended the session
-# WITHOUT committing" — which the commit/PR gate (bughunt-clean-gate) never sees
+# Stop hook. Closes hole B -- "deployed real AWS resources, then ended the session
+# WITHOUT committing" -- which the commit/PR gate (bughunt-clean-gate) never sees
 # because no commit/PR is attempted. At session end, if THIS session/owner's
-# bughunt-clean sentinel is armed, print a prominent reminder to clean up.
+# bughunt-clean sentinel is armed, say so.
 #
 # PER-SESSION scope (mirrors bughunt-clean-gate exactly): warn only about resources
-# THIS session/owner is responsible for — (a) the cwd worktree's owner file (per-stack
-# tracking) and (b) this session's autoarm-<session> token — NOT a peer session's live
+# THIS session/owner is responsible for -- (a) the cwd worktree's owner file (per-stack
+# tracking) and (b) this session's autoarm-<session> token -- NOT a peer session's live
 # hunt (its stacks are uniquely named; its own gate/warn covers them). Warning about a
 # peer's resources here would be a false "you forgot to clean up". The legacy flat
 # sentinel stays global for back-compat.
@@ -16,10 +16,73 @@
 # WARN ONLY (exit 0): a /hunt-bugs session legitimately keeps resources live between
 # turns, so this must NOT hard-block stopping (that is the commit/PR gate's job).
 # It only surfaces outstanding resources so they are never SILENTLY forgotten.
+#
+# CHANNELS. Until go-to-k/cdk-real-drift#1844 this "surfacing" was an `echo ... >&2`
+# followed by `exit 0`, which reaches NOBODY: a hook's stderr is surfaced only on a
+# NON-ZERO exit, and stdout at exit 0 is parsed as JSON and discarded when it is not.
+# So a billing guardrail printed its warning into a hole. The three Stop channels are:
+#
+#   hookSpecificOutput.additionalContext -- the MODEL, and the turn CONTINUES
+#   systemMessage                        -- the USER only, and the turn ends
+#   stdout / stderr at exit 0            -- nobody
+#
+# This hook is the one place in the repo that emits BOTH of the first two, and the
+# two branches are independent in the harness so both can be present at once:
+#
+#   systemMessage      -- on EVERY turn it fires. A billing guardrail must never be
+#                         silent to the human, whatever the model is or is not being
+#                         told. This is a different trade from stop-unmerged-lane-warn
+#                         next door, where the same wall of text every turn WAS the
+#                         complaint; an unmerged lane costs nothing while it sits.
+#   additionalContext  -- additionally, when the cadence below arms. The text names a
+#                         command to run (`/sweep-resources`), so it is written at the
+#                         model, and only the model can act on it.
+#
+# CADENCE. `stop_hook_active` marks a turn the harness has already resumed on a hook's
+# account, so it stops a nudge SPINNING inside one turn -- and that is all it does.
+# Across turns the armed sentinel persists until the resources are actually deleted, so
+# an unconditional `additionalContext` would fire at every turn-end for as long as they
+# live. That is not merely slow: a Stop hook's `additionalContext` travels in the same
+# return value as a `decision: "block"`, so both spend one budget --
+# `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, 8 consecutive blocks by default -- after which the
+# harness overrides the hook and ends the turn. The hook that spends the budget is not
+# necessarily the one with something urgent to say.
+#
+# So the model is nudged at most once per distinct SUBJECT, and the subject is the
+# SORTED SET OF ARMED TOKENS: deploying another stack or clearing one changes it and
+# re-arms, while ordinary turns do not. Two deliberate differences from the lane hook:
+#
+#   1. a WALL-CLOCK re-arm (REARM_SECONDS below) fires even when the subject is
+#      unchanged, because money accrues on the clock rather than per turn. An idle
+#      session sitting on a live NAT gateway is exactly the case a subject-only rule
+#      would go quiet on. The escalated message says how long the tokens have been
+#      armed, so the second telling carries information the first did not.
+#   2. `systemMessage` on EVERY fire, per the channel note above.
+#
+# The record is one file in the PER-WORKTREE git dir, holding
+# `<session id>TAB<subject>TAB<last nudge epoch>TAB<armed since epoch>`, written
+# tmp-then-`mv`. The first three fields are the shape the sibling Stop hooks use; the
+# fourth exists only here, to answer "how long" without being reset by each nudge.
+# Per-worktree because that is where markgate keeps its markers, and because removing a
+# worktree takes its record with it. ONE file rather than one per session, because a
+# per-session file would accumulate with nobody to clean it up; a concurrent session in
+# the same worktree can therefore clobber it, which costs an EXTRA nudge rather than a
+# missed one -- the safe direction for a guardrail about money.
 
 set -u
 
+# How long an unchanged subject may stay quiet before the model is told again.
+REARM_SECONDS=1200 # 20 minutes
+
 input=$(cat 2>/dev/null || true)
+
+# `jq` builds the payload as well as parsing the event. Without it this script would
+# end on a `command not found` and return 127 -- a hook ERROR reported on every single
+# turn, from a hook that is advisory by design. Say nothing instead. (Every other gate
+# in this repo assumes `jq` unguarded; the difference is that they run per tool call
+# and this one runs per turn-end.)
+command -v jq >/dev/null 2>&1 || exit 0
+
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 target_dir="${hook_cwd:-$PWD}"
 
@@ -50,18 +113,97 @@ sid="${CLAUDE_CODE_SESSION_ID:-}"
 sid_key="$(printf '%s' "$sid" | sed 's#[^A-Za-z0-9._-]#_#g')"
 autoarm_file="${pending_dir}/autoarm-${sid_key:-shared}"
 
-count=0
-for f in "$owner_file" "$autoarm_file" "$legacy"; do
-  [ -s "$f" ] && count=$((count + $(grep -cvE '^[[:space:]]*$' "$f" 2>/dev/null || echo 0)))
-done
+# The armed TOKENS, not just how many: the set of them is the cadence subject below,
+# so a stack deployed or cleaned re-arms the nudge while an ordinary turn does not.
+armed=$(cat "$owner_file" "$autoarm_file" "$legacy" 2>/dev/null | grep -vE '^[[:space:]]*$' || true)
+[ -n "$armed" ] || exit 0
+count=$(printf '%s\n' "$armed" | grep -c '' 2>/dev/null || echo 0)
 
-[ "$count" -gt 0 ] || exit 0
+# Tabs are folded to spaces because the record below is tab-separated, and a token
+# carrying one would shift every later field.
+subject=$(printf '%s\n' "$armed" | tr '\t' ' ' | LC_ALL=C sort -u | tr '\n' ',')
+subject="${subject%,}"
 
-{
-  echo "⚠️  cdkrd cleanup reminder: ${count} deploy/stack token(s) are still ARMED in the"
-  echo "    bughunt-clean sentinel — you deployed real AWS resources this session and have"
-  echo "    NOT yet verified them gone. Do not leave them billing:"
-  echo "      /sweep-resources        # discover + delete cdkrd test resources, then release the gate"
-  echo "    (or: delstack the stacks, run bughunt-track.sh verify, then clear)."
-} >&2
+# `stop_hook_active` is a required boolean on the Stop payload. A STRING "false" is
+# truthy to a naive read, so the textual spellings are folded down rather than trusted;
+# reading one as "already continued" would silence this hook permanently.
+active=$(printf '%s' "$input" | jq -r '
+  (.stop_hook_active // false) as $f
+  | if ($f | type) == "string"
+    then (if ($f | ascii_downcase | gsub("^\\s+|\\s+$"; "") | . == "" or . == "false" or . == "0" or . == "no") then "0" else "1" end)
+    else (if $f then "1" else "0" end) end' 2>/dev/null || echo "0")
+
+# Already surfaced once this turn and the model came back to Stop. Repeating it would
+# spin the turn instead of ending it, and the human has already seen the systemMessage
+# from the earlier pass of this same turn, so stand down entirely.
+[ "$active" = "1" ] && exit 0
+
+now=$(date +%s)
+armed_since="$now"
+arm=1
+arm_reason="new"
+
+git_dir=$(git -C "$target_dir" rev-parse --absolute-git-dir 2>/dev/null || true)
+state_file=""
+if [ -n "$git_dir" ]; then
+  state_file="${git_dir}/stop-nudge-cleanup"
+  prev_sid=""
+  prev_subject=""
+  prev_nudge=""
+  prev_since=""
+  if [ -r "$state_file" ]; then
+    IFS="$(printf '\t')" read -r prev_sid prev_subject prev_nudge prev_since <"$state_file" 2>/dev/null || true
+  fi
+  if [ "$prev_sid" = "$sid" ] && [ "$prev_subject" = "$subject" ]; then
+    case "$prev_since" in '' | *[!0-9]*) prev_since="$prev_nudge" ;; esac
+    case "$prev_since" in '' | *[!0-9]*) prev_since="$now" ;; esac
+    armed_since="$prev_since"
+    case "$prev_nudge" in '' | *[!0-9]*) prev_nudge=0 ;; esac
+    # Same tokens, same session: quiet, UNLESS the wall clock says these resources have
+    # been billing for another REARM_SECONDS since the model was last told.
+    if [ "$((now - prev_nudge))" -ge "$REARM_SECONDS" ]; then
+      arm_reason="clock"
+    else
+      arm=0
+    fi
+  fi
+fi
+
+armed_minutes=$(((now - armed_since) / 60))
+
+user_msg="cdkrd cleanup reminder: ${count} deploy/stack token(s) are still ARMED in the bughunt-clean
+sentinel -- real AWS resources were deployed this session and have NOT been verified gone. They are
+still billing. Clear them with /sweep-resources (or: delstack the stacks, run bughunt-track.sh verify,
+then clear).
+Armed token(s): ${subject}"
+
+model_msg="WARNING: ${count} deploy/stack token(s) are still ARMED in the bughunt-clean sentinel -- you
+deployed real AWS resources this session and have NOT yet verified them gone. Do not leave them billing:
+  /sweep-resources        # discover + delete cdkrd test resources, then release the gate
+(or: delstack the stacks, run bughunt-track.sh verify, then clear).
+Armed token(s): ${subject}"
+
+if [ "$arm_reason" = "clock" ]; then
+  model_msg="${model_msg}
+This is a REPEAT: the same token(s) have now been armed for ~${armed_minutes} minute(s) of wall clock and
+are still billing. Nothing here goes away on its own -- clean up now, or say explicitly why the resources
+must stay live."
+fi
+
+if [ "$arm" = "1" ] && [ -n "$state_file" ]; then
+  # tmp + `mv` so a Stop racing another never leaves a half-written line behind.
+  tmp="${state_file}.$$"
+  if printf '%s\t%s\t%s\t%s\n' "$sid" "$subject" "$now" "$armed_since" >"$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  else
+    rm -f "$tmp" 2>/dev/null || true
+  fi
+fi
+
+if [ "$arm" = "1" ]; then
+  jq -n --arg sys "$user_msg" --arg ctx "$model_msg" \
+    '{systemMessage: $sys, hookSpecificOutput: {hookEventName: "Stop", additionalContext: $ctx}}'
+else
+  jq -n --arg sys "$user_msg" '{systemMessage: $sys}'
+fi
 exit 0

--- a/.claude/hooks/stop-cleanup-warn.test.sh
+++ b/.claude/hooks/stop-cleanup-warn.test.sh
@@ -11,6 +11,28 @@ HOOK="$(cd "$(dirname "$0")" && pwd)/stop-cleanup-warn.sh"
 PASS=0
 FAIL=0
 
+# --- BASH 3.2 FENCE ---
+# macOS ships bash 3.2 as /bin/bash and this repo runs on it, so the hook has to
+# stay 3.2-clean. It was, but only ACCIDENTALLY: every case here launches the hook
+# as `bash "$HOOK"`, which resolves through PATH -- normally a modern Homebrew
+# build -- and the shebang is `#!/usr/bin/env bash`, which resolves the same way.
+# So running this SUITE under /bin/bash proved nothing whatsoever about the hook;
+# both interpreters were 5.x either way.
+#
+# A shim directory holding one symlink named `bash` goes FIRST on PATH, so every
+# child `bash` -- the explicit invocations, the shebang, and the ones inside the
+# stubbed-PATH cases, whose `command -v bash` now resolves here -- is the fenced
+# interpreter. Default /bin/bash (3.2 on macOS, whatever the distro ships
+# elsewhere); override with HOOK_BASH to take the other tally.
+SHIMDIR="$(cd "$(mktemp -d)" && pwd -P)"
+HOOK_BASH="${HOOK_BASH:-/bin/bash}"
+[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+ln -sf "$HOOK_BASH" "$SHIMDIR/bash"
+PATH="$SHIMDIR:$PATH"
+export PATH
+printf 'hook interpreter: %s (bash %s)\n' "$HOOK_BASH" \
+  "$("$HOOK_BASH" -c 'echo "$BASH_VERSION"')"
+
 # The warn is PER-SESSION (mirrors bughunt-clean-gate): it fires only for THIS
 # session/owner's resources — the cwd worktree's owner file, this session's
 # autoarm-<session> token, or the legacy flat file — never a peer's.
@@ -105,7 +127,7 @@ check2() {
 # strings, the owner file is never found, and every case below measures the
 # nothing-armed branch instead of the one it names.
 SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
-trap 'rm -rf "$SANDBOX"' EXIT
+trap 'rm -rf "$SANDBOX" "$SHIMDIR"' EXIT
 
 FIX="$SANDBOX/repo"
 mkdir -p "$FIX/.markgate-bughunt-pending.d"
@@ -119,6 +141,18 @@ git -C "$FIX" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 OWNER_KEY=$(printf '%s' "$(git -C "$FIX" rev-parse --show-toplevel)" | sed 's#[^A-Za-z0-9._-]#_#g')
 OWNER_FILE="$FIX/.markgate-bughunt-pending.d/$OWNER_KEY"
 STATE="$FIX/.git/stop-nudge-cleanup"
+# The other two sentinel files the hook unions in. The cadence cases below used to
+# write ONLY the owner file, so the union itself was unfenced: a hook that read
+# just that one file passed every cadence case.
+AUTOARM_FILE="$FIX/.markgate-bughunt-pending.d/autoarm-s1"
+LEGACY_FILE="$FIX/.markgate-bughunt-pending"
+
+# A copy of the hook INSIDE the fixture, for the cases about where the hook looks
+# when the payload `cwd` is unusable: the fallback of last resort is this file's
+# own checkout, and the real one has nothing armed in it.
+mkdir -p "$FIX/.claude/hooks"
+cp "$HOOK" "$FIX/.claude/hooks/"
+FIX_HOOK="$FIX/.claude/hooks/$(basename "$HOOK")"
 
 # The exit STATUS is parked in a FILE, not a variable: every call site is a
 # `$(...)` subshell, so an assignment made here dies with it and the assertion
@@ -138,7 +172,35 @@ run_cleanup() { # <session-id> [extra-json-fragment, e.g. ,"stop_hook_active":tr
   printf '%s' "$out"
 }
 
+# The same run with the session id supplied ONLY through the environment, and no
+# `session_id` in the payload. Needed because the odd session ids below (empty, and
+# one containing a TAB) cannot be interpolated into a hand-built JSON string: a raw
+# tab is not legal inside a JSON string, `jq` would then fail on the WHOLE payload,
+# `cwd` would be lost with it, and the case would silently measure a different
+# fixture instead of the one it names.
+run_cleanup_env() { # <session-id>
+  local sess="$1" out rc
+  set +e
+  out=$(printf '{"cwd":"%s"}' "$FIX" | CLAUDE_CODE_SESSION_ID="$sess" bash "$HOOK" 2>/dev/null)
+  rc=$?
+  set -e
+  printf '%s' "$rc" > "$RC_FILE"
+  printf '%s' "$out"
+}
+
 rc_of() { cat "$RC_FILE"; }
+
+# The token count the user-facing line claims, and the armed duration the escalated
+# model line claims. Both are NUMBERS the message states, and nothing asserted them
+# before: a hook that hard-coded either passed every case in this file.
+count_in() {
+  printf '%s' "$1" | jq -r '.systemMessage // ""' |
+    sed -n 's/^cdkrd cleanup reminder: \([0-9][0-9]*\) deploy.*/\1/p'
+}
+minutes_in() {
+  printf '%s' "$1" | jq -r '.hookSpecificOutput.additionalContext // ""' |
+    sed -n 's/.*armed for ~\(-*[0-9][0-9]*\) minute(s).*/\1/p'
+}
 
 # ctx | sys | both | none. `both` is the ARMED shape here, unlike
 # stop-unmerged-lane-warn.sh next door where it would be a defect: the two hooks
@@ -252,20 +314,47 @@ fi
 out=$(run_cleanup s1)
 check2 "...and the clock re-arm resets, so the next turn is quiet again" "sys" "$(channel_of "$out")"
 
-# --- The continuation flag outranks everything. `additionalContext` CONTINUES
-# the turn, so a hook that emits it again on the resumed pass turns one nudge
-# into a spin; the harness caps that at 8 and then overrides the hook entirely.
-# Silence here is right even though the guardrail is armed: the human already saw
-# the systemMessage on the earlier pass of this same turn. ---
+# --- The continuation flag drops the MODEL half, and only that half.
+# `additionalContext` CONTINUES the turn, so emitting it again on the resumed pass
+# turns one nudge into a spin; the harness caps that at 8 and then overrides the
+# hook entirely. The hook used to `exit 0` here, taking the `systemMessage` with
+# it -- on the reasoning that the human had already seen it on the earlier pass of
+# the same turn. That reasoning is FALSE whenever the tokens were not armed then:
+# the neighbouring Stop hook forces a continuation, the model runs a deploy inside
+# it, `deploy-autoarm-gate.sh` arms, and this pass is the first on which there is
+# anything to say at all. A bare `systemMessage` does not continue a turn, so the
+# user half costs nothing. ---
 rm -f "$STATE"
 out=$(run_cleanup s1 ',"stop_hook_active":true')
-check2 "a resumed turn stays silent even when armed" "" "$out"
+check2 "a resumed turn drops the model half but still tells the user" "sys" "$(channel_of "$out")"
 check2 "...and standing down is exit 0" "0" "$(rc_of)"
+if printf '%s' "$out" | jq -r '.systemMessage' | grep -q 'stack-a'; then
+  PASS=$((PASS + 1)); printf 'ok   - ...and the surviving half still NAMES the token\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the surviving half still names the token\n'
+fi
+# No nudge was spent on that pass, so none may be recorded either -- otherwise the
+# resumed pass silently consumes this subject's one model nudge and the next
+# ordinary turn-end, which CAN continue, says nothing.
+out=$(run_cleanup s1)
+check2 "...and no record was written, so the next ordinary turn still nudges" "both" "$(channel_of "$out")"
 # ...and the flag as the STRING "false" must not be read as a continuation. A
 # naive truthiness read makes it identical to `true`, and since a quiet hook
 # still exits 0 the failure looks exactly like "nothing armed" forever.
+rm -f "$STATE"
 out=$(run_cleanup s1 ',"stop_hook_active":"false"')
 check2 "the string \"false\" does not count as a continuation" "both" "$(channel_of "$out")"
+# ...nor may a NON-boolean. `jq` and Python disagree here in opposite directions --
+# `0`, `[]` and `{}` are all truthy to jq and all falsy to Python -- so a plain
+# truthiness read made this hook treat a malformed payload as a continuation while
+# stop-unmerged-lane-warn.sh next door treated it as an ordinary turn. Measured:
+# `"stop_hook_active": 0` went fully silent here and fired there.
+rm -f "$STATE"
+out=$(run_cleanup s1 ',"stop_hook_active":0')
+check2 "a NUMERIC stop_hook_active is not a continuation" "both" "$(channel_of "$out")"
+rm -f "$STATE"
+out=$(run_cleanup s1 ',"stop_hook_active":{}')
+check2 "...and neither is an empty object" "both" "$(channel_of "$out")"
 
 # --- Nothing armed: no payload at all, on either channel. The channel cases
 # above all run armed, so without this a hook that emitted unconditionally would
@@ -275,25 +364,234 @@ out=$(run_cleanup s1)
 check2 "an empty sentinel emits nothing on any channel" "" "$out"
 check2 "...and still exits 0" "0" "$(rc_of)"
 
-# --- SILENT, and exit 0, without `jq`. It both parses the event and builds the
-# payload, so without the guard the script ends on `command not found` and
-# returns 127 -- a hook ERROR on every single turn, from a hook that is advisory
-# by design. The stub PATH carries every external the hook reaches for BEFORE the
-# guard (and `bash`/`env` themselves, since `PATH=... bash` and the `env bash`
-# shebang both resolve through it); a stub that is too small makes this pass for
-# a different reason than the one under test. ---
+# ---------------------------------------------------------------------------
+# The SUBJECT and the RECORD. Everything above drives the cadence through one
+# file and one well-formed session id, which left most of the machinery that
+# builds the subject unfenced -- each of the mutations named below survived a
+# full 33/33 green run before these cases existed.
+# ---------------------------------------------------------------------------
+
+# --- The session id goes into a TAB-separated record read back with `IFS=<TAB>
+# read`, where a tab is IFS *whitespace*: a leading empty field is dropped and a
+# run of tabs collapses. So an EMPTY id wrote `<TAB>subject<TAB>...`, every field
+# read back one to the left, `prev_sid` never compared equal, and the cadence
+# never armed down -- an unbounded `additionalContext` on the one hook that
+# guards MONEY, which is precisely what the block-cap budget cannot afford. An id
+# CONTAINING a tab did the same from the other side. Both are ordinary: the id is
+# absent whenever the harness sends no `session_id` and no environment variable.
+rm -f "$STATE" "$AUTOARM_FILE" "$LEGACY_FILE"
 printf 'stack-a\n' > "$OWNER_FILE"
+out=$(run_cleanup_env "")
+check2 "an EMPTY session id nudges the first time" "both" "$(channel_of "$out")"
+out=$(run_cleanup_env "")
+check2 "...and the cadence still bounds it" "sys" "$(channel_of "$out")"
+
+rm -f "$STATE"
+TAB_SID=$(printf 'sess\tid')
+out=$(run_cleanup_env "$TAB_SID")
+check2 "a session id containing a TAB nudges the first time" "both" "$(channel_of "$out")"
+out=$(run_cleanup_env "$TAB_SID")
+check2 "...and the cadence still bounds that one too" "sys" "$(channel_of "$out")"
+
+# --- The TOKENS get the same treatment, and for the same reason: a token
+# carrying a tab lands in the subject field of a tab-separated record and shifts
+# every field after it, so the read-back never matches and the nudge is unbounded
+# again. Removing the tab fold left the suite green before this case.
+rm -f "$STATE"
+printf 'stack-a\tus-east-1\n' > "$OWNER_FILE"
+out=$(run_cleanup s1)
+check2 "a token containing a TAB nudges the first time" "both" "$(channel_of "$out")"
+out=$(run_cleanup s1)
+check2 "...and the record still reads back as four fields" "sys" "$(channel_of "$out")"
+
+# --- The subject is a SORTED set, so the same tokens arriving in a different
+# order are the same subject. They legitimately do: the three sentinel files are
+# concatenated, and nothing orders the lines within one. Removing `LC_ALL=C sort`
+# left the suite green.
+rm -f "$STATE"
+printf 'stack-b\nstack-a\n' > "$OWNER_FILE"
+out=$(run_cleanup s1)
+check2 "a two-token set nudges the first time" "both" "$(channel_of "$out")"
+printf 'stack-a\nstack-b\n' > "$OWNER_FILE"
+out=$(run_cleanup s1)
+check2 "...and the SAME set in a different order is the same subject" "sys" "$(channel_of "$out")"
+
+# --- ...and a DEDUPED one, which is also what the message counts. The legacy
+# flat file and the owner file name the same stack whenever both are in use, and
+# counting raw lines while listing the deduped set made the text say "2 token(s)"
+# and then name one. No case asserted the NUMBER at all, so hard-coding `count=1`
+# left the suite green.
+rm -f "$STATE"
+printf 'stack-a\n' > "$OWNER_FILE"
+printf 'stack-a\n' > "$LEGACY_FILE"
+out=$(run_cleanup s1)
+check2 "one token armed through two files is counted once" "1" "$(count_in "$out")"
+printf 'stack-a\n' > "$OWNER_FILE"
+printf 'stack-z\n' > "$LEGACY_FILE"
+rm -f "$STATE"
+out=$(run_cleanup s1)
+check2 "...and two distinct tokens are counted as two" "2" "$(count_in "$out")"
+
+# --- The subject is the union of ALL THREE sentinel files. Every cadence case
+# above writes only the owner file, so a hook that read just that one satisfied
+# all of them -- while missing exactly the token `deploy-autoarm-gate.sh` writes,
+# which is the one armed by a deploy the model itself just ran.
+rm -f "$STATE" "$LEGACY_FILE" "$AUTOARM_FILE"
+printf 'stack-a\n' > "$OWNER_FILE"
+out=$(run_cleanup s1)
+check2 "the owner file alone nudges once" "both" "$(channel_of "$out")"
+out=$(run_cleanup s1)
+check2 "...then settles" "sys" "$(channel_of "$out")"
+printf 'autoarm-stack\n' > "$AUTOARM_FILE"
+out=$(run_cleanup s1)
+check2 "a token appearing in THIS SESSION'S autoarm file re-arms" "both" "$(channel_of "$out")"
+check2 "...and both files' tokens are counted" "2" "$(count_in "$out")"
+out=$(run_cleanup s1)
+check2 "...then settles again" "sys" "$(channel_of "$out")"
+printf 'legacy-stack\n' > "$LEGACY_FILE"
+out=$(run_cleanup s1)
+check2 "a token appearing in the LEGACY flat file re-arms too" "both" "$(channel_of "$out")"
+check2 "...and all three files' tokens are counted" "3" "$(count_in "$out")"
+
+# --- A MALFORMED record. Nothing here ever wrote one, so deleting BOTH `case`
+# sanitisers left the suite green -- while in production a record is exactly the
+# thing another process, an interrupted write or an older version of this hook
+# can leave in a shape this one does not expect. Two properties: the arithmetic
+# must not spill an error onto the hook's real stderr, and the hook must fall to
+# ARMING rather than to silence, because silence about live resources is the
+# direction that costs money.
+rm -f "$LEGACY_FILE" "$AUTOARM_FILE"
+printf 'stack-a\n' > "$OWNER_FILE"
+malformed_record() { # <literal record line>
+  printf '%s' "$1" > "$STATE"
+}
+err_of_run() { # stderr only, with stdout discarded
+  printf '{"cwd":"%s","session_id":"s1"}' "$FIX" | CLAUDE_CODE_SESSION_ID=s1 bash "$HOOK" 2>&1 >/dev/null
+}
+malformed_record "$(printf 's1\tstack-a\tnotanumber\talsonot\n')"
+check2 "a non-numeric stamp puts nothing on the hook's real stderr" "" "$(err_of_run)"
+malformed_record "$(printf 's1\tstack-a\tnotanumber\talsonot\n')"
+out=$(run_cleanup s1)
+check2 "...and a record it cannot parse re-arms rather than freezing" "both" "$(channel_of "$out")"
+
+# A LEADING ZERO passes a digits-only sanitiser and then fails ARITHMETIC: bash
+# reads `08` as octal and aborts with "value too great for base", twice, on the
+# hook's real stderr, every turn. `10#` is what makes the sanitiser's own output
+# safe to do arithmetic on.
+malformed_record "$(printf 's1\tstack-a\t08\t09\n')"
+check2 "a leading-zero stamp is not read as octal" "" "$(err_of_run)"
+
+# --- A FUTURE stamp. No attacker needed: a forward clock jump plus the NTP
+# correction that follows leaves one behind, and bash WRAPS an over-long value
+# silently rather than refusing it. The wall-clock test only asked whether enough
+# time had PASSED, so a future last-nudge made `now - prev_nudge` negative and the
+# model channel went silent for as long as the stamp said -- the same unbounded
+# silence as a record that never matches, in the opposite direction.
+rm -f "$STATE"
+out=$(run_cleanup s1)
+check2 "control: the future-stamp case starts from a real record" "both" "$(channel_of "$out")"
+future=$(($(date +%s) + 315360000)) # ~10 years
+awk -v t="$future" 'BEGIN{FS=OFS="\t"} {$3=t; $4=t; print}' "$STATE" > "$STATE.f"
+mv -f "$STATE.f" "$STATE"
+out=$(run_cleanup s1)
+check2 "a FUTURE last-nudge stamp does not silence the model forever" "both" "$(channel_of "$out")"
+check2 "...and a future armed-since never prints a negative duration" "0" "$(minutes_in "$out")"
+
+# --- The fourth field, ARMED-SINCE, is what lets the escalated message say how
+# long without a nudge resetting it. The wall-clock case above ages field 3 and
+# field 4 to the SAME value, which makes them indistinguishable -- dropping the
+# fourth field entirely (and measuring from the last nudge instead) left the
+# suite green. These age them DIFFERENTLY, across two clock cycles, which is the
+# only shape that separates the two readings.
+rm -f "$STATE"
+out=$(run_cleanup s1) # first nudge: the record is written with both stamps at now
+base=$(date +%s)
+age_record() { # <last-nudge epoch> <armed-since epoch>
+  awk -v n="$1" -v a="$2" 'BEGIN{FS=OFS="\t"} {$3=n; $4=a; print}' "$STATE" > "$STATE.a"
+  mv -f "$STATE.a" "$STATE"
+}
+age_record "$((base - 6000))" "$((base - 6000))"
+out=$(run_cleanup s1)
+check2 "the first clock re-arm measures the full armed age" "100" "$(minutes_in "$out")"
+check2 "...and the nudge moved ONLY the last-nudge stamp" "$((base - 6000))" "$(cut -f4 "$STATE")"
+# Second cycle: the last nudge is recent-ish, armed-since is old. Measuring from
+# the wrong field now reads 50 rather than 100.
+age_record "$((base - 3000))" "$((base - 6000))"
+out=$(run_cleanup s1)
+check2 "a second re-arm still measures from ARMED-SINCE, not the last nudge" "100" "$(minutes_in "$out")"
+
+# --- A record that cannot be PERSISTED. The record is what bounds the nudge, so
+# an unwritable git dir (a read-only checkout, a full disk, a directory owned by
+# another user) meant every later turn re-armed -- unbounded, the failure the
+# cadence exists to remove. The warning still has to reach the human; only the
+# model half is dropped. And the redirect order is asserted separately: written
+# `>"$tmp" 2>/dev/null`, bash has already replaced fd 2 by the time it fails to
+# open the file, so "Permission denied" surfaces on the hook's real stderr.
+rm -f "$STATE"
+printf 'stack-a\n' > "$OWNER_FILE"
+chmod 555 "$FIX/.git"
+out=$(run_cleanup s1)
+err=$(err_of_run)
+chmod 755 "$FIX/.git"
+check2 "an unpersistable record downgrades to the user channel" "sys" "$(channel_of "$out")"
+check2 "...and the failed redirect stays off the hook's real stderr" "" "$err"
+if printf '%s' "$out" | jq -r '.systemMessage' | grep -q 'stack-a'; then
+  PASS=$((PASS + 1)); printf 'ok   - ...and the human is still told which token\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the human is still told which token\n'
+fi
+
+# --- A STALE `cwd`. Only an EMPTY one fell back before, so a payload naming a
+# directory that has since been removed -- a worktree cleaned up mid-session --
+# made `git -C` fail and the hook exit 0, silent about resources still billing.
+# The last-resort anchor is this hook copy's own checkout, which is why the case
+# runs the copy INSIDE the fixture: the real one has nothing armed. `$PWD` is
+# deliberately outside any repository here, so the fallback under test is the
+# BASH_SOURCE one and not the middle candidate.
+rm -f "$STATE"
+printf 'stack-a\n' > "$OWNER_FILE"
+set +e
+out=$( (cd "$SANDBOX" && printf '{"cwd":"%s","session_id":"s1"}' "$SANDBOX/removed-worktree" |
+  CLAUDE_CODE_SESSION_ID=s1 bash "$FIX_HOOK" 2>/dev/null) )
+set -e
+check2 "a STALE cwd falls back to the hook's own checkout, not to silence" "both" "$(channel_of "$out")"
+
+# --- SILENT without `jq`. It both parses the event and builds the payload, so
+# without the guard the script ends on `command not found` -- a "jq: command not
+# found" line on the hook's stderr on every single turn, from a hook that is
+# advisory by design. The stub PATH carries every external the hook reaches for
+# BEFORE the guard (and `bash`/`env` themselves, since `PATH=... bash` and the
+# `env bash` shebang both resolve through it); a stub that is too small makes this
+# pass for a different reason than the one under test.
+#
+# THE CWD IS INSIDE THE ARMED FIXTURE, and that is the load-bearing half. Run from
+# anywhere else this case was VACUOUS: without `jq` the payload `cwd` cannot be
+# parsed at all, `target_dir` falls back to `$PWD`, and from the suite's own
+# directory nothing is armed -- so the hook returned at the not-armed check, long
+# before it would have reached `jq -n`, and DELETING the guard left the suite
+# 33/33 green. The control immediately below pins that the fixture really is armed
+# under this same cwd, so a future change cannot quietly restore the vacuum.
+#
+# The old companion assertion ("...and exits 0 rather than 127") is gone rather
+# than fixed: the hook ends on an unconditional `exit 0`, so no mutation of it can
+# make that line fail. ---
+printf 'stack-a\n' > "$OWNER_FILE"
+rm -f "$STATE" "$AUTOARM_FILE" "$LEGACY_FILE"
+set +e
+out=$( (cd "$FIX" && printf '{}' | CLAUDE_CODE_SESSION_ID=s1 bash "$HOOK" 2>&1) )
+set -e
+check2 "control: jq present, cwd inside the armed fixture -> it speaks" "both" "$(channel_of "$out")"
+
+rm -f "$STATE"
 STUBBIN="$SANDBOX/no-jq"
 mkdir -p "$STUBBIN"
 for c in bash env cat git sed grep date tr sort dirname awk mv rm; do
   ln -sf "$(command -v "$c")" "$STUBBIN/$c"
 done
 set +e
-out=$(printf '{"cwd":"%s","session_id":"s1"}' "$FIX" | PATH="$STUBBIN" bash "$HOOK" 2>&1)
-rc=$?
+out=$( (cd "$FIX" && printf '{"cwd":"%s","session_id":"s1"}' "$FIX" | PATH="$STUBBIN" bash "$HOOK" 2>&1) )
 set -e
 check2 "silent when jq is unavailable" "" "$out"
-check2 "...and exits 0 rather than 127" "0" "$rc"
 
 echo "----"
 echo "stop-cleanup-warn: $PASS passed, $FAIL failed"

--- a/.claude/hooks/stop-cleanup-warn.test.sh
+++ b/.claude/hooks/stop-cleanup-warn.test.sh
@@ -141,6 +141,23 @@ check2() {
   fi
 }
 
+# `require_state <label>` -- assert the hook actually WROTE a cadence record,
+# and report it as a case. Every block below that AGES the record needs one to
+# age, and a bare `awk ... "$STATE"` on a missing file aborts this `set -e`
+# suite mid-file. Measured before this was shared: the suite died at the
+# future-stamp block with `awk: can't open file .../stop-nudge-cleanup`, rc=2,
+# after emitting 60 of 71 cases -- ELEVEN cases hidden by ANY mutation that
+# stops the hook writing a record, which is exactly the class a mutation probe
+# is looking for. rc=2 is loud, so it was never a false green; the mutation
+# tallies taken through it were simply not re-derivable. One site was guarded
+# and two were not, which is why this is a helper rather than a third copy.
+require_state() {
+  if [ -r "$STATE" ]; then
+    PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; return 0
+  fi
+  FAIL=$((FAIL + 1)); printf 'FAIL - %s (no record was written)\n' "$1"; return 1
+}
+
 # `pwd -P` is load-bearing, not tidiness: on macOS `mktemp -d` returns a
 # `/var/folders/...` path whose real location is `/private/var/...`, while git
 # canonicalises every path it reports. An uncanonicalised sandbox therefore makes
@@ -307,12 +324,9 @@ check2 "...settling again afterwards" "sys" "$(channel_of "$out")"
 # bare `awk` would abort this `set -e` suite mid-file and hide every case after
 # it, which is exactly what a mutation probe needs to see.
 aged=$(( $(date +%s) - 3000 ))
-if [ -r "$STATE" ]; then
-  PASS=$((PASS + 1)); printf 'ok   - the hook wrote a cadence record to age\n'
+if require_state "the hook wrote a cadence record to age"; then
   awk -v t="$aged" 'BEGIN{FS=OFS="\t"} {$3=t; $4=t; print}' "$STATE" > "$STATE.aged"
   mv -f "$STATE.aged" "$STATE"
-else
-  FAIL=$((FAIL + 1)); printf 'FAIL - the hook wrote a cadence record to age\n'
 fi
 check2 "the fixture really did age the record" "$aged" "$(cut -f3 "$STATE" 2>/dev/null || echo MISSING)"
 out=$(run_cleanup s1)
@@ -533,8 +547,10 @@ rm -f "$STATE"
 out=$(run_cleanup s1)
 check2 "control: the future-stamp case starts from a real record" "both" "$(channel_of "$out")"
 future=$(($(date +%s) + 315360000)) # ~10 years
-awk -v t="$future" 'BEGIN{FS=OFS="\t"} {$3=t; $4=t; print}' "$STATE" > "$STATE.f"
-mv -f "$STATE.f" "$STATE"
+if require_state "the future-stamp fixture has a record to age"; then
+  awk -v t="$future" 'BEGIN{FS=OFS="\t"} {$3=t; $4=t; print}' "$STATE" > "$STATE.f"
+  mv -f "$STATE.f" "$STATE"
+fi
 out=$(run_cleanup s1)
 check2 "a FUTURE last-nudge stamp does not silence the model forever" "both" "$(channel_of "$out")"
 check2 "...and a future armed-since never prints a negative duration" "0" "$(minutes_in "$out")"
@@ -549,13 +565,14 @@ rm -f "$STATE"
 out=$(run_cleanup s1) # first nudge: the record is written with both stamps at now
 base=$(date +%s)
 age_record() { # <last-nudge epoch> <armed-since epoch>
+  require_state "the armed-since fixture has a record to age" || return 0
   awk -v n="$1" -v a="$2" 'BEGIN{FS=OFS="\t"} {$3=n; $4=a; print}' "$STATE" > "$STATE.a"
   mv -f "$STATE.a" "$STATE"
 }
 age_record "$((base - 6000))" "$((base - 6000))"
 out=$(run_cleanup s1)
 check2 "the first clock re-arm measures the full armed age" "100" "$(minutes_in "$out")"
-check2 "...and the nudge moved ONLY the last-nudge stamp" "$((base - 6000))" "$(cut -f4 "$STATE")"
+check2 "...and the nudge moved ONLY the last-nudge stamp" "$((base - 6000))" "$(cut -f4 "$STATE" 2>/dev/null || echo MISSING)"
 # Second cycle: the last nudge is recent-ish, armed-since is old. Measuring from
 # the wrong field now reads 50 rather than 100.
 age_record "$((base - 3000))" "$((base - 6000))"
@@ -636,5 +653,46 @@ set -e
 check2 "silent when jq is unavailable" "" "$out"
 
 echo "----"
+# --- The record path is a DIRECTORY. `mv -f <file> <dir>` returns SUCCESS -- it
+# moves the tmp INSIDE the directory -- so `wrote` was set, the readback on the
+# next turn found nothing, and EVERY turn re-armed `additionalContext` against
+# CLAUDE_CODE_STOP_HOOK_BLOCK_CAP while the git dir grew one orphan tmp per
+# turn. That is the unbounded cadence this whole mechanism exists to remove,
+# arriving through the success check -- the one failure `mv`'s own exit code
+# cannot report, so the unwritable-git-dir case above does not cover it.
+# Measured with `mv` alone: `both both both both`. The shipped answer is
+# `sys sys sys sys` -- the model half is dropped on EVERY turn including the
+# first, because `[ "$wrote" = "1" ] || arm=0` is what a record that can never
+# be written costs -- while the USER half is still promised on every one, which
+# is this hook's whole point and the half the lane twin does not keep.
+rm -f "$STATE"
+mkdir -p "$STATE"
+dir_channels=""
+for _ in 1 2 3 4; do
+  out=$(run_cleanup s1)
+  dir_channels="${dir_channels}$(channel_of "$out") "
+done
+dir_orphans=$(find "$STATE" -type f 2>/dev/null | wc -l | tr -d ' ')
+rm -f "$STATE"/* 2>/dev/null || true
+rmdir "$STATE" 2>/dev/null || true
+check2 "a record path that is a DIRECTORY never arms the model channel" "sys sys sys sys " "$dir_channels"
+check2 "...and leaves no orphan tmp behind in the git dir" "0" "$dir_orphans"
+# ...and the CONTROL: with the directory gone the hook arms again, so the four
+# `sys` above are the directory's doing rather than a hook that stopped arming.
+out=$(run_cleanup s1)
+check2 "...and it arms again once the record path is writable" "both" "$(channel_of "$out")"
+
+
+# A FLOOR on the case total. Every `for` loop above expands a LIST, and emptying
+# one -- or deleting a case -- removes assertions SILENTLY while the tally still
+# reads `fail: 0`. No suite in this repo had one, so the only thing standing
+# between a gutted loop and a green run was somebody noticing the number move.
+# Raise it when cases are added; never lower it to make a red run green.
+CASE_FLOOR=77
+if [ "$((PASS + FAIL))" -lt "$CASE_FLOOR" ]; then
+  FAIL=$((FAIL + 1))
+  printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((PASS + FAIL))" "$CASE_FLOOR"
+fi
+
 echo "stop-cleanup-warn: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/.claude/hooks/stop-cleanup-warn.test.sh
+++ b/.claude/hooks/stop-cleanup-warn.test.sh
@@ -24,9 +24,30 @@ FAIL=0
 # stubbed-PATH cases, whose `command -v bash` now resolves here -- is the fenced
 # interpreter. Default /bin/bash (3.2 on macOS, whatever the distro ships
 # elsewhere); override with HOOK_BASH to take the other tally.
+#
+# An explicitly set HOOK_BASH that is not executable is a FATAL error rather than a
+# silent fall back to PATH bash: falling back hides a typo in the one setting this
+# fence exists to pin, and the run would then report a tally under an interpreter
+# nobody asked for. Only the built-in DEFAULT may fall back, since a machine
+# without /bin/bash is a fact rather than a mistake.
+#
+# The shim is trapped for removal the moment it exists, not once the sandbox is
+# built: an early failure between the two leaked a directory per run.
 SHIMDIR="$(cd "$(mktemp -d)" && pwd -P)"
-HOOK_BASH="${HOOK_BASH:-/bin/bash}"
-[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+trap 'rm -rf "$SHIMDIR"' EXIT
+if [ -n "${HOOK_BASH:-}" ]; then
+  if [ ! -x "$HOOK_BASH" ]; then
+    printf 'FATAL - HOOK_BASH is not an executable: %s\n' "$HOOK_BASH" >&2
+    exit 2
+  fi
+else
+  HOOK_BASH=/bin/bash
+  [ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+  [ -n "$HOOK_BASH" ] && [ -x "$HOOK_BASH" ] || {
+    printf 'FATAL - no usable bash found for the hook interpreter\n' >&2
+    exit 2
+  }
+fi
 ln -sf "$HOOK_BASH" "$SHIMDIR/bash"
 PATH="$SHIMDIR:$PATH"
 export PATH
@@ -349,12 +370,33 @@ check2 "the string \"false\" does not count as a continuation" "both" "$(channel
 # truthiness read made this hook treat a malformed payload as a continuation while
 # stop-unmerged-lane-warn.sh next door treated it as an ordinary turn. Measured:
 # `"stop_hook_active": 0` went fully silent here and fired there.
+# ...nor may a NON-boolean be read differently from how the sibling hook reads it.
+# `stop-unmerged-lane-warn.sh` parses the same field with `python3`, so the pair has
+# to agree on what a malformed payload MEANS, and the two obvious jq spellings each
+# get it wrong in an opposite direction: plain truthiness makes `0`, `[]` and `{}`
+# continuations (Python says no), while `$f == true` makes `1`, `[1]` and `{"a":1}`
+# ordinary turns (Python says yes). Both directions are measured, and BOTH are
+# fenced here -- the falsy shapes must fire, the truthy ones must not. The truthy
+# half is the dangerous one for THIS hook: reading a resumed pass as fresh emits
+# `additionalContext` again and spins the turn against the 8-block cap.
 rm -f "$STATE"
 out=$(run_cleanup s1 ',"stop_hook_active":0')
-check2 "a NUMERIC stop_hook_active is not a continuation" "both" "$(channel_of "$out")"
+check2 "a FALSY number is not a continuation" "both" "$(channel_of "$out")"
 rm -f "$STATE"
 out=$(run_cleanup s1 ',"stop_hook_active":{}')
 check2 "...and neither is an empty object" "both" "$(channel_of "$out")"
+rm -f "$STATE"
+out=$(run_cleanup s1 ',"stop_hook_active":[]')
+check2 "...nor an empty array" "both" "$(channel_of "$out")"
+rm -f "$STATE"
+out=$(run_cleanup s1 ',"stop_hook_active":1')
+check2 "a TRUTHY number IS a continuation, as python3 reads it next door" "sys" "$(channel_of "$out")"
+rm -f "$STATE"
+out=$(run_cleanup s1 ',"stop_hook_active":[1]')
+check2 "...and so is a non-empty array" "sys" "$(channel_of "$out")"
+rm -f "$STATE"
+out=$(run_cleanup s1 ',"stop_hook_active":{"a":1}')
+check2 "...and a non-empty object" "sys" "$(channel_of "$out")"
 
 # --- Nothing armed: no payload at all, on either channel. The channel cases
 # above all run armed, so without this a hook that emitted unconditionally would

--- a/.claude/hooks/stop-cleanup-warn.test.sh
+++ b/.claude/hooks/stop-cleanup-warn.test.sh
@@ -2,7 +2,7 @@
 # Smoke tests for stop-cleanup-warn.sh
 #
 # Sets up a throwaway git repo, optionally arms the sentinel, runs the Stop hook, and
-# asserts it exits 0 always (warn-only) and prints a reminder ONLY when armed.
+# asserts it exits 0 always (warn-only) and reports ONLY when armed.
 # Run: bash .claude/hooks/stop-cleanup-warn.test.sh
 
 set -euo pipefail
@@ -66,6 +66,234 @@ check "a PEER session's autoarm does NOT warn" "autoarm-peer"   "mySess" 0
 check "a PEER worktree's owner does NOT warn"  "someOtherOwner" "mySess" 0
 # Silent when nothing is armed.
 check "empty sentinel is silent"               ""               "mySess" 0
+
+# ---------------------------------------------------------------------------
+# CHANNELS and CADENCE (go-to-k/cdk-real-drift#1844).
+#
+# Until #1844 the reminder above was an `echo >&2` followed by `exit 0`, which
+# reaches NOBODY: hook stderr surfaces only on a NON-zero exit, and stdout at
+# exit 0 is parsed as JSON and dropped when it is not. So the seven cases above
+# were green while the guardrail delivered its warning into a hole -- they grep
+# a combined `2>&1` capture, which cannot tell the difference. Everything below
+# reads the CHANNEL out of the JSON, which is what decides who sees it.
+#
+#   systemMessage      -> the USER, turn ends.        Emitted on EVERY fire: a
+#                         billing guardrail must never go silent to the human.
+#   additionalContext  -> the MODEL, turn CONTINUES.  Emitted additionally when
+#                         the cadence arms; the text names /sweep-resources, so
+#                         only the model can act on it.
+#
+# The cadence bounds the second one: at most one nudge per distinct SUBJECT (the
+# sorted set of armed tokens), plus a WALL-CLOCK re-arm, because money accrues on
+# the clock and an idle session sitting on a live stack is exactly what a
+# subject-only rule would go quiet on.
+# ---------------------------------------------------------------------------
+
+check2() {
+  local name="$1" want="$2" got="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS + 1)); printf 'ok   - %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1)); printf 'FAIL - %s (want %s, got %s)\n' "$name" "$want" "$got"
+  fi
+}
+
+# `pwd -P` is load-bearing, not tidiness: on macOS `mktemp -d` returns a
+# `/var/folders/...` path whose real location is `/private/var/...`, while git
+# canonicalises every path it reports. An uncanonicalised sandbox therefore makes
+# the OWNER key computed here and the one the hook computes two different
+# strings, the owner file is never found, and every case below measures the
+# nothing-armed branch instead of the one it names.
+SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+FIX="$SANDBOX/repo"
+mkdir -p "$FIX/.markgate-bughunt-pending.d"
+git -C "$FIX" init -q -b main .
+git -C "$FIX" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+# The OWNER file, not an `autoarm-<session>` one: the owner key is the worktree
+# toplevel, so it is the same for every session. The cadence cases below compare
+# what TWO sessions see, and a per-session sentinel would give the second one an
+# empty token set -- the case would then pass for "nothing armed" reasons.
+OWNER_KEY=$(printf '%s' "$(git -C "$FIX" rev-parse --show-toplevel)" | sed 's#[^A-Za-z0-9._-]#_#g')
+OWNER_FILE="$FIX/.markgate-bughunt-pending.d/$OWNER_KEY"
+STATE="$FIX/.git/stop-nudge-cleanup"
+
+# The exit STATUS is parked in a FILE, not a variable: every call site is a
+# `$(...)` subshell, so an assignment made here dies with it and the assertion
+# reads an empty string. Silence is not success on `Stop` -- a non-zero exit is a
+# hook ERROR -- so every case that asserts empty output would otherwise pass
+# against a hook that crashed before printing. Measured: with `RC2=$?` the three
+# exit-status cases below reported `want 0, got ''`.
+RC_FILE="$SANDBOX/rc"
+run_cleanup() { # <session-id> [extra-json-fragment, e.g. ,"stop_hook_active":true]
+  local sess="$1" extra="${2-}" out rc
+  set +e
+  out=$(printf '{"cwd":"%s","session_id":"%s"%s}' "$FIX" "$sess" "$extra" |
+    CLAUDE_CODE_SESSION_ID="$sess" bash "$HOOK" 2>/dev/null)
+  rc=$?
+  set -e
+  printf '%s' "$rc" > "$RC_FILE"
+  printf '%s' "$out"
+}
+
+rc_of() { cat "$RC_FILE"; }
+
+# ctx | sys | both | none. `both` is the ARMED shape here, unlike
+# stop-unmerged-lane-warn.sh next door where it would be a defect: the two hooks
+# make opposite trades, and reading only one key cannot see either.
+channel_of() {
+  [ -n "$1" ] || { printf 'none'; return; }
+  printf '%s' "$1" | jq -r '
+    ((.hookSpecificOutput.additionalContext // "") != "") as $c
+    | ((.systemMessage // "") != "") as $s
+    | if $c and $s then "both" elif $c then "ctx" elif $s then "sys" else "none" end' 2>/dev/null ||
+    printf 'malformed'
+}
+
+rm -f "$STATE"
+printf 'stack-a\n' > "$OWNER_FILE"
+
+out=$(run_cleanup s1)
+check2 "first sight of an armed token reaches the model AND the user" "both" "$(channel_of "$out")"
+check2 "...and that is exit 0, not a crash" "0" "$(rc_of)"
+if printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "Stop"' >/dev/null 2>&1; then
+  PASS=$((PASS + 1)); printf 'ok   - the hookEventName is Stop\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the hookEventName is Stop\n'
+fi
+# The model half must carry the remedy, or the continuation it buys is wasted.
+if printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext' | grep -q '/sweep-resources'; then
+  PASS=$((PASS + 1)); printf 'ok   - the model half names the command to run\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the model half names the command to run\n'
+fi
+# The user half must name the token, or a human reading it cannot tell WHICH
+# resources are live. A hook that emitted an empty-but-present systemMessage
+# would satisfy the channel assertion above and nothing else.
+if printf '%s' "$out" | jq -r '.systemMessage' | grep -q 'stack-a'; then
+  PASS=$((PASS + 1)); printf 'ok   - the user half names the armed token\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the user half names the armed token\n'
+fi
+
+out=$(run_cleanup s1)
+check2 "the same token set again does NOT force a second turn" "sys" "$(channel_of "$out")"
+# The downgrade is a DOWNGRADE, not a mute. This is the half that differs from
+# the lane hook: there the repeat is the user's problem to notice, here the
+# repeat is money still burning, so the human keeps being told every turn.
+if printf '%s' "$out" | jq -r '.systemMessage' | grep -q 'stack-a'; then
+  PASS=$((PASS + 1)); printf 'ok   - ...and the downgraded turn still NAMES the token\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the downgraded turn still names the token\n'
+fi
+if printf '%s' "$out" | jq -r '.systemMessage' | grep -q 'cleanup reminder'; then
+  PASS=$((PASS + 1)); printf 'ok   - ...and the user is still told on the downgraded turn\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the user is still told on the downgraded turn\n'
+fi
+
+# A CHANGED token set is a different subject: another stack was deployed, which
+# is exactly when the model needs telling again. Without this the first deploy of
+# a session would silence every later one.
+printf 'stack-a\nstack-b\n' > "$OWNER_FILE"
+out=$(run_cleanup s1)
+check2 "arming another stack re-arms the nudge" "both" "$(channel_of "$out")"
+out=$(run_cleanup s1)
+check2 "...and the new set then settles back to the user channel" "sys" "$(channel_of "$out")"
+
+# A different SESSION gets its own one nudge. It also overwrites the single
+# per-worktree record, so the earlier session re-arms once -- an EXTRA nudge
+# rather than a missed one, which is the safe direction for money and is pinned
+# here rather than left to be rediscovered as a bug.
+out=$(run_cleanup s2)
+check2 "a DIFFERENT session gets its own one nudge" "both" "$(channel_of "$out")"
+out=$(run_cleanup s1)
+check2 "...and a concurrent session's write costs an extra nudge, not a lost one" "both" "$(channel_of "$out")"
+out=$(run_cleanup s1)
+check2 "...settling again afterwards" "sys" "$(channel_of "$out")"
+
+# --- WALL CLOCK. The subject has not changed, so the subject rule alone says
+# quiet -- forever, while the resources bill. Age the LAST-NUDGE and ARMED-SINCE
+# stamps in the record and the hook must speak to the model again. This is the
+# case that separates this hook from stop-unmerged-lane-warn.sh, which has no
+# wall-clock re-arm at all and must not grow one. ---
+# Ageing the record is also the only case that asserts the hook WROTE one, so it
+# is guarded rather than assumed: under a hook that keeps no record at all the
+# bare `awk` would abort this `set -e` suite mid-file and hide every case after
+# it, which is exactly what a mutation probe needs to see.
+aged=$(( $(date +%s) - 3000 ))
+if [ -r "$STATE" ]; then
+  PASS=$((PASS + 1)); printf 'ok   - the hook wrote a cadence record to age\n'
+  awk -v t="$aged" 'BEGIN{FS=OFS="\t"} {$3=t; $4=t; print}' "$STATE" > "$STATE.aged"
+  mv -f "$STATE.aged" "$STATE"
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the hook wrote a cadence record to age\n'
+fi
+check2 "the fixture really did age the record" "$aged" "$(cut -f3 "$STATE" 2>/dev/null || echo MISSING)"
+out=$(run_cleanup s1)
+check2 "an unchanged subject re-arms on the WALL CLOCK" "both" "$(channel_of "$out")"
+ctx_text=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext')
+if printf '%s' "$ctx_text" | grep -q 'REPEAT'; then
+  PASS=$((PASS + 1)); printf 'ok   - ...and the escalated text says it is a repeat\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - the escalated text says it is a repeat\n'
+fi
+# The duration is the information the second telling adds. `~50 minute(s)` for a
+# 3000s-old stamp; asserting the NUMBER rather than just the word is what stops a
+# hard-coded "a while" from passing.
+if printf '%s' "$ctx_text" | grep -q 'armed for ~50 minute(s)'; then
+  PASS=$((PASS + 1)); printf 'ok   - ...and says how long it has been armed\n'
+else
+  FAIL=$((FAIL + 1)); printf 'FAIL - says how long it has been armed (got: %s)\n' \
+    "$(printf '%s' "$ctx_text" | grep -o 'armed for [^ ]* [^ ]*' || echo NONE)"
+fi
+out=$(run_cleanup s1)
+check2 "...and the clock re-arm resets, so the next turn is quiet again" "sys" "$(channel_of "$out")"
+
+# --- The continuation flag outranks everything. `additionalContext` CONTINUES
+# the turn, so a hook that emits it again on the resumed pass turns one nudge
+# into a spin; the harness caps that at 8 and then overrides the hook entirely.
+# Silence here is right even though the guardrail is armed: the human already saw
+# the systemMessage on the earlier pass of this same turn. ---
+rm -f "$STATE"
+out=$(run_cleanup s1 ',"stop_hook_active":true')
+check2 "a resumed turn stays silent even when armed" "" "$out"
+check2 "...and standing down is exit 0" "0" "$(rc_of)"
+# ...and the flag as the STRING "false" must not be read as a continuation. A
+# naive truthiness read makes it identical to `true`, and since a quiet hook
+# still exits 0 the failure looks exactly like "nothing armed" forever.
+out=$(run_cleanup s1 ',"stop_hook_active":"false"')
+check2 "the string \"false\" does not count as a continuation" "both" "$(channel_of "$out")"
+
+# --- Nothing armed: no payload at all, on either channel. The channel cases
+# above all run armed, so without this a hook that emitted unconditionally would
+# pass every one of them. ---
+rm -f "$OWNER_FILE" "$STATE"
+out=$(run_cleanup s1)
+check2 "an empty sentinel emits nothing on any channel" "" "$out"
+check2 "...and still exits 0" "0" "$(rc_of)"
+
+# --- SILENT, and exit 0, without `jq`. It both parses the event and builds the
+# payload, so without the guard the script ends on `command not found` and
+# returns 127 -- a hook ERROR on every single turn, from a hook that is advisory
+# by design. The stub PATH carries every external the hook reaches for BEFORE the
+# guard (and `bash`/`env` themselves, since `PATH=... bash` and the `env bash`
+# shebang both resolve through it); a stub that is too small makes this pass for
+# a different reason than the one under test. ---
+printf 'stack-a\n' > "$OWNER_FILE"
+STUBBIN="$SANDBOX/no-jq"
+mkdir -p "$STUBBIN"
+for c in bash env cat git sed grep date tr sort dirname awk mv rm; do
+  ln -sf "$(command -v "$c")" "$STUBBIN/$c"
+done
+set +e
+out=$(printf '{"cwd":"%s","session_id":"s1"}' "$FIX" | PATH="$STUBBIN" bash "$HOOK" 2>&1)
+rc=$?
+set -e
+check2 "silent when jq is unavailable" "" "$out"
+check2 "...and exits 0 rather than 127" "0" "$rc"
 
 echo "----"
 echo "stop-cleanup-warn: $PASS passed, $FAIL failed"

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -49,7 +49,16 @@ input=$(cat 2>/dev/null || true)
 # fallback for `session_root` further down, where it answers the opposite
 # question -- which worktree IS the session's -- and being the lane is exactly
 # what makes it the right answer there.
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+# `[ -n "$REPO" ]` FIRST, and it is not belt-and-braces. When the subshell above
+# fails, `REPO` is EMPTY, and `cd "" || exit 0` does not stand the hook down:
+# measured, `cd ""` returns 0 on bash 3.2 (macOS's /bin/bash, which
+# `#!/usr/bin/env bash` finds on a machine without Homebrew bash first on PATH)
+# and 1 on bash 5.3. So on 3.2 the guard passed and the hook went on to run
+# `git` against whatever cwd the harness happened to hand it. The `2>/dev/null`
+# on the assignment is the same correction one line up: the sibling hook has it
+# and this one did not, so a failing `cd` also wrote to the hook's REAL stderr.
+[ -n "$REPO" ] || exit 0
 cd "$REPO" 2>/dev/null || exit 0
 
 # Cheap: no fetch. A stale `origin/main` can only OVER-report: `rev-list --count
@@ -73,8 +82,13 @@ git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 # about a lane that exists, which is the one failure direction it must not have.
 lanes=""
 lane_paths=""
+# EVERY worktree, not only the lanes: the no-lane exit below has to be able
+# to clear a cadence record wherever one was left.
+all_worktrees=""
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
+  all_worktrees="${all_worktrees}${wt}
+"
   br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
   [ -n "$br" ] || continue
   case "$br" in main | master) continue ;; esac
@@ -86,7 +100,47 @@ while IFS= read -r wt; do
 "
 done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10)}')
 
-[ -n "$lanes" ] || exit 0
+if [ -z "$lanes" ]; then
+  # The condition has CLEARED: no worktree in this repo is ahead of
+  # `origin/main`. Drop every cadence record, so the NEXT lane starts ARMED.
+  #
+  # Without this the record outlived the condition, and the miss is reachable
+  # by the very remedy this hook prints. Measured: nudge (ctx), repeat (sys),
+  # `git switch --detach origin/main` so nothing is a lane, re-attach and
+  # commit again in the SAME session -> `sys`, never `ctx`. The subject is
+  # `<branch>:<push state>`, so returning to the same branch in the same push
+  # state reproduces the stored subject exactly and the nudge is SWALLOWED --
+  # a MISSED nudge, which this file and `CLAUDE.md` both call the
+  # unsafe direction. `stop-warn.sh` in the sibling repo has always dropped its
+  # record on the clean-tree exit for exactly this reason.
+  #
+  # EVERY worktree's record is dropped, including other sessions'. "No lane is
+  # ahead" is a REPO-GLOBAL fact, so no session has anything left to be quiet
+  # about; and the cost of being wrong is one EXTRA nudge, which is the trade
+  # the record's own concurrent-clobber comment already accepts.
+  #
+  # The git dir is derived without forking -- a main worktree has `.git` as a
+  # DIRECTORY, a linked one has it as a FILE holding `gitdir: <path>`. This
+  # runs on the silent path, which is most turns, so a `git rev-parse` per
+  # worktree here would be a per-turn cost paid by every clean session.
+  while IFS= read -r wt; do
+    [ -n "$wt" ] || continue
+    wt_git_dir=""
+    if [ -d "$wt/.git" ]; then
+      wt_git_dir="$wt/.git"
+    elif [ -f "$wt/.git" ]; then
+      IFS=' ' read -r _ wt_git_dir <"$wt/.git" 2>/dev/null || wt_git_dir=""
+    fi
+    # git writes an ABSOLUTE `gitdir:`; a relative one would resolve against
+    # this hook's own cwd and the `rm -f` would simply find nothing, which is
+    # the safe direction (an extra nudge, never a missed one).
+    [ -n "$wt_git_dir" ] || continue
+    rm -f "$wt_git_dir/stop-nudge-lane" 2>/dev/null || true
+  done <<CLEAR_RECORDS_EOF
+$all_worktrees
+CLEAR_RECORDS_EOF
+  exit 0
+fi
 
 # Everything past here builds a payload with `python3`. Without it the script
 # would end on a `command not found` and exit 127 -- on every turn, for a hook
@@ -149,12 +203,24 @@ print("1" if flag else "0")
 # session. Measured: a payload whose `cwd` was "<lane path>\nJUNK" wrote
 # `sid=JUNK`.
 #
-# Tabs are NOT stripped from `cwd`, and that asymmetry is deliberate. `sid` is
-# written into a tab-separated record, so a tab in it would shift every field
-# after it; `cwd` is only ever compared against a worktree path, and a tab is legal
-# in one -- folding it would break the tab-in-path case this suite already fences.
-print((data.get("cwd") or "").replace("\n", " "))
-print((data.get("session_id") or "").replace("\t", " ").replace("\n", " "))
+# Tabs are stripped from NEITHER here, and that is not the asymmetry this
+# comment used to describe. `cwd` must keep its tabs: it is only ever compared
+# against a worktree path, a tab is legal in one, and folding it would break the
+# tab-in-path case this suite fences. `session_id` must lose them, because it is
+# written into a tab-separated record -- but that fold now happens ONCE, below,
+# after BOTH of its sources have been consulted. Doing it here as well was a
+# second spelling of the same rule that covered only one of the two paths.
+# `str()` around each, because `(data.get(x) or "")` is only a STRING when the
+# field is absent, null or a string. A payload whose `cwd` is a number or a list
+# hands `.replace` a non-string and raises AttributeError -- an advisory hook
+# writing a traceback to its REAL stderr, which is the one thing this file
+# spends paragraphs avoiding, and `cwd` prints first so BOTH values are lost.
+# The block already hardens `json.loads` and `isinstance(data, dict)`; this is
+# that same check, stopped one field short. (`stop-cleanup-warn.sh` reads its
+# fields with `jq -r`, which COERCES instead of raising, so the pair diverged
+# here too.)
+print(str(data.get("cwd") or "").replace("\n", " "))
+print(str(data.get("session_id") or "").replace("\n", " "))
 ')
 active=$(printf '%s\n' "$parsed" | sed -n 1p)
 hook_cwd=$(printf '%s\n' "$parsed" | sed -n 2p)
@@ -170,8 +236,18 @@ sid=$(printf '%s\n' "$parsed" | sed -n 3p)
 # `additionalContext` against the 8-block cap, which is the whole failure the
 # cadence exists to prevent. Doing it once, after both sources have been consulted,
 # is what makes "every field is normalised before it is written" true rather than
-# true-of-one-path. (`stop-cleanup-warn.sh` next door has the same two sources and
-# the same single fold.)
+# true-of-one-path.
+#
+# `stop-cleanup-warn.sh` next door has the same two sources and the same single
+# fold, but NOT the same PRECEDENCE, and both files used to claim symmetry they
+# do not have. This hook is PAYLOAD-first (the harness's `session_id` is the
+# authority on which session this is; the env var is the fallback for a payload
+# that omits it). That hook is ENV-first, because its sid also keys the
+# `autoarm-<sid>` sentinel filename it shares with `deploy-autoarm-gate.sh` and
+# `bughunt-clean-gate.sh`, which read the env var and never see a Stop payload.
+# The two agree whenever both sources are present and identical, which is every
+# real session; they are left divergent because converging them would rename
+# that shared sentinel.
 sid=$(printf '%s' "$sid" | tr '\t\n' '  ')
 [ -n "$sid" ] || sid="shared"
 
@@ -351,12 +427,39 @@ elif [ "$channel" = "ctx" ]; then
     subject="${self_branch}:${push_state}"
     prev_sid=""
     prev_subject=""
+    prev_ts=""
+    prev_rest=""
     if [ -r "$state_file" ]; then
-      IFS="$TAB" read -r prev_sid prev_subject _ <"$state_file" 2>/dev/null || true
+      IFS="$TAB" read -r prev_sid prev_subject prev_ts prev_rest <"$state_file" 2>/dev/null || true
     fi
+    # A record is consulted only when it is WELL-FORMED: exactly three
+    # tab-separated fields with a numeric epoch. Anything else -- an empty file,
+    # a truncated write, a fourth field from a future format, a clobber that
+    # interleaved two writers -- is treated as NO record, which falls to ARM.
+    # That is the safe direction: an extra nudge, never a missed one.
+    #
+    # It is also what makes the record's THIRD field load-bearing. Before this
+    # the epoch was written on every turn and read by nothing, while CLAUDE.md
+    # documented it as part of the shape -- and its absence was precisely what
+    # could not be detected. A TAB is IFS *whitespace*, so `read` folds a RUN of
+    # them into one separator: a record with an EMPTY subject field
+    # (`<sid><TAB><TAB><subject>`) shifted the real subject INTO `prev_subject`,
+    # the predicate below matched it, and the lane went QUIET -- a malformed
+    # record SILENCING the nudge, the one direction this must not fail in. With
+    # the shape check that same record leaves `prev_ts` empty and arms.
+    # (Ported from go-to-k/cdk-local's copy of this hook, which had it; this one
+    # did not, so only the twin that already had the fix could detect its own
+    # regression.)
+    case "$prev_ts" in
+      "" | *[!0-9]*) prev_sid=""; prev_subject="" ;;
+    esac
+    [ -z "$prev_rest" ] || { prev_sid=""; prev_subject=""; }
     # A refname may not contain a colon, so the LAST one splits the subject
     # unambiguously. A subject carrying none is not a subject this hook wrote --
-    # treat it as absent, which arms, the safe direction.
+    # treat it as absent, which arms, the safe direction. Reachable only through
+    # a HAND-EDITED record now that the shape check above runs first: this hook
+    # never writes a colon-free subject, and any record it did not write is
+    # already rejected unless it also carries a numeric third field.
     case "$prev_subject" in
       *:*)
         prev_branch=${prev_subject%:*}
@@ -404,10 +507,19 @@ elif [ "$channel" = "ctx" ]; then
     # fd 2 before the open that can fail.
     tmp="${state_file}.$$"
     if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" 2>/dev/null >"$tmp"; then
-      if mv -f "$tmp" "$state_file" 2>/dev/null; then
+      # `mv -f <file> <dir>` returns SUCCESS -- it moves the tmp INSIDE the
+      # directory -- so `mv` alone certified a record that was never written.
+      # The readback next turn then found nothing, `persisted` was 1 anyway,
+      # and every later turn re-armed: the UNBOUNDED model channel this whole
+      # cadence exists to remove, arriving through the success check.
+      # Measured: `mv -f <file> <dir>` -> rc 0, file inside the directory.
+      # So the destination is confirmed to be a regular FILE, and the tmp the
+      # non-move left inside it is swept -- otherwise the git dir grows one
+      # orphan per turn.
+      if mv -f "$tmp" "$state_file" 2>/dev/null && [ -f "$state_file" ]; then
         persisted=1
       else
-        rm -f "$tmp" 2>/dev/null || true
+        rm -f "$tmp" "$state_file/${tmp##*/}" 2>/dev/null || true
       fi
     else
       rm -f "$tmp" 2>/dev/null || true

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -7,7 +7,9 @@
 # is. (The sibling cdkd repo pairs this with a `stop-warn.sh` covering the
 # UNCOMMITTED half in the main tree. This repo has no such hook, so do not read
 # the pair as coverage here; an earlier revision of this comment named it as if
-# it sat next to this file.)
+# it sat next to this file. The other Stop hook registered here,
+# `stop-cleanup-warn.sh`, covers a different axis entirely -- real AWS resources
+# left running -- and shares only the channel and cadence rules below.)
 #
 # Why this is a hook rather than another sentence. CLAUDE.md already says a
 # NOT-CLOSEABLE verdict is a to-do list and not a stopping point, and already
@@ -25,6 +27,15 @@
 # alone separates "there is unmerged work here" from "there is not".
 set -u
 
+# The Stop event's JSON arrives on stdin, and is consumed here rather than
+# lazily: the payload has to be drained whether or not this hook goes on to use
+# it. Three fields are PARSED out of it further down, once a lane has actually
+# been found -- `stop_hook_active` (has the harness already continued this
+# turn?), `cwd` (which worktree is the session in?) and `session_id` (whose
+# nudge record is this?). Claude Code writes the payload and closes the pipe, so
+# this does not block.
+input=$(cat 2>/dev/null || true)
+
 # BASH_SOURCE resolves to whichever checkout this copy of the hook lives in --
 # in a linked worktree that is the LANE, not the main tree. That is fine as a
 # place to run `git` from (every worktree shares one object store and one
@@ -33,15 +44,35 @@ set -u
 # earlier revision skipped exactly that one. Measured from a lane 5 commits
 # ahead: the hook printed nothing. The main tree is excluded by BRANCH below
 # (`main`/`master`), which is the property that actually identifies it.
+#
+# BASH_SOURCE is not banned here, only that USE of it. The same value is the
+# fallback for `session_root` further down, where it answers the opposite
+# question -- which worktree IS the session's -- and being the lane is exactly
+# what makes it the right answer there.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO" 2>/dev/null || exit 0
 
-# Cheap: no fetch. A stale `origin/main` can only UNDER-report (a branch whose
-# work already merged still looks ahead until the next fetch), and the failure
-# direction that matters is missing a real lane, not naming a merged one.
+# Cheap: no fetch. A stale `origin/main` can only OVER-report: `rev-list --count
+# origin/main..$br` only grows as `origin/main` ages, so a branch whose work has
+# already merged keeps reading as ahead. That is the safe direction -- the
+# failure that matters is MISSING a real lane, and staleness cannot cause it.
+# (This comment said UNDER-report until go-to-k/cdk-real-drift#1844, copying a
+# sentence the sibling repo had already corrected.)
 git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 
+# `lane_paths` carries the same rows as `lanes` in a machine-readable form --
+# BRANCH, TAB, worktree path -- so the session's OWN lane can be picked out of
+# them below. The branch comes FIRST because it is the field that is safe to
+# bound a split by: git refnames may not contain a tab, a space or a backslash,
+# while a worktree PATH may contain all three.
+#
+# `substr($0, 10)`, not `$2`: `git worktree list --porcelain` prints
+# `worktree <path>` with the path unquoted and unescaped, so `$2` truncates at
+# the first space. A truncated path makes `git -C` fail and the lane vanishes
+# from BOTH the enumeration and the ownership comparison -- the hook goes SILENT
+# about a lane that exists, which is the one failure direction it must not have.
 lanes=""
+lane_paths=""
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
   br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
@@ -51,19 +82,220 @@ while IFS= read -r wt; do
   [ "${ahead:-0}" -gt 0 ] || continue
   lanes="${lanes}  ${br}  (${ahead} commit(s) ahead, worktree ${wt##*/})
 "
-done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+  lane_paths="${lane_paths}${br}	${wt}
+"
+done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10)}')
 
 [ -n "$lanes" ] || exit 0
 
-msg="WARNING: unmerged lane(s) still open -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
-Each branch below is committed but not on origin/main. If any is YOURS, you are not done: rebase, run the
-gates, open the PR, merge. If one belongs to another session, say which and why, rather than leaving it
-unexplained. And if you are ending the turn with nothing that will re-invoke you, the honest label is
-STOPPED, not WAITING.
-One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
-becomes an ancestor of origin/main and keeps reading as ahead. If a lane below is already merged, the
-remaining work is to remove its worktree and delete the branch -- not to open another PR."
+# Everything past here builds a payload with `python3`. Without it the script
+# would end on a `command not found` and exit 127 -- on every turn, for a hook
+# whose entire job is advisory. Say nothing instead.
+command -v python3 >/dev/null 2>&1 || exit 0
 
-payload=$(printf '%s\n%s' "$msg" "$lanes" |
-  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
-printf '{"systemMessage": %s}' "$payload"
+# Everything below decides WHICH CHANNEL the warning leaves by, and the three
+# are not interchangeable -- on the Stop event they differ in who reads them and
+# in whether the turn ends:
+#
+#   hookSpecificOutput.additionalContext -- delivered to the MODEL, and the turn
+#     CONTINUES so it can act.
+#   systemMessage -- shown to the USER only, and the turn ends normally.
+#   stdout / stderr at exit 0 -- read by NOBODY.
+#
+# There is no fourth option that reaches the model without continuing the turn,
+# which is the whole reason this hook has to choose. It used to emit
+# `systemMessage` unconditionally, so every word of a message written AT THE
+# AGENT ("you are not done", "the honest label is STOPPED") reached only the
+# party that cannot act on it (go-to-k/cdkd#2389, ported here as
+# go-to-k/cdk-real-drift#1844).
+#
+# The split is by OWNERSHIP, because that is what decides whether a continuation
+# buys anything:
+#
+#   this session's own worktree is a lane -> additionalContext. This is the
+#     failure the hook exists for -- ending the turn with your own branch
+#     committed and no PR -- and a nudge the model may simply stop over is
+#     exactly what did not work.
+#   only OTHER worktrees are lanes -> systemMessage. The model cannot act on
+#     someone else's lane, so continuing the turn would buy a second reply that
+#     can only say "not mine". Measured in the sibling while fixing this: four
+#     forced continuations in one session over ONE lane belonging to another
+#     session, each producing a reply whose entire content was that it was not
+#     this session's to touch. And because this repo SQUASH-merges, a merged
+#     branch reads as ahead forever, so one un-removed worktree would have made
+#     that permanent.
+parsed=$(HOOK_INPUT="$input" python3 -c '
+import json, os
+
+try:
+    data = json.loads(os.environ.get("HOOK_INPUT") or "{}")
+except ValueError:
+    data = {}
+if not isinstance(data, dict):
+    data = {}
+
+# The harness sends a JSON boolean. A STRING "false" is truthy in Python, and
+# reading it as "already continued" would silence the hook permanently, so the
+# textual spellings are folded down here rather than trusted.
+flag = data.get("stop_hook_active")
+if isinstance(flag, str):
+    flag = flag.strip().lower() not in ("", "false", "0", "no")
+print("1" if flag else "0")
+print(data.get("cwd") or "")
+print((data.get("session_id") or "").replace("\t", " ").replace("\n", " "))
+')
+active=$(printf '%s\n' "$parsed" | sed -n 1p)
+hook_cwd=$(printf '%s\n' "$parsed" | sed -n 2p)
+sid=$(printf '%s\n' "$parsed" | sed -n 3p)
+[ -n "$sid" ] || sid="${CLAUDE_CODE_SESSION_ID:-shared}"
+
+# Already nudged once this turn and the model came back to Stop. Saying it again
+# would spin the turn instead of ending it, so stand down.
+[ "$active" = "1" ] && exit 0
+
+# Where is the SESSION? `cwd` from the event payload, resolved to its worktree
+# root. Falling back to this hook copy's own checkout is correct rather than
+# merely convenient: in a linked worktree BASH_SOURCE IS the lane. Note the
+# POLARITY -- an earlier revision used that same path to SKIP a worktree and so
+# went blind to the one case that matters; here it IDENTIFIES the lane instead.
+session_root=""
+[ -n "$hook_cwd" ] && session_root=$(git -C "$hook_cwd" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$session_root" ] || session_root="$REPO"
+# `pwd -P` is the load-bearing half. The `git` answers above are already
+# canonical, but the BASH_SOURCE fallback is not: `REPO` is built with `cd ...
+# && pwd`, which keeps the spelling it was reached by, so a session launched
+# through a symlinked worktree path compares a symlink against git's real path
+# and never matches -- silently taking the not-mine branch for its OWN lane.
+session_root=$(cd "$session_root" 2>/dev/null && pwd -P) || session_root=$(pwd -P)
+
+# Plain shell rather than awk. Every awk spelling of this comparison mangles
+# some path: `-v root=...` expands backslash escapes in the value, and `-F'\t'`
+# splits a path containing a tab into the wrong field. Both are the same class
+# as the space truncation fixed above, and parameter expansion has neither.
+TAB=$(printf '\t')
+self_branch=""
+while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  row_branch=${row%%"$TAB"*}
+  row_path=${row#*"$TAB"}
+  if [ "$row_path" = "$session_root" ]; then
+    self_branch="$row_branch"
+    break
+  fi
+done <<LANE_ROWS
+$lane_paths
+LANE_ROWS
+
+if [ -n "$self_branch" ]; then
+  # Whether the branch has been PUSHED is NOT used to decide the channel. It
+  # would have gone quiet on a branch that is pushed with NO PR, which is a real
+  # failure and one of the two this hook exists to catch. It earns its keep in
+  # the TEXT instead, where it names which half of the remaining work is left,
+  # and in the cadence SUBJECT below. No upstream at all reads as unpushed,
+  # which is what it is.
+  unpushed=$(git -C "$session_root" rev-list --count '@{u}..' 2>/dev/null || echo "")
+  if [ -z "$unpushed" ]; then
+    push_state="unpushed"
+    push_line="It has no upstream yet, so nothing has been submitted: push it, open the PR, then merge."
+  elif [ "$unpushed" -gt 0 ]; then
+    push_state="unpushed"
+    push_line="It has ${unpushed} commit(s) not yet pushed, so nothing carrying them has been submitted: push, open or update the PR, then merge."
+  else
+    push_state="pushed"
+    push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none."
+  fi
+  msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
+This session's worktree is on '$self_branch', which is committed but not on origin/main, so you are not
+done: rebase, run the gates, open the PR, merge. $push_line
+If you are ending the turn with nothing that will re-invoke you, the honest label is STOPPED, not WAITING.
+One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
+becomes an ancestor of origin/main and keeps reading as ahead. If '$self_branch' is already merged, the
+remaining work is to remove its worktree and delete the branch -- not to open another PR. When this tree
+is one you must NOT remove (an outer tool owns it, or you were launched inside it), detach instead:
+'git switch --detach origin/main' clears the lane here, because a worktree with no current branch is not
+a lane at all.
+Every unmerged lane in this checkout:"
+  channel="ctx"
+else
+  msg="NOTE: unmerged lane(s) exist in this checkout, none of them this session's.
+This session's worktree is not among them, so there is likely nothing here for it to do; they belong to
+other sessions, or are already merged (this repo SQUASH-merges, so a merged branch never becomes an
+ancestor of origin/main and keeps reading as ahead -- clearing one means removing its worktree and
+deleting the branch, not opening another PR).
+Lanes:"
+  channel="sys"
+fi
+
+# CADENCE. `stop_hook_active` above stops a nudge from SPINNING inside one
+# turn, and that is all it does. Across turns the condition persists, so an
+# unconditional `additionalContext` costs one forced model turn at every single
+# turn-end for as long as the lane exists -- including the two states where
+# there is nothing left to do: the PR is open and CI is running (the session is
+# legitimately WAITING), and the lane was squash-merged with its worktree left
+# behind, which reads as ahead FOREVER. Worse than slow: a Stop hook's
+# `additionalContext` travels in the same return value as a `decision: "block"`,
+# so both spend one budget -- `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, 8 consecutive
+# blocks by default -- after which the harness overrides the hook and ends the
+# turn. The hook that spends the budget is not necessarily the one with
+# something urgent to say.
+#
+# So the model is nudged at most once per distinct SUBJECT, and a repeat of the
+# same subject falls back to `systemMessage`: the user still sees it, the turn
+# ends. The subject is the branch plus whether it is pushed, so:
+#
+#   a lane never nudged in this session -> nudge
+#   the same lane, unpushed -> pushed   -> nudge (a PR should exist now, and a
+#                                          pushed branch with none is the
+#                                          failure this hook is for)
+#   the same lane, same push state      -> quiet
+#   a DIFFERENT lane                    -> nudge (it is a different subject)
+#
+# The commit COUNT is deliberately not in the key: it changes every time the
+# model commits, which would re-arm the nudge on ordinary work and leave the
+# cadence as unbounded as it started.
+#
+# There is no WALL-CLOCK re-arm here, unlike `stop-cleanup-warn.sh` next door.
+# The difference is deliberate: an unmerged lane costs nothing while it sits, so
+# a second telling buys only annoyance, whereas that hook's subject is real AWS
+# resources whose cost accrues on the clock.
+#
+# The record lives in the PER-WORKTREE git dir, so lanes never share one and
+# removing a worktree takes its record with it -- the same resolution markgate
+# uses for its marker store. One file rewritten in place, not one per session:
+# a per-session file would accumulate with nobody to clean it up. A concurrent
+# session in the same worktree can therefore clobber it, which costs an EXTRA
+# nudge rather than a missed one, the safe direction.
+if [ "$channel" = "ctx" ]; then
+  git_dir=$(git -C "$session_root" rev-parse --absolute-git-dir 2>/dev/null || true)
+  if [ -n "$git_dir" ]; then
+    state_file="${git_dir}/stop-nudge-lane"
+    subject="${self_branch}:${push_state}"
+    prev_sid=""
+    prev_subject=""
+    if [ -r "$state_file" ]; then
+      IFS="$TAB" read -r prev_sid prev_subject _ <"$state_file" 2>/dev/null || true
+    fi
+    if [ "$prev_sid" = "$sid" ] && [ "$prev_subject" = "$subject" ]; then
+      channel="sys"
+    else
+      tmp="${state_file}.$$"
+      if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" >"$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+      else
+        rm -f "$tmp" 2>/dev/null || true
+      fi
+    fi
+  fi
+fi
+
+MSG="$msg
+$lanes" CHANNEL="$channel" python3 -c '
+import json, os
+
+msg = os.environ["MSG"]
+if os.environ["CHANNEL"] == "ctx":
+    payload = {"hookSpecificOutput": {"hookEventName": "Stop", "additionalContext": msg}}
+else:
+    payload = {"systemMessage": msg}
+print(json.dumps(payload))
+'

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -141,7 +141,19 @@ flag = data.get("stop_hook_active")
 if isinstance(flag, str):
     flag = flag.strip().lower() not in ("", "false", "0", "no")
 print("1" if flag else "0")
-print(data.get("cwd") or "")
+# `cwd` is stripped of NEWLINES for the same reason `session_id` is: this block
+# prints three LINES which the shell picks apart with `sed -n 1p/2p/3p`, so a
+# newline inside an earlier value shifts every later one. Only `session_id` was
+# stripped, so a `cwd` carrying a newline put the TAIL OF THE PATH into `sid` and
+# the cadence record was keyed on a fragment of a directory name instead of the
+# session. Measured: a payload whose `cwd` was "<lane path>\nJUNK" wrote
+# `sid=JUNK`.
+#
+# Tabs are NOT stripped from `cwd`, and that asymmetry is deliberate. `sid` is
+# written into a tab-separated record, so a tab in it would shift every field
+# after it; `cwd` is only ever compared against a worktree path, and a tab is legal
+# in one -- folding it would break the tab-in-path case this suite already fences.
+print((data.get("cwd") or "").replace("\n", " "))
 print((data.get("session_id") or "").replace("\t", " ").replace("\n", " "))
 ')
 active=$(printf '%s\n' "$parsed" | sed -n 1p)
@@ -149,9 +161,18 @@ hook_cwd=$(printf '%s\n' "$parsed" | sed -n 2p)
 sid=$(printf '%s\n' "$parsed" | sed -n 3p)
 [ -n "$sid" ] || sid="${CLAUDE_CODE_SESSION_ID:-shared}"
 
-# Already nudged once this turn and the model came back to Stop. Saying it again
-# would spin the turn instead of ending it, so stand down.
-[ "$active" = "1" ] && exit 0
+# Already nudged once this turn and the model came back to Stop. Repeating the
+# MODEL half would spin the turn instead of ending it, so that half stands
+# down -- but the warning still goes to the user. This used to `exit 0`
+# outright, on the reasoning that the human had already seen it on the earlier
+# pass of the same turn. That is false whenever the condition first becomes TRUE
+# during the continuation: the lane can be committed inside it (the continuation
+# exists precisely to push the model back to work), in which case this pass is
+# the first on which there is anything to report, and a silent hook means nobody
+# ever learns. A bare `systemMessage` does not continue a turn, so nothing spins.
+# (`stop-cleanup-warn.sh` next door takes the same shape, for the same reason.)
+resumed=0
+[ "$active" = "1" ] && resumed=1
 
 # Where is the SESSION? `cwd` from the event payload, resolved to its worktree
 # root. Falling back to this hook copy's own checkout is correct rather than
@@ -248,6 +269,7 @@ fi
 #                                          pushed branch with none is the
 #                                          failure this hook is for)
 #   the same lane, same push state      -> quiet
+#   the same lane, pushed -> unpushed   -> quiet (see the DIRECTED note below)
 #   a DIFFERENT lane                    -> nudge (it is a different subject)
 #
 # The commit COUNT is deliberately not in the key: it changes every time the
@@ -265,7 +287,15 @@ fi
 # a per-session file would accumulate with nobody to clean it up. A concurrent
 # session in the same worktree can therefore clobber it, which costs an EXTRA
 # nudge rather than a missed one, the safe direction.
-if [ "$channel" = "ctx" ]; then
+if [ "$resumed" = "1" ]; then
+  # A pass the harness already resumed never spends the model channel, and never
+  # writes a record either: no nudge was spent, so the next ordinary turn-end is
+  # still this subject's first. Recording here would consume the one nudge on a
+  # pass that emitted nothing to the model.
+  channel="sys"
+elif [ "$channel" = "ctx" ]; then
+  arm=1
+  persisted=0
   git_dir=$(git -C "$session_root" rev-parse --absolute-git-dir 2>/dev/null || true)
   if [ -n "$git_dir" ]; then
     state_file="${git_dir}/stop-nudge-lane"
@@ -275,17 +305,69 @@ if [ "$channel" = "ctx" ]; then
     if [ -r "$state_file" ]; then
       IFS="$TAB" read -r prev_sid prev_subject _ <"$state_file" 2>/dev/null || true
     fi
-    if [ "$prev_sid" = "$sid" ] && [ "$prev_subject" = "$subject" ]; then
-      channel="sys"
-    else
-      tmp="${state_file}.$$"
-      if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" >"$tmp" 2>/dev/null; then
-        mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+    # A refname may not contain a colon, so the LAST one splits the subject
+    # unambiguously. A subject carrying none is not a subject this hook wrote --
+    # treat it as absent, which arms, the safe direction.
+    case "$prev_subject" in
+      *:*)
+        prev_branch=${prev_subject%:*}
+        prev_push=${prev_subject##*:}
+        ;;
+      *)
+        prev_branch=""
+        prev_push=""
+        ;;
+    esac
+
+    # The predicate is DIRECTED, and the plain equality it replaces was a real
+    # bug rather than a simplification. `pushed -> unpushed` is what an ordinary
+    # COMMIT looks like, so `prev_subject != subject` re-armed on every commit
+    # and again on every push: measured on one lane as
+    # `commit ctx, repeat sys, push ctx, repeat sys, commit ctx, push ctx, ...`
+    # -- two forced continuations per commit/push cycle, forever, which is the
+    # per-commit cadence the comment above explicitly disclaims.
+    #
+    # So the nudge arms on: a new session, a lane never seen, a DIFFERENT
+    # branch, a record this hook cannot make sense of, or the one transition
+    # that opens an action the model did not have before (`unpushed -> pushed`,
+    # after which a PR should exist and its absence is the failure this hook is
+    # for). Never `pushed -> unpushed`.
+    if [ "$prev_sid" = "$sid" ] && [ -n "$prev_branch" ] && [ "$prev_branch" = "$self_branch" ] &&
+      { [ "$prev_push" = "pushed" ] || [ "$prev_push" = "unpushed" ]; }; then
+      if [ "$prev_push" = "unpushed" ] && [ "$push_state" = "pushed" ]; then
+        arm=1
+      else
+        arm=0
+      fi
+    fi
+
+    # Written on BOTH arms, because the record holds the last OBSERVED subject
+    # rather than the last NUDGED one. Writing it only when arming freezes
+    # `prev_push` at whatever state last nudged, so the next genuine
+    # `unpushed -> pushed` compares against a stale half and goes silent. Only
+    # the CHANNEL branches on `arm`.
+    #
+    # `2>/dev/null` precedes the write redirect: applied the other way round,
+    # bash has already replaced fd 2 with the tmp file when it fails to open it,
+    # and reports the failure on the hook's real stderr.
+    tmp="${state_file}.$$"
+    if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" 2>/dev/null >"$tmp"; then
+      if mv -f "$tmp" "$state_file" 2>/dev/null; then
+        persisted=1
       else
         rm -f "$tmp" 2>/dev/null || true
       fi
+    else
+      rm -f "$tmp" 2>/dev/null || true
     fi
   fi
+
+  # A nudge that cannot be RECORDED cannot be bounded, and an unbounded one is
+  # exactly what this mechanism exists to remove -- so an unresolvable or
+  # unwritable git dir (a read-only checkout, a full disk, a dir owned by
+  # someone else) costs the MODEL channel, not the warning itself.
+  [ "$persisted" = "1" ] || arm=0
+  [ "$arm" = "1" ] || channel="sys"
 fi
 
 MSG="$msg

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -254,12 +254,22 @@ if [ -n "$self_branch" ]; then
   # WHICH half of the work is left; only the framing around them changes voice.
   # (`stop-cleanup-warn.sh` next door has carried a `user_msg` / `model_msg` pair
   # from the start, for exactly this reason.)
+  # The user text says nothing about whether the AGENT has been told, and that
+  # omission is deliberate. One string reaches all THREE downgrade paths --
+  # cadence repeat, unpersistable record, resumed pass -- and "the agent has
+  # already been nudged once" is true only of the first. On the other two no
+  # nudge was ever spent, and on the unpersistable one the model half is dropped
+  # precisely BECAUSE the record cannot be kept, so the agent will never be told
+  # and the claim would repeat every turn. That is the same one-emitter,
+  # three-paths shape this comment block was written about, reproduced in the
+  # TEXT rather than in the code -- and the paragraph above already argues that
+  # "the human has already seen it" is false on the resumed path.
   user_msg="NOTE: this session's own lane is unmerged -- '$self_branch' is committed but not on origin/main.
 $push_note
-The agent has already been nudged about this lane once, so this repeat is for you: if the session ends
-here, the work stays on the branch and nothing carries it to main. One false positive is expected and is
-cheap to clear -- this repo SQUASH-merges, so an already-merged branch keeps reading as ahead, and
-clearing that one means removing its worktree and deleting the branch rather than opening another PR.
+If the session ends here, the work stays on the branch and nothing carries it to main. One false positive
+is expected and is cheap to clear -- this repo SQUASH-merges, so an already-merged branch keeps reading as
+ahead, and clearing that one means removing its worktree and deleting the branch rather than opening
+another PR.
 Every unmerged lane in this checkout:"
   model_msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
 This session's worktree is on '$self_branch', which is committed but not on origin/main, so you are not

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -159,7 +159,21 @@ print((data.get("session_id") or "").replace("\t", " ").replace("\n", " "))
 active=$(printf '%s\n' "$parsed" | sed -n 1p)
 hook_cwd=$(printf '%s\n' "$parsed" | sed -n 2p)
 sid=$(printf '%s\n' "$parsed" | sed -n 3p)
-[ -n "$sid" ] || sid="${CLAUDE_CODE_SESSION_ID:-shared}"
+[ -n "$sid" ] || sid="${CLAUDE_CODE_SESSION_ID:-}"
+# Normalised HERE rather than in the Python above, because there are TWO sources
+# and only one of them went through it. The environment fallback lands after the
+# parse, so `CLAUDE_CODE_SESSION_ID` reached the record RAW -- and the record is
+# tab-separated, read back with `IFS=<TAB> read`, where a tab is IFS *whitespace*:
+# a leading empty field is dropped and a run collapses. Measured in a sandbox lane
+# with a payload carrying no `session_id`: `s1` gave `ctx, sys, sys` while
+# `<TAB>abc`, `a<TAB>b` and `a<NL>b` each gave `ctx, ctx, ctx` -- an unbounded
+# `additionalContext` against the 8-block cap, which is the whole failure the
+# cadence exists to prevent. Doing it once, after both sources have been consulted,
+# is what makes "every field is normalised before it is written" true rather than
+# true-of-one-path. (`stop-cleanup-warn.sh` next door has the same two sources and
+# the same single fold.)
+sid=$(printf '%s' "$sid" | tr '\t\n' '  ')
+[ -n "$sid" ] || sid="shared"
 
 # Already nudged once this turn and the model came back to Stop. Repeating the
 # MODEL half would spin the turn instead of ending it, so that half stands
@@ -218,14 +232,36 @@ if [ -n "$self_branch" ]; then
   if [ -z "$unpushed" ]; then
     push_state="unpushed"
     push_line="It has no upstream yet, so nothing has been submitted: push it, open the PR, then merge."
+    push_note="It has no upstream yet, so nothing has been submitted."
   elif [ "$unpushed" -gt 0 ]; then
     push_state="unpushed"
     push_line="It has ${unpushed} commit(s) not yet pushed, so nothing carrying them has been submitted: push, open or update the PR, then merge."
+    push_note="It has ${unpushed} commit(s) not yet pushed, so nothing carrying them has been submitted."
   else
     push_state="pushed"
     push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none."
+    push_note="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches."
   fi
-  msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
+  # TWO texts for the self-lane case, not one routed twice. The model text is
+  # written AT the agent ("you are not done", "rebase, run the gates"), and every
+  # path that downgrades it to `systemMessage` -- the cadence repeat, an
+  # unpersistable record, a resumed pass -- would otherwise hand a human a list of
+  # instructions addressed to somebody else. That is go-to-k/cdkd#2389 in
+  # miniature, the very defect this hook was rewritten to fix, and the downgrades
+  # added here would have widened it from one path to three.
+  #
+  # Both keep `$push_note` / `$push_line`, which share the three phrases that name
+  # WHICH half of the work is left; only the framing around them changes voice.
+  # (`stop-cleanup-warn.sh` next door has carried a `user_msg` / `model_msg` pair
+  # from the start, for exactly this reason.)
+  user_msg="NOTE: this session's own lane is unmerged -- '$self_branch' is committed but not on origin/main.
+$push_note
+The agent has already been nudged about this lane once, so this repeat is for you: if the session ends
+here, the work stays on the branch and nothing carries it to main. One false positive is expected and is
+cheap to clear -- this repo SQUASH-merges, so an already-merged branch keeps reading as ahead, and
+clearing that one means removing its worktree and deleting the branch rather than opening another PR.
+Every unmerged lane in this checkout:"
+  model_msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
 This session's worktree is on '$self_branch', which is committed but not on origin/main, so you are not
 done: rebase, run the gates, open the PR, merge. $push_line
 If you are ending the turn with nothing that will re-invoke you, the honest label is STOPPED, not WAITING.
@@ -238,7 +274,10 @@ a lane at all.
 Every unmerged lane in this checkout:"
   channel="ctx"
 else
-  msg="NOTE: unmerged lane(s) exist in this checkout, none of them this session's.
+  # Only ever emitted on the user channel, so it needs no twin -- and it is
+  # already written for a human: the model cannot act on another session's lane.
+  model_msg=""
+  user_msg="NOTE: unmerged lane(s) exist in this checkout, none of them this session's.
 This session's worktree is not among them, so there is likely nothing here for it to do; they belong to
 other sessions, or are already merged (this repo SQUASH-merges, so a merged branch never becomes an
 ancestor of origin/main and keeps reading as ahead -- clearing one means removing its worktree and
@@ -347,9 +386,12 @@ elif [ "$channel" = "ctx" ]; then
     # `unpushed -> pushed` compares against a stale half and goes silent. Only
     # the CHANNEL branches on `arm`.
     #
-    # `2>/dev/null` precedes the write redirect: applied the other way round,
-    # bash has already replaced fd 2 with the tmp file when it fails to open it,
-    # and reports the failure on the hook's real stderr.
+    # `2>/dev/null` precedes the write redirect, and the order is the whole point.
+    # Redirections are applied left to right, and the one that FAILS here is the
+    # fd-1 open of `$tmp`. Written `>"$tmp" 2>/dev/null` that open is attempted
+    # while fd 2 is still the REAL stderr, so "Permission denied" is reported there
+    # -- from an advisory hook, on every turn. Putting `2>/dev/null` first silences
+    # fd 2 before the open that can fail.
     tmp="${state_file}.$$"
     if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" 2>/dev/null >"$tmp"; then
       if mv -f "$tmp" "$state_file" 2>/dev/null; then
@@ -368,6 +410,15 @@ elif [ "$channel" = "ctx" ]; then
   # someone else) costs the MODEL channel, not the warning itself.
   [ "$persisted" = "1" ] || arm=0
   [ "$arm" = "1" ] || channel="sys"
+fi
+
+# The channel decides WHICH text, not just which field: `additionalContext`
+# carries the model text and `systemMessage` the user one, so a downgrade changes
+# voice as well as audience.
+if [ "$channel" = "ctx" ]; then
+  msg="$model_msg"
+else
+  msg="$user_msg"
 fi
 
 MSG="$msg

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -111,9 +111,14 @@ run_hook_keep() {
 # that sits after the JSON parse -- so nothing in this file exercised it: every
 # payload above carries `session_id`, which means the environment fallback had zero
 # coverage and its value reached the cadence record unnormalised.
-run_hook_env() { # <dir> <hook> <session-id-from-env> [stdin]
+# Named `_keep` like its sibling because it does NOT clear the nudge record --
+# the cadence is the whole subject of the cases that use it, and a helper whose
+# name does not encode that is how a later case gets its reset silently removed.
+run_hook_env_keep() { # <dir> <hook> <session-id-from-env> [stdin]
   local dir="$1" hook="$2" sess="$3" stdin="${4-}"
-  [ -n "$stdin" ] || stdin='{}'
+  # `$#`, not `-n`: an explicitly EMPTY payload is a case (the hook must survive
+  # unparseable stdin), and `-n` would silently replace it with `{}`.
+  [ "$#" -ge 4 ] || stdin='{}'
   printf '%s' "$stdin" | (cd "$dir" && CLAUDE_CODE_SESSION_ID="$sess" bash "$hook")
   printf '%s' "$?" > "$RC_FILE"
 }
@@ -720,9 +725,9 @@ env_n=0
 for esid in 's1' "$(printf '\tabc')" "$(printf 'a\tb')" "$(printf 'a\nb')"; do
   env_n=$((env_n + 1))
   clear_nudge_records
-  out=$(run_hook_env "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
+  out=$(run_hook_env_keep "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
   check "an env-supplied session id nudges the model once [$env_n]" "ctx" "$(channel_of "$out")"
-  out=$(run_hook_env "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
+  out=$(run_hook_env_keep "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
   check "...and the cadence still bounds it [$env_n]" "sys" "$(channel_of "$out")"
 done
 

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -669,6 +669,17 @@ check "an unpersistable record downgrades to the user channel" "sys" "$(channel_
 check "...but the user is still told which lane" "yes" "$(has "$out" -F 'feat/cad-a')"
 check "...in the user's voice, not the agent's" "no" \
   "$(has "$out" -E 'YOUR OWN lane|rebase, run the gates')"
+# --- ...and it does not tell the human the AGENT has been told. That claim is
+# the delta's central fix and NOTHING pinned it: the user text is one string
+# reaching all three downgrade paths, and "the agent has already been nudged
+# about this lane once, so this repeat is for you" is true of the cadence repeat
+# ONLY. HERE it is worst -- the model half was dropped precisely BECAUSE the
+# record cannot be written, so the agent will never be told and the false claim
+# would repeat on every later turn. The voice checks above cannot see it: the
+# sentence names no agent-voice phrase and does name the lane, so restoring it
+# leaves them green. Measured: with the sentence put back, all 93 cases passed. ---
+check "...and does not claim the agent has already been nudged" "no" \
+  "$(has "$out" -E 'already been nudged|already been told|this repeat is for you')"
 
 # --- The continuation flag outranks the cadence: the harness has already resumed
 # once inside this turn, so even a freshly-armed subject drops the MODEL half. It
@@ -685,6 +696,13 @@ check "a resumed pass drops the model half but still tells the user" "sys" "$(ch
 check "...and still names the lane" "yes" "$(has "$out" -F 'feat/cad-b')"
 check "...in the user's voice, not the agent's" "no" \
   "$(has "$out" -E 'YOUR OWN lane|rebase, run the gates')"
+# The second of the two paths on which "the agent has already been nudged" is
+# false: no nudge was spent here at all -- the subject is freshly armed and the
+# model half is dropped only because the harness has already resumed once inside
+# this turn. See the unpersistable case above for why the voice checks cannot
+# stand in for this one.
+check "...and does not claim the agent has already been nudged" "no" \
+  "$(has "$out" -E 'already been nudged|already been told|this repeat is for you')"
 # No nudge was spent, so none may be recorded: a record written here would consume
 # this subject's one model nudge on a pass that reached the model with nothing.
 check "...and it wrote no cadence record" "absent" \
@@ -730,6 +748,47 @@ for esid in 's1' "$(printf '\tabc')" "$(printf 'a\tb')" "$(printf 'a\nb')"; do
   out=$(run_hook_env_keep "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
   check "...and the cadence still bounds it [$env_n]" "sys" "$(channel_of "$out")"
 done
+
+# --- An EXPLICITLY EMPTY payload on the env path. `run_hook` has carried this
+# case from the start ("fires when stdin is empty"); the env helper had none,
+# which is why its payload guard could be written as `[ -n "$stdin" ]` -- a form
+# that silently REPLACES an empty payload with `{}` -- with nothing to notice.
+#
+# Two cases, because the obvious one alone does not fence the guard. Through the
+# real hook, empty stdin and `{}` are INDISTINGUISHABLE by construction: the
+# parse is `json.loads(os.environ.get("HOOK_INPUT") or "{}")`, so an empty string
+# IS `{}` there. Measured -- reverting the guard to `[ -n "$stdin" ]` leaves the
+# case below green. It is still worth having (the hook must survive an empty
+# payload on this path, and nothing said so), but it is documentation, not a
+# fence.
+clear_nudge_records
+out=$(run_hook_env_keep "$REPO" "$RUN" 'sess-empty' '')
+# By NAME rather than by count: this sits late in the file, after several
+# worktrees have been added and removed, so a total would pass or fail on its
+# position -- the order-dependence `clear_nudge_records` exists to remove,
+# arriving through the assertion instead of through the record.
+check "an empty payload on the env path still enumerates the lanes" "yes" \
+  "$(has "$out" -F 'feat/cad-b')"
+check "...and claims no lane it cannot attribute" "sys" "$(channel_of "$out")"
+check "...and exits 0" "0" "$(rc_of)"
+
+# The fence itself, aimed at the HELPER rather than at the hook: point it at a
+# probe that reports the byte count of the stdin it was handed. `$#` keeps an
+# explicit empty payload empty (0 bytes) and still defaults an OMITTED one to
+# `{}` (2 bytes); `[ -n "$stdin" ]` cannot tell the two apart and sends `{}`
+# both times. Both polarities are asserted, so neither a guard that always
+# defaults nor one that never does can pass.
+STDIN_PROBE="$SANDBOX/stdin-probe.sh"
+cat > "$STDIN_PROBE" <<'PROBE'
+#!/usr/bin/env bash
+printf 'bytes=%s
+' "$(cat | wc -c | tr -d ' ')"
+PROBE
+chmod +x "$STDIN_PROBE"
+out=$(run_hook_env_keep "$REPO" "$STDIN_PROBE" 'sess-empty' '')
+check "an explicitly empty env payload reaches the hook empty" "bytes=0" "$out"
+out=$(run_hook_env_keep "$REPO" "$STDIN_PROBE" 'sess-empty')
+check "...while an OMITTED env payload still defaults to {}" "bytes=2" "$out"
 
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-a"
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-b"

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -18,6 +18,28 @@ pass=0
 fail=0
 fail_log=""
 
+# --- BASH 3.2 FENCE ---
+# macOS ships bash 3.2 as /bin/bash and this repo runs on it, so the hook has to
+# stay 3.2-clean. It was, but only ACCIDENTALLY: every case here launches the hook
+# as `bash "$hook"`, which resolves through PATH -- normally a modern Homebrew
+# build -- and the shebang is `#!/usr/bin/env bash`, which resolves the same way.
+# So running this SUITE under /bin/bash proved nothing whatsoever about the hook;
+# both interpreters stayed 5.x.
+#
+# A shim directory holding one symlink named `bash` goes FIRST on PATH, so every
+# child `bash` -- the explicit invocations, the shebang, and the ones inside the
+# stubbed-PATH case, whose `command -v bash` now resolves here -- is the fenced
+# interpreter. Default /bin/bash (3.2 on macOS, whatever the distro ships
+# elsewhere); override with HOOK_BASH to take the other tally.
+SHIMDIR="$(cd "$(mktemp -d)" && pwd -P)"
+HOOK_BASH="${HOOK_BASH:-/bin/bash}"
+[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+ln -sf "$HOOK_BASH" "$SHIMDIR/bash"
+PATH="$SHIMDIR:$PATH"
+export PATH
+printf 'hook interpreter: %s (bash %s)\n' "$HOOK_BASH" \
+  "$("$HOOK_BASH" -c 'echo "$BASH_VERSION"')"
+
 check() {
   local name="$1" want="$2" got="$3"
   if [ "$got" = "$want" ]; then
@@ -117,7 +139,7 @@ print("BOTH" if ctx and sysm else "ctx" if ctx else "sys" if sysm else "none")
 # defect it was written for (a skip keyed on the hook's own checkout) could be
 # reintroduced and the suite stayed green.
 SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
-trap 'rm -rf "$SANDBOX"' EXIT
+trap 'rm -rf "$SANDBOX" "$SHIMDIR"' EXIT
 
 RC_FILE="$SANDBOX/rc"
 
@@ -302,15 +324,24 @@ ln -s "$REPO/wt-two" "$SANDBOX/wt-two-link"
 out=$(run_hook "$SANDBOX/wt-two-link" "$SANDBOX/wt-two-link/.claude/hooks/$(basename "$HOOK")")
 check "a symlinked lane path is still the session's own lane" "ctx" "$(channel_of "$out")"
 
-# --- SILENT on the continuation pass. `additionalContext` CONTINUES the turn,
+# --- USER-ONLY on the continuation pass. `additionalContext` CONTINUES the turn,
 # so a hook that keeps emitting it turns one nudge into a spin: the model is
 # pushed back to work, reaches Stop again with the same unmerged lane, and is
 # pushed again. The harness marks that second pass with `stop_hook_active`, and
-# standing down on it is what bounds this hook to a single forced continuation.
-# Without this case the loop is unfenced -- every case above passes `{}`, where
-# the flag is absent, so the branch could be deleted and the suite stay green. ---
+# dropping the MODEL half on it is what bounds this hook to a single forced
+# continuation. Without this case that branch is unfenced -- every case above
+# passes `{}`, where the flag is absent, so it could be deleted and the suite stay
+# green.
+#
+# It used to go fully SILENT here, which was wrong for the same reason the
+# neighbouring stop-cleanup-warn.sh was: the condition can first become TRUE
+# during the continuation. The continuation exists to push the model back to work,
+# and committing the lane is exactly that work -- so this pass can be the first on
+# which there is any lane at all, and a silent hook means nobody ever learns. A
+# bare `systemMessage` does not continue a turn, so the user half costs nothing. ---
 out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")" '{"stop_hook_active": true}')
-check "silent once the harness reports a continuation already happened" "" "$out"
+check "a resumed pass drops the model half but still tells the user" "sys" "$(channel_of "$out")"
+check "...and still enumerates the lanes" "2" "$(lanes_in "$out")"
 check "...standing down is exit 0, not a crash" "0" "$(rc_of)"
 
 # --- ...and NOT silent when the flag is present but false, which is the shape
@@ -372,14 +403,22 @@ for odd in 'bs\path' "$(printf 'tab\tpath')"; do
   git -C "$REPO" branch -q -D "feat/odd-$odd_n"
 done
 
-# --- `stop_hook_active` as the STRING "false" must not silence the hook. Python
-# treats any non-empty string as truthy, so the naive read makes this the same
-# as `true` -- and since a hook that goes quiet still exits 0, the failure looks
-# exactly like "no lanes" forever. The boolean cases above cannot see it. ---
-out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "false"}')
-check "the string \"false\" does not count as a continuation" "2" "$(lanes_in "$out")"
-out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "true"}')
-check "the string \"true\" does count as one" "" "$out"
+# --- `stop_hook_active` as the STRING "false" must not be read as a
+# continuation. Python treats any non-empty string as truthy, so the naive read
+# makes this the same as `true`. The boolean cases above cannot see it.
+#
+# Both run from INSIDE a lane, which is now the load-bearing half: since a
+# resumed pass emits `systemMessage` rather than nothing, the flag no longer
+# separates silence from output -- it separates the MODEL channel from the user
+# one, and only a session standing in its own lane has a model channel to lose.
+# Run from the main tree these two would read `sys` either way. ---
+WT_TWO_HOOK="$REPO/wt-two/.claude/hooks/$(basename "$HOOK")"
+out=$(run_hook "$REPO/wt-two" "$WT_TWO_HOOK" '{"stop_hook_active": "false"}')
+check "the string \"false\" does not count as a continuation" "ctx" "$(channel_of "$out")"
+check "...and it still enumerates every lane" "2" "$(lanes_in "$out")"
+out=$(run_hook "$REPO/wt-two" "$WT_TWO_HOOK" '{"stop_hook_active": "true"}')
+check "the string \"true\" does count as one" "sys" "$(channel_of "$out")"
+check "...and a continuation still enumerates the lanes for the user" "2" "$(lanes_in "$out")"
 
 # --- Malformed / absent stdin must not take the warning down with it. The hook
 # reads stdin only to find three fields; a harness that sends nothing parseable
@@ -488,12 +527,111 @@ check "...and the text switches to the pushed-but-maybe-no-PR wording" "yes" "$(
 out=$(run_hook_keep "$REPO" "$RUN" "$A1")
 check "...and a pushed lane stops nagging again after that one" "sys" "$(channel_of "$out")"
 
-# The continuation flag outranks the cadence: the harness has already resumed
-# once inside this turn, so even a freshly-armed subject must stay silent rather
-# than swap channels and print the same wall of text twice.
+# --- The predicate is DIRECTED, and a plain `prev_subject != subject` was not a
+# simplification of it but a bug. `pushed -> unpushed` is what an ordinary COMMIT
+# looks like, so an undirected test re-armed on every commit and again on every
+# push: measured on one lane as `commit ctx, repeat sys, push ctx, repeat sys,
+# commit ctx, push ctx, ...` -- two forced continuations per commit/push cycle,
+# forever, which is the per-commit cadence this hook's own comment disclaims. Only
+# `unpushed -> pushed` re-arms, because only that transition opens an action the
+# model did not have before (a PR should now exist, and a pushed branch with none
+# is the failure this hook is for). ---
+git -C "$REPO/wt-cad-a" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'more work'
+check "the fixture really did leave a commit unpushed" "1" \
+  "$(git -C "$REPO/wt-cad-a" rev-list --count '@{u}..' 2>/dev/null || echo MISSING)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "a COMMIT on a pushed lane does NOT re-arm the nudge" "sys" "$(channel_of "$out")"
+# ...and while it is there, the MIDDLE push arm. Three arms exist -- no upstream,
+# N commits unpushed, fully pushed -- and only the outer two were ever asserted:
+# corrupting this one's wording left the suite 56/56 green.
+check "...and the text names how many commits are unpushed" "yes" \
+  "$(printf '%s' "$out" | grep -qF '1 commit(s) not yet pushed' && echo yes || echo no)"
+
+# --- The record is written on BOTH arms, because it holds the last OBSERVED
+# subject rather than the last NUDGED one. Recording only when arming freezes
+# `prev_push` at whatever state last nudged -- here `pushed`, from before the
+# commit above -- so the next genuine `unpushed -> pushed` compares against a
+# stale half and goes silent. This is the case that separates the two: it can
+# only pass if the quiet turn above still wrote what it saw. ---
+git -C "$REPO" update-ref "refs/remotes/origin/feat/cad-a" "$(git -C "$REPO" rev-parse feat/cad-a)"
+check "the fixture really did push the new commit" "0" \
+  "$(git -C "$REPO/wt-cad-a" rev-list --count '@{u}..' 2>/dev/null || echo MISSING)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...so the NEXT genuine unpushed -> pushed still re-arms" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...and then goes quiet again" "sys" "$(channel_of "$out")"
+
+# --- A MALFORMED record falls to ARMING, the safe direction. Nothing here ever
+# wrote one, so every shape below was unfenced -- while in production a record is
+# exactly what an interrupted write, a concurrent session or an older version of
+# this hook can leave behind in a shape this one does not expect. A subject that
+# cannot be split into `<branch>:<pushed|unpushed>` is not a subject this hook
+# wrote, and treating it as a match would silence a real lane. ---
+CAD_A_STATE="$(git -C "$REPO/wt-cad-a" rev-parse --absolute-git-dir)/stop-nudge-lane"
+mal_n=0
+for mal in \
+  'sess-one' \
+  "$(printf 'sess-one\t\t123')" \
+  "$(printf 'sess-one\tfeat/cad-a\t123')" \
+  "$(printf 'sess-one\tfeat/cad-a:banana\t123')" \
+  'total garbage'; do
+  mal_n=$((mal_n + 1))
+  printf '%s\n' "$mal" > "$CAD_A_STATE"
+  out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+  check "a record this hook cannot parse re-arms rather than silencing [$mal_n]" "ctx" "$(channel_of "$out")"
+done
+
+# --- A record that cannot be PERSISTED costs the MODEL channel, not the warning.
+# The record is what BOUNDS the nudge, so an unwritable git dir (a read-only
+# checkout, a full disk, a directory owned by another user) meant every later turn
+# re-armed -- unbounded, which is the failure the cadence exists to remove. ---
+CAD_A_GITDIR="$(git -C "$REPO/wt-cad-a" rev-parse --absolute-git-dir)"
 clear_nudge_records
-out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\", \"stop_hook_active\": true}")
-check "a resumed turn stays silent even when armed" "" "$out"
+chmod 555 "$CAD_A_GITDIR"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+chmod 755 "$CAD_A_GITDIR"
+check "an unpersistable record downgrades to the user channel" "sys" "$(channel_of "$out")"
+check "...but the user is still told which lane" "yes" \
+  "$(printf '%s' "$out" | grep -qF 'feat/cad-a' && echo yes || echo no)"
+
+# --- The continuation flag outranks the cadence: the harness has already resumed
+# once inside this turn, so even a freshly-armed subject drops the MODEL half. It
+# does NOT go silent -- the lane can be committed DURING the continuation (that is
+# what the continuation pushed the model back to do), in which case this pass is
+# the first on which there is any lane to report and silence means nobody ever
+# learns. A bare `systemMessage` does not continue a turn, so nothing spins. ---
+CAD_B_STATE="$(git -C "$REPO/wt-cad-b" rev-parse --absolute-git-dir)/stop-nudge-lane"
+B3_RESUMED="{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\", \"stop_hook_active\": true}"
+B3_PLAIN="{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\"}"
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "$B3_RESUMED")
+check "a resumed pass drops the model half but still tells the user" "sys" "$(channel_of "$out")"
+check "...and still names the lane" "yes" \
+  "$(printf '%s' "$out" | grep -qF 'feat/cad-b' && echo yes || echo no)"
+# No nudge was spent, so none may be recorded: a record written here would consume
+# this subject's one model nudge on a pass that reached the model with nothing.
+check "...and it wrote no cadence record" "absent" \
+  "$([ -e "$CAD_B_STATE" ] && echo present || echo absent)"
+out=$(run_hook_keep "$REPO" "$RUN" "$B3_PLAIN")
+check "...so the next ordinary turn still gets its nudge" "ctx" "$(channel_of "$out")"
+
+# --- `cwd` carrying a NEWLINE must not corrupt the session id. The payload is
+# parsed by printing three LINES and picking them apart with `sed -n 1p/2p/3p`, so
+# an unstripped newline in `cwd` shifts `session_id` off the end and `sid` becomes
+# the TAIL OF THE PATH. Measured before the fix: a payload whose `cwd` was
+# "<lane path>\nJUNK" wrote `sid=JUNK` into the cadence record -- keyed on a
+# fragment of a directory name, so no two turns of one session ever agreed.
+# Folded to a space, the value no longer names a directory and the hook falls to
+# the not-mine channel, which is the safe direction for a field it cannot trust. ---
+clear_nudge_records
+NL_PAYLOAD=$(CWD="$REPO/wt-cad-b" python3 -c '
+import json, os
+print(json.dumps({"cwd": os.environ["CWD"] + "\nJUNK", "session_id": "sess-nl"}))
+')
+out=$(run_hook_keep "$REPO" "$RUN" "$NL_PAYLOAD")
+check "a cwd containing a newline is not attributed to a lane" "sys" "$(channel_of "$out")"
+check "...and no record was keyed on a fragment of the path" "absent" \
+  "$([ -e "$CAD_B_STATE" ] && echo present || echo absent)"
 
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-a"
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-b"

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -677,7 +677,11 @@ check "...in the user's voice, not the agent's" "no" \
 # record cannot be written, so the agent will never be told and the false claim
 # would repeat on every later turn. The voice checks above cannot see it: the
 # sentence names no agent-voice phrase and does name the lane, so restoring it
-# leaves them green. Measured: with the sentence put back, all 93 cases passed. ---
+# leaves them green: measured at the time, every OTHER case in this file passed
+# with the sentence put back, and only the case below reddened. The figure that
+# used to stand here was a case COUNT, which reads as a claim about this suite's
+# current size and went stale the moment a case was added. The property is
+# "every other case stays green", so it is stated that way instead. ---
 check "...and does not claim the agent has already been nudged" "no" \
   "$(has "$out" -E 'already been nudged|already been told|this repeat is for you')"
 
@@ -772,6 +776,147 @@ check "an empty payload on the env path still enumerates the lanes" "yes" \
 check "...and claims no lane it cannot attribute" "sys" "$(channel_of "$out")"
 check "...and exits 0" "0" "$(rc_of)"
 
+# --- The DISCRIMINATING malformed record: subject empty, and the field after it
+# is a well-formed subject. A TAB is IFS *whitespace*, so `IFS=<TAB> read` folds
+# a RUN of them into ONE separator and that field arrives as `prev_subject` --
+# the predicate matches it and the lane goes QUIET. A malformed record SILENCING
+# the nudge is the one direction this must not fail in, and none of the five
+# shapes above reaches it: each hands `prev_subject` a value that cannot split
+# into `<branch>:<state>`, so they arm under the fold too. The sibling repo's
+# copy of this hook has carried the shape check that rejects this since its own
+# review; this one did not.
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "the fold fixture starts from a real arm" "ctx" "$(channel_of "$out")"
+REAL_SUBJECT=$(awk -F'\t' 'NR==1{print $2}' "$CAD_A_STATE")
+check "...and the record really carries a subject to shift" "yes" \
+  "$([ -n "$REAL_SUBJECT" ] && echo yes || echo no)"
+printf 'sess-one\t\t%s\n' "$REAL_SUBJECT" > "$CAD_A_STATE"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "an EMPTY subject field does not let the next field silence the lane" "ctx" "$(channel_of "$out")"
+# A FOURTH field is the other half of the shape check, and the same argument: a
+# record this hook did not write must not be trusted verbatim.
+printf 'sess-one\t%s\t123\textra\n' "$REAL_SUBJECT" > "$CAD_A_STATE"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "a record carrying a FOURTH field arms" "ctx" "$(channel_of "$out")"
+# The control, so none of the above is satisfied by a hook that stopped reading
+# the record: the WELL-FORMED record it writes itself is still trusted.
+printf 'sess-one\t%s\t123\n' "$REAL_SUBJECT" > "$CAD_A_STATE"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...while a WELL-FORMED repeat still goes quiet" "sys" "$(channel_of "$out")"
+
+# --- The record path is a DIRECTORY. `mv -f <file> <dir>` returns SUCCESS -- it
+# moves the tmp INSIDE the directory -- so the write was certified, the readback
+# next turn found nothing, and EVERY turn re-armed `additionalContext` against
+# CLAUDE_CODE_STOP_HOOK_BLOCK_CAP while the git dir grew one orphan tmp per
+# turn. That is the unbounded cadence this whole mechanism exists to remove,
+# arriving through the success check -- the one failure `mv`'s own exit code
+# cannot report, which is why the unwritable-git-dir case above does not cover
+# it. Measured with `mv` alone: `ctx ctx ctx`.
+clear_nudge_records
+rm -f "$CAD_A_STATE"
+mkdir -p "$CAD_A_STATE"
+dir_channels=""
+for _ in 1 2 3; do
+  out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+  dir_channels="${dir_channels}$(channel_of "$out") "
+done
+dir_orphans=$(find "$CAD_A_STATE" -type f 2>/dev/null | wc -l | tr -d ' ')
+rm -f "$CAD_A_STATE"/* 2>/dev/null || true
+rmdir "$CAD_A_STATE" 2>/dev/null || true
+check "a record path that is a DIRECTORY never arms the model channel" "sys sys sys " "$dir_channels"
+check "...and leaves no orphan tmp behind in the git dir" "0" "$dir_orphans"
+
+# --- The failed record write must not reach the hook's REAL stderr. The
+# redirect is spelled `2>/dev/null >"$tmp"`, in that order, and the order is the
+# whole point: redirections are applied left to right, and the open that FAILS
+# is the fd-1 open of `$tmp`. Written `>"$tmp" 2>/dev/null` that open happens
+# while fd 2 is still the real stderr, so "Permission denied" is printed there
+# from an ADVISORY hook, on every turn. Swapping the two left this suite green
+# because nothing here captured the hook's stderr at all; the cleanup twin has
+# fenced this exact claim for two rounds.
+clear_nudge_records
+chmod 555 "$CAD_A_GITDIR"
+err=$( (printf '%s' "$A1" | (cd "$REPO" && bash "$RUN")) 2>&1 >/dev/null )
+chmod 755 "$CAD_A_GITDIR"
+check "a failed record write says nothing on the hook's real stderr" "" "$err"
+
+# --- The session-id SOURCES, keyed on the record rather than on the reset. The
+# loop above clears the record between values, so it fences the tab/newline FOLD
+# and not the `CLAUDE_CODE_SESSION_ID` fallback it names: with that line deleted
+# every run reads `sid=shared`, and clearing the record first makes each value's
+# FIRST run arm regardless. Driving A, B, A through ONE record is what separates
+# them: three distinct sessions each get their own nudge, while a hook that
+# cannot tell them apart swallows the second and third.
+clear_nudge_records
+env_src=""
+for esid in 'src-a' 'src-b' 'src-a'; do
+  out=$(run_hook_env_keep "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
+  env_src="${env_src}$(channel_of "$out") "
+done
+check "each env-supplied session gets its own nudge" "ctx ctx ctx " "$env_src"
+
+# --- NEITHER source present. `sid` then defaults to `shared`, and the cadence
+# has to bound that bucket like any other: without a default the record's first
+# field is empty, which is where a tab-separated read is least forgiving.
+clear_nudge_records
+noid_channels=""
+for _ in 1 2 3 4; do
+  out=$(run_hook_env_keep "$REPO" "$RUN" "" "$ENV_PAYLOAD")
+  noid_channels="${noid_channels}$(channel_of "$out") "
+done
+check "a session with no id at all is still bounded after one nudge" "ctx sys sys sys " "$noid_channels"
+
+# --- A payload whose `cwd` / `session_id` are not STRINGS. `(data.get(x) or "")`
+# is a string only when the field is absent, null or a string; a number or a
+# list reaches `.replace` and raises AttributeError, so an advisory hook writes a
+# TRACEBACK to its real stderr -- and `cwd` prints first, so both values are
+# lost. The guard block already hardens `json.loads` and `isinstance(data, dict)`
+# and stopped one field short of this.
+clear_nudge_records
+for badpay in '{"cwd": 42, "session_id": "sess-num"}' '{"cwd": ["a"], "session_id": ["b"]}' '{"cwd": {"x": 1}, "session_id": 7}'; do
+  err=$( (printf '%s' "$badpay" | (cd "$REPO" && bash "$RUN")) 2>&1 >/dev/null )
+  check "a non-string cwd/session_id writes nothing to real stderr" "" "$err"
+  check "...and still exits 0" "0" "$(rc_of)"
+done
+
+# --- The cadence record must not OUTLIVE the condition. When no worktree is
+# ahead of `origin/main` any more, the stored subject is stale, and returning
+# to the same branch in the same push state reproduces it exactly -- so the
+# next genuine first-sighting is DOWNGRADED. That is a MISSED nudge, the unsafe
+# direction. Reachable through the very remedy this hook prints: nudge, repeat,
+# `git switch --detach origin/main`, re-attach, commit. Its sibling
+# `stop-warn.sh` has always dropped its record on the clean-tree exit.
+#
+# A SEPARATE sandbox repo, because the property is repo-GLOBAL ("no lane
+# anywhere is ahead") and the fixtures above leave other lanes standing.
+CLR_REPO="$SANDBOX/clear-repo"
+mkdir -p "$CLR_REPO/.claude/hooks"
+cp "$HOOK" "$CLR_REPO/.claude/hooks/"
+CLR_RUN="$CLR_REPO/.claude/hooks/$(basename "$HOOK")"
+git -C "$CLR_REPO" init -q .
+git -C "$CLR_REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$CLR_REPO" update-ref refs/remotes/origin/main HEAD
+git -C "$CLR_REPO" worktree add -q "$CLR_REPO/wt-clr" -b feat/clr HEAD
+git -C "$CLR_REPO/wt-clr" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+CLR_PAYLOAD="{\"cwd\": \"$CLR_REPO/wt-clr\", \"session_id\": \"sess-clr\"}"
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "the clearing fixture arms once" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "...and the repeat is downgraded" "sys" "$(channel_of "$out")"
+# The condition CLEARS: the lane is no longer ahead of origin/main.
+git -C "$CLR_REPO/wt-clr" reset -q --hard origin/main
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "...the hook is silent once nothing is ahead" "" "$out"
+check "...and the stale record is gone" "absent" \
+  "$([ -e "$(git -C "$CLR_REPO/wt-clr" rev-parse --absolute-git-dir)/stop-nudge-lane" ] && echo present || echo absent)"
+# ...and the same subject is a FIRST sighting again.
+git -C "$CLR_REPO/wt-clr" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'work again'
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "...so the SAME subject nudges the model again" "ctx" "$(channel_of "$out")"
+git -C "$CLR_REPO" worktree remove --force "$CLR_REPO/wt-clr"
+
+
 # The fence itself, aimed at the HELPER rather than at the hook: point it at a
 # probe that reports the byte count of the stdin it was handed. `$#` keeps an
 # explicit empty payload empty (0 bytes) and still defaults an OMITTED one to
@@ -794,6 +939,18 @@ git -C "$REPO" worktree remove --force "$REPO/wt-cad-a"
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-b"
 clear_nudge_records
 
+
+# A FLOOR on the case total. Every `for` loop above expands a LIST, and emptying
+# one -- or deleting a case -- removes assertions SILENTLY while the tally still
+# reads `fail: 0`. No suite in this repo had one, so the only thing standing
+# between a gutted loop and a green run was somebody noticing the number move.
+# Raise it when cases are added; never lower it to make a red run green.
+CASE_FLOOR=121
+if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
+  fail=$((fail + 1))
+  fail_log+="FAIL case floor: only $((pass + fail)) cases ran, expected at least 121\n"
+  printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
+fi
 printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then
   printf '%b' "$fail_log" >&2

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -31,9 +31,30 @@ fail_log=""
 # stubbed-PATH case, whose `command -v bash` now resolves here -- is the fenced
 # interpreter. Default /bin/bash (3.2 on macOS, whatever the distro ships
 # elsewhere); override with HOOK_BASH to take the other tally.
+#
+# An explicitly set HOOK_BASH that is not executable is a FATAL error rather than a
+# silent fall back to PATH bash: falling back hides a typo in the one setting this
+# fence exists to pin, and the run would then report a tally under an interpreter
+# nobody asked for. Only the built-in DEFAULT may fall back, since a machine
+# without /bin/bash is a fact rather than a mistake.
+#
+# The shim is trapped for removal the moment it exists, not once the sandbox is
+# built: an early failure between the two leaked a directory per run.
 SHIMDIR="$(cd "$(mktemp -d)" && pwd -P)"
-HOOK_BASH="${HOOK_BASH:-/bin/bash}"
-[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+trap 'rm -rf "$SHIMDIR"' EXIT
+if [ -n "${HOOK_BASH:-}" ]; then
+  if [ ! -x "$HOOK_BASH" ]; then
+    printf 'FATAL - HOOK_BASH is not an executable: %s\n' "$HOOK_BASH" >&2
+    exit 2
+  fi
+else
+  HOOK_BASH=/bin/bash
+  [ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+  [ -n "$HOOK_BASH" ] && [ -x "$HOOK_BASH" ] || {
+    printf 'FATAL - no usable bash found for the hook interpreter\n' >&2
+    exit 2
+  }
+fi
 ln -sf "$HOOK_BASH" "$SHIMDIR/bash"
 PATH="$SHIMDIR:$PATH"
 export PATH
@@ -85,8 +106,28 @@ run_hook_keep() {
   printf '%s' "$?" > "$RC_FILE"
 }
 
+# The same run with the session id supplied ONLY through the environment, and no
+# `session_id` in the payload. That is a SECOND source for `sid`, reached by a line
+# that sits after the JSON parse -- so nothing in this file exercised it: every
+# payload above carries `session_id`, which means the environment fallback had zero
+# coverage and its value reached the cadence record unnormalised.
+run_hook_env() { # <dir> <hook> <session-id-from-env> [stdin]
+  local dir="$1" hook="$2" sess="$3" stdin="${4-}"
+  [ -n "$stdin" ] || stdin='{}'
+  printf '%s' "$stdin" | (cd "$dir" && CLAUDE_CODE_SESSION_ID="$sess" bash "$hook")
+  printf '%s' "$?" > "$RC_FILE"
+}
+
 # `rc_of` -> the status of the most recent run_hook call.
 rc_of() { cat "$RC_FILE"; }
+
+# `has <output> <grep-args...>` -> yes | no. Used by the VOICE cases, where the
+# question is which of two texts the payload carries rather than which field.
+has() {
+  local out="$1"
+  shift
+  printf '%s' "$out" | grep -q "$@" && echo yes || echo no
+}
 
 # `lanes_in <output>` -> how many branch lines the payload named, whichever
 # channel carried it. Deliberately channel-AGNOSTIC: the cases below split into
@@ -420,6 +461,18 @@ out=$(run_hook "$REPO/wt-two" "$WT_TWO_HOOK" '{"stop_hook_active": "true"}')
 check "the string \"true\" does count as one" "sys" "$(channel_of "$out")"
 check "...and a continuation still enumerates the lanes for the user" "2" "$(lanes_in "$out")"
 
+# --- ...and the NON-boolean shapes must be read the same way `stop-cleanup-warn.sh`
+# reads them. That hook parses this field with `jq`, this one with `python3`, and
+# the two spellings do not agree by default -- jq truthiness makes `0` a
+# continuation, `$f == true` makes `1` an ordinary turn, and Python does neither.
+# Python's rule is the one both now follow, so these pin this side of the pair.
+out=$(run_hook "$REPO/wt-two" "$WT_TWO_HOOK" '{"stop_hook_active": 1}')
+check "a TRUTHY number counts as a continuation" "sys" "$(channel_of "$out")"
+out=$(run_hook "$REPO/wt-two" "$WT_TWO_HOOK" '{"stop_hook_active": 0}')
+check "...and a falsy one does not" "ctx" "$(channel_of "$out")"
+out=$(run_hook "$REPO/wt-two" "$WT_TWO_HOOK" '{"stop_hook_active": []}')
+check "...nor does an empty array" "ctx" "$(channel_of "$out")"
+
 # --- Malformed / absent stdin must not take the warning down with it. The hook
 # reads stdin only to find three fields; a harness that sends nothing parseable
 # is not a reason to go quiet about an unmerged lane. ---
@@ -472,8 +525,25 @@ B1="{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-one\"}"
 clear_nudge_records
 out=$(run_hook_keep "$REPO" "$RUN" "$A1")
 check "first sight of a lane nudges the model" "ctx" "$(channel_of "$out")"
+# The armed half is the control for the voice cases below: without it a hook that
+# sent the USER text on both channels would satisfy every "not addressed to the
+# agent" check and lose the nudge's entire content.
+check "...and the model half is the text written AT the agent" "yes" \
+  "$(has "$out" -F 'WARNING: YOUR OWN lane is unmerged')"
 out=$(run_hook_keep "$REPO" "$RUN" "$A1")
 check "the same lane again does NOT force a second turn" "sys" "$(channel_of "$out")"
+# --- ...and the downgrade changes VOICE, not only audience. The model text is
+# written AT the agent ("YOUR OWN lane", "rebase, run the gates", "the honest label
+# is STOPPED"); routing it to `systemMessage` hands a human a list of instructions
+# addressed to somebody else, which is go-to-k/cdkd#2389 in miniature -- the very
+# defect this hook was rewritten to fix. There are THREE paths that downgrade a
+# self-lane warning (this cadence repeat, an unpersistable record, a resumed pass)
+# and each is checked, since one shared emitter is exactly the shape where fixing
+# one path leaves the others.
+check "...and the downgraded text carries nothing addressed to the agent" "no" \
+  "$(has "$out" -E 'YOUR OWN lane|rebase, run the gates|the honest label is STOPPED')"
+check "...while still naming the lane as the session's own" "yes" \
+  "$(has "$out" -F "own lane is unmerged -- 'feat/cad-a'")"
 # The downgrade must not be a MUTE. Choosing `systemMessage` over silence is the
 # whole point -- the human keeps seeing the lane -- and a hook that simply
 # exited would also read as "not ctx" and pass the line above.
@@ -591,8 +661,9 @@ chmod 555 "$CAD_A_GITDIR"
 out=$(run_hook_keep "$REPO" "$RUN" "$A1")
 chmod 755 "$CAD_A_GITDIR"
 check "an unpersistable record downgrades to the user channel" "sys" "$(channel_of "$out")"
-check "...but the user is still told which lane" "yes" \
-  "$(printf '%s' "$out" | grep -qF 'feat/cad-a' && echo yes || echo no)"
+check "...but the user is still told which lane" "yes" "$(has "$out" -F 'feat/cad-a')"
+check "...in the user's voice, not the agent's" "no" \
+  "$(has "$out" -E 'YOUR OWN lane|rebase, run the gates')"
 
 # --- The continuation flag outranks the cadence: the harness has already resumed
 # once inside this turn, so even a freshly-armed subject drops the MODEL half. It
@@ -606,8 +677,9 @@ B3_PLAIN="{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\"}"
 clear_nudge_records
 out=$(run_hook_keep "$REPO" "$RUN" "$B3_RESUMED")
 check "a resumed pass drops the model half but still tells the user" "sys" "$(channel_of "$out")"
-check "...and still names the lane" "yes" \
-  "$(printf '%s' "$out" | grep -qF 'feat/cad-b' && echo yes || echo no)"
+check "...and still names the lane" "yes" "$(has "$out" -F 'feat/cad-b')"
+check "...in the user's voice, not the agent's" "no" \
+  "$(has "$out" -E 'YOUR OWN lane|rebase, run the gates')"
 # No nudge was spent, so none may be recorded: a record written here would consume
 # this subject's one model nudge on a pass that reached the model with nothing.
 check "...and it wrote no cadence record" "absent" \
@@ -632,6 +704,27 @@ out=$(run_hook_keep "$REPO" "$RUN" "$NL_PAYLOAD")
 check "a cwd containing a newline is not attributed to a lane" "sys" "$(channel_of "$out")"
 check "...and no record was keyed on a fragment of the path" "absent" \
   "$([ -e "$CAD_B_STATE" ] && echo present || echo absent)"
+
+# --- The session id read from the ENVIRONMENT. It is a SECOND source, consulted
+# by a line that sits after the JSON parse, so the normalisation applied inside the
+# parse never touched it -- and every other payload in this file carries a
+# `session_id`, which left that line with no coverage at all. It reaches a
+# tab-separated record read back with `IFS=<TAB> read`, where a tab is IFS
+# *whitespace*: a leading empty field is dropped and a run collapses, so the
+# read-back never compares equal and the nudge never arms down. Measured before the
+# fix: `s1` gave `ctx, sys, sys` while `<TAB>abc`, `a<TAB>b` and `a<NL>b` each gave
+# `ctx, ctx, ctx` -- an unbounded `additionalContext` against the 8-block cap. The
+# well-formed id is included as the control that these measure the env path at all.
+ENV_PAYLOAD="{\"cwd\": \"$REPO/wt-cad-b\"}"
+env_n=0
+for esid in 's1' "$(printf '\tabc')" "$(printf 'a\tb')" "$(printf 'a\nb')"; do
+  env_n=$((env_n + 1))
+  clear_nudge_records
+  out=$(run_hook_env "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
+  check "an env-supplied session id nudges the model once [$env_n]" "ctx" "$(channel_of "$out")"
+  out=$(run_hook_env "$REPO" "$RUN" "$esid" "$ENV_PAYLOAD")
+  check "...and the cadence still bounds it [$env_n]" "sys" "$(channel_of "$out")"
+done
 
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-a"
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-b"

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -30,15 +30,79 @@ check() {
   fi
 }
 
-# `lanes_in <output>` -> how many branch lines the payload named.
+# Since go-to-k/cdk-real-drift#1844 the hook READS the Stop event's JSON from
+# stdin, so every invocation has to feed it one. Left unfed, `cat` inherits this
+# script's stdin and a case can hang instead of failing -- and a Stop hook that
+# hangs never lets a turn end.
+#
+# Every call starts from a CLEAN nudge record unless a case opts out with
+# `run_hook_keep`. The hook nudges the model at most once per subject per
+# session and downgrades a repeat to the user channel, so without this reset the
+# cases below would each depend on how many earlier ones happened to share their
+# branch -- and every case that asserts `ctx` would pass or fail on its POSITION
+# in the file rather than on the hook's behaviour.
+clear_nudge_records() {
+  find "$SANDBOX" -name 'stop-nudge-lane' -type f -delete 2>/dev/null || true
+}
+
+run_hook() {
+  clear_nudge_records
+  run_hook_keep "$@"
+}
+
+# The same call WITHOUT the reset -- for the cadence cases, which are precisely
+# about what a second invocation does.
+run_hook_keep() {
+  local dir="$1" hook="$2" stdin="${3-}"
+  [ "$#" -ge 3 ] || stdin='{}'
+  printf '%s' "$stdin" | (cd "$dir" && bash "$hook")
+  # The exit STATUS, parked in a file because every call site is a `$(...)`
+  # subshell. Silence is not the same as success here: on `Stop` a non-zero exit
+  # is a hook ERROR, and every case below that asserts empty output would pass
+  # against a hook that crashed before printing.
+  printf '%s' "$?" > "$RC_FILE"
+}
+
+# `rc_of` -> the status of the most recent run_hook call.
+rc_of() { cat "$RC_FILE"; }
+
+# `lanes_in <output>` -> how many branch lines the payload named, whichever
+# channel carried it. Deliberately channel-AGNOSTIC: the cases below split into
+# two groups, and only one of them is about the channel. Every count assertion
+# is about which BRANCHES got enumerated, and folding the channel into it would
+# make each of those fail for two unrelated reasons at once.
 lanes_in() {
   printf '%s' "$1" | python3 -c '
 import json, sys
 raw = sys.stdin.read()
 if not raw.strip():
     print(0); raise SystemExit
-msg = json.loads(raw)["systemMessage"]
+d = json.loads(raw)
+msg = d.get("hookSpecificOutput", {}).get("additionalContext") or d.get("systemMessage") or ""
 print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
+'
+}
+
+# `channel_of <output>` -> ctx | sys | none | BOTH.
+#
+# On the Stop event the channel IS the behaviour, not a formatting detail:
+# `additionalContext` is delivered to the model and CONTINUES the turn, while
+# `systemMessage` is shown to the user and lets it end. `BOTH` is reported
+# rather than silently preferring one, because a payload carrying both fields
+# would continue the turn AND print to the user -- neither of the two designs
+# this hook chooses between, and something a test that reads only its own key
+# cannot see. (`stop-cleanup-warn.sh` next door deliberately DOES emit both;
+# this hook must not.)
+channel_of() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+if not raw.strip():
+    print("none"); raise SystemExit
+d = json.loads(raw)
+ctx = bool(d.get("hookSpecificOutput", {}).get("additionalContext"))
+sysm = bool(d.get("systemMessage"))
+print("BOTH" if ctx and sysm else "ctx" if ctx else "sys" if sysm else "none")
 '
 }
 
@@ -55,6 +119,8 @@ print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
 SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
+RC_FILE="$SANDBOX/rc"
+
 REPO="$SANDBOX/repo"
 mkdir -p "$REPO/.claude/hooks"
 cp "$HOOK" "$REPO/.claude/hooks/"
@@ -66,45 +132,55 @@ git -C "$REPO" update-ref refs/remotes/origin/main HEAD
 
 # --- SILENT: nothing unmerged. The expensive half to get right, because a
 # false alarm every turn is indistinguishable from noise. ---
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "silent when no worktree exists" "" "$out"
+check "...and silent means exit 0, not a crash" "0" "$(rc_of)"
 
 # --- SILENT: a worktree that is level with origin/main is not a lane. ---
 git -C "$REPO" worktree add -q "$REPO/wt-level" -b feat/level HEAD
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "silent for a worktree with no commits of its own" "" "$out"
 
-# --- SILENT: a DETACHED worktree has no branch to report. ---
+# --- SILENT: a DETACHED worktree has no branch to report. It is committed
+# AHEAD on purpose: added at HEAD and left alone, the ahead-count check already
+# excludes it and the `[ -n "$br" ]` guard this case is named for is never what
+# makes it pass. Ahead and branchless, the guard is the only thing standing
+# between this and a lane line with an empty branch name.
 git -C "$REPO" worktree add -q "$REPO/wt-detached" --detach HEAD
-out=$(cd "$REPO" && bash "$RUN")
-check "silent for a detached worktree" "" "$out"
+git -C "$REPO/wt-detached" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'detached work'
+out=$(run_hook "$REPO" "$RUN")
+check "silent for a detached worktree that is ahead" "" "$out"
 
 # --- FIRES: one lane with a commit of its own. ---
 git -C "$REPO/wt-level" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "names the one lane that is ahead" "1" "$(lanes_in "$out")"
 
 # --- FIRES: counts each lane separately, and still ignores the detached one. ---
 git -C "$REPO" worktree add -q "$REPO/wt-two" -b feat/two HEAD
 git -C "$REPO/wt-two" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
 
 # --- FIRES: run from INSIDE a lane worktree, that lane must still be named. ---
 # The case the hook exists for, and the one every case above misses: they all
 # `cd "$REPO"` (the main tree), so a skip keyed on the hook's OWN checkout was
-# invisible to all seven of them. An earlier revision derived the skip from
+# invisible to all of them. An earlier revision derived the skip from
 # `BASH_SOURCE` and went silent for exactly this run. The main tree is excluded
 # by BRANCH, so removing that skip costs nothing here -- which this case pins
 # from the other side, by asserting the count is 2 rather than 3.
 mkdir -p "$REPO/wt-two/.claude/hooks"
 cp "$HOOK" "$REPO/wt-two/.claude/hooks/"
-out=$(cd "$REPO/wt-two" && bash "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
 check "names its OWN lane when run from inside it" "2" "$(lanes_in "$out")"
-if printf '%s' "$out" | grep -q 'feat/two'; then
-  pass=$((pass + 1)); printf 'OK   the self-lane is the one named\n'
+# Bind to the SELF line, not to the enumeration. The payload lists every lane,
+# so `grep feat/two` is satisfied by the listing no matter which branch the
+# message calls the session's own. `-F` plus the trailing comma so `feat/two-x`
+# cannot satisfy it either.
+if printf '%s' "$out" | grep -qF "This session's worktree is on 'feat/two',"; then
+  pass=$((pass + 1)); printf 'OK   the self-lane is the one the message names\n'
 else
-  fail=$((fail + 1)); fail_log+="FAIL the self-lane is not named\n"; printf 'FAIL the self-lane is named\n'
+  fail=$((fail + 1)); fail_log+="FAIL the message names the wrong self-lane\n"; printf 'FAIL the self-lane is the one the message names\n'
 fi
 
 # --- SILENT: the main tree ON `main`, ahead of origin/main, is NOT a lane.
@@ -115,7 +191,7 @@ fi
 # suite green. Direct commits on `main` are a different problem with its own
 # gate; this hook reports unmerged LANES.
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'on main'
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "the main tree on main is not a lane even when ahead" "2" "$(lanes_in "$out")"
 
 # --- The BRANCH filter, not the path, is what excludes the main tree. Put the
@@ -123,7 +199,7 @@ check "the main tree on main is not a lane even when ahead" "2" "$(lanes_in "$ou
 # other lane; otherwise the two filters mask each other and neither is fenced.
 git -C "$REPO" checkout -q -b feat/main-tree-lane
 git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
-out=$(cd "$REPO" && bash "$RUN")
+out=$(run_hook "$REPO" "$RUN")
 check "the main tree on a feature branch is a lane too" "3" "$(lanes_in "$out")"
 git -C "$REPO" checkout -q -
 git -C "$REPO" branch -q -D feat/main-tree-lane
@@ -135,6 +211,24 @@ else
   fail=$((fail + 1)); fail_log+="FAIL payload is not valid JSON\n"; printf 'FAIL payload is valid JSON\n'
 fi
 
+# --- SILENT, and exit 0, when `python3` is not installed. Everything past the
+# lane check is built by `python3`, so without the guard the script ends on a
+# `command not found` and returns 127 -- an ERROR reported on every single turn,
+# from a hook whose entire job is advisory. ---
+# The list is every external the hook reaches for BEFORE the guard, `bash` and
+# `env` included -- `PATH=... bash` resolves `bash` through the replaced PATH
+# too, and the shebang is `env bash`. Each of them was added because its absence
+# produced a DIFFERENT failure than the one under test, which is the trap here:
+# a stub PATH that is too small makes the case pass for the wrong reason.
+STUBBIN="$SANDBOX/no-python"
+mkdir -p "$STUBBIN"
+for c in bash env dirname git awk sed cat; do
+  ln -sf "$(command -v "$c")" "$STUBBIN/$c"
+done
+out=$( (cd "$REPO" && printf '%s' '{}' | PATH="$STUBBIN" bash "$RUN"); printf '%s' "$?" > "$RC_FILE")
+check "silent when python3 is unavailable" "" "$out"
+check "...and exits 0 rather than 127" "0" "$(rc_of)"
+
 # --- SILENT: no `origin/main` at all (a fresh clone before the first fetch)
 # must not error or spam. ---
 BARE="$SANDBOX/norem"
@@ -142,8 +236,268 @@ mkdir -p "$BARE/.claude/hooks"
 cp "$HOOK" "$BARE/.claude/hooks/"
 git -C "$BARE" init -q .
 git -C "$BARE" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
-out=$(cd "$BARE" && bash "$BARE/.claude/hooks/$(basename "$HOOK")")
+out=$(run_hook "$BARE" "$BARE/.claude/hooks/$(basename "$HOOK")")
 check "silent when origin/main is unresolvable" "" "$out"
+check "...and that too is exit 0" "0" "$(rc_of)"
+
+# Re-run against the two-lane sandbox: the case above left `$out` empty (it ran
+# in the no-remote repo), and an assertion about the payload's SHAPE cannot be
+# made against no payload.
+out=$(run_hook "$REPO" "$RUN")
+check "still names both lanes on re-run" "2" "$(lanes_in "$out")"
+
+# --- CHANNEL (go-to-k/cdk-real-drift#1844): the session's OWN lane reaches the
+# MODEL. `additionalContext` is the only field that does, and it continues the
+# turn so the model can act -- which is the failure this hook was written for,
+# an agent ending the turn with its own branch committed and no PR. Until #1844
+# every word left as `systemMessage`, the USER-only channel: a message written
+# at the AGENT reached only the party who cannot act on it. ---
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
+check "own lane goes to the model" "ctx" "$(channel_of "$out")"
+check "own lane payload still enumerates every lane" "2" "$(lanes_in "$out")"
+if printf '%s' "$out" | python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+sys.exit(0 if d["hookSpecificOutput"]["hookEventName"] == "Stop" else 1)
+'; then
+  pass=$((pass + 1)); printf 'OK   the hookEventName is Stop\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the hookEventName is not Stop\n"; printf 'FAIL the hookEventName is Stop\n'
+fi
+
+# --- CHANNEL: lanes that belong to SOMEONE ELSE go to the user instead. The
+# model cannot act on another session's worktree, so continuing the turn buys
+# one extra reply that can only say "not mine". This repo SQUASH-merges, so a
+# merged branch reads as ahead forever and one un-removed worktree would have
+# made that permanent. ---
+out=$(run_hook "$REPO" "$RUN")
+check "other sessions' lanes go to the user" "sys" "$(channel_of "$out")"
+check "the user-facing payload still enumerates them" "2" "$(lanes_in "$out")"
+
+# --- The OWNERSHIP test reads `cwd` out of the event payload, not just the path
+# the hook was launched from. Run from the main tree while `cwd` names the lane:
+# without reading `cwd` this answers `sys`, so the two cases above cannot see
+# the difference on their own -- each of them has the launch path and `cwd`
+# agreeing, which is exactly the pair that makes either signal look sufficient.
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-two\"}")
+check "cwd naming a lane makes it the session's own" "ctx" "$(channel_of "$out")"
+
+# --- ...and the same field pointing at a NON-lane worktree must NOT. Otherwise
+# "cwd is set" rather than "cwd is a lane" would be what flips the channel, and
+# the case above would pass under a hook that simply believes any cwd. ---
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-detached\"}")
+check "cwd naming a non-lane worktree stays user-facing" "sys" "$(channel_of "$out")"
+
+# --- The session reached through a SYMLINKED spelling of its lane is still the
+# owner of that lane. No `cwd` in the payload, so the BASH_SOURCE fallback is
+# what has to answer -- and that path is built with `cd ... && pwd`, which keeps
+# the spelling it was reached BY, while git reports the real one. Without the
+# canonicalisation this compares a symlink to a real path, never matches, and
+# quietly hands the agent its own lane on the user-only channel.
+#
+# Every other case here is blind to that: git canonicalises both of ITS answers,
+# so the two sides agree no matter what, and dropping the canonicalisation
+# leaves the suite green. ---
+ln -s "$REPO/wt-two" "$SANDBOX/wt-two-link"
+out=$(run_hook "$SANDBOX/wt-two-link" "$SANDBOX/wt-two-link/.claude/hooks/$(basename "$HOOK")")
+check "a symlinked lane path is still the session's own lane" "ctx" "$(channel_of "$out")"
+
+# --- SILENT on the continuation pass. `additionalContext` CONTINUES the turn,
+# so a hook that keeps emitting it turns one nudge into a spin: the model is
+# pushed back to work, reaches Stop again with the same unmerged lane, and is
+# pushed again. The harness marks that second pass with `stop_hook_active`, and
+# standing down on it is what bounds this hook to a single forced continuation.
+# Without this case the loop is unfenced -- every case above passes `{}`, where
+# the flag is absent, so the branch could be deleted and the suite stay green. ---
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")" '{"stop_hook_active": true}')
+check "silent once the harness reports a continuation already happened" "" "$out"
+check "...standing down is exit 0, not a crash" "0" "$(rc_of)"
+
+# --- ...and NOT silent when the flag is present but false, which is the shape
+# every ordinary turn actually sends. A truthiness check that reads the KEY
+# rather than its VALUE would go permanently silent here, and the case above
+# cannot see that -- it only ever sends `true`. ---
+out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")" '{"stop_hook_active": false}')
+check "fires when the continuation flag is present but false" "2" "$(lanes_in "$out")"
+check "...and still reaches the model, not just the user" "ctx" "$(channel_of "$out")"
+
+# --- A worktree path containing a SPACE is still a lane. `git worktree list
+# --porcelain` prints `worktree <path>` with the path unquoted and unescaped, so
+# reading it with `$2` -- which is what this hook did until #1844 -- truncates at
+# the first space; `git -C <truncated>` then fails and the lane is dropped from
+# BOTH the enumeration and the ownership comparison, so the hook goes silent
+# about a lane that exists. That is the one failure direction it must not have. ---
+git -C "$REPO" worktree add -q "$REPO/wt with space" -b feat/spaced HEAD
+git -C "$REPO/wt with space" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(run_hook "$REPO" "$RUN")
+check "a worktree path with a space is still enumerated" "3" "$(lanes_in "$out")"
+if printf '%s' "$out" | grep -q 'feat/spaced'; then
+  pass=$((pass + 1)); printf 'OK   the spaced lane is named\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the spaced lane is not named\n"; printf 'FAIL the spaced lane is named\n'
+fi
+
+# --- ...and it can be the session's OWN lane. Enumeration and ownership read
+# the same path through two different paths in the script, so a truncation that
+# still enumerates could break only the comparison. ---
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt with space\"}")
+check "a spaced path can be the session's own lane" "ctx" "$(channel_of "$out")"
+git -C "$REPO" worktree remove --force "$REPO/wt with space"
+git -C "$REPO" branch -q -D feat/spaced
+
+# --- A worktree path containing a BACKSLASH or a TAB is still matched. Both
+# are legal in a path and neither is legal in a git refname, which is why the
+# row is `branch<TAB>path` and split at the FIRST tab -- the branch side cannot
+# contain one, so whatever follows is the whole path however it is spelled.
+# These fence the two awk spellings that were tried and rejected: `-v root=...`
+# expands backslash escapes in the value (the backslash case), and `-F'\t'`
+# puts a tabbed path in the wrong field (the tab case). Neither is visible to
+# any other case -- both mismatch quietly and fall through to the not-mine
+# branch, which is the safe direction and therefore the silent one. ---
+#
+# The payload is built with `json.dumps`, not `printf`: a literal backslash or
+# tab inside a JSON string is not valid JSON, so hand-formatting one makes the
+# hook fall back to BASH_SOURCE and the case then passes or fails for a reason
+# that has nothing to do with the path. A real harness escapes these; the
+# fixture must too.
+odd_n=0
+for odd in 'bs\path' "$(printf 'tab\tpath')"; do
+  odd_n=$((odd_n + 1))
+  git -C "$REPO" worktree add -q "$REPO/$odd" -b "feat/odd-$odd_n" HEAD
+  git -C "$REPO/$odd" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+  payload=$(CWD="$REPO/$odd" python3 -c 'import json, os; print(json.dumps({"cwd": os.environ["CWD"]}))')
+  out=$(run_hook "$REPO" "$RUN" "$payload")
+  check "a path with a backslash or tab is the session's own lane [$odd_n]" "ctx" "$(channel_of "$out")"
+  git -C "$REPO" worktree remove --force "$REPO/$odd"
+  git -C "$REPO" branch -q -D "feat/odd-$odd_n"
+done
+
+# --- `stop_hook_active` as the STRING "false" must not silence the hook. Python
+# treats any non-empty string as truthy, so the naive read makes this the same
+# as `true` -- and since a hook that goes quiet still exits 0, the failure looks
+# exactly like "no lanes" forever. The boolean cases above cannot see it. ---
+out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "false"}')
+check "the string \"false\" does not count as a continuation" "2" "$(lanes_in "$out")"
+out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "true"}')
+check "the string \"true\" does count as one" "" "$out"
+
+# --- Malformed / absent stdin must not take the warning down with it. The hook
+# reads stdin only to find three fields; a harness that sends nothing parseable
+# is not a reason to go quiet about an unmerged lane. ---
+# The channel is asserted alongside the count, not just the count: an
+# unparseable payload yields no `cwd`, and a hook that fell back to claiming the
+# FIRST lane as the session's own would still enumerate two and pass on the
+# count alone.
+out=$(run_hook "$REPO" "$RUN" 'not json at all')
+check "fires when the event JSON is unparseable" "2" "$(lanes_in "$out")"
+check "...and does not claim a lane it cannot attribute" "sys" "$(channel_of "$out")"
+out=$(run_hook "$REPO" "$RUN" '')
+check "fires when stdin is empty" "2" "$(lanes_in "$out")"
+check "...and likewise claims nothing" "sys" "$(channel_of "$out")"
+
+# --- The realistic `cwd`: a session sits SOMEWHERE INSIDE its worktree, rarely
+# at the root. Resolution is via `rev-parse --show-toplevel`, so a subdirectory
+# must attribute the same as the root; a naive string compare would not. ---
+mkdir -p "$REPO/wt-two/src/deep"
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-two/src/deep\"}")
+check "a subdirectory of a lane attributes to that lane" "ctx" "$(channel_of "$out")"
+
+# --- `cwd` in no git repository at all, and `cwd` in the MAIN tree: both are
+# "not a lane of mine", and neither may error out. ---
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$SANDBOX\"}")
+check "cwd outside any repo stays user-facing" "sys" "$(channel_of "$out")"
+check "...and still exits 0" "0" "$(rc_of)"
+out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO\"}")
+check "cwd in the main tree stays user-facing" "sys" "$(channel_of "$out")"
+
+# --- CADENCE (go-to-k/cdk-real-drift#1844). `stop_hook_active` stops a nudge
+# spinning INSIDE one turn; nothing stops it firing again at every later
+# turn-end for as long as the lane exists, and a Stop `additionalContext` spends
+# the same 8-block budget a `decision: "block"` does. Every case here fails
+# against a hook with no record to consult, which answers `ctx` unconditionally.
+#
+# These build their OWN lanes rather than reusing the ones above, several of
+# which have been removed by this point in the file -- reusing one would measure
+# the not-my-lane branch and pass or fail on where it sits, exactly the
+# order-dependence `clear_nudge_records` exists to remove. They are also the
+# only cases that must NOT reset the record, so they call `run_hook_keep`.
+git -C "$REPO" worktree add -q "$REPO/wt-cad-a" -b feat/cad-a HEAD
+git -C "$REPO/wt-cad-a" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+git -C "$REPO" worktree add -q "$REPO/wt-cad-b" -b feat/cad-b HEAD
+git -C "$REPO/wt-cad-b" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+
+A1="{\"cwd\": \"$REPO/wt-cad-a\", \"session_id\": \"sess-one\"}"
+A2="{\"cwd\": \"$REPO/wt-cad-a\", \"session_id\": \"sess-two\"}"
+B1="{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-one\"}"
+
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "first sight of a lane nudges the model" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "the same lane again does NOT force a second turn" "sys" "$(channel_of "$out")"
+# The downgrade must not be a MUTE. Choosing `systemMessage` over silence is the
+# whole point -- the human keeps seeing the lane -- and a hook that simply
+# exited would also read as "not ctx" and pass the line above.
+if printf '%s' "$out" | grep -q 'feat/cad-a'; then
+  pass=$((pass + 1)); printf 'OK   ...but the user is still told which lane\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the downgraded warning still names the lane\n"; printf 'FAIL the downgraded warning still names the lane\n'
+fi
+
+# A different LANE is a different subject, so it re-arms. Without this the first
+# lane of a session would silence every later one -- strictly worse than the
+# bounded cost being paid here. The two lanes keep SEPARATE records, since each
+# lives in its own worktree git dir, so this cannot be satisfied by a single
+# shared slot.
+out=$(run_hook_keep "$REPO" "$RUN" "$B1")
+check "a different lane in the same session nudges again" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...and the first lane stays quiet, records being per-worktree" "sys" "$(channel_of "$out")"
+
+# A different SESSION gets its own one nudge. It also overwrites the record --
+# one file per worktree, not one per session, so nothing accumulates in the git
+# dir with no one to clean it up. The cost is that the earlier session re-arms
+# once, which is an EXTRA nudge rather than a missed one; that direction is the
+# reason the trade is acceptable, so it is pinned rather than left to be
+# rediscovered as a bug.
+out=$(run_hook_keep "$REPO" "$RUN" "$A2")
+check "a DIFFERENT session gets its own one nudge" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...and a concurrent session's write costs an extra nudge, not a lost one" "ctx" "$(channel_of "$out")"
+
+# --- PUSH STATE. It is in the SUBJECT (so unpushed -> pushed re-arms exactly
+# once) and in the TEXT (so the message names which half of the work is left) --
+# but NOT in the channel decision, which would go quiet on a branch pushed with
+# NO PR: a real failure, and one of the two this hook exists to catch.
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "an unpushed lane says so in the text" "yes" "$(printf '%s' "$out" | grep -qF 'no upstream yet' && echo yes || echo no)"
+
+# `remote.origin.fetch` is load-bearing, not boilerplate: without the refspec
+# git refuses `@{u}` with "upstream branch ... not stored as a remote-tracking
+# branch", the hook reads that as unpushed, and the two cases below pass or fail
+# for a reason that has nothing to do with the cadence.
+git -C "$REPO" config remote.origin.url "$REPO"
+git -C "$REPO" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+git -C "$REPO" update-ref "refs/remotes/origin/feat/cad-a" "$(git -C "$REPO" rev-parse feat/cad-a)"
+git -C "$REPO" config "branch.feat/cad-a.remote" origin
+git -C "$REPO" config "branch.feat/cad-a.merge" refs/heads/feat/cad-a
+check "the fixture really did give the lane an upstream" "0" "$(git -C "$REPO/wt-cad-a" rev-list --count '@{u}..' 2>/dev/null || echo MISSING)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "pushing the lane re-arms the nudge once" "ctx" "$(channel_of "$out")"
+check "...and the text switches to the pushed-but-maybe-no-PR wording" "yes" "$(printf '%s' "$out" | grep -qF 'pushed branch with NO PR' && echo yes || echo no)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...and a pushed lane stops nagging again after that one" "sys" "$(channel_of "$out")"
+
+# The continuation flag outranks the cadence: the harness has already resumed
+# once inside this turn, so even a freshly-armed subject must stay silent rather
+# than swap channels and print the same wall of text twice.
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\", \"stop_hook_active\": true}")
+check "a resumed turn stays silent even when armed" "" "$out"
+
+git -C "$REPO" worktree remove --force "$REPO/wt-cad-a"
+git -C "$REPO" worktree remove --force "$REPO/wt-cad-b"
+clear_nudge_records
 
 printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,12 +410,39 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   bug first: it is written on BOTH arms of the lane hook's decision, because it
   holds the last OBSERVED subject rather than the last NUDGED one (recording only
   on the arm freezes the push half and silences the next genuine
-  `unpushed -> pushed`); every field is NORMALISED before it is written, since a
-  tab or an empty leading field in a tab-separated line read back with
-  `IFS=<TAB> read` shifts every later field and the comparison then never matches
-  — an unbounded nudge; and a record that cannot be PERSISTED (an unresolvable or
+  `unpushed -> pushed`); every field is NORMALISED — folded free of tabs and
+  newlines and defaulted when empty — **once, after every source of it has been
+  consulted**, since a tab or an empty leading field in a tab-separated line read
+  back with `IFS=<TAB> read` shifts every later field and the comparison then never
+  matches, an unbounded nudge. The "after every source" half is the part that gets
+  lost: BOTH hooks read the session id from the payload AND from
+  `CLAUDE_CODE_SESSION_ID`, and normalising inside the payload parse leaves the
+  environment path raw. Measured on the lane hook in exactly that state: a
+  well-formed id gave `ctx, sys, sys` while `<TAB>abc`, `a<TAB>b` and `a<NL>b` each
+  gave `ctx, ctx, ctx`. And a record that cannot be PERSISTED (an unresolvable or
   unwritable git dir) costs the MODEL channel rather than the warning, because a
   nudge that cannot be recorded cannot be bounded.
+
+  **A downgrade to `systemMessage` must change VOICE, not only audience.** Both
+  hooks now keep a `user_msg` / `model_msg` pair. The model text is written at the
+  agent ("YOUR OWN lane", "rebase, run the gates", "the honest label is STOPPED"),
+  so routing it down the user channel hands a human instructions addressed to
+  somebody else — go-to-k/cdkd#2389 in miniature, the defect these hooks were
+  rewritten to fix. The lane hook has THREE paths that downgrade a self-lane
+  warning (a cadence repeat, an unpersistable record, a resumed pass) and one
+  shared emitter, which is precisely the shape where fixing one path leaves the
+  others; each is fenced by its own case.
+
+  **The `stop_hook_active` fold follows PYTHON's truthiness in both hooks, and
+  neither obvious spelling gets there.** The cleanup hook parses the field with
+  `jq` and the lane hook with `python3`, so a malformed payload must not mean two
+  different things. Measured: plain jq truthiness makes `0`, `[]` and `{}`
+  continuations while Python says they are not, and `$f == true` makes `1`, `[1]`
+  and `{"a":1}` ordinary turns while Python says they ARE continuations — opposite
+  errors, and the second is the dangerous one for the money hook, which then reads
+  a resumed pass as fresh and spins the turn. The rule both follow is Python's:
+  null, `false`, `0` and an empty container are falsy, every other value is truthy,
+  with the textual spellings of `false` folded down first.
 
 - **The two Stop hooks then DIVERGE deliberately, and the difference is the
   point.** `stop-unmerged-lane-warn` picks ONE channel by OWNERSHIP: the session's
@@ -434,7 +461,7 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   the token set is unchanged, because money accrues on the clock rather than per
   turn, with the escalated message naming how long the tokens have been armed. Both
   hooks are exercised by `.claude/hooks/stop-cleanup-warn.test.sh` and
-  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (67 and 77 cases), run by
+  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (71 and 93 cases), run by
   `vp run test:hooks`.
 
   **Both suites run the HOOK under an explicitly chosen interpreter, and that is
@@ -444,7 +471,10 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   cleanliness these files need on macOS was only ever accidental. Each suite now
   puts a one-symlink shim directory first on PATH so every child `bash` is the
   fenced interpreter: `/bin/bash` by default, `HOOK_BASH=<path>` to take the other
-  tally. The suites print which one they used on their first line.
+  tally. The suites print which one they used on their first line, and an explicitly
+  set `HOOK_BASH` that is not executable is FATAL rather than a silent fall back to
+  PATH bash — falling back would hide a typo in the one setting the fence exists to
+  pin, and report a tally under an interpreter nobody asked for.
 
 - **Registration is not execution — prove the gates are ALIVE before the first
   commit of a session**: run `git commit --dry-run -m "gate liveness probe"` from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,9 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     never be forgotten. As a backstop (even for a live-test that never called
     `add`), the `deploy-autoarm-gate` hook arms a generic token on ANY
     deploy-shaped command, and the `stop-cleanup-warn` Stop hook warns at session
-    end if the sentinel is still armed. Run **`/sweep-resources`** to do the
+    end if the sentinel is still armed — to the USER on every turn and to the MODEL
+    on the cadence below, having reached NEITHER until
+    go-to-k/cdk-real-drift#1844. Run **`/sweep-resources`** to do the
     cleanup + release the gate.
 - **`issue-dup-check-gate` — the one PreToolUse gate that is not a markgate gate.**
   It blocks `gh issue create`, and the REST mint `gh api repos/<o>/<r>/issues`,
@@ -341,6 +343,70 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   foreign-`-R` half asserts the refusal MESSAGE, not just the exit code: every
   gate in that fixture already blocks for its own reasons, so an exit-code-only
   check stayed green with the refusal deleted.
+- **The two `Stop` hooks: which CHANNEL reaches which audience, and the nudge
+  cadence.** `stop-cleanup-warn.sh` and `stop-unmerged-lane-warn.sh` fire at
+  turn-end rather than on a tool call, and until go-to-k/cdk-real-drift#1844 both
+  picked an output channel their text's audience never reads. Read from the
+  installed Claude Code (2.1.251) rather than the published docs, a Stop hook has
+  exactly three ways out:
+  - `hookSpecificOutput.additionalContext` — reaches the MODEL, and the turn
+    CONTINUES so it can act on what it was told.
+  - `systemMessage` — reaches the USER only (rendered as `<hookName> says: ...`),
+    and the turn ends normally.
+  - stdout / stderr at exit 0 — reaches NOBODY. Hook stderr is surfaced only on a
+    NON-zero exit, and stdout at exit 0 is parsed as JSON and dropped when it is
+    not one.
+
+  There is no fourth option that reaches the model WITHOUT continuing the turn,
+  which is why each hook has to CHOOSE rather than simply emit. The two JSON
+  fields are independent branches in the harness, so one payload may carry both.
+  `stop-cleanup-warn` was in the third state — `echo ... >&2` then `exit 0` — so a
+  BILLING guardrail delivered its warning into a hole for months; the lane hook
+  emitted `systemMessage` only, while every word of it is addressed to the agent.
+
+- **A Stop continuation is not free, and it is not merely slow.** A Stop hook's
+  `additionalContext` travels in the SAME return value as a `decision: "block"`,
+  so both spend one budget — `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, default 8
+  consecutive blocks — after which the harness overrides the hook and ends the turn
+  itself. A hook that nudges at every turn-end therefore spends a budget shared
+  with every other Stop hook, and the one that spends it is not necessarily the one
+  with something urgent to say. Hence the **cadence rule**, which both hooks
+  follow: `stop_hook_active` (a required boolean on the Stop payload) marks a turn
+  the harness has ALREADY resumed on a hook's account, so it stops a nudge SPINNING
+  inside one turn — and that is all it does. Across turns the condition persists,
+  so an unconditional `additionalContext` fires at every turn-end for as long as it
+  holds. Each hook therefore nudges the model at most once per distinct SUBJECT,
+  and a repeat of the same subject falls back to `systemMessage`: the user still
+  sees it, the turn ends. The subject is chosen so ORDINARY WORK does not change
+  it, or the rule bounds nothing — the lane hook keys on
+  `<own branch>:<pushed|unpushed>` and NOT on the commit count, which changes every
+  time the model commits, while the cleanup hook keys on the sorted set of armed
+  sentinel tokens. The record is ONE file in the PER-WORKTREE git dir
+  (`stop-nudge-lane` / `stop-nudge-cleanup`) holding
+  `<session id>TAB<subject>TAB<epoch>`, written tmp-then-`mv`; the cleanup hook
+  appends a fourth `armed since` field, which each nudge must not reset. One file
+  rather than one per session, so nothing accumulates in the git dir with nobody to
+  clean it up, and a concurrent session in the same worktree costs an EXTRA nudge
+  rather than a missed one — the safe direction.
+- **The two Stop hooks then DIVERGE deliberately, and the difference is the
+  point.** `stop-unmerged-lane-warn` picks ONE channel by OWNERSHIP: the session's
+  own lane (resolved from `cwd` in the payload, falling back to the hook copy's own
+  checkout) goes to the model, another session's lane goes to the user, because the
+  model cannot act on a worktree that is not its own. It has NO wall-clock re-arm —
+  an unmerged lane costs nothing while it sits, so a second telling buys only
+  annoyance, and the same wall of text every turn was the original complaint. Push
+  state is deliberately not its channel discriminator: that would go quiet on a
+  branch pushed with NO PR, one of the two failures the hook exists to catch, so it
+  lives in the cadence subject and in the message TEXT instead.
+  `stop-cleanup-warn` makes the opposite trade on both axes, because its subject is
+  real AWS resources: it emits `systemMessage` on EVERY fire and ADDS
+  `additionalContext` when the cadence arms, since a billing guardrail must never
+  go silent to the human; and it DOES re-arm on a 20-minute wall clock even when
+  the token set is unchanged, because money accrues on the clock rather than per
+  turn, with the escalated message naming how long the tokens have been armed. Both
+  hooks are exercised by `.claude/hooks/stop-cleanup-warn.test.sh` and
+  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (33 and 56 cases, green under
+  bash 5.x and macOS system bash 3.2), run by `vp run test:hooks`.
 - **Registration is not execution — prove the gates are ALIVE before the first
   commit of a session**: run `git commit --dry-run -m "gate liveness probe"` from
   the repo root **as a Bash TOOL CALL**. PreToolUse hooks gate the AGENT's tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,6 +433,18 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   shared emitter, which is precisely the shape where fixing one path leaves the
   others; each is fenced by its own case.
 
+  The same one-emitter-three-paths shape also reproduces in the TEXT rather than
+  in the code, and it needs its own assertion. The user text once said "the agent
+  has already been nudged about this lane once, so this repeat is for you" —
+  true of the cadence repeat and false of the other two: a resumed pass spends no
+  nudge at all, and an unpersistable record drops the model half precisely
+  BECAUSE the record cannot be kept, so the agent is never told and the claim
+  would repeat every turn. Removing the clause is invisible to the voice checks —
+  the sentence names no agent-voice phrase and does name the lane — so the
+  resumed and unpersistable cases assert the ABSENCE of an "already been nudged"
+  claim as well. Measured: restoring the sentence leaves every other case green
+  and reddens exactly those two.
+
   **The `stop_hook_active` fold follows PYTHON's truthiness in both hooks, and
   neither obvious spelling gets there.** The cleanup hook parses the field with
   `jq` and the lane hook with `python3`, so a malformed payload must not mean two
@@ -443,6 +455,19 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   a resumed pass as fresh and spins the turn. The rule both follow is Python's:
   null, `false`, `0` and an empty container are falsy, every other value is truthy,
   with the textual spellings of `false` folded down first.
+
+  One shape still diverges, and it is recorded with BOTH sides because "the two
+  hooks must not disagree" is the whole reason the ladder exists. `1e-999` reads
+  truthy in jq (jq 1.8 preserves the literal, so `$f == 0` is false) and falsy in
+  Python, which underflows it to `0.0`. Measured on jq-1.8.1 / CPython 3. On that
+  one payload the cleanup hook reads RESUMED and goes quiet to the model, while
+  the lane hook reads NOT resumed and spends its model nudge — so it is a
+  disagreement, not merely one hook being conservative. Left as is because both
+  halves are bounded: the quiet costs a nudge a later ordinary turn emits anyway,
+  and the lane hook's nudge is held to one by its per-subject cadence record, so
+  neither side spins. And no producer emits it — the harness sends a JSON
+  boolean — so special-casing it would mean teaching jq to underflow, a rule with
+  no other use, to reconcile a value neither hook will see.
 
 - **The two Stop hooks then DIVERGE deliberately, and the difference is the
   point.** `stop-unmerged-lane-warn` picks ONE channel by OWNERSHIP: the session's
@@ -461,7 +486,7 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   the token set is unchanged, because money accrues on the clock rather than per
   turn, with the escalated message naming how long the tokens have been armed. Both
   hooks are exercised by `.claude/hooks/stop-cleanup-warn.test.sh` and
-  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (71 and 93 cases), run by
+  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (71 and 100 cases), run by
   `vp run test:hooks`.
 
   **Both suites run the HOOK under an explicitly chosen interpreter, and that is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,22 +372,51 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   with every other Stop hook, and the one that spends it is not necessarily the one
   with something urgent to say. Hence the **cadence rule**, which both hooks
   follow: `stop_hook_active` (a required boolean on the Stop payload) marks a turn
-  the harness has ALREADY resumed on a hook's account, so it stops a nudge SPINNING
-  inside one turn — and that is all it does. Across turns the condition persists,
-  so an unconditional `additionalContext` fires at every turn-end for as long as it
-  holds. Each hook therefore nudges the model at most once per distinct SUBJECT,
-  and a repeat of the same subject falls back to `systemMessage`: the user still
-  sees it, the turn ends. The subject is chosen so ORDINARY WORK does not change
-  it, or the rule bounds nothing — the lane hook keys on
-  `<own branch>:<pushed|unpushed>` and NOT on the commit count, which changes every
-  time the model commits, while the cleanup hook keys on the sorted set of armed
-  sentinel tokens. The record is ONE file in the PER-WORKTREE git dir
-  (`stop-nudge-lane` / `stop-nudge-cleanup`) holding
-  `<session id>TAB<subject>TAB<epoch>`, written tmp-then-`mv`; the cleanup hook
-  appends a fourth `armed since` field, which each nudge must not reset. One file
-  rather than one per session, so nothing accumulates in the git dir with nobody to
-  clean it up, and a concurrent session in the same worktree costs an EXTRA nudge
-  rather than a missed one — the safe direction.
+  the harness has ALREADY resumed on a hook's account, so it drops the MODEL half —
+  and that is all it does. It is deliberately NOT a full stand-down in either hook:
+  both used to `exit 0` on it, on the reasoning that the human had seen the message
+  on the earlier pass of the same turn, and that reasoning is false whenever the
+  condition first becomes TRUE during the continuation (the continuation exists to
+  push the model back to work, and deploying a stack or committing the lane is
+  exactly that work). A bare `systemMessage` does not continue a turn, so the user
+  half costs nothing; a resumed pass writes no cadence record either, so the nudge
+  it did not spend is still available to the next ordinary turn-end.
+
+  Across turns the condition persists, so an unconditional `additionalContext`
+  fires at every turn-end for as long as it holds. Each hook therefore nudges the
+  model at most once per distinct SUBJECT, and a repeat falls back to
+  `systemMessage`: the user still sees it, the turn ends. The subject is chosen so
+  ORDINARY WORK does not change it, or the rule bounds nothing — the lane hook keys
+  on `<own branch>:<pushed|unpushed>` and NOT on the commit count, which changes
+  every time the model commits, while the cleanup hook keys on the sorted set of
+  armed sentinel tokens.
+
+  **The lane hook's predicate is DIRECTED, and a plain inequality is not a
+  simplification of it.** `pushed -> unpushed` is what an ordinary COMMIT looks
+  like, so `prev_subject != subject` re-armed on every commit and again on every
+  push — measured as `commit ctx, repeat sys, push ctx, repeat sys, ...`, two
+  forced continuations per commit/push cycle, which is exactly the per-commit
+  cadence the subject was chosen to avoid. It arms on a new session, a lane never
+  seen, a DIFFERENT branch, a record it cannot parse, or `unpushed -> pushed` only,
+  since that is the one transition opening an action the model did not have before.
+
+  The record is ONE file in the PER-WORKTREE git dir (`stop-nudge-lane` /
+  `stop-nudge-cleanup`) holding `<session id>TAB<subject>TAB<epoch>`, written
+  tmp-then-`mv`; the cleanup hook appends a fourth `armed since` field, which each
+  nudge must not reset. One file rather than one per session, so nothing
+  accumulates in the git dir with nobody to clean it up, and a concurrent session
+  in the same worktree costs an EXTRA nudge rather than a missed one — the safe
+  direction. Three properties of the record are load-bearing and each was a live
+  bug first: it is written on BOTH arms of the lane hook's decision, because it
+  holds the last OBSERVED subject rather than the last NUDGED one (recording only
+  on the arm freezes the push half and silences the next genuine
+  `unpushed -> pushed`); every field is NORMALISED before it is written, since a
+  tab or an empty leading field in a tab-separated line read back with
+  `IFS=<TAB> read` shifts every later field and the comparison then never matches
+  — an unbounded nudge; and a record that cannot be PERSISTED (an unresolvable or
+  unwritable git dir) costs the MODEL channel rather than the warning, because a
+  nudge that cannot be recorded cannot be bounded.
+
 - **The two Stop hooks then DIVERGE deliberately, and the difference is the
   point.** `stop-unmerged-lane-warn` picks ONE channel by OWNERSHIP: the session's
   own lane (resolved from `cwd` in the payload, falling back to the hook copy's own
@@ -405,8 +434,18 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   the token set is unchanged, because money accrues on the clock rather than per
   turn, with the escalated message naming how long the tokens have been armed. Both
   hooks are exercised by `.claude/hooks/stop-cleanup-warn.test.sh` and
-  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (33 and 56 cases, green under
-  bash 5.x and macOS system bash 3.2), run by `vp run test:hooks`.
+  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (67 and 77 cases), run by
+  `vp run test:hooks`.
+
+  **Both suites run the HOOK under an explicitly chosen interpreter, and that is
+  not cosmetic.** They invoke it as `bash "$HOOK"` and its shebang is
+  `#!/usr/bin/env bash`, so both resolve through PATH — which means launching the
+  SUITE with `/bin/bash` proved nothing at all about the hook, and the bash 3.2
+  cleanliness these files need on macOS was only ever accidental. Each suite now
+  puts a one-symlink shim directory first on PATH so every child `bash` is the
+  fenced interpreter: `/bin/bash` by default, `HOOK_BASH=<path>` to take the other
+  tally. The suites print which one they used on their first line.
+
 - **Registration is not execution — prove the gates are ALIVE before the first
   commit of a session**: run `git commit --dry-run -m "gate liveness probe"` from
   the repo root **as a Bash TOOL CALL**. PreToolUse hooks gate the AGENT's tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,6 +423,27 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   unwritable git dir) costs the MODEL channel rather than the warning, because a
   nudge that cannot be recorded cannot be bounded.
 
+  Three corrections landed 2026-09-01, each mutation-proved. **`mv -f` is not
+  proof of a write**: `mv -f <tmp> <dir>` returns 0 and moves the tmp INSIDE the
+  directory, so a record path that is a DIRECTORY set `wrote`/`persisted`, the
+  readback found nothing, and every turn re-armed — unbounded
+  `additionalContext` against `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, arriving
+  through the success check, plus one orphan tmp per turn. Both hooks now
+  confirm the destination is a regular FILE and sweep the stray tmp. **The
+  record's THIRD field is now READ**: the lane hook consults a record only when
+  it is well-formed (exactly three tab-separated fields, numeric epoch), which
+  both makes that field load-bearing and closes the `IFS=<TAB>` fold — a record
+  with an EMPTY subject field shifted the next field into `prev_subject`, and
+  when that field parsed as `<branch>:<state>` the lane went QUIET. **The lane
+  hook DELETES the record when no worktree is ahead**, so the next lane starts
+  armed; without it the stored subject outlived the condition and the same
+  subject returning was downgraded — a missed nudge, reachable through the
+  `git switch --detach origin/main` remedy the hook itself prints. The cleanup
+  hook deliberately does NOT delete, and says why in the file: its subject is
+  the armed-token SET, its `systemMessage` fires every turn regardless, and
+  `REARM_SECONDS` re-arms the model channel within 20 minutes, so the worst case
+  is bounded where the lane hook's was not.
+
   **A downgrade to `systemMessage` must change VOICE, not only audience.** Both
   hooks now keep a `user_msg` / `model_msg` pair. The model text is written at the
   agent ("YOUR OWN lane", "rebase, run the gates", "the honest label is STOPPED"),
@@ -486,7 +507,7 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   the token set is unchanged, because money accrues on the clock rather than per
   turn, with the escalated message naming how long the tokens have been armed. Both
   hooks are exercised by `.claude/hooks/stop-cleanup-warn.test.sh` and
-  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (71 and 100 cases), run by
+  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (74 and 121 cases), run by
   `vp run test:hooks`.
 
   **Both suites run the HOOK under an explicitly chosen interpreter, and that is


### PR DESCRIPTION
Closes #1844

Closes go-to-k/cdk-real-drift#1844.

Both Stop hooks in this repo picked an output channel that does not reach the
audience their text is written for. Measured from the installed Claude Code
(2.1.251) rather than the published docs:

  hookSpecificOutput.additionalContext -> the MODEL, and the turn CONTINUES
  systemMessage                        -> the USER only, and the turn ends
  stdout / stderr at exit 0            -> NOBODY

`stop-cleanup-warn.sh` wrote to stderr and exited 0, so it reached neither: hook
stderr surfaces only through the non-blocking-error path, which is reached on a
NON-zero exit. That made a BILLING guardrail completely inert -- its whole job
is to stop a session ending with real AWS resources still running, and nothing
it printed was read by anyone.

`stop-unmerged-lane-warn.sh` emitted `systemMessage` only, while its text is
written at the agent ("you are not done", "the honest label is STOPPED"). That
is the defect go-to-k/cdkd#2389 described and go-to-k/cdkd#2392 fixed in the
sibling; it was never carried across. This copy turned out to be an OLDER FORK,
not merely a missing channel split: it never read stdin at all (no
`stop_hook_active`, no `cwd`, no `session_id`), parsed worktree paths with
`awk '{print $2}'` (which TRUNCATES any path containing a space, dropping that
lane from both the enumeration and the ownership comparison -- the one failure
direction this hook must never have), had no `python3` guard (exit 127 on every
turn without it), and carried the stale-`origin/main` comment inverted, saying
UNDER-report where it over-reports. All four are fixed alongside the port.

CADENCE. Routing to `additionalContext` is not free, and `stop_hook_active` only
stops a nudge SPINNING inside one turn. Across turns the condition persists --
for the cleanup hook, until the resources are actually deleted -- so an
unconditional continuation fires at every turn-end for as long as it holds. From
the same binary: a Stop `additionalContext` travels in the SAME `blockingErrors`
value as a `decision: "block"`, so both spend one budget,
`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (default 8 consecutive), after which the
harness overrides the hook and ends the turn. An every-turn nudge therefore
spends a budget shared with every other Stop hook.

So each hook nudges the model at most once per distinct SUBJECT, with the
subject chosen so ORDINARY WORK does not change it:

  lane hook      <own branch>:<pushed|unpushed>, a repeat downgrading to
                 systemMessage. NOT the commit count, which changes on every
                 commit; and push state is deliberately not the CHANNEL
                 discriminator, since that goes quiet on a branch pushed with
                 NO PR -- a real failure, and one of the two this hook is for.
  cleanup hook   the sorted set of armed tokens, and it diverges from its
                 neighbour in two deliberate ways.

Both cleanup divergences are about money rather than style. It emits
`systemMessage` on EVERY fire and adds `additionalContext` only when armed --
the two are independent branches, and a billing guardrail must never be silent
to the human. And it re-arms on a WALL CLOCK (20 minutes) even when the subject
is unchanged, because cost accrues on the clock rather than per turn; a
long-thinking, few-turn session would otherwise sit silent for hours. Its record
carries a fourth field, "armed since", so a nudge does not reset how long, and
the escalated text says `armed for ~N minute(s)`.

Records live one per hook in the per-worktree git dir, written tmp-then-`mv`.
One file rather than one per session, since a per-session file accumulates with
nobody to clean it up; a concurrent session can clobber it, which costs an EXTRA
nudge rather than a missed one, and that direction is pinned by a case.

Verification. Green under bash 5.3.9 AND macOS system bash 3.2. Every count in
this body was RE-MEASURED at the final tree on 2026-09-01, after the
consolidated review round described at the end: lane suite 121 cases, cleanup
suite 77 (from 56 and 33 when this lane began). Mutation-probed rather than asserted, and RE-DERIVED at the final tree because
the earlier figures were taken through a suite that aborted mid-file (see the
fixture bug below, whose guard covered one of three sites): swapping in
`origin/main`'s hooks and running the CURRENT suites, 45 of the lane suite's 121
cases flip and 65 of the cleanup suite's 77. The silence / enumeration /
JSON-validity cases pass on both sides as controls. Stated honestly: three of
the cleanup controls are weak alone against that particular pre-fix version,
which printed nothing on stdout under any input, and discriminate only together
with the armed cases.

One fixture bug the probe forced out: the record-ageing step ran a bare `awk` on
the state file, which under `set -euo pipefail` aborted the whole suite mid-file
against a hook that keeps no record -- hiding every later case. It is now guarded
and doubles as the assertion that the hook wrote a record at all. The guard was
applied at ONE of the three ageing sites; the other two were found by the
consolidated round below and the guard is now a shared helper.

CLAUDE.md is this repo's hooks rules doc (there is no `.claude/rules/` tree, and
`grep -rl stop-unmerged-lane-warn` finds only it and settings.json), so the three
channels, the block-cap budget, the cadence rule and the deliberate divergence
between the two hooks are recorded there. The existing `/hunt-bugs` bullet, which
claimed the cleanup hook "warns at session end" without saying it reached nobody,
is corrected in the same pass.

`stop-warn.sh` is deliberately NOT ported: the sibling's third Stop hook has no
counterpart here, the issue names only the two that exist, and adding one would
need a settings.json registration plus its own harness -- a different change with
its own review surface.

## Review rounds

Three independent reviewers on the original, then a scoped re-review of each fix
delta. The escalation rule (three consecutive rounds finding a blocker inside the
previous fix means change the approach, not patch again) was watched explicitly;
round 3 found no blocker, so it did not fire.

**Round 1 → commit 2** — the session-id normalisation was inert whenever the id
was empty or contained a tab (tab is IFS whitespace, so the read-back shifted
every field and `prev_sid` never matched): unbounded `additionalContext` on the
billing guardrail, the exact failure the cadence was added to prevent. The
`stop_hook_active` early exit also killed the `systemMessage` half, and the
end-to-end path is real — the lane hook forces a continuation, `deploy-autoarm-gate`
arms on a `cdk deploy` inside it, and pass 2 printed nothing. The lane hook's
predicate was undirected, so an ordinary commit re-armed it. Plus an unwritable
git dir, a future timestamp, a leading-zero timestamp, a stale `cwd`, jq
truthiness and a non-deduped count. The `jq`-missing test pair was VACUOUS:
deleting the guard left the suite green, because without `jq` the payload `cwd`
is unparseable and the hook exits before it would have called it.

**Round 2 → commit 3** — the sid fix had been applied to one hook and one SOURCE:
the env fallback landed after the fold and stayed raw. Measured with no
`session_id` in the payload: `s1` gives `ctx sys sys`, while a leading tab, an
embedded tab and an embedded newline each give `ctx ctx ctx`. It survived because
every lane-suite payload carries an explicit `session_id`, leaving that line with
zero coverage. `($f == true)` moved the jq/Python divergence rather than closing
it. And the downgrade was sending model-directed text down the user channel —
go-to-k/cdkd#2389's defect in miniature, inside the change that exists to fix it.

**Round 3 → commit 4** — no blocker. One string reached all three downgrade paths
while asserting something true of only one ("the agent has already been nudged
about this lane once"); on a resumed pass no nudge was spent, and on an
unpersistable record the model half is dropped precisely because the record
cannot be kept, so the claim would repeat every turn against an agent that will
never be told. Two unreachable-code nits of the kind these files argue against
elsewhere.

Suites 33 → 77 (cleanup) and 56 → 121 (lane) cases, green under bash 5.3.9 and
macOS system bash 3.2 — and that second number is earned: the suites invoked the hooks through
`#!/usr/bin/env bash`, so running them under `/bin/bash` measured the SUITE on
3.2 and the SUBJECT on 5.x. A `bash -> $HOOK_BASH` PATH shim fixes it, and an
explicitly-requested interpreter that is not executable is now a FATAL rc=2
rather than a silent fallback, which would have hidden a typo in the very thing
the fence exists to pin.

Thirty mutations across the rounds, all killed but one — an `armed_minutes >= 0`
clamp that SURVIVED, because the timestamp clamp upstream already makes a
negative unreachable. It was deleted rather than kept with a case that cannot
fail. One mutation attempt is also recorded because it first reported GREEN: it
inserted a marker without actually removing the fold, so it measured nothing.


## Consolidated review round (2026-09-01)

Nine reviewers across the three sibling repos produced one brief, applied here
in a single pass. The dominant pattern was TWIN ASYMMETRY: a fix or a fence that
landed in one of two near-identical hooks and not the other, where the twin
lacking it is precisely the one that cannot detect its own regression.

**Blocker -- `mv -f <tmp> <record>` reports SUCCESS onto a DIRECTORY.** It moves
the tmp inside it, so `wrote` / `persisted` was set, the readback next turn
found nothing, and every later turn re-armed: unbounded `additionalContext`
against `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, arriving through the success check,
plus one orphan tmp per turn in the git dir. Reproduced with the record path a
directory: the cleanup hook gave `both both both both` where the cadence
promises `both sys sys sys`, and the lane hook `ctx ctx ctx` where it promises
`ctx sys sys`. Both hooks now confirm the destination is a regular FILE and
sweep the stray tmp. Fenced in both suites by a three-turn case: shipped
`sys sys sys` and 0 orphans, with `mv` alone `ctx ctx ctx` and 3 orphans.

**Three guards in the lane hook survived deletion with the suite fully green,
and the CLEANUP twin fenced every one of them.** Each is now fenced here too:

- the env session-id fallback. The existing loop calls `clear_nudge_records` per
  value, so it fences the tab / newline FOLD and not the SOURCE it claims to.
  Driving A, B, A through ONE record separates them: shipped `ctx ctx ctx`, with
  the fallback deleted `ctx sys sys` -- a second concurrent session's nudge
  SWALLOWED, the missed-nudge direction both files call unsafe.
- `sid="shared"`. With no `session_id` and no env var, deleting it gives
  `ctx ctx ctx ctx`; the cleanup suite fenced the identical twin while the lane
  suite's `esid` list simply omitted the empty string. Four turns now assert
  `ctx sys sys sys`.
- the `2>/dev/null >"$tmp"` redirect ORDER. Swapping it stays green while
  "Permission denied" leaks to the hook's REAL stderr from an ADVISORY hook, on
  every turn. The lane suite never captured hook stderr at all; it does now, and
  the swap reddens it.

**The record's THIRD field was written every turn and read by nothing**, while
CLAUDE.md documented it as part of the shape -- so its ABSENCE was exactly what
could not be detected. The lane hook now consults a record only when it is
WELL-FORMED (three tab-separated fields, numeric epoch), ported from the sibling
repo's copy of this same hook, which has carried that check since its own
review. That also closes an `IFS=<TAB>` fold: a TAB is IFS whitespace, so a run
collapses and a record with an EMPTY subject field shifted the real subject into
`prev_subject` -- and when it parsed as `<branch>:<state>` the predicate matched
and the lane went QUIET. The five existing malformed-record cases do NOT reach
that shape (each hands `prev_subject` something that cannot split), so a
discriminating case was added: reverting the shape check reddens it and the
fourth-field case, and a well-formed repeat still goes quiet as the control.

**The cadence record outlived its condition.** When no worktree is ahead of
`origin/main` the stored subject is stale, and returning to the same branch in
the same push state reproduces it exactly, so the next genuine first sighting is
DOWNGRADED -- a MISSED nudge, reachable through the `git switch --detach
origin/main` remedy the hook itself prints. The lane hook now clears every
worktree's record on the no-lane exit ("no lane is ahead" is a repo-global
fact, and being wrong costs one extra nudge, the trade the record's
concurrent-clobber comment already accepts). Reverting the clear reddens 2 of
the new cases. `stop-cleanup-warn.sh` deliberately does NOT clear, and now says
why in the file rather than leaving it unstated: its subject is the armed-token
SET, its `systemMessage` fires every turn regardless, and `REARM_SECONDS`
re-arms the model channel within 20 minutes, so the worst case is bounded at 20
minutes of model silence about resources the human is being told about every
turn -- against the lane hook's unbounded "never told again".

**Two guards that did not guard.** A non-string `cwd` or `session_id` --
legal JSON -- made `(data.get("cwd") or "")` a non-string, so `.replace` raised
`AttributeError` and an advisory hook wrote a TRACEBACK to its real stderr, the
one thing both files spend paragraphs avoiding; `cwd` prints first, so BOTH
values were lost. The block already hardened `json.loads` and
`isinstance(data, dict)` and stopped one field short. Three payloads now assert
empty stderr and rc 0, and reverting the coercion reddens all three. Separately,
`REPO="$(cd ... && pwd)"` had no `2>/dev/null` (unlike the sibling) and its
`cd "$REPO" || exit 0` does not stand the hook down when `REPO` is empty:
measured, `cd ""` returns 0 on bash 3.2 -- macOS's `/bin/bash`, which
`#!/usr/bin/env bash` finds on a machine without Homebrew bash first on PATH --
and 1 on bash 5.3. Now `[ -n "$REPO" ] || exit 0`. Stated honestly: that one is
FIXED BUT NOT FENCED. Reaching it needs the hook's own grandparent directory to
be unreadable while the hook file itself is still readable and executable, which
could not be constructed -- bash must traverse those same components to open the
script.

**The fixture guard the body says is applied was applied at ONE of three
sites.** `stop-cleanup-warn.test.sh` guarded the first ageing block and left two
bare `awk ... "$STATE"` calls. Reproduced: under any mutation that stops the
hook writing a record, the suite died at the second site with
`awk: can't open file .../stop-nudge-cleanup`, rc=2, after emitting 60 of 71
cases -- ELEVEN hidden, exactly the class a mutation probe is looking for. rc=2
is loud, so it was never a false green; the mutation tallies taken through it
simply were not re-derivable, which is why every figure in this body is now
re-measured. The guard is a shared `require_state` helper used at all three
sites: with the same mutation the suite now runs all 77 cases and reports 36 red
at rc=1.

**Nits.** `arm_reason`'s `new` / `active` values are never read by name (only
`clock` is tested) and are now documented as such rather than left looking dead;
the session-id source PRECEDENCE genuinely differs between the two hooks
(payload-first here, env-first in the cleanup hook, whose sid also keys the
`autoarm-<sid>` sentinel shared with `deploy-autoarm-gate.sh`) and both comments
claimed symmetry they do not have; the payload-side tab fold was redundant with
the single fold after both sources are consulted; the `case *:*` subject guard
is now reachable only through a hand-edited record and says so; the
`additionalContext` justification claimed the model channel is the model's
because it names `/sweep-resources`, while the `systemMessage` names the same
command -- what actually makes it the model's is that only it CONTINUES the
turn; a suite comment quoted "all 93 cases passed" as a current tally beside a
suite that has since grown, and now states the property instead of a number; and
both suites gained a FLOOR on their case totals, because emptying a `for` loop
removed assertions silently while the tally still read `0 failed`.

**Re-measured bash 3.2 evidence.** Injecting a bash-4-only PARSE error (`;;&`)
into each hook, with the shim in place: 101 of the lane suite's 121 cases red
under 3.2.57 and 0 under 5.3.9; 67 of the cleanup suite's 77 red under 3.2 and 0
under 5.3.9.
