### PR TITLE
chore(work-issues): restore LAUNCH_BRANCH at the end of an IN-PLACE run

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -34,8 +34,9 @@ stage 0 because §1 and §2 already consume the answer — §1's
 collision scan, whose relative `.worktrees/<w>` paths resolve to nothing there,
 reports an empty board that reads as "no competing agents". In the PARENT
 because stages 0–3 are delegated to a subagent whose return payload carries no
-git state. State all three printed values — `MODE`, which is
-`MAIN-CHECKOUT` or `IN-PLACE`, plus `LANE_TREE` and `MAIN_CHECKOUT` — in the
+git state. State all four printed values — `MODE`, which is
+`MAIN-CHECKOUT` or `IN-PLACE`, plus `LANE_TREE`, `MAIN_CHECKOUT` and
+`LAUNCH_BRANCH` (the branch §9 puts back; empty if launched detached) — in the
 opening report, the first message you write after running the probe and before
 any lane starts, and pass them into the triage dispatch and into every lane
 dispatch. Read `LANE_TREE` as "the tree this run stands in", NOT "the lane
@@ -45,7 +46,8 @@ IN-PLACE-only arms (every MAIN-CHECKOUT arm beside them uses no `-C`).
 
 `IN-PLACE` changes a great deal more than the lane count: §1's pull, the
 collision scan's paths, the claim, the branch recipe, §7's rebase, the worktree
-and branch cleanup, and where the retro branch is created.
+and branch cleanup, where the retro branch is created, and the `LAUNCH_BRANCH`
+restore that ends the run.
 `references/launch-mode.md` carries the COMPLETE list as a table mapping each
 consequence to the stage that fires it — read it there, and do NOT re-summarise
 it here. The previous revision of this paragraph said "changes four things" and
@@ -108,7 +110,7 @@ wants to watch); the stage files apply unchanged either way.
 
 | Stage                        | File (read at entry)         | What it covers                                                                                                                     |
 | ---------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Before 0. Launch mode        | `references/launch-mode.md`  | The probe (the ONLY copy), its three values, and the table mapping every IN-PLACE consequence to its stage                         |
+| Before 0. Launch mode        | `references/launch-mode.md`  | The probe (the ONLY copy), its four values, and the table mapping every IN-PLACE consequence to its stage                          |
 | 0. Safety screen             | `references/triage.md`       | Untrusted issues/comments: `author_association` via REST, never run third-party content, defer engage/block to the maintainer      |
 | 1. List backlog              | `references/triage.md`       | REST listing (PR filter, `per_page=100`, `created_at`), volume assessment                                                          |
 | 2. Collision landscape       | `references/triage.md`       | Worktree/branch/PR/claim probes (absolute, via `<MAIN_CHECKOUT>`) and their blind spots; the central contested files               |

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -10,19 +10,21 @@ holds. The competing-claim/PR re-check below also runs in the parent, right
 before dispatch. Everything else in this section is unchanged.
 
 **An IN-PLACE run names the tree it is STANDING IN**
-(`references/launch-mode.md`): the `<ref>` is the branch and worktree already
-checked out, and neither is composed. The worktree is the `LANE_TREE` path the
+(`references/launch-mode.md`): the `<ref>` is the branch §5 will create plus the
+worktree already checked out. The worktree is the `LANE_TREE` path the
 launch-mode probe captured and the opening report recorded — never re-derived
-from `git rev-parse --show-toplevel` here, for §5's reason — and the branch is
-`git -C "<LANE_TREE>" branch --show-current`. Nothing new will be created, and a
-claim pointing at a worktree that never appears is exactly what §9's ownership
-probes misread.
+from `git rev-parse --show-toplevel` here, for §5's reason. No WORKTREE will be
+created, and a claim pointing at a worktree that never appears is exactly what
+§9's ownership probes misread.
 
