### PR TITLE
chore(work-issues): when the skill is launched inside a worktree, take the tree it is standing in instead of nesting another

### DIFF
--- a/.claude/skills/hunt-bugs/references/cleanup-and-ship.md
+++ b/.claude/skills/hunt-bugs/references/cleanup-and-ship.md
@@ -15,12 +15,19 @@ Take it all the way to merged — do not leave a green PR hanging:
 
 1. `gh pr merge <#> --squash --delete-branch` (the remote branch). If CI is down
    for billing, `--admin` after confirming the local gates passed.
-2. **Remove the worktree** — a hunt always creates one (`.worktrees/<name>`), and a
-   left-behind worktree is the silent residue of this flow. From the MAIN checkout:
+2. **Remove the worktree YOU created** — a hunt launched from the main checkout
+   creates one (`.worktrees/<name>`), and a left-behind worktree is the silent
+   residue of this flow. From the MAIN checkout:
    `git worktree remove .worktrees/<name>` (add `--force` if it refuses on
    leftover build artifacts), then `git branch -D wt-<name>` if the branch lingers,
-   and `git worktree prune`. Confirm with `git worktree list` — only the main
-   checkout should remain. (Mirror of CLAUDE.md's integrate-then-remove rule.)
+   and `git worktree prune`. Confirm with `git worktree list` — every worktree
+   this hunt ADDED should be gone. (Mirror of CLAUDE.md's integrate-then-remove
+   rule.) **A hunt launched IN-PLACE (§1) added none, so it removes none**: it
+   must not `git worktree remove` the tree it is running in — that deletes its own
+   cwd — nor `git branch -D` the branch it is standing on. Cleanup of that tree
+   belongs to whoever created it (the outer tool, or the operator), so say so in
+   the wrap instead of doing it; `--delete-branch` on the merge still removes the
+   REMOTE branch, which is fine.
 
 ### 9. Record what you learned
 

--- a/.claude/skills/hunt-bugs/references/plan.md
+++ b/.claude/skills/hunt-bugs/references/plan.md
@@ -38,6 +38,17 @@ Per CLAUDE.md, never work in the main checkout:
 `mise trust .worktrees/<name>/.mise.toml` → `pnpm install` → `vp run build` (the CLI
 runs from `dist/`).
 
+**That recipe is CWD-RELATIVE, so it only applies when this hunt was launched
+from the MAIN checkout.** Launched from inside a linked worktree (an Orca/ADE
+workspace, a stray `cd` into `.worktrees/<x>`) it NESTS a worktree inside one,
+and deleting the outer workspace takes the inner directory, its uncommitted work
+and its git registration with it (go-to-k/cdk-real-drift#1842). Settle the launch
+mode with the one-command probe in `.claude/skills/work-issues/SKILL.md`
+("Launch mode"); IN-PLACE means create nothing and hunt on the branch already
+checked out here (deps and `dist/` are usually already built), and §8 then
+removes nothing. A hunt takes one fix at a time, so the one-lane limit that
+probe carries for `/work-issues` costs this skill nothing.
+
 ### 2. Scaffold fixtures + ARM the cleanup gate
 
 Add fixtures under `tests/integration/<name>/` — mirror an existing one (`app.ts` +

--- a/.claude/skills/hunt-bugs/references/plan.md
+++ b/.claude/skills/hunt-bugs/references/plan.md
@@ -43,11 +43,14 @@ from the MAIN checkout.** Launched from inside a linked worktree (an Orca/ADE
 workspace, a stray `cd` into `.worktrees/<x>`) it NESTS a worktree inside one,
 and deleting the outer workspace takes the inner directory, its uncommitted work
 and its git registration with it (go-to-k/cdk-real-drift#1842). Settle the launch
-mode with the one-command probe in `.claude/skills/work-issues/SKILL.md`
-("Launch mode"); IN-PLACE means create nothing and hunt on the branch already
-checked out here (deps and `dist/` are usually already built), and §8 then
-removes nothing. A hunt takes one fix at a time, so the one-lane limit that
-probe carries for `/work-issues` costs this skill nothing.
+mode with the probe in `.claude/skills/work-issues/references/launch-mode.md`,
+the file that holds the ONLY copy of it — `/work-issues` SKILL.md points there
+rather than carrying it.
+IN-PLACE means create nothing and hunt on the branch already checked out here
+(deps and `dist/` are usually already built), and §8 then removes nothing. The
+probe reports a mode and two paths and carries no lane limit of its own; the
+one-lane rule is `/work-issues` prose, and a hunt takes one fix at a time
+anyway, so it costs this skill nothing.
 
 ### 2. Scaffold fixtures + ARM the cleanup gate
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -19,6 +19,31 @@ and colliding on the same file. The run does not end at the last merge: the retr
 stage folds what this run taught you back into this skill's files, while the
 evidence still exists.
 
+## Launch mode: main checkout, or already inside a worktree
+
+The flow below adds one worktree per lane. That is right from the MAIN checkout
+and wrong when this run was launched INSIDE a linked worktree (an Orca/ADE
+workspace, a stray `cd` into `.worktrees/<x>`): `git worktree add` then NESTS
+one, and deleting the outer workspace takes the inner directory, its uncommitted
+work and its git registration with it (go-to-k/cdk-real-drift#1842). Compute the
+mode before stage 0 and state it in the opening report:
+
+```bash
+[ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
+ = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] && echo MAIN-CHECKOUT || echo IN-PLACE
+```
+
+Equal only in the main checkout — a linked worktree's `--git-dir` is
+`<common-dir>/worktrees/<name>`. `pwd -P` is load-bearing both ways: the main
+checkout answers `.git` RELATIVELY for both, and macOS spells `/tmp` as
+`/private/tmp`.
+
+`IN-PLACE` changes four things: take ONE issue (§3); claim the branch/worktree
+already checked out (§4); add no worktree and work on the branch already here,
+after confirming the tree is YOURS (§5); remove no worktree, delete no branch,
+and reach `main` through the main checkout rather than leaving this tree (§9,
+§10-d).
+
 ## How this skill is packaged (read this before stage 0)
 
 This file is a thin orchestrator. The full procedure lives in per-stage files
@@ -81,7 +106,7 @@ the user wants to watch); the stage files apply unchanged either way.
 | 2. Collision landscape       | `references/triage.md`       | Worktree/branch/PR/claim probes and their blind spots; the central contested files (`src/normalize/noise.ts` / `src/diff/classify.ts` / `src/revert/plan.ts`)                       |
 | 3. Pick file-disjoint issues | `references/triage.md`       | Disjointness gate, fresh-issue quarantine (§3-a), ranking rules, naming the next session's verification before writing `next` (§3-b), premise checks against `origin/main`          |
 | 4. Claim                     | `references/claim.md`        | Claim comment BEFORE first edit, re-check for a competing claim/PR right before starting, claim what you FILE too (a `Session-fit: now` deferral gets its claim in the filing turn) |
-| 5. Implement                 | `references/implement.md`    | One worktree per lane (`.worktrees/`), build before first test, sibling-site sweeps, dup-check window when filing                                                                   |
+| 5. Implement                 | `references/implement.md`    | One tree per lane (`.worktrees/`, or in place), build before first test, sibling-site sweeps, dup-check window when filing                                                          |
 | 6. Gates + PR                | `references/gates-and-pr.md` | `/check`, `/check-docs`, marker freshness per worktree, PR create                                                                                                                   |
 | 7. Main advanced             | `references/gates-and-pr.md` | Rebase over parallel merges, stale-base phantom diffs, re-grep what LANDED                                                                                                          |
 | 8. Verify before merge       | `references/verify.md`       | `/verify-pr`, live-test tiers, mutation probes (§8-z when a probe reports no discrimination)                                                                                        |
@@ -99,8 +124,8 @@ the user wants to watch); the stage files apply unchanged either way.
   appeared. (§4)
 - **Two lanes never edit the same file**; at most one lane per central table
   (`noise.ts` / `classify.ts` / `revert/plan.ts`). (§2, §3)
-- **Never work in the main checkout** — one worktree per lane under
-  `.worktrees/`, `mise trust` + `pnpm install` in each. (§5)
+- **Never work in the main checkout** — one tree per lane: a new worktree under
+  `.worktrees/` (`mise trust` + `pnpm install`), or, IN-PLACE, this one. (§5)
 - **Real-AWS live tests and merges are SERIALIZED across lanes** — the parent
   grants the turn, one lane at a time; a lane subagent never starts either on
   its own. Everything else (edits, unit tests, markers, PR create, reviews,

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -27,7 +27,9 @@ workspace, a stray `cd` into `.worktrees/<x>`): `git worktree add` then NESTS
 one, and deleting the outer workspace takes the inner directory, its uncommitted
 work and its git registration with it (go-to-k/cdk-real-drift#1842). Run the
 one-line probe at the top of §3 — the ONLY copy of it — before stage 0, and
-state the answer in the opening report.
+state BOTH of its answers in the opening report — the mode, and the absolute
+`LANE_TREE` path it captured, which §4, §5 and §10 all hand to `git -C` (§3 says
+why that path is recorded rather than re-derived later).
 
 `IN-PLACE` changes four things: take ONE issue (§3); claim the branch/worktree
 already checked out (§4); add no worktree and work on the branch already here,

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -25,31 +25,41 @@ The flow below adds one worktree per lane. That is right from the MAIN checkout
 and wrong when this run was launched INSIDE a linked worktree (an Orca/ADE
 workspace, a stray `cd` into `.worktrees/<x>`): `git worktree add` then NESTS
 one, and deleting the outer workspace takes the inner directory, its uncommitted
-work and its git registration with it (go-to-k/cdk-real-drift#1842). COMPUTE
-which one you are in AT THE TOP OF STAGE 3, which holds the ONLY copy of the
-one-line probe and is the first place the answer is used. State BOTH of its
-answers — the mode, and the absolute `LANE_TREE` path — in the opening report,
-the first message you write after running the probe and before any lane starts.
-Read that name as "the tree this run stands in", NOT "the lane worktree" —
-MAIN-CHECKOUT records the MAIN checkout under it, and the `git -C
-"<LANE_TREE>"` recipes consuming it in §4, §5 and §10 are IN-PLACE-only arms
-(every MAIN-CHECKOUT arm beside them uses no `-C`). §3 says why it is captured
-there and why it is SUBSTITUTED into a command, never kept as a shell variable.
+work and its git registration with it (go-to-k/cdk-real-drift#1842).
 
-`IN-PLACE` changes four things: take ONE issue (§3); claim the branch/worktree
-already checked out (§4); add no worktree and work on the branch already here,
-after confirming the tree is YOURS (§5); remove no worktree, delete no branch,
-and reach `main` through the main checkout rather than leaving this tree (§9,
-§10-d).
+**The PARENT computes which case applies BEFORE stage 0**: read
+`references/launch-mode.md` and run the probe it holds (the ONLY copy). Before
+stage 0 because §1 and §2 already consume the answer — §1's
+`git checkout main && git pull` cannot run in a linked worktree, and §2's
+collision scan, whose relative `.worktrees/<w>` paths resolve to nothing there,
+reports an empty board that reads as "no competing agents". In the PARENT
+because stages 0–3 are delegated to a subagent whose return payload carries no
+git state. State all three printed values — `MODE`, which is
+`MAIN-CHECKOUT` or `IN-PLACE`, plus `LANE_TREE` and `MAIN_CHECKOUT` — in the
+opening report, the first message you write after running the probe and before
+any lane starts, and pass them into the triage dispatch and into every lane
+dispatch. Read `LANE_TREE` as "the tree this run stands in", NOT "the lane
+worktree": MAIN-CHECKOUT records the MAIN checkout under it, and the
+`git -C "<LANE_TREE>"` recipes consuming it in §4, §5, §7 and §10 are
+IN-PLACE-only arms (every MAIN-CHECKOUT arm beside them uses no `-C`).
+
+`IN-PLACE` changes a great deal more than the lane count: §1's pull, the
+collision scan's paths, the claim, the branch recipe, §7's rebase, the worktree
+and branch cleanup, and where the retro branch is created.
+`references/launch-mode.md` carries the COMPLETE list as a table mapping each
+consequence to the stage that fires it — read it there, and do NOT re-summarise
+it here. The previous revision of this paragraph said "changes four things" and
+named four; an undercount in the always-loaded orchestrator wins over the
+reference file it points at, which is the one direction this file must never be
+wrong in.
 
 ## How this skill is packaged (read this before stage 0)
 
 This file is a thin orchestrator. The full procedure lives in per-stage files
-under `references/`, split so a run loads only the stage it is in instead of the
-whole corpus. **Reading the stage file at stage entry is MANDATORY, not
-optional** — each file carries hard rules and measured failure modes without
-which the stage summary below is not executable. A bare `§N` anywhere in this
-skill points into the file that holds that section (map in the table).
+under `references/`, so a run loads only the stage it is in. **Reading the stage
+file at stage entry is MANDATORY** — each carries hard rules and measured
+failure modes without which the summary below is not executable. A bare `§N`
+points into the file holding that section (map in the table).
 
 **Delegate for context; keep the locks and the serialization in the parent.**
 The placements below are live-proven, not aspirational — §5 carries the run
@@ -59,54 +69,58 @@ that proved them.
   whose prompt is: read `references/triage.md` in full, execute it against
   this repo, and return ONLY the candidate table — per issue: number, title,
   target files, rank + the rule that decided it, collision evidence
-  (worktrees / branches / claims found), and any premise-check findings. The
-  raw backlog listing and issue bodies stay out of the parent context.
+  (worktrees / branches / claims found), and any premise-check findings. Hand
+  it `MODE` / `LANE_TREE` / `MAIN_CHECKOUT` from the probe: §1 and §2 need the
+  absolute main checkout, and a read-only subagent cannot return git state the
+  parent does not already hold. The raw backlog listing and issue bodies stay
+  out of the parent context.
 - **Claim (stage 4): the PARENT, never a subagent** — the claim is the lock,
   so it names the session accountable for the lane; it also names the lane
-  branch/worktree the dispatched subagent will create, and the parent runs
-  §4's competing-claim re-check right before dispatching (§4).
+  branch/worktree the dispatched subagent will create (or, IN-PLACE, the one
+  already checked out), and the parent runs the competing-claim re-check right
+  before dispatching (§4).
 - **Lanes (stages 5–8): one general-purpose subagent per claimed issue.**
   Dispatch each with the issue number(s), the posted claim, and the stage
   files to read at stage entry (`references/implement.md`,
   `references/gates-and-pr.md`, `references/verify.md`). The lane creates its
-  own worktree per §5, implements, runs `/check` + `/check-docs`, opens the
-  PR, dispatches read-only reviewers when the diff warrants them (§8),
-  addresses findings, and drives CI to green — then STOPS at merge-ready and
-  reports back: PR number, HEAD sha, markers set, review verdicts, the
-  live-test tier it owes (§8), anything deferred. Its diffs, test logs and
-  review round-trips never enter the parent context. A lane must NOT run a
-  real-AWS live test (a deploy → mutate → revert fixture) or merge on its
-  own — that is the serialization invariant below, not a capability gap.
+  own worktree per §5 — or works in place — implements, runs `/check` +
+  `/check-docs`, opens the PR, dispatches read-only reviewers when the diff
+  warrants them (§8), addresses findings, and drives CI to green — then STOPS
+  at merge-ready and reports back: PR number, HEAD sha, markers set, review
+  verdicts, the live-test tier it owes (§8), anything deferred. Its diffs, test
+  logs and review round-trips never enter the parent context. A lane must NOT
+  run a real-AWS live test or merge on its own — that is the serialization
+  invariant below, not a capability gap.
 - **Finishing (stage 9): the parent, one lane at a time.** Grant each
   merge-ready lane its turn — resume the lane agent (SendMessage) to run its
-  owed live test + `/sweep-resources` and merge while it holds the turn, or
-  run them yourself FROM THAT LANE'S WORKTREE (gate verdicts are computed
-  against the tree the command runs from — §9). Post-merge (pull → release →
-  install → worktree cleanup) follows §9.
+  owed live test + `/sweep-resources` and merge while it holds the turn, or run
+  them yourself FROM THAT LANE'S WORKTREE (gate verdicts are computed against
+  the tree the command runs from — §9). Post-merge follows §9.
 - **Retro (stage 10): a subagent**, dispatched after the last merge with
   `references/retro.md` plus this run's key evidence (what you re-read, what
   the text sent you into, corrections the user made) to measure the backlog
   effect, draft the skill edits, and ship them as the retro PR.
 
-Running a lane in the parent instead stays legal (a single-lane run, or a lane
-the user wants to watch); the stage files apply unchanged either way.
+Running a lane in the parent stays legal (a single-lane run, or one the user
+wants to watch); the stage files apply unchanged either way.
 
 ## Stages
 
-| Stage                        | File (read at entry)         | What it covers                                                                                                                                                                      |
-| ---------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0. Safety screen             | `references/triage.md`       | Untrusted issues/comments: `author_association` via REST, never download/run third-party content, defer engage/minimize/block to the maintainer                                     |
-| 1. List backlog              | `references/triage.md`       | REST listing (PR filter, `per_page=100`, `created_at`), volume assessment                                                                                                           |
-| 2. Collision landscape       | `references/triage.md`       | Worktree/branch/PR/claim probes and their blind spots; the central contested files (`src/normalize/noise.ts` / `src/diff/classify.ts` / `src/revert/plan.ts`)                       |
-| 3. Pick file-disjoint issues | `references/triage.md`       | Disjointness gate, fresh-issue quarantine (§3-a), ranking rules, naming the next session's verification before writing `next` (§3-b), premise checks against `origin/main`          |
-| 4. Claim                     | `references/claim.md`        | Claim comment BEFORE first edit, re-check for a competing claim/PR right before starting, claim what you FILE too (a `Session-fit: now` deferral gets its claim in the filing turn) |
-| 5. Implement                 | `references/implement.md`    | One tree per lane (`.worktrees/`, or in place), build before first test, sibling-site sweeps, dup-check window when filing                                                          |
-| 6. Gates + PR                | `references/gates-and-pr.md` | `/check`, `/check-docs`, marker freshness per worktree, PR create                                                                                                                   |
-| 7. Main advanced             | `references/gates-and-pr.md` | Rebase over parallel merges, stale-base phantom diffs, re-grep what LANDED                                                                                                          |
-| 8. Verify before merge       | `references/verify.md`       | `/verify-pr`, live-test tiers, mutation probes (§8-z when a probe reports no discrimination)                                                                                        |
-| 9. Ship                      | `references/ship.md`         | Merge → pull → release → global install → worktree cleanup                                                                                                                          |
-| 10. Retro                    | `references/retro.md`        | Net backlog effect (§10-0), promotion check on this run's `next` filings, where a lesson lands (§10-b/c), ship the retro PR (§10-d)                                                 |
-| Appendix                     | `references/gotchas.md`      | Gotchas learned the hard way + the existing rules this skill leans on                                                                                                               |
+| Stage                        | File (read at entry)         | What it covers                                                                                                                     |
+| ---------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Before 0. Launch mode        | `references/launch-mode.md`  | The probe (the ONLY copy), its three values, and the table mapping every IN-PLACE consequence to its stage                         |
+| 0. Safety screen             | `references/triage.md`       | Untrusted issues/comments: `author_association` via REST, never run third-party content, defer engage/block to the maintainer      |
+| 1. List backlog              | `references/triage.md`       | REST listing (PR filter, `per_page=100`, `created_at`), volume assessment                                                          |
+| 2. Collision landscape       | `references/triage.md`       | Worktree/branch/PR/claim probes (absolute, via `<MAIN_CHECKOUT>`) and their blind spots; the central contested files               |
+| 3. Pick file-disjoint issues | `references/triage.md`       | Lane count from the launch mode, disjointness gate, fresh-issue quarantine (§3-a), ranking (§3-b), premise checks vs `origin/main` |
+| 4. Claim                     | `references/claim.md`        | Claim comment BEFORE first edit, re-check for a competing claim/PR right before starting, claim what you FILE too                  |
+| 5. Implement                 | `references/implement.md`    | One tree per lane (`.worktrees/`, or in place), build before first test, sibling-site sweeps, dup-check window when filing         |
+| 6. Gates + PR                | `references/gates-and-pr.md` | `/check`, `/check-docs`, marker freshness per worktree, PR create                                                                  |
+| 7. Main advanced             | `references/gates-and-pr.md` | Rebase over parallel merges, stale-base phantom diffs, re-grep what LANDED                                                         |
+| 8. Verify before merge       | `references/verify.md`       | `/verify-pr`, live-test tiers, mutation probes (§8-z when a probe reports no discrimination)                                       |
+| 9. Ship                      | `references/ship.md`         | Merge → pull → release → global install → worktree cleanup                                                                         |
+| 10. Retro                    | `references/retro.md`        | Net backlog effect (§10-0), promotion check on `next` filings, where a lesson lands (§10-b/c), ship the retro PR (§10-d)           |
+| Appendix                     | `references/gotchas.md`      | Gotchas learned the hard way + the existing rules this skill leans on                                                              |
 
 ## Hard invariants (hold even between stage reads)
 
@@ -122,10 +136,9 @@ the user wants to watch); the stage files apply unchanged either way.
   `.worktrees/` (`mise trust` + `pnpm install`), or, IN-PLACE, this one. (§5)
 - **Real-AWS live tests and merges are SERIALIZED across lanes** — the parent
   grants the turn, one lane at a time; a lane subagent never starts either on
-  its own. Everything else (edits, unit tests, markers, PR create, reviews,
-  CI) runs concurrently, subject to two repo-local caveats §9 states in full
-  (the markgate store is SHARED across worktrees, and the deploy-autoarm
-  sentinel is per-SESSION). (§9)
+  its own. Everything else runs concurrently, subject to two repo-local caveats
+  §9 states in full (the markgate store is SHARED across worktrees, the
+  deploy-autoarm sentinel is per-SESSION). (§9)
 - **English only in every published artifact** — issue bodies/comments, PR
   titles/bodies, commits, code. (CLAUDE.md)
 - **The run ends with the retro (stage 10) and the standard wrap report**
@@ -136,9 +149,8 @@ the user wants to watch); the stage files apply unchanged either way.
 
 The retro amends the STAGE FILE the lesson belongs to — `references/<stage>.md`
 — never this orchestrator, unless the stage list itself changed. This file's
-byte size is capped by `tests/skill-file-payload.test.ts`; the cap is the
-mechanical stop on the growth loop that produced the 123 KB predecessor of this
-layout. §10-b/§10-c (in `references/retro.md`) govern how to edit: amend in
-place, escalate a twice-violated sentence to a test or hook, qualify every
-cross-repo issue reference (`go-to-k/cdk-real-drift#N`, never a bare `#N` —
-`tests/skill-doc-paths.test.ts` enforces it over every `.md` file here).
+byte size is capped by `tests/skill-file-payload.test.ts`, the mechanical stop
+on the growth loop that produced the 123 KB predecessor of this layout;
+§10-b/§10-c (in `references/retro.md`) govern how to edit, including the
+qualified-reference rule `tests/skill-doc-paths.test.ts` enforces over every
+`.md` file here.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -27,9 +27,12 @@ workspace, a stray `cd` into `.worktrees/<x>`): `git worktree add` then NESTS
 one, and deleting the outer workspace takes the inner directory, its uncommitted
 work and its git registration with it (go-to-k/cdk-real-drift#1842). Run the
 one-line probe at the top of §3 — the ONLY copy of it — before stage 0, and
-state BOTH of its answers in the opening report — the mode, and the absolute
-`LANE_TREE` path it captured, which §4, §5 and §10 all hand to `git -C` (§3 says
-why that path is recorded rather than re-derived later).
+state BOTH of its answers in the opening report: the mode, and the absolute
+`LANE_TREE` path. Read that name as "the tree this run stands in", NOT "the lane
+worktree" — MAIN-CHECKOUT records the MAIN checkout under it, and the `git -C
+"<LANE_TREE>"` recipes consuming it in §4, §5 and §10 are IN-PLACE-only arms
+(every MAIN-CHECKOUT arm beside them uses no `-C`). §3 says why it is captured
+there and why it is SUBSTITUTED into a command, never kept as a shell variable.
 
 `IN-PLACE` changes four things: take ONE issue (§3); claim the branch/worktree
 already checked out (§4); add no worktree and work on the branch already here,
@@ -47,12 +50,8 @@ which the stage summary below is not executable. A bare `§N` anywhere in this
 skill points into the file that holds that section (map in the table).
 
 **Delegate for context; keep the locks and the serialization in the parent.**
-The placements below are live-proven, not aspirational: on 2026-08-28 this
-repo's own skill-split PR (go-to-k/cdk-real-drift#1831), like its sibling
-go-to-k/cdk-local#621, was built END-TO-END by a lane subagent — worktree,
-implementation, gates, CI — with the parent doing only claims, serialized
-merges and cleanup, and every hook and markgate gate fired inside the lane's
-calls exactly as in the parent.
+The placements below are live-proven, not aspirational — §5 carries the run
+that proved them.
 
 - **Triage (stages 0–3): a read-only subagent** (general-purpose or Explore)
   whose prompt is: read `references/triage.md` in full, execute it against
@@ -122,12 +121,9 @@ the user wants to watch); the stage files apply unchanged either way.
 - **Real-AWS live tests and merges are SERIALIZED across lanes** — the parent
   grants the turn, one lane at a time; a lane subagent never starts either on
   its own. Everything else (edits, unit tests, markers, PR create, reviews,
-  CI) runs concurrently, with two repo-local caveats: the markgate store is
-  SHARED across worktrees with hashes from the setter's cwd, so a peer's
-  `markgate set` landing between your set and your commit fails closed (a
-  re-run, not a wrong pass); and the deploy-autoarm sentinel is per-SESSION,
-  so one lane's live deploy blocks EVERY lane's commit and PR until the
-  sweep clears it. (§9)
+  CI) runs concurrently, subject to two repo-local caveats §9 states in full
+  (the markgate store is SHARED across worktrees, and the deploy-autoarm
+  sentinel is per-SESSION). (§9)
 - **English only in every published artifact** — issue bodies/comments, PR
   titles/bodies, commits, code. (CLAUDE.md)
 - **The run ends with the retro (stage 10) and the standard wrap report**

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -25,11 +25,13 @@ The flow below adds one worktree per lane. That is right from the MAIN checkout
 and wrong when this run was launched INSIDE a linked worktree (an Orca/ADE
 workspace, a stray `cd` into `.worktrees/<x>`): `git worktree add` then NESTS
 one, and deleting the outer workspace takes the inner directory, its uncommitted
-work and its git registration with it (go-to-k/cdk-real-drift#1842). Run the
-one-line probe at the top of §3 — the ONLY copy of it — before stage 0, and
-state BOTH of its answers in the opening report: the mode, and the absolute
-`LANE_TREE` path. Read that name as "the tree this run stands in", NOT "the lane
-worktree" — MAIN-CHECKOUT records the MAIN checkout under it, and the `git -C
+work and its git registration with it (go-to-k/cdk-real-drift#1842). COMPUTE
+which one you are in AT THE TOP OF STAGE 3, which holds the ONLY copy of the
+one-line probe and is the first place the answer is used. State BOTH of its
+answers — the mode, and the absolute `LANE_TREE` path — in the opening report,
+the first message you write after running the probe and before any lane starts.
+Read that name as "the tree this run stands in", NOT "the lane worktree" —
+MAIN-CHECKOUT records the MAIN checkout under it, and the `git -C
 "<LANE_TREE>"` recipes consuming it in §4, §5 and §10 are IN-PLACE-only arms
 (every MAIN-CHECKOUT arm beside them uses no `-C`). §3 says why it is captured
 there and why it is SUBSTITUTED into a command, never kept as a shell variable.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -25,18 +25,9 @@ The flow below adds one worktree per lane. That is right from the MAIN checkout
 and wrong when this run was launched INSIDE a linked worktree (an Orca/ADE
 workspace, a stray `cd` into `.worktrees/<x>`): `git worktree add` then NESTS
 one, and deleting the outer workspace takes the inner directory, its uncommitted
-work and its git registration with it (go-to-k/cdk-real-drift#1842). Compute the
-mode before stage 0 and state it in the opening report:
-
-```bash
-[ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
- = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] && echo MAIN-CHECKOUT || echo IN-PLACE
-```
-
-Equal only in the main checkout — a linked worktree's `--git-dir` is
-`<common-dir>/worktrees/<name>`. `pwd -P` is load-bearing both ways: the main
-checkout answers `.git` RELATIVELY for both, and macOS spells `/tmp` as
-`/private/tmp`.
+work and its git registration with it (go-to-k/cdk-real-drift#1842). Run the
+one-line probe at the top of §3 — the ONLY copy of it — before stage 0, and
+state the answer in the opening report.
 
 `IN-PLACE` changes four things: take ONE issue (§3); claim the branch/worktree
 already checked out (§4); add no worktree and work on the branch already here,

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -9,6 +9,13 @@ the session accountable for the lane — and the claim's `<ref>` names the branc
 holds. The competing-claim/PR re-check below also runs in the parent, right
 before dispatch. Everything else in this section is unchanged.
 
+**An IN-PLACE run names the tree it is STANDING IN** (SKILL.md "Launch mode"):
+the `<ref>` is the branch and worktree already checked out — read them out of
+git rather than composing a name (`git branch --show-current`,
+`git rev-parse --show-toplevel`) — because nothing new will be created, and a
+claim pointing at a worktree that never appears is exactly what §9's ownership
+probes misread. Such a run claims ONE issue (§3), not a set.
+
 For EACH issue you will start:
 
 ```bash

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -10,9 +10,11 @@ holds. The competing-claim/PR re-check below also runs in the parent, right
 before dispatch. Everything else in this section is unchanged.
 
 **An IN-PLACE run names the tree it is STANDING IN** (SKILL.md "Launch mode"):
-the `<ref>` is the branch and worktree already checked out — read them out of
-git rather than composing a name (`git branch --show-current`,
-`git rev-parse --show-toplevel`) — because nothing new will be created, and a
+the `<ref>` is the branch and worktree already checked out, and neither is
+composed: the worktree is the `LANE_TREE` path §3's probe captured and the
+opening report recorded — never re-derived from `git rev-parse --show-toplevel`
+here, for §5's reason — and the branch is
+`git -C "<LANE_TREE>" branch --show-current`. Nothing new will be created, and a
 claim pointing at a worktree that never appears is exactly what §9's ownership
 probes misread. Such a run claims ONE issue (§3), not a set.
 

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -9,14 +9,20 @@ the session accountable for the lane — and the claim's `<ref>` names the branc
 holds. The competing-claim/PR re-check below also runs in the parent, right
 before dispatch. Everything else in this section is unchanged.
 
-**An IN-PLACE run names the tree it is STANDING IN** (SKILL.md "Launch mode"):
-the `<ref>` is the branch and worktree already checked out, and neither is
-composed: the worktree is the `LANE_TREE` path §3's probe captured and the
-opening report recorded — never re-derived from `git rev-parse --show-toplevel`
-here, for §5's reason — and the branch is
+**An IN-PLACE run names the tree it is STANDING IN**
+(`references/launch-mode.md`): the `<ref>` is the branch and worktree already
+checked out, and neither is composed. The worktree is the `LANE_TREE` path the
+launch-mode probe captured and the opening report recorded — never re-derived
+from `git rev-parse --show-toplevel` here, for §5's reason — and the branch is
 `git -C "<LANE_TREE>" branch --show-current`. Nothing new will be created, and a
 claim pointing at a worktree that never appears is exactly what §9's ownership
-probes misread. Such a run claims ONE issue (§3), not a set.
+probes misread.
+
+**An empty branch name means the tree is DETACHED, not that the claim is
+blocked.** The branch is created in §5, after this stage — so write "the branch
+§5 will create in `<LANE_TREE>`" and post the claim on time. A claim delayed
+until a branch exists is a claim posted after the first edit, which is the one
+thing this stage forbids. Such a run claims ONE issue (§3), not a set.
 
 For EACH issue you will start:
 

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -86,7 +86,7 @@ artifact, NOT real deletions. Confirm the TRUE diff and rebase:
 
 ```bash
 git diff --stat $(git merge-base origin/main <branch>)..<branch>   # the real change
-git -C .worktrees/<name> rebase origin/main                        # clean if disjoint
+git -C <lane tree> rebase origin/main   # .worktrees/<name>, or, IN-PLACE, this tree
 ```
 
 Re-run gates, `git push --force-with-lease`.

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -86,7 +86,7 @@ artifact, NOT real deletions. Confirm the TRUE diff and rebase:
 
 ```bash
 git diff --stat $(git merge-base origin/main <branch>)..<branch>   # the real change
-git -C <lane tree> rebase origin/main   # .worktrees/<name>, or, IN-PLACE, this tree
+git -C "<LANE_TREE>" rebase origin/main   # the path the launch-mode probe recorded
 ```
 
 Re-run gates, `git push --force-with-lease`.

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -49,10 +49,17 @@
   worktree and delete the branch, which SKILL.md "Launch mode" forbids for the
   tree you are standing in. Expected, not a defect: confirm the PR is MERGED
   (`gh pr view <n> --json state,mergedAt`) and say so in the wrap. The only way
-  to clear it from inside is to leave the branch, `git switch --detach origin/main`
-  — the hook skips a worktree with no current branch, and `main` itself is
-  checked out in the main checkout — and whether to do that belongs to whoever
-  owns the workspace, not to this run.
+  to clear it from inside is to leave the branch —
+  `git -C "<LANE_TREE>" switch --detach origin/main`, since the hook skips a
+  worktree with no current branch and `main` itself is checked out in the main
+  checkout. **Never write that BARE.** Nothing in this repo gates a branch
+  switch (§5 spends fourteen lines proving it: `branch-gate` fires only on
+  commit/push, `worktree-guard` only on Edit/Write, and there is no
+  `main-tree-branch-gate` — go-to-k/cdk-real-drift#1845), so a bare
+  `git switch --detach` run after a cwd reset detaches the SHARED main checkout,
+  unblocked. Whether to detach at all belongs to whoever owns the workspace, not
+  to this run — except in §10-d, where THIS run creates the retro branch in this
+  tree and therefore owns that one branch move.
 
 ## Important existing rules this skill leans on
 

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -41,6 +41,19 @@
     `git worktree remove …`, `git branch -D wt-…` (the `git push origin --delete` will
     report "remote ref does not exist" — benign, gh already removed it).
 
+- **An IN-PLACE run ends with the Stop hook still calling its lane unmerged, and
+  the remedy that warning names is one this mode forbids.**
+  `.claude/hooks/stop-unmerged-lane-warn.sh` lists every worktree whose branch is
+  ahead of `origin/main`, and this repo SQUASH-merges, so a merged branch reads
+  as ahead forever; its own text then says the remaining work is to remove the
+  worktree and delete the branch, which SKILL.md "Launch mode" forbids for the
+  tree you are standing in. Expected, not a defect: confirm the PR is MERGED
+  (`gh pr view <n> --json state,mergedAt`) and say so in the wrap. The only way
+  to clear it from inside is to leave the branch, `git switch --detach origin/main`
+  — the hook skips a worktree with no current branch, and `main` itself is
+  checked out in the main checkout — and whether to do that belongs to whoever
+  owns the workspace, not to this run.
+
 ## Important existing rules this skill leans on
 
 - **Core invariant**: a clean, un-mutated deploy has ZERO `[Potential Drift]` on
@@ -52,7 +65,9 @@
   the bodies it files).
 - **Always add unit tests** for a fix — do not wait to be asked.
 - **All changes via PR; never commit to `main`.** Develop in a git worktree with
-  DISJOINT files; the orchestrator integrates. (`CLAUDE.md` → Workflow Rules.)
+  DISJOINT files — a new one per lane, or the worktree this run was launched in
+  when the mode is IN-PLACE (SKILL.md "Launch mode"); the orchestrator
+  integrates. (`CLAUDE.md` → Workflow Rules.)
 - **Never download/run/install untrusted third-party content** (§0).
 - **Wrap with a Remaining-work section + Session-close verdict, scoped to the
   issues this run actually worked.** This skill is the easiest place to get that

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -154,8 +154,11 @@ The two arms differ in BASE and that is not a property of the mode: this one
 branches from local `main`, the IN-PLACE one below from `origin/main`. Local
 `main` only advances on an explicit pull in the main checkout, so this arm can
 start stale — the class `stale-base-gate.sh` exists to catch. It is a separate
-defect from the nesting one, deliberately left for its own change; the new arm
-is written with the correct base rather than copying the wrong one.
+defect from the nesting one and NO issue tracks it yet (unlike the branch-gate
+gap below, which is go-to-k/cdk-real-drift#1845); it is left for its own change
+because moving this arm to `origin/main` changes what `stale-base-gate.sh`
+sees, and that gate's behaviour has to be re-measured rather than assumed. The
+new arm is written with the correct base rather than copying the wrong one.
 
 **IN-PLACE mode (SKILL.md "Launch mode") skips that block entirely**: this run
 was launched inside a linked worktree, so it keeps that tree and the branch
@@ -163,37 +166,7 @@ already checked out there, and creates NOTHING — a nested worktree dies with
 the outer workspace, taking its uncommitted work and leaving a registration
 that needs `git worktree prune` (go-to-k/cdk-real-drift#1842). Deps and `dist/`
 are usually already there; run `pnpm install` / `vp run build` only if they are
-not. If the tree is detached, or its branch has already merged (reusing it
-would push an orphan ref), take a fresh branch WITHOUT leaving the tree:
-
-```bash
-# `-C <LANE_TREE>` is load-bearing HERE in a way it is not in the siblings.
-# Nothing in this repo gates a branch switch: `branch-gate` fires on
-# `git commit` / `git push` and only when the target tree is on `main` /
-# `master`, `worktree-guard` fires on Edit/Write into the MAIN checkout, and
-# there is no `main-tree-branch-gate` here at all (go-to-k/cdk-real-drift#1845
-# tracks adding one) -- so a BARE `git switch -c` run after the shell's cwd has
-# silently reset to the main checkout (the appendix's cwd-reset failure, and the
-# reason section 9 pulls through -C) takes the MAIN checkout off `main`,
-# unblocked, in a tree other lanes are sharing. Both siblings DO have that gate:
-# cdkd and cdk-local carry the `-C`-free spelling because their gate refuses a
-# stray `git switch -c` in the main checkout, and it covers the chained
-# `fetch && switch -c` form as of this session's hooks change (measured there).
-# So this divergence is temporary, and it closes from the HOOK side, not by
-# copying this comment into the siblings.
-# Substitute the ABSOLUTE path section 3's probe printed as
-# `LANE_TREE` and the opening report recorded -- the one value captured while
-# the cwd was provably right. Do NOT re-derive it here as
-# `$(git rev-parse --show-toplevel)` or `pwd`: both resolve against the same
-# reset cwd, so the guard would answer "the main checkout" in exactly the case
-# it exists for, and inherit the bug it is guarding.
-#
-# The `&&` is load-bearing too: unchained, a failed `fetch` still branches, off
-# a stale `origin/main` -- the class `stale-base-gate.sh` exists to catch, and
-# the one the paragraph above this block is about.
-git -C "<LANE_TREE>" fetch origin \
-  && git -C "<LANE_TREE>" switch -c wt-<name> origin/main
-```
+not.
 
 **Confirm the tree is YOURS before adopting it.** A stray `cd` into a peer's
 live lane looks exactly like a workspace handed to you. This repo ships no
@@ -204,19 +177,69 @@ read for a claim naming this branch:
 ```bash
 git -C "<LANE_TREE>" status --porcelain          # work you did not write
 git -C "<LANE_TREE>" log --oneline -3            # whose branch this is
-gh pr list --state all \
-  --head "$(git -C "<LANE_TREE>" branch --show-current)"
+BR=$(git -C "<LANE_TREE>" branch --show-current)
+# The emptiness test is load-bearing, not defensive style: this same file
+# contemplates a DETACHED tree two paragraphs down, where `$BR` is EMPTY -- and
+# `gh pr list --state all --head ""` exits 0 and returns EVERY PR in the repo
+# (measured 2026-09-01 against this repo). Under the rule below ("any one saying
+# someone is here means STOP") that is a guaranteed FALSE STOP on every detached
+# adoption. Same empty-argument-retargets family that
+# references/launch-mode.md records for `git -C ""`. Written as if/else rather
+# than `&& ... || ...`: with the latter, a `gh` TRANSPORT failure would also
+# take the second arm and report "detached" about a tree that is not.
+if [ -n "$BR" ]; then
+  gh pr list --state all --head "$BR"
+else
+  echo 'detached: no branch to query -- ownership rests on the two probes above plus the issue thread'
+fi
 ```
 
-**Every one of them takes `-C <LANE_TREE>` for the same reason the switch above
-does, and omitting it costs more here than a wrong branch**: a bare probe run
+**Every one of them takes `-C "<LANE_TREE>"` for the same reason the switch
+below does, and omitting it costs more here than a wrong branch**: a bare probe run
 after a cwd reset describes the MAIN checkout while READING as a description of
 this lane, so it answers "clean, no claim, no PR" about a tree nobody asked
 about — and the run then adopts a peer's live lane believing it checked. Read
-them under §9's rule
-that every ownership signal establishes LIFE and never absence: any one of them
-saying "someone is here" means STOP and report — never nest a worktree inside a
-peer's lane to get out of it.
+them under §9's rule that every ownership signal establishes LIFE and never
+absence: any one of them saying "someone is here" means STOP and report — never
+nest a worktree inside a peer's lane to get out of it.
+
+This block comes BEFORE the branch recipe below because it GUARDS it, and a
+previous revision had the two the other way round: a run following the file in
+order took a peer's live lane off its branch and only then checked whose tree it
+was. The order is the guard.
+
+**Only once the tree is confirmed yours**: if it is DETACHED, or its branch has
+already merged (reusing it would push an orphan ref), take a fresh branch
+WITHOUT leaving the tree.
+
+```bash
+# `-C <LANE_TREE>` is load-bearing HERE in a way it is not in the siblings.
+# Nothing in this repo gates a branch switch: `branch-gate` fires on
+# `git commit` / `git push` and only when the target tree is on `main` /
+# `master`, `worktree-guard` fires on Edit/Write into the MAIN checkout, and
+# there is no `main-tree-branch-gate` here at all (go-to-k/cdk-real-drift#1845
+# tracks adding one) -- so a BARE `git switch -c` run after the shell's cwd has
+# silently reset to the main checkout (§6's `cd <worktree> &&` rule, and the
+# reason section 9 pulls through -C) takes the MAIN checkout off `main`,
+# unblocked, in a tree other lanes are sharing. Both siblings DO have that gate:
+# cdkd and cdk-local carry the `-C`-free spelling because their gate refuses a
+# stray `git switch -c` in the main checkout, and it covers the chained
+# `fetch && switch -c` form as of this session's hooks change (measured there).
+# So this divergence is temporary, and it closes from the HOOK side, not by
+# copying this comment into the siblings.
+# Substitute the ABSOLUTE path the launch-mode probe printed as `LANE_TREE`
+# and the opening report recorded -- the one value captured while the cwd was
+# provably right. Do NOT re-derive it here as
+# `$(git rev-parse --show-toplevel)` or `pwd`: both resolve against the same
+# reset cwd, so the guard would answer "the main checkout" in exactly the case
+# it exists for, and inherit the bug it is guarding.
+#
+# The `&&` is load-bearing too: unchained, a failed `fetch` still branches, off
+# a stale `origin/main` -- the class `stale-base-gate.sh` exists to catch, and
+# the one the paragraph above this block is about.
+git -C "<LANE_TREE>" fetch origin \
+  && git -C "<LANE_TREE>" switch -c wt-<name> origin/main
+```
 
 **Build BEFORE the first test run, and read a fresh worktree's failures with
 that in mind.** A worktree starts with no `dist/`; a test spawning the built CLI
@@ -323,10 +346,10 @@ case reuses the first case's fixture setup, so the suite covers one row of a
 table it never drew (2026-08-27, go-to-k/cdk-local#609: a commit gate twice
 shipped green suites — 52 cases, then 93 — each hiding live fail-opens in file
 STATEs the fixture never entered: untracked, tracked-but-modified, deleted on
-disk). DRAW THE GRID: states on one axis,
-input shapes on the other, write the cells out — uncovered cells become
-NAMEABLE, and the grid surfaces FALSE blocks a one-dimensional suite cannot
-produce. Name the state axis from what the subject READS: a
+disk). DRAW THE GRID: states on one axis, input shapes on the other, write the
+cells out — uncovered cells become NAMEABLE, and the grid surfaces FALSE blocks
+a one-dimensional suite cannot produce. Name the state axis from what the subject
+READS: a
 `.claude/hooks/*.test.sh` case reads the TREE (clean, staged-only, dirty,
 untracked-only, on `main`, on a branch, inside a worktree); a fold or classify
 fence reads the TIER a property lands in (`declared`, `undeclared`, `atDefault`,

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -144,6 +144,13 @@ mise trust .worktrees/<name>/.mise.toml
 ( cd .worktrees/<name> && vp run build )     # ...and no dist/ -- see below
 ```
 
+The two arms differ in BASE and that is not a property of the mode: this one
+branches from local `main`, the IN-PLACE one below from `origin/main`. Local
+`main` only advances on an explicit pull in the main checkout, so this arm can
+start stale — the class `stale-base-gate.sh` exists to catch. It is a separate
+defect from the nesting one, deliberately left for its own change; the new arm
+is written with the correct base rather than copying the wrong one.
+
 **IN-PLACE mode (SKILL.md "Launch mode") skips that block entirely**: this run
 was launched inside a linked worktree, so it keeps that tree and the branch
 already checked out there, and creates NOTHING — a nested worktree dies with
@@ -154,13 +161,20 @@ not. If the tree is detached, or its branch has already merged (reusing it
 would push an orphan ref), take a fresh branch WITHOUT leaving the tree:
 
 ```bash
-git fetch origin && git switch -c wt-<name> origin/main
+# `-C <this lane's own absolute path>` is load-bearing HERE in a way it is not
+# in the siblings. Nothing in this repo gates a branch switch: `branch-gate`
+# fires on `git commit` / `git push` and only when the target tree is on
+# `main` / `master`, `worktree-guard` fires on Edit/Write into the MAIN
+# checkout, and there is no `main-tree-branch-gate` here at all -- so a BARE
+# `git switch -c` run after the shell's cwd has silently reset to the main
+# checkout (the appendix's cwd-reset failure, and the reason section 9 pulls
+# through -C) takes the MAIN checkout off `main`, unblocked, in a tree other
+# lanes are sharing. Pass the ABSOLUTE path this run recorded when it adopted
+# the tree; do NOT re-derive it as `$(git rev-parse --show-toplevel)`, which
+# resolves against the same reset cwd and inherits the bug it is guarding.
+git -C "<lane-worktree-abs-path>" fetch origin
+git -C "<lane-worktree-abs-path>" switch -c wt-<name> origin/main
 ```
-
-Nothing gates that: `branch-gate` fires on `git commit` / `git push` and only
-when the target tree is on `main` / `master`, and `worktree-guard` fires on
-Edit/Write into the MAIN checkout — neither sees a branch switch inside a
-worktree.
 
 **Confirm the tree is YOURS before adopting it.** A stray `cd` into a peer's
 live lane looks exactly like a workspace handed to you. This repo ships no

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -6,12 +6,18 @@ This stage (and stages 6-8) normally runs INSIDE a lane subagent the
 orchestrator dispatched — one general-purpose agent per claimed issue, so the
 lane's diffs, test output and review round-trips never land in the parent
 context. Every rule below applies unchanged inside the lane: hooks fire on the
-lane's tool calls (measured on go-to-k/cdk-real-drift#1831, built end-to-end by
-a lane subagent on 2026-08-28), and markgate markers land in the lane's own
-worktree. Two actions are reserved to the parent's serialization turn and are
-NOT the lane's to start: a real-AWS live test (deploy → mutate → revert) and
-the merge (the orchestrator's serialization invariant; §9). A lane stops at
-merge-ready and reports.
+lane's tool calls, and markgate markers land in the lane's own worktree. Two
+actions are reserved to the parent's serialization turn and are NOT the lane's
+to start: a real-AWS live test (deploy → mutate → revert) and the merge (the
+orchestrator's serialization invariant; §9). A lane stops at merge-ready and
+reports.
+
+**That placement is live-proven, not aspirational, and SKILL.md points here for
+the run that proved it**: on 2026-08-28 this repo's own skill-split PR
+(go-to-k/cdk-real-drift#1831), like its sibling go-to-k/cdk-local#621, was built
+END-TO-END by a lane subagent — worktree, implementation, gates, CI — with the
+parent doing only claims, serialized merges and cleanup, and every hook and
+markgate gate firing inside the lane's calls exactly as in the parent.
 
 **Before fixing, ask whether the defect has SIBLING SITES — and if it does, sweep
 them in THIS lane rather than filing them.** Most defects here are a CLASS, not an
@@ -165,11 +171,17 @@ would push an orphan ref), take a fresh branch WITHOUT leaving the tree:
 # Nothing in this repo gates a branch switch: `branch-gate` fires on
 # `git commit` / `git push` and only when the target tree is on `main` /
 # `master`, `worktree-guard` fires on Edit/Write into the MAIN checkout, and
-# there is no `main-tree-branch-gate` here at all -- so a BARE `git switch -c`
-# run after the shell's cwd has silently reset to the main checkout (the
-# appendix's cwd-reset failure, and the reason section 9 pulls through -C)
-# takes the MAIN checkout off `main`, unblocked, in a tree other lanes are
-# sharing. Substitute the ABSOLUTE path section 3's probe printed as
+# there is no `main-tree-branch-gate` here at all (go-to-k/cdk-real-drift#1845
+# tracks adding one) -- so a BARE `git switch -c` run after the shell's cwd has
+# silently reset to the main checkout (the appendix's cwd-reset failure, and the
+# reason section 9 pulls through -C) takes the MAIN checkout off `main`,
+# unblocked, in a tree other lanes are sharing. Both siblings DO have that gate:
+# cdkd and cdk-local carry the `-C`-free spelling because their gate refuses a
+# stray `git switch -c` in the main checkout, and it covers the chained
+# `fetch && switch -c` form as of this session's hooks change (measured there).
+# So this divergence is temporary, and it closes from the HOOK side, not by
+# copying this comment into the siblings.
+# Substitute the ABSOLUTE path section 3's probe printed as
 # `LANE_TREE` and the opening report recorded -- the one value captured while
 # the cwd was provably right. Do NOT re-derive it here as
 # `$(git rev-parse --show-toplevel)` or `pwd`: both resolve against the same

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -144,21 +144,29 @@ exists, and always allows a path under `.worktrees/`. Per lane, in
 MAIN-CHECKOUT mode:
 
 ```bash
-git worktree add .worktrees/<name> -b wt-<name> main
+git worktree add .worktrees/<name> -b wt-<name> origin/main
 mise trust .worktrees/<name>/.mise.toml
 ( cd .worktrees/<name> && pnpm install )     # worktrees have no node_modules
 ( cd .worktrees/<name> && vp run build )     # ...and no dist/ -- see below
 ```
 
-The two arms differ in BASE and that is not a property of the mode: this one
-branches from local `main`, the IN-PLACE one below from `origin/main`. Local
-`main` only advances on an explicit pull in the main checkout, so this arm can
-start stale — the class `stale-base-gate.sh` exists to catch. It is a separate
-defect from the nesting one and NO issue tracks it yet (unlike the branch-gate
-gap below, which is go-to-k/cdk-real-drift#1845); it is left for its own change
-because moving this arm to `origin/main` changes what `stale-base-gate.sh`
-sees, and that gate's behaviour has to be re-measured rather than assumed. The
-new arm is written with the correct base rather than copying the wrong one.
+`origin/main`, not local `main`, and both arms now agree. This one branched from
+local `main` until 2026-09-01, which only advances on an explicit pull in the
+main checkout, so the lane started whatever the last pull left behind; §1's
+refresh usually hides that, which is exactly why it survived. Both sibling repos
+already spelled it `origin/main`, so this was drift rather than a considered
+difference.
+
+The reason recorded for leaving it — that changing the base changes what
+`stale-base-gate.sh` sees, and that had to be measured — was right to demand the
+measurement and wrong about which way it points. That gate opens with
+`git merge-base --is-ancestor "$base" HEAD || exit 0`, so it fires only on a
+branch that CLAIMS to be current. A lane cut from a stale local `main` does not
+have `origin/main` as an ancestor, so the gate exited 0 and never looked: it was
+INERT for precisely this shape, and the sentence that said it "exists to catch"
+this class had it backwards. Basing on `origin/main` makes `origin/main` an
+ancestor, which is what turns the gate ON for these lanes. The change gains
+coverage rather than risking it.
 
 **IN-PLACE mode (SKILL.md "Launch mode") skips that block entirely**: this run
 was launched inside a linked worktree, so it keeps that tree and the branch

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -1,6 +1,6 @@
 <!-- Part of the /work-issues skill. Stage files: triage.md (§0–§3), claim.md (§4), implement.md (§5), gates-and-pr.md (§6–§7), verify.md (§8), ship.md (§9), retro.md (§10), gotchas.md (appendix). A bare §N points into the file that holds that section. READ THIS FILE IN FULL when your run enters this stage. -->
 
-## 5. One worktree per lane, then implement
+## 5. One tree per lane, then implement
 
 This stage (and stages 6-8) normally runs INSIDE a lane subagent the
 orchestrator dispatched — one general-purpose agent per claimed issue, so the
@@ -132,7 +132,10 @@ Enforced by `.claude/hooks/issue-dup-check-gate.sh`, which refuses
   LIST endpoint (`-X GET … --paginate` and `-f state=open` pass); only an
   explicit `POST`, or a `title=` field with no method (gh infers POST), mints.
 
-Never edit in the main checkout. Per lane:
+Never edit in the main checkout — `.claude/hooks/worktree-guard.sh` blocks an
+Edit/Write to the main checkout's `src/**` or `tests/**` while any worktree
+exists, and always allows a path under `.worktrees/`. Per lane, in
+MAIN-CHECKOUT mode:
 
 ```bash
 git worktree add .worktrees/<name> -b wt-<name> main
@@ -140,6 +143,35 @@ mise trust .worktrees/<name>/.mise.toml
 ( cd .worktrees/<name> && pnpm install )     # worktrees have no node_modules
 ( cd .worktrees/<name> && vp run build )     # ...and no dist/ -- see below
 ```
+
+**IN-PLACE mode (SKILL.md "Launch mode") skips that block entirely**: this run
+was launched inside a linked worktree, so it keeps that tree and the branch
+already checked out there, and creates NOTHING — a nested worktree dies with
+the outer workspace, taking its uncommitted work and leaving a registration
+that needs `git worktree prune` (go-to-k/cdk-real-drift#1842). Deps and `dist/`
+are usually already there; run `pnpm install` / `vp run build` only if they are
+not. If the tree is detached, or its branch has already merged (reusing it
+would push an orphan ref), take a fresh branch WITHOUT leaving the tree:
+
+```bash
+git fetch origin && git switch -c wt-<name> origin/main
+```
+
+Nothing gates that: `branch-gate` fires on `git commit` / `git push` and only
+when the target tree is on `main` / `master`, and `worktree-guard` fires on
+Edit/Write into the MAIN checkout — neither sees a branch switch inside a
+worktree.
+
+**Confirm the tree is YOURS before adopting it.** A stray `cd` into a peer's
+live lane looks exactly like a workspace handed to you. This repo ships no
+per-worktree session-owner sentinel (the sibling cdkd has one; do not go
+looking for it here), so the probes are `git status --porcelain` (uncommitted
+work you did not write), the branch's own history and PR
+(`git log --oneline -3`, `gh pr list --state all --head "$(git branch --show-current)"`),
+and the issue thread for a claim naming this branch. Read them under §9's rule
+that every ownership signal establishes LIFE and never absence: any one of them
+saying "someone is here" means STOP and report — never nest a worktree inside a
+peer's lane to get out of it.
 
 **Build BEFORE the first test run, and read a fresh worktree's failures with
 that in mind.** A worktree starts with no `dist/`; a test spawning the built CLI
@@ -149,8 +181,8 @@ checkout (which HAS a `dist/`) passes, so every comparison points at main
 merge broke main"; `vp run build` made them green). **A fresh worktree failing
 where the main checkout passes is evidence about the WORKTREE first.**
 
-Do the fix in the worktree (match the existing table/entry pattern exactly; ESM
-relative imports need the `.js` extension). **Always add a unit test that fails
+Do the fix in the lane's tree (match the existing table/entry pattern exactly;
+ESM relative imports need the `.js` extension). **Always add a unit test that fails
 without the fix and passes with it** — for a fold/FP fix use the issue's exact
 harvested live model; for revert, assert the update document / patch op.
 **Check first whether the artifact already has a harness** — fold-table entries

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -161,28 +161,47 @@ not. If the tree is detached, or its branch has already merged (reusing it
 would push an orphan ref), take a fresh branch WITHOUT leaving the tree:
 
 ```bash
-# `-C <this lane's own absolute path>` is load-bearing HERE in a way it is not
-# in the siblings. Nothing in this repo gates a branch switch: `branch-gate`
-# fires on `git commit` / `git push` and only when the target tree is on
-# `main` / `master`, `worktree-guard` fires on Edit/Write into the MAIN
-# checkout, and there is no `main-tree-branch-gate` here at all -- so a BARE
-# `git switch -c` run after the shell's cwd has silently reset to the main
-# checkout (the appendix's cwd-reset failure, and the reason section 9 pulls
-# through -C) takes the MAIN checkout off `main`, unblocked, in a tree other
-# lanes are sharing. Pass the ABSOLUTE path this run recorded when it adopted
-# the tree; do NOT re-derive it as `$(git rev-parse --show-toplevel)`, which
-# resolves against the same reset cwd and inherits the bug it is guarding.
-git -C "<lane-worktree-abs-path>" fetch origin
-git -C "<lane-worktree-abs-path>" switch -c wt-<name> origin/main
+# `-C <LANE_TREE>` is load-bearing HERE in a way it is not in the siblings.
+# Nothing in this repo gates a branch switch: `branch-gate` fires on
+# `git commit` / `git push` and only when the target tree is on `main` /
+# `master`, `worktree-guard` fires on Edit/Write into the MAIN checkout, and
+# there is no `main-tree-branch-gate` here at all -- so a BARE `git switch -c`
+# run after the shell's cwd has silently reset to the main checkout (the
+# appendix's cwd-reset failure, and the reason section 9 pulls through -C)
+# takes the MAIN checkout off `main`, unblocked, in a tree other lanes are
+# sharing. Substitute the ABSOLUTE path section 3's probe printed as
+# `LANE_TREE` and the opening report recorded -- the one value captured while
+# the cwd was provably right. Do NOT re-derive it here as
+# `$(git rev-parse --show-toplevel)` or `pwd`: both resolve against the same
+# reset cwd, so the guard would answer "the main checkout" in exactly the case
+# it exists for, and inherit the bug it is guarding.
+#
+# The `&&` is load-bearing too: unchained, a failed `fetch` still branches, off
+# a stale `origin/main` -- the class `stale-base-gate.sh` exists to catch, and
+# the one the paragraph above this block is about.
+git -C "<LANE_TREE>" fetch origin \
+  && git -C "<LANE_TREE>" switch -c wt-<name> origin/main
 ```
 
 **Confirm the tree is YOURS before adopting it.** A stray `cd` into a peer's
 live lane looks exactly like a workspace handed to you. This repo ships no
 per-worktree session-owner sentinel (the sibling cdkd has one; do not go
-looking for it here), so the probes are `git status --porcelain` (uncommitted
-work you did not write), the branch's own history and PR
-(`git log --oneline -3`, `gh pr list --state all --head "$(git branch --show-current)"`),
-and the issue thread for a claim naming this branch. Read them under §9's rule
+looking for it here), so the probes are the three below plus the issue thread,
+read for a claim naming this branch:
+
+```bash
+git -C "<LANE_TREE>" status --porcelain          # work you did not write
+git -C "<LANE_TREE>" log --oneline -3            # whose branch this is
+gh pr list --state all \
+  --head "$(git -C "<LANE_TREE>" branch --show-current)"
+```
+
+**Every one of them takes `-C <LANE_TREE>` for the same reason the switch above
+does, and omitting it costs more here than a wrong branch**: a bare probe run
+after a cwd reset describes the MAIN checkout while READING as a description of
+this lane, so it answers "clean, no claim, no PR" about a tree nobody asked
+about — and the run then adopts a peer's live lane believing it checked. Read
+them under §9's rule
 that every ownership signal establishes LIFE and never absence: any one of them
 saying "someone is here" means STOP and report — never nest a worktree inside a
 peer's lane to get out of it.

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -1,0 +1,133 @@
+<!-- Part of the /work-issues skill. Stage files: launch-mode.md (before stage 0), triage.md (§0–§3), claim.md (§4), implement.md (§5), gates-and-pr.md (§6–§7), verify.md (§8), ship.md (§9), retro.md (§10), gotchas.md (appendix). A bare §N points into the file that holds that section. READ THIS FILE IN FULL before stage 0. -->
+
+## Launch mode — the PARENT runs this BEFORE stage 0
+
+This is the ONLY copy of the probe. SKILL.md "Launch mode" points here rather
+than restating it, because a second verbatim copy of a command is the drift
+shape section 10-b fences elsewhere.
+
+```bash
+[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = true ] \
+  || { echo 'PROBE FAILED: not inside a git work tree -- do not guess the mode'; exit 1; }
+COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
+GITDIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)
+LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
+MAIN_CHECKOUT=$(dirname "$COMMON")
+[ "$GITDIR" = "$COMMON" ] && MODE=MAIN-CHECKOUT || MODE=IN-PLACE
+printf 'MODE=%s\nLANE_TREE=%s\nMAIN_CHECKOUT=%s\n' "$MODE" "$LANE_TREE" "$MAIN_CHECKOUT"
+```
+
+### Why here and not at the top of stage 3
+
+The probe used to sit at the top of §3, on the reasoning that §3 is the first
+place the answer is used. That was wrong twice over, and either half alone
+would be enough to move it:
+
+- **Stages 1 and 2 already consume the mode.** §1 runs
+  `git checkout main && git pull origin main --ff-only`, which IN-PLACE dies
+  with the same `fatal: 'main' is already used by worktree ...` §9 documents.
+  §2's collision map then runs `git -C .worktrees/<w> log|show|status` — a
+  RELATIVE path, correct only from the main checkout. IN-PLACE the cwd is a
+  lane tree, that path does not exist, git errors, and the scan returns
+  NOTHING. An empty collision map reads as "no competing agents", which is the
+  exact failure §2 exists to prevent, and unlike §1 it fails QUIETLY.
+  `MAIN_CHECKOUT` is what makes both absolute, so it has to exist before §1
+  runs, not after §2.
+- **Stages 0–3 are DELEGATED to a read-only triage subagent** (SKILL.md), whose
+  return payload is a candidate table — no git state, no paths. An answer
+  computed inside it never reaches the parent, and the parent is the party that
+  later runs `git worktree add` or does not. Computing it in the parent before
+  dispatching anything removes the problem instead of documenting it.
+
+So: run it in the parent, pass `MODE` / `LANE_TREE` / `MAIN_CHECKOUT` into the
+triage dispatch and into every lane dispatch, and state all three in the
+opening report.
+
+### Reading the three values
+
+`GITDIR` equals `COMMON` only in the main checkout — a linked worktree's
+`--git-dir` is `<common-dir>/worktrees/<name>`. `pwd -P` settles both the main
+checkout's RELATIVE `.git` answer and macOS's `/tmp` -> `/private/tmp`.
+
+`MAIN_CHECKOUT` is `dirname "$COMMON"` — the parent of the ONE shared git dir —
+never `pwd` and never `--show-toplevel`, both of which answer "the tree I am
+standing in" and so are exactly wrong in the mode that needs the value. It also
+needs no `git worktree list` row ordering, which §9 used to depend on.
+
+`LANE_TREE` is "the tree this run stands in", NOT "the lane worktree":
+MAIN-CHECKOUT records the MAIN checkout under it, and the two are equal there.
+IN-PLACE they differ, and that difference is the whole point.
+
+**The guard on the first line is not decoration.** Outside a work tree every
+`git rev-parse` fails and each substitution collapses to the empty string, so
+an unguarded compare tests `""` against `""` and prints MAIN-CHECKOUT — a wrong
+verdict, with a wrong `LANE_TREE` beside it. Measured 2026-08-31, the shells
+even disagreed about the wreckage: bash REFUSES `cd ""` (rc=1, `cd: null
+directory`) so the `&& pwd -P` never runs, while zsh accepts it (rc=0) and
+prints the same cwd twice. `--is-inside-work-tree` is compared to the literal
+`true` rather than trusted for its exit status, because inside a `.git`
+directory it prints `false` and exits 0 — measured 2026-09-01; the exit-status
+form passed there and produced an empty `LANE_TREE` under a `MAIN-CHECKOUT`
+verdict. With the value compare, both non-repo positions fail loudly in both
+shells, and the shell divergence stops mattering. That is why the guard
+replaced the prose: the divergence used to be recorded and re-checked by
+nothing.
+
+**An empty value is worse than a failed command, which is why the probe stops
+rather than warning.** Measured the same day: `git -C "" rev-parse
+--show-toplevel` exits 0 and prints the CWD's repo, so every
+`git -C "<LANE_TREE>"` recipe in §4, §5 and §10 handed a blank silently
+retargets the tree the shell is standing in — the main checkout, in exactly the
+scenario the `-C` was added for. The guard degrades into the bug it guards,
+with no failure to read.
+
+### The values are RECORDED, never re-derived
+
+This instant is the one moment the cwd is provably the tree whose mode is being
+decided; every later stage runs in a fresh shell whose cwd may have silently
+reset to the main checkout (§6's `cd <worktree> &&` rule). So **state all
+three in the opening report**, verbatim and absolute — that report is their ONLY
+recorded copy. A later stage that re-derives `LANE_TREE` from
+`$(git rev-parse --show-toplevel)` or from `pwd` resolves against the reset cwd
+and answers "the main checkout" in precisely the case the `-C` exists to guard.
+
+**`<LANE_TREE>` and `<MAIN_CHECKOUT>` in a later stage are SUBSTITUTION
+PLACEHOLDERS, not shell variables, and the difference is the whole guard.**
+Paste the absolute path from the opening report into the command text. Do NOT
+write `git -C "$LANE_TREE"`: the assignments live in THIS fenced block and every
+later block is its own Bash call and its own shell (§9 spells the same trap out
+for `MAIN`, §10-d for `B`), so the variable is already empty there — and per the
+paragraph above, an empty `-C` does not fail, it re-targets. A placeholder that
+was never substituted is visible in the command you are about to run; an empty
+variable is not visible anywhere.
+
+### What IN-PLACE changes, and where each consequence fires
+
+SKILL.md carries the same list in short form; this is the one with the stage
+pointers. IN-PLACE means this run was launched inside a worktree someone else
+created (an Orca/ADE workspace, a stray `cd`), so it has exactly ONE working
+tree:
+
+| #   | Consequence                                                                                                                                                                                 | Where     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| 1   | Take ONE issue and finish it — a second lane would need a worktree NESTED inside this one, which dies with the outer workspace and takes its uncommitted work (go-to-k/cdk-real-drift#1842) | §3        |
+| 2   | §1's `git checkout main && git pull` cannot run here; pull through `git -C "<MAIN_CHECKOUT>"` and read the refs with `git show origin/main:<file>`                                          | §1        |
+| 3   | §2's worktree probes take `<MAIN_CHECKOUT>/.worktrees/<w>`, not a relative path                                                                                                             | §2        |
+| 4   | The claim names the branch and tree already checked out here, read out of git rather than composed                                                                                          | §4        |
+| 5   | Create no worktree; work on the branch already here, after confirming the tree is YOURS                                                                                                     | §5        |
+| 6   | A tree that is DETACHED or whose PR already merged does create a branch — in place, without leaving the tree                                                                                | §5        |
+| 7   | §7's rebase runs `git -C "<LANE_TREE>"`                                                                                                                                                     | §7        |
+| 8   | Remove no worktree and delete no branch: a lane that removes the tree it runs in deletes its own cwd. Cleanup belongs to whoever created it                                                 | §9, §10-d |
+| 9   | §9's post-merge pull goes through `git -C "<MAIN_CHECKOUT>"` for the same reason as row 2                                                                                                   | §9        |
+| 10  | The retro branch is created in THIS tree, so the run legitimately ends on a branch that is not the one it started on                                                                        | §10-d     |
+
+There is deliberately no rebuild row. The global install here is
+`vp i -g cdk-real-drift`, BY NAME from npm, so it reads no tree's build output
+and is mode-independent. The sibling cdkd links its global CLI at the MAIN
+checkout's `dist/` and must relocate that step; do not import it here (§9 says
+the same).
+
+"Four things" was the previous count and it was an undercount, in the direction
+that matters: this file is not always loaded, SKILL.md is, so a short list in
+the orchestrator wins over the reference file it points at. Count the rows
+before writing a number beside them.

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -229,6 +229,8 @@ Every run appending one more bullet is how a long skill becomes an unread one.
 Every worktree is gone by §9 and you are back on `main`, where `branch-gate`
 blocks a commit — so the retro gets its own worktree:
 
+MAIN-CHECKOUT (SKILL.md "Launch mode") — run THIS block, and not the next one:
+
 ```bash
 # Date-suffix the branch: the previous run's branch was deleted on merge, so
 # reusing the name re-creates it as an orphan ref that no PR tracks.
@@ -237,12 +239,22 @@ git worktree add ".worktrees/${B##*/}" -b "$B" origin/main
 cd ".worktrees/${B##*/}"
 mise trust && mise install    # untrusted .mise.toml: vp / markgate will not resolve
 pnpm install                  # worktrees have no node_modules
+```
 
-# IN-PLACE (SKILL.md "Launch mode"): you are NOT on `main` and there is no
-# worktree to add -- the lane's own tree is still here with its deps installed.
-# Take the retro branch IN IT; the merged lane branch cannot be reused, and
-# nothing gates a branch switch inside a worktree (see section 5).
-git fetch origin && git switch -c "$B" origin/main
+IN-PLACE — run THIS block INSTEAD of the one above, never both: there is no
+worktree to add, and `git worktree add` from inside this tree NESTS the very
+worktree this mode exists to prevent. You are also not on `main`; the lane's own
+tree is still here with its deps installed, so take the retro branch IN IT, and
+the merged lane branch cannot be reused. `B` is re-assigned because a separate
+fenced block is a separate shell (section 9's `MAIN` trap), and the switch is
+addressed with `-C` for the reason section 5 gives: no gate in this repo refuses
+a branch switch, so a bare one after a cwd reset would take the MAIN checkout
+off `main`.
+
+```bash
+B=chore/work-issues-retro-$(date +%Y%m%d)
+git -C "<lane-worktree-abs-path>" fetch origin
+git -C "<lane-worktree-abs-path>" switch -c "$B" origin/main
 ```
 
 - `chore:` prefix — agent tooling, not `src/**`; a `fix:` / `feat:` prefix

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -249,12 +249,17 @@ the merged lane branch cannot be reused. `B` is re-assigned because a separate
 fenced block is a separate shell (section 9's `MAIN` trap), and the switch is
 addressed with `-C` for the reason section 5 gives: no gate in this repo refuses
 a branch switch, so a bare one after a cwd reset would take the MAIN checkout
-off `main`.
+off `main`. Substitute the absolute path section 3's probe printed as
+`LANE_TREE` and the opening report recorded — captured while the cwd was
+provably right — and do NOT re-derive it here from `$(git rev-parse
+--show-toplevel)` or `pwd`, which resolve against the reset cwd and hand the
+guard the very tree it is guarding against. Keep the `&&`: unchained, a failed
+`fetch` still branches, off a stale `origin/main`.
 
 ```bash
 B=chore/work-issues-retro-$(date +%Y%m%d)
-git -C "<lane-worktree-abs-path>" fetch origin
-git -C "<lane-worktree-abs-path>" switch -c "$B" origin/main
+git -C "<LANE_TREE>" fetch origin \
+  && git -C "<LANE_TREE>" switch -c "$B" origin/main
 ```
 
 - `chore:` prefix — agent tooling, not `src/**`; a `fix:` / `feat:` prefix

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -2,8 +2,9 @@
 
 ## 10. Fold what the run taught you back into this skill
 
-Trigger: after the last lane in §9 is merged and its worktree removed, BEFORE
-the wrap report — the evidence dies with this session's context. Distinct from
+Trigger: after the last lane in §9 is merged and every worktree THIS run added
+is removed — an IN-PLACE run added none, so for it the trigger is the last merge
+— BEFORE the wrap report; the evidence dies with this session's context. Distinct from
 `/verify-pr` step 8's per-LANE retrospective: the subject is **the flow
 itself** (the orchestrator `SKILL.md`, its `references/` stage files, the
 skills it drives — not the lane's code), the scope is the WHOLE run (cross-lane
@@ -226,8 +227,11 @@ Every run appending one more bullet is how a long skill becomes an unread one.
 
 ### 10-d. Ship it like any other change
 
-Every worktree is gone by §9 and you are back on `main`, where `branch-gate`
-blocks a commit — so the retro gets its own worktree:
+MAIN-CHECKOUT: every worktree is gone by §9 and you are back on `main`, where
+`branch-gate` blocks a commit — so the retro gets its own worktree. IN-PLACE:
+§9 removed nothing and you are standing in the lane's tree on its (merged)
+branch, so the retro takes a branch IN THAT TREE. The two blocks below are the
+two cases; run exactly one.
 
 MAIN-CHECKOUT (SKILL.md "Launch mode") — run THIS block, and not the next one:
 
@@ -247,14 +251,17 @@ worktree this mode exists to prevent. You are also not on `main`; the lane's own
 tree is still here with its deps installed, so take the retro branch IN IT, and
 the merged lane branch cannot be reused. `B` is re-assigned because a separate
 fenced block is a separate shell (section 9's `MAIN` trap), and the switch is
-addressed with `-C` for the reason section 5 gives: no gate in this repo refuses
-a branch switch, so a bare one after a cwd reset would take the MAIN checkout
-off `main`. Substitute the absolute path section 3's probe printed as
+addressed with `-C` for the reason §5 gives: no gate in this repo refuses a
+branch switch, so a bare one after a cwd reset would take the MAIN checkout off
+`main`. Substitute the absolute path the launch-mode probe printed as
 `LANE_TREE` and the opening report recorded — captured while the cwd was
 provably right — and do NOT re-derive it here from `$(git rev-parse
 --show-toplevel)` or `pwd`, which resolve against the reset cwd and hand the
 guard the very tree it is guarding against. Keep the `&&`: unchained, a failed
-`fetch` still branches, off a stale `origin/main`.
+`fetch` still branches, off a stale `origin/main`. **Every command after this
+one takes the same `-C "<LANE_TREE>"`** — the edits, `git add`, the commit, the
+push, `gh pr create` — for the identical reason: this block never `cd`s, so a
+later bare command runs in whatever tree the shell is standing in.
 
 ```bash
 B=chore/work-issues-retro-$(date +%Y%m%d)
@@ -327,10 +334,10 @@ git -C "<LANE_TREE>" fetch origin \
   with every worktree gone and §10 must not undo that. An IN-PLACE run added
   none: it merges and stops there, leaving the tree on the retro branch for
   whoever owns the workspace (the appendix has what the Stop hook will say
-  about that). This is
-  `Session-fit: now` on the leaves-main-self-inconsistent criterion (the skill
-  would keep telling the next run to do what this run just proved wrong); its
-  evidence dies with this session, and an open PR is NOT CLOSEABLE besides.
+  about that). This is `Session-fit: now` on the leaves-main-self-inconsistent
+  criterion (the skill would keep telling the next run to do what this run just
+  proved wrong); its evidence dies with this session, and an open PR is NOT
+  CLOSEABLE besides.
 
 Then report the outcome in one wrap line: what changed, in which step, and the
 run evidence behind it — or "no skill change" plus what held.

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -237,6 +237,12 @@ git worktree add ".worktrees/${B##*/}" -b "$B" origin/main
 cd ".worktrees/${B##*/}"
 mise trust && mise install    # untrusted .mise.toml: vp / markgate will not resolve
 pnpm install                  # worktrees have no node_modules
+
+# IN-PLACE (SKILL.md "Launch mode"): you are NOT on `main` and there is no
+# worktree to add -- the lane's own tree is still here with its deps installed.
+# Take the retro branch IN IT; the merged lane branch cannot be reused, and
+# nothing gates a branch switch inside a worktree (see section 5).
+git fetch origin && git switch -c "$B" origin/main
 ```
 
 - `chore:` prefix — agent tooling, not `src/**`; a `fix:` / `feat:` prefix
@@ -301,7 +307,10 @@ pnpm install                  # worktrees have no node_modules
   into every future session.
 - **Merge it before the wrap report, then remove the worktree**
   (`git worktree remove .worktrees/<name> && git worktree prune`) — §9 ends
-  with every worktree gone and §10 must not undo that. This is
+  with every worktree gone and §10 must not undo that. An IN-PLACE run added
+  none: it merges and stops there, leaving the tree on the retro branch for
+  whoever owns the workspace (the appendix has what the Stop hook will say
+  about that). This is
   `Session-fit: now` on the leaves-main-self-inconsistent criterion (the skill
   would keep telling the next run to do what this run just proved wrong); its
   evidence dies with this session, and an open PR is NOT CLOSEABLE besides.

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -50,8 +50,19 @@ merged in parallel). Same cause as §7's repo-wide-check collision; the same
 rebase answers both.
 
 ```bash
+# The main checkout is always the FIRST row of `git worktree list`.
+MAIN=$(git worktree list --porcelain | awk 'NR==1{print substr($0,10)}')
 git checkout main && git pull origin main    # bring the merges local
+# IN-PLACE (SKILL.md "Launch mode"): `main` is checked out in $MAIN, so a
+# `checkout main` here fails with "already used by worktree ..." -- never leave
+# your own tree; pull the main checkout through -C instead:
+git -C "$MAIN" pull origin main
 ```
+
+That second form is not IN-PLACE-only trivia: it is the same
+`fatal: 'main' is already used by worktree ...` the appendix records for
+`gh pr merge --delete-branch`. What differs is that a MAIN-CHECKOUT run has a
+tree it may return to and an IN-PLACE run does not.
 
 **Release** is automated (`.github/workflows/release.yml`) — merging a `feat:` /
 `fix:` / `perf:` / `revert:` commit to `main` produces a `chore(release): <ver>
@@ -68,6 +79,12 @@ Once released, **global install by NAME** (published npm package):
 vp i -g cdk-real-drift
 ```
 
+That install is BY NAME from npm, so it is mode-independent: it resolves the
+published package and never reads any tree's build output. (The sibling cdkd
+links its global CLI at the MAIN checkout's `dist/`, which forces a post-release
+rebuild there; nothing in this repo's ship stage does, so an IN-PLACE run has no
+main-checkout rebuild to perform. Do not add one.)
+
 **A run whose lanes are all `chore:` / `docs:` releases NOTHING** (CLAUDE.md → State
 of the Repo): skip both steps above rather than polling — the bump is never
 coming and the installed binary is already current; say so in the wrap. This is
@@ -76,7 +93,13 @@ go-to-k/cdk-real-drift#1767 merged as `chore:` and this text still sent the run
 polling for a bump).
 
 **Remove every worktree you created** (a left-behind worktree is the silent
-residue of this flow):
+residue of this flow). **An IN-PLACE run created none, so it removes none**: it
+must not `git worktree remove` the tree it is running in (that deletes its own
+cwd) and must not `git branch -D` the branch it is standing on. Cleanup of that
+tree belongs to whoever created it — the outer tool, or the operator — so the
+wrap SAYS so instead of doing it, and the run ends with the tree still standing.
+`--delete-branch` on the merge still removes the REMOTE branch, which is fine;
+only the local tree and its branch are off limits:
 
 ```bash
 git worktree remove .worktrees/<name>        # --force if it refuses on artifacts
@@ -88,7 +111,7 @@ git worktree list                            # yours should be gone
 `git worktree list` cannot tell you whose it is — a finished run's leftover and a
 live session look identical, including a branch whose tip is already on `main`.
 The closing check is "every worktree I added is gone", never "only the main
-checkout remains". **Every ownership signal establishes LIFE, never absence**: a
+checkout remains" — which an IN-PLACE run satisfies by having added none. **Every ownership signal establishes LIFE, never absence**: a
 dirty tree or an open PR proves a lane is live; the absence of either proves
 nothing. A tip on `main` is not death (the owner may be in ship/retro steps), and
 a claim comment carries CLAIM time, not last activity. Measured both "finished"

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -49,13 +49,21 @@ fetch + rebase + re-run; do NOT start distrusting the peer's new test
 merged in parallel). Same cause as §7's repo-wide-check collision; the same
 rebase answers both.
 
+MAIN-CHECKOUT (SKILL.md "Launch mode") — run THIS block, and not the next one:
+
+```bash
+git checkout main && git pull origin main    # bring the merges local
+```
+
+IN-PLACE — run THIS block INSTEAD, never both: `main` is checked out in the main
+tree, so a `checkout main` here fails with "already used by worktree ...". Never
+leave your own tree; pull the main checkout through `-C`. `MAIN` is derived HERE
+rather than borrowed from a neighbouring block — each fenced block is its own
+Bash call and its own shell, so a variable assigned in another one is empty here:
+
 ```bash
 # The main checkout is always the FIRST row of `git worktree list`.
 MAIN=$(git worktree list --porcelain | awk 'NR==1{print substr($0,10)}')
-git checkout main && git pull origin main    # bring the merges local
-# IN-PLACE (SKILL.md "Launch mode"): `main` is checked out in $MAIN, so a
-# `checkout main` here fails with "already used by worktree ..." -- never leave
-# your own tree; pull the main checkout through -C instead:
 git -C "$MAIN" pull origin main
 ```
 

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -57,20 +57,25 @@ git checkout main && git pull origin main    # bring the merges local
 
 IN-PLACE — run THIS block INSTEAD, never both: `main` is checked out in the main
 tree, so a `checkout main` here fails with "already used by worktree ...". Never
-leave your own tree; pull the main checkout through `-C`. `MAIN` is derived HERE
-rather than borrowed from a neighbouring block — each fenced block is its own
-Bash call and its own shell, so a variable assigned in another one is empty here:
+leave your own tree; pull the main checkout through `-C`, substituting the
+absolute `<MAIN_CHECKOUT>` the launch-mode probe printed and the opening report
+recorded. Two things that spelling fixes over the `MAIN=$(git worktree list …)`
+form this block used to carry: it does not depend on the main checkout being row
+1 of the listing (true today, not a documented guarantee), and it cannot be
+EMPTY. An empty `$MAIN` is the dangerous half — `git -C "" pull origin main`
+exits 0 and pulls `origin/main` into whatever tree the shell is standing in,
+which IN-PLACE is this lane's branch. A placeholder that was never substituted
+is visible in the command you are about to run; an empty variable is not:
 
 ```bash
-# The main checkout is always the FIRST row of `git worktree list`.
-MAIN=$(git worktree list --porcelain | awk 'NR==1{print substr($0,10)}')
-git -C "$MAIN" pull origin main
+git -C "<MAIN_CHECKOUT>" pull origin main
 ```
 
 That second form is not IN-PLACE-only trivia: it is the same
 `fatal: 'main' is already used by worktree ...` the appendix records for
-`gh pr merge --delete-branch`. What differs is that a MAIN-CHECKOUT run has a
-tree it may return to and an IN-PLACE run does not.
+`gh pr merge --delete-branch`, and the same one §1's pull hits. What differs is
+that a MAIN-CHECKOUT run has a tree it may return to and an IN-PLACE run does
+not.
 
 **Release** is automated (`.github/workflows/release.yml`) — merging a `feat:` /
 `fix:` / `perf:` / `revert:` commit to `main` produces a `chore(release): <ver>
@@ -163,7 +168,6 @@ found), so the next lane inherits the evidence rather than the diagnosis.
 A claim on an issue that DID auto-close needs nothing: a closed issue is not a
 lock, and commenting on it only adds noise.
 
-Do NOT stop
-here: what the run taught you is still only in this session's context, so go on to
-§10 — which also decides WHERE each lesson belongs (memory is the weakest of the
-options there, not the default one).
+Do NOT stop here: what the run taught you is still only in this session's
+context, so go on to §10 — which also decides WHERE each lesson belongs (memory
+is the weakest of the options there, not the default one).

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -143,7 +143,10 @@ PARAGRAPH still collide.
 ## 3. Pick a FEW FILE-DISJOINT issues
 
 **How many lanes you may pick is decided by the LAUNCH MODE, so settle that
-first — it is one command and it is not guessable from the prompt:**
+first — it is one command and it is not guessable from the prompt.** This is
+the ONLY copy of the probe; SKILL.md "Launch mode" points here rather than
+restating it, because a second verbatim copy of a two-line command is the drift
+shape section 10-b fences elsewhere:
 
 ```bash
 [ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
@@ -152,7 +155,10 @@ first — it is one command and it is not guessable from the prompt:**
 
 Equal only in the main checkout: a linked worktree's `--git-dir` is
 `<common-dir>/worktrees/<name>`, and `pwd -P` settles both the main checkout's
-RELATIVE `.git` answer and macOS's `/tmp` -> `/private/tmp`. `IN-PLACE` means
+RELATIVE `.git` answer and macOS's `/tmp` -> `/private/tmp`. Run it INSIDE the
+repo: outside one, both substitutions are empty and `cd ""` returns 0, so it
+prints MAIN-CHECKOUT — a wrong verdict, caught only by the next git command
+failing loudly. `IN-PLACE` means
 this run was launched inside a worktree someone else created (an Orca/ADE
 workspace, a stray `cd`), so it has exactly ONE working tree: **take ONE issue
 and finish it** — a second lane would need a worktree nested inside this one,

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -149,8 +149,10 @@ restating it, because a second verbatim copy of a two-line command is the drift
 shape section 10-b fences elsewhere:
 
 ```bash
+LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)   # capture it HERE
 [ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
- = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] && echo MAIN-CHECKOUT || echo IN-PLACE
+ = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] \
+  && echo "MAIN-CHECKOUT (tree $LANE_TREE)" || echo "IN-PLACE (LANE_TREE $LANE_TREE)"
 ```
 
 Equal only in the main checkout: a linked worktree's `--git-dir` is
@@ -158,7 +160,18 @@ Equal only in the main checkout: a linked worktree's `--git-dir` is
 RELATIVE `.git` answer and macOS's `/tmp` -> `/private/tmp`. Run it INSIDE the
 repo: outside one, both substitutions are empty and `cd ""` returns 0, so it
 prints MAIN-CHECKOUT — a wrong verdict, caught only by the next git command
-failing loudly. `IN-PLACE` means
+failing loudly.
+
+**`LANE_TREE` is the whole reason the path is captured on THIS line**, and it is
+not decoration on the mode. This instant is the one moment the cwd is provably
+the tree whose mode is being decided; every later stage runs in a fresh shell
+whose cwd may have silently reset to the main checkout (appendix, "Bash cwd
+silent reset"). So **state `LANE_TREE` in the opening report beside the mode**,
+verbatim and absolute — that report is its ONLY recorded copy, and §4, §5 and
+§10 all hand it to `git -C`. A later stage that re-derives it instead, from
+`$(git rev-parse --show-toplevel)` or from `pwd`, resolves against the reset cwd
+and answers "the main checkout" in precisely the case the `-C` exists to guard:
+the guard then degrades into the bug it guards. `IN-PLACE` means
 this run was launched inside a worktree someone else created (an Orca/ADE
 workspace, a stray `cd`), so it has exactly ONE working tree: **take ONE issue
 and finish it** — a second lane would need a worktree nested inside this one,

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -158,9 +158,21 @@ LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)   # capture it HERE
 Equal only in the main checkout: a linked worktree's `--git-dir` is
 `<common-dir>/worktrees/<name>`, and `pwd -P` settles both the main checkout's
 RELATIVE `.git` answer and macOS's `/tmp` -> `/private/tmp`. Run it INSIDE the
-repo: outside one, both substitutions are empty and `cd ""` returns 0, so it
-prints MAIN-CHECKOUT — a wrong verdict, caught only by the next git command
-failing loudly.
+repo. Outside one, `git rev-parse` fails and every substitution collapses to the
+empty string, so the test compares `""` with `""` and prints MAIN-CHECKOUT — a
+wrong verdict. Measured 2026-08-31, and the mechanism differs by shell without
+changing the answer: bash REFUSES `cd ""` (rc=1, `cd: null directory`) so the
+`&& pwd -P` never runs, while zsh accepts it (rc=0) and `pwd -P` then prints the
+same cwd twice.
+
+**And nothing downstream catches that, which is the part the previous wording
+got wrong** ("caught only by the next git command failing loudly"). Outside a
+repo `LANE_TREE` is EMPTY, and an empty `-C` argument is not an error: measured
+the same day, `git -C "" rev-parse --show-toplevel` exits 0 and prints the
+CWD's repo — so every `git -C "<LANE_TREE>"` recipe in §4, §5 and §10 silently
+retargets the tree the shell is standing in, which is the main checkout in
+exactly the scenario the `-C` was added for. The guard degrades into the bug it
+guards, with no failure to read. Re-run the probe rather than trusting a blank.
 
 **`LANE_TREE` is the whole reason the path is captured on THIS line**, and it is
 not decoration on the mode. This instant is the one moment the cwd is provably
@@ -171,7 +183,17 @@ verbatim and absolute — that report is its ONLY recorded copy, and §4, §5 an
 §10 all hand it to `git -C`. A later stage that re-derives it instead, from
 `$(git rev-parse --show-toplevel)` or from `pwd`, resolves against the reset cwd
 and answers "the main checkout" in precisely the case the `-C` exists to guard:
-the guard then degrades into the bug it guards. `IN-PLACE` means
+the guard then degrades into the bug it guards.
+
+**`<LANE_TREE>` in a later stage is a SUBSTITUTION PLACEHOLDER, not a shell
+variable, and the difference is the whole guard.** Paste the absolute path from
+the opening report into the command text. Do NOT write `git -C "$LANE_TREE"`:
+the assignment above lives in THIS fenced block and every later block is its own
+Bash call and its own shell (§9 spells the same trap out for `MAIN`, §10-d for
+`B`), so the variable is already empty there — and per the paragraph above, an
+empty `-C` does not fail, it re-targets the cwd. A placeholder that was never
+substituted is visible in the command you are about to run; an empty variable is
+not visible anywhere. `IN-PLACE` means
 this run was launched inside a worktree someone else created (an Orca/ADE
 workspace, a stray `cd`), so it has exactly ONE working tree: **take ONE issue
 and finish it** — a second lane would need a worktree nested inside this one,

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -142,6 +142,25 @@ PARAGRAPH still collide.
 
 ## 3. Pick a FEW FILE-DISJOINT issues
 
+**How many lanes you may pick is decided by the LAUNCH MODE, so settle that
+first — it is one command and it is not guessable from the prompt:**
+
+```bash
+[ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
+ = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] && echo MAIN-CHECKOUT || echo IN-PLACE
+```
+
+Equal only in the main checkout: a linked worktree's `--git-dir` is
+`<common-dir>/worktrees/<name>`, and `pwd -P` settles both the main checkout's
+RELATIVE `.git` answer and macOS's `/tmp` -> `/private/tmp`. `IN-PLACE` means
+this run was launched inside a worktree someone else created (an Orca/ADE
+workspace, a stray `cd`), so it has exactly ONE working tree: **take ONE issue
+and finish it** — a second lane would need a worktree nested inside this one,
+which dies with the outer workspace and takes its uncommitted work
+(go-to-k/cdk-real-drift#1842). Rank as usual, claim the top candidate, and leave
+the rest for the next run. Everything below is the MAIN-CHECKOUT case; SKILL.md
+"Launch mode" carries the other three consequences (§4, §5, §9).
+
 **Two lanes must edit DISJOINT files** (same as the worktree rule): two issues
 both landing in `noise.ts` cannot be parallelized — bundle into ONE lane or
 defer one. **At most one lane per central table.** Map each candidate to its

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -73,9 +73,25 @@ FRESH issue is the MOST likely stale: filed at the end of a lane against a
 listed five asks, three shipped in go-to-k/cdk-real-drift#1772 three minutes
 earlier.
 
+MAIN-CHECKOUT — run THIS block, and not the next one:
+
 ```bash
 git fetch origin && git checkout main && git pull origin main --ff-only
 ```
+
+IN-PLACE — run THIS block INSTEAD, never both. `main` is checked out in the main
+checkout, so `git checkout main` HERE dies with
+`fatal: 'main' is already used by worktree ...` (the same failure §9 records).
+Never leave your own tree; refresh the main checkout through `-C`, substituting
+the absolute `<MAIN_CHECKOUT>` the launch-mode probe printed:
+
+```bash
+git fetch origin && git -C "<MAIN_CHECKOUT>" pull origin main --ff-only
+```
+
+Either way the reads below use `git show origin/main:<file>`, which answers from
+the fetched ref rather than from whatever tree the shell is standing in — so
+they are correct in both modes once the fetch has run.
 
 Then, per shortlisted issue, **check the FIX FILE, not the issue's claim**,
 before claiming in §4 — `git show origin/main:<target-file> | grep -n "<marker>"`
@@ -94,9 +110,16 @@ gh pr list --state open --json number,title,headRefName   # their PRs
 For each active worktree, find what it ACTUALLY edits (not the stale-base noise):
 
 ```bash
-git -C .worktrees/<w> log --oneline -1            # its own commit subject → the issue it owns
-git -C .worktrees/<w> show --stat HEAD            # the files that commit touches
-git -C .worktrees/<w> status --porcelain          # what it is editing RIGHT NOW
+# <MAIN_CHECKOUT> is the ABSOLUTE path the launch-mode probe printed
+# (references/launch-mode.md). A relative `.worktrees/<w>` is correct only from
+# the main checkout: run IN-PLACE the cwd is a lane tree, the path does not
+# exist, git errors, and this scan reports NOTHING -- which reads as "no
+# competing agents", the exact failure this stage exists to prevent, and it
+# fails QUIETLY. Substitute the recorded path; never `$MAIN_CHECKOUT`, which is
+# empty in this shell and makes `-C` re-target the cwd instead of failing.
+git -C "<MAIN_CHECKOUT>/.worktrees/<w>" log --oneline -1            # its own commit subject → the issue it owns
+git -C "<MAIN_CHECKOUT>/.worktrees/<w>" show --stat HEAD            # the files that commit touches
+git -C "<MAIN_CHECKOUT>/.worktrees/<w>" status --porcelain          # what it is editing RIGHT NOW
 ```
 
 **The third probe is the only one that sees a LIVE lane; it outranks the other
@@ -142,65 +165,31 @@ PARAGRAPH still collide.
 
 ## 3. Pick a FEW FILE-DISJOINT issues
 
-**How many lanes you may pick is decided by the LAUNCH MODE, so settle that
-first — it is one command and it is not guessable from the prompt.** This is
-the ONLY copy of the probe; SKILL.md "Launch mode" points here rather than
-restating it, because a second verbatim copy of a two-line command is the drift
-shape section 10-b fences elsewhere:
+**How many lanes you may pick is decided by the LAUNCH MODE, and the parent
+already settled it before stage 0** — `references/launch-mode.md` holds the
+probe (the ONLY copy), the reading of its edge cases, and the rule that
+`<LANE_TREE>` / `<MAIN_CHECKOUT>` are SUBSTITUTION PLACEHOLDERS rather than
+shell variables. The dispatch that started this stage carries all three values;
+if it did not, STOP and ask for them rather than re-running the probe here — a
+triage subagent's answer is not the parent's, and the parent is the party that
+later runs `git worktree add` or does not.
 
-```bash
-LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)   # capture it HERE
-[ "$(cd "$(git rev-parse --git-dir)" && pwd -P)" \
- = "$(cd "$(git rev-parse --git-common-dir)" && pwd -P)" ] \
-  && echo "MAIN-CHECKOUT (tree $LANE_TREE)" || echo "IN-PLACE (LANE_TREE $LANE_TREE)"
-```
+`IN-PLACE` means this run was launched inside a worktree someone else created
+(an Orca/ADE workspace, a stray `cd`), so it has exactly ONE working tree:
+**take ONE issue and finish it** — a second lane would need a worktree nested
+inside this one, which dies with the outer workspace and takes its uncommitted
+work (go-to-k/cdk-real-drift#1842). That one-lane limit is stated HERE, in
+prose; the probe reports a mode and two paths and carries no limit of its own.
+Rank as usual, claim the top candidate, and leave the rest for the next run.
 
-Equal only in the main checkout: a linked worktree's `--git-dir` is
-`<common-dir>/worktrees/<name>`, and `pwd -P` settles both the main checkout's
-RELATIVE `.git` answer and macOS's `/tmp` -> `/private/tmp`. Run it INSIDE the
-repo. Outside one, `git rev-parse` fails and every substitution collapses to the
-empty string, so the test compares `""` with `""` and prints MAIN-CHECKOUT — a
-wrong verdict. Measured 2026-08-31, and the mechanism differs by shell without
-changing the answer: bash REFUSES `cd ""` (rc=1, `cd: null directory`) so the
-`&& pwd -P` never runs, while zsh accepts it (rc=0) and `pwd -P` then prints the
-same cwd twice.
-
-**And nothing downstream catches that, which is the part the previous wording
-got wrong** ("caught only by the next git command failing loudly"). Outside a
-repo `LANE_TREE` is EMPTY, and an empty `-C` argument is not an error: measured
-the same day, `git -C "" rev-parse --show-toplevel` exits 0 and prints the
-CWD's repo — so every `git -C "<LANE_TREE>"` recipe in §4, §5 and §10 silently
-retargets the tree the shell is standing in, which is the main checkout in
-exactly the scenario the `-C` was added for. The guard degrades into the bug it
-guards, with no failure to read. Re-run the probe rather than trusting a blank.
-
-**`LANE_TREE` is the whole reason the path is captured on THIS line**, and it is
-not decoration on the mode. This instant is the one moment the cwd is provably
-the tree whose mode is being decided; every later stage runs in a fresh shell
-whose cwd may have silently reset to the main checkout (appendix, "Bash cwd
-silent reset"). So **state `LANE_TREE` in the opening report beside the mode**,
-verbatim and absolute — that report is its ONLY recorded copy, and §4, §5 and
-§10 all hand it to `git -C`. A later stage that re-derives it instead, from
-`$(git rev-parse --show-toplevel)` or from `pwd`, resolves against the reset cwd
-and answers "the main checkout" in precisely the case the `-C` exists to guard:
-the guard then degrades into the bug it guards.
-
-**`<LANE_TREE>` in a later stage is a SUBSTITUTION PLACEHOLDER, not a shell
-variable, and the difference is the whole guard.** Paste the absolute path from
-the opening report into the command text. Do NOT write `git -C "$LANE_TREE"`:
-the assignment above lives in THIS fenced block and every later block is its own
-Bash call and its own shell (§9 spells the same trap out for `MAIN`, §10-d for
-`B`), so the variable is already empty there — and per the paragraph above, an
-empty `-C` does not fail, it re-targets the cwd. A placeholder that was never
-substituted is visible in the command you are about to run; an empty variable is
-not visible anywhere. `IN-PLACE` means
-this run was launched inside a worktree someone else created (an Orca/ADE
-workspace, a stray `cd`), so it has exactly ONE working tree: **take ONE issue
-and finish it** — a second lane would need a worktree nested inside this one,
-which dies with the outer workspace and takes its uncommitted work
-(go-to-k/cdk-real-drift#1842). Rank as usual, claim the top candidate, and leave
-the rest for the next run. Everything below is the MAIN-CHECKOUT case; SKILL.md
-"Launch mode" carries the other three consequences (§4, §5, §9).
+**The MAIN-CHECKOUT case is the DISJOINTNESS PARAGRAPH below and nothing
+wider.** An earlier revision said "everything below is the MAIN-CHECKOUT case",
+which told an IN-PLACE run to skip the security-first ranking, the `Severity`
+ranking, the premise-check-against-`origin/main` rule and §3-a's freshness gate
+— all mode-independent, and the last a HARD gate. The rest of what IN-PLACE
+changes lives in `references/launch-mode.md`'s table, which maps ten
+consequences to §1, §2, §4, §5, §7, §9 and §10-d — the four this sentence used
+to name were an undercount.
 
 **Two lanes must edit DISJOINT files** (same as the worktree rule): two issues
 both landing in `noise.ts` cannot be parallelized — bundle into ONE lane or

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -178,7 +178,10 @@ at once, not trickled.
   **ESM `import` ignores `NODE_PATH`**), and `ln -s <repo>/node_modules
 node_modules` to borrow `aws-cdk-lib` (rm any existing dir first — `ln -sfn` into
   an existing dir nests a symlink). Inline/no-asset stacks need no bootstrap. Build
-  the FIX binary with `vp pack` and run `node .worktrees/<w>/dist/cli.js`.
+  the FIX binary with `vp pack` and run `node "<LANE_TREE>/dist/cli.js"` —
+  the absolute path from the launch-mode probe, not `.worktrees/<w>/…`, which
+  is wrong twice: it is relative to the main checkout, and an IN-PLACE launch
+  tree (an Orca/ADE workspace) need not live under `.worktrees/` at all.
 
 **Fresh deploys: UNIQUE hunt-style stack names only** (`Cdkrd<issue>Verify`),
 never a shared fixed name and never a real prod stack — the account may hold

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,7 +543,16 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   orchestrator integrates by `git checkout <branch> -- <files>` (NEVER `git merge` —
   the leaked cdkd session hooks block it), then `git worktree remove`. The main
   checkout is reserved for integration: `main` checkouts, pulls, and PR plumbing
-  only.
+  only. **That recipe is the MAIN-CHECKOUT case and is wrong from anywhere
+  else** (go-to-k/cdk-real-drift#1842): when the session is ALREADY inside a
+  linked worktree — an Orca/ADE workspace, or a stray `cd` into an existing
+  lane — `git worktree add` NESTS one worktree inside another, and deleting the
+  outer workspace takes the inner directory, its uncommitted work and its git
+  registration with it. There, create nothing and remove nothing: work on the
+  branch already checked out, take ONE line of work rather than several, and
+  leave the tree for whoever made it. `/work-issues` computes which case applies
+  before its first stage and `/hunt-bugs` points at that probe; do not
+  re-implement it here.
 - **All changes go through a pull request — never commit directly to `main`.**
   Branch (or worktree branch) → run the gates + set markers → commit → push →
   `gh pr create`. The reviewer re-reviews the PR diff before merge. cdkd's

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -38,8 +38,16 @@ import { describe, expect, it } from 'vite-plus/test';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
 
-const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill measured 12,175 B (verify-pr)
-const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators measured 7,952 B / 6,932 B at the split
+const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill re-measured 12,571 B (verify-pr, 2026-09-01) -- the 12,175 B this line used to quote was stale
+const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B at the 2026-08-28 split; re-measured 2026-09-01: work-issues 11,476 B (524 B of margin), hunt-bugs 6,932 B
+// The re-measurement is the point, not trivia: work-issues had grown to 11,746 B
+// -- 254 B under its cap -- while this comment still quoted the at-split figure,
+// so nobody adding a paragraph could see how little room was left. This pass
+// MOVED the split-PR provenance paragraph into references/implement.md (where the
+// lane subagent it describes actually reads) and replaced the duplicated
+// serialization caveats with a pointer to the section 9 that states them in full,
+// rather than compressing anything away. Re-measure whenever an orchestrator is
+// edited -- a cap with an unmeasured margin is one nobody can plan against.
 const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B (hunt-bugs gotchas.md); 41,922 B after the rule+citation compression pass (2026-08-28)
 
 // The split skills' stage files must still exist and still carry the moved
@@ -66,18 +74,20 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // drop is not a weaker guard but a SILENT one. A genuine compression pass
 // re-derives the floor downward in the same commit -- that stays legal; what
 // the floor stops is a deletion with no re-derivation at all.
-// Re-derived again 2026-08-31 (review round 2, after the LANE_TREE capture):
-// corpus 111,362 B, largest implement.md 23,436 B, so the floor must exceed
-// 111,362 - 23,436 = 87,926. 89,000 still HELD -- by 1,074 B, and is raised to
-// 90,000 anyway, because the MARGIN is what decays: cdk-local was left at 759 B
-// of it one day and had lapsed the next. 90,000 leaves 2,074 B of margin and
-// ~21 KB of compression room below the floor.
-// hunt-bugs stays at 60,000: 88,426 - 41,922 = 46,504 < 60,000, so its property
+// Re-derived again 2026-09-01 (review round 3) at the final tree: corpus
+// 113,699 B, largest implement.md 24,238 B, so the floor must exceed
+// 113,699 - 24,238 = 89,461. The 90,000 set one round earlier still HELD, but by
+// 539 B -- half the margin it was raised to take, one round later, which is the
+// decay this comment keeps warning about and keeps under-pricing. 93,000 leaves
+// 3,539 B of margin and ~20 KB (113,699 - 93,000 = 20,699 B) of compression room
+// below the floor.
+// hunt-bugs stays at 60,000: re-measured 2026-09-01, corpus 88,426 B and largest
+// gotchas.md 41,922 B, so 88,426 - 41,922 = 46,504 < 60,000 and its property
 // still holds. Re-measure both numbers for each skill whenever a stage file
 // changes size materially -- the property is silent when it lapses.
 const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }> = {
   // 8 files / 125,139 B measured at the split (2026-08-28); largest 26,621 B; 94,136 B post-compression
-  'work-issues': { minFiles: 6, minCorpusBytes: 90_000 },
+  'work-issues': { minFiles: 6, minCorpusBytes: 93_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 5, minCorpusBytes: 60_000 },
 };

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -38,17 +38,20 @@ import { describe, expect, it } from 'vite-plus/test';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
 
-const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill re-measured 12,571 B (verify-pr, 2026-09-01) -- the 12,175 B this line used to quote was stale
-const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B at the 2026-08-28 split; re-measured 2026-09-01, review round 4: work-issues 11,617 B (383 B of margin), hunt-bugs 6,932 B
-// The re-measurement is the point, not trivia: work-issues had grown to 11,746 B
-// -- 254 B under its cap -- while this comment still quoted the at-split figure,
-// so nobody adding a paragraph could see how little room was left. This pass
-// MOVED the split-PR provenance paragraph into references/implement.md (where the
-// lane subagent it describes actually reads) and replaced the duplicated
-// serialization caveats with a pointer to the section 9 that states them in full,
-// rather than compressing anything away. Re-measure whenever an orchestrator is
-// edited -- a cap with an unmeasured margin is one nobody can plan against.
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B (hunt-bugs gotchas.md); 41,922 B after the rule+citation compression pass (2026-08-28)
+const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill re-measured 12,571 B (verify-pr, 2026-09-01, unchanged in round 6) -- the 12,175 B this line used to quote was stale
+const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B at the 2026-08-28 split; re-measured 2026-09-01, review round 6: work-issues 11,694 B (306 B of margin), hunt-bugs 6,932 B
+// The re-measurement is the point, not trivia: work-issues has repeatedly grown to
+// within a few hundred bytes of its cap while this comment still quoted the
+// at-split figure, so nobody adding a paragraph could see how little room was
+// left. Round 6 added the parent-runs-the-probe design and paid for it three ways
+// rather than by loosening anything: the probe and its edge-case reading moved to
+// references/launch-mode.md (9,519 B, read once before stage 0), the IN-PLACE
+// consequence list became a pointer to that file's table, and the stage table's
+// widest cells were shortened -- which, since `vp fmt` pads markdown table columns
+// to the widest cell, reclaimed the padding on all fourteen rows at once.
+// Re-measure whenever an orchestrator is edited -- a cap with an unmeasured margin
+// is one nobody can plan against.
+const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B (hunt-bugs gotchas.md); 41,922 B after the rule+citation compression pass (2026-08-28), re-measured unchanged 2026-09-01
 
 // The split skills' stage files must still exist and still carry the moved
 // content. Floors sit far enough below the at-split measurement that narrative
@@ -59,37 +62,48 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // survived deleting its 55,137 B gotchas.md). `skill-doc-paths.test.ts` does
 // not catch it either: its citation extractor only resolves spans whose first
 // segment is a repo-root directory, and `references/...` is skill-relative
-// (measured, not assumed). Beyond the floors, the pointer-integrity block below
-// is what catches a single deleted stage file: every `references/<stage>.md`
-// the orchestrator names must exist.
+// (measured, not assumed).
 //
-// Re-measured 2026-08-31. work-issues: corpus 109,106 B, largest implement.md
-// 22,600 B, so the property needs a floor above 109,106 - 22,600 = 86,506 --
-// which the 60,000 held here had stopped providing as the stage files grew.
-// 89,000 restored it: strictly TIGHTER, and no upper bound was touched. The
-// older note declined such a floor for work-issues because it leaves little
-// compression room, and that is still the trade (~20 KB of room below the
-// floor); the call is reversed to match the sibling cdk-local (88,000 on a
-// 113,468 B corpus) because a floor that cannot catch the likeliest wholesale
+// A SINGLE deleted stage file is caught by `minFiles`, pinned to the EXACT
+// count on disk rather than left slack. The pointer-integrity block below is
+// NOT that guard, and this comment used to claim it was: deleting a stage file
+// TOGETHER WITH the orchestrator row pointing at it leaves both sides
+// consistent, so `retro.md` or `verify.md` could go with its pointer and stay
+// green (measured 2026-09-01). Pointer integrity catches the OTHER half -- a
+// row left dangling by a deletion -- and the two are complementary, not
+// redundant. Raising `minFiles` when a stage file is ADDED is the price of the
+// exact pin, and it is the same edit that already updates this comment.
+//
+// The older note declined such a floor for work-issues because it leaves little
+// compression room, and that is still the trade; the call was reversed to match
+// the sibling cdk-local because a floor that cannot catch the likeliest wholesale
 // drop is not a weaker guard but a SILENT one. A genuine compression pass
 // re-derives the floor downward in the same commit -- that stays legal; what
-// the floor stops is a deletion with no re-derivation at all.
-// Re-derived again 2026-09-01 (review round 3) at the final tree: corpus
-// 113,699 B, largest implement.md 24,238 B, so the floor must exceed
-// 113,699 - 24,238 = 89,461. The 90,000 set one round earlier still HELD, but by
-// 539 B -- half the margin it was raised to take, one round later, which is the
-// decay this comment keeps warning about and keeps under-pricing. 93,000 leaves
-// 3,539 B of margin and ~20 KB (113,699 - 93,000 = 20,699 B) of compression room
-// below the floor.
-// hunt-bugs stays at 60,000: re-measured 2026-09-01, corpus 88,426 B and largest
-// gotchas.md 41,922 B, so 88,426 - 41,922 = 46,504 < 60,000 and its property
-// still holds. Re-measure both numbers for each skill whenever a stage file
-// changes size materially -- the property is silent when it lapses.
+// the floor stops is a deletion with no re-derivation at all. The property is
+// now ASSERTED at the bottom of this file as well as described here, because
+// three consecutive rounds re-derived it BY HAND and one of them found it
+// lapsed.
+// Re-derived 2026-09-01 (review round 6) at the final tree. work-issues: 9 stage
+// files, corpus 125,713 B, largest implement.md 25,599 B, so the floor must
+// exceed 125,713 - 25,599 = 100,114 -- the 93,000 set one round earlier no
+// longer does. The binding number is not the worst case here: triage.md is
+// 20,782 B, only 4,817 B behind, and round 3 already warned that a flip would
+// leave the floor clearing by under 1 KB. Sizing against the FLIP instead
+// (125,713 - 20,782 = 104,931), 108,000 clears the binding number by 7,886 B and
+// the flip case by 3,069 B, and leaves ~17 KB (125,713 - 108,000 = 17,713 B) of
+// compression room below the floor.
+// hunt-bugs stays at 60,000: re-measured the same day, corpus 88,598 B and
+// largest gotchas.md 41,922 B, so 88,598 - 41,922 = 46,676 < 60,000 and its
+// property still holds. Re-measure both numbers for each skill whenever a stage
+// file changes size materially -- the property is silent when it lapses.
 const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }> = {
-  // 8 files / 125,139 B measured at the split (2026-08-28); largest 26,621 B; 94,136 B post-compression
-  'work-issues': { minFiles: 6, minCorpusBytes: 93_000 },
+  // 8 files / 125,139 B measured at the split (2026-08-28); largest 26,621 B; 94,136 B
+  // post-compression. 9 files as of 2026-09-01, when the launch-mode probe and its
+  // reading moved out of triage.md into references/launch-mode.md, which the PARENT
+  // reads before stage 0.
+  'work-issues': { minFiles: 9, minCorpusBytes: 108_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
-  'hunt-bugs': { minFiles: 5, minCorpusBytes: 60_000 },
+  'hunt-bugs': { minFiles: 7, minCorpusBytes: 60_000 },
 };
 
 function skillNames(): string[] {
@@ -188,6 +202,26 @@ describe('skill file payload budget', () => {
           `wholesale deletion as an improvement; this floor is what notices content ` +
           `being DROPPED rather than moved or compressed.`
       ).toBeGreaterThanOrEqual(floors.minCorpusBytes);
+
+      // The floor's OWN invariant, asserted rather than described. Everything
+      // above only says "the corpus is big enough"; what the floor is FOR is
+      // that deleting the single largest stage file cannot pass, which holds
+      // only while the floor sits above `corpus - largest`. That property decays
+      // silently as the OTHER files grow -- the comment above records it lapsing
+      // at 60,000 and then holding by only 539 B at 90,000, each time found by a
+      // human re-deriving it by hand. Asserting it makes the next lapse a red
+      // test at the commit that causes it, including the flip case that comment
+      // worries about (implement.md and triage.md are close enough that either
+      // can become "largest"), and the message carries the number to raise to.
+      const largest = Math.max(...refs.map((f) => statSync(f).size));
+      expect(
+        floors.minCorpusBytes,
+        `minCorpusBytes (${floors.minCorpusBytes}) has lapsed for ${name}: the corpus is ` +
+          `${total} B and its largest stage file is ${largest} B, so deleting that one ` +
+          `file would leave ${total - largest} B and still pass. Raise the floor above ` +
+          `${total - largest} (and re-derive the comment beside it), or re-derive it ` +
+          `DOWNWARD in the same commit as a genuine compression pass.`
+      ).toBeGreaterThan(total - largest);
     });
   }
 });

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -58,7 +58,7 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // Re-measured 2026-08-31. work-issues: corpus 109,106 B, largest implement.md
 // 22,600 B, so the property needs a floor above 109,106 - 22,600 = 86,506 --
 // which the 60,000 held here had stopped providing as the stage files grew.
-// 89,000 restores it: strictly TIGHTER, and no upper bound was touched. The
+// 89,000 restored it: strictly TIGHTER, and no upper bound was touched. The
 // older note declined such a floor for work-issues because it leaves little
 // compression room, and that is still the trade (~20 KB of room below the
 // floor); the call is reversed to match the sibling cdk-local (88,000 on a
@@ -66,12 +66,18 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // drop is not a weaker guard but a SILENT one. A genuine compression pass
 // re-derives the floor downward in the same commit -- that stays legal; what
 // the floor stops is a deletion with no re-derivation at all.
+// Re-derived again 2026-08-31 (review round 2, after the LANE_TREE capture):
+// corpus 111,362 B, largest implement.md 23,436 B, so the floor must exceed
+// 111,362 - 23,436 = 87,926. 89,000 still HELD -- by 1,074 B, and is raised to
+// 90,000 anyway, because the MARGIN is what decays: cdk-local was left at 759 B
+// of it one day and had lapsed the next. 90,000 leaves 2,074 B of margin and
+// ~21 KB of compression room below the floor.
 // hunt-bugs stays at 60,000: 88,426 - 41,922 = 46,504 < 60,000, so its property
 // still holds. Re-measure both numbers for each skill whenever a stage file
 // changes size materially -- the property is silent when it lapses.
 const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }> = {
   // 8 files / 125,139 B measured at the split (2026-08-28); largest 26,621 B; 94,136 B post-compression
-  'work-issues': { minFiles: 6, minCorpusBytes: 89_000 },
+  'work-issues': { minFiles: 6, minCorpusBytes: 90_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 5, minCorpusBytes: 60_000 },
 };

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -46,23 +46,32 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // content. Floors sit far enough below the at-split measurement that narrative
 // COMPRESSION stays legal while wholesale deletion fails.
 // Calibration (probed, not guessed): a byte floor should sit ABOVE the corpus
-// minus its LARGEST stage file where compression room allows, or deleting that
-// one file — the likeliest wholesale drop — stays green (measured: hunt-bugs at
-// a 50,000 B floor survived deleting its 55,137 B gotchas.md). work-issues'
-// corpus is spread evenly enough that no such floor also leaves compression
-// room (`skill-doc-paths.test.ts` cannot catch it either — its citation
-// extractor only resolves spans whose first segment is a repo-root directory,
-// and `references/...` is skill-relative; measured, not assumed), so the
-// pointer-integrity block below is what catches a single deleted stage file:
-// every `references/<stage>.md` the orchestrator names must exist.
-// Floors re-measured after the rule+citation compression pass (2026-08-28):
-// work-issues 94,136 B and hunt-bugs 87,180 B. Both floors deliberately KEPT at
-// 60,000 B rather than re-derived at ~50% of the new totals — for hunt-bugs,
-// 87,180 − 41,922 (its largest file) = 45,258 < 60,000, so the floor now
-// catches deleting gotchas.md outright, a property a ~43,000 floor would lose.
+// minus its LARGEST stage file, or deleting that one file — the likeliest
+// wholesale drop — stays green (measured: hunt-bugs at a 50,000 B floor
+// survived deleting its 55,137 B gotchas.md). `skill-doc-paths.test.ts` does
+// not catch it either: its citation extractor only resolves spans whose first
+// segment is a repo-root directory, and `references/...` is skill-relative
+// (measured, not assumed). Beyond the floors, the pointer-integrity block below
+// is what catches a single deleted stage file: every `references/<stage>.md`
+// the orchestrator names must exist.
+//
+// Re-measured 2026-08-31. work-issues: corpus 109,106 B, largest implement.md
+// 22,600 B, so the property needs a floor above 109,106 - 22,600 = 86,506 --
+// which the 60,000 held here had stopped providing as the stage files grew.
+// 89,000 restores it: strictly TIGHTER, and no upper bound was touched. The
+// older note declined such a floor for work-issues because it leaves little
+// compression room, and that is still the trade (~20 KB of room below the
+// floor); the call is reversed to match the sibling cdk-local (88,000 on a
+// 113,468 B corpus) because a floor that cannot catch the likeliest wholesale
+// drop is not a weaker guard but a SILENT one. A genuine compression pass
+// re-derives the floor downward in the same commit -- that stays legal; what
+// the floor stops is a deletion with no re-derivation at all.
+// hunt-bugs stays at 60,000: 88,426 - 41,922 = 46,504 < 60,000, so its property
+// still holds. Re-measure both numbers for each skill whenever a stage file
+// changes size materially -- the property is silent when it lapses.
 const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }> = {
   // 8 files / 125,139 B measured at the split (2026-08-28); largest 26,621 B; 94,136 B post-compression
-  'work-issues': { minFiles: 6, minCorpusBytes: 60_000 },
+  'work-issues': { minFiles: 6, minCorpusBytes: 89_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 5, minCorpusBytes: 60_000 },
 };

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -39,7 +39,7 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
 
 const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill re-measured 12,571 B (verify-pr, 2026-09-01) -- the 12,175 B this line used to quote was stale
-const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B at the 2026-08-28 split; re-measured 2026-09-01: work-issues 11,476 B (524 B of margin), hunt-bugs 6,932 B
+const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B at the 2026-08-28 split; re-measured 2026-09-01, review round 4: work-issues 11,617 B (383 B of margin), hunt-bugs 6,932 B
 // The re-measurement is the point, not trivia: work-issues had grown to 11,746 B
 // -- 254 B under its cap -- while this comment still quoted the at-split figure,
 // so nobody adding a paragraph could see how little room was left. This pass

--- a/tests/work-issues-launch-mode.test.ts
+++ b/tests/work-issues-launch-mode.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { execFileSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * The `/work-issues` LAUNCH-MODE machinery, which decides whether a run creates
+ * a worktree per lane or works in the tree it was launched in.
+ *
+ * WHY THIS FILE EXISTS. `skill-file-payload.test.ts` and
+ * `work-issues-skill-refs.test.ts` measure BYTES and CITATIONS. Neither looks at
+ * what the prose says, so every mode-specific arm in this skill was untested --
+ * and the orchestrator cap made that worse than merely untested: `SKILL.md` sits
+ * a few hundred bytes under a 12,000 B cap, so DELETING the launch-mode section
+ * was the cheapest way to buy headroom and the suite would have called it an
+ * improvement. Measured 2026-09-01: deleting the probe block, deleting the whole
+ * `## Launch mode` section, and deleting every line containing `IN-PLACE` or
+ * `MAIN-CHECKOUT` were all GREEN before this file existed.
+ *
+ * Three properties, in increasing order of what they actually prove:
+ *
+ *   1. the probe exists EXACTLY ONCE in the skill directory -- pinning both its
+ *      presence and the single-copy claim the text makes about it (a second
+ *      verbatim copy is the drift shape section 10-b fences elsewhere);
+ *   2. every file carrying a mode-specific ARM still names the mode(s) it
+ *      branches on, so gutting one file's arms fails even though the corpus
+ *      byte floor (which only notices the LARGEST file disappearing) would not;
+ *   3. the probe is EXECUTED, in a real git repo and in a real linked worktree
+ *      of it, and must answer with the two literal verdicts. This is the one
+ *      arm of the whole change that is executable rather than prose, and the
+ *      shell-edge-case reading beside it in the doc is otherwise re-checked by
+ *      nothing.
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const skillDir = join(repoRoot, '.claude', 'skills', 'work-issues');
+const LAUNCH_MODE_DOC = join('references', 'launch-mode.md');
+
+/** Every markdown file of the skill, orchestrator first. */
+function skillDocs(): string[] {
+  return [
+    'SKILL.md',
+    ...readdirSync(join(skillDir, 'references'))
+      .filter((f) => f.endsWith('.md'))
+      .sort()
+      .map((f) => join('references', f)),
+  ];
+}
+
+function read(rel: string): string {
+  return readFileSync(join(skillDir, rel), 'utf8');
+}
+
+/**
+ * The probe's distinguishing token. `--git-common-dir` is what makes the mode
+ * decidable at all (a linked worktree's `--git-dir` differs from it, the main
+ * checkout's does not), so counting it counts copies of the probe.
+ */
+const PROBE_TOKEN = '--git-common-dir';
+
+/**
+ * Files that carry a mode-specific ARM and the marker(s) each must still name.
+ * Not every file needs both: `claim.md` and `gotchas.md` only qualify the
+ * IN-PLACE side, and `gates-and-pr.md` deliberately carries NO arm (its
+ * `git -C "<LANE_TREE>"` spelling is correct in both modes, which is why the
+ * mode words were removed from it rather than duplicated).
+ */
+const ARM_BEARING: Record<string, string[]> = {
+  'SKILL.md': ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [LAUNCH_MODE_DOC]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'triage.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'implement.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'ship.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'retro.md')]: ['MAIN-CHECKOUT', 'IN-PLACE'],
+  [join('references', 'claim.md')]: ['IN-PLACE'],
+  [join('references', 'gotchas.md')]: ['IN-PLACE'],
+};
+
+/** The first fenced ```bash block of a markdown file. */
+export function firstBashBlock(markdown: string): string | null {
+  const lines = markdown.split('\n');
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (start === -1) {
+      if (/^```bash\s*$/.test(lines[i]!)) start = i + 1;
+    } else if (/^```\s*$/.test(lines[i]!)) {
+      return lines.slice(start, i).join('\n');
+    }
+  }
+  return null;
+}
+
+describe('work-issues launch-mode probe', () => {
+  it('the probe exists exactly once across the skill directory, in launch-mode.md', () => {
+    const hits = skillDocs().filter((doc) => read(doc).includes(PROBE_TOKEN));
+    expect(
+      hits,
+      `Expected exactly one file to carry the launch-mode probe (\`${PROBE_TOKEN}\`), found ` +
+        `${hits.length}: ${hits.join(', ') || '(none)'}. The skill's own text calls ` +
+        `${LAUNCH_MODE_DOC} the ONLY copy: zero hits means the probe was deleted and every ` +
+        `IN-PLACE arm downstream is unreachable; two means a second verbatim copy that will ` +
+        `drift out of step with the first.`
+    ).toEqual([LAUNCH_MODE_DOC]);
+    const occurrences = read(LAUNCH_MODE_DOC).split(PROBE_TOKEN).length - 1;
+    expect(occurrences, `${LAUNCH_MODE_DOC} repeats the probe token ${occurrences} times`).toBe(1);
+  });
+
+  it('the orchestrator points at the launch-mode stage file', () => {
+    // The parent reads SKILL.md and nothing else before stage 0; if the pointer
+    // goes, the probe is unreachable however intact the file it lives in is.
+    expect(read('SKILL.md')).toContain(`references/launch-mode.md`);
+  });
+
+  for (const [doc, markers] of Object.entries(ARM_BEARING)) {
+    it(`${doc} still names the mode(s) it branches on: ${markers.join(', ')}`, () => {
+      const text = read(doc);
+      const missing = markers.filter((m) => !text.includes(m));
+      expect(
+        missing,
+        `${doc} no longer mentions ${missing.join(' / ')}. Either its mode-specific arm was ` +
+          `deleted (the byte floors do not notice: they only catch the LARGEST stage file ` +
+          `disappearing), or the arm moved -- in which case update ARM_BEARING in this file ` +
+          `so the assertion keeps tracking where the behaviour actually lives.`
+      ).toEqual([]);
+    });
+  }
+
+  describe('the probe, executed', () => {
+    /**
+     * Runs the doc's OWN fenced probe -- extracted, not re-typed -- against a
+     * throwaway repo and a linked worktree of it. A copy re-typed here would
+     * pass while the shipped one was broken, which is the whole failure this
+     * test is for.
+     */
+    const block = firstBashBlock(read(LAUNCH_MODE_DOC));
+
+    it('extracts a non-vacuous probe block from the doc', () => {
+      expect(block, `no fenced bash block found in ${LAUNCH_MODE_DOC}`).not.toBeNull();
+      expect(block!).toContain(PROBE_TOKEN);
+      expect(block!).toContain('MAIN-CHECKOUT');
+      expect(block!).toContain('IN-PLACE');
+    });
+
+    it('answers MAIN-CHECKOUT in a main checkout and IN-PLACE in a linked worktree', () => {
+      const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'wi-launch-mode-')));
+      try {
+        const main = join(tmp, 'main');
+        const lane = join(tmp, 'lane');
+        const script = join(tmp, 'probe.sh');
+        writeFileSync(script, `${block}\n`);
+        // Hermetic: a user's global config (hooksPath, templates, signing) must
+        // not decide whether this test passes.
+        const env = {
+          ...process.env,
+          GIT_CONFIG_GLOBAL: '/dev/null',
+          GIT_CONFIG_SYSTEM: '/dev/null',
+        };
+        const git = (args: string[], cwd = tmp) =>
+          execFileSync('git', args, { cwd, env, encoding: 'utf8' });
+        git(['init', '-q', main]);
+        git([
+          '-C',
+          main,
+          '-c',
+          'user.email=t@example.com',
+          '-c',
+          'user.name=t',
+          'commit',
+          '-q',
+          '--allow-empty',
+          '-m',
+          'init',
+        ]);
+        git(['-C', main, 'worktree', 'add', '-q', lane, '-b', 'lane-branch']);
+
+        const run = (cwd: string) =>
+          Object.fromEntries(
+            execFileSync('bash', [script], { cwd, env, encoding: 'utf8' })
+              .trim()
+              .split('\n')
+              .map((l) => {
+                const at = l.indexOf('=');
+                return [l.slice(0, at), l.slice(at + 1)] as const;
+              })
+          );
+
+        const fromMain = run(main);
+        expect(fromMain.MODE).toBe('MAIN-CHECKOUT');
+        expect(fromMain.LANE_TREE).toBe(main);
+        expect(fromMain.MAIN_CHECKOUT).toBe(main);
+
+        const fromLane = run(lane);
+        expect(fromLane.MODE).toBe('IN-PLACE');
+        // The two values differing IS the mode, and MAIN_CHECKOUT must point at
+        // the OTHER tree -- that is the value section 2's collision scan needs
+        // and the one a `pwd`- or `--show-toplevel`-derived probe gets wrong.
+        expect(fromLane.LANE_TREE).toBe(lane);
+        expect(fromLane.MAIN_CHECKOUT).toBe(main);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses to answer outside a work tree instead of printing a wrong verdict', () => {
+      // The dangerous failure is not an error, it is a CONFIDENT MAIN-CHECKOUT:
+      // with every `git rev-parse` failing, an unguarded compare tests "" against
+      // "" and says "main checkout" while standing nowhere. Inside `.git` the
+      // trap is subtler still -- `--is-inside-work-tree` prints `false` and exits
+      // ZERO there, so an exit-status guard passes and yields an empty LANE_TREE.
+      const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'wi-launch-mode-neg-')));
+      try {
+        const main = join(tmp, 'main');
+        const script = join(tmp, 'probe.sh');
+        writeFileSync(script, `${block}\n`);
+        const env = {
+          ...process.env,
+          GIT_CONFIG_GLOBAL: '/dev/null',
+          GIT_CONFIG_SYSTEM: '/dev/null',
+        };
+        execFileSync('git', ['init', '-q', main], { cwd: tmp, env, encoding: 'utf8' });
+
+        for (const cwd of [tmp, join(main, '.git')]) {
+          let failed = false;
+          let output = '';
+          try {
+            output = execFileSync('bash', [script], { cwd, env, encoding: 'utf8', stdio: 'pipe' });
+          } catch (e) {
+            failed = true;
+            output = String((e as { stdout?: string }).stdout ?? '');
+          }
+          expect(
+            failed,
+            `the probe answered "${output.trim()}" from ${cwd} instead of failing`
+          ).toBe(true);
+          expect(output).not.toContain('MODE=');
+        }
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #1842

Closes go-to-k/cdk-real-drift#1842.

`/work-issues` adds its lane worktree with a CWD-RELATIVE path, which is right
from the main checkout and wrong from anywhere else. Launched inside a linked
worktree -- an Orca/ADE workspace, or a session that just `cd`-ed into
`.worktrees/<x>` -- `git worktree add` NESTS one worktree inside another, and
deleting the outer workspace takes the inner directory, its uncommitted work and
its git registration with it.

This is the cdk-real-drift half of a three-repo change (go-to-k/cdkd#2399,
go-to-k/cdk-local#638); the three lanes stay convergent, and every remaining
divergence is stated in the text rather than left to a reader to guess.

## The probe runs in the PARENT, before stage 0

Earlier revisions of this branch put the probe "at the top of stage 3", on the
reasoning that nothing before stage 3 consumes the launch mode. That was wrong
twice over, and either half alone moves the probe:

- **Stages 1 AND 2 already consume it.** Section 1 runs
  `git fetch origin && git checkout main && git pull origin main --ff-only`,
  which IN-PLACE dies with the same
  `fatal: 'main' is already used by worktree ...` section 9 documents. Section
  2's collision map then runs `git -C .worktrees/<w> log|show|status` -- a
  RELATIVE path, correct only from the main checkout. IN-PLACE the cwd is a lane
  tree, the path does not exist, git errors, and the scan returns NOTHING. An
  empty collision map reads as "no competing agents", which is precisely the
  failure that stage exists to prevent, and unlike section 1 it fails QUIETLY.
- **Stages 0-3 are DELEGATED to a read-only triage subagent**, whose return
  payload is a candidate table: no git state, no paths. An answer computed
  inside it never reaches the parent -- and the parent is the party that later
  runs `git worktree add` or does not.

So the probe now lives in a new stage file, `references/launch-mode.md`
(9,519 B), read by the PARENT before stage 0. It captures three values at one
instant, and the parent passes all three into the triage dispatch and every lane
dispatch:

    [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = true ] \
      || { echo 'PROBE FAILED: not inside a git work tree -- do not guess the mode'; exit 1; }
    COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
    GITDIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)
    LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
    MAIN_CHECKOUT=$(dirname "$COMMON")
    [ "$GITDIR" = "$COMMON" ] && MODE=MAIN-CHECKOUT || MODE=IN-PLACE
    printf 'MODE=%s\nLANE_TREE=%s\nMAIN_CHECKOUT=%s\n' "$MODE" "$LANE_TREE" "$MAIN_CHECKOUT"

`MAIN_CHECKOUT` is the parent of the ONE shared git dir -- never `pwd`, never
`--show-toplevel`, both of which answer "the tree I am standing in" and so are
exactly wrong in the mode that needs the value. Section 1 gains an IN-PLACE arm
that refreshes the main checkout through `git -C "<MAIN_CHECKOUT>"`, section 2's
scan takes `git -C "<MAIN_CHECKOUT>/.worktrees/<w>"`, and section 9's post-merge
pull drops the `MAIN=$(git worktree list --porcelain | awk 'NR==1{...}')` form
for the same substituted path -- which cannot be EMPTY, the dangerous half:
`git -C "" pull origin main` exits 0 and pulls `origin/main` into whatever tree
the shell is standing in, IN-PLACE this lane's branch.

**The first-line guard is new and it closes a hole this repo's own prose had
already measured but nothing re-checked.** The text recorded that outside a repo
every substitution collapses to `""`, so the compare tests `""` against `""` and
prints a confident MAIN-CHECKOUT, and that bash and zsh differ in how they fail.
Worse, `git rev-parse --is-inside-work-tree` prints `false` and exits **zero**
inside a `.git` directory (measured 2026-09-01), so an exit-status guard passes
there and yields an empty `LANE_TREE` under a `MAIN-CHECKOUT` verdict. Comparing
the VALUE to the literal `true` makes both non-repo positions fail loudly in
both shells, so the shell divergence stops mattering -- and the executable test
below now re-checks that, which nothing did before.

## The IN-PLACE list was an undercount, and so was its cross-reference

`SKILL.md` said "IN-PLACE changes four things"; the previous body's own list of
"four things, and three of them are not X" contained five items. It changes at
least ten. `references/triage.md` said "SKILL.md carries the other three
consequences (4, 5, 9)", omitting 10-d (which SKILL.md itself listed) and 7
(`gates-and-pr.md`'s `git -C`).

Because `SKILL.md` is the always-loaded orchestrator, a short list there wins
over the reference files it points at. So both places now name the AREAS and
point at the COMPLETE table in `references/launch-mode.md`, which maps ten
consequences to sections 1, 2, 4, 5, 7, 9 and 10-d -- with no count for a later
edit to falsify.

`triage.md`'s "Everything below is the MAIN-CHECKOUT case" was FALSE and told an
IN-PLACE run to skip a HARD gate: below it sit the security-first ranking, the
`Severity` ranking, the premise-check-against-`origin/main` rule and section
3-a's freshness gate, all mode-independent. It is now scoped to the disjointness
paragraph it actually describes. Section 3's headline question ("how many
lanes") was also answered about fifty lines down, inside a paragraph titled
about substitution placeholders -- an insertion artifact; the whole passage is
rewritten in order.

## Ordering and empty-argument defects

- **`implement.md`: the ownership check guarded a recipe that came BEFORE it.**
  "Confirm the tree is YOURS before adopting it" sat AFTER the branch-switch
  recipe, and its own trigger needed a probe printed later still. A run following
  the file in order took a peer's live lane off its branch and only then checked
  whose tree it was. The probe block now comes first, and says so.
- **`implement.md`: `gh pr list --state all --head "$(... branch --show-current)"`
  on a DETACHED tree.** The same file contemplates that tree two paragraphs
  down, where the substitution is EMPTY. Measured on this repo 2026-09-01:
  `gh pr list --state all --head ""` exits 0 and returns EVERY PR. Under the
  surrounding rule ("any one saying someone is here means STOP") that is a
  guaranteed FALSE STOP on every detached adoption. Now an explicit if/else on
  the captured branch name -- if/else rather than `&& ... || ...`, because with
  the latter a `gh` TRANSPORT failure would also take the second arm and report
  "detached" about a tree that is not. Same empty-argument-retargets family
  `references/launch-mode.md` records for `git -C ""`.
- **`gotchas.md`: a bare `git switch --detach origin/main`,** in a repo whose own
  section 5 spends fourteen lines proving nothing here gates a branch switch.
  After a cwd reset that detaches the SHARED main checkout. Now
  `git -C "<LANE_TREE>" switch --detach origin/main`, with the reason inline.
  The same entry said leaving the branch "belongs to whoever owns the workspace,
  not to this run" while `retro.md` section 10-d has the IN-PLACE run do exactly
  that; the exception is now named.

## Tests: the change's own behaviour, not its byte count

Every assertion the previous rounds added was a byte count or a file-existence
check, so the diff's own behaviour was untested -- and the 12,000 B orchestrator
cap made it worse than untested. `SKILL.md` sits a few hundred bytes under that
cap, so DELETING the launch-mode section was the cheapest way to buy headroom
and the suite would have applauded it. Measured before this round: deleting the
`## Launch mode` section (1,481 B), the probe plus IN-PLACE prose from
`triage.md` (3,882 B), and the `hunt-bugs` IN-PLACE cleanup arm (476 B) were all
GREEN.

`tests/work-issues-launch-mode.test.ts` (13 cases) asserts three properties,
each mutation-proven against a scratch copy:

| assertion | mutation | result |
| --- | --- | --- |
| probe occurs exactly once in the skill dir | delete the probe block | 3 failed |
| ...and only once | add a second copy to `triage.md` | 1 failed |
| orchestrator points at the stage file | repoint it at `triage.md` | 1 failed |
| each arm-bearing file names its mode(s) | delete the `## Launch mode` section | 1 failed |
| " | delete every `IN-PLACE`/`MAIN-CHECKOUT` line in `SKILL.md` | 1 failed |
| " | delete them across all 10 docs | 10 failed |
| " | gut `triage.md`'s arms | 1 failed |
| the probe, EXECUTED in a repo and a worktree of it | swap the two verdicts | 1 failed |
| " | derive `MAIN_CHECKOUT` from `--show-toplevel` | 1 failed |
| refuses to answer outside a work tree | revert to the exit-status guard | 1 failed |

The executable case extracts the doc's OWN fenced block rather than re-typing
it, builds a throwaway repo plus a real `git worktree add` child, and asserts
`MODE` / `LANE_TREE` / `MAIN_CHECKOUT` in both. It also drives the two non-repo
positions (outside any repo, and inside `.git`) and requires a non-zero exit --
which is what makes the bash/zsh claim in the prose something a test now holds.

## The corpus floor asserts its own invariant, and minFiles stops over-claiming

`skill-file-payload.test.ts` derived its floor from "it must sit above
`corpus - largest`" and then never checked it -- three consecutive rounds
re-derived it BY HAND, and one of them found it lapsed. It is now one assertion
whose failure message carries the number to raise to:

    expect(floors.minCorpusBytes).toBeGreaterThan(total - largest)

Re-derived at the FINAL tree: 9 stage files, corpus 125,713 B, largest
`implement.md` 25,599 B, so the floor must exceed 100,114 -- the 93,000 this
branch held no longer does. `triage.md` is 20,782 B, only 4,817 B behind, and
round 3 already warned a flip would leave the floor clearing by under 1 KB, so
the new value is sized against the FLIP (104,931): **108,000**, clearing the
binding number by 7,886 B and the flip case by 3,069 B, with 17,713 B of
compression room below it. `hunt-bugs` stays at 60,000 (corpus 88,598 B, largest
41,922 B, so 46,676 -- still comfortable).

The comment claiming "the pointer-integrity block below is what catches a single
deleted stage file" was FALSE: deleting a stage file TOGETHER WITH the
orchestrator row pointing at it leaves both sides consistent, so `retro.md` or
`verify.md` could go with its pointer and stay green. `minFiles` is now pinned
to the EXACT count on disk (work-issues 9, hunt-bugs 7), which does catch it --
verified by deleting the SMALLEST stage file, `claim.md`, which the old floor of
6 ignored and the new one fails on. Pointer integrity catches the other half (a
row left dangling by a deletion); the comment now says which does which.

## Also in this diff

- **Pointers that did not resolve.** `hunt-bugs/references/plan.md` cited
  `/work-issues` `SKILL.md` "Launch mode" as CARRYING the probe, and said "the
  one-lane limit that probe carries" -- the probe carries no limit, the prose
  does. Both corrected. `implement.md` and the new `launch-mode.md` cited "the
  appendix's cwd-reset failure"; no such appendix entry exists here -- the rule
  is section 6's `cd <worktree> &&` rule, which is what they now name.
- **`verify.md`'s live-test path.** `node .worktrees/<w>/dist/cli.js` is wrong
  twice: relative to the main checkout, and an IN-PLACE launch tree (an Orca
  workspace) need not live under `.worktrees/` at all. Now
  `node "<LANE_TREE>/dist/cli.js"`.
- **`retro.md` section 10-d.** "Every worktree is gone by section 9 and you are
  back on `main`" was unconditional and then retracted seventeen lines later; it
  now states both cases up front. The IN-PLACE block also had no tree target for
  the steps that follow the branch switch -- it now says every later command
  takes the same `git -C "<LANE_TREE>"`, since that block never `cd`s.
- **The claim names a branch that may not exist yet.** On a DETACHED IN-PLACE
  tree `git branch --show-current` is empty and the branch is only created in
  stage 5. `claim.md` now says to write "the branch section 5 will create in
  `<LANE_TREE>`" and post the claim ON TIME.
- **The stale-base residual now says what it is waiting on.** It read
  "deliberately left for its own change" with no issue number while the residual
  beside it cites go-to-k/cdk-real-drift#1845. No issue tracks it (searched); the
  text now says so, and says why it is separable: moving that arm to
  `origin/main` changes what `stale-base-gate.sh` sees, which has to be measured
  rather than assumed.
- **One spelling for the lane tree.** `gates-and-pr.md`'s unquoted
  `git -C <lane tree>` was a third spelling of the same placeholder; all three
  repos now write `git -C "<LANE_TREE>"`, quoted, matching the probe's output
  name.
- **Broken wraps** in `implement.md`, `ship.md`, `retro.md` and `claim.md`
  reflowed, and the table in `launch-mode.md` is `vp fmt`-clean.

## Byte accounting (re-measured at the final tree)

| file | bytes | note |
| --- | --- | --- |
| `work-issues/SKILL.md` | 11,694 | 306 B under the 12,000 B cap (the previous body's "11,904 B -- 96 B under" was wrong in both halves: it was 11,617, i.e. 383 B under) |
| `references/launch-mode.md` | 9,519 | new; read once, before stage 0 |
| `references/implement.md` | 25,599 | largest stage file, well under the 64,000 B cap |
| `references/triage.md` | 20,782 | lost the probe and the insertion-artifact passage |

No cap was raised. The orchestrator absorbed the parent-probe design and stayed
under, paid for three ways: the probe and its edge-case reading moved to the new
stage file, the IN-PLACE list became a pointer to that file's table, and the
stage table's widest cells were shortened -- which, since `vp fmt` pads markdown
table columns to the widest cell, reclaimed padding on all fourteen rows at
once.

CLAUDE.md is unchanged in this round: it already said `/work-issues` "computes
which case applies before its first stage", which was aspirational when written
and is now literally true, so the SKILL.md side was fixed rather than the rule.

## Suite

`vp test run`: 349 test files, 6,620 passed. `vp run format:check`: clean.
`vp run lint`: 0 errors (148 pre-existing warnings).
