### PR TITLE
chore(work-issues): make the IN-PLACE branch unconditional, and land two flow lessons

### DIFF
--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -141,7 +141,8 @@ Enforced by `.claude/hooks/issue-dup-check-gate.sh`, which refuses
 Never edit in the main checkout — `.claude/hooks/worktree-guard.sh` blocks an
 Edit/Write to the main checkout's `src/**` or `tests/**` while any worktree
 exists, and always allows a path under `.worktrees/`. Per lane, in
-MAIN-CHECKOUT mode:
+MAIN-CHECKOUT mode (`references/launch-mode.md` holds the probe that decides
+which mode this is — the ONLY copy of it):
 
 ```bash
 git worktree add .worktrees/<name> -b wt-<name> origin/main
@@ -169,12 +170,12 @@ ancestor, which is what turns the gate ON for these lanes. The change gains
 coverage rather than risking it.
 
 **IN-PLACE mode (SKILL.md "Launch mode") skips that block entirely**: this run
-was launched inside a linked worktree, so it keeps that tree and the branch
-already checked out there, and creates NOTHING — a nested worktree dies with
-the outer workspace, taking its uncommitted work and leaving a registration
-that needs `git worktree prune` (go-to-k/cdk-real-drift#1842). Deps and `dist/`
-are usually already there; run `pnpm install` / `vp run build` only if they are
-not.
+was launched inside a linked worktree, so it keeps that tree and creates NO
+WORKTREE — a nested one dies with the outer workspace, taking its uncommitted
+work and leaving a registration that needs `git worktree prune`
+(go-to-k/cdk-real-drift#1842). It does still take a BRANCH, in place, by the
+recipe below. Deps and `dist/` are usually already there; run `pnpm install` /
+`vp run build` only if they are not.
 
 **Confirm the tree is YOURS before adopting it.** A stray `cd` into a peer's
 live lane looks exactly like a workspace handed to you. This repo ships no
@@ -216,9 +217,14 @@ previous revision had the two the other way round: a run following the file in
 order took a peer's live lane off its branch and only then checked whose tree it
 was. The order is the guard.
 
-**Only once the tree is confirmed yours**: if it is DETACHED, or its branch has
-already merged (reusing it would push an orphan ref), take a fresh branch
-WITHOUT leaving the tree.
+**Only once the tree is confirmed yours**: take a fresh branch here, ALWAYS,
+without leaving the tree. This used to be conditional — a DETACHED tree, or one
+whose branch had already merged (reusing it would push an orphan ref) — and the
+condition is WITHDRAWN. The branch the tree arrived on is `LAUNCH_BRANCH`
+(`references/launch-mode.md`): the OUTER TOOL's, not this run's, and §9 puts it
+back untouched at the very end, so committing onto it would leave the run
+nothing to restore and hand `gh pr merge --delete-branch` the outer tool's own
+remote branch to delete (go-to-k/cdkd#2417).
 
 ```bash
 # `-C <LANE_TREE>` is load-bearing, and the REASON changed on 2026-09-01.
@@ -345,6 +351,22 @@ so `vp test run` never saw them (`vp run test:hooks` now runs them, in CI too).
 The general shape: **a fence is not evidence until you have watched it go red on
 something you had not already counted.** Calibration says it is not noisy; only
 the spelling and deletion probes say it is load-bearing.
