### PR TITLE
feat: honor HTTPS_PROXY / HTTP_PROXY / NO_PROXY for every AWS call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,54 @@ access-log / route settings back to unset).
 
 </details>
 
+## Behind a corporate proxy
+
+`cdkrd` honours the standard proxy environment variables for **every** AWS call
+it makes — the live reads, the revert writes, credential resolution (STS / SSO),
+and the CDK synth/discovery path:
+
+| variable                      | effect                                                      |
+| ----------------------------- | ----------------------------------------------------------- |
+| `HTTPS_PROXY` / `https_proxy` | proxy for `https://` requests — all AWS traffic in practice |
+| `HTTP_PROXY` / `http_proxy`   | proxy for plain `http://` requests                          |
+| `ALL_PROXY` / `all_proxy`     | fallback for either scheme                                  |
+| `NO_PROXY` / `no_proxy`       | hosts to reach directly, bypassing the proxy                |
+
+Both spellings work; the lower-case ones win where a tool sets both. The proxy
+is chosen **per request**, so `HTTPS_PROXY` and `HTTP_PROXY` may name different
+proxies and each scheme goes to its own. This needed explicit support in
+`cdkrd` because the AWS SDK for JavaScript v3 does not read these variables the
+way the AWS CLI does — without it, a machine whose only egress is a corporate
+proxy fails on the very first call, typically with a certificate error naming
+the network's TLS interceptor rather than the proxy.
+
+A few sharp edges worth knowing:
+
+- **`NO_PROXY` matching is exact, unlike curl.** An entry that does not start
+  with `.` or `*` must equal the hostname exactly: `NO_PROXY=example.com` does
+  NOT cover `api.example.com`, and `.example.com` does not cover the apex — so
+  covering a domain and its subdomains takes two entries
+  (`NO_PROXY=example.com,.example.com`). CIDR ranges (`10.0.0.0/8`) are
+  silently ignored; IP addresses must be listed literally. For a VPC-endpoint
+  setup, write `NO_PROXY=.amazonaws.com,amazonaws.com`.
+- **A TLS-terminating proxy still needs `NODE_EXTRA_CA_CERTS`.** A proxy that
+  opens a CONNECT tunnel needs nothing extra (the origin's own certificate is
+  validated end to end), but one that terminates TLS presents its own
+  certificate, and Node must be told to trust it:
+  `export NODE_EXTRA_CA_CERTS=/path/to/corporate-root-ca.pem`. (The AWS CLI's
+  equivalent is `AWS_CA_BUNDLE`; it does not affect `cdkrd`.)
+- **A whitespace-only proxy variable is an error**, reported with the variable's
+  name — treating it as set would fail later with an unnamed URL-parse error,
+  and treating it as unset would silently go direct.
+
+To verify traffic is actually routed, point `cdkrd` at a proxy that cannot work
+and confirm the command fails (if it succeeds, the variable is not reaching the
+process):
+
+```bash
+HTTPS_PROXY=http://127.0.0.1:1 https_proxy=http://127.0.0.1:1 cdkrd check MyStack
+```
+
 ## Limitations
 
 `cdkrd` is **fail-closed**: anything it can't confidently compare is reported as

--- a/README.md
+++ b/README.md
@@ -1301,6 +1301,10 @@ A few sharp edges worth knowing:
   in a proxy variable is rejected up front with the variable's name — the
   routing speaks HTTP CONNECT only, and accepting it would fail every call
   mid-run with an opaque proxy-protocol error instead.
+- **A proxy value needs an explicit scheme.** `proxy.example:8080` (which curl
+  accepts as `http://`) is rejected up front with the variable's name — the
+  library `cdkrd` routes with would prepend the _request's_ scheme, turning it
+  into a TLS handshake against a plaintext proxy port mid-run.
 - **A whitespace-only proxy variable is an error**, reported with the variable's
   name — treating it as set would fail later with an unnamed URL-parse error,
   and treating it as unset would silently go direct.

--- a/README.md
+++ b/README.md
@@ -1297,6 +1297,10 @@ A few sharp edges worth knowing:
   certificate, and Node must be told to trust it:
   `export NODE_EXTRA_CA_CERTS=/path/to/corporate-root-ca.pem`. (The AWS CLI's
   equivalent is `AWS_CA_BUNDLE`; it does not affect `cdkrd`.)
+- **SOCKS proxies are not supported.** A `socks5://` (or any `socks*://`) value
+  in a proxy variable is rejected up front with the variable's name — the
+  routing speaks HTTP CONNECT only, and accepting it would fail every call
+  mid-run with an opaque proxy-protocol error instead.
 - **A whitespace-only proxy variable is an error**, reported with the variable's
   name — treating it as set would fail later with an unnamed URL-parse error,
   and treating it as unset would silently go direct.

--- a/package.json
+++ b/package.json
@@ -114,8 +114,13 @@
     "@aws-sdk/credential-providers": "^3.1065.0",
     "@clack/core": "^1.4.1",
     "@clack/prompts": "^1.5.1",
+    "@smithy/node-http-handler": "^4.12.0",
+    "agent-base": "^9.0.0",
+    "http-proxy-agent": "^9.1.0",
+    "https-proxy-agent": "^9.1.0",
     "jsonata": "^1.8.7",
     "picocolors": "^1.1.1",
+    "proxy-from-env": "^2.1.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
@@ -125,6 +130,7 @@
     "@semantic-release/github": "^12.0.0",
     "@semantic-release/npm": "^13.0.0",
     "@types/node": "^20.19.0",
+    "@types/proxy-from-env": "^1.0.4",
     "aws-sdk-client-mock": "^4.1.0",
     "semantic-release": "^25.0.0",
     "tsdown": "^0.22.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,18 +194,33 @@ importers:
       '@clack/prompts':
         specifier: ^1.5.1
         version: 1.5.1
+      '@smithy/node-http-handler':
+        specifier: ^4.12.0
+        version: 4.12.0
+      agent-base:
+        specifier: ^9.0.0
+        version: 9.0.0
       aws-cdk-lib:
         specifier: ^2.0.0
         version: 2.258.1(constructs@10.6.0)
       constructs:
         specifier: ^10.0.0
         version: 10.6.0
+      http-proxy-agent:
+        specifier: ^9.1.0
+        version: 9.1.0
+      https-proxy-agent:
+        specifier: ^9.1.0
+        version: 9.1.0
       jsonata:
         specifier: ^1.8.7
         version: 1.8.7
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      proxy-from-env:
+        specifier: ^2.1.0
+        version: 2.1.0
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -228,6 +243,9 @@ importers:
       '@types/node':
         specifier: ^20.19.0
         version: 20.19.43
+      '@types/proxy-from-env':
+        specifier: ^1.0.4
+        version: 1.0.4
       aws-sdk-client-mock:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1467,6 +1485,10 @@ packages:
     resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.16':
     resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
     engines: {node: '>=18.0.0'}
