### PR TITLE
docs(contributing): integration-test cost policy and when a real-AWS run is required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,30 @@ changes** before testing manually. Integration tests (real AWS, self-cleaning)
 live under `tests/integration/` — see
 [tests/integration/README.md](tests/integration/README.md).
 
+## Integration tests
+
+The integration tests deploy and inspect **real AWS resources**, so running
+them incurs real AWS charges. CI does not run them.
+
+**You are not required to run them.** If your change needs integration
+coverage (see below), just say so in your PR — the maintainer runs the
+required tests before merging, at no cost to you. The maintainer's pre-merge
+checklist requires a fresh real-AWS integration run for any PR that touches
+`src/**`, and merging is blocked until it has passed, so coverage is
+guaranteed either way; asking is never a burden.
+
+You are welcome to run them yourself against your own AWS account if you
+prefer — see [tests/integration/README.md](tests/integration/README.md).
+
+### When is an integration run needed?
+
+Which verification a PR needs is derived mechanically from the paths it
+touches — the `integ` gate scope in [`.markgate.yml`](.markgate.yml) is the
+source of truth. In summary: any change under `src/**` or
+`tests/integration/**` needs a real-AWS integration run before merge; a
+docs / tooling-only PR needs none (unit tests and CI are enough). When in
+doubt, open the PR and ask.
+
 ## Conventions
 
 - **English-only**: all committed files (source, comments, scripts, docs, config,


### PR DESCRIPTION
## Summary

- Add an "Integration tests" section to CONTRIBUTING.md stating the cost policy: the integration tests deploy real AWS resources and incur charges, CI does not run them, and contributors are NOT required to run them — asking in the PR is enough, and the maintainer runs the required tests before merging (the maintainer's pre-merge checklist requires a fresh real-AWS run for any `src/**`-touching PR, and merging is blocked until it passes).
- Document WHEN a run is needed, pointing at the `integ` gate scope in `.markgate.yml` as the source of truth: any `src/**` or `tests/integration/**` change needs one; docs / tooling-only PRs need none.

## Why

External contributors have no way to know whether a change needs a real-AWS integration run, and may reasonably not want to pay AWS charges to contribute. The gate scope already encodes the answer mechanically; this surfaces it in the contributor-facing doc. Same change as go-to-k/cdkd#2405 and go-to-k/cdk-local#640, adapted to this repo's single `integ` gate.

## Test plan

- Docs-only change (CONTRIBUTING.md is outside the `check` / `docs` gate scopes). Full quality pass run anyway: `vp run typecheck`, `vp check --fix`, `vp pack`, and `vp test run` (349 files / 6620 tests) all pass.
- Verified claims against the tree: `ci.yml` never runs the integration tests; the `integ` gate's include in `.markgate.yml` is exactly `src/**` + `tests/integration/**`; `tests/integration/README.md` (the linked run guide) exists.

https://claude.ai/code/session_01XxNpeqCebgrMHDHJDZRGvb