-**An empty branch name means the tree is DETACHED, not that the claim is
-blocked.** The branch is created in §5, after this stage — so write "the branch
-§5 will create in `<LANE_TREE>`" and post the claim on time. A claim delayed
-until a branch exists is a claim posted after the first edit, which is the one
-thing this stage forbids. Such a run claims ONE issue (§3), not a set.
+**Do NOT claim `LAUNCH_BRANCH` — the branch checked out here right now is the
+OUTER TOOL's, not this run's** (`references/launch-mode.md`: "a branch to PUT
+BACK, never one to commit to"). So the name is COMPOSED here rather than read out
+of git with `git -C "<LANE_TREE>" branch --show-current`, and it does not exist
+yet: §5 creates it, after this stage. Write "the branch §5 will create in
+`<LANE_TREE>`" and post the claim on time. A claim delayed until the branch
+exists is a claim posted after the first edit, which is the one thing this stage
+forbids. Such a run claims ONE issue (§3), not a set.
 
 For EACH issue you will start:
 

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -13,8 +13,10 @@ COMMON=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
 GITDIR=$(cd "$(git rev-parse --git-dir)" && pwd -P)
 LANE_TREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
 MAIN_CHECKOUT=$(dirname "$COMMON")
+LAUNCH_BRANCH=$(git branch --show-current)   # empty when launched detached
 [ "$GITDIR" = "$COMMON" ] && MODE=MAIN-CHECKOUT || MODE=IN-PLACE
-printf 'MODE=%s\nLANE_TREE=%s\nMAIN_CHECKOUT=%s\n' "$MODE" "$LANE_TREE" "$MAIN_CHECKOUT"
+printf 'MODE=%s\nLANE_TREE=%s\nMAIN_CHECKOUT=%s\nLAUNCH_BRANCH=%s\n' \
+  "$MODE" "$LANE_TREE" "$MAIN_CHECKOUT" "$LAUNCH_BRANCH"
 ```
 
 ### Why here and not at the top of stage 3
@@ -39,11 +41,11 @@ would be enough to move it:
   later runs `git worktree add` or does not. Computing it in the parent before
   dispatching anything removes the problem instead of documenting it.
 
-So: run it in the parent, pass `MODE` / `LANE_TREE` / `MAIN_CHECKOUT` into the
-triage dispatch and into every lane dispatch, and state all three in the
-opening report.
+So: run it in the parent, pass `MODE` / `LANE_TREE` / `MAIN_CHECKOUT` /
+`LAUNCH_BRANCH` into the triage dispatch and into every lane dispatch, and state
+all four in the opening report.
 
-### Reading the three values
+### Reading the four values
 
 `GITDIR` equals `COMMON` only in the main checkout — a linked worktree's
 `--git-dir` is `<common-dir>/worktrees/<name>`. `pwd -P` settles both the main
@@ -57,6 +59,25 @@ needs no `git worktree list` row ordering, which §9 used to depend on.
 `LANE_TREE` is "the tree this run stands in", NOT "the lane worktree":
 MAIN-CHECKOUT records the MAIN checkout under it, and the two are equal there.
 IN-PLACE they differ, and that difference is the whole point.
+
+`LAUNCH_BRANCH` is `git branch --show-current` **at probe time** — the branch the
+tree was handed to this run ON, which IN-PLACE means the branch the OUTER TOOL
+created. An EMPTY value is a legitimate answer, not a probe failure: it says the
+run was launched detached, and §9's restore keeps a detach fallback for exactly
+that case. It is the one value that becomes UNRECOVERABLE if not recorded now —
+§5 switches the tree onto the lane's own branch, so every later
+`git branch --show-current` answers with the LANE's branch and the thing this
+value exists to name (what to put back) is gone. MAIN-CHECKOUT records it and
+does nothing with it: the run never leaves the main checkout, so §9's restore arm
+does not fire there.
+
+**IN-PLACE, `LAUNCH_BRANCH` is a branch to PUT BACK, never one to commit to.**
+§5 branches in place off `origin/main` instead of committing onto it, and the
+reason is not tidiness: `gh pr merge --delete-branch` (§9) deletes the REMOTE
+branch the PR was opened from, so a lane that worked directly on the outer tool's
+branch would delete the outer tool's branch on the way out — a far heavier
+interference than the detached HEAD this whole rule exists to avoid. The lane
+owns its own branch and deletes only that one.
 
 **The guard on the first line is not decoration.** Outside a work tree every
 `git rev-parse` fails and each substitution collapses to the empty string, so
@@ -86,7 +107,7 @@ with no failure to read.
 This instant is the one moment the cwd is provably the tree whose mode is being
 decided; every later stage runs in a fresh shell whose cwd may have silently
 reset to the main checkout (§6's `cd <worktree> &&` rule). So **state all
-three in the opening report**, verbatim and absolute — that report is their ONLY
+four in the opening report**, verbatim and absolute — that report is their ONLY
 recorded copy. A later stage that re-derives `LANE_TREE` from
 `$(git rev-parse --show-toplevel)` or from `pwd` resolves against the reset cwd
 and answers "the main checkout" in precisely the case the `-C` exists to guard.
@@ -108,18 +129,18 @@ pointers. IN-PLACE means this run was launched inside a worktree someone else
 created (an Orca/ADE workspace, a stray `cd`), so it has exactly ONE working
 tree:
 
-| #   | Consequence                                                                                                                                                                                 | Where     |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| 1   | Take ONE issue and finish it — a second lane would need a worktree NESTED inside this one, which dies with the outer workspace and takes its uncommitted work (go-to-k/cdk-real-drift#1842) | §3        |
-| 2   | §1's `git checkout main && git pull` cannot run here; pull through `git -C "<MAIN_CHECKOUT>"` and read the refs with `git show origin/main:<file>`                                          | §1        |
-| 3   | §2's worktree probes take `<MAIN_CHECKOUT>/.worktrees/<w>`, not a relative path                                                                                                             | §2        |
-| 4   | The claim names the branch and tree already checked out here, read out of git rather than composed                                                                                          | §4        |
-| 5   | Create no worktree; work on the branch already here, after confirming the tree is YOURS                                                                                                     | §5        |
-| 6   | A tree that is DETACHED or whose PR already merged does create a branch — in place, without leaving the tree                                                                                | §5        |
-| 7   | §7's rebase runs `git -C "<LANE_TREE>"`                                                                                                                                                     | §7        |
-| 8   | Remove no worktree and delete no branch: a lane that removes the tree it runs in deletes its own cwd. Cleanup belongs to whoever created it                                                 | §9, §10-d |
-| 9   | §9's post-merge pull goes through `git -C "<MAIN_CHECKOUT>"` for the same reason as row 2                                                                                                   | §9        |
-| 10  | The retro branch is created in THIS tree, so the run legitimately ends on a branch that is not the one it started on                                                                        | §10-d     |
+| #   | Consequence                                                                                                                                                                                             | Where     |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| 1   | Take ONE issue and finish it — a second lane would need a worktree NESTED inside this one, which dies with the outer workspace and takes its uncommitted work (go-to-k/cdk-real-drift#1842)             | §3        |
+| 2   | §1's `git checkout main && git pull` cannot run here; pull through `git -C "<MAIN_CHECKOUT>"` and read the refs with `git show origin/main:<file>`                                                      | §1        |
+| 3   | §2's worktree probes take `<MAIN_CHECKOUT>/.worktrees/<w>`, not a relative path                                                                                                                         | §2        |
+| 4   | The claim names the tree already checked out here plus the branch §5 WILL create in it — never `LAUNCH_BRANCH`, which belongs to the outer tool                                                         | §4        |
+| 5   | Create no worktree; after confirming the tree is YOURS, branch IN PLACE off `origin/main` — ALWAYS, not only when the tree is detached or its PR has merged — and never commit onto `LAUNCH_BRANCH`     | §5        |
+| 6   | Switch back to `LAUNCH_BRANCH` **as-is** — no pull, no rebase, no fast-forward — and delete only the branches THIS run created; detach only when `LAUNCH_BRANCH` was empty at probe time or is now gone | §9        |
+| 7   | §7's rebase runs `git -C "<LANE_TREE>"`                                                                                                                                                                 | §7        |
+| 8   | Remove no worktree: a lane that removes the tree it runs in deletes its own cwd. Cleanup of the TREE belongs to whoever created it                                                                      | §9, §10-d |
+| 9   | §9's post-merge pull goes through `git -C "<MAIN_CHECKOUT>"` for the same reason as row 2                                                                                                               | §9        |
+| 10  | The retro branch is created in THIS tree too, so the `LAUNCH_BRANCH` restore is the run's LAST step — after the retro PR merges, not inside §9's per-lane cleanup                                       | §10-d     |
 
 There is deliberately no rebuild row. The global install here is
 `vp i -g cdk-real-drift`, BY NAME from npm, so it reads no tree's build output

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -332,9 +332,15 @@ git -C "<LANE_TREE>" fetch origin \
 - **Merge it before the wrap report, then remove the worktree**
   (`git worktree remove .worktrees/<name> && git worktree prune`) — §9 ends
   with every worktree gone and §10 must not undo that. An IN-PLACE run added
-  none: it merges and stops there, leaving the tree on the retro branch for
-  whoever owns the workspace (the appendix has what the Stop hook will say
-  about that). This is `Session-fit: now` on the leaves-main-self-inconsistent
+  none, so instead this is where it runs §9's IN-PLACE cleanup arm — **the LAST
+  step of the whole run**: `git switch <LAUNCH_BRANCH>` as-is (no pull, no
+  rebase, no fast-forward) and `git branch -D` every branch this run created,
+  the retro branch included. §9 deliberately does NOT do it per-lane, because
+  THIS section branches in the same tree and would undo it. Leaving the tree on
+  the retro branch — the previous instruction here — makes the unmerged-lane
+  Stop hook warn every turn (the appendix has the wording), and detaching
+  instead is visible-surprising in the outer tool's UI; restoring what the tool
+  created is quiet on both counts. This is `Session-fit: now` on the leaves-main-self-inconsistent
   criterion (the skill would keep telling the next run to do what this run just
   proved wrong); its evidence dies with this session, and an open PR is NOT
   CLOSEABLE besides.

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -20,6 +20,20 @@ lane's commit / PR create / merge until `/sweep-resources` clears it. Never
 two lanes' live tests or merges concurrently; everything after the merge in
 this section (pull → release → install → cleanup) stays with the parent.
 
+**A `SendMessage` that answers "queued" has NOT been delivered — read the reply
+every time.** The tool returns one of two things: `Resuming agent ...`, meaning
+the agent was stopped and has been RESTARTED to receive it, or `Message queued
+for delivery at its next tool round`, which delivers only if something ELSE
+resumes the agent. A lane that ended its turn on "merge-ready" is stopped by
+definition, so the turn-grant it is waiting for lands in a queue nothing will
+drain — and both sides then look identical to a party waiting on the other.
+Measured 2026-09-02 (go-to-k/cdkd#2417): a lane sat idle about five minutes
+mid-pipeline that way, surfaced only by the maintainer asking why nothing was
+running, and an immediate re-send answered `Resuming agent` and unstuck it. So
+after any send: if the answer was "queued", either confirm the agent actually
+runs (its next completion notification) or re-send at once. A queued message is
+never a granted turn.
+
 ```bash
 gh pr merge <n> --squash --delete-branch     # squash is the repo's only method
 ```
@@ -106,19 +120,65 @@ go-to-k/cdk-real-drift#1767 merged as `chore:` and this text still sent the run
 polling for a bump).
 
 **Remove every worktree you created** (a left-behind worktree is the silent
-residue of this flow). **An IN-PLACE run created none, so it removes none**: it
-must not `git worktree remove` the tree it is running in (that deletes its own
-cwd) and must not `git branch -D` the branch it is standing on. Cleanup of that
-tree belongs to whoever created it — the outer tool, or the operator — so the
-wrap SAYS so instead of doing it, and the run ends with the tree still standing.
-`--delete-branch` on the merge still removes the REMOTE branch, which is fine;
-only the local tree and its branch are off limits:
+residue of this flow).
+
+MAIN-CHECKOUT (SKILL.md "Launch mode") — run THIS block, and not the next one:
 
 ```bash
 git worktree remove .worktrees/<name>        # --force if it refuses on artifacts
 git worktree prune
 git worktree list                            # yours should be gone
 ```
+
+IN-PLACE — run THIS block INSTEAD, never both. **An IN-PLACE run created no
+worktree, so it removes none**: it must not `git worktree remove` the tree it is
+running in (that deletes its own cwd). Cleanup of the TREE belongs to whoever
+created it — the outer tool, or the operator — so the wrap SAYS so instead of
+doing it, and the run ends with the tree still standing. What it DOES owe is the
+BRANCH: put back the one it found, delete the one it made. `<LAUNCH_BRANCH>` and
+`<lane branch>` are SUBSTITUTION PLACEHOLDERS taken from the opening report, not
+shell variables (`references/launch-mode.md` — a fresh Bash call is a fresh
+shell, and an empty `git switch ""` is not the failure you want):
+
+```bash
+git switch <LAUNCH_BRANCH>     # AS-IS: no pull, no rebase, no fast-forward
+git branch -D <lane branch>    # -D, not -d (squash) - see the merge above
+git branch --show-current      # must print <LAUNCH_BRANCH>
+git status --porcelain         # must be empty: the tree is as you found it
+```
+
+Fallback, and ONLY when `LAUNCH_BRANCH` was empty at probe time (the run was
+launched detached) or the branch is now gone — never as the default:
+
+```bash
+git fetch origin && git switch --detach origin/main
+git branch -D <lane branch>
+```
+
+**Three end states, and only one of them is quiet.** Staying on the lane branch
+leaves a squash-merged tip that the unmerged-lane Stop hook warns about on EVERY
+turn (its tip is never an ancestor of `main` — the same squash artifact that
+forces `-D` above). Detaching silences that, and was this step's recommendation
+until 2026-09-02 — but it is VISIBLE-SURPRISING in the outer tool's UI, which
+created the workspace ON a branch and displays the detached state prominently;
+the maintainer flagged it live (go-to-k/cdk-real-drift#1854). `LAUNCH_BRANCH`
+restored is both: it sits at whatever tip the outer tool left, 0 commits ahead of
+`origin/main`, so the Stop hook stays silent AND the workspace looks untouched.
+
+**AS-IS is the whole rule: RESTORE, never ADJUST.** The first draft of this step
+fast-forwarded `LAUNCH_BRANCH` to `origin/main` on the way back, so it would not
+be left "stale"; that clause is WITHDRAWN. The tree and the branch are the outer
+tool's artifacts and this run's job is to leave them exactly as it found them — a
+fast-forward is an edit to somebody else's branch, made for the convenience of a
+run that is on its way out, and "it was only a fast-forward" is precisely the
+reasoning that produced the detached HEAD this rule replaces. If the branch is
+behind, that is the tool's business.
+
+**This step runs LAST, not per-lane.** §10 takes its retro branch in this same
+tree, so restoring here and branching again in §10-d would just undo itself:
+IN-PLACE, do the merge in §9 and come back for the restore once the retro PR has
+merged. `--delete-branch` on each merge still removes the REMOTE branches, which
+is fine and independent of any of this.
 
 **Only the ones YOU created.** A worktree you did not create is a peer lane, and
 `git worktree list` cannot tell you whose it is — a finished run's leftover and a

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -39,7 +39,7 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
 
 const MAX_SKILL_MD_BYTES = 36_000; // largest non-split skill re-measured 12,571 B (verify-pr, 2026-09-01, unchanged in round 6) -- the 12,175 B this line used to quote was stale
-const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B at the 2026-08-28 split; re-measured 2026-09-01, review round 6: work-issues 11,694 B (306 B of margin), hunt-bugs 6,932 B
+const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B at the 2026-08-28 split; re-measured 2026-09-02 (go-to-k/cdk-real-drift#1854): work-issues 11,812 B (188 B of margin), hunt-bugs 6,932 B
 // The re-measurement is the point, not trivia: work-issues has repeatedly grown to
 // within a few hundred bytes of its cap while this comment still quoted the
 // at-split figure, so nobody adding a paragraph could see how little room was
@@ -50,7 +50,11 @@ const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B a
 // widest cells were shortened -- which, since `vp fmt` pads markdown table columns
 // to the widest cell, reclaimed the padding on all fourteen rows at once.
 // Re-measure whenever an orchestrator is edited -- a cap with an unmeasured margin
-// is one nobody can plan against.
+// is one nobody can plan against. The 2026-09-02 LAUNCH_BRANCH round spent 118 B
+// of the 306 B that were left: the fourth probe value has to be NAMED in the
+// always-loaded file (a lane cannot pass on a value it was never told to record),
+// while its reading, its restore recipe and the IN-PLACE consequence rows all
+// went to references/launch-mode.md and references/ship.md.
 const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B (hunt-bugs gotchas.md); 41,922 B after the rule+citation compression pass (2026-08-28), re-measured unchanged 2026-09-01
 
 // The split skills' stage files must still exist and still carry the moved
@@ -83,15 +87,18 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // now ASSERTED at the bottom of this file as well as described here, because
 // three consecutive rounds re-derived it BY HAND and one of them found it
 // lapsed.
-// Re-derived 2026-09-01 (review round 6) at the final tree. work-issues: 9 stage
-// files, corpus 125,713 B, largest implement.md 25,599 B, so the floor must
-// exceed 125,713 - 25,599 = 100,114 -- the 93,000 set one round earlier no
-// longer does. The binding number is not the worst case here: triage.md is
-// 20,782 B, only 4,817 B behind, and round 3 already warned that a flip would
-// leave the floor clearing by under 1 KB. Sizing against the FLIP instead
-// (125,713 - 20,782 = 104,931), 108,000 clears the binding number by 7,886 B and
-// the flip case by 3,069 B, and leaves ~17 KB (125,713 - 108,000 = 17,713 B) of
-// compression room below the floor.
+// Re-derived 2026-09-02 (go-to-k/cdk-real-drift#1854) at the final tree.
+// work-issues: 9 stage files, corpus 134,827 B, largest implement.md 26,041 B, so
+// the floor must exceed 134,827 - 26,041 = 108,786 -- the 108,000 set one round
+// earlier no longer does, and the assertion at the bottom of this file is what
+// said so rather than a human re-deriving it. The binding number is again not
+// the worst case: triage.md is 22,342 B, 3,699 B behind implement.md, so a flip
+// would put the requirement at 134,827 - 22,342 = 112,485. Sizing against the
+// FLIP, 116,000 clears the binding number by 7,214 B and the flip case by
+// 3,515 B, and leaves ~18 KB (134,827 - 116,000 = 18,827 B) of compression room
+// below the floor. The growth is the LAUNCH_BRANCH restore contract landing
+// across launch-mode.md (+1,541 B), ship.md (+3,471 B), retro.md (+471 B) and
+// claim.md (+152 B).
 // hunt-bugs stays at 60,000: re-measured the same day, corpus 88,598 B and
 // largest gotchas.md 41,922 B, so 88,598 - 41,922 = 46,676 < 60,000 and its
 // property still holds. Re-measure both numbers for each skill whenever a stage
@@ -101,7 +108,7 @@ const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }>
   // post-compression. 9 files as of 2026-09-01, when the launch-mode probe and its
   // reading moved out of triage.md into references/launch-mode.md, which the PARENT
   // reads before stage 0.
-  'work-issues': { minFiles: 9, minCorpusBytes: 108_000 },
+  'work-issues': { minFiles: 9, minCorpusBytes: 116_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 7, minCorpusBytes: 60_000 },
 };

--- a/tests/work-issues-launch-mode.test.ts
+++ b/tests/work-issues-launch-mode.test.ts
@@ -84,6 +84,23 @@ const ARM_BEARING: Record<string, string[]> = {
   [join('references', 'gotchas.md')]: ['IN-PLACE'],
 };
 
+/**
+ * Files carrying an arm of the LAUNCH_BRANCH contract
+ * (go-to-k/cdk-real-drift#1854): the probe records the branch the outer tool
+ * handed the tree over on, section 5 refuses to commit onto it, and section 9
+ * puts it back AS-IS at the very end. Separate from ARM_BEARING because the mode
+ * words survive deleting the restore -- a file can still say IN-PLACE everywhere
+ * while the one step that makes the mode leave no trace is gone, which is what
+ * the byte floors also cannot see.
+ */
+const LAUNCH_BRANCH_BEARING = [
+  'SKILL.md',
+  LAUNCH_MODE_DOC,
+  join('references', 'claim.md'),
+  join('references', 'ship.md'),
+  join('references', 'retro.md'),
+];
+
 /** The first fenced ```bash block of a markdown file. */
 export function firstBashBlock(markdown: string): string | null {
   const lines = markdown.split('\n');
@@ -133,6 +150,34 @@ describe('work-issues launch-mode probe', () => {
     });
   }
 
+  for (const doc of LAUNCH_BRANCH_BEARING) {
+    it(`${doc} still carries its LAUNCH_BRANCH arm`, () => {
+      expect(
+        read(doc),
+        `${doc} no longer mentions LAUNCH_BRANCH. Its arm of the restore contract was ` +
+          `deleted or moved: without it an IN-PLACE run ends on a squash-merged lane ` +
+          `branch (the Stop hook warns every turn) or detached (visible-surprising in the ` +
+          `outer tool's UI) instead of on the branch the tool created. If the arm MOVED, ` +
+          `update LAUNCH_BRANCH_BEARING so the assertion keeps tracking it.`
+      ).toContain('LAUNCH_BRANCH');
+    });
+  }
+
+  it('section 9 restores LAUNCH_BRANCH as-is rather than fast-forwarding it', () => {
+    // The spec was CORRECTED mid-filing: an early draft fast-forwarded the branch
+    // to origin/main first. Restoring is the point -- the branch is the outer
+    // tool's artifact -- so a re-introduced `git pull`/`git merge`/`git rebase`
+    // ON that branch is the regression this pins. The withdrawal is discussed in
+    // prose, so the assertion reads the COMMAND, not the surrounding narrative.
+    const ship = read(join('references', 'ship.md'));
+    expect(ship).toMatch(/git switch <LAUNCH_BRANCH>/);
+    expect(
+      ship,
+      `references/ship.md pipes LAUNCH_BRANCH into a command that MOVES it. The ` +
+        `restore is AS-IS: no pull, no rebase, no fast-forward, no merge.`
+    ).not.toMatch(/git (pull|rebase|merge|fetch)[^\n]*<LAUNCH_BRANCH>/);
+  });
+
   describe('the probe, executed', () => {
     /**
      * Runs the doc's OWN fenced probe -- extracted, not re-typed -- against a
@@ -147,6 +192,7 @@ describe('work-issues launch-mode probe', () => {
       expect(block!).toContain(PROBE_TOKEN);
       expect(block!).toContain('MAIN-CHECKOUT');
       expect(block!).toContain('IN-PLACE');
+      expect(block!).toContain('LAUNCH_BRANCH');
     });
 
     it('answers MAIN-CHECKOUT in a main checkout and IN-PLACE in a linked worktree', () => {
@@ -165,7 +211,9 @@ describe('work-issues launch-mode probe', () => {
         };
         const git = (args: string[], cwd = tmp) =>
           execFileSync('git', args, { cwd, env, encoding: 'utf8' });
-        git(['init', '-q', main]);
+        // Explicit initial branch: the probe's LAUNCH_BRANCH assertion below must
+        // not depend on whichever default this git build compiles in.
+        git(['init', '-q', '-b', 'probe-main', main]);
         git([
           '-C',
           main,
@@ -196,14 +244,29 @@ describe('work-issues launch-mode probe', () => {
         expect(fromMain.MODE).toBe('MAIN-CHECKOUT');
         expect(fromMain.LANE_TREE).toBe(main);
         expect(fromMain.MAIN_CHECKOUT).toBe(main);
+        expect(fromMain.LAUNCH_BRANCH).toBe('probe-main');
 
         const fromLane = run(lane);
         expect(fromLane.MODE).toBe('IN-PLACE');
+        // The value section 9 puts back. Read at probe time and NEVER re-derived:
+        // section 5 switches this tree onto the lane's own branch, after which
+        // `git branch --show-current` answers with that one instead.
+        expect(fromLane.LAUNCH_BRANCH).toBe('lane-branch');
         // The two values differing IS the mode, and MAIN_CHECKOUT must point at
         // the OTHER tree -- that is the value section 2's collision scan needs
         // and the one a `pwd`- or `--show-toplevel`-derived probe gets wrong.
         expect(fromLane.LANE_TREE).toBe(lane);
         expect(fromLane.MAIN_CHECKOUT).toBe(main);
+
+        // Launched DETACHED: LAUNCH_BRANCH is empty, and that is an ANSWER, not a
+        // failure -- it is what selects section 9's detach fallback over the
+        // restore. The mode verdict must be unaffected, since a detached worktree
+        // is still a worktree.
+        git(['-C', lane, 'switch', '--detach', 'HEAD']);
+        const fromDetachedLane = run(lane);
+        expect(fromDetachedLane.MODE).toBe('IN-PLACE');
+        expect(fromDetachedLane.LANE_TREE).toBe(lane);
+        expect(fromDetachedLane.LAUNCH_BRANCH).toBe('');
       } finally {
         rmSync(tmp, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Problem

An IN-PLACE `/work-issues` run (launched inside a worktree someone else created — an Orca/ADE workspace, a stray `cd`) ended wherever its last branch left the tree:

- on a squash-merged lane branch, whose tip is never an ancestor of `main`, so the unmerged-lane Stop hook warns on EVERY turn; or
- detached, which section 9 recommended until 2026-09-02 — quiet for the Stop hook, but VISIBLE-SURPRISING in the outer tool's UI, which created the workspace ON a branch and shows the detached state prominently. The maintainer flagged it live.

Neither leaves the tree as it was handed over, and the branch it was handed over ON was never recorded anywhere.

## Change

- **The probe records a fourth value.** `references/launch-mode.md` adds `LAUNCH_BRANCH=$(git branch --show-current)` and prints it as a fourth `KEY=VALUE` line. It is read AT PROBE TIME because that is the only moment it is still readable: section 5 switches the tree onto the lane's own branch, after which every `git branch --show-current` answers with the lane's. An EMPTY value is an ANSWER (launched detached), not a probe failure.
- **Section 9 puts it back AS-IS.** `references/ship.md`'s cleanup recipe is split into the MAIN-CHECKOUT / IN-PLACE two-arm shape the file already uses elsewhere. The IN-PLACE arm restores `LAUNCH_BRANCH` with no pull, no rebase, no fast-forward — the branch is the outer tool's artifact, and "it was only a fast-forward" is the same reasoning that produced the detached HEAD this replaces — and deletes only the branches THIS run created. The detach fallback survives for the empty / branch-gone case.
- **The restore runs LAST, not per-lane.** Section 10-d branches in the same tree, so `references/retro.md` is where the IN-PLACE arm actually fires, after the retro PR merges.
- **The claim never names `LAUNCH_BRANCH`.** `references/claim.md`: the IN-PLACE `<ref>` is the branch section 5 WILL create, composed rather than read out of git. A lane that worked on the outer tool's branch would have `gh pr merge --delete-branch` delete the outer tool's REMOTE branch on the way out — heavier interference than the detached HEAD.
- **`SKILL.md`** states all four printed values (the orchestrator is the always-loaded file, so a value it does not name is one no lane is told to record) and the launch-mode table maps each IN-PLACE consequence to its stage.

Mirrored from the same 2026-09-02 run (`go-to-k/cdkd#2417`), per section 10-c's mirror rule:

- **`references/ship.md`** — a `SendMessage` that answers "queued" has NOT been delivered. A lane that ended its turn on "merge-ready" is stopped by definition, so its turn-grant lands in a queue nothing drains and both sides look like they are waiting on the other (measured: ~5 min idle mid-pipeline, unstuck by an immediate re-send that answered `Resuming agent`).

## Fences

`tests/work-issues-launch-mode.test.ts`:

- `LAUNCH_BRANCH_BEARING` — the five docs carrying an arm of the contract. Separate from `ARM_BEARING` because the mode words survive deleting the restore.
- the restore is pinned as a COMMAND (`git switch <LAUNCH_BRANCH>` present; no `git pull|rebase|merge|fetch … <LAUNCH_BRANCH>`), because the withdrawn fast-forward is discussed in the prose right beside it.
- the executed probe asserts the value in a main checkout (`probe-main`, with the fixture's initial branch pinned by `git init -b` rather than riding git's compiled-in default), in a linked worktree (`lane-branch`), and EMPTY in a detached worktree with `MODE` still `IN-PLACE`.

`tests/skill-file-payload.test.ts`: the corpus floor's own lapse assertion fired at 108,000 (corpus 134,827 B, largest `implement.md` 26,041 B, so deleting it would leave 108,786 B and still pass). Raised to 116,000, sized against the FLIP case as the comment prescribes (`triage.md` 22,342 B → 112,485), clearing the binding number by 7,214 B and the flip by 3,515 B, and leaving 18,827 B of compression room. Both byte comments carry freshly measured numbers: `work-issues/SKILL.md` is 11,812 B, 188 B under the 12,000 B orchestrator cap.

## Verification

- `vp run typecheck` / `vp check --fix` / `vp pack` / `vp test run` — all green (352 files, 6665 tests). Two subprocess-spawning suites (`json-empty-on-error`, `markdown-fmt-corruption-1771`) timed out under host load at full parallelism and passed both in isolation and on a `--maxWorkers=4` full run; this is the flake section 9 already records, distinguishable from a missing `dist/` by the failure count.
- **Every new assertion mutation-probed**: each arm deletion (5 docs), the restore command removed, a fast-forward re-introduced, the printf dropping the fourth value, the probe block no longer carrying it, an empty value defaulted away, the fixture's initial branch unpinned, and the corpus floor left at 108,000 — 11 probes, each failing the intended assertion with the intended message and green again after a byte-exact restore.

## Deliberately not in this PR

- **`references/verify.md`** — the second lesson from the same run (reviewer subagents spawned BY A LANE report to the MAIN session, not to the lane) belongs there, but that file is held by a live peer lane (`chore/work-issues-retro-20260902`, unpushed commit `e5c7a37a`), confirmed live on 2026-09-02. Left untouched; it will be filed as a follow-up.
- **`references/implement.md`** — section 5's IN-PLACE arm is left as it is for cross-repo parity; the normative "branch in place off `origin/main` ALWAYS" rule lives in the launch-mode table, which is the file the parent reads before stage 0.

Closes go-to-k/cdk-real-drift#1854