@@ -1499,12 +1521,8 @@ packages:
     resolution: {integrity: sha512-M+gG6eQ0y073mSmNB+erRXJvwpsqsN72ol2w6vcd8FEKeG7pqYK0JvzfVqONkPj2ElBB2pg+cU13I850b//Wag==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.9.13':
-    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.9.6':
-    resolution: {integrity: sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==}
+  '@smithy/node-http-handler@4.12.0':
+    resolution: {integrity: sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.3.6':
@@ -1576,6 +1594,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/proxy-from-env@1.0.4':
+    resolution: {integrity: sha512-TPR9/bCZAr3V1eHN4G3LD3OLicdJjqX1QRXWuNcCYgE66f/K8jO2ZRtHxI2D9MbnuUP6+qiKSS8eUHp6TFHGCw==}
 
   '@types/sinon@17.0.4':
     resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
@@ -2872,34 +2893,16 @@ packages:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   lightningcss-darwin-arm64@1.33.0:
     resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.33.0:
@@ -2908,36 +2911,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
   lightningcss-freebsd-x64@1.33.0:
     resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
   lightningcss-linux-arm-gnueabihf@1.33.0:
     resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
@@ -2946,26 +2930,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
@@ -2974,13 +2944,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
@@ -2988,22 +2951,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.33.0:
@@ -3011,10 +2962,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
-
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
-    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.33.0:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
@@ -3464,6 +3411,10 @@ packages:
     peerDependenciesMeta:
       kerberos:
         optional: true
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -4342,7 +4293,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4356,7 +4307,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4369,7 +4320,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4382,7 +4333,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4393,7 +4344,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4406,7 +4357,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4417,7 +4368,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4430,7 +4381,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4443,7 +4394,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4456,7 +4407,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4469,7 +4420,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4482,7 +4433,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4495,7 +4446,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4507,7 +4458,7 @@ snapshots:
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
       '@smithy/middleware-compression': 4.5.5
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4520,7 +4471,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4531,7 +4482,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4544,7 +4495,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4557,7 +4508,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4570,7 +4521,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4583,7 +4534,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4594,7 +4545,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4605,7 +4556,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4616,7 +4567,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4630,7 +4581,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4644,7 +4595,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4657,7 +4608,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4670,7 +4621,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4683,7 +4634,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4694,7 +4645,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4707,7 +4658,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4720,7 +4671,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4734,7 +4685,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4747,7 +4698,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4758,7 +4709,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4771,7 +4722,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4782,7 +4733,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4793,7 +4744,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4806,7 +4757,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4817,7 +4768,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4830,7 +4781,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4841,7 +4792,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4852,7 +4803,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4863,7 +4814,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4876,7 +4827,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4890,7 +4841,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4901,7 +4852,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4915,7 +4866,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4932,7 +4883,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4943,7 +4894,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4956,7 +4907,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4969,7 +4920,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4982,7 +4933,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4995,7 +4946,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5007,7 +4958,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5020,7 +4971,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5033,7 +4984,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5047,7 +4998,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5060,7 +5011,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5074,7 +5025,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5087,7 +5038,7 @@ snapshots:
       '@aws-sdk/types': 3.974.1
       '@smithy/core': 3.29.4
       '@smithy/fetch-http-handler': 5.6.6
-      '@smithy/node-http-handler': 4.9.6
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5143,7 +5094,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5153,7 +5104,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5313,7 +5264,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5386,7 +5337,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5397,7 +5348,7 @@ snapshots:
       '@aws-sdk/types': 3.974.2
       '@smithy/core': 3.31.1
       '@smithy/fetch-http-handler': 5.6.13
-      '@smithy/node-http-handler': 4.9.13
+      '@smithy/node-http-handler': 4.12.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -6029,6 +5980,11 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.16':
     dependencies:
       '@smithy/core': 3.31.1
@@ -6074,15 +6030,9 @@ snapshots:
       '@smithy/core': 3.31.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.9.13':
+  '@smithy/node-http-handler@4.12.0':
     dependencies:
-      '@smithy/core': 3.31.1
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.9.6':
-    dependencies:
-      '@smithy/core': 3.31.1
+      '@smithy/core': 3.33.3
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -6170,6 +6120,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/proxy-from-env@1.0.4':
+    dependencies:
+      '@types/node': 20.19.43
 
   '@types/sinon@17.0.4':
     dependencies:
@@ -7189,87 +7143,38 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  lightningcss-android-arm64@1.32.0:
-    optional: true
-
   lightningcss-android-arm64@1.33.0:
-    optional: true
-
-  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
-    optional: true
-
   lightningcss-darwin-x64@1.33.0:
-    optional: true
-
-  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
-
   lightningcss-linux-arm-gnueabihf@1.33.0:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-arm64-musl@1.33.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-x64-musl@1.33.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    optional: true
-
   lightningcss-win32-x64-msvc@1.33.0:
     optional: true
-
-  lightningcss@1.32.0:
-    dependencies:
-      detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
 
   lightningcss@1.33.0:
     dependencies:
@@ -7631,6 +7536,8 @@ snapshots:
   proto-list@1.2.4: {}
 
   proxy-agent-negotiate@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   quansync@1.0.0: {}
 
@@ -8229,7 +8136,7 @@ snapshots:
 
   vite@8.0.16(@types/node@20.19.43)(yaml@2.9.0):
     dependencies:
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.19
       rolldown: 1.0.3

--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -66,6 +66,10 @@ export function defaultProfileRegionFromIni(): string | undefined {
 // AWS_EC2_METADATA_DISABLED exactly like toolkit-lib, best-effort with a short timeout so
 // a non-EC2 host (where the link-local IMDS address blackholes) never hangs the CLI.
 // IMDSv2: fetch a token, then placement/region. Any error → undefined. Exported for tests.
+// The undici `fetch` here CORRECTLY ignores HTTPS_PROXY (#1841): IMDS is link-local
+// (169.254.169.254), reachable only from the instance itself — a corporate proxy could
+// never relay to it, so this call must always go direct, exactly as the SDK's own IMDS
+// credential provider does.
 export async function regionFromImds(): Promise<string | undefined> {
   if (process.env.AWS_EC2_METADATA_DISABLED === 'true') return undefined;
   const base = 'http://169.254.169.254';
@@ -108,6 +112,13 @@ export async function resolveProfileRegion(
   profile: string | undefined
 ): Promise<string | undefined> {
   try {
+    // Deliberately OUTSIDE the shared CLIENT_TIMEOUTS/READ_RETRY config (#1841): this
+    // client never sends a request — `config.region()` resolves purely from env vars and
+    // the shared ini files — so it needs neither the proxy routing nor the timeouts. It
+    // must also keep constructing its own transport: it is the one call site that invokes
+    // `client.destroy()`, which tears down the handler's agents (harmless here, on a
+    // handler nothing else shares). Fenced by tests/client-proxy-conformance-1841.test.ts
+    // (this is its single ALLOWED entry).
     const client = new CloudControlClient(profile ? { profile } : {});
     const region = await client.config.region();
     client.destroy();

--- a/src/read/client-config.ts
+++ b/src/read/client-config.ts
@@ -24,6 +24,8 @@ import {
   fromEnv,
   fromNodeProviderChain,
 } from '@aws-sdk/credential-providers';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { ProxyRoutingAgent } from './proxy-routing-agent.js';
 
 // #954: align the raw SDK clients' credential precedence with toolkit-lib / the AWS CLI.
 //
@@ -77,6 +79,89 @@ export const CLIENT_REQUEST_HANDLER = {
   throwOnRequestTimeout: true,
 };
 
+// #1841: honor HTTPS_PROXY / HTTP_PROXY / NO_PROXY. The AWS SDK for JavaScript v3 does NOT
+// read the proxy variables the way botocore (the AWS CLI) and Go's net/http do — its guide
+// says a proxy is supplied "through a third-party HTTP agent" by whoever constructs the
+// client — so on a machine whose only egress is a corporate proxy every cdkrd AWS call
+// dialed out directly and failed (typically as a certificate error naming the network's
+// TLS interceptor, not the proxy). Node's own NODE_USE_ENV_PROXY=1 is not a way out: it
+// rewires the GLOBAL agent, and every SDK client builds its own.
+//
+// The variables below, in the order proxy-from-env itself reads them. Only their PRESENCE
+// is decided here. Which one applies to a given request — and whether NO_PROXY exempts
+// it — is getProxyForUrl's job, per request, inside ProxyRoutingAgent. Deciding it here
+// instead would collapse HTTP_PROXY and HTTPS_PROXY into one answer and send http://
+// traffic to an HTTPS proxy.
+export const PROXY_ENV_VARS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+] as const;
+
+let proxyConfigured: boolean | undefined;
+
+/** Whether any proxy environment variable is set (memoized parse; see resetProxyConfig). */
+export function isProxyConfigured(): boolean {
+  // Read lazily and memoize only the PARSE RESULT, so module import order cannot freeze
+  // an answer at load time, and so a test can control the environment via resetProxyConfig.
+  if (proxyConfigured === undefined) {
+    // Every spelling is examined before the answer is decided. A `.some()` here would
+    // short-circuit at the first VALID variable, so `HTTPS_PROXY=http://ok` beside a
+    // typo'd `http_proxy='   '` would never reach the guard below — and the typo then
+    // resurfaces per request as exactly the unnamed URL-parse error the guard pre-empts.
+    let configured = false;
+    for (const name of PROXY_ENV_VARS) {
+      const value = process.env[name];
+      if (value === undefined || value === '') continue;
+      if (value.trim() === '') {
+        // Whitespace-only is a typo, not a configuration. Treating it as SET fails later
+        // with a URL-parse error naming neither the variable nor cdkrd; treating it as
+        // UNSET is worse still, because the run then goes direct and fails with the
+        // certificate error this whole mechanism exists to remove — with no hint that
+        // the variable was the cause.
+        throw new Error(
+          `${name} is set to whitespace only. Set it to a proxy URL ` +
+            `(e.g. http://proxy.example:8080) or unset it.`
+        );
+      }
+      configured = true;
+    }
+    proxyConfigured = configured;
+  }
+  return proxyConfigured;
+}
+
+/** Drop the memoized proxy-environment read. Test seam. */
+export function resetProxyConfig(): void {
+  proxyConfigured = undefined;
+}
+
+// The requestHandler value every client construction reads (via the CLIENT_TIMEOUTS /
+// READ_RETRY getters below and CLIENT_CREDENTIALS' clientConfig).
+//
+// - No proxy configured: the plain CLIENT_REQUEST_HANDLER option bag, byte-identical to
+//   the pre-#1841 path — the SDK wraps it in its own NodeHttpHandler with its own
+//   keepAlive agent, so existing users see zero change.
+// - Proxy configured: a NodeHttpHandler carrying the SAME #1066 timeout contract plus a
+//   ProxyRoutingAgent for both schemes. A FRESH handler + agent per call (i.e. per client
+//   construction): NodeHttpHandler.destroy() destroys httpAgent and httpsAgent
+//   unconditionally, and Node's Agent.destroy() aborts ACTIVE sockets, so one shared
+//   instance would let a single client's teardown (`client.destroy()`, which
+//   resolve-stacks.ts' region probe already calls) kill every other client's in-flight
+//   requests. See proxy-routing-agent.ts.
+export function clientRequestHandler(): typeof CLIENT_REQUEST_HANDLER | NodeHttpHandler {
+  if (!isProxyConfigured()) return CLIENT_REQUEST_HANDLER;
+  const agent = new ProxyRoutingAgent();
+  return new NodeHttpHandler({
+    ...CLIENT_REQUEST_HANDLER,
+    httpAgent: agent,
+    httpsAgent: agent,
+  });
+}
+
 // The shared credential provider spread into EVERY raw SDK client (via CLIENT_TIMEOUTS /
 // READ_RETRY). A single function reference is reused across all clients; it decides env-vs-
 // profile precedence lazily on each resolution (see shouldPrioritizeEnv).
@@ -87,23 +172,46 @@ export const CLIENT_REQUEST_HANDLER = {
 // contract. A stalled STS endpoint would then hang check/record/revert FOREVER, BEFORE any
 // wired client's own timeout could even start (credential resolution runs first). The
 // clientConfig propagates the same requestHandler to those inner clients, so they abort too.
-export const CLIENT_CREDENTIALS = (awsIdentityProperties?: Record<string, unknown>) =>
-  (shouldPrioritizeEnv()
-    ? createCredentialChain(
-        fromEnv(),
-        fromNodeProviderChain({ clientConfig: { requestHandler: CLIENT_REQUEST_HANDLER } })
-      )
-    : fromNodeProviderChain({ clientConfig: { requestHandler: CLIENT_REQUEST_HANDLER } }))(
-    awsIdentityProperties
-  );
+//
+// #1841: the clientConfig requestHandler is clientRequestHandler(), not the bare bag, so
+// under a proxy the inner STS / SSO / SSO-OIDC clients route through it too. That is not
+// optional: STS reads the handler off parentClientConfig (it would inherit), but the SSO
+// portal client and the SSO-OIDC refresh build from clientConfig ALONE, so an SSO profile
+// would otherwise fail at resolveSSOCredentials — before any service call. IMDS and ECS
+// container credentials call node:http / build their own handler; they are link-local /
+// in-VPC and correctly bypass a proxy, so they need no casing. Evaluated per invocation
+// (this is already a lazy provider — see above), so the handler is fresh per resolution.
+export const CLIENT_CREDENTIALS = (awsIdentityProperties?: Record<string, unknown>) => {
+  const requestHandler = clientRequestHandler();
+  return (
+    shouldPrioritizeEnv()
+      ? createCredentialChain(
+          fromEnv(),
+          fromNodeProviderChain({ clientConfig: { requestHandler } })
+        )
+      : fromNodeProviderChain({ clientConfig: { requestHandler } })
+  )(awsIdentityProperties);
+};
 
+// `requestHandler` is a GETTER on both bags, so every `...CLIENT_TIMEOUTS` /
+// `...READ_RETRY` spread at a client construction site re-evaluates
+// clientRequestHandler() — unproxied it returns the same shared CLIENT_REQUEST_HANDLER
+// bag as before (zero change), proxied it hands each client its OWN handler + routing
+// agent (the destroy-safety reason above). READ_RETRY repeats the getter instead of
+// spreading CLIENT_TIMEOUTS because a spread HERE would evaluate the getter once at
+// module load and freeze a single shared handler into every read client.
 export const CLIENT_TIMEOUTS = {
   credentials: CLIENT_CREDENTIALS,
-  requestHandler: CLIENT_REQUEST_HANDLER,
+  get requestHandler() {
+    return clientRequestHandler();
+  },
 };
 
 export const READ_RETRY = {
   maxAttempts: 10,
   retryMode: 'adaptive' as const,
-  ...CLIENT_TIMEOUTS,
+  credentials: CLIENT_CREDENTIALS,
+  get requestHandler() {
+    return clientRequestHandler();
+  },
 };

--- a/src/read/client-config.ts
+++ b/src/read/client-config.ts
@@ -127,6 +127,16 @@ export function isProxyConfigured(): boolean {
             `(e.g. http://proxy.example:8080) or unset it.`
         );
       }
+      if (/^socks/i.test(value.trim())) {
+        // SOCKS is not supported: the routing agent speaks HTTP CONNECT only, so a
+        // socks:// value would be accepted here and then fail every AWS call mid-run
+        // with an opaque proxy-protocol error naming neither the variable nor cdkrd.
+        // Same philosophy as the whitespace guard: name the variable, fail up front.
+        throw new Error(
+          `${name} names a SOCKS proxy, which cdkrd does not support (HTTP(S) proxies ` +
+            `only). Use an http:// or https:// proxy URL, or unset ${name}.`
+        );
+      }
       configured = true;
     }
     proxyConfigured = configured;

--- a/src/read/client-config.ts
+++ b/src/read/client-config.ts
@@ -87,11 +87,14 @@ export const CLIENT_REQUEST_HANDLER = {
 // TLS interceptor, not the proxy). Node's own NODE_USE_ENV_PROXY=1 is not a way out: it
 // rewires the GLOBAL agent, and every SDK client builds its own.
 //
-// The variables below, in the order proxy-from-env itself reads them. Only their PRESENCE
-// is decided here. Which one applies to a given request — and whether NO_PROXY exempts
-// it — is getProxyForUrl's job, per request, inside ProxyRoutingAgent. Deciding it here
-// instead would collapse HTTP_PROXY and HTTPS_PROXY into one answer and send http://
-// traffic to an HTTPS proxy.
+// The variables proxy-from-env consults (its getEnv reads the LOWERCASE spelling first;
+// the guard below deliberately examines BOTH spellings, so a typo'd value is reported even
+// when a valid other-case twin would shadow it at routing time — fail closed, with the
+// variable's name, rather than half-working per request). Only their PRESENCE is decided
+// here. Which one applies to a given request — and whether NO_PROXY exempts it — is
+// getProxyForUrl's job, per request, inside ProxyRoutingAgent. Deciding it here instead
+// would collapse HTTP_PROXY and HTTPS_PROXY into one answer and send http:// traffic to
+// an HTTPS proxy.
 export const PROXY_ENV_VARS = [
   'HTTPS_PROXY',
   'https_proxy',
@@ -135,6 +138,18 @@ export function isProxyConfigured(): boolean {
         throw new Error(
           `${name} names a SOCKS proxy, which cdkrd does not support (HTTP(S) proxies ` +
             `only). Use an http:// or https:// proxy URL, or unset ${name}.`
+        );
+      }
+      if (!value.includes('://')) {
+        // A scheme-less value (`proxy.example:8080` — curl treats it as http://) is NOT
+        // normalized by proxy-from-env: it prepends the REQUEST's scheme, so an https
+        // request turns it into `https://proxy.example:8080` and HttpsProxyAgent then
+        // opens a TLS handshake to a plaintext proxy port — failing mid-run with a
+        // `wrong version number` error naming neither the variable nor cdkrd. Same
+        // philosophy as the guards beside it: name the variable, fail up front.
+        throw new Error(
+          `${name} has no scheme. Set it to a full proxy URL ` +
+            `(e.g. http://proxy.example:8080) or unset ${name}.`
         );
       }
       configured = true;

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -6,6 +6,7 @@
 // differ from the underlying target. Returns CFn-shaped properties for the
 // classifier; undefined when the target can't be resolved/read (→ skipped).
 
+import { get as httpsGet } from 'node:https';
 import {
   ACMClient,
   DescribeCertificateCommand,
@@ -193,7 +194,8 @@ import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { ResourceGoneError } from '../aws-errors.js';
 import { partitionForRegion } from '../desired/template-adapter.js';
 import { pageResourceRecordSets, unescapeRoute53Name } from './child-enumerators.js';
-import { CLIENT_REQUEST_HANDLER, READ_RETRY } from './client-config.js';
+import { CLIENT_REQUEST_HANDLER, isProxyConfigured, READ_RETRY } from './client-config.js';
+import { ProxyRoutingAgent } from './proxy-routing-agent.js';
 import { isDefinitiveDenial } from './kms-aliases.js';
 import { hashCaBundle, sha256Hex } from './pem.js';
 
@@ -4068,19 +4070,9 @@ const supplementTrustStore: SupplementReader = async ({ physicalId, region }) =>
   const url = str(r.Location);
   if (!url) return undefined;
   try {
-    // The ONLY non-SDK HTTP call on the read path — the global undici `fetch`, which
-    // predates #1066 and so bypassed its timeout contract: undici bounds headers only
-    // at 300s, so a trickling / never-completing body hung `check` FOREVER (#1321).
-    // Bound it with the SAME #1066 requestTimeout the wired SDK clients use
-    // (CLIENT_REQUEST_HANDLER.requestTimeout) via AbortSignal.timeout — the one signal
-    // aborts BOTH the fetch and the subsequent `resp.text()` body read. On timeout the
-    // AbortError falls into this catch and DEGRADES to the documented best-effort skip
-    // (keep the CC model), never a fatal hang or a false-flag.
-    const resp = await fetch(url, {
-      signal: AbortSignal.timeout(CLIENT_REQUEST_HANDLER.requestTimeout),
-    });
-    if (!resp.ok) return undefined;
-    const hash = hashCaBundle(await resp.text());
+    const body = await fetchPresignedText(url);
+    if (body === undefined) return undefined;
+    const hash = hashCaBundle(body);
     return hash !== undefined ? { CaCertificatesBundleSha256: hash } : undefined;
   } catch {
     // Fetch/read failed (timeout/abort, network error, non-PEM body): the CA-bundle
@@ -4088,6 +4080,58 @@ const supplementTrustStore: SupplementReader = async ({ physicalId, region }) =>
     return undefined;
   }
 };
+
+// GET the TrustStore presigned S3 URL's body — the ONLY non-SDK HTTP call on the read
+// path. Two contracts meet here:
+//
+// - #1066/#1321 timeouts: the global undici `fetch` bounds headers only at 300s, so a
+//   trickling / never-completing body hung `check` FOREVER. Both branches below bound the
+//   whole exchange with the SAME requestTimeout the wired SDK clients use
+//   (CLIENT_REQUEST_HANDLER.requestTimeout) via AbortSignal.timeout — on the fetch branch
+//   the one signal aborts BOTH the fetch and the `resp.text()` body read. A timeout
+//   rejects into the caller's catch and DEGRADES to the documented best-effort skip.
+// - #1841 proxy: undici does not read HTTPS_PROXY (and takes an undici dispatcher, not an
+//   http.Agent, so the shared ProxyRoutingAgent cannot be handed to it). When a proxy is
+//   configured, make the same GET through node:https with a fresh ProxyRoutingAgent —
+//   NO_PROXY is still consulted per request, matching every SDK call — and destroy the
+//   agent after (its sockets must not outlive this one-shot read). When no proxy is
+//   configured, keep the exact pre-#1841 undici path, byte-identical.
+//
+// Returns undefined on a non-2xx status (the best-effort skip); rejects on timeout /
+// network errors, which the caller's catch also folds to the skip.
+async function fetchPresignedText(url: string): Promise<string | undefined> {
+  if (!isProxyConfigured()) {
+    const resp = await fetch(url, {
+      signal: AbortSignal.timeout(CLIENT_REQUEST_HANDLER.requestTimeout),
+    });
+    if (!resp.ok) return undefined;
+    return resp.text();
+  }
+  const agent = new ProxyRoutingAgent();
+  try {
+    return await new Promise<string | undefined>((resolvePromise, rejectPromise) => {
+      const req = httpsGet(
+        url,
+        { agent, signal: AbortSignal.timeout(CLIENT_REQUEST_HANDLER.requestTimeout) },
+        (res) => {
+          const status = res.statusCode ?? 0;
+          if (status < 200 || status >= 300) {
+            res.resume(); // drain so the socket is released
+            resolvePromise(undefined);
+            return;
+          }
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => resolvePromise(Buffer.concat(chunks).toString('utf-8')));
+          res.on('error', rejectPromise);
+        }
+      );
+      req.on('error', rejectPromise);
+    });
+  } finally {
+    agent.destroy();
+  }
+}
 
 // AWS::Lambda::Function — the function `Code` is writeOnly (Cloud Control returns a
 // pointer, never the bytes), so an out-of-band code swap (`aws lambda

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -4098,7 +4098,11 @@ const supplementTrustStore: SupplementReader = async ({ physicalId, region }) =>
 //   configured, keep the exact pre-#1841 undici path, byte-identical.
 //
 // Returns undefined on a non-2xx status (the best-effort skip); rejects on timeout /
-// network errors, which the caller's catch also folds to the skip.
+// network errors, which the caller's catch also folds to the skip. One knowing
+// divergence: undici follows 3xx redirects and the proxied branch treats them as the
+// non-2xx skip — a redirected presigned URL (rare: the API returns a regional
+// direct-object URL) loses the OPTIONAL digest under a proxy rather than mis-hashing,
+// which is exactly the documented degrade.
 async function fetchPresignedText(url: string): Promise<string | undefined> {
   if (!isProxyConfigured()) {
     const resp = await fetch(url, {

--- a/src/read/proxy-routing-agent.ts
+++ b/src/read/proxy-routing-agent.ts
@@ -1,0 +1,127 @@
+/**
+ * An `http.Agent` that routes each request through the environment's proxy, or
+ * direct, according to `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` (#1841).
+ *
+ * WHY A ROUTING AGENT AND NOT A PLAIN PROXY AGENT
+ *
+ * `NodeHttpHandler` picks its agent by PROTOCOL alone — `httpsAgent` for an
+ * `https:` request, `httpAgent` otherwise — and never consults the request's
+ * host. `https-proxy-agent` does not read `NO_PROXY` either. So a statically
+ * chosen proxy agent cannot express "this host is exempt", which is the whole
+ * of what `NO_PROXY` means. Deciding per REQUEST is the only place the host is
+ * known, and `agent-base` gives us that hook: when `connect()` returns an
+ * `http.Agent` rather than a socket, the base class delegates the request to it
+ * via `socket.addRequest(req, connectOpts)`.
+ *
+ * That delegation is also why the INNER agents carry `keepAlive` rather than
+ * this one: the sockets pool on whichever agent `connect()` hands back, so a
+ * `keepAlive` set only here would never be consulted.
+ *
+ * WHY THE INNER CACHE IS PER INSTANCE
+ *
+ * Node's `Agent.prototype.destroy()` walks `[this.freeSockets, this.sockets]`,
+ * and the second is the ACTIVE set — it aborts in-flight requests, not just
+ * idle sockets. `NodeHttpHandler.destroy()` forwards to `httpAgent` and
+ * `httpsAgent` unconditionally, external instances included, and cdkrd calls
+ * `client.destroy()` (the region probe in `commands/resolve-stacks.ts` does
+ * today, and nothing stops a future site). A module-global inner cache would
+ * therefore let one client's teardown kill another client's live request —
+ * which is also why `clientRequestHandler()` in `read/client-config.ts` builds
+ * a FRESH routing agent per client rather than sharing one. The cache is
+ * scoped to `this` and {@link destroy} forwards to the inner agents — without
+ * that forwarding the tunneled sockets would outlive the client and keep the
+ * process alive.
+ *
+ * The cost of not sharing is duplicate CONNECT + TLS handshakes where two
+ * clients talk to the same host. Pooling is per host either way, so sharing
+ * could never remove the FIRST handshake to each distinct AWS endpoint. This
+ * is also what the SDK already does: it builds a `keepAlive` agent per client
+ * on the unproxied path.
+ */
+
+import { Agent as HttpAgent } from 'node:http';
+import type { ClientRequest } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
+import { Agent, type AgentConnectOpts } from 'agent-base';
+import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { getProxyForUrl } from 'proxy-from-env';
+
+/**
+ * Applied to every inner agent.
+ *
+ * The SDK sets these itself, but ONLY when it is handed a plain option bag —
+ * an external `Agent` instance is passed through untouched
+ * (`@smithy/node-http-handler`'s `NodeHttpHandler` constructor). Since a
+ * routing agent IS such an instance, omitting them would silently drop
+ * connection reuse for every proxied run, and a concurrent `check` (gather.ts
+ * reads a whole stack with pooled concurrency) would renegotiate TLS per
+ * request.
+ */
+const INNER_AGENT_OPTIONS = { keepAlive: true, maxSockets: 50 } as const;
+
+/**
+ * Build the absolute URL `getProxyForUrl` needs from what `connect()` is given.
+ *
+ * An IPv6 literal is bracketed, or the `host:port` join produces a string no
+ * URL parser accepts (`https://::1:443`) and `NO_PROXY` could never match an
+ * IPv6 entry. Unreachable with AWS hostnames; handled because the alternative
+ * is a silent wrong answer rather than an error.
+ */
+function requestUrl(options: AgentConnectOpts): string {
+  const secure = options.secureEndpoint;
+  const rawHost = options.host ?? 'localhost';
+  const host = rawHost.includes(':') && !rawHost.startsWith('[') ? `[${rawHost}]` : rawHost;
+  const port = options.port ?? (secure ? 443 : 80);
+  return `${secure ? 'https' : 'http'}://${host}:${port}`;
+}
+
+export class ProxyRoutingAgent extends Agent {
+  /**
+   * Inner agents by `<scheme>|<proxy url or "direct">`.
+   *
+   * Keyed on the proxy URL and not merely on "proxied or not" because
+   * `NO_PROXY` is not the only thing that varies per host: `HTTP_PROXY` and
+   * `HTTPS_PROXY` may name different proxies, and a single agent bound to one
+   * of them would quietly send the other scheme's traffic to the wrong place.
+   */
+  private readonly innerAgents = new Map<string, HttpAgent>();
+
+  connect(_req: ClientRequest, options: AgentConnectOpts): HttpAgent {
+    const secure = options.secureEndpoint;
+    const proxyUrl = getProxyForUrl(requestUrl(options));
+    const key = `${secure ? 'https' : 'http'}|${proxyUrl || 'direct'}`;
+
+    const cached = this.innerAgents.get(key);
+    if (cached) return cached;
+
+    const agent = createInnerAgent(secure, proxyUrl);
+    this.innerAgents.set(key, agent);
+    return agent;
+  }
+
+  override destroy(): void {
+    for (const agent of this.innerAgents.values()) {
+      agent.destroy();
+    }
+    this.innerAgents.clear();
+    super.destroy();
+  }
+}
+
+function createInnerAgent(secure: boolean, proxyUrl: string): HttpAgent {
+  if (!proxyUrl) {
+    // No proxy for this host — `NO_PROXY` matched, or no proxy variable is set
+    // for this scheme. A plain agent keeps the request byte-identical to the
+    // unproxied path.
+    return secure ? new HttpsAgent(INNER_AGENT_OPTIONS) : new HttpAgent(INNER_AGENT_OPTIONS);
+  }
+  // `HttpsProxyAgent` opens a CONNECT tunnel and upgrades it to TLS, so the
+  // origin's own certificate is what gets validated; `HttpProxyAgent` rewrites
+  // the request line for a plain `http:` origin. Which one applies is decided
+  // by the ORIGIN's scheme, not the proxy's — a plain `http://` proxy serves
+  // both.
+  return secure
+    ? new HttpsProxyAgent<string>(proxyUrl, INNER_AGENT_OPTIONS)
+    : new HttpProxyAgent<string>(proxyUrl, INNER_AGENT_OPTIONS);
+}

--- a/src/read/proxy-routing-agent.ts
+++ b/src/read/proxy-routing-agent.ts
@@ -13,9 +13,19 @@
  * `http.Agent` rather than a socket, the base class delegates the request to it
  * via `socket.addRequest(req, connectOpts)`.
  *
- * That delegation is also why the INNER agents carry `keepAlive` rather than
- * this one: the sockets pool on whichever agent `connect()` hands back, so a
- * `keepAlive` set only here would never be consulted.
+ * KEEP-ALIVE NEEDS BOTH LAYERS, for different reasons. Sockets POOL on
+ * whichever agent `connect()` hands back, so the INNER agents carry
+ * `keepAlive` (and `maxSockets`) to do the pooling. But Node's
+ * `ClientRequest` decides the `Connection:` header from the agent handed to
+ * the REQUEST — this one — and with a default outer agent
+ * (`keepAlive: false`, `maxSockets: Infinity`) it stamps `Connection: close`
+ * on every request, so the response teardown destroys the socket before the
+ * inner pool ever keeps it (measured: two sequential proxied SDK calls opened
+ * two CONNECT tunnels; with the outer `keepAlive` they share one). Hence the
+ * constructor passes `keepAlive: true` UP as well; the outer `maxSockets`
+ * stays unlimited on purpose — concurrency is bounded by the inner agents,
+ * and an outer bound would add agent-base's fake-socket accounting for no
+ * benefit.
  *
  * WHY THE INNER CACHE IS PER INSTANCE
  *
@@ -77,6 +87,13 @@ function requestUrl(options: AgentConnectOpts): string {
 }
 
 export class ProxyRoutingAgent extends Agent {
+  constructor() {
+    // The outer `keepAlive` is what makes `ClientRequest` stamp
+    // `Connection: keep-alive` (see the header comment); the POOLING still
+    // happens on the inner agents `connect()` returns.
+    super({ keepAlive: true });
+  }
+
   /**
    * Inner agents by `<scheme>|<proxy url or "direct">`.
    *

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -11,12 +11,25 @@ import {
   StackSelectionStrategy,
   Toolkit,
 } from '@aws-cdk/toolkit-lib';
+import { isProxyConfigured } from '../read/client-config.js';
+import { ProxyRoutingAgent } from '../read/proxy-routing-agent.js';
 import { QuietIoHost } from './io-host.js';
 import {
   collectMissingRecursively,
   missingContextKeys,
   missingContextWarning,
 } from './missing-context.js';
+
+// #1841: toolkit-lib builds its OWN SDK clients (context lookups, environment
+// resolution) and, like the raw SDK, never reads HTTPS_PROXY on its own — its SdkConfig
+// takes an explicit agent instead. Route it through the same per-request
+// ProxyRoutingAgent the raw clients use (read/client-config.ts), so discovery and synth
+// work behind a corporate proxy too. Spread into the Toolkit's sdkConfig; empty when no
+// proxy is configured, so the unproxied path stays byte-identical to toolkit-lib's own
+// default (the SDK's per-client keepAlive agent). Exported for unit tests.
+export function proxyHttpOptions(): { httpOptions?: { agent: ProxyRoutingAgent } } {
+  return isProxyConfigured() ? { httpOptions: { agent: new ProxyRoutingAgent() } } : {};
+}
 
 export interface SynthOptions {
   region?: string | undefined;
@@ -265,6 +278,7 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
         ...(region && { defaultRegion: region }),
         ...(profile && { profile }),
       }),
+      ...proxyHttpOptions(),
     },
   });
 

--- a/tests/client-config-proxy-1841.test.ts
+++ b/tests/client-config-proxy-1841.test.ts
@@ -1,0 +1,233 @@
+import { readFileSync } from 'node:fs';
+import { createServer, type Server, type Socket } from 'node:net';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import {
+  CLIENT_REQUEST_HANDLER,
+  clientRequestHandler,
+  CLIENT_TIMEOUTS,
+  isProxyConfigured,
+  PROXY_ENV_VARS,
+  READ_RETRY,
+  resetProxyConfig,
+} from '../src/read/client-config.js';
+import { ProxyRoutingAgent } from '../src/read/proxy-routing-agent.js';
+import { proxyHttpOptions } from '../src/synth/synth.js';
+
+// #1841 — the AWS SDK v3 does not read HTTPS_PROXY / HTTP_PROXY / NO_PROXY, so cdkrd
+// could not run behind a corporate proxy: every client dialed out directly and failed.
+// clientRequestHandler() now hands every construction site (via the CLIENT_TIMEOUTS /
+// READ_RETRY getters) either the unchanged shared option bag (no proxy configured) or a
+// per-client NodeHttpHandler routing through ProxyRoutingAgent.
+
+const ALL_PROXY_VARS = [...PROXY_ENV_VARS, 'NO_PROXY', 'no_proxy'] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ALL_PROXY_VARS.map((name) => [name, process.env[name]]));
+  for (const name of ALL_PROXY_VARS) delete process.env[name];
+  resetProxyConfig();
+});
+
+afterEach(() => {
+  for (const name of ALL_PROXY_VARS) {
+    const value = saved[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  resetProxyConfig();
+});
+
+describe('#1841 clientRequestHandler', () => {
+  it('returns the unchanged shared option bag when no proxy is configured', () => {
+    // byte-identical unproxied path: the SDK wraps the same bag it always got
+    expect(clientRequestHandler()).toBe(CLIENT_REQUEST_HANDLER);
+    expect(isProxyConfigured()).toBe(false);
+  });
+
+  it('returns a NodeHttpHandler when a proxy variable is set', () => {
+    process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+    resetProxyConfig();
+    expect(clientRequestHandler()).toBeInstanceOf(NodeHttpHandler);
+  });
+
+  it.each(PROXY_ENV_VARS)('honours the %s spelling', (name) => {
+    process.env[name] = 'http://proxy.example:8080';
+    resetProxyConfig();
+    expect(isProxyConfigured()).toBe(true);
+  });
+
+  it('hands each client its OWN handler under a proxy (destroy-safety)', () => {
+    // NodeHttpHandler.destroy() destroys its agents unconditionally and Agent.destroy()
+    // aborts ACTIVE sockets, so a shared instance would let one client's teardown
+    // (resolve-stacks.ts' region probe calls client.destroy()) kill every other client's
+    // in-flight requests. Every getter read — i.e. every `...READ_RETRY` spread at a
+    // construction site — must therefore mint a fresh handler.
+    process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+    resetProxyConfig();
+    const first = READ_RETRY.requestHandler;
+    const second = READ_RETRY.requestHandler;
+    expect(first).toBeInstanceOf(NodeHttpHandler);
+    expect(second).toBeInstanceOf(NodeHttpHandler);
+    expect(first).not.toBe(second);
+    expect(CLIENT_TIMEOUTS.requestHandler).toBeInstanceOf(NodeHttpHandler);
+  });
+
+  it('rejects a whitespace-only proxy variable, naming it', () => {
+    // Treating it as SET fails later with a URL-parse error naming neither the variable
+    // nor cdkrd; treating it as UNSET silently goes direct — the very failure #1841 is
+    // about, with no hint that the variable was the cause.
+    process.env['https_proxy'] = '   ';
+    resetProxyConfig();
+    expect(() => isProxyConfigured()).toThrow(/https_proxy/);
+  });
+
+  it('examines every spelling before answering, so a typo beside a valid one still throws', () => {
+    process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+    process.env['http_proxy'] = '   ';
+    resetProxyConfig();
+    expect(() => isProxyConfigured()).toThrow(/http_proxy/);
+  });
+
+  it('resetProxyConfig() drops the memoized read', () => {
+    expect(isProxyConfigured()).toBe(false);
+    process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+    // memoized: the earlier answer stands until reset
+    expect(isProxyConfigured()).toBe(false);
+    resetProxyConfig();
+    expect(isProxyConfigured()).toBe(true);
+  });
+});
+
+describe("#1841 toolkit-lib's Toolkit gets the routing agent too", () => {
+  // toolkit-lib builds its own SDK clients (context lookups, environment resolution) and
+  // never reads HTTPS_PROXY — synthApp spreads proxyHttpOptions() into its sdkConfig.
+  it('is empty when no proxy is configured (byte-identical toolkit default)', () => {
+    expect(proxyHttpOptions()).toEqual({});
+  });
+
+  it('carries a ProxyRoutingAgent when a proxy is configured', () => {
+    process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+    resetProxyConfig();
+    const options = proxyHttpOptions();
+    expect(options.httpOptions?.agent).toBeInstanceOf(ProxyRoutingAgent);
+  });
+
+  it('synthApp actually spreads it into the Toolkit sdkConfig', () => {
+    // the helper being right proves nothing if the construction site drops the spread —
+    // pin the source until a Toolkit-level seam exists
+    const source = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'synth', 'synth.ts'),
+      'utf-8'
+    );
+    const toolkitConstruction = /new Toolkit\(\{[\s\S]*?\.\.\.proxyHttpOptions\(\)/;
+    expect(source).toMatch(toolkitConstruction);
+  });
+});
+
+// End-to-end, offline: a REAL SDK client built exactly the way every cdkrd construction
+// site builds one (`...READ_RETRY`) must route its request through the proxy the
+// environment names — and NOT through it when NO_PROXY exempts the host. Asserting on
+// what a local TCP server actually RECEIVES proves the whole chain (getter → handler →
+// routing agent → proxy selection) with no network and no AWS.
+describe('#1841 a READ_RETRY client routes through the proxy environment', () => {
+  let proxy: Server;
+  let proxyPort = 0;
+  let proxyReceived: string[];
+  const sockets: Socket[] = [];
+
+  beforeEach(async () => {
+    proxyReceived = [];
+    proxy = createServer((sock) => {
+      sockets.push(sock);
+      sock.once('data', (chunk) => {
+        proxyReceived.push(chunk.toString('utf-8'));
+        sock.destroy(); // enough evidence — fail the request fast
+      });
+    });
+    await new Promise<void>((resolve) => proxy.listen(0, '127.0.0.1', resolve));
+    const addr = proxy.address();
+    proxyPort = typeof addr === 'object' && addr ? addr.port : 0;
+  });
+
+  afterEach(async () => {
+    for (const s of sockets) s.destroy();
+    sockets.length = 0;
+    await new Promise<void>((resolve) => proxy.close(() => resolve()));
+  });
+
+  function readClient(endpoint: string): CloudControlClient {
+    return new CloudControlClient({
+      region: 'us-east-1',
+      endpoint,
+      ...READ_RETRY,
+      // AFTER the spread, so the static keys actually win over READ_RETRY's provider
+      // chain: credential-free resolution keeps the FIRST network exchange the API call
+      // itself, which is the exchange these tests observe
+      credentials: { accessKeyId: 'x', secretAccessKey: 'x' },
+      maxAttempts: 1, // no retries — one observed connection is the whole story
+    });
+  }
+
+  it('opens a CONNECT tunnel to HTTPS_PROXY for an https endpoint', async () => {
+    process.env['HTTPS_PROXY'] = `http://127.0.0.1:${proxyPort}`;
+    resetProxyConfig();
+    const client = readClient('https://cdkrd-proxy-e2e.invalid');
+    await expect(
+      client.send(new GetResourceCommand({ TypeName: 'AWS::SNS::Topic', Identifier: 'x' }))
+    ).rejects.toThrow();
+    // the request reached the PROXY as a tunnel request for the ENDPOINT host — the
+    // hostname never resolves (.invalid), which is itself proof the route was the proxy
+    expect(proxyReceived.length).toBeGreaterThan(0);
+    expect(proxyReceived[0]).toMatch(/^CONNECT cdkrd-proxy-e2e\.invalid:443/);
+    // the proxied handler still carries the #1066 timeout contract — the request above
+    // resolved the handler's lazy config, so it is readable now
+    const handler = client.config.requestHandler;
+    expect(handler).toBeInstanceOf(NodeHttpHandler);
+    const configs = (handler as NodeHttpHandler).httpHandlerConfigs();
+    expect(configs.connectionTimeout).toBe(CLIENT_REQUEST_HANDLER.connectionTimeout);
+    expect(configs.requestTimeout).toBe(CLIENT_REQUEST_HANDLER.requestTimeout);
+    expect(configs.throwOnRequestTimeout).toBe(CLIENT_REQUEST_HANDLER.throwOnRequestTimeout);
+    client.destroy();
+  });
+
+  it('goes DIRECT when NO_PROXY names the endpoint host', async () => {
+    process.env['HTTPS_PROXY'] = `http://127.0.0.1:${proxyPort}`;
+    process.env['HTTP_PROXY'] = `http://127.0.0.1:${proxyPort}`;
+    process.env['NO_PROXY'] = '127.0.0.1';
+    resetProxyConfig();
+
+    // a second local server plays the exempt endpoint itself
+    const received: string[] = [];
+    const svcSockets: Socket[] = [];
+    const svc = createServer((sock) => {
+      svcSockets.push(sock);
+      sock.once('data', (chunk) => {
+        received.push(chunk.toString('utf-8'));
+        sock.destroy();
+      });
+    });
+    await new Promise<void>((resolve) => svc.listen(0, '127.0.0.1', resolve));
+    const addr = svc.address();
+    const svcPort = typeof addr === 'object' && addr ? addr.port : 0;
+
+    try {
+      const client = readClient(`http://127.0.0.1:${svcPort}`);
+      await expect(
+        client.send(new GetResourceCommand({ TypeName: 'AWS::SNS::Topic', Identifier: 'x' }))
+      ).rejects.toThrow();
+      client.destroy();
+      // the endpoint got an ORIGIN-FORM request line (direct), not a proxy's
+      // absolute-form one, and the proxy saw nothing at all
+      expect(received.length).toBeGreaterThan(0);
+      expect(received[0]).toMatch(/^POST \//);
+      expect(proxyReceived).toHaveLength(0);
+    } finally {
+      for (const s of svcSockets) s.destroy();
+      await new Promise<void>((resolve) => svc.close(() => resolve()));
+    }
+  });
+});

--- a/tests/client-config-proxy-1841.test.ts
+++ b/tests/client-config-proxy-1841.test.ts
@@ -92,6 +92,14 @@ describe('#1841 clientRequestHandler', () => {
     expect(() => isProxyConfigured()).toThrow(/http_proxy/);
   });
 
+  it('rejects a SOCKS proxy URL up front, naming the variable', () => {
+    // the routing agent speaks HTTP CONNECT only — accepting socks:// here would fail
+    // every AWS call mid-run with an opaque proxy-protocol error instead
+    process.env['ALL_PROXY'] = 'socks5://127.0.0.1:1080';
+    resetProxyConfig();
+    expect(() => isProxyConfigured()).toThrow(/ALL_PROXY.*SOCKS/);
+  });
+
   it('resetProxyConfig() drops the memoized read', () => {
     expect(isProxyConfigured()).toBe(false);
     process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
@@ -118,13 +126,28 @@ describe("#1841 toolkit-lib's Toolkit gets the routing agent too", () => {
 
   it('synthApp actually spreads it into the Toolkit sdkConfig', () => {
     // the helper being right proves nothing if the construction site drops the spread —
-    // pin the source until a Toolkit-level seam exists
+    // pin the source until a Toolkit-level seam exists. The span is the BALANCED
+    // argument of `new Toolkit(`, not an unbounded regex, so a spread that migrates
+    // elsewhere in the file cannot satisfy this by accident.
     const source = readFileSync(
       join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'synth', 'synth.ts'),
       'utf-8'
     );
-    const toolkitConstruction = /new Toolkit\(\{[\s\S]*?\.\.\.proxyHttpOptions\(\)/;
-    expect(source).toMatch(toolkitConstruction);
+    const start = source.indexOf('new Toolkit(');
+    expect(start).toBeGreaterThanOrEqual(0);
+    let depth = 0;
+    let end = source.length;
+    for (let i = start + 'new Toolkit'.length; i < source.length; i++) {
+      if (source[i] === '(') depth++;
+      else if (source[i] === ')') {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    expect(source.slice(start, end)).toContain('...proxyHttpOptions()');
   });
 });
 

--- a/tests/client-config-proxy-1841.test.ts
+++ b/tests/client-config-proxy-1841.test.ts
@@ -100,6 +100,16 @@ describe('#1841 clientRequestHandler', () => {
     expect(() => isProxyConfigured()).toThrow(/ALL_PROXY.*SOCKS/);
   });
 
+  it('rejects a scheme-less proxy value up front, naming the variable', () => {
+    // proxy-from-env prepends the REQUEST's scheme to a scheme-less value, so an https
+    // request would turn `proxy.example:8080` into an https:// proxy URL and open a TLS
+    // handshake to a plaintext port — a mid-run `wrong version number` error naming
+    // neither the variable nor cdkrd.
+    process.env['HTTPS_PROXY'] = 'proxy.example:8080';
+    resetProxyConfig();
+    expect(() => isProxyConfigured()).toThrow(/HTTPS_PROXY.*scheme/);
+  });
+
   it('resetProxyConfig() drops the memoized read', () => {
     expect(isProxyConfigured()).toBe(false);
     process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';

--- a/tests/client-cred-timeout-1319.test.ts
+++ b/tests/client-cred-timeout-1319.test.ts
@@ -5,6 +5,8 @@ import {
   CLIENT_CREDENTIALS,
   CLIENT_REQUEST_HANDLER,
   CLIENT_TIMEOUTS,
+  PROXY_ENV_VARS,
+  resetProxyConfig,
 } from '../src/read/client-config.js';
 
 // #1319 — credential resolution had NO timeouts. CLIENT_CREDENTIALS called fromNodeProviderChain
@@ -24,10 +26,28 @@ describe('#1319 CLIENT_REQUEST_HANDLER is the single source of truth', () => {
     expect(CLIENT_REQUEST_HANDLER.throwOnRequestTimeout).toBe(true);
   });
 
-  it('CLIENT_TIMEOUTS reuses the SAME shared requestHandler reference', () => {
+  it('CLIENT_TIMEOUTS reuses the SAME shared requestHandler reference (unproxied)', () => {
     // one source of truth — a regression that gives the wired clients a different handler
-    // (or drops it) fails here
-    expect(CLIENT_TIMEOUTS.requestHandler).toBe(CLIENT_REQUEST_HANDLER);
+    // (or drops it) fails here. Pinned to the UNPROXIED environment: since #1841 the
+    // getter hands out per-client NodeHttpHandlers when a proxy variable is set (see
+    // tests/client-config-proxy-1841.test.ts), so a developer shell exporting HTTPS_PROXY
+    // must not decide this assertion.
+    const saved: Record<string, string | undefined> = {};
+    for (const name of PROXY_ENV_VARS) {
+      saved[name] = process.env[name];
+      delete process.env[name];
+    }
+    resetProxyConfig();
+    try {
+      expect(CLIENT_TIMEOUTS.requestHandler).toBe(CLIENT_REQUEST_HANDLER);
+    } finally {
+      for (const name of PROXY_ENV_VARS) {
+        const value = saved[name];
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+      resetProxyConfig();
+    }
   });
 });
 

--- a/tests/client-proxy-conformance-1841.test.ts
+++ b/tests/client-proxy-conformance-1841.test.ts
@@ -43,22 +43,38 @@ function walk(dir: string): string[] {
   return out;
 }
 
-/** Local names of `*Client` identifiers imported from `@aws-sdk/client-*` packages. */
-function sdkClientNames(source: string): Set<string> {
-  const names = new Set<string>();
-  const importRe = /import\s+(?:type\s+)?\{([\s\S]*?)\}\s+from\s+'@aws-sdk\/client-[^']+'/g;
+interface SdkImports {
+  /** Local names of `*Client` identifiers imported from `@aws-sdk/client-*` packages. */
+  clientNames: Set<string>;
+  /** Every VALUE (non-type) exported name imported from those packages. */
+  valueExports: string[];
+}
+
+function sdkImports(source: string): SdkImports {
+  const clientNames = new Set<string>();
+  const valueExports: string[] = [];
+  // `[^}]*` (never `[\s\S]*?`) is load-bearing: an unanchored non-greedy span can start
+  // at a PRECEDING non-SDK brace import (e.g. `import { get } from 'node:https';`) and
+  // swallow everything up to the first `} from '@aws-sdk/client-…'`, silently dropping
+  // that package's clients from the population — measured on this very branch, where the
+  // node:https import ahead of the ACM import made `new ACMClient(...)` invisible.
+  const importRe = /import\s+(type\s+)?\{([^}]*)\}\s*from\s*'@aws-sdk\/client-[^']+'/g;
   for (const m of source.matchAll(importRe)) {
-    for (const rawSpec of m[1]!.split(',')) {
-      const spec = rawSpec.trim().replace(/^type\s+/, '');
-      if (spec === '') continue;
+    const typeOnlyImport = m[1] !== undefined;
+    for (const rawSpec of m[2]!.split(',')) {
+      const trimmed = rawSpec.trim();
+      if (trimmed === '') continue;
+      const typeSpec = typeOnlyImport || /^type\s/.test(trimmed);
+      const spec = trimmed.replace(/^type\s+/, '');
       const asMatch = /^(\S+)\s+as\s+(\S+)$/.exec(spec);
       const local = asMatch ? asMatch[2]! : spec;
       const exported = asMatch ? asMatch[1]! : spec;
       // the EXPORTED name decides SDK-client-ness; the LOCAL name is what `new` uses
-      if (exported.endsWith('Client')) names.add(local);
+      if (exported.endsWith('Client')) clientNames.add(local);
+      if (!typeSpec) valueExports.push(exported);
     }
   }
-  return names;
+  return { clientNames, valueExports };
 }
 
 /** The balanced-paren argument span of `new <name>(` starting at `openParen`. */
@@ -86,7 +102,7 @@ function collectSites(): Site[] {
   const sites: Site[] = [];
   for (const path of walk(SRC)) {
     const source = readFileSync(path, 'utf-8');
-    const names = sdkClientNames(source);
+    const names = sdkImports(source).clientNames;
     if (names.size === 0) continue;
     const rel = path.slice(SRC.length + 1);
     for (const m of source.matchAll(/new\s+([A-Za-z0-9_$]+)\s*\(/g)) {
@@ -108,8 +124,8 @@ describe('#1841 every AWS SDK client construction carries the shared config', ()
   const sites = collectSites();
 
   it('finds the population (floors against a collapsed parse)', () => {
-    // calibrated 2026-09-02: 188 sites across 8 files. A parser regression that finds
-    // nothing must fail HERE, loudly, not report "no gaps".
+    // calibrated 2026-09-02 (post regex fix): 188 sites across 9 files. A parser
+    // regression that finds nothing must fail HERE, loudly, not report "no gaps".
     expect(sites.length).toBeGreaterThanOrEqual(150);
     expect(new Set(sites.map((s) => s.file)).size).toBeGreaterThanOrEqual(6);
   });
@@ -124,6 +140,27 @@ describe('#1841 every AWS SDK client construction carries the shared config', ()
         'the #1841 proxy routing — spread READ_RETRY (read path) or CLIENT_TIMEOUTS ' +
         '(write path), or add a justified ALLOWED entry'
     ).toEqual([]);
+  });
+
+  it('no aggregate SDK client classes sneak past the Client-suffix binding', () => {
+    // The scan binds on the `Client` suffix, so the v2-style aggregate classes each
+    // package also exports (`S3`, `EC2`, `Lambda` — subclasses of `XClient`) would be
+    // INVISIBLE to it: a `new S3({ region })` is a real transport construction the
+    // fence could never flag. Close the hole at the IMPORT instead: every VALUE
+    // specifier imported from `@aws-sdk/client-*` must be a Client, a Command, or an
+    // Exception class (the three shapes the tree uses). The day an aggregate class —
+    // or a paginator/waiter helper — is imported, this fails loudly and the scanner
+    // gets extended deliberately rather than silently bypassed.
+    const offenders: string[] = [];
+    for (const path of walk(SRC)) {
+      const source = readFileSync(path, 'utf-8');
+      for (const exported of sdkImports(source).valueExports) {
+        if (!/(Client|Command|Exception)$/.test(exported)) {
+          offenders.push(`${path.slice(SRC.length + 1)}: ${exported}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 
   it('the ALLOWED list stays honest (each entry matches EXACTLY one live gap)', () => {

--- a/tests/client-proxy-conformance-1841.test.ts
+++ b/tests/client-proxy-conformance-1841.test.ts
@@ -1,0 +1,141 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+// #1841 — every AWS SDK client constructed under src/ must spread the shared config
+// (READ_RETRY or CLIENT_TIMEOUTS), because that spread is what carries the
+// requestHandler getter: the #1066 timeouts AND the proxy routing. A client built
+// without it silently dials out directly, which behind a corporate proxy fails at the
+// first call with a certificate error naming neither the proxy nor the client — invisible
+// in review and to every unit test, and the next new SDK-override reader or revert writer
+// is exactly where it would decay. cdkd fences the same invariant with
+// scripts/check-aws-client-defaults.ts; here a unit test is enough because cdkrd has ONE
+// shared config module instead of a per-site helper call.
+//
+// The scan binds to the IMPORT plus the `Client` suffix, not to either alone: the import
+// alone matches commands/paginators from the same packages, and the suffix alone matches
+// non-SDK classes named `*Client`. Aliased imports (`S3Client as Foo`) are tracked by
+// their LOCAL name.
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+// The one construction allowed OUTSIDE the shared config, with why. An entry here is
+// LOAD-BEARING in both directions: a site that starts conforming (or disappears) makes
+// the assertion on ALLOWED below fail, so the list can only shrink.
+const ALLOWED: ReadonlyArray<{ file: string; identifier: string; reason: string }> = [
+  {
+    file: 'commands/resolve-stacks.ts',
+    identifier: 'CloudControlClient',
+    // the region probe: config.region() resolves from env + ini files, no request is
+    // ever sent — and it calls client.destroy(), which must not tear down shared state
+    reason: 'region probe, never sends a request',
+  },
+];
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(p));
+    else if (entry.name.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+/** Local names of `*Client` identifiers imported from `@aws-sdk/client-*` packages. */
+function sdkClientNames(source: string): Set<string> {
+  const names = new Set<string>();
+  const importRe = /import\s+(?:type\s+)?\{([\s\S]*?)\}\s+from\s+'@aws-sdk\/client-[^']+'/g;
+  for (const m of source.matchAll(importRe)) {
+    for (const rawSpec of m[1]!.split(',')) {
+      const spec = rawSpec.trim().replace(/^type\s+/, '');
+      if (spec === '') continue;
+      const asMatch = /^(\S+)\s+as\s+(\S+)$/.exec(spec);
+      const local = asMatch ? asMatch[2]! : spec;
+      const exported = asMatch ? asMatch[1]! : spec;
+      // the EXPORTED name decides SDK-client-ness; the LOCAL name is what `new` uses
+      if (exported.endsWith('Client')) names.add(local);
+    }
+  }
+  return names;
+}
+
+/** The balanced-paren argument span of `new <name>(` starting at `openParen`. */
+function argumentSpan(source: string, openParen: number): string {
+  let depth = 0;
+  for (let i = openParen; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return source.slice(openParen + 1, i);
+    }
+  }
+  return source.slice(openParen + 1); // unbalanced — return the rest, the check still runs
+}
+
+interface Site {
+  file: string;
+  identifier: string;
+  line: number;
+  conforms: boolean;
+}
+
+function collectSites(): Site[] {
+  const sites: Site[] = [];
+  for (const path of walk(SRC)) {
+    const source = readFileSync(path, 'utf-8');
+    const names = sdkClientNames(source);
+    if (names.size === 0) continue;
+    const rel = path.slice(SRC.length + 1);
+    for (const m of source.matchAll(/new\s+([A-Za-z0-9_$]+)\s*\(/g)) {
+      const identifier = m[1]!;
+      if (!names.has(identifier)) continue;
+      const span = argumentSpan(source, m.index! + m[0].length - 1);
+      sites.push({
+        file: rel,
+        identifier,
+        line: source.slice(0, m.index!).split('\n').length,
+        conforms: span.includes('READ_RETRY') || span.includes('CLIENT_TIMEOUTS'),
+      });
+    }
+  }
+  return sites;
+}
+
+describe('#1841 every AWS SDK client construction carries the shared config', () => {
+  const sites = collectSites();
+
+  it('finds the population (floors against a collapsed parse)', () => {
+    // calibrated 2026-09-02: 188 sites across 8 files. A parser regression that finds
+    // nothing must fail HERE, loudly, not report "no gaps".
+    expect(sites.length).toBeGreaterThanOrEqual(150);
+    expect(new Set(sites.map((s) => s.file)).size).toBeGreaterThanOrEqual(6);
+  });
+
+  it('every construction spreads READ_RETRY or CLIENT_TIMEOUTS, or is explicitly allowed', () => {
+    const violations = sites.filter(
+      (s) => !s.conforms && !ALLOWED.some((a) => a.file === s.file && a.identifier === s.identifier)
+    );
+    expect(
+      violations.map((v) => `${v.file}:${v.line} new ${v.identifier}(...)`),
+      'an AWS SDK client built without the shared config bypasses the #1066 timeouts AND ' +
+        'the #1841 proxy routing — spread READ_RETRY (read path) or CLIENT_TIMEOUTS ' +
+        '(write path), or add a justified ALLOWED entry'
+    ).toEqual([]);
+  });
+
+  it('the ALLOWED list stays honest (each entry matches EXACTLY one live gap)', () => {
+    for (const a of ALLOWED) {
+      const matches = sites.filter(
+        (s) => s.file === a.file && s.identifier === a.identifier && !s.conforms
+      );
+      expect(
+        matches,
+        `${a.file} / ${a.identifier}: a stale ALLOWED entry hides the next real gap in ` +
+          'the same file — remove or tighten it'
+      ).toHaveLength(1);
+    }
+  });
+});

--- a/tests/client-timeouts-1066.test.ts
+++ b/tests/client-timeouts-1066.test.ts
@@ -1,20 +1,48 @@
 import { createServer, type Server } from 'node:net';
 import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
-import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
-import { CLIENT_TIMEOUTS, READ_RETRY } from '../src/read/client-config.js';
+import { afterEach, afterAll, beforeEach, beforeAll, describe, expect, it } from 'vite-plus/test';
+import {
+  CLIENT_REQUEST_HANDLER,
+  CLIENT_TIMEOUTS,
+  PROXY_ENV_VARS,
+  READ_RETRY,
+  resetProxyConfig,
+} from '../src/read/client-config.js';
 
 // #1066 — no cdkrd AWS client configured any timeout, so a stalled TCP connect or a
 // connected-but-silent server hung check/record/revert FOREVER. CLIENT_TIMEOUTS carries the
 // connection + per-request timeouts applied to every client (READ clients via READ_RETRY,
 // revert WRITE clients spread directly).
-describe('#1066 CLIENT_TIMEOUTS config', () => {
-  it('carries a connectionTimeout and requestTimeout', () => {
-    expect(typeof CLIENT_TIMEOUTS.requestHandler.connectionTimeout).toBe('number');
-    expect(typeof CLIENT_TIMEOUTS.requestHandler.requestTimeout).toBe('number');
-    expect(CLIENT_TIMEOUTS.requestHandler.connectionTimeout).toBeGreaterThan(0);
-    expect(CLIENT_TIMEOUTS.requestHandler.requestTimeout).toBeGreaterThan(0);
+//
+// Since #1841 `requestHandler` is a getter (proxied runs get a per-client NodeHttpHandler);
+// this suite asserts the UNPROXIED contract, so it pins the environment to unproxied
+// rather than inheriting whatever the developer's shell exports.
+describe('#1066 CLIENT_TIMEOUTS config (unproxied)', () => {
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const name of PROXY_ENV_VARS) {
+      saved[name] = process.env[name];
+      delete process.env[name];
+    }
+    resetProxyConfig();
+  });
+  afterEach(() => {
+    for (const name of PROXY_ENV_VARS) {
+      const value = saved[name];
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    resetProxyConfig();
+  });
+
+  it('hands every client the shared option bag with connectionTimeout and requestTimeout', () => {
+    // unproxied, the getter returns the SAME shared bag as before #1841 — byte-identical
+    // client config for every existing user
+    expect(CLIENT_TIMEOUTS.requestHandler).toBe(CLIENT_REQUEST_HANDLER);
+    expect(CLIENT_REQUEST_HANDLER.connectionTimeout).toBeGreaterThan(0);
+    expect(CLIENT_REQUEST_HANDLER.requestTimeout).toBeGreaterThan(0);
     // without this the requestTimeout only WARNS and the request keeps hanging
-    expect(CLIENT_TIMEOUTS.requestHandler.throwOnRequestTimeout).toBe(true);
+    expect(CLIENT_REQUEST_HANDLER.throwOnRequestTimeout).toBe(true);
   });
 
   it('READ_RETRY keeps the adaptive read retry AND inherits the timeouts', () => {

--- a/tests/crossregion-ssm-timeout-1286.test.ts
+++ b/tests/crossregion-ssm-timeout-1286.test.ts
@@ -20,8 +20,13 @@ import {
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
 import { mockClient } from 'aws-sdk-client-mock';
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { CLIENT_TIMEOUTS, READ_RETRY } from '../src/read/client-config.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import {
+  CLIENT_TIMEOUTS,
+  PROXY_ENV_VARS,
+  READ_RETRY,
+  resetProxyConfig,
+} from '../src/read/client-config.js';
 
 // Capture every SSMClient config the code under test constructs. `vi.hoisted` so the array is
 // live when the mock factory (hoisted above the imports) runs.
@@ -110,6 +115,25 @@ function mockCfn(account: string): CloudFormationClient {
 }
 
 describe('#1286 crossRegion SSM prefetch client gets READ_RETRY (timeouts + adaptive retry)', () => {
+  // The `.toBe(CLIENT_TIMEOUTS.requestHandler)` identity asserts below hold only on the
+  // UNPROXIED path (#1841: under a proxy the getter mints a fresh handler per read), so
+  // pin the environment rather than inheriting the developer shell's proxy exports.
+  const savedProxyEnv: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const name of PROXY_ENV_VARS) {
+      savedProxyEnv[name] = process.env[name];
+      delete process.env[name];
+    }
+    resetProxyConfig();
+  });
+  afterEach(() => {
+    for (const name of PROXY_ENV_VARS) {
+      const value = savedProxyEnv[name];
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    resetProxyConfig();
+  });
   beforeEach(() => {
     captured.configs.length = 0;
   });

--- a/tests/proxy-routing-agent.test.ts
+++ b/tests/proxy-routing-agent.test.ts
@@ -68,6 +68,15 @@ describe('ProxyRoutingAgent', () => {
       agent.destroy();
     });
 
+    it('falls back to ALL_PROXY when the scheme-specific variables are unset', () => {
+      // The one PROXY_ENV_VARS entry no other test exercises at ROUTING time —
+      // proxy-from-env's fallback line, not just the presence check.
+      process.env['ALL_PROXY'] = 'http://fallback.example:8080';
+      const agent = new ProxyRoutingAgent();
+      expect(route(agent, 'sts.us-east-1.amazonaws.com').constructor.name).toBe('HttpsProxyAgent');
+      agent.destroy();
+    });
+
     it('routes an http request through HTTP_PROXY, not HTTPS_PROXY', () => {
       // The bug a `HTTPS_PROXY || HTTP_PROXY` fallback chain produces: with
       // only HTTPS_PROXY set, plain-http traffic must NOT be sent to it.

--- a/tests/proxy-routing-agent.test.ts
+++ b/tests/proxy-routing-agent.test.ts
@@ -1,0 +1,197 @@
+import { Agent as HttpAgent } from 'node:http';
+import type { ClientRequest } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+
+import { ProxyRoutingAgent } from '../src/read/proxy-routing-agent.js';
+
+const PROXY_VARS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy',
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(PROXY_VARS.map((name) => [name, process.env[name]]));
+  for (const name of PROXY_VARS) delete process.env[name];
+});
+
+afterEach(() => {
+  for (const name of PROXY_VARS) {
+    const value = saved[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+const REQ = {} as ClientRequest;
+
+function route(agent: ProxyRoutingAgent, host: string, secure = true, port?: number): HttpAgent {
+  return agent.connect(REQ, {
+    host,
+    port: port ?? (secure ? 443 : 80),
+    secureEndpoint: secure,
+  } as never);
+}
+
+/**
+ * Issue #1841.
+ *
+ * `NodeHttpHandler` picks an agent by PROTOCOL alone and never looks at the
+ * host, and `https-proxy-agent` does not read `NO_PROXY`, so a statically
+ * chosen proxy agent cannot express a host exemption. Routing per request is
+ * the only place the host is known.
+ */
+describe('ProxyRoutingAgent', () => {
+  describe('routing', () => {
+    it('returns a plain agent when nothing is configured', () => {
+      const agent = new ProxyRoutingAgent();
+      const inner = route(agent, 'sts.us-east-1.amazonaws.com');
+      expect(inner).toBeInstanceOf(HttpsAgent);
+      expect(inner.constructor.name).toBe('Agent');
+      agent.destroy();
+    });
+
+    it('routes an https request through HTTPS_PROXY', () => {
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      const agent = new ProxyRoutingAgent();
+      expect(route(agent, 'sts.us-east-1.amazonaws.com').constructor.name).toBe('HttpsProxyAgent');
+      agent.destroy();
+    });
+
+    it('routes an http request through HTTP_PROXY, not HTTPS_PROXY', () => {
+      // The bug a `HTTPS_PROXY || HTTP_PROXY` fallback chain produces: with
+      // only HTTPS_PROXY set, plain-http traffic must NOT be sent to it.
+      process.env['HTTPS_PROXY'] = 'http://secure-only.example:8080';
+      const agent = new ProxyRoutingAgent();
+      const inner = route(agent, 'example.internal', false);
+      expect(inner).toBeInstanceOf(HttpAgent);
+      expect(inner.constructor.name).toBe('Agent');
+      agent.destroy();
+    });
+
+    it('honours NO_PROXY, which is the whole reason for routing per request', () => {
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      process.env['NO_PROXY'] = 'vpce.internal';
+      const agent = new ProxyRoutingAgent();
+      expect(route(agent, 'vpce.internal').constructor.name).toBe('Agent');
+      expect(route(agent, 'sts.us-east-1.amazonaws.com').constructor.name).toBe('HttpsProxyAgent');
+      agent.destroy();
+    });
+
+    it('matches a NO_PROXY entry EXACTLY unless it starts with `.` or `*`', () => {
+      // Documented in README.md, and different from curl. Getting this wrong
+      // produces a config that silently proxies what the user believed was
+      // exempt.
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      process.env['NO_PROXY'] = 'example.com';
+      const agent = new ProxyRoutingAgent();
+      expect(route(agent, 'example.com').constructor.name).toBe('Agent');
+      expect(route(agent, 'api.example.com').constructor.name).toBe('HttpsProxyAgent');
+      agent.destroy();
+
+      process.env['NO_PROXY'] = '.example.com';
+      const suffix = new ProxyRoutingAgent();
+      expect(route(suffix, 'api.example.com').constructor.name).toBe('Agent');
+      // `.example.com` does NOT cover the apex — covering both takes two entries.
+      expect(route(suffix, 'example.com').constructor.name).toBe('HttpsProxyAgent');
+      suffix.destroy();
+    });
+
+    it('silently ignores a CIDR NO_PROXY entry, so IPs must be listed literally', () => {
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      process.env['NO_PROXY'] = '10.0.0.0/8';
+      const cidr = new ProxyRoutingAgent();
+      expect(route(cidr, '10.1.2.3').constructor.name).toBe('HttpsProxyAgent');
+      cidr.destroy();
+
+      process.env['NO_PROXY'] = '10.1.2.3';
+      const literal = new ProxyRoutingAgent();
+      expect(route(literal, '10.1.2.3').constructor.name).toBe('Agent');
+      literal.destroy();
+    });
+  });
+
+  describe('inner agents', () => {
+    it('carries keepAlive and maxSockets, which the SDK does not apply to an instance', () => {
+      // `NodeHttpHandler` sets those defaults only on a plain option bag and
+      // passes an external Agent through untouched, so omitting them here would
+      // renegotiate TLS per request on a concurrent `check`.
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      const agent = new ProxyRoutingAgent();
+      const inner = route(agent, 'sts.us-east-1.amazonaws.com') as HttpAgent & {
+        keepAlive?: boolean;
+        maxSockets?: number;
+      };
+      expect(inner.keepAlive).toBe(true);
+      expect(inner.maxSockets).toBe(50);
+      agent.destroy();
+    });
+
+    it('reuses one inner agent per route, so sockets actually pool', () => {
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      const agent = new ProxyRoutingAgent();
+      expect(route(agent, 'a.amazonaws.com')).toBe(route(agent, 'b.amazonaws.com'));
+      agent.destroy();
+    });
+
+    it('keeps separate inner agents per scheme', () => {
+      process.env['HTTPS_PROXY'] = 'http://secure.example:8080';
+      process.env['HTTP_PROXY'] = 'http://plain.example:8080';
+      const agent = new ProxyRoutingAgent();
+      expect(route(agent, 'x.amazonaws.com', true)).not.toBe(route(agent, 'x.internal', false));
+      agent.destroy();
+    });
+
+    it('does NOT share inner agents between instances', () => {
+      // The correctness property, not an optimisation: Node's `Agent.destroy()`
+      // walks `[freeSockets, sockets]` and the second is the ACTIVE set, and
+      // `NodeHttpHandler.destroy()` forwards unconditionally. A module-global
+      // cache would let one client's teardown abort another client's in-flight
+      // request — and cdkrd calls `client.destroy()` (resolve-stacks.ts).
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      const first = new ProxyRoutingAgent();
+      const second = new ProxyRoutingAgent();
+      expect(route(first, 'sts.us-east-1.amazonaws.com')).not.toBe(
+        route(second, 'sts.us-east-1.amazonaws.com')
+      );
+      first.destroy();
+      second.destroy();
+    });
+
+    it('a destroy on one instance leaves another instance usable', () => {
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      const first = new ProxyRoutingAgent();
+      const second = new ProxyRoutingAgent();
+      const survivor = route(second, 'sts.us-east-1.amazonaws.com');
+      route(first, 'sts.us-east-1.amazonaws.com');
+      first.destroy();
+      expect(route(second, 'sts.us-east-1.amazonaws.com')).toBe(survivor);
+      second.destroy();
+    });
+
+    it('forwards destroy() to the inner agents', () => {
+      // Without the forwarding, tunneled sockets outlive the client that opened
+      // them and keep the process alive.
+      process.env['HTTPS_PROXY'] = 'http://proxy.example:8080';
+      const agent = new ProxyRoutingAgent();
+      const inner = route(agent, 'sts.us-east-1.amazonaws.com');
+      let destroyed = false;
+      const original = inner.destroy.bind(inner);
+      inner.destroy = (): void => {
+        destroyed = true;
+        original();
+      };
+      agent.destroy();
+      expect(destroyed).toBe(true);
+    });
+  });
+});

--- a/tests/proxy-routing-agent.test.ts
+++ b/tests/proxy-routing-agent.test.ts
@@ -1,6 +1,7 @@
-import { Agent as HttpAgent } from 'node:http';
+import { Agent as HttpAgent, createServer, get as httpGet } from 'node:http';
 import type { ClientRequest } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
+import type { Socket } from 'node:net';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
 
@@ -176,6 +177,54 @@ describe('ProxyRoutingAgent', () => {
       first.destroy();
       expect(route(second, 'sts.us-east-1.amazonaws.com')).toBe(survivor);
       second.destroy();
+    });
+
+    it('the OUTER agent advertises keepAlive too — ClientRequest consults IT for the Connection header', () => {
+      // Node's ClientRequest stamps `Connection: close` when the agent handed to the
+      // REQUEST (the outer one) has neither keepAlive nor a finite maxSockets, and the
+      // response teardown then destroys the socket before the inner pool ever keeps
+      // it. The inner keepAlive alone is NOT enough — measured as one CONNECT tunnel
+      // per request until the constructor passed keepAlive up as well.
+      const agent = new ProxyRoutingAgent() as ProxyRoutingAgent & { keepAlive?: boolean };
+      expect(agent.keepAlive).toBe(true);
+      agent.destroy();
+    });
+
+    it('reuses ONE proxy connection across sequential requests', async () => {
+      // The behavioral half of the assertion above: a local plain-HTTP "proxy" counts
+      // its inbound connections; two sequential proxied GETs must share one. Without
+      // the outer keepAlive this measures TWO (Connection: close per request).
+      const connections: Socket[] = [];
+      const server = createServer((_req, res) => {
+        res.end('ok');
+      });
+      server.on('connection', (sock) => connections.push(sock));
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      process.env['HTTP_PROXY'] = `http://127.0.0.1:${port}`;
+
+      const agent = new ProxyRoutingAgent();
+      const getOnce = (): Promise<void> =>
+        new Promise((resolve, reject) => {
+          const req = httpGet('http://cdkrd-keepalive.invalid/', { agent }, (res) => {
+            res.resume();
+            res.on('end', resolve);
+            res.on('error', reject);
+          });
+          req.on('error', reject);
+        });
+      try {
+        await getOnce();
+        // one macrotask so the agent's free-socket bookkeeping settles before reuse
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        await getOnce();
+        expect(connections).toHaveLength(1);
+      } finally {
+        agent.destroy();
+        for (const sock of connections) sock.destroy();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     });
 
     it('forwards destroy() to the inner agents', () => {

--- a/tests/truststore-timeout-1321.test.ts
+++ b/tests/truststore-timeout-1321.test.ts
@@ -38,10 +38,14 @@ const ts = (): DesiredResource => ({
 // The fetch-stub describes below assert the UNPROXIED branch (#1841 keeps it
 // byte-identical), so pin the environment to unproxied rather than inheriting whatever
 // the developer's shell exports; the proxied branch has its own describe at the bottom.
+// NO_PROXY is pinned too — PROXY_ENV_VARS deliberately excludes it (it configures no
+// proxy), but a shell exporting `NO_PROXY='*'` would exempt the proxied describe's
+// endpoint and dial direct, failing its CONNECT assertion.
+const PINNED_PROXY_ENV = [...PROXY_ENV_VARS, 'NO_PROXY', 'no_proxy'] as const;
 const savedProxyEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
-  for (const name of PROXY_ENV_VARS) {
+  for (const name of PINNED_PROXY_ENV) {
     savedProxyEnv[name] = process.env[name];
     delete process.env[name];
   }
@@ -58,7 +62,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  for (const name of PROXY_ENV_VARS) {
+  for (const name of PINNED_PROXY_ENV) {
     const value = savedProxyEnv[name];
     if (value === undefined) delete process.env[name];
     else process.env[name] = value;

--- a/tests/truststore-timeout-1321.test.ts
+++ b/tests/truststore-timeout-1321.test.ts
@@ -14,7 +14,11 @@ import {
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import { mockClient } from 'aws-sdk-client-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { CLIENT_REQUEST_HANDLER } from '../src/read/client-config.js';
+import {
+  CLIENT_REQUEST_HANDLER,
+  PROXY_ENV_VARS,
+  resetProxyConfig,
+} from '../src/read/client-config.js';
 import { readLive } from '../src/read/router.js';
 import type { DesiredResource } from '../src/types.js';
 
@@ -31,7 +35,17 @@ const ts = (): DesiredResource => ({
   declared: { Name: 'cdkrd-ts' },
 });
 
+// The fetch-stub describes below assert the UNPROXIED branch (#1841 keeps it
+// byte-identical), so pin the environment to unproxied rather than inheriting whatever
+// the developer's shell exports; the proxied branch has its own describe at the bottom.
+const savedProxyEnv: Record<string, string | undefined> = {};
+
 beforeEach(() => {
+  for (const name of PROXY_ENV_VARS) {
+    savedProxyEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+  resetProxyConfig();
   cc.reset();
   elbv2.reset();
   cc.on(GetResourceCommand).resolves({
@@ -44,6 +58,12 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  for (const name of PROXY_ENV_VARS) {
+    const value = savedProxyEnv[name];
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  resetProxyConfig();
 });
 
 describe('supplementTrustStore CA-bundle fetch honors the #1066 timeout contract (#1321)', () => {
@@ -111,5 +131,48 @@ describe('supplementTrustStore CA-bundle fetch honors the #1066 timeout contract
 
     expect(r.live).toEqual({ TrustStoreArn: arn, Name: 'cdkrd-ts' });
     expect(r.skippedReason).toBeUndefined();
+  });
+});
+
+describe('the presigned CA-bundle fetch honours HTTPS_PROXY (#1841)', () => {
+  it('routes through the proxy (undici fetch never consulted), degrading when it fails', async () => {
+    // undici ignores the proxy variables, so under a proxy the supplement makes the GET
+    // through node:https + ProxyRoutingAgent instead. Point HTTPS_PROXY at a local TCP
+    // server that records what arrives and then kills the connection: the proxy must
+    // receive a CONNECT for the presigned URL's host, the stubbed global fetch must stay
+    // untouched, and the failed read must degrade to the documented best-effort skip.
+    const { createServer } = await import('node:net');
+    const received: string[] = [];
+    const proxy = createServer((sock) => {
+      sock.once('data', (chunk) => {
+        received.push(chunk.toString('utf-8'));
+        sock.destroy();
+      });
+    });
+    await new Promise<void>((resolve) => proxy.listen(0, '127.0.0.1', resolve));
+    const addr = proxy.address();
+    const proxyPort = typeof addr === 'object' && addr ? addr.port : 0;
+    process.env['HTTPS_PROXY'] = `http://127.0.0.1:${proxyPort}`;
+    resetProxyConfig();
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve(bundle) });
+    vi.stubGlobal('fetch', fetchMock);
+    elbv2
+      .on(GetTrustStoreCaCertificatesBundleCommand)
+      .resolves({ Location: 'https://cdkrd-bundle.invalid/presigned' });
+
+    try {
+      const r = await readLive(cc as unknown as CloudControlClient, ts(), 'us-east-1', '1');
+
+      expect(received.length).toBeGreaterThan(0);
+      expect(received[0]).toMatch(/^CONNECT cdkrd-bundle\.invalid:443/);
+      expect(fetchMock).not.toHaveBeenCalled();
+      // the destroyed tunnel degrades to the best-effort skip, exactly like a fetch error
+      expect(r.live).toEqual({ TrustStoreArn: arn, Name: 'cdkrd-ts' });
+      expect(r.live?.CaCertificatesBundleSha256).toBeUndefined();
+      expect(r.skippedReason).toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve) => proxy.close(() => resolve()));
+    }
   });
 });


### PR DESCRIPTION
Closes #1841

## What

`cdkrd` now honours `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` / `NO_PROXY` (upper- and lower-case) for **every** AWS call, so it works behind a corporate proxy. The AWS SDK for JavaScript v3 does not read these variables on its own (unlike botocore / Go's net/http), so every call previously dialed out directly and failed — typically with a certificate error naming the network's TLS interceptor rather than the proxy.

- New `src/read/proxy-routing-agent.ts`: an `agent-base` router that picks the proxy **per request** via `proxy-from-env`'s `getProxyForUrl` (so `NO_PROXY` and scheme-specific proxies work), tunnels via `https-proxy-agent` / `http-proxy-agent`, caches inner agents per `<scheme>|<proxy>`, and keep-alives at BOTH layers (the outer agent decides the `Connection:` header; the inner ones do the pooling — without the outer half every proxied request opened its own CONNECT tunnel).
- `src/read/client-config.ts`: `clientRequestHandler()` — unproxied it returns the exact pre-#1841 shared option bag (byte-identical path, fenced by a unit test); proxied it hands **each client its own** `NodeHttpHandler` + agent (a shared one would let one client's `destroy()` abort every other client's in-flight sockets). Wired through getters on `CLIENT_TIMEOUTS` / `READ_RETRY`, so all client constructions inherit it, and through `CLIENT_CREDENTIALS`' `clientConfig` so the inner STS / SSO / SSO-OIDC clients route too (the SSO portal / OIDC clients build from `clientConfig` alone and would otherwise fail before any service call).
- `src/synth/synth.ts`: toolkit-lib builds its own SDK clients; `proxyHttpOptions()` hands the same routing agent to the Toolkit's `sdkConfig.httpOptions`, so discovery / synth-time lookups route too. Empty when no proxy is set.
- `src/read/overrides.ts`: the one non-SDK HTTP call on the read path (TrustStore presigned-URL GET, undici `fetch`) gets a proxied branch through `node:https` + a fresh routing agent, with the same #1066 timeout contract; the unproxied branch is byte-identical to before.
- Guard rails: a whitespace-only proxy variable and a `socks*://` proxy URL are rejected up front **naming the variable** (both would otherwise fail mid-run with errors naming neither the variable nor cdkrd).
- IMDS / ECS container credentials deliberately stay direct (link-local / in-VPC — a proxy could never relay to them), as does `resolve-stacks.ts`' region probe (never sends a request).
- README: a "Behind a corporate proxy" section documenting the variables, `NO_PROXY` semantics (exact-match, no CIDR), `NODE_EXTRA_CA_CERTS` for TLS-terminating proxies, and the SOCKS limitation.

## Tests

- 36 new unit tests across three files (all offline): routing-agent behavior (per-request choice, NO_PROXY, inner-agent cache + destroy forwarding, keep-alive at both layers incl. a live two-request reuse test against a local proxy), client-config wiring (unproxied identity, per-client handler, guards, memoization seam), and a **conformance test** that parses `src/**` and asserts every AWS SDK client construction spreads the shared config or is on an explicitly-justified allow list (the repo-wide guard cdkd ships as a script, here as a unit test).
- An independent orchestrator-level review round (full-diff, deps-source cross-checked) found no blockers; its three minors are addressed in the last commit: a scheme-less proxy value (`proxy.example:8080`) is now rejected up front naming the variable, the env-var read-order comment is corrected, and `ALL_PROXY` has a routing-time test.
- keep-alive fix mutation-proved: removing the outer `keepAlive` reddens exactly its two tests.

## Live verification (no resources created)

Five arms against real AWS (read-only; nothing deployed, nothing to sweep):

1. **Routed**: a local logging CONNECT proxy + `cdkrd check` on an undeployed unique-named stack → all AWS traffic (STS + CloudFormation, us-east-1) tunneled through the proxy (4 CONNECT tunnels logged), CLI exits 0 with "not deployed yet — skipped".
2. **No silent fallback**: `HTTPS_PROXY=http://127.0.0.1:1` → fails with `connect ECONNREFUSED 127.0.0.1:1` (never goes direct).
3. **NO_PROXY bypass**: dead proxy + `NO_PROXY='*'` → goes direct and succeeds.
4. **Control**: no proxy vars → behavior unchanged.
5. **SOCKS guard**: `HTTPS_PROXY=socks5://…` → up-front error naming `HTTPS_PROXY`.

Shared-name core integ suite **deferred** — the unproxied hot path is byte-identical (returns the same shared option bag; fenced by `tests/client-config-proxy-1841.test.ts` "returns the unchanged shared option bag"), and the proxied path is live-proven by the five arms above. Not re-run; the suite still runs at the next clean-window release verification.

https://claude.ai/code/session_01Xt1m1fZkLZHrQFACgE3vtd
