### PR TITLE
chore(work-issues): two more questions before `next`, because "it needs its own PR" is not a deferral reason

### DIFF
--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -353,6 +353,30 @@ The ladder, cheapest first — the SECOND entry, which looks like an ordinary
   an unbounded deferral. Do it now, or say in the body why the fix would be
   unverifiable.
 
+**Then ask what the next session will have to RE-DERIVE.** The question above
+names the verification; this one names the cost of the gap between now and it.
+If you can point at something that exists only in THIS session — a table you
+measured, a probe you built, a shape you just proved correct in a sibling repo —
+the deferral is not free and the answer is `now`. Understanding survives in an
+issue body; a measurement does not, and neither does a fix whose correctness you
+established once and would have to establish again.
+
+**And "it needs its own PR" is NOT a `next` reason.** It is a `now` item that
+gets its own PR. The bar is the SESSION, not the diff — a separate review
+surface, a new file, a hook plus its suite plus its registration are all good
+reasons to split the PR and none of them is a reason to end the session.
+Writing "independent review surface" on a `Session-fit` line is the
+classify-by-MEANS error this section already forbids, arriving through the PR
+boundary instead of through the work's category.
+
+(2026-09-01: a hook missing from one sibling was filed `next` on exactly that
+wording — minutes after the same hook's two-directional defect had been
+measured and fixed in the other two repos. The probe, the corrected shape and
+the rc table were all in hand, and a later session would have re-derived all
+three. Re-classified `now` in the same session on the maintainer's challenge,
+and shipped; the port then found four more defects in the shape it was copying,
+none of which a fresh session would have known to look for.)
+
 Origin: go-to-k/cdk-local#560 was deferred on "a fixture / base-image change on
 a different axis" — the KIND of work, not who could check it. The defect was a
 Go RIE segfault under `linux/amd64` emulation on an arm64 host; the filing


### PR DESCRIPTION
chore(work-issues): two more questions before `next`, because "it needs its own PR" is not a deferral reason

Section 3-b already refuses `Session-fit: next` until you can name the command
the NEXT session will run. That gate is generative and it works, and it did not
catch this one, so it gains two questions rather than a new section.

**"It needs its own PR" is not a `next` reason.** It is a `now` item that gets
its own PR. The bar is the SESSION, not the diff -- a separate review surface, a
new file, a hook plus its suite plus its registration are all good reasons to
split the PR, and none of them is a reason to end the session. `CLAUDE.md`
already says exactly this ("Same session is the bar; same PR only when the work
is small enough to review together"), but it says it in the prose ABOUT
deferrals rather than in the criteria a deferral is decided against, so the
`next` list reads as a checklist and "independent review surface"
pattern-matches onto "bundling would make the PR unreviewable". That is the
classify-by-MEANS error 3-b already forbids, arriving through the PR boundary
instead of through the work's category.

**And name what the next session will have to RE-DERIVE.** 3-b names the
verification; this names the cost of the gap before it. Understanding survives
in an issue body; a measurement does not, and neither does a fix whose
correctness you established once and would have to establish again. If you can
point at something that exists only in THIS session -- a table you measured, a
probe you built, a shape you just proved correct in a sibling repo -- the
deferral is not free.

That is the trigger that fired and was missed here. `Session-fit: now` already
lists "its evidence exists only in this session", but its examples are a live
repro, a real-AWS observation, a measurement -- and a VERIFIED FIX SHAPE ported
from a sibling reads like none of them.

Measured 2026-09-01, and recorded in the section as its example:
go-to-k/cdk-real-drift#1845 (a missing `main-tree-branch-gate`) was filed
`Session-fit: next` on "new hook + suite + registration = its own review
surface" -- minutes after the same hook's two-directional defect had been
measured and fixed in the two sibling repos. The probe, the corrected shape and
the rc table were all in hand. Re-classified `now` on the maintainer's
challenge and shipped in the same session; the port then found four further
defects in the shape it was copying, none of which a fresh session would have
known to look for.

The addition is 1,560 B and lands inside 3-b in all three repos -- cdkd's and
cdk-real-drift's `references/triage.md`, cdk-local's `references/implement.md`,
each immediately before that file's "the converse is the honest use of `next`"
paragraph, so the new questions and the honest-`next` case read as one
argument. No new section, and nothing added to any `SKILL.md`: the orchestrator
files sit 306-541 B under their 12,000 B cap in the three repos, and this
belongs where the decision is made rather than where it is summarised.

Suites: cdkd 845 files / 17,522 tests, cdk-local 242 / 4,359, cdk-real-drift
71 skill-checker tests, all rc=0 with no type errors.

