### PR TITLE
chore(work-issues): commit before mutation probes, and the zero-resource transport live-test tier

### DIFF
--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -171,6 +171,17 @@ at once, not trickled.
   bold paragraph. Root cause + toolchain bump: go-to-k/cdk-real-drift#1771 /
   go-to-k/cdk-real-drift#1780.
 
+- **transport / client-config change** (`src/read/client-config.ts`
+  requestHandler / agents / timeouts, proxy routing) → live-verify with ZERO
+  deployed resources: `check` on an UNDEPLOYED unique-named stack still makes
+  real AWS calls (STS + CloudFormation DescribeStacks) and exits 0 with "not
+  deployed yet — skipped", so the transport is exercised end-to-end with
+  nothing to sweep and no sentinel armed. The oracle is whatever observes the
+  transport — for go-to-k/cdk-real-drift#1841 (PR
+  go-to-k/cdk-real-drift#1852) a ~25-line local logging HTTP CONNECT proxy
+  proved every call tunneled, plus dead-proxy (no silent direct fallback),
+  `NO_PROXY` bypass, and no-proxy control arms. Reach for the deploy tier below
+  only when the change needs a real RESOURCE, not just real calls.
 - **revert / read HOT-PATH fix** → live-verify with a MINIMAL, UNIQUE-named
   fixture: deploy → mutate out of band → `check` detects → `revert --yes`
   converges → confirm the live value. A throwaway CDK app works:
@@ -252,6 +263,16 @@ only, never the working tree). This repo's lanes live under a `.worktrees/`
 directory, so the hazard is identical here.
 
 ### 8-z. When a mutation probe reports NO discrimination
+
+**First, a rule that applies BEFORE any probe runs: COMMIT the round's real
+fixes, then probe.** A probe deliberately breaks the tree, so an interruption
+mid-probe (a session limit, a crash) leaves deliberate breakage and unfinished
+fixes in ONE undifferentiated dirty tree. Measured 2026-09-02 on the
+go-to-k/cdk-real-drift#1841 lane: the subagent died at the 5-hour session limit
+mid-probe with 9 dirty files, and the resuming session had to read the full
+diff to establish that none of it was probe wreckage before it could commit.
+With a pre-probe commit the separator is just `git diff` — anything unstaged
+after a probe is the probe's.
 
 **A probe that reports NO discrimination is a claim about the FENCE, and three
 other things produce the identical output.** Ask them in order before touching


### PR DESCRIPTION
Stage-10 retro of the 2026-09-02 /work-issues run (go-to-k/cdk-real-drift#1841 → PR go-to-k/cdk-real-drift#1852). Two lessons with run evidence, both in `references/verify.md`:

1. **Commit the round's real fixes BEFORE running mutation probes** (§8-z lead). The lane subagent died at the 5-hour session limit mid-probe with 9 dirty files; the resuming session had to read the full diff to prove none of it was probe wreckage before committing. With a pre-probe commit the separator is just `git diff`.
2. **A transport / client-config change live-verifies with ZERO deployed resources** (new live-test tier). `check` on an undeployed unique-named stack still makes real AWS calls (STS + CloudFormation); the oracle is whatever observes the transport — for #1841 a local logging CONNECT proxy, five arms, nothing to sweep, no sentinel armed.

Prose-only diff: `vp fmt` run twice (second a no-op), all three doc fences green (`skill-doc-paths` / `skill-file-payload` / `markdown-fmt-corruption`), full suite 352/6659 green. No `src/**` → verify-pr exempt.

Retro flow lesson mirroring: both lessons are repo-specific to this repo's verify stage (the transport tier names cdkrd's own check semantics; the probe rule cites this run) — the probe rule is arguably a FLOW lesson, but the sibling repos' work-issues verify stages differ in shape; deferring cross-repo mirroring rather than filing three issues, per §10-c's whole-remainder rule, is noted below in the session wrap.

https://claude.ai/code/session_01Xt1m1fZkLZHrQFACgE3vtd