+
+**Restore from a BYTE-EXACT copy of the subject, never by inverting the edit.**
+A probe deliberately breaks a file, so the restore is the half that has to be
+right, and an inverse string replace is not one: measured 2026-09-02 on this
+skill's own fences, a probe that deleted a line reverted with
+`text.replace('', deleted_line)` — Python inserts between EVERY character —
+turned an 11 KB stage file into 838 KB, and the three probes queued behind it
+ran against the corrupted subject and returned verdicts about nothing. Copy the
+file aside first and copy it back (`cp` / `shutil.copyfile`), then re-run the
+suite and confirm GREEN before the next probe. `git checkout -- <file>` is not
+the alternative: at probe time the fix itself is usually uncommitted, so that
+discards the work along with the wreckage (the pre-probe commit rule in
+`references/verify.md` narrows this, and a `git stash` cycle around an unrelated
+peer's changes has its own trap). Verify the restore by HASH, not by eye — a
+`shasum -a 256` recorded before the first probe turns "I think I put it back"
+into a check.
 
 **Both probes above vary the INPUT. The second axis is the STATE the subject is
 in when the input arrives, and that one gets enumerated by ACCIDENT** — every

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -147,6 +147,26 @@ at once, not trickled.
     failed once and the identical re-run went 343/343 rc=0. Tell them apart by
     the COUNT — 13 failures means no `dist/`, fewer means the flake — and
     never let a single red run stand as the verdict.
+  - **The COUNT stops discriminating once the host is loaded; re-run at
+    `--maxWorkers=4` instead.** Every suite that SPAWNS the built CLI or `vp`
+    itself is racing the machine's other agents for cores, and a 5,000 ms
+    default timeout is what gives way first — so the reds land in whichever
+    subprocess suites the run happened to schedule during the crunch, at a
+    count that says nothing about `dist/`. Measured 2026-09-02
+    (go-to-k/cdk-real-drift#1854): `json-empty-on-error` plus
+    `markdown-fmt-corruption-1771` failed 10, then 13, then 14 tests across
+    three full runs with `dist/` freshly packed; both files passed run in
+    ISOLATION, and one `vp test run --maxWorkers=4` over the whole suite was
+    352 files / 6,665 tests green. The sibling go-to-k/cdkd reproduced the same
+    class within the hour — a 5,000 ms test failing twice under load, then 3/3
+    once the parallel lanes finished. So the discriminator is the RE-RUN SHAPE,
+    not the count: isolation, reduced parallelism, and simply waiting for the
+    host to quiesce turn a load artifact green while leaving a real failure red.
+    Measure the host before believing any of them — the same day, at
+    `load average 137` with 40 `vitest` processes from peer lanes, `--maxWorkers=4`
+    was no longer enough and one test still timed out running its file ALONE.
+    `uptime` costs nothing and tells you whether the machine, not the diff, is
+    the subject.
   - **Repeating a `vp run <task>` DOES re-execute here** — `check` (5/5) and
     `test` (3/3) reported `not cached because it modified its input`. Do not
     import the sibling's cache-hit warning; the local cache trap (PR
@@ -241,6 +261,18 @@ on the same class, its flow-style `exclude:` staying green through the first
 fix for it. So the depth is your own read of the whole diff plus a round you
 dispatch yourself, and a lane's clean round is evidence about the lane's
 assumptions, not about the diff.
+
+**Reviewer subagents spawned BY A LANE report to the MAIN session, not to the
+lane that spawned them.** Completion notifications go to the top-level session,
+so a lane that dispatches reviewers and then waits on their reports waits for
+something that cannot arrive, while the parent collects verdicts it did not ask
+for and may not connect to a lane. Measured 2026-09-02 (go-to-k/cdkd#2417): a
+lane's two reviewers both delivered upward, the lane blocked, and the parent
+relayed both verdicts by hand. Pick one shape and say which in the dispatch: the
+lane runs its reviewers **synchronously** (so it holds its own turn until they
+return), or the **parent owns the review dispatch** and relays each verdict down
+— the latter under §9's queued-versus-`Resuming` rule, because a lane waiting on
+a review is stopped at exactly the moment the relay is sent.
 
 **A reviewer's scratch COPY of a worktree is not detached from git, so its
 `git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -50,8 +50,10 @@ const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B a
 // widest cells were shortened -- which, since `vp fmt` pads markdown table columns
 // to the widest cell, reclaimed the padding on all fourteen rows at once.
 // Re-measure whenever an orchestrator is edited -- a cap with an unmeasured margin
-// is one nobody can plan against. The 2026-09-02 LAUNCH_BRANCH round spent 118 B
-// of the 306 B that were left: the fourth probe value has to be NAMED in the
+// is one nobody can plan against. work-issues/SKILL.md is UNCHANGED at 11,812 B
+// by the follow-up round (go-to-k/cdk-real-drift#1856), which landed entirely in
+// stage files. The LAUNCH_BRANCH round before it spent 118 B of the 306 B that
+// were left: the fourth probe value has to be NAMED in the
 // always-loaded file (a lane cannot pass on a value it was never told to record),
 // while its reading, its restore recipe and the IN-PLACE consequence rows all
 // went to references/launch-mode.md and references/ship.md.
@@ -87,18 +89,23 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // now ASSERTED at the bottom of this file as well as described here, because
 // three consecutive rounds re-derived it BY HAND and one of them found it
 // lapsed.
-// Re-derived 2026-09-02 (go-to-k/cdk-real-drift#1854) at the final tree.
-// work-issues: 9 stage files, corpus 134,827 B, largest implement.md 26,041 B, so
-// the floor must exceed 134,827 - 26,041 = 108,786 -- the 108,000 set one round
-// earlier no longer does, and the assertion at the bottom of this file is what
-// said so rather than a human re-deriving it. The binding number is again not
-// the worst case: triage.md is 22,342 B, 3,699 B behind implement.md, so a flip
-// would put the requirement at 134,827 - 22,342 = 112,485. Sizing against the
-// FLIP, 116,000 clears the binding number by 7,214 B and the flip case by
-// 3,515 B, and leaves ~18 KB (134,827 - 116,000 = 18,827 B) of compression room
-// below the floor. The growth is the LAUNCH_BRANCH restore contract landing
-// across launch-mode.md (+1,541 B), ship.md (+3,471 B), retro.md (+471 B) and
-// claim.md (+152 B).
+// Re-derived 2026-09-02 (go-to-k/cdk-real-drift#1856) at the final tree.
+// work-issues: 9 stage files, corpus 139,801 B, largest implement.md 27,509 B, so
+// the binding requirement is 139,801 - 27,509 = 112,292, which the 116,000 set
+// hours earlier still clears -- the assertion below did NOT fire, and this raise
+// is preventive rather than a repair. What no longer clears is the FLIP case the
+// comment has been sized against since go-to-k/cdk-real-drift#1854: the next
+// candidates to become largest are verify.md at 23,304 B and triage.md at
+// 23,139 B, and the worst of those requires 139,801 - 23,139 = 116,662, which
+// 116,000 sits BELOW. Probed rather than reasoned (2026-09-02): with triage.md
+// grown past implement.md, the assertion reports "would leave 116,293 B and
+// still pass" at 116,000 and passes at 120,000. So 120,000 -- clearing the
+// binding number by 7,708 B and the flip by 3,338 B, and leaving ~19 KB
+// (139,801 - 120,000 = 19,801 B) of compression room below the floor. The growth
+// this round is the IN-PLACE branch rule and the byte-exact probe-restore rule
+// in implement.md (+1,628 B) plus the reviewer-reporting and host-load lessons
+// in verify.md (+2,316 B); the round before it was the LAUNCH_BRANCH restore
+// contract across launch-mode.md, ship.md, retro.md and claim.md.
 // hunt-bugs stays at 60,000: re-measured the same day, corpus 88,598 B and
 // largest gotchas.md 41,922 B, so 88,598 - 41,922 = 46,676 < 60,000 and its
 // property still holds. Re-measure both numbers for each skill whenever a stage
@@ -108,7 +115,7 @@ const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }>
   // post-compression. 9 files as of 2026-09-01, when the launch-mode probe and its
   // reading moved out of triage.md into references/launch-mode.md, which the PARENT
   // reads before stage 0.
-  'work-issues': { minFiles: 9, minCorpusBytes: 116_000 },
+  'work-issues': { minFiles: 9, minCorpusBytes: 120_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 7, minCorpusBytes: 60_000 },
 };

--- a/tests/work-issues-launch-mode.test.ts
+++ b/tests/work-issues-launch-mode.test.ts
@@ -87,8 +87,9 @@ const ARM_BEARING: Record<string, string[]> = {
 /**
  * Files carrying an arm of the LAUNCH_BRANCH contract
  * (go-to-k/cdk-real-drift#1854): the probe records the branch the outer tool
- * handed the tree over on, section 5 refuses to commit onto it, and section 9
- * puts it back AS-IS at the very end. Separate from ARM_BEARING because the mode
+ * handed the tree over on, section 5 refuses to commit onto it -- taking a fresh
+ * branch in place, ALWAYS, which is why implement.md carries an arm too -- and
+ * section 9 puts it back AS-IS at the very end. Separate from ARM_BEARING because the mode
  * words survive deleting the restore -- a file can still say IN-PLACE everywhere
  * while the one step that makes the mode leave no trace is gone, which is what
  * the byte floors also cannot see.
@@ -97,6 +98,7 @@ const LAUNCH_BRANCH_BEARING = [
   'SKILL.md',
   LAUNCH_MODE_DOC,
   join('references', 'claim.md'),
+  join('references', 'implement.md'),
   join('references', 'ship.md'),
   join('references', 'retro.md'),
 ];


### PR DESCRIPTION
Follow-up to go-to-k/cdk-real-drift#1855. That PR put the `LAUNCH_BRANCH` restore contract into `references/launch-mode.md`'s consequence table and deliberately left `references/implement.md` alone for cross-repo parity. The peer PRs that held it have since merged in all three repos, so parity is no longer a reason to skip it — and the contradiction it leaves is in the file a lane actually opens at stage 5.

## The contradiction

`references/launch-mode.md` row 5 says an IN-PLACE run branches in place off `origin/main` **ALWAYS** and never commits onto `LAUNCH_BRANCH`. `references/implement.md` §5 still said the run "keeps that tree and the branch already checked out there, and creates NOTHING", and its branch recipe fired only **if** the tree was detached or its branch had already merged. A lane following §5 in order would commit onto the outer tool's branch — leaving §9 nothing to restore, and handing `gh pr merge --delete-branch` the outer tool's own remote branch to delete.

## Changes

**`references/implement.md`**

- The MAIN-CHECKOUT `git worktree add` block's header now names `references/launch-mode.md` as the holder of the probe that decides the mode — the ONLY copy.
- The IN-PLACE paragraph: creates no **WORKTREE** (a nested one dies with the outer workspace) but **does take a BRANCH, in place**, by the recipe below it.
- That recipe is now **unconditional** — "take a fresh branch here, ALWAYS, without leaving the tree" — with the withdrawn condition stated as withdrawn and `go-to-k/cdkd#2417` cited as why. The existing `git fetch origin && git switch -c …` recipe and all of its `-C` / gate warnings are unchanged.
- **Mutation-probe restore rule**, beside the existing probe rules: restore from a BYTE-EXACT copy, never by inverting the edit. Measured on this skill's own fences — a probe reverted with Python's `replace('', line)` (which inserts between every character) turned an 11 KB stage file into 838 KB, and the three probes queued behind it ran against the corrupted subject and returned verdicts about nothing. `git checkout -- <file>` is named as the wrong alternative (the fix is usually uncommitted at probe time), and the restore is verified by `shasum`, not by eye.

**`references/verify.md`**

- **Reviewer subagents spawned BY A LANE report to the MAIN session**, so a lane that dispatches reviewers and waits on their reports waits for something that cannot arrive while the parent collects verdicts it did not ask for. Placed in the independent-review-round section; pick synchronous-in-lane or parent-owned dispatch and say which, the latter under §9's queued-versus-`Resuming` rule.
- **A full-suite red from subprocess-spawn timeouts is a HOST-LOAD artifact**, discriminated by the re-run SHAPE rather than by a failure count, placed directly under the bullet where the full-suite verdict is read (which discriminates a missing `dist/` by count — a rule that stops working once the host is loaded). Measured both here and in the sibling `go-to-k/cdkd` within the hour; the text says to check `uptime` first, because at `load average 137` with 40 `vitest` processes `--maxWorkers=4` was no longer enough and one test still timed out running its file alone.

**Fences**

- `references/implement.md` joins `LAUNCH_BRANCH_BEARING` in `tests/work-issues-launch-mode.test.ts` — it now carries an arm of the contract, so gutting it must fail.
- `MIN_REFERENCE_CORPUS_BYTES` 116,000 → 120,000. **Preventive, not a repair**: the lapse assertion did NOT fire (corpus 139,801, largest `implement.md` 27,509 → binding 112,292). What no longer cleared is the FLIP case the comment has been sized against since go-to-k/cdk-real-drift#1855 — the next candidates to become largest are `verify.md` (23,304 B) and `triage.md` (23,139 B), and the worst requires 116,662. 120,000 clears binding by 7,708 B and the flip by 3,338 B, leaving 19,801 B of compression room. `work-issues/SKILL.md` is untouched at 11,812 B (188 B under its cap); this round landed entirely in stage files.

## Verification

- `vp run typecheck` / `vp check --fix` / `vp pack` — pass. Skill fences (`work-issues-launch-mode`, `skill-file-payload`, `skill-doc-paths`): **92 tests green**.
- `vp test run` excluding the two subprocess-spawning suites: **6,633 tests green**. Those two suites (`json-empty-on-error`, `markdown-fmt-corruption-1771`) are untouched by this diff and were 352 files / 6,665 tests green earlier today; they now time out at 5,000 ms under `load average 137–201` with 40 peer `vitest` processes on this host — the exact class this PR documents. CI on a dedicated runner is the authoritative verdict here, and `ci-green-gate` enforces it.
- **Both new assertions mutation-probed** with byte-exact restores (per the rule this PR lands): deleting `implement.md`'s `LAUNCH_BRANCH` arm fails its new entry with the intended message and is green again after restore; and the floor's flip case was probed rather than reasoned — with `triage.md` grown past `implement.md`, the assertion reports "would leave 116,293 B and still pass" at 116,000 and passes at 120,000.

Follow-up to go-to-k/cdk-real-drift#1855 / go-to-k/cdk-real-drift#1854.
