### PR TITLE
chore(hooks): tell a detached HEAD apart from a tree branch-gate cannot see

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -108,11 +108,106 @@ if [[ -z "$target_top" || ! -f "$target_top/.markgate.yml" ]]; then
   exit 0
 fi
 
-# Read the branch from the resolved target dir. `-C` lets git operate
-# on a directory that isn't our cwd; if the dir doesn't exist or isn't
-# inside a git repo, symbolic-ref returns empty and we fall through to
-# the safe `exit 0` below (we can't gate what we can't see).
+# Read the branch from the resolved target dir. `-C` lets git operate on a
+# directory that isn't our cwd. An EMPTY answer is not one condition -- see the
+# `if [ -z "$branch" ]` arm below, which is where that used to be got wrong.
 branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+# The MAIN-vs-LINKED distinction, in the shape `main-tree-branch-gate.sh`
+# already uses: the main checkout is whatever `git worktree list --porcelain`
+# lists FIRST. Reused rather than re-invented, per go-to-k/cdkd#2402 -- but two
+# parts of that shape are deliberately NOT copied here, because each was
+# measured to buy nothing at this call site:
+#
+#   NO MEMO. That gate asks the question once per matched SEGMENT and caches the
+#   last answer in a pair of globals. This gate asks at most once per command,
+#   so a memo would cache nothing.
+#
+#   NO `canonicalize`. That gate compares its RAW `<dir>` argument -- a payload
+#   cwd, which may still carry a symlink -- against the porcelain path, so it
+#   must resolve both. This gate compares `$target_top`, which git has ALREADY
+#   resolved. Probed against git 2.x on macOS, where `/var` is a symlink to
+#   `/private/var`, with `<dir>` also reached through a symlinked parent and
+#   through a subdir under one -- `rev-parse --show-toplevel` returned the fully
+#   resolved real path in all four shapes, byte-identical to `worktree list
+#   --porcelain`'s first entry. A local `canonicalize` copy was written here
+#   first and NO mutation could kill it, which is what sent the question to a
+#   probe. If a future git ever stopped resolving `--show-toplevel`, this
+#   compare would fail OPEN and the five BLOCK cases in `branch-gate.test.sh`
+#   are what go red.
+if [ -z "$branch" ]; then
+  # `symbolic-ref --short HEAD` prints NOTHING in two situations that are not
+  # the same thing, and the comment that used to stand here asserted only the
+  # harmless one ("if the dir doesn't exist or isn't inside a git repo ... we
+  # can't gate what we can't see"):
+  #
+  #   (a) there is no repo to read       -> genuinely invisible; pass through.
+  #   (b) a real repo with a DETACHED HEAD -> the tree has LEFT `main`, which is
+  #       exactly the state this gate exists to catch, wearing a spelling it
+  #       could not see because it recognised the state only by branch NAME.
+  #
+  # (b) is reachable from the documented flow. `main-tree-branch-gate.sh`
+  # deliberately passes `git checkout <sha>` in the main checkout (its own
+  # `--detach` note carries the measurement, and keeps the verdict); the tree
+  # detaches, and this gate then waved a commit straight into the SHARED main
+  # checkout. Measured on a scratch opted-in repo before this arm existed,
+  # driving this hook with a `git commit -m x` payload: rc=2 on `main`, rc=0
+  # once detached. Two gates, a hole neither has alone (go-to-k/cdkd#2402).
+  #
+  # THE DISCRIMINATOR IS ALREADY IN HAND. `$target_top` is `rev-parse
+  # --show-toplevel` from this same dir, and it is non-empty here because the
+  # opt-in check above returned early otherwise. A non-empty toplevel IS a real
+  # repo with a work tree, so an empty branch beside it can only mean a detached
+  # HEAD; a second `rev-parse --git-dir` probe would fork again to re-learn what
+  # `$target_top` already said.
+  #
+  # IT COMPARES TOPLEVELS, NOT THE RAW DIR, and that single choice removes TWO
+  # independent failures. `main_tree_of` in the sibling gate compares its
+  # `<dir>` argument, which is the payload cwd, so (i) a cwd one level down
+  # (`cd <repo>/src && ...`) is not equal to the checkout root, and (ii) the cwd
+  # still carries whatever symlink the caller typed, while the porcelain path
+  # does not. `$target_top` has neither problem: git resolves both out of
+  # `--show-toplevel`. Measured -- swapping this compare to `$target_dir` turns
+  # ALL FIVE block rows in `branch-gate.test.sh` red, the subdir row for reason
+  # (i) and the other four for reason (ii), since a macOS `mktemp -d` hands out
+  # a `/var` path that git reports as `/private/var`.
+  #
+  # BLOCKED ONLY IN THE MAIN CHECKOUT. A detached HEAD in a LINKED worktree is
+  # the remedy this repo's own Stop hook prints -- `stop-unmerged-lane-warn.sh`
+  # tells a session that must not remove its worktree to run
+  # `git switch --detach origin/main`, "because a worktree with no current
+  # branch is not a lane". Blocking that would refuse a documented instruction.
+  #
+  # `substr($0, 10)` rather than `$2`, for the reason the sibling gate records:
+  # awk splits on whitespace, so a checkout path containing a SPACE is truncated
+  # at it and the compare below then never matches -- the gate standing down
+  # over a main checkout it had mis-read. Fenced by the spaced-path case in
+  # `branch-gate.test.sh`.
+  main_checkout=$(git -C "$target_dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10); exit}')
+  if [ "$target_top" = "$main_checkout" ]; then
+    echo "Blocked by branch-gate: target git working tree has a DETACHED HEAD in the MAIN checkout." >&2
+    echo "  resolved target dir: $target_dir" >&2
+    echo "  main checkout      : $main_checkout" >&2
+    echo "  HEAD               : $(git -C "$target_dir" rev-parse --short HEAD 2>/dev/null || echo '?')" >&2
+    echo "  command: $cmd" >&2
+    echo "A detached HEAD is not a feature branch, and this is the SHARED main checkout," >&2
+    echo "so a commit here puts off-branch work in the tree every other lane reads." >&2
+    echo "Re-attach first: git -C \"$main_checkout\" switch main" >&2
+    echo "Then do the work in its own worktree: git worktree add <path> -b fix/xxx origin/main" >&2
+    echo "A detached HEAD in a LINKED worktree is NOT blocked -- that is the documented" >&2
+    echo "way to clear a lane." >&2
+    exit 2
+  fi
+  # FAIL-OPEN, deliberate and stated. Three readings reach this line, and the
+  # compare above sends all three here without needing a guard of their own,
+  # since `$target_top` is non-empty and so can equal none of the empty answers:
+  #   - `git worktree list` gave nothing (not a repo we can read) -- we do not
+  #     gate what we cannot see;
+  #   - the awk found no `worktree ` line at all -- same reading;
+  #   - the detached tree is a LINKED worktree, the sanctioned lane-clearing
+  #     state named above.
+  exit 0
+fi
 
 case "$branch" in
   main|master)

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -27,6 +27,32 @@ set -u
 # Read the entire stdin payload once; we need both .tool_input.command
 # and .cwd from it. Reading via two separate jq invocations would
 # consume stdin twice and the second read would see nothing.
+
+# STATED FAIL-OPENS AT THE PAYLOAD LEVEL, here rather than at the enumeration far
+# below -- that one lists the readings that reach ITS line, and these never get
+# that far, so the enumeration reads as a complete list of exit-0 paths and is
+# not one. Both measured by driving this hook with a `git commit -m x` payload
+# whose cwd is an opted-in repo on `main`, which scores rc=2 normally:
+#
+#   `jq` absent from PATH entirely  -> rc=0. `$cmd` is empty, so the verb match
+#     below finds nothing. (Easy to mis-measure: a dev Mac carries `jq` at BOTH
+#     /opt/homebrew/bin and /usr/bin, so dropping only the first proves nothing. Measured under `env -i PATH=<dir with bash/git/cat/dirname only>`.)
+#   a malformed or truncated JSON payload -> rc=0, same way.
+#
+# Deliberate and unchanged. A gate that could not read its own input has nothing
+# to say about a command it never saw, and the alternative -- refusing every
+# Bash call on a box without `jq` -- is worse than the hole.
+#
+# A THIRD CANDIDATE WAS RAISED IN REVIEW AND DOES NOT BELONG HERE AS STATED: a
+# `git -C "$W" commit` whose target is an unexpanded variable. It is not
+# unconditionally an exit 0. Measured, three shapes: with the payload cwd IN the
+# gated repo it BLOCKS (rc=2) -- the unresolvable `-C` is dropped and the cwd
+# answers -- and it exits 0 only when the fallback itself lands somewhere
+# non-gated, i.e. when the payload cwd has drifted out of the repo or an
+# explicit `cd <non-gated>` precedes the verb (rc=0 for both). That last shape
+# IS the real hole, and it is the ordinary opt-in reached by a wrong route
+# rather than an unstated fail-open of its own; go-to-k/cdkd#2027 is where the
+# sibling repo closed it with a strict resolver that refuses instead.
 input=$(cat 2>/dev/null || true)
 
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
@@ -133,8 +159,14 @@ branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
 #   --porcelain`'s first entry. A local `canonicalize` copy was written here
 #   first and NO mutation could kill it, which is what sent the question to a
 #   probe. If a future git ever stopped resolving `--show-toplevel`, this
-#   compare would fail OPEN and the five BLOCK cases in `branch-gate.test.sh`
-#   are what go red.
+#   compare would fail OPEN, and `branch-gate.test.sh` is what goes red -- but
+#   NOT the five cases this sentence used to name. That count was stale in two
+#   directions at once: the suite has grown since, and the number was never a
+#   constant to begin with. Stood in for by swapping the compare to
+#   `$target_dir` and re-running: 22 of 42 rows red on this macOS fixture root,
+#   3 of 42 on a non-symlinked one, for the reason the arm below spells out.
+#   The only fixed number in the pair is the SCOPED one that arm already
+#   quotes, so that is where a count is given and this is not.
 if [ -z "$branch" ]; then
   # `symbolic-ref --short HEAD` prints NOTHING in two situations that are not
   # the same thing, and the comment that used to stand here asserted only the
@@ -270,6 +302,26 @@ if [ -z "$branch" ]; then
     # hand-made directory above. The comment used to name both files as the
     # discriminator, which overstated what the code looks at.)
     #
+    # STATED BOUND -- A `$` IN THE CHECKOUT PATH. Every remedy this gate prints
+    # wraps the path in DOUBLE quotes, which is how the sibling gates spell it
+    # too, so a literal `$` in the path RE-EXPANDS in whatever shell the reader
+    # pastes it into. Measured on git 2.53 by rebuilding `branch-gate.test.sh`'s
+    # fixture under a root containing `$`: the printed `rebase --abort` exits 1
+    # with `<rest-of-path>: unbound variable` under `set -u`, and in a shell
+    # without `set -u` it would expand to nothing and quietly act on the WRONG
+    # directory -- the silent half being the worse one.
+    #
+    # Left as a bound rather than fixed, and the reasons are worth writing down
+    # because "the quoting is just a convention" is how it stayed implied. (1)
+    # It is not local to this arm: the branch-NAME arm's `switch -c fix/xxx`
+    # line is printed the same way, so single-quoting here alone would leave the
+    # gate inconsistent with itself and with the other gates. (2) The same
+    # fixture also reddens rows whose PAYLOAD carries a `-C` target, so the
+    # gate's own path handling is already affected upstream of any remedy -- a
+    # `$` path is outside what these gates read correctly at all, not merely
+    # outside what they print correctly. Fixing the print alone would buy the
+    # appearance of a fix.
+    #
     # The order below follows git's own status precedence: rebase, then
     # cherry-pick / revert, then merge, then bisect.
     git_dir=$(git -C "$target_dir" rev-parse --absolute-git-dir 2>/dev/null || echo "")
@@ -303,7 +355,8 @@ if [ -z "$branch" ]; then
     #   rebase --abort, rebase started FROM a branch      -> branch main
     #   rebase --abort, rebase started ALREADY detached   -> DETACHED
     #   am / cherry-pick / revert / merge --abort         -> DETACHED (all four)
-    #   bisect reset                                      -> branch main
+    #   bisect reset, bisect started FROM a branch        -> branch main
+    #   bisect reset, bisect started ALREADY detached     -> DETACHED
     #
     # `am` / `cherry-pick` / `revert` / `merge` never detach HEAD themselves, so
     # this arm is reachable for them ONLY from an already-detached tree, and
@@ -326,6 +379,35 @@ if [ -z "$branch" ]; then
     # `detached HEAD`, empty -- is read as "no branch to return to", the
     # conservative direction: it under-promises instead of repeating the
     # overclaim.
+    #
+    # BISECT HAS THE SAME TWO POLARITIES AND ITS OWN DISCRIMINATOR, and the
+    # sentence below it used to carry was the SAME defect one arm over: it said
+    # the bisect "is what detached HEAD here" and that `bisect reset` "restores
+    # the branch you started from". Both are false of a bisect begun in a tree
+    # that was ALREADY detached -- and `main-tree-branch-gate.sh` passes
+    # `git checkout <sha>` in the main checkout, so that is one allowed command
+    # away. Measured on git 2.53, same fixture both ways:
+    #
+    #   started FROM a branch   BISECT_START = main    reset -> branch main
+    #   started DETACHED        BISECT_START = <sha>   reset -> rc=0, STILL DETACHED
+    #
+    # `git bisect start` records what it must return to in `.git/BISECT_START`:
+    # the BRANCH NAME when it began on a branch, a raw SHA when it began
+    # detached. That file is to bisect exactly what `head-name` is to rebase.
+    #
+    # ASKED WITH `show-ref`, NOT WITH A 40-HEX PATTERN, because `git bisect
+    # reset` ends in `git checkout "$(cat BISECT_START)"` and `show-ref
+    # --verify refs/heads/<x>` is the same question that checkout resolves
+    # against. Three consequences, all measured on git 2.53: a branch whose NAME
+    # happens to be 40 hex characters is answered "re-attaches", and checkout
+    # agrees, where a pattern would have called it a sha; an EMPTY or missing
+    # `BISECT_START` is answered "no branch", and reset does leave HEAD
+    # detached; and a start branch that no longer exists is answered "no
+    # branch", where reset fails loudly (`fatal: invalid reference`) rather than
+    # re-attaching. That last state is not reachable by ordinary commands --
+    # `git branch -D` refuses with `cannot delete branch 'x' used by worktree`
+    # while the bisect holds it -- and needs a low-level `update-ref -d` to
+    # produce, so it is a bound rather than a case.
     reattach_to=""
     if [ "$inflight" = "rebase" ] && [ -n "$git_dir" ]; then
       __head_name=""
@@ -337,6 +419,15 @@ if [ -z "$branch" ]; then
       case "$__head_name" in
         refs/heads/?*) reattach_to="${__head_name#refs/heads/}" ;;
       esac
+    elif [ "$inflight" = "bisect" ] && [ -n "$git_dir" ]; then
+      __bisect_start=""
+      if [ -f "$git_dir/BISECT_START" ]; then
+        __bisect_start=$(cat "$git_dir/BISECT_START" 2>/dev/null || echo "")
+      fi
+      if [ -n "$__bisect_start" ] &&
+        git -C "$target_dir" show-ref --verify --quiet "refs/heads/$__bisect_start" 2>/dev/null; then
+        reattach_to="$__bisect_start"
+      fi
     fi
     echo "Blocked by branch-gate: target git working tree has a DETACHED HEAD in the MAIN checkout." >&2
     echo "  resolved target dir: $target_dir" >&2
@@ -347,9 +438,17 @@ if [ -z "$branch" ]; then
     echo "A detached HEAD is not a feature branch, and this is the SHARED main checkout," >&2
     echo "so a commit here puts off-branch work in the tree every other lane reads." >&2
     if [ "$inflight" = "bisect" ]; then
-      echo "A 'git bisect' is what detached HEAD here, and 'switch main' would leave the" >&2
-      echo "bisect running. End it instead -- this restores the branch you started from:" >&2
+      echo "A 'git bisect' is IN PROGRESS, and 'switch main' would leave it running --" >&2
+      echo "git switches with a warning and the bisect survives. End it instead:" >&2
       echo "  git -C \"$main_checkout\" bisect reset" >&2
+      if [ -n "$reattach_to" ]; then
+        echo "That restores the branch you started from, '$reattach_to'." >&2
+      else
+        echo "That does NOT re-attach HEAD: this bisect started from a tree that was" >&2
+        echo "ALREADY detached, so 'bisect reset' returns to that same detached commit." >&2
+        echo "Re-attach afterwards:" >&2
+        echo "  git -C \"$main_checkout\" switch main" >&2
+      fi
     elif [ -n "$inflight" ]; then
       echo "A '$inflight' is IN PROGRESS, so 'switch main' is not available here -- git" >&2
       echo "refuses it outright. Finish or abandon the operation first:" >&2
@@ -370,7 +469,9 @@ if [ -z "$branch" ]; then
     echo "way to clear a lane." >&2
     exit 2
   fi
-  # FAIL-OPEN, deliberate and stated. FOUR readings reach this line, and the
+  # FAIL-OPEN, deliberate and stated. FOUR readings reach this line -- and this
+  # list is NOT every exit-0 path in the hook, only every path to THIS one; the
+  # payload-level ones are stated at the `jq` read near the top. The
   # compare above sends all four here without needing a guard of their own,
   # since `$target_top` is non-empty and so can equal none of the answers below:
   #   - `git worktree list` gave nothing (not a repo we can read) -- we do not

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -238,10 +238,40 @@ if [ -z "$branch" ]; then
     # already has rows for, and this arm is reachable by `-C` from anywhere.
     #
     # `rebase-apply` is shared by `git am` and `git rebase --apply`; the
-    # `applying` / `rebasing` sentinel inside that directory is what separates
-    # them, and it is load-bearing -- `git rebase --abort` inside an am session
-    # answers "No rebase in progress?". The order below follows git's own status
-    # precedence: rebase, then cherry-pick / revert, then merge, then bisect.
+    # `applying` sentinel inside that directory is what separates them, and it is
+    # load-bearing IN THE DIRECTION THAT FAILS SILENTLY. Both crossings measured
+    # on git 2.53, from a MAIN checkout detached mid-operation:
+    #
+    #   `git rebase --abort` inside an AM session -> rc=128, `fatal: It looks
+    #     like 'git am' is in progress. Cannot rebase.`, HEAD unchanged. LOUD --
+    #     the reader is told the remedy was the wrong one.
+    #   `git am --abort` inside a `rebase --apply` session -> rc=0, NO output,
+    #     HEAD still DETACHED -- where `git rebase --abort` from that same state
+    #     lands on `main`. SILENT: exit 0 reads as "done", and the one thing the
+    #     remedy existed to fix is still true.
+    #
+    # An earlier version of this comment cited "No rebase in progress?" as git's
+    # answer to the FIRST crossing. It is not: `fatal: no rebase in progress` is
+    # what git says when NOTHING is in progress, a different condition -- and the
+    # quiet crossing is the one worth naming anyway, since a loud one cannot
+    # mislead anybody.
+    #
+    # STATED BOUND -- a `rebase-apply/` holding neither `applying` nor
+    # `head-name` reads as a rebase here, and the printed `rebase --abort` then
+    # exits 1 with `warning: could not read '.git/rebase-apply/head-name'`.
+    # `git status` calls that same state "You are currently rebasing.", so the
+    # hook agrees with git; and no git command produces it, since both rebase
+    # backends write `head-name` at start and `git am` writes `applying`. A bound
+    # rather than a bug. Measured on git 2.53 by creating the directory by hand.
+    # (`git rebase --apply` also writes a `rebasing` file, and this code
+    # deliberately does not read it. `rebase-apply` WITHOUT `applying` is a
+    # rebase, so the negative read already answers the question; a positive read
+    # would add a third, ambiguous state whose only member is exactly the
+    # hand-made directory above. The comment used to name both files as the
+    # discriminator, which overstated what the code looks at.)
+    #
+    # The order below follows git's own status precedence: rebase, then
+    # cherry-pick / revert, then merge, then bisect.
     git_dir=$(git -C "$target_dir" rev-parse --absolute-git-dir 2>/dev/null || echo "")
     inflight=""
     if [ -n "$git_dir" ]; then
@@ -263,6 +293,51 @@ if [ -z "$branch" ]; then
         inflight="bisect"
       fi
     fi
+
+    # WHERE THE REMEDY LEAVES HEAD -- the observable the previous round did not
+    # take. That round verified every printed remedy EXITS 0, which all nine do,
+    # and then promised `--abort` would "re-attach". Measured on git 2.53 by
+    # running each printed remedy verbatim against the fixture and reading HEAD
+    # afterwards:
+    #
+    #   rebase --abort, rebase started FROM a branch      -> branch main
+    #   rebase --abort, rebase started ALREADY detached   -> DETACHED
+    #   am / cherry-pick / revert / merge --abort         -> DETACHED (all four)
+    #   bisect reset                                      -> branch main
+    #
+    # `am` / `cherry-pick` / `revert` / `merge` never detach HEAD themselves, so
+    # this arm is reachable for them ONLY from an already-detached tree, and
+    # `--abort` restores exactly that pre-op state: still detached. The user runs
+    # the remedy, reads exit 0 as success, and the next gated command blocks
+    # again with `in progress : nothing` -- the same dead end this arm exists to
+    # remove, one layer down. So the promise is made conditional on what results.
+    #
+    # ONE SENTENCE COVERS BOTH ENDINGS, because the outcome is a property of the
+    # SESSION rather than of which ending is picked. Measured the same way: a
+    # completed `rebase --continue` re-attaches only when the rebase started from
+    # a branch, and `am` / `cherry-pick` / `revert` / `merge --continue` all
+    # leave HEAD detached.
+    #
+    # THE DISCRIMINATOR IS GIT'S OWN `head-name`, written by both rebase backends
+    # into `rebase-merge/` or `rebase-apply/`: `refs/heads/<branch>` when the
+    # rebase started from that branch, the literal string `detached HEAD` when it
+    # did not. `git am` writes no `head-name` at all, which is consistent with it
+    # never re-attaching. Anything not matching `refs/heads/<name>` -- absent,
+    # `detached HEAD`, empty -- is read as "no branch to return to", the
+    # conservative direction: it under-promises instead of repeating the
+    # overclaim.
+    reattach_to=""
+    if [ "$inflight" = "rebase" ] && [ -n "$git_dir" ]; then
+      __head_name=""
+      if [ -f "$git_dir/rebase-merge/head-name" ]; then
+        __head_name=$(cat "$git_dir/rebase-merge/head-name" 2>/dev/null || echo "")
+      elif [ -f "$git_dir/rebase-apply/head-name" ]; then
+        __head_name=$(cat "$git_dir/rebase-apply/head-name" 2>/dev/null || echo "")
+      fi
+      case "$__head_name" in
+        refs/heads/?*) reattach_to="${__head_name#refs/heads/}" ;;
+      esac
+    fi
     echo "Blocked by branch-gate: target git working tree has a DETACHED HEAD in the MAIN checkout." >&2
     echo "  resolved target dir: $target_dir" >&2
     echo "  main checkout      : $main_checkout" >&2
@@ -277,9 +352,16 @@ if [ -z "$branch" ]; then
       echo "  git -C \"$main_checkout\" bisect reset" >&2
     elif [ -n "$inflight" ]; then
       echo "A '$inflight' is IN PROGRESS, so 'switch main' is not available here -- git" >&2
-      echo "refuses it outright. Finish or abandon the operation instead:" >&2
+      echo "refuses it outright. Finish or abandon the operation first:" >&2
       echo "  git -C \"$main_checkout\" $inflight --continue   # after resolving the conflict" >&2
-      echo "  git -C \"$main_checkout\" $inflight --abort      # to abandon it and re-attach" >&2
+      echo "  git -C \"$main_checkout\" $inflight --abort      # to abandon it" >&2
+      if [ -n "$reattach_to" ]; then
+        echo "Either ending re-attaches HEAD to '$reattach_to' (the branch the rebase started from)." >&2
+      else
+        echo "NEITHER ending re-attaches HEAD: git has no branch recorded to return to, so" >&2
+        echo "both leave this checkout DETACHED. Re-attach afterwards:" >&2
+        echo "  git -C \"$main_checkout\" switch main" >&2
+      fi
     else
       echo "Re-attach first: git -C \"$main_checkout\" switch main" >&2
     fi

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -36,7 +36,8 @@ set -u
 #
 #   `jq` absent from PATH entirely  -> rc=0. `$cmd` is empty, so the verb match
 #     below finds nothing. (Easy to mis-measure: a dev Mac carries `jq` at BOTH
-#     /opt/homebrew/bin and /usr/bin, so dropping only the first proves nothing. Measured under `env -i PATH=<dir with bash/git/cat/dirname only>`.)
+#     /opt/homebrew/bin and /usr/bin, so dropping only the first proves nothing.
+#     Measured under `env -i PATH=<dir with bash/git/cat/dirname only>`.)
 #   a malformed or truncated JSON payload -> rc=0, same way.
 #
 # Deliberate and unchanged. A gate that could not read its own input has nothing
@@ -85,7 +86,9 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # first shape here, and it silently disabled the gate whenever the library was
 # unreadable or truncated — with the sibling gates' own comments claiming the
 # opposite (go-to-k/cdkd#2130 review). The `declare -F` check catches a partial
-# source, where `.` succeeds but the function is missing.
+# source, where `.` succeeds but the functions are missing -- ALL of the ones
+# this hook goes on to call, which is the part this copy had drifted from; see
+# the list below for the measurement.
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
 if [ ! -r "$_gate_lib" ]; then
   echo "Blocked: .claude/hooks/_command-match.sh is missing or unreadable, so this gate cannot evaluate the command." >&2
@@ -93,10 +96,31 @@ if [ ! -r "$_gate_lib" ]; then
 fi
 # shellcheck source=/dev/null
 . "$_gate_lib"
-if ! declare -F gate_matches >/dev/null 2>&1; then
-  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
-  exit 2
-fi
+# EVERY library function this hook calls, which is the shape cdkd's twin has
+# carried since go-to-k/cdkd#2130 and the shape this copy lost. `gate_matches`
+# alone was the entire check. It is defined at line 239 of 1094, while
+# `gate_target_dir` -- called from the line right after the match -- is at
+# 962. A copy cut anywhere between the two DEFINES `gate_matches`, passes
+# the guard, and then dies on an undefined `gate_target_dir` inside a
+# command substitution; the hook reads
+# that 127 as "no target dir", exits 0, and the gate is silently off.
+# Measured against this hook, payload `git commit -m oops` in an opted-in
+# repo on `main`, truncating the library at every 25th line: 30 of 44
+# offsets scored rc=0 NOT BLOCKED, every one of them in [251..976]. With
+# the list below, 0 of 44. `branch-gate.test.sh` drives a real cut inside
+# that window.
+#
+# A LIST, not just the last-defined name, even though
+# `gate_target_dir` alone would cover the rest today: the definition
+# ORDER is a property of the library, not of this hook, so reordering it must
+# not silently reopen the window. One entry per library function called below.
+for _gate_fn in gate_matches gate_re_any gate_target_dir; do
+  if ! declare -F "$_gate_fn" >/dev/null 2>&1; then
+    echo "Blocked: .claude/hooks/_command-match.sh loaded but $_gate_fn is undefined (truncated file?)." >&2
+    exit 2
+  fi
+done
+unset _gate_fn
 
 # Which commands this gate applies to. The segment matcher sees a gated verb in
 # ANY position — `git add -A && git commit` used to run ungated
@@ -163,8 +187,8 @@ branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
 #   NOT the five cases this sentence used to name. That count was stale in two
 #   directions at once: the suite has grown since, and the number was never a
 #   constant to begin with. Stood in for by swapping the compare to
-#   `$target_dir` and re-running: 22 of 42 rows red on this macOS fixture root,
-#   3 of 42 on a non-symlinked one, for the reason the arm below spells out.
+#   `$target_dir` and re-running: 31 of 81 rows red on this macOS fixture root,
+#   3 of 81 on a non-symlinked one, for the reason the arm below spells out.
 #   The only fixed number in the pair is the SCOPED one that arm already
 #   quotes, so that is where a count is given and this is not.
 if [ -z "$branch" ]; then
@@ -408,6 +432,20 @@ if [ -z "$branch" ]; then
     # `git branch -D` refuses with `cannot delete branch 'x' used by worktree`
     # while the bisect holds it -- and needs a low-level `update-ref -d` to
     # produce, so it is a bound rather than a case.
+    #
+    # THE NEGATIVE ARM NAMES NO CAUSE, and that is a correction rather than a
+    # style choice. `reattach_to=""` is reached from FIVE states -- a bisect
+    # begun already detached, an EMPTY `BISECT_START`, a missing one, an
+    # unreadable one, and a start branch deleted under the bisect -- and the
+    # sentence used to assert the first ("this bisect started from a tree that
+    # was ALREADY detached"), which the code never established. With the start
+    # branch deleted, BOTH halves of that sentence are false: measured on git
+    # 2.53, `bisect reset` exits 1 with `fatal: invalid reference: <name>`, so
+    # it does not "return to that same detached commit", and the printed
+    # `switch main` fallback is what actually re-attaches. The sibling rebase
+    # arm below already had the neutral spelling ("git has no branch recorded
+    # to return to"); this arm now uses it, so one file no longer states the
+    # same fact two ways.
     reattach_to=""
     if [ "$inflight" = "rebase" ] && [ -n "$git_dir" ]; then
       __head_name=""
@@ -444,9 +482,8 @@ if [ -z "$branch" ]; then
       if [ -n "$reattach_to" ]; then
         echo "That restores the branch you started from, '$reattach_to'." >&2
       else
-        echo "That does NOT re-attach HEAD: this bisect started from a tree that was" >&2
-        echo "ALREADY detached, so 'bisect reset' returns to that same detached commit." >&2
-        echo "Re-attach afterwards:" >&2
+        echo "That does NOT re-attach HEAD: git has no branch recorded to return to, so" >&2
+        echo "'bisect reset' leaves this checkout DETACHED. Re-attach afterwards:" >&2
         echo "  git -C \"$main_checkout\" switch main" >&2
       fi
     elif [ -n "$inflight" ]; then

--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -167,10 +167,24 @@ if [ -z "$branch" ]; then
   # (`cd <repo>/src && ...`) is not equal to the checkout root, and (ii) the cwd
   # still carries whatever symlink the caller typed, while the porcelain path
   # does not. `$target_top` has neither problem: git resolves both out of
-  # `--show-toplevel`. Measured -- swapping this compare to `$target_dir` turns
-  # ALL FIVE block rows in `branch-gate.test.sh` red, the subdir row for reason
-  # (i) and the other four for reason (ii), since a macOS `mktemp -d` hands out
-  # a `/var` path that git reports as `/private/var`.
+  # `--show-toplevel`.
+  #
+  # THE FIRST VERSION OF THIS SENTENCE OVERCLAIMED, and the correction is the
+  # reason the symlinked-cwd row below exists. Swapping the compare to
+  # `$target_dir` does turn all five pre-existing block rows red -- but only
+  # because macOS's `mktemp -d` hands out a `/var` path that git reports as
+  # `/private/var`, so the ENTIRE fixture is symlinked and reason (ii) fires on
+  # every row for free. Re-measured with the same fixture built on a
+  # NON-symlinked root -- which is what a Linux runner gets, `/tmp` being a real
+  # directory there -- that mutation kills exactly ONE of the five, the subdir
+  # row, for reason (i). So wherever this suite runs on Linux, reason (ii) had no
+  # coverage at all. That is cdk-local and cdk-real-drift, which run it from
+  # `ci.yml` on `ubuntu-latest`; cdkd pins its own `hooks.yml` to `macos-latest`,
+  # because that is the only runner image carrying the bash 3.2 this suite also
+  # exists to exercise -- so there the accident holds and the gap does not open.
+  # `branch-gate.test.sh` now carries a row whose payload cwd is an explicit
+  # `ln -s` to the main checkout, and that row dies under the mutation on BOTH
+  # roots: non-symlinked 1/5 -> 2/6, symlinked 5/5 -> 6/6.
   #
   # BLOCKED ONLY IN THE MAIN CHECKOUT. A detached HEAD in a LINKED worktree is
   # the remedy this repo's own Stop hook prints -- `stop-unmerged-lane-warn.sh`
@@ -183,29 +197,114 @@ if [ -z "$branch" ]; then
   # at it and the compare below then never matches -- the gate standing down
   # over a main checkout it had mis-read. Fenced by the spaced-path case in
   # `branch-gate.test.sh`.
+  #
+  # STATED BOUND -- a NEWLINE in the path still fails open, and no field
+  # expression fixes it: awk's records ARE lines, so an embedded newline ends the
+  # record early whatever reads it. Measured on git 2.53, same fixture twice: a
+  # detached MAIN checkout at `<tmp>/nl<LF>repo` scores rc=0, and rc=2 with the
+  # newline removed. `worktree list --porcelain -z` DOES read it correctly
+  # (checked under bash 3.2 and 5.3 on git 2.53, and it still names the MAIN
+  # checkout when run from a linked worktree), and is deliberately not taken.
+  # `-z` is a later addition to `worktree list` than `--porcelain` itself, so it
+  # would need this awk kept behind it as a fallback for older git anyway --
+  # measured: an unsupported flag makes `worktree list` print NOTHING, so a
+  # `-z`-only read fails OPEN there, which is the same bug class this arm exists
+  # to close. And once `-z` runs first, the awk stops executing on every git new
+  # enough to have it, retiring the spaced-path fence -- trading a fence over a
+  # shape that has actually been produced here for one over a shape nobody has.
+  # Only this arm is affected; the branch-NAME arm parses no paths.
   main_checkout=$(git -C "$target_dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10); exit}')
   if [ "$target_top" = "$main_checkout" ]; then
+    # WHICH REMEDY TO PRINT. A refusal that names a command git itself rejects is
+    # worse than no refusal at all: the block is correct and the reader still has
+    # no way out. A conflicted rebase is one of the ways a MAIN checkout reaches a
+    # detached HEAD, and `git pull` on `main` in the main checkout is this repo's
+    # own mandated post-merge sync, so the route is a documented one rather than a
+    # contrived one. Measured on git 2.53, HEAD detached in each case:
+    #
+    #   rebase / rebase -i / rebase --apply  ->  fatal: cannot switch branch while rebasing
+    #   am                                   ->  fatal: cannot switch branch in the middle of an am session
+    #   cherry-pick                          ->  fatal: cannot switch branch while cherry-picking
+    #   revert                               ->  fatal: cannot switch branch while reverting
+    #   merge                                ->  fatal: cannot switch branch while merging
+    #   bisect                               ->  warning, then Switched -- but BISECT_LOG survives
+    #   nothing in progress                  ->  Switched to branch 'main'
+    #
+    # Five of those make `switch main` a dead end and the sixth makes it
+    # incomplete, so the operation is detected and the remedy follows it.
+    #
+    # THE GIT DIR IS RESOLVED, NOT ASSUMED. `<target_dir>/.git` is wrong whenever
+    # `$target_dir` is a SUBDIRECTORY of the checkout, which is a shape this arm
+    # already has rows for, and this arm is reachable by `-C` from anywhere.
+    #
+    # `rebase-apply` is shared by `git am` and `git rebase --apply`; the
+    # `applying` / `rebasing` sentinel inside that directory is what separates
+    # them, and it is load-bearing -- `git rebase --abort` inside an am session
+    # answers "No rebase in progress?". The order below follows git's own status
+    # precedence: rebase, then cherry-pick / revert, then merge, then bisect.
+    git_dir=$(git -C "$target_dir" rev-parse --absolute-git-dir 2>/dev/null || echo "")
+    inflight=""
+    if [ -n "$git_dir" ]; then
+      if [ -d "$git_dir/rebase-merge" ]; then
+        inflight="rebase"
+      elif [ -d "$git_dir/rebase-apply" ]; then
+        if [ -f "$git_dir/rebase-apply/applying" ]; then
+          inflight="am"
+        else
+          inflight="rebase"
+        fi
+      elif [ -f "$git_dir/CHERRY_PICK_HEAD" ]; then
+        inflight="cherry-pick"
+      elif [ -f "$git_dir/REVERT_HEAD" ]; then
+        inflight="revert"
+      elif [ -f "$git_dir/MERGE_HEAD" ]; then
+        inflight="merge"
+      elif [ -f "$git_dir/BISECT_LOG" ]; then
+        inflight="bisect"
+      fi
+    fi
     echo "Blocked by branch-gate: target git working tree has a DETACHED HEAD in the MAIN checkout." >&2
     echo "  resolved target dir: $target_dir" >&2
     echo "  main checkout      : $main_checkout" >&2
     echo "  HEAD               : $(git -C "$target_dir" rev-parse --short HEAD 2>/dev/null || echo '?')" >&2
+    echo "  in progress        : ${inflight:-nothing}" >&2
     echo "  command: $cmd" >&2
     echo "A detached HEAD is not a feature branch, and this is the SHARED main checkout," >&2
     echo "so a commit here puts off-branch work in the tree every other lane reads." >&2
-    echo "Re-attach first: git -C \"$main_checkout\" switch main" >&2
+    if [ "$inflight" = "bisect" ]; then
+      echo "A 'git bisect' is what detached HEAD here, and 'switch main' would leave the" >&2
+      echo "bisect running. End it instead -- this restores the branch you started from:" >&2
+      echo "  git -C \"$main_checkout\" bisect reset" >&2
+    elif [ -n "$inflight" ]; then
+      echo "A '$inflight' is IN PROGRESS, so 'switch main' is not available here -- git" >&2
+      echo "refuses it outright. Finish or abandon the operation instead:" >&2
+      echo "  git -C \"$main_checkout\" $inflight --continue   # after resolving the conflict" >&2
+      echo "  git -C \"$main_checkout\" $inflight --abort      # to abandon it and re-attach" >&2
+    else
+      echo "Re-attach first: git -C \"$main_checkout\" switch main" >&2
+    fi
     echo "Then do the work in its own worktree: git worktree add <path> -b fix/xxx origin/main" >&2
     echo "A detached HEAD in a LINKED worktree is NOT blocked -- that is the documented" >&2
     echo "way to clear a lane." >&2
     exit 2
   fi
-  # FAIL-OPEN, deliberate and stated. Three readings reach this line, and the
-  # compare above sends all three here without needing a guard of their own,
-  # since `$target_top` is non-empty and so can equal none of the empty answers:
+  # FAIL-OPEN, deliberate and stated. FOUR readings reach this line, and the
+  # compare above sends all four here without needing a guard of their own,
+  # since `$target_top` is non-empty and so can equal none of the answers below:
   #   - `git worktree list` gave nothing (not a repo we can read) -- we do not
   #     gate what we cannot see;
   #   - the awk found no `worktree ` line at all -- same reading;
   #   - the detached tree is a LINKED worktree, the sanctioned lane-clearing
-  #     state named above.
+  #     state named above;
+  #   - the detached tree is a SUBMODULE. This one is not an empty answer, which
+  #     is why it went unenumerated: `worktree list --porcelain` inside a
+  #     submodule reports the GITDIR (`<super>/.git/modules/<name>`) where
+  #     `--show-toplevel` reports the work tree (`<super>/<name>`), so the two
+  #     never match. Measured on git 2.53 with a `.markgate.yml` planted at the
+  #     submodule root to clear the opt-in: rc=0. The outcome is the one we want
+  #     -- a submodule left detached is what `git submodule update` does, and it
+  #     is nobody's shared main checkout -- but it arrives by a different route
+  #     than the other three.
   exit 0
 fi
 

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -17,6 +17,68 @@ HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/branch-gate.sh"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
+# --- BASH INTERPRETER FENCE (go-to-k/cdkd#2402) ------------------------------
+# Running this SUITE under bash 3.2 did NOT run the HOOK under it. The hook is
+# `#!/usr/bin/env bash`, which resolves through PATH and finds whatever bash is
+# first there -- the 5.x on a dev Mac -- so running this SUITE under 3.2 would
+# still have exercised a 5.x SUBJECT.
+#
+# TWO SEPARATE GAPS, and this shim closes only the second. `scripts/run-hook-tests.sh`
+# runs each harness under ONE bash -- it has no per-shell loop and exports no
+# HOOK_BASH, unlike cdkd's `run-tests.sh` -- so nothing here ran under 3.2 at
+# all. Taking the 3.2 tally is therefore an explicit invocation for now:
+#
+#   HOOK_BASH=/bin/bash /bin/bash .claude/hooks/branch-gate.test.sh
+#
+# The interpreter is an explicit symlink at the FRONT of PATH, the shape
+# cdk-local's `gate-command-recognition.test.sh` already uses. Default
+# `/bin/bash`; `HOOK_BASH=/opt/homebrew/bin/bash` takes the 5.x tally. An
+# explicitly set HOOK_BASH that is not executable is FATAL rather than a silent
+# fall-back: a typo'd override that quietly ran the default would report the
+# version it did not run.
+#
+# PROVEN TO REACH THE HOOK, not merely to be exported. With `;;&` (a bash-4
+# `case` terminator, a PARSE error under 3.2 and valid syntax under 5.x)
+# injected into the hook's detached-HEAD arm, this suite reports
+# 39 pass / 8 fail under `HOOK_BASH=/bin/bash` and 47 pass / 0 fail under
+# `HOOK_BASH=/opt/homebrew/bin/bash` -- same suite, same mutant, only the
+# interpreter differs. A shim that did not reach the subject would print the
+# same tally twice.
+#
+# PATH keeps its existing entries after the shim rather than being replaced with
+# `/usr/bin:/bin`: the hook needs `jq`, which is not in either on every machine.
+if [ -n "${HOOK_BASH:-}" ]; then
+  # RESOLVE A BARE NAME BEFORE TESTING IT. `run-tests.sh` loops over the
+  # CANDIDATES `bash` and `/bin/bash` and exports `HOOK_BASH="$shell"`, so the
+  # PATH shell arrives here as the bare word `bash` -- and `-x` does no PATH
+  # lookup, so testing the raw value FATALs on a perfectly good interpreter.
+  # Measured: the first shape of this block failed the whole suite with
+  # `FATAL - HOOK_BASH is not an executable: bash` on the 5.x pass of
+  # `bash .claude/hooks/run-tests.sh`, while the 3.2 pass (an absolute
+  # `/bin/bash`) passed -- so half the matrix went missing and the tally said
+  # FAIL rather than saying nothing, which is the only reason it was caught.
+  # The `ln -sf` below needs an absolute target anyway.
+  case "$HOOK_BASH" in
+    */*) ;;
+    *) HOOK_BASH="$(command -v "$HOOK_BASH" 2>/dev/null || printf '%s' "$HOOK_BASH")" ;;
+  esac
+  if [ ! -x "$HOOK_BASH" ]; then
+    printf 'FATAL - HOOK_BASH is not an executable: %s\n' "$HOOK_BASH" >&2
+    exit 1
+  fi
+else
+  HOOK_BASH=/bin/bash
+  [ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+  [ -n "$HOOK_BASH" ] && [ -x "$HOOK_BASH" ] || {
+    printf 'FATAL - no usable bash found for the hook\n' >&2
+    exit 1
+  }
+fi
+SHIM="$TMPDIR/bin"; mkdir -p "$SHIM"
+ln -sf "$HOOK_BASH" "$SHIM/bash"
+printf 'hook interpreter: %s (bash %s)\n' "$HOOK_BASH" \
+  "$("$HOOK_BASH" -c 'echo "$BASH_VERSION"')"
+
 # Two fixture git working trees: one on `main`, one on a feature branch.
 # Both have a config user so commit works if we ever exercise it.
 main_repo="$TMPDIR/main-repo"
@@ -43,6 +105,33 @@ git init -q -b main "$spaced_repo"
 touch "$spaced_repo/.markgate.yml"
 git -C "$spaced_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 
+# --- DETACHED-HEAD fixture (go-to-k/cdkd#2402) -------------------------------
+# A MAIN checkout that owns a real LINKED worktree. `main_repo` above cannot
+# discriminate the two halves of the detached verdict, because it has no linked
+# worktree for the allowed half to live in.
+mt_repo="$TMPDIR/mt-repo"
+mt_wt="$TMPDIR/mt-wt"
+git init -q -b main "$mt_repo"
+touch "$mt_repo/.markgate.yml"
+mkdir -p "$mt_repo/sub"
+touch "$mt_repo/sub/f.txt"
+git -C "$mt_repo" -c user.email=t@t -c user.name=t add -A
+git -C "$mt_repo" -c user.email=t@t -c user.name=t commit -q -m init
+mt_sha=$(git -C "$mt_repo" rev-parse HEAD)
+git -C "$mt_repo" -c user.email=t@t -c user.name=t worktree add -q "$mt_wt" -b lane/y
+# The same fixture at a path containing a SPACE. `git worktree list --porcelain`
+# emits one `worktree <path>` line, and reading it with awk's `$2` truncates at
+# the space -- the compare then never matches and the gate stands down over a
+# main checkout it mis-read. `substr($0, 10)` reads the whole field; this case
+# is what says so.
+mt_spaced="$TMPDIR/mt repo spaces"
+mt_spaced_wt="$TMPDIR/mt wt spaces"
+git init -q -b main "$mt_spaced"
+touch "$mt_spaced/.markgate.yml"
+git -C "$mt_spaced" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+mt_spaced_sha=$(git -C "$mt_spaced" rev-parse HEAD)
+git -C "$mt_spaced" -c user.email=t@t -c user.name=t worktree add -q "$mt_spaced_wt" -b lane/s
+
 pass=0
 fail=0
 fail_log=""
@@ -51,11 +140,11 @@ fail_log=""
 run_case() {
   local name="$1"; local want="$2"; local payload="$3"
   local got out
-  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) || true
+  out=$(printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" 2>&1) || true
   got=$?
   # The above always evaluates to 0 (`|| true`), so capture status
   # via a separate run.
-  printf '%s' "$payload" | "$HOOK" >/dev/null 2>&1
+  printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" >/dev/null 2>&1
   got=$?
   if [[ "$got" == "$want" ]]; then
     pass=$((pass + 1))
@@ -92,9 +181,14 @@ run_case "git -C <feature> commit from main-cwd allowed" 0 \
 run_case "cd <feature> && git commit from main-cwd allowed" 0 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"cd %s && git commit -m wip"}}' "$main_repo" "$feature_repo")"
 
-# 6. Detached HEAD / non-git dir → symbolic-ref empty → allow (we can't
-#    gate what we can't see).
-run_case "non-git target dir allowed (silent pass)" 0 \
+# 6. A dir that is not inside a git repo at all: nothing to read, so nothing to
+#    gate. This case's name USED TO SAY "Detached HEAD / non-git dir", which
+#    collapsed two conditions that share one observable (an empty
+#    `symbolic-ref`) and are not the same thing -- a detached HEAD is a real
+#    repo whose tree has LEFT `main`. That conflation is go-to-k/cdkd#2402; the
+#    detached rows now live in their own block below, and this row keeps only
+#    the reading it actually exercises.
+run_case "non-git target dir allowed (genuinely nothing to see)" 0 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$TMPDIR")"
 
 # --- ALLOW cases for read-only `git` commands that contain the literal
@@ -253,6 +347,85 @@ run_case "git -C \"<main with spaces>\" commit blocked" 2 \
 #     is about the FLAG parsing and not about the path being unusable.
 run_case "cd \"<main with spaces>\" && git commit blocked" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"cd \\"%s\\" && git commit -m oops"}}' "$feature_repo" "$spaced_repo")"
+
+# --- DETACHED HEAD (go-to-k/cdkd#2402) ---------------------------------------
+#
+# `symbolic-ref --short HEAD` is EMPTY on a detached HEAD, so the gate's
+# `case "$branch" in main|master)` matched neither arm and fell to `exit 0`.
+# Measured on a scratch opted-in repo before the fix, same payload both times:
+# rc=2 on `main`, rc=0 once detached -- while `main-tree-branch-gate.sh` passes
+# `git checkout <sha>` in the main checkout, so the route to that state is one
+# allowed command.
+#
+# BOTH POLARITIES ARE PINNED, because the fix has an allowed half that is easy
+# to lose: a detached HEAD in a LINKED worktree is what this repo's own
+# `stop-unmerged-lane-warn.sh` tells a session to do (`git switch --detach
+# origin/main`) when it must not remove its worktree.
+
+git -C "$mt_repo" checkout -q --detach "$mt_sha"
+
+run_case "detached HEAD in the MAIN checkout: commit BLOCKED" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")"
+run_case "detached HEAD in the MAIN checkout: push BLOCKED" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin HEAD"}}' "$mt_repo")"
+# The cwd one level DOWN. The gate compares TOPLEVELS rather than the raw
+# resolved dir, so a subdirectory of the main checkout is still the main
+# checkout. `main_tree_of` in main-tree-branch-gate.sh compares the raw dir and
+# would answer "not the main checkout" here.
+run_case "detached HEAD in the MAIN checkout, cwd a SUBDIR: BLOCKED" 2 \
+  "$(printf '{"cwd":"%s/sub","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")"
+# Reached by `-C` from a LINKED worktree cwd, so the verdict is on the RESOLVED
+# tree and not on where the session happens to be sitting.
+run_case "detached MAIN checkout via -C from a worktree: BLOCKED" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s commit -m oops"}}' "$mt_wt" "$mt_repo")"
+# Polarity control at the VERB level: the new arm must not turn this gate into
+# "refuse everything in a detached main checkout".
+run_case "detached HEAD in the MAIN checkout: git status still allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$mt_repo")"
+
+# The LINKED worktree, while the MAIN checkout is still detached -- so a gate
+# that blocked on "some tree in this repo is detached" would fail here.
+run_case "LINKED worktree on a branch, main checkout detached: allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$mt_wt")"
+
+git -C "$mt_repo" checkout -q main
+
+# The main checkout on a FEATURE branch, with a linked worktree present: the
+# control that says the block above is about DETACHMENT and not about being the
+# main checkout of a repo that has worktrees.
+git -C "$mt_repo" checkout -q -b feat/z
+run_case "MAIN checkout on a feature branch: allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$mt_repo")"
+git -C "$mt_repo" checkout -q main
+# ...and back on `main` it blocks again, by NAME, exactly as before.
+run_case "MAIN checkout re-attached to main: commit BLOCKED" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")"
+
+# The ALLOWED half: a detached HEAD in a LINKED worktree.
+git -C "$mt_wt" switch -q --detach "$mt_sha"
+run_case "detached HEAD in a LINKED worktree: STILL ALLOWED" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$mt_wt")"
+run_case "detached HEAD in a LINKED worktree, cwd a SUBDIR: STILL ALLOWED" 0 \
+  "$(printf '{"cwd":"%s/sub","tool_input":{"command":"git commit -m wip"}}' "$mt_wt")"
+run_case "detached LINKED worktree via -C from the main checkout: ALLOWED" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s commit -m wip"}}' "$mt_repo" "$mt_wt")"
+git -C "$mt_wt" switch -q lane/y
+
+# A detached MAIN checkout whose PATH CONTAINS A SPACE. Both polarities, so a
+# reader can see the space is the only variable.
+git -C "$mt_spaced" checkout -q --detach "$mt_spaced_sha"
+run_case "detached HEAD in a SPACED main checkout: BLOCKED" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_spaced")"
+run_case "detached HEAD in a SPACED linked worktree: ALLOWED" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$mt_spaced_wt")"
+git -C "$mt_spaced" checkout -q main
+
+# The OPT-IN still governs the new arm: a detached HEAD in a repo with no
+# `.markgate.yml` is none of this gate's business.
+git -C "$optout_repo" checkout -q --detach HEAD
+run_case "detached HEAD in a NON-opted-in repo: allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m ok"}}' "$optout_repo")"
+git -C "$optout_repo" checkout -q main
 
 echo
 echo "Pass: $pass  Fail: $fail"

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -15,28 +15,59 @@ HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/branch-gate.sh"
 
 # --- MACHINE INDEPENDENCE ----------------------------------------------------
 # The developer's own git config must not decide what this suite exercises, and
-# before this block it did. Measured by breaking the hook's `rebase-merge`
-# detection arm and running the suite:
+# before this block it did.
 #
-#   default on the author's machine                  38 pass /  4 fail   catches it
-#   with a global `rebase.backend = apply`           42 pass /  0 fail   GREEN, broken hook
+# THE ORIGINAL EXHIBIT NO LONGER REPRODUCES, and it is repeated here as HISTORY
+# rather than as evidence, because a reader taking it as evidence would be
+# reading a claim this file has since falsified. It was: break the hook's
+# `rebase-merge` detection arm, and a global `rebase.backend = apply` sends
+# every plain `git rebase` down `rebase-apply/` instead, so the broken arm is
+# never reached and the rows that exist to hold it down pass without exercising
+# it -- a fully green suite over a broken hook. That was true when the rows said
+# `git rebase`. They now say `git rebase --merge` / `git rebase --apply`, which
+# is the OTHER half of the same fix, and an explicit backend outranks the config
+# key. Re-measured at this tree, broken arm, 81 rows:
 #
-# `rebase.backend = apply` sends every plain `git rebase` down `rebase-apply/`
-# instead, so the `rebase-merge` arm is never reached and the rows that exist to
-# hold it down pass without exercising it. Two more ordinary global options turn
-# half the suite red against the UNMUTATED hook, for the same inheritance:
+#   broken `rebase-merge` arm, clean global config    76 pass / 5 fail
+#   ...and with a global `rebase.backend = apply`     76 pass / 5 fail   same
 #
-#   global `commit.gpgsign = true`                   25 pass / 21 fail
-#   global `init.templateDir = <dir with a hook>`    25 pass / 21 fail
+# WHAT STILL BITES, and what keeps the two exports below load-bearing: two
+# ordinary global options turn nearly half the suite red against the UNMUTATED
+# hook, because they break the fixture COMMITS rather than the rebase backend.
 #
-# The author's machine HAS `init.templateDir` set (git-secrets), so this suite
-# was green only because those installed hooks happen to exit 0. That is exactly
-# the "green for a reason other than the one claimed" class the rest of this
-# file exists to correct, landing in the file itself.
+#   global `commit.gpgsign = true`                    56 pass / 25 fail
+#   global `init.templateDir = <dir with a FAILING hook>`
+#                                                     56 pass / 25 fail
+#
+# Both also report 18 FIXTURE failures -- setups that never entered their
+# operation because the commit behind them was rejected -- which is the count
+# the old numbers folded into `fail` and why their denominators did not add up
+# to the case list.
+#
+# `init.templateDir` has to point at a hook that FAILS. The author's machine has
+# one set (git-secrets) whose hooks exit 0, which is why this suite was green:
+# green for a reason other than the one claimed, landing in the file whose
+# subject is that class.
 #
 # `/dev/null` rather than an empty scratch file: nothing to clean up, and a
 # stray `git config --global` from a child cannot write to it. Honoured since
-# git 2.32; an older git ignores both variables and is no worse off than before.
+# git 2.32, which the probe below now checks rather than assumes.
+#
+# SCOPE, stated because it is narrower than "machine independence": these two
+# variables neutralise git's CONFIG FILES. They do not neutralise the
+# ENVIRONMENT, and the environment has twins for most of what a config file can
+# say. Measured at this tree, each set for the whole run:
+#
+#   GIT_TEMPLATE_DIR=<dir with a failing hook>        56 pass / 25 fail
+#   GIT_CONFIG_COUNT / _KEY_0 / _VALUE_0              56 pass / 25 fail
+#   GIT_DIR=<elsewhere>                               49 pass / 32 fail
+#
+# All three fail LOUD rather than green, which is the direction that costs a
+# reader an hour rather than a release, and the one direction that COULD go
+# quiet -- a rebase backend chosen for us -- is closed on the other side by
+# naming `--merge` / `--apply` on every rebase row. So this is a stated bound,
+# not an open hole: a suite cannot scrub an environment it did not create, and
+# `env -i` would take `PATH` and `HOME` with it.
 export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_SYSTEM=/dev/null
 # Two consequences, both already satisfied below and stated so they stay so:
@@ -55,7 +86,35 @@ export GIT_CONFIG_SYSTEM=/dev/null
 # the fixture; on Linux `mktemp` does honour it. Renaming is correct on both
 # without having to know which one is running.)
 FIXROOT="$(mktemp -d)"
-trap 'rm -rf "$FIXROOT"' EXIT
+# `EXIT INT TERM`, not `EXIT` alone. The repo's leak-safety convention, and it
+# bites here: a Ctrl-C anywhere in the operation block leaves a git repo, a
+# linked worktree and a patch directory behind under the per-user temp dir,
+# which nothing else ever cleans.
+trap 'rm -rf "$FIXROOT"' EXIT INT TERM
+
+# ...AND PROVE THE NEUTRALISER ABOVE ACTUALLY TOOK EFFECT. `GIT_CONFIG_GLOBAL`
+# and `GIT_CONFIG_SYSTEM` are honoured only from git 2.32; an older git ignores
+# both SILENTLY. Exported-but-ignored looks exactly like protection while the
+# suite goes on inheriting the developer's config -- the same "green for a
+# reason other than the one claimed" the block above exists to end, one level
+# up, and the one thing about it nothing asserted.
+#
+# A POSITIVE probe, not "is the global config empty?": pointing the variable at
+# a file holding a known key and reading that key back proves the variable IS
+# consulted whatever the developer's real config contains. The negative probe
+# passes trivially on a machine with no global config, which is precisely the
+# machine that cannot tell you anything.
+_ni_probe="$FIXROOT/ni-probe.gitconfig"
+printf '[hooktest]\n\tmarker = seen\n' > "$_ni_probe"
+for _ni_var in GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM; do
+  if [ "$(env "$_ni_var=$_ni_probe" git config --get hooktest.marker 2>/dev/null)" != "seen" ]; then
+    printf 'FATAL: this git ignores %s, so the machine-independence block above\n' "$_ni_var" >&2
+    printf '       is inert and this suite would be reading the developer config.\n' >&2
+    printf '       Needs git >= 2.32; this is %s\n' "$(git --version)" >&2
+    exit 1
+  fi
+done
+unset _ni_probe _ni_var
 
 # --- BASH INTERPRETER FENCE (go-to-k/cdkd#2402) ------------------------------
 # Running this SUITE under bash 3.2 did NOT run the HOOK under it. The hook is
@@ -80,7 +139,7 @@ trap 'rm -rf "$FIXROOT"' EXIT
 # PROVEN TO REACH THE HOOK, not merely to be exported. With `;;&` (a bash-4
 # `case` terminator, a PARSE error under 3.2 and valid syntax under 5.x)
 # injected into the hook's detached-HEAD arm, this suite reports
-# 42 pass / 30 fail under `HOOK_BASH=/bin/bash` and 72 pass / 0 fail under
+# 43 pass / 38 fail under `HOOK_BASH=/bin/bash` and 81 pass / 0 fail under
 # `HOOK_BASH=/opt/homebrew/bin/bash` -- same suite, same mutant, only the
 # interpreter differs. A shim that did not reach the subject would print the
 # same tally twice.
@@ -94,13 +153,19 @@ trap 'rm -rf "$FIXROOT"' EXIT
 # ones to re-measure whenever rows are added; this round did, and the pair
 # above is that measurement.
 #
-# WHAT THIS MUTANT IS BLIND TO, and why -- because 42 of the rows still
-# pass under it and a reader should not mistake that for coverage:
+# WHAT THIS MUTANT IS BLIND TO, and why -- because 43 of the rows still
+# pass under it and a reader should not mistake that for coverage. Counted,
+# because "every row that wants exit 2" was the shape this used to claim and
+# it is not true: a row that also reads the MESSAGE fails under the mutant,
+# since a parse error prints no message.
 #
-#   Every row that wants exit 2 passes, because a bash PARSE ERROR *is*
-#     exit 2 -- for the wrong reason.
-#   Every row that wants exit 0 and EXITS BEFORE the broken construct is
-#     parsed also passes. Bash parses a script one complete command at a time, and the
+#   20 rows want exit 2 and check nothing else, and a bash PARSE ERROR *is*
+#     exit 2. They pass for the wrong reason.
+#   3 rows also want exit 2 and pass for the RIGHT one: the fail-CLOSED rows
+#     refuse at the top of the hook, before the parser has reached the
+#     compound the mutation sits in.
+#   20 rows want exit 0 and EXIT BEFORE the broken construct is
+#     parsed. Bash parses a script one complete command at a time, and the
 #     mutation sits inside the single `if [ -z "$branch" ]; then ... fi`
 #     compound; a payload that leaves at the verb match, at the repo opt-in, or
 #     at "not a git repo" never reaches it. Those rows are genuinely unaffected.
@@ -220,6 +285,13 @@ git -C "$mt_spaced" -c user.email=t@t -c user.name=t worktree add -q "$mt_spaced
 
 pass=0
 fail=0
+# FIXTURE failures are counted apart from ROW failures. They are not cases: a
+# fixture that did not build says nothing about the hook, and folding it into
+# `fail` made `Pass + Fail` exceed the number of rows -- a denominator no reader
+# can reconcile with the case list -- while also inflating the `ran` count the
+# case FLOOR at the bottom compares against, so a broken fixture could hide a
+# row that stopped running. Both counters gate the exit status.
+fixture_fail=0
 fail_log=""
 
 # run_case <name> <expect_exit> <stdin_json>
@@ -350,7 +422,17 @@ run_case_head() {
   if [ -n "$forbid" ] && printf '%s\n' "$out" | grep -qF -- "$forbid"; then
     ok=0; why="${why:+$why; }message must not contain: $forbid"
   fi
-  line=$(printf '%s\n' "$out" | grep -F -- "$need" | head -1)
+  # ANCHORED ON THE HOOK'S TWO-SPACE COMMAND INDENT, not on print order.
+  # `$need` is a fragment like `bisect reset`, and the PROSE around the remedy
+  # contains the same fragment ("...so 'bisect reset' leaves this checkout
+  # DETACHED"); `head -1` picked the command only because the command happens to
+  # print FIRST today. Re-ordering the message would silently start EVAL-ing a
+  # sentence -- with the quoting of an English clause, not of a command. Every
+  # remedy this hook offers is printed as two spaces then `git `, and nothing
+  # else in the message is -- the diagnosis lines are two spaces then a
+  # LABEL (`resolved target dir`, `main checkout`, `HEAD`, `in progress`,
+  # `command`), never two spaces then `git`.
+  line=$(printf '%s\n' "$out" | grep -E '^  git ' | grep -F -- "$need" | head -1)
   # Strip the trailing ` # after resolving the conflict` the hook prints on its
   # `--continue` / `--abort` lines. `%` (SHORTEST suffix) anchored on the space
   # before the `#`, not `%%#*`, which was the first spelling: that one cut at
@@ -596,13 +678,51 @@ fc_payload=$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}'
 # fail-closed mutation reddens it. It is NOT an inert row in general, and saying
 # so would be the mislabel this file has twice avoided by measuring: it reads the
 # branch-NAME message, so gutting that message reddens it alongside the
-# branch-NAME row above (measured: 2 red, not 1).
+# branch-NAME row above (measured: 3 red, not 1).
 run_case_hook "$fc_ok/branch-gate.sh" "copied hook WITH its matcher library still blocks on main" \
   2 "$fc_payload" "is on branch 'main'"
+# ARM-SPECIFIC NEEDLES. Both rows used to ask for the same prefix -- the file
+# path, which BOTH refusals print -- so neither was pinned to the arm it names.
+# Measured: deleting the `[ ! -r "$_gate_lib" ]` guard outright left this suite
+# fully green, because the MISSING fixture then fell through to the `declare -F`
+# arm and printed a message the MISSING row still matched. Two rows over one
+# needle are one row. Each now asks for the tail only its own arm emits.
 run_case_hook "$fc_missing/branch-gate.sh" "matcher library MISSING: gate refuses (fail CLOSED)" \
-  2 "$fc_payload" "Blocked: .claude/hooks/_command-match.sh"
+  2 "$fc_payload" "is missing or unreadable"
 run_case_hook "$fc_trunc/branch-gate.sh" "matcher library TRUNCATED: gate refuses (fail CLOSED)" \
-  2 "$fc_payload" "Blocked: .claude/hooks/_command-match.sh"
+  2 "$fc_payload" "loaded but gate_matches is undefined"
+
+# TRUNCATED AT AN OFFSET THAT DISCRIMINATES. The row above cuts the library to a
+# single comment line, which defines NOTHING -- and that is the ONE truncation
+# shape a guard naming only `gate_matches` can see. Every realistic cut lands
+# further in: the library is over a thousand lines and this hook also calls
+# `gate_target_dir`, defined near its end. Measured against the pre-fix hook,
+# same payload, cutting at every 25th line: a THIRD of the offsets scored rc=0
+# NOT BLOCKED -- gate silently disabled -- and the row above passed every one of
+# them, because a file cut there still defines `gate_matches`.
+#
+# The cut below is DERIVED from the library rather than a hard-coded line
+# number, so it stays inside the window as the library grows: stop one line
+# before `gate_target_dir`'s definition. The fixture then asserts it is really
+# in the window -- `gate_matches` present, `gate_target_dir` absent -- so this
+# row cannot quietly decay into a second copy of the zero-definition row above.
+fc_mid="$FIXROOT/fc-mid"; mkdir -p "$fc_mid"; fc_mk "$fc_mid"
+fc_cut=$(grep -n '^gate_target_dir()' "${HOOK%/*}/_command-match.sh" | head -1 | cut -d: -f1)
+if [ -z "$fc_cut" ] || [ "$fc_cut" -lt 2 ]; then
+  fixture_fail=$((fixture_fail + 1))
+  fail_log="${fail_log}FAIL mid-file truncation fixture: no gate_target_dir definition line\n"
+  printf 'FAIL mid-file truncation fixture: gate_target_dir has no definition line\n'
+else
+  head -n $((fc_cut - 1)) "${HOOK%/*}/_command-match.sh" > "$fc_mid/_command-match.sh"
+fi
+if ! bash -c '. "$1" >/dev/null 2>&1; declare -F gate_matches >/dev/null 2>&1 &&
+    ! declare -F gate_target_dir >/dev/null 2>&1' _ "$fc_mid/_command-match.sh"; then
+  fixture_fail=$((fixture_fail + 1))
+  fail_log="${fail_log}FAIL mid-file truncation fixture: the cut is not inside the window\n"
+  printf 'FAIL mid-file truncation fixture: the cut is not inside the window\n'
+fi
+run_case_hook "$fc_mid/branch-gate.sh" "matcher library truncated MID-FILE: gate refuses, naming the missing function" \
+  2 "$fc_payload" "loaded but gate_target_dir is undefined"
 
 # --- LINE-START ANCHORING cases (issue #563) ---
 #
@@ -654,6 +774,36 @@ run_case "detached HEAD in the MAIN checkout: commit BLOCKED" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")"
 run_case "detached HEAD in the MAIN checkout: push BLOCKED" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin HEAD"}}' "$mt_repo")"
+# THE DIAGNOSIS BLOCK, which nothing read. The two rows above take the exit
+# code; the four below take the four lines that tell the reader WHICH tree the
+# gate resolved, which checkout it decided was the main one, where HEAD is, and
+# whether an operation is running. Measured before they existed: deleting all
+# four `echo` lines while keeping `exit 2` left this suite fully green -- the
+# same defect this round fixed for the branch-NAME arm, still standing one arm
+# over, on the arm with four times as much to say.
+#
+# FOUR ROWS RATHER THAN ONE, so a dropped line is attributable to the line
+# rather than to "the message changed". Each needle is built from a value read
+# back a DIFFERENT way than the hook computes it: the target dir is the payload
+# cwd this row passed in, the main checkout comes from `rev-parse
+# --show-toplevel` where the hook reads `worktree list --porcelain`, and the sha
+# comes from a separate `rev-parse --short`. On Linux the first two strings are
+# equal (no `/var` symlink); the rows still separate, because each needle
+# carries its own label.
+mt_top=$(git -C "$mt_repo" rev-parse --show-toplevel)
+mt_head_short=$(git -C "$mt_repo" rev-parse --short HEAD)
+run_case_msg "detached block names the RESOLVED TARGET DIR" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")" \
+  "  resolved target dir: $mt_repo"
+run_case_msg "detached block names the MAIN CHECKOUT it compared against" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")" \
+  "  main checkout      : $mt_top"
+run_case_msg "detached block prints the HEAD it is refusing over" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")" \
+  "  HEAD               : $mt_head_short"
+run_case_msg "detached block prints 'in progress: nothing' when nothing is" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_repo")" \
+  "  in progress        : nothing"
 # The cwd one level DOWN. The gate compares TOPLEVELS rather than the raw
 # resolved dir, so a subdirectory of the main checkout is still the main
 # checkout. `main_tree_of` in main-tree-branch-gate.sh compares the raw dir and
@@ -781,12 +931,22 @@ op_wt="$FIXROOT/op-wt"
 opg() { git -C "$op_repo" -c user.email=t@t -c user.name=t "$@"; }
 git init -q -b main "$op_repo"
 # Identity in the REPO's own config, not only in the `opg` wrapper's `-c` flags.
-# The resulting-HEAD rows run the remedy the hook PRINTS, verbatim, and that line
-# carries no `-c` -- so a machine with no global identity answers `Committer
-# identity unknown` (exit 128) and the row blames the remedy for the fixture.
-# Measured: green locally, red on the CI runner, which has no global identity.
-# Setting it here is also the more faithful fixture: a user copy-pasting that
-# line has an identity, and the row is about whether the line WORKS.
+# The resulting-HEAD rows run the remedy the hook PRINTS, verbatim, and that
+# line carries no `-c` -- so a tree with no identity available answers
+# `Committer identity unknown` (exit 128) and the row blames the remedy for the
+# fixture.
+#
+# THE RECORDED REASON NO LONGER REPRODUCES, and saying so is the point. It read
+# "green locally, red on the CI runner, which has no global identity" -- true
+# when it was written, and no longer a discriminator now that
+# `GIT_CONFIG_GLOBAL=/dev/null` is exported at the top of this file: there is no
+# global identity on ANY machine here, so removing these two lines leaves the
+# suite green everywhere rather than red on CI alone. Measured this round.
+# Kept anyway, for the reason that still holds and is not about CI: none of the
+# remedies this suite EVALs commits anything today, but each is run verbatim as
+# a user would paste it, and a fixture that only works because no printed remedy
+# happens to need an identity is one edit away from failing for a reason that
+# has nothing to do with the hook.
 git -C "$op_repo" config user.email hook-test@example.invalid
 git -C "$op_repo" config user.name "Hook Test"
 touch "$op_repo/.markgate.yml"
@@ -813,8 +973,11 @@ opg format-patch -q -1 other -o "$FIXROOT/op-patches" >/dev/null
 # right after EVERY operation setup in both blocks below and before the hook
 # runs, so a fixture that silently did not start reports ITSELF rather than
 # blaming the hook's remedy.
+# <want> <label> [<repo>] -- <repo> defaults to `$op_repo`, so the second
+# fixture below (a checkout root containing `#`) can be asserted by the same
+# helper rather than by an open-coded `[ -f ... ]` that reports differently.
 op_assert_inflight() {
-  local want="$1" label="$2" found=""
+  local want="$1" label="$2" repo="${3:-$op_repo}" found=""
   # FIRST-match-wins, spelled as an if/elif chain in the hook's own precedence
   # order. It used to be a run of `[ … ] && found=…` lines, which is LAST-match
   # -wins: the two disagree for any state where more than one marker is present
@@ -822,23 +985,30 @@ op_assert_inflight() {
   # answering different questions. Latent today -- git does not currently leave
   # two of these behind together -- and fixed rather than documented, because
   # the agreement is free and the divergence would be silent.
-  if [ -d "$op_repo/.git/rebase-merge" ]; then
+  if [ -d "$repo/.git/rebase-merge" ]; then
     found="rebase"
-  elif [ -d "$op_repo/.git/rebase-apply" ]; then
-    if [ -f "$op_repo/.git/rebase-apply/applying" ]; then found="am"; else found="rebase"; fi
-  elif [ -f "$op_repo/.git/CHERRY_PICK_HEAD" ]; then
+  elif [ -d "$repo/.git/rebase-apply" ]; then
+    if [ -f "$repo/.git/rebase-apply/applying" ]; then found="am"; else found="rebase"; fi
+  elif [ -f "$repo/.git/CHERRY_PICK_HEAD" ]; then
     found="cherry-pick"
-  elif [ -f "$op_repo/.git/REVERT_HEAD" ]; then
+  elif [ -f "$repo/.git/REVERT_HEAD" ]; then
     found="revert"
-  elif [ -f "$op_repo/.git/MERGE_HEAD" ]; then
+  elif [ -f "$repo/.git/MERGE_HEAD" ]; then
     found="merge"
-  elif [ -f "$op_repo/.git/BISECT_LOG" ]; then
+  elif [ -f "$repo/.git/BISECT_LOG" ]; then
     found="bisect"
   fi
   if [ "$found" != "$want" ]; then
-    fail=$((fail + 1))
+    # REPORTED THE WAY EVERY OTHER HELPER REPORTS: into `fail_log`, on stdout.
+    # It used to bump `fail` and print only to stderr, so its failure never
+    # reached the replay block at the bottom, and the final `Pass + Fail` came
+    # out larger than the number of rows -- a denominator a reader cannot
+    # reconcile with the case list. It is not a CASE, so it does not touch
+    # `pass`; the tally below counts it only when it fires.
+    fixture_fail=$((fixture_fail + 1))
+    fail_log="${fail_log}FAIL $label: fixture is in ${found:-nothing}, expected ${want:-nothing}\n"
     printf 'FAIL %s: fixture is in %s, expected %s\n' \
-      "$label" "${found:-nothing}" "${want:-nothing}" >&2
+      "$label" "${found:-nothing}" "${want:-nothing}"
     return 1
   fi
   return 0
@@ -1000,8 +1170,11 @@ opg checkout -q main
 # one leaves the fixture MID-OPERATION and every row after it then fails for a
 # reason that is not its own. Measured before this helper existed: dropping the
 # `applying` sentinel red-lined the `am` row (correctly) and then cherry-pick,
-# revert, merge and bisect (cascade) -- 6 rows for a defect that touches 1. A
-# tally that cannot be attributed to a row is not a fence, it is noise.
+# revert, merge and bisect (cascade). Re-measured at this tree WITH the helper
+# in place, the same drop reddens 2 rows -- the `am` row it should, plus the
+# one `detached MAIN mid-AM` row that reads the same message -- and no others,
+# which is the helper working. A tally that cannot be attributed to a row is
+# not a fence, it is noise.
 #
 # It also VERIFIES that it cleaned up, because `git am` and `git rebase --apply`
 # SHARE `.git/rebase-apply`: if an abort leaves that directory behind, the next
@@ -1025,6 +1198,12 @@ op_reset() {
   rm -rf "$op_repo/.git/rebase-apply" "$op_repo/.git/rebase-merge" 2>/dev/null
   rm -f "$op_repo/.git/CHERRY_PICK_HEAD" "$op_repo/.git/REVERT_HEAD" \
         "$op_repo/.git/MERGE_HEAD" "$op_repo/.git/BISECT_LOG" 2>/dev/null
+  # The whole `BISECT_*` family, not `BISECT_LOG` alone. `git bisect reset`
+  # FAILS (rc=1, `fatal: invalid reference`) when the branch recorded in
+  # `BISECT_START` has been deleted under the bisect -- the state the
+  # deleted-start-branch row below builds on purpose -- and then leaves
+  # `BISECT_START` behind for the next `git bisect start` to trip over.
+  rm -f "$op_repo"/.git/BISECT_* 2>/dev/null
   :
 }
 
@@ -1032,6 +1211,12 @@ op_reset() {
 # really does re-attach, and the row that pins the `head-name` READ.
 opg rebase --merge other >/dev/null 2>&1
 op_assert_inflight rebase "mid-REBASE-from-main fixture"
+# The OTHER polarity of the `in progress` line the block above pins as
+# `nothing`. Without this row a hook that hard-coded `nothing` would keep both
+# halves green, and the field's whole job is telling those two apart.
+run_case_msg "detached block names the operation in the 'in progress' field" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  "  in progress        : rebase"
 run_case_head "mid-REBASE from main: 'rebase --abort' lands on main, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
@@ -1158,9 +1343,101 @@ run_case_head "mid-BISECT started DETACHED: 'bisect reset' stays detached, and s
   'bisect reset' 'DETACHED' 'does NOT re-attach HEAD' \
   'restores the branch you started from'
 op_reset
+# 10. A BRANCH WHOSE NAME IS 40 HEX CHARACTERS. This is the row that fences the
+# `show-ref` LOOKUP against the 40-hex PATTERN the comment above that code
+# spends a paragraph rejecting -- and nothing held it down: swapping the lookup
+# for the pattern left this suite fully green, with none of the three
+# consequences that paragraph names carrying a row.
+#
+# `git bisect reset` ends in `git checkout "$(cat BISECT_START)"`, so the
+# question is "does checkout resolve this as a branch", and `show-ref --verify
+# refs/heads/<x>` is that same question. A pattern asks a DIFFERENT one -- "does
+# this look like a sha" -- and the two disagree exactly here. Measured on git
+# 2.53: the branch is created, `BISECT_START` records its name, `show-ref` finds
+# it, and `bisect reset` re-attaches to it; the pattern would have called the
+# name a sha and printed "does NOT re-attach HEAD" over a reset that does.
+op_hexb=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+opg checkout -q -b "$op_hexb" main
+opg bisect start >/dev/null 2>&1
+opg bisect bad >/dev/null 2>&1
+opg bisect good "$op_root" >/dev/null 2>&1
+op_assert_inflight bisect "mid-BISECT-from-a-hex-named-branch fixture"
+run_case_head "mid-BISECT from a 40-HEX-NAMED branch: 'bisect reset' re-attaches to it" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'bisect reset' "branch $op_hexb" "restores the branch you started from, '$op_hexb'" \
+  'does NOT re-attach'
+op_reset
+opg branch -q -D "$op_hexb"
+
+# 11. THE START BRANCH DELETED UNDER THE BISECT -- the other side of the same
+# lookup, and the row that also pins the negative arm's WORDING.
+#
+# Against the pattern the recorded name `bisect-start-gone` is "not a sha", so
+# the hook would promise re-attachment to a branch that no longer exists. Against
+# `show-ref` it is simply absent, and no promise is made. `git branch -D`
+# REFUSES while the bisect holds the branch ("cannot delete branch ... used by
+# worktree"), so the state needs the low-level `update-ref -d` -- which is why
+# the hook's comment calls it a bound rather than a case. It is still the state
+# that separates the two implementations, so it is worth one row.
+#
+# The second forbidden string is item 5's: the arm used to explain the empty
+# `reattach_to` as "this bisect started from a tree that was ALREADY detached",
+# a cause the code never established and one that is FALSE here -- this bisect
+# started from a branch. Measured: `bisect reset` in this state exits 1 with
+# `fatal: invalid reference: bisect-start-gone`, so the old sentence's other
+# half ("returns to that same detached commit") is false too, and the printed
+# `switch main` fallback is what actually re-attaches.
+opg checkout -q -b bisect-start-gone main
+opg bisect start >/dev/null 2>&1
+opg bisect bad >/dev/null 2>&1
+opg bisect good "$op_root" >/dev/null 2>&1
+opg update-ref -d refs/heads/bisect-start-gone
+op_assert_inflight bisect "mid-BISECT-with-a-deleted-start-branch fixture"
+run_case_msg "mid-BISECT whose start branch was DELETED: promises nothing, blames nothing" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'does NOT re-attach HEAD' \
+  'restores the branch you started from' \
+  'ALREADY detached'
+op_reset
+
+# 12. THE REMEDY LINE, EXTRACTED FROM UNDER A ROOT CONTAINING `#`. `run_case_head`
+# cuts the hook's trailing ` # to abandon it` off the line it EVALs, and the
+# comment beside that cut records a `%%#*` spelling which truncated the PATH
+# instead, leaving `git -C "<truncated` and charging the resulting rc=2 to the
+# hook. Nothing held the fix down: reverting `%` to `%%` left this suite fully
+# green, because every fixture above lives under `mktemp -d`, whose paths never
+# contain a `#`. One fixture that does closes it -- and it exercises the hook
+# under such a path too, which nothing else did.
+hash_repo="$FIXROOT/ha#sh/op-repo"
+mkdir -p "$hash_repo"
+git init -q -b main "$hash_repo"
+git -C "$hash_repo" config user.email hook-test@example.invalid
+git -C "$hash_repo" config user.name "Hook Test"
+touch "$hash_repo/.markgate.yml"
+printf 'base\n' > "$hash_repo/f.txt"
+git -C "$hash_repo" add -A
+git -C "$hash_repo" commit -q -m base
+git -C "$hash_repo" checkout -q -b other
+printf 'other\n' > "$hash_repo/f.txt"
+git -C "$hash_repo" commit -q -am other
+git -C "$hash_repo" checkout -q main
+printf 'mine\n' > "$hash_repo/f.txt"
+git -C "$hash_repo" commit -q -am mine
+git -C "$hash_repo" checkout -q --detach main
+git -C "$hash_repo" merge other >/dev/null 2>&1
+op_assert_inflight merge "mid-MERGE-under-a-hash-root fixture" "$hash_repo"
+run_case_head "detached mid-MERGE under a root containing '#': the printed remedy still runs" \
+  "$hash_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$hash_repo")" \
+  'merge --abort' 'DETACHED' 'NEITHER ending re-attaches HEAD' 'Either ending'
+
 echo
 echo "Pass: $pass  Fail: $fail"
-if [[ "$fail" -gt 0 ]]; then
+if [ "$fixture_fail" -gt 0 ]; then
+  echo "Fixture failures: $fixture_fail  (not cases -- a fixture that did not build)"
+fi
+if [[ "$fail" -gt 0 || "$fixture_fail" -gt 0 ]]; then
   echo
   printf '%b' "$fail_log"
   exit 1

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -40,7 +40,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # PROVEN TO REACH THE HOOK, not merely to be exported. With `;;&` (a bash-4
 # `case` terminator, a PARSE error under 3.2 and valid syntax under 5.x)
 # injected into the hook's detached-HEAD arm, this suite reports
-# 39 pass / 8 fail under `HOOK_BASH=/bin/bash` and 47 pass / 0 fail under
+# 40 pass / 17 fail under `HOOK_BASH=/bin/bash` and 57 pass / 0 fail under
 # `HOOK_BASH=/opt/homebrew/bin/bash` -- same suite, same mutant, only the
 # interpreter differs. A shim that did not reach the subject would print the
 # same tally twice.
@@ -48,16 +48,26 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # PATH keeps its existing entries after the shim rather than being replaced with
 # `/usr/bin:/bin`: the hook needs `jq`, which is not in either on every machine.
 if [ -n "${HOOK_BASH:-}" ]; then
-  # RESOLVE A BARE NAME BEFORE TESTING IT. `run-tests.sh` loops over the
-  # CANDIDATES `bash` and `/bin/bash` and exports `HOOK_BASH="$shell"`, so the
-  # PATH shell arrives here as the bare word `bash` -- and `-x` does no PATH
-  # lookup, so testing the raw value FATALs on a perfectly good interpreter.
-  # Measured: the first shape of this block failed the whole suite with
-  # `FATAL - HOOK_BASH is not an executable: bash` on the 5.x pass of
-  # `bash .claude/hooks/run-tests.sh`, while the 3.2 pass (an absolute
-  # `/bin/bash`) passed -- so half the matrix went missing and the tally said
-  # FAIL rather than saying nothing, which is the only reason it was caught.
-  # The `ln -sf` below needs an absolute target anyway.
+  # RESOLVE A BARE NAME BEFORE TESTING IT. `-x` does no PATH lookup, so testing
+  # the raw value FATALs on a perfectly good interpreter whenever HOOK_BASH is a
+  # bare word rather than a path -- and `HOOK_BASH=bash` is the obvious spelling
+  # for "whatever PATH gives", which is the shape the header above invites.
+  #
+  # THE JUSTIFICATION THAT USED TO STAND HERE NAMED A FILE THIS REPO DOES NOT
+  # HAVE. It said `run-tests.sh` loops over the candidates and exports
+  # `HOOK_BASH="$shell"`; that is true of CDKD's `.claude/hooks/run-tests.sh`,
+  # which is where this guard was first needed and where it was measured (the
+  # first shape of this block failed the whole 5.x pass with
+  # `FATAL - HOOK_BASH is not an executable: bash` while the 3.2 pass, an
+  # absolute `/bin/bash`, sailed through -- half the matrix gone, reported as a
+  # FAIL rather than as silence, which is the only reason it was caught).
+  #
+  # In THIS repo the runner is `scripts/run-hook-tests.sh`, which runs each
+  # harness under ONE `bash` and exports no HOOK_BASH -- as the header of this
+  # file already says, so the two paragraphs used to contradict each other.
+  # Nothing here hands this file a bare word on its own, so the guard covers the
+  # documented MANUAL invocation instead and the comment now says which. The
+  # `ln -sf` below needs an absolute target anyway.
   case "$HOOK_BASH" in
     */*) ;;
     *) HOOK_BASH="$(command -v "$HOOK_BASH" 2>/dev/null || printf '%s' "$HOOK_BASH")" ;;
@@ -155,6 +165,49 @@ run_case() {
     fail_log+="  payload: $payload\n"
     fail_log+="  output : $out\n"
     printf 'FAIL %s (want %s, got %s)\n' "$name" "$want" "$got"
+  fi
+}
+
+# run_case_msg <name> <expect_exit> <stdin_json> <substring that MUST appear> \
+#              [<substring that must NOT appear>] [<a second one>]
+#
+# BOTH REMEDY ARMS EXIT 2, so an rc-only case cannot tell the operation-specific
+# wording from the plain one -- and the whole point of the operation-specific arm
+# is that the plain one names a command git refuses. The verdict under test here
+# is the TEXT, so the text is what is asserted.
+#
+# The forbidden needle for an operation row is `Re-attach first`, the literal
+# opening of the fallback remedy LINE, and not the string `switch main`: the
+# operation arms mention `switch main` themselves, in the sentence explaining why
+# it is unavailable. A needle that also matches prose about the wrong answer
+# cannot say whether the wrong answer was PRINTED.
+#
+# `grep -F --` because several needles start with a `-`.
+run_case_msg() {
+  local name="$1"; local want="$2"; local payload="$3"; local need="$4"
+  local forbid="${5:-}"; local forbid2="${6:-}"
+  local out got ok=1 why="" __f
+  out=$(printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" 2>&1)
+  printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" >/dev/null 2>&1
+  got=$?
+  if [ "$got" != "$want" ]; then ok=0; why="want exit $want, got $got"; fi
+  if [ -n "$need" ] && ! printf '%s\n' "$out" | grep -qF -- "$need"; then
+    ok=0; why="${why:+$why; }message lacks: $need"
+  fi
+  for __f in "$forbid" "$forbid2"; do
+    if [ -n "$__f" ] && printf '%s\n' "$out" | grep -qF -- "$__f"; then
+      ok=0; why="${why:+$why; }message must not contain: $__f"
+    fi
+  done
+  if [ "$ok" = 1 ]; then
+    pass=$((pass + 1))
+    printf 'OK   %s (exit %s)\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    fail_log+="FAIL $name: $why\n"
+    fail_log+="  payload: $payload\n"
+    fail_log+="  output : $out\n"
+    printf 'FAIL %s (%s)\n' "$name" "$why"
   fi
 }
 
@@ -378,6 +431,21 @@ run_case "detached HEAD in the MAIN checkout, cwd a SUBDIR: BLOCKED" 2 \
 # tree and not on where the session happens to be sitting.
 run_case "detached MAIN checkout via -C from a worktree: BLOCKED" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s commit -m oops"}}' "$mt_wt" "$mt_repo")"
+# The payload cwd reached through an EXPLICIT SYMLINK to the main checkout, which
+# is the fence for reason (ii) in the hook's toplevel-compare comment: the cwd
+# carries whatever symlink the caller typed, the porcelain path does not.
+#
+# WHY IT NEEDS ITS OWN ROW even though the four rows above already die under the
+# `$target_dir` mutation. They die for reason (ii) only because macOS's
+# `mktemp -d` hands back a `/var` path git reports as `/private/var`, so the whole
+# fixture is symlinked for free. Rebuild the same fixture on a NON-symlinked root
+# and that mutation kills exactly one of the five -- the subdir row, for reason
+# (i). `ci.yml` runs this suite via `vp run test:hooks` on `ubuntu-latest`, where
+# `mktemp -d` returns a real `/tmp/...` path, so reason (ii) had NO coverage on
+# the platform CI actually runs. This row dies on both roots.
+ln -sfn "$mt_repo" "$TMPDIR/mt-link"
+run_case "detached MAIN checkout via a SYMLINKED cwd: BLOCKED" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$TMPDIR/mt-link")"
 # Polarity control at the VERB level: the new arm must not turn this gate into
 # "refuse everything in a detached main checkout".
 run_case "detached HEAD in the MAIN checkout: git status still allowed" 0 \
@@ -427,6 +495,140 @@ run_case "detached HEAD in a NON-opted-in repo: allowed" 0 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m ok"}}' "$optout_repo")"
 git -C "$optout_repo" checkout -q main
 
+
+# --- THE REMEDY MUST BE A COMMAND GIT ACCEPTS (go-to-k/cdkd#2402 review) ------
+#
+# The arm above blocks correctly and, before this round, printed
+# `git -C <main> switch main` unconditionally. A conflicted rebase is one of the
+# ways a MAIN checkout reaches a detached HEAD -- and `git pull` on `main` in the
+# main checkout is this repo's own mandated post-merge sync, so the route is a
+# documented one. Measured on git 2.53, mid-rebase in the main checkout:
+#
+#   git commit -m resolve   ->  rc=2 (correct)
+#   the remedy it printed   ->  git -C <main> switch main
+#   what git answers        ->  fatal: cannot switch branch while rebasing
+#
+# A gate that refuses correctly and then names an impossible command is worse
+# than one that does not refuse, because the reader has nowhere to go. The block
+# stays; the remedy now follows the operation.
+#
+# EVERY REMEDY BELOW WAS RUN, not just read: each `--abort` / `bisect reset` the
+# gate printed was executed verbatim against the fixture and exited 0 (rebase,
+# rebase -i, rebase --apply, am, cherry-pick, merge, revert, bisect).
+#
+# WHAT EACH ROW HOLDS DOWN, measured by mutating the hook and re-running this
+# suite (cdkd numbers; the siblings differ only in the pre-existing case count):
+#
+#   never detect an operation                -> 7 rows red (the six op rows + bisect)
+#   report every operation as a `rebase`     -> 5 (am, cherry-pick, merge, revert, bisect)
+#   drop the `applying` / `rebasing` sentinel-> 1 (am, and only am)
+#   `<target_dir>/.git` for the git dir      -> 1 (the mid-rebase SUBDIR row)
+#   always print the operation wording       -> 1 (the NOTHING-in-progress row)
+#
+# The one row below with no mutation against it is labelled a CONTROL where it
+# stands, rather than left looking like a fence.
+op_repo="$TMPDIR/op-repo"
+op_wt="$TMPDIR/op-wt"
+opg() { git -C "$op_repo" -c user.email=t@t -c user.name=t "$@"; }
+git init -q -b main "$op_repo"
+touch "$op_repo/.markgate.yml"
+mkdir -p "$op_repo/sub"
+touch "$op_repo/sub/f.txt"
+printf 'base\n' > "$op_repo/f.txt"
+opg add -A
+opg commit -q -m base
+opg checkout -q -b other
+printf 'other\n' > "$op_repo/f.txt"
+opg commit -q -am other
+opg checkout -q main
+# Six more commits so `git bisect` lands on something that is NOT a branch tip:
+# with a two-commit history it picks an endpoint and HEAD stays ATTACHED, and the
+# bisect row would then be exercising the branch-NAME arm instead of this one.
+for op_i in 1 2 3 4 5 6; do
+  printf 'mine%s\n' "$op_i" > "$op_repo/f.txt"
+  opg commit -q -am "m$op_i"
+done
+op_root=$(git -C "$op_repo" rev-list --max-parents=0 HEAD)
+opg worktree add -q "$op_wt" -b lane/op
+opg format-patch -q -1 other -o "$TMPDIR/op-patches" >/dev/null
+
+# 1 + 2. A conflicted rebase, from the checkout root and from a SUBDIRECTORY of
+# it. The subdir row is the one that fences RESOLVING the git dir rather than
+# assuming `<target_dir>/.git`: there, `$target_dir` is `<main>/sub`, which has
+# no `.git` of its own.
+opg rebase other >/dev/null 2>&1
+run_case_msg "detached MAIN mid-REBASE: remedy is 'rebase --abort', not 'switch main'" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'rebase --abort' 'Re-attach first'
+run_case_msg "detached MAIN mid-REBASE from a SUBDIR: remedy still 'rebase --abort'" 2 \
+  "$(printf '{"cwd":"%s/sub","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'rebase --abort' 'Re-attach first'
+# CONTROL, not a fence: the LINKED worktree is on a branch, so it exits at the
+# branch-NAME arm and never reaches any of the new code. No mutation of the
+# detection turns it red -- it is here to say the new arm changed nothing on the
+# path a lane actually uses while the shared checkout is mid-rebase.
+run_case "LINKED worktree while the MAIN checkout is mid-rebase: allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$op_wt")"
+opg rebase --abort >/dev/null 2>&1
+
+# 3. `git am`. `rebase-apply/` is shared by `git am` and `git rebase --apply`, so
+# the directory alone cannot name the remedy -- the `applying` sentinel inside it
+# is what does, and it is load-bearing: `git rebase --abort` inside an am session
+# answers "No rebase in progress?". Without this row, dropping that discriminator
+# survives.
+opg checkout -q --detach main
+opg am "$TMPDIR/op-patches"/*.patch >/dev/null 2>&1
+run_case_msg "detached MAIN mid-AM: remedy is 'am --abort'" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'am --abort' 'Re-attach first'
+opg am --abort >/dev/null 2>&1
+
+# 4-6. cherry-pick / merge / revert. Each is reachable here only from a tree that
+# was ALREADY detached (on a branch, git leaves HEAD attached and the branch-NAME
+# arm catches it), and each has its own marker file, so each needs its own row or
+# deleting that branch of the detection survives.
+opg checkout -q --detach main
+opg cherry-pick other >/dev/null 2>&1
+run_case_msg "detached MAIN mid-CHERRY-PICK: remedy is 'cherry-pick --abort'" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'cherry-pick --abort' 'Re-attach first'
+opg cherry-pick --abort >/dev/null 2>&1
+
+opg checkout -q --detach main
+opg merge other >/dev/null 2>&1
+run_case_msg "detached MAIN mid-MERGE: remedy is 'merge --abort'" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'merge --abort' 'Re-attach first'
+opg merge --abort >/dev/null 2>&1
+
+opg checkout -q --detach main
+opg revert --no-edit other >/dev/null 2>&1
+run_case_msg "detached MAIN mid-REVERT: remedy is 'revert --abort'" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'revert --abort' 'Re-attach first'
+opg revert --abort >/dev/null 2>&1
+
+# 7. bisect, the one operation git does NOT refuse a `switch main` during -- it
+# switches with a warning and leaves the bisect running. So the old wording was
+# not a dead end here, only incomplete, and the remedy has a different SHAPE
+# (`bisect reset`, no `--continue` / `--abort` pair), so this row forbids BOTH
+# the generic operation wording and the fallback one.
+opg checkout -q main
+opg bisect start >/dev/null 2>&1
+opg bisect bad >/dev/null 2>&1
+opg bisect good "$op_root" >/dev/null 2>&1
+run_case_msg "detached MAIN mid-BISECT: remedy is 'bisect reset'" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'bisect reset' '--abort' 'Re-attach first'
+opg bisect reset >/dev/null 2>&1
+
+# 8. NOTHING in progress: the fallback wording is the one that must survive, and
+# it is the row that says the detection is a discriminator rather than a rewrite.
+opg checkout -q --detach main
+run_case_msg "detached MAIN, NOTHING in progress: remedy stays 'switch main'" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$op_repo")" \
+  'Re-attach first: git -C' '--abort' 'rebase --continue'
+opg checkout -q main
 echo
 echo "Pass: $pass  Fail: $fail"
 if [[ "$fail" -gt 0 ]]; then

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -211,6 +211,68 @@ run_case_msg() {
   fi
 }
 
+# run_case_head <name> <repo> <stdin_json> <remedy substring> <expected HEAD> \
+#               <claim substring> [<substring that must NOT appear>]
+#
+# ASSERTS THE RESULTING HEAD, the observable the previous round did not take. That
+# round verified every printed remedy EXITS 0 -- all nine do -- and the message
+# then promised `--abort` would "re-attach", which is true for exactly one of the
+# six operations. An exit status cannot see that; HEAD can.
+#
+# So this helper closes the loop rather than reading the message twice. It drives
+# the hook, requires the sentence the message CLAIMS about HEAD, then EXTRACTS the
+# printed remedy line verbatim (trailing `# comment` stripped), EVALS it, and
+# compares the tree's actual HEAD against <expected HEAD>. Two independent things
+# must agree with the measurement -- what git does, and what the message said git
+# would do -- so a wrong remedy and a wrong promise each turn a row red alone.
+#
+# Running the line verbatim also proves it is COPY-PASTEABLE: the fixture path is
+# a `/private/var` symlink target and the quoting is the hook's own.
+#
+# <expected HEAD> is the literal `branch <name>` or the literal `DETACHED`.
+run_case_head() {
+  local name="$1"; local repo="$2"; local payload="$3"; local need="$4"
+  local want_head="$5"; local claim="$6"; local forbid="${7:-}"
+  local out got line rc got_head ok=1 why=""
+  out=$(printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" 2>&1)
+  printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" >/dev/null 2>&1
+  got=$?
+  if [ "$got" != 2 ]; then ok=0; why="want exit 2, got $got"; fi
+  if ! printf '%s\n' "$out" | grep -qF -- "$need"; then
+    ok=0; why="${why:+$why; }message lacks the remedy: $need"
+  fi
+  if ! printf '%s\n' "$out" | grep -qF -- "$claim"; then
+    ok=0; why="${why:+$why; }message lacks the HEAD claim: $claim"
+  fi
+  if [ -n "$forbid" ] && printf '%s\n' "$out" | grep -qF -- "$forbid"; then
+    ok=0; why="${why:+$why; }message must not contain: $forbid"
+  fi
+  line=$(printf '%s\n' "$out" | grep -F -- "$need" | head -1)
+  line="${line%%#*}"
+  if [ -z "$line" ]; then
+    ok=0; why="${why:+$why; }no remedy line to run"
+  else
+    eval "$line" >/dev/null 2>&1
+    rc=$?
+    if [ "$rc" != 0 ]; then ok=0; why="${why:+$why; }the printed remedy exited $rc"; fi
+  fi
+  got_head=$(git -C "$repo" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [ -n "$got_head" ]; then got_head="branch $got_head"; else got_head="DETACHED"; fi
+  if [ "$got_head" != "$want_head" ]; then
+    ok=0; why="${why:+$why; }HEAD after the remedy is '$got_head', want '$want_head'"
+  fi
+  if [ "$ok" = 1 ]; then
+    pass=$((pass + 1))
+    printf 'OK   %s (HEAD after remedy: %s)\n' "$name" "$got_head"
+  else
+    fail=$((fail + 1))
+    fail_log+="FAIL $name: $why\n"
+    fail_log+="  payload: $payload\n"
+    fail_log+="  output : $out\n"
+    printf 'FAIL %s (%s)\n' "$name" "$why"
+  fi
+}
+
 # --- ALLOW cases ---
 
 # 1. Non-git command always passes through.
@@ -517,13 +579,15 @@ git -C "$optout_repo" checkout -q main
 # rebase -i, rebase --apply, am, cherry-pick, merge, revert, bisect).
 #
 # WHAT EACH ROW HOLDS DOWN, measured by mutating the hook and re-running this
-# suite (cdkd numbers; the siblings differ only in the pre-existing case count):
+# suite. TWO numbers per mutation, `<in this block> / <whole suite>`, because
+# the resulting-HEAD block below shares these rows' subject and dies with them
+# (cdkd numbers; the siblings differ only in the pre-existing case count):
 #
-#   never detect an operation                -> 7 rows red (the six op rows + bisect)
-#   report every operation as a `rebase`     -> 5 (am, cherry-pick, merge, revert, bisect)
-#   drop the `applying` / `rebasing` sentinel-> 1 (am, and only am)
-#   `<target_dir>/.git` for the git dir      -> 1 (the mid-rebase SUBDIR row)
-#   always print the operation wording       -> 1 (the NOTHING-in-progress row)
+#   never detect an operation                -> 7 / 15 (the six op rows + bisect)
+#   report every operation as a `rebase`     -> 5 / 10 (am, cherry-pick, merge, revert, bisect)
+#   drop the `applying` sentinel             -> 1 / 2  (am, and only am)
+#   `<target_dir>/.git` for the git dir      -> 1 / 1  (the mid-rebase SUBDIR row)
+#   always print the operation wording       -> 1 / 1  (the NOTHING-in-progress row)
 #
 # The one row below with no mutation against it is labelled a CONTROL where it
 # stands, rather than left looking like a fence.
@@ -573,9 +637,15 @@ opg rebase --abort >/dev/null 2>&1
 
 # 3. `git am`. `rebase-apply/` is shared by `git am` and `git rebase --apply`, so
 # the directory alone cannot name the remedy -- the `applying` sentinel inside it
-# is what does, and it is load-bearing: `git rebase --abort` inside an am session
-# answers "No rebase in progress?". Without this row, dropping that discriminator
-# survives.
+# is what does. This row pins the `am` direction; the `rebase --apply` direction
+# is pinned in the resulting-HEAD block below, and it is the one that matters
+# more, because it fails QUIETLY. Measured on git 2.53: `git rebase --abort`
+# inside an am session is LOUD (rc=128, `fatal: It looks like 'git am' is in
+# progress. Cannot rebase.`), while `git am --abort` inside a `rebase --apply`
+# session exits 0 with no output and leaves HEAD DETACHED where the right remedy
+# lands on `main`. An earlier version of this comment cited "No rebase in
+# progress?" for the first crossing; that string is what git says when NOTHING is
+# in progress, a different condition.
 opg checkout -q --detach main
 opg am "$TMPDIR/op-patches"/*.patch >/dev/null 2>&1
 run_case_msg "detached MAIN mid-AM: remedy is 'am --abort'" 2 \
@@ -629,6 +699,153 @@ run_case_msg "detached MAIN, NOTHING in progress: remedy stays 'switch main'" 2 
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$op_repo")" \
   'Re-attach first: git -C' '--abort' 'rebase --continue'
 opg checkout -q main
+
+# --- THE REMEDY'S RESULTING HEAD (go-to-k/cdkd#2402 review round 3) -----------
+#
+# The block above asserts the remedy TEXT, and its header recorded that every
+# printed remedy had been RUN and exited 0. Both were true and the message was
+# still wrong: it promised `--abort` would "abandon it and re-attach", which
+# happens in exactly one of the six operations. Measured on git 2.53, each
+# printed remedy run verbatim against a detached MAIN checkout, HEAD read
+# afterwards -- every one rc=0:
+#
+#   cherry-pick --abort   before DETACHED   after DETACHED
+#   revert      --abort   before DETACHED   after DETACHED
+#   merge       --abort   before DETACHED   after DETACHED
+#   am          --abort   before DETACHED   after DETACHED
+#   rebase      --abort   before DETACHED   after main       (started FROM main)
+#   rebase      --abort   before DETACHED   after DETACHED   (started detached)
+#   bisect reset          before DETACHED   after main
+#
+# EXIT STATUS WAS THE WRONG OBSERVABLE. Nine remedies exiting 0 is exactly what
+# a message that leaves the user one step short also looks like, and no row here
+# asserted the right thing, which is how the wording survived the round that
+# checked all nine. The rows below RUN the printed command and assert where HEAD
+# lands, beside the sentence the message claims about it -- so the claim and the
+# outcome are pinned to each other and cannot drift apart again.
+#
+# WHAT EACH ROW HOLDS DOWN, measured by mutating the hook and re-running this
+# suite (cdkd numbers; the siblings differ only in the pre-existing case count):
+#
+#   restore `# to abandon it and re-attach`, drop the conditional -> 7 of the 8.
+#     Every operation row. The BISECT row SURVIVES, and that is the honest
+#     number rather than the one predicted: `bisect reset` is a separate arm
+#     with its own claim, which that mutation does not touch.
+#   force `reattach_to=""`, never reading `head-name`             -> 2.
+#     The two rebase-started-FROM-a-branch rows, one per backend.
+#   force `reattach_to="main"` whenever a rebase is in progress   -> 1.
+#     The rebase-started-DETACHED row, and only it.
+#   `rebase-apply` branch of the sentinel set to `am`             -> 1.
+#     The `rebase --apply` row -- the branch the `am`-direction row above
+#     cannot see, and the one whose wrong answer is silent.
+#
+# All four tallies are identical in cdk-local and cdk-real-drift (7 / 2 / 1 / 1),
+# measured the same way.
+#
+# The fixture is `op_repo` again, left on `main` by the block above. Each row
+# builds its own state; running the printed remedy IS the assertion, and the
+# teardown is a separate, explicit step -- see `op_reset` immediately below for
+# why it cannot be the remedy itself.
+
+# EACH ROW TEARS DOWN EXPLICITLY rather than relying on "the printed remedy
+# cleaned up". The remedy IS the assertion here, so a mutant that stops printing
+# one leaves the fixture MID-OPERATION and every row after it then fails for a
+# reason that is not its own. Measured before this helper existed: dropping the
+# `applying` sentinel red-lined the `am` row (correctly) and then cherry-pick,
+# revert, merge and bisect (cascade) -- 6 rows for a defect that touches 1. A
+# tally that cannot be attributed to a row is not a fence, it is noise.
+op_reset() {
+  opg rebase --abort >/dev/null 2>&1
+  opg am --abort >/dev/null 2>&1
+  opg cherry-pick --abort >/dev/null 2>&1
+  opg revert --abort >/dev/null 2>&1
+  opg merge --abort >/dev/null 2>&1
+  opg bisect reset >/dev/null 2>&1
+  opg checkout -q --force main >/dev/null 2>&1
+  :
+}
+
+# 1. rebase (merge backend) started FROM `main`: the ONE arm where `--abort`
+# really does re-attach, and the row that pins the `head-name` READ.
+opg rebase other >/dev/null 2>&1
+run_case_head "mid-REBASE from main: 'rebase --abort' lands on main, and says so" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'rebase --abort' 'branch main' "Either ending re-attaches HEAD to 'main'" 'NEITHER ending'
+op_reset
+
+# 2. The SAME operation started while ALREADY detached. Same `in progress`, same
+# printed remedy, OPPOSITE outcome -- so a blanket sentence is wrong even inside
+# `rebase`, and git's own `head-name` (the literal `detached HEAD` here, against
+# `refs/heads/main` above) is the only thing that tells the two apart.
+opg checkout -q --detach main
+opg rebase other >/dev/null 2>&1
+run_case_head "mid-REBASE started DETACHED: 'rebase --abort' stays detached, and says so" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'rebase --abort' 'DETACHED' 'NEITHER ending re-attaches HEAD' 'Either ending'
+op_reset
+
+# 3. `git rebase --apply` -- the branch of the `rebase-apply` sentinel that NO
+# row reached before. Mutating it to `inflight="am"`, the inverse of the `am`
+# direction the block above pins, left all three suites fully green. It is the
+# direction worth a row because it fails QUIETLY: measured on git 2.53 from this
+# state, `git am --abort` exits 0 with no output and leaves HEAD DETACHED, where
+# `git rebase --abort` lands on `main`. The reverse crossing is loud (rc=128,
+# `fatal: It looks like 'git am' is in progress. Cannot rebase.`).
+opg rebase --apply other >/dev/null 2>&1
+run_case_head "mid-REBASE --apply: remedy is 'rebase --abort', never 'am --abort'" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'rebase --abort' 'branch main' "Either ending re-attaches HEAD to 'main'" 'am --abort'
+op_reset
+
+# 4-7. am / cherry-pick / revert / merge -- the four the old wording got wrong.
+# None of them detaches HEAD itself, so this arm is reachable for them only from
+# an ALREADY-detached tree, and `--abort` restores exactly that.
+opg checkout -q --detach main
+opg am "$TMPDIR/op-patches"/*.patch >/dev/null 2>&1
+run_case_head "mid-AM: 'am --abort' leaves HEAD DETACHED, and says so" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'am --abort' 'DETACHED' 'NEITHER ending re-attaches HEAD' 'Either ending'
+op_reset
+
+opg checkout -q --detach main
+opg cherry-pick other >/dev/null 2>&1
+run_case_head "mid-CHERRY-PICK: 'cherry-pick --abort' leaves HEAD DETACHED, and says so" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'cherry-pick --abort' 'DETACHED' 'NEITHER ending re-attaches HEAD' 'Either ending'
+op_reset
+
+opg checkout -q --detach main
+opg revert --no-edit other >/dev/null 2>&1
+run_case_head "mid-REVERT: 'revert --abort' leaves HEAD DETACHED, and says so" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'revert --abort' 'DETACHED' 'NEITHER ending re-attaches HEAD' 'Either ending'
+op_reset
+
+opg checkout -q --detach main
+opg merge other >/dev/null 2>&1
+run_case_head "mid-MERGE: 'merge --abort' leaves HEAD DETACHED, and says so" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'merge --abort' 'DETACHED' 'NEITHER ending re-attaches HEAD' 'Either ending'
+op_reset
+
+# 8. bisect, whose remedy has a different SHAPE and whose message makes its own
+# claim ("this restores the branch you started from"). This row turns that claim
+# into a measurement, the same way the seven above do for `--abort`.
+opg bisect start >/dev/null 2>&1
+opg bisect bad >/dev/null 2>&1
+opg bisect good "$op_root" >/dev/null 2>&1
+run_case_head "mid-BISECT: 'bisect reset' lands on main, as the message says" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'bisect reset' 'branch main' 'restores the branch you started from' '--abort'
+op_reset
 echo
 echo "Pass: $pass  Fail: $fail"
 if [[ "$fail" -gt 0 ]]; then

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -252,9 +252,15 @@ run_case_head() {
   if [ -z "$line" ]; then
     ok=0; why="${why:+$why; }no remedy line to run"
   else
-    eval "$line" >/dev/null 2>&1
+    remedy_out=$(eval "$line" 2>&1)
     rc=$?
-    if [ "$rc" != 0 ]; then ok=0; why="${why:+$why; }the printed remedy exited $rc"; fi
+    # Capture the remedy's own words. An exit code alone cannot be diagnosed from
+    # a CI log on a machine you do not have -- and this row has already cost one
+    # wrong diagnosis for exactly that reason.
+    if [ "$rc" != 0 ]; then
+      ok=0
+      why="${why:+$why; }the printed remedy exited $rc: ${remedy_out}"
+    fi
   fi
   got_head=$(git -C "$repo" symbolic-ref --short HEAD 2>/dev/null || echo "")
   if [ -n "$got_head" ]; then got_head="branch $got_head"; else got_head="DETACHED"; fi

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -601,6 +601,15 @@ op_repo="$TMPDIR/op-repo"
 op_wt="$TMPDIR/op-wt"
 opg() { git -C "$op_repo" -c user.email=t@t -c user.name=t "$@"; }
 git init -q -b main "$op_repo"
+# Identity in the REPO's own config, not only in the `opg` wrapper's `-c` flags.
+# The resulting-HEAD rows run the remedy the hook PRINTS, verbatim, and that line
+# carries no `-c` -- so a machine with no global identity answers `Committer
+# identity unknown` (exit 128) and the row blames the remedy for the fixture.
+# Measured: green locally, red on the CI runner, which has no global identity.
+# Setting it here is also the more faithful fixture: a user copy-pasting that
+# line has an identity, and the row is about whether the line WORKS.
+git -C "$op_repo" config user.email hook-test@example.invalid
+git -C "$op_repo" config user.name "Hook Test"
 touch "$op_repo/.markgate.yml"
 mkdir -p "$op_repo/sub"
 touch "$op_repo/sub/f.txt"

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -13,9 +13,49 @@ set -u
 
 HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/branch-gate.sh"
 
+# --- MACHINE INDEPENDENCE ----------------------------------------------------
+# The developer's own git config must not decide what this suite exercises, and
+# before this block it did. Measured by breaking the hook's `rebase-merge`
+# detection arm and running the suite:
+#
+#   default on the author's machine                  38 pass /  4 fail   catches it
+#   with a global `rebase.backend = apply`           42 pass /  0 fail   GREEN, broken hook
+#
+# `rebase.backend = apply` sends every plain `git rebase` down `rebase-apply/`
+# instead, so the `rebase-merge` arm is never reached and the rows that exist to
+# hold it down pass without exercising it. Two more ordinary global options turn
+# half the suite red against the UNMUTATED hook, for the same inheritance:
+#
+#   global `commit.gpgsign = true`                   25 pass / 21 fail
+#   global `init.templateDir = <dir with a hook>`    25 pass / 21 fail
+#
+# The author's machine HAS `init.templateDir` set (git-secrets), so this suite
+# was green only because those installed hooks happen to exit 0. That is exactly
+# the "green for a reason other than the one claimed" class the rest of this
+# file exists to correct, landing in the file itself.
+#
+# `/dev/null` rather than an empty scratch file: nothing to clean up, and a
+# stray `git config --global` from a child cannot write to it. Honoured since
+# git 2.32; an older git ignores both variables and is no worse off than before.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+# Two consequences, both already satisfied below and stated so they stay so:
+# `init.defaultBranch` is gone, so every `git init` here passes an explicit
+# `-b`; and there is no global identity, so every commit brings its own.
+
 # Per-run scratch dir; cleaned on EXIT.
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+#
+# NOT named `TMPDIR`, which is what it used to be. That variable is already
+# exported in the environment this suite inherits, and assigning to an exported
+# name keeps the export -- so every child process, git included, was writing its
+# own temporaries inside the fixture that the EXIT trap then deleted. A private
+# name leaves the ambient `TMPDIR` alone, which is also what `mktemp` reads.
+# (On this macOS box `mktemp -d` with no template ignores `TMPDIR` entirely and
+# uses the Darwin per-user temp dir, so the old assignment could not even move
+# the fixture; on Linux `mktemp` does honour it. Renaming is correct on both
+# without having to know which one is running.)
+FIXROOT="$(mktemp -d)"
+trap 'rm -rf "$FIXROOT"' EXIT
 
 # --- BASH INTERPRETER FENCE (go-to-k/cdkd#2402) ------------------------------
 # Running this SUITE under bash 3.2 did NOT run the HOOK under it. The hook is
@@ -40,10 +80,33 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # PROVEN TO REACH THE HOOK, not merely to be exported. With `;;&` (a bash-4
 # `case` terminator, a PARSE error under 3.2 and valid syntax under 5.x)
 # injected into the hook's detached-HEAD arm, this suite reports
-# 40 pass / 17 fail under `HOOK_BASH=/bin/bash` and 57 pass / 0 fail under
+# 42 pass / 30 fail under `HOOK_BASH=/bin/bash` and 72 pass / 0 fail under
 # `HOOK_BASH=/opt/homebrew/bin/bash` -- same suite, same mutant, only the
 # interpreter differs. A shim that did not reach the subject would print the
 # same tally twice.
+#
+# THE PAIR THAT USED TO STAND HERE WAS STALE, and stale in the direction that
+# flatters: it predated the resulting-HEAD rows, so it under-reported both the
+# damage under 3.2 and the clean 5.x total. Unlike the two sibling repos, no doc
+# here carried a competing pair to notice the drift against -- which is the
+# weaker position, not the safer one: nothing disagreed because nothing else
+# had been measured. Numbers that are cheap to leave behind are exactly the
+# ones to re-measure whenever rows are added; this round did, and the pair
+# above is that measurement.
+#
+# WHAT THIS MUTANT IS BLIND TO, and why -- because 42 of the rows still
+# pass under it and a reader should not mistake that for coverage:
+#
+#   Every row that wants exit 2 passes, because a bash PARSE ERROR *is*
+#     exit 2 -- for the wrong reason.
+#   Every row that wants exit 0 and EXITS BEFORE the broken construct is
+#     parsed also passes. Bash parses a script one complete command at a time, and the
+#     mutation sits inside the single `if [ -z "$branch" ]; then ... fi`
+#     compound; a payload that leaves at the verb match, at the repo opt-in, or
+#     at "not a git repo" never reaches it. Those rows are genuinely unaffected.
+#
+# So the mutant proves the INTERPRETER reached the hook, which is its job here.
+# It is not a fence on the arm's logic, and the tally is not a coverage figure.
 #
 # PATH keeps its existing entries after the shim rather than being replaced with
 # `/usr/bin:/bin`: the hook needs `jq`, which is not in either on every machine.
@@ -84,15 +147,15 @@ else
     exit 1
   }
 fi
-SHIM="$TMPDIR/bin"; mkdir -p "$SHIM"
+SHIM="$FIXROOT/bin"; mkdir -p "$SHIM"
 ln -sf "$HOOK_BASH" "$SHIM/bash"
 printf 'hook interpreter: %s (bash %s)\n' "$HOOK_BASH" \
   "$("$HOOK_BASH" -c 'echo "$BASH_VERSION"')"
 
 # Two fixture git working trees: one on `main`, one on a feature branch.
 # Both have a config user so commit works if we ever exercise it.
-main_repo="$TMPDIR/main-repo"
-feature_repo="$TMPDIR/feature-repo"
+main_repo="$FIXROOT/main-repo"
+feature_repo="$FIXROOT/feature-repo"
 git init -q -b main "$main_repo"
 git -C "$main_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 git init -q -b feature/x "$feature_repo"
@@ -100,9 +163,16 @@ git -C "$feature_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty 
 # Opt the fixtures into the gate (cdkd#1259): the gate only protects
 # repos with a .markgate.yml at the repo root.
 touch "$main_repo/.markgate.yml" "$feature_repo/.markgate.yml"
+
+# The other protected branch NAME. `main|master` is one case arm with two
+# patterns and only one of them had a row, so half of it was free to delete.
+master_repo="$FIXROOT/master-repo"
+git init -q -b master "$master_repo"
+git -C "$master_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+touch "$master_repo/.markgate.yml"
 # A repo WITHOUT .markgate.yml (e.g. a personal blog repo worked on
 # from a session rooted here) must never be gated, even on main.
-optout_repo="$TMPDIR/optout-repo"
+optout_repo="$FIXROOT/optout-repo"
 git init -q -b main "$optout_repo"
 git -C "$optout_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 # A main-branch repo whose path contains a SPACE. The gate's verb regex was a
@@ -110,7 +180,7 @@ git -C "$optout_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -
 # alternative had no quoted form — so `git -C "<path with space>" commit` matched
 # NOTHING and committed straight to main. Measured 2026-08-25: rc=0 quoted vs
 # rc=2 unquoted on the same repo.
-spaced_repo="$TMPDIR/main repo with spaces"
+spaced_repo="$FIXROOT/main repo with spaces"
 git init -q -b main "$spaced_repo"
 touch "$spaced_repo/.markgate.yml"
 git -C "$spaced_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
@@ -119,8 +189,8 @@ git -C "$spaced_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -
 # A MAIN checkout that owns a real LINKED worktree. `main_repo` above cannot
 # discriminate the two halves of the detached verdict, because it has no linked
 # worktree for the allowed half to live in.
-mt_repo="$TMPDIR/mt-repo"
-mt_wt="$TMPDIR/mt-wt"
+mt_repo="$FIXROOT/mt-repo"
+mt_wt="$FIXROOT/mt-wt"
 git init -q -b main "$mt_repo"
 touch "$mt_repo/.markgate.yml"
 mkdir -p "$mt_repo/sub"
@@ -134,11 +204,17 @@ git -C "$mt_repo" -c user.email=t@t -c user.name=t worktree add -q "$mt_wt" -b l
 # the space -- the compare then never matches and the gate stands down over a
 # main checkout it mis-read. `substr($0, 10)` reads the whole field; this case
 # is what says so.
-mt_spaced="$TMPDIR/mt repo spaces"
-mt_spaced_wt="$TMPDIR/mt wt spaces"
+mt_spaced="$FIXROOT/mt repo spaces"
+mt_spaced_wt="$FIXROOT/mt wt spaces"
 git init -q -b main "$mt_spaced"
 touch "$mt_spaced/.markgate.yml"
-git -C "$mt_spaced" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+# `add -A` + a real commit, NOT `commit --allow-empty`, which is what this was.
+# `.markgate.yml` is the gate's opt-in signal and an UNTRACKED one does not
+# appear in a linked worktree -- so the spaced-worktree row below asked the hook
+# a question it exited before reaching, and was green for that reason rather
+# than for the one its name gives.
+git -C "$mt_spaced" -c user.email=t@t -c user.name=t add -A
+git -C "$mt_spaced" -c user.email=t@t -c user.name=t commit -q -m init
 mt_spaced_sha=$(git -C "$mt_spaced" rev-parse HEAD)
 git -C "$mt_spaced" -c user.email=t@t -c user.name=t worktree add -q "$mt_spaced_wt" -b lane/s
 
@@ -211,6 +287,33 @@ run_case_msg() {
   fi
 }
 
+# run_case_hook <hook path> <name> <expect_exit> <stdin_json> <needle>
+#
+# run_case_msg against a COPY of the hook instead of the lane's own file. It
+# exists for the fail-CLOSED arms, whose subject is the hook's shared matcher
+# library being absent or truncated -- a state that cannot be produced without
+# either editing the checkout or driving a copy, and only one of those is
+# acceptable in a test.
+run_case_hook() {
+  local hook="$1"; local name="$2"; local want="$3"; local payload="$4"; local need="$5"
+  local out got ok=1 why=""
+  out=$(printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$hook" 2>&1)
+  printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$hook" >/dev/null 2>&1
+  got=$?
+  if [ "$got" != "$want" ]; then ok=0; why="want exit $want, got $got"; fi
+  if [ -n "$need" ] && ! printf '%s\n' "$out" | grep -qF -- "$need"; then
+    ok=0; why="${why:+$why; }message lacks: $need"
+  fi
+  if [ "$ok" = 1 ]; then
+    pass=$((pass + 1))
+    printf 'OK   %s (exit %s)\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    fail_log="${fail_log}FAIL $name: $why\n  payload: $payload\n  output : $out\n"
+    printf 'FAIL %s (%s)\n' "$name" "$why"
+  fi
+}
+
 # run_case_head <name> <repo> <stdin_json> <remedy substring> <expected HEAD> \
 #               <claim substring> [<substring that must NOT appear>]
 #
@@ -233,7 +336,7 @@ run_case_msg() {
 run_case_head() {
   local name="$1"; local repo="$2"; local payload="$3"; local need="$4"
   local want_head="$5"; local claim="$6"; local forbid="${7:-}"
-  local out got line rc got_head ok=1 why=""
+  local out got line rc got_head remedy_out ok=1 why=""
   out=$(printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" 2>&1)
   printf '%s' "$payload" | env PATH="$SHIM:$PATH" "$HOOK" >/dev/null 2>&1
   got=$?
@@ -248,7 +351,15 @@ run_case_head() {
     ok=0; why="${why:+$why; }message must not contain: $forbid"
   fi
   line=$(printf '%s\n' "$out" | grep -F -- "$need" | head -1)
-  line="${line%%#*}"
+  # Strip the trailing ` # after resolving the conflict` the hook prints on its
+  # `--continue` / `--abort` lines. `%` (SHORTEST suffix) anchored on the space
+  # before the `#`, not `%%#*`, which was the first spelling: that one cut at
+  # the FIRST `#` anywhere in the line, so a checkout path containing one left
+  # `git -C "<truncated` -- an unterminated quote, rc=2, charged to the hook.
+  # Reproduced by building the fixture under a path with a `#` in it. Suite-only;
+  # the hook prints the path whole. The shortest-suffix form still cuts at the
+  # real comment when the path holds a `#` too, because the comment is last.
+  line="${line% #*}"
   if [ -z "$line" ]; then
     ok=0; why="${why:+$why; }no remedy line to run"
   else
@@ -310,7 +421,7 @@ run_case "cd <feature> && git commit from main-cwd allowed" 0 \
 #    detached rows now live in their own block below, and this row keeps only
 #    the reading it actually exercises.
 run_case "non-git target dir allowed (genuinely nothing to see)" 0 \
-  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$TMPDIR")"
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$FIXROOT")"
 
 # --- ALLOW cases for read-only `git` commands that contain the literal
 # words `commit` / `push` in args or refspecs (issue #281).
@@ -362,10 +473,24 @@ run_case "git symbolic-ref HEAD on main allowed" 0 \
 # 7. Plain git commit when cwd is on main.
 run_case "git commit on main blocked" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$main_repo")"
+# `master`, the other half of the gate's `main|master` arm and the half no row
+# reached: dropping `master` from that case left the whole suite green.
+run_case "git commit on master blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$master_repo")"
 
 # 8. git push on main blocked too.
 run_case "git push on main blocked" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin main"}}' "$main_repo")"
+# The branch-NAME arm's MESSAGE, which no row read: gutting the body while
+# keeping `exit 2` left the suite green, so the oldest verdict in this file was
+# pinned only by its exit code. Two rows, because the two halves fail
+# separately -- the diagnosis (which branch, in which tree) and the remedy.
+run_case_msg "branch-NAME block names the offending branch" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$main_repo")" \
+  "is on branch 'main'"
+run_case_msg "branch-NAME block prints the feature-branch remedy" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$main_repo")" \
+  "switch -c fix/xxx"
 
 # 9. cd <main> && git commit from a feature-branch cwd. The cd target
 #    is what matters, not the inherited cwd. THIS is the regression
@@ -439,6 +564,46 @@ run_case "missing .cwd does not crash" 0 \
 run_case "empty stdin allowed" 0 \
   ''
 
+# --- THE FAIL-CLOSED ARMS ----------------------------------------------------
+#
+# The hook's header spends a paragraph on this discipline and cites
+# go-to-k/cdkd#2130 for it: the first shape here was `[ -r … ] || exit 0`, which
+# silently disabled the gate whenever the shared matcher was unreadable, so a
+# refusal replaced it. What no row held down was the refusal ITSELF -- flipping
+# either arm to `exit 0` left this suite fully green. A fail-closed arm that
+# nothing pins is a fail-OPEN arm waiting to be re-introduced by the next
+# person who reads `exit 2` as noise.
+#
+# Driven against COPIES, so the lane's own hook is never touched. The payload is
+# an ordinary gated command in an opted-in repo, and the refusal lands before
+# any repo is looked at -- which is itself the property being asserted.
+fc_mk() {
+  cp "$HOOK" "$1/branch-gate.sh"
+}
+fc_ok="$FIXROOT/fc-ok"; mkdir -p "$fc_ok"; fc_mk "$fc_ok"
+cp "${HOOK%/*}/_command-match.sh" "$fc_ok/_command-match.sh"
+fc_missing="$FIXROOT/fc-missing"; mkdir -p "$fc_missing"; fc_mk "$fc_missing"
+fc_trunc="$FIXROOT/fc-trunc"; mkdir -p "$fc_trunc"; fc_mk "$fc_trunc"
+# "Loads, but defines nothing" -- the partial-source shape the `declare -F`
+# check exists for, which a plain readability test cannot see.
+printf '# truncated\n' > "$fc_trunc/_command-match.sh"
+
+fc_payload=$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$main_repo")
+
+# A CONTROL FOR THE TWO ROWS BELOW, and only for those: the same copy WITH its
+# library still blocks, which is what says their refusals come from the missing
+# library rather than from the hook having been copied somewhere. Neither
+# fail-closed mutation reddens it. It is NOT an inert row in general, and saying
+# so would be the mislabel this file has twice avoided by measuring: it reads the
+# branch-NAME message, so gutting that message reddens it alongside the
+# branch-NAME row above (measured: 2 red, not 1).
+run_case_hook "$fc_ok/branch-gate.sh" "copied hook WITH its matcher library still blocks on main" \
+  2 "$fc_payload" "is on branch 'main'"
+run_case_hook "$fc_missing/branch-gate.sh" "matcher library MISSING: gate refuses (fail CLOSED)" \
+  2 "$fc_payload" "Blocked: .claude/hooks/_command-match.sh"
+run_case_hook "$fc_trunc/branch-gate.sh" "matcher library TRUNCATED: gate refuses (fail CLOSED)" \
+  2 "$fc_payload" "Blocked: .claude/hooks/_command-match.sh"
+
 # --- LINE-START ANCHORING cases (issue #563) ---
 #
 # The matcher MUST NOT fire when the literal substrings `git commit` /
@@ -511,9 +676,9 @@ run_case "detached MAIN checkout via -C from a worktree: BLOCKED" 2 \
 # (i). `ci.yml` runs this suite via `vp run test:hooks` on `ubuntu-latest`, where
 # `mktemp -d` returns a real `/tmp/...` path, so reason (ii) had NO coverage on
 # the platform CI actually runs. This row dies on both roots.
-ln -sfn "$mt_repo" "$TMPDIR/mt-link"
+ln -sfn "$mt_repo" "$FIXROOT/mt-link"
 run_case "detached MAIN checkout via a SYMLINKED cwd: BLOCKED" 2 \
-  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$TMPDIR/mt-link")"
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$FIXROOT/mt-link")"
 # Polarity control at the VERB level: the new arm must not turn this gate into
 # "refuse everything in a detached main checkout".
 run_case "detached HEAD in the MAIN checkout: git status still allowed" 0 \
@@ -552,8 +717,16 @@ git -C "$mt_wt" switch -q lane/y
 git -C "$mt_spaced" checkout -q --detach "$mt_spaced_sha"
 run_case "detached HEAD in a SPACED main checkout: BLOCKED" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$mt_spaced")"
+# ...and its polarity twin, which until this round was neither DETACHED (the
+# worktree was on `lane/s`) nor opted in (see the fixture note above), and so
+# survived the one mutation it existed to catch: blocking EVERY detached tree
+# reddens the three unspaced linked rows and left this one green. Both halves
+# are fixed here -- the fixture tracks `.markgate.yml`, and the worktree is
+# actually detached -- so the row now reaches the main-vs-linked compare.
+git -C "$mt_spaced_wt" switch -q --detach "$mt_spaced_sha"
 run_case "detached HEAD in a SPACED linked worktree: ALLOWED" 0 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$mt_spaced_wt")"
+git -C "$mt_spaced_wt" switch -q lane/s
 git -C "$mt_spaced" checkout -q main
 
 # The OPT-IN still governs the new arm: a detached HEAD in a repo with no
@@ -589,16 +762,22 @@ git -C "$optout_repo" checkout -q main
 # the resulting-HEAD block below shares these rows' subject and dies with them
 # (cdkd numbers; the siblings differ only in the pre-existing case count):
 #
-#   never detect an operation                -> 7 / 15 (the six op rows + bisect)
-#   report every operation as a `rebase`     -> 5 / 10 (am, cherry-pick, merge, revert, bisect)
+#   never detect an operation                -> 7 / 16 (the six op rows + bisect)
+#   report every operation as a `rebase`     -> 5 / 11 (am, cherry-pick, merge, revert, bisect)
 #   drop the `applying` sentinel             -> 1 / 2  (am, and only am)
 #   `<target_dir>/.git` for the git dir      -> 1 / 1  (the mid-rebase SUBDIR row)
 #   always print the operation wording       -> 1 / 1  (the NOTHING-in-progress row)
 #
+# Re-measured this round, after the bisect polarity row was added below. The
+# IN-BLOCK numbers did not move; the two whole-suite ones each gained 1, both
+# from that new row. Recording the re-measurement rather than only the result,
+# because the pair one section down had gone stale unnoticed for exactly the
+# reason a table like this does: adding rows changes it, and nothing checks it.
+#
 # The one row below with no mutation against it is labelled a CONTROL where it
 # stands, rather than left looking like a fence.
-op_repo="$TMPDIR/op-repo"
-op_wt="$TMPDIR/op-wt"
+op_repo="$FIXROOT/op-repo"
+op_wt="$FIXROOT/op-wt"
 opg() { git -C "$op_repo" -c user.email=t@t -c user.name=t "$@"; }
 git init -q -b main "$op_repo"
 # Identity in the REPO's own config, not only in the `opg` wrapper's `-c` flags.
@@ -629,13 +808,48 @@ for op_i in 1 2 3 4 5 6; do
 done
 op_root=$(git -C "$op_repo" rev-list --max-parents=0 HEAD)
 opg worktree add -q "$op_wt" -b lane/op
-opg format-patch -q -1 other -o "$TMPDIR/op-patches" >/dev/null
+opg format-patch -q -1 other -o "$FIXROOT/op-patches" >/dev/null
+# Assert that a row's fixture actually entered the operation it is about. Called
+# right after EVERY operation setup in both blocks below and before the hook
+# runs, so a fixture that silently did not start reports ITSELF rather than
+# blaming the hook's remedy.
+op_assert_inflight() {
+  local want="$1" label="$2" found=""
+  # FIRST-match-wins, spelled as an if/elif chain in the hook's own precedence
+  # order. It used to be a run of `[ … ] && found=…` lines, which is LAST-match
+  # -wins: the two disagree for any state where more than one marker is present
+  # at once, and then the fixture assertion and the hook under test would be
+  # answering different questions. Latent today -- git does not currently leave
+  # two of these behind together -- and fixed rather than documented, because
+  # the agreement is free and the divergence would be silent.
+  if [ -d "$op_repo/.git/rebase-merge" ]; then
+    found="rebase"
+  elif [ -d "$op_repo/.git/rebase-apply" ]; then
+    if [ -f "$op_repo/.git/rebase-apply/applying" ]; then found="am"; else found="rebase"; fi
+  elif [ -f "$op_repo/.git/CHERRY_PICK_HEAD" ]; then
+    found="cherry-pick"
+  elif [ -f "$op_repo/.git/REVERT_HEAD" ]; then
+    found="revert"
+  elif [ -f "$op_repo/.git/MERGE_HEAD" ]; then
+    found="merge"
+  elif [ -f "$op_repo/.git/BISECT_LOG" ]; then
+    found="bisect"
+  fi
+  if [ "$found" != "$want" ]; then
+    fail=$((fail + 1))
+    printf 'FAIL %s: fixture is in %s, expected %s\n' \
+      "$label" "${found:-nothing}" "${want:-nothing}" >&2
+    return 1
+  fi
+  return 0
+}
 
 # 1 + 2. A conflicted rebase, from the checkout root and from a SUBDIRECTORY of
 # it. The subdir row is the one that fences RESOLVING the git dir rather than
 # assuming `<target_dir>/.git`: there, `$target_dir` is `<main>/sub`, which has
 # no `.git` of its own.
-opg rebase other >/dev/null 2>&1
+opg rebase --merge other >/dev/null 2>&1
+op_assert_inflight rebase "mid-REBASE fixture"
 run_case_msg "detached MAIN mid-REBASE: remedy is 'rebase --abort', not 'switch main'" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
   'rebase --abort' 'Re-attach first'
@@ -662,7 +876,8 @@ opg rebase --abort >/dev/null 2>&1
 # progress?" for the first crossing; that string is what git says when NOTHING is
 # in progress, a different condition.
 opg checkout -q --detach main
-opg am "$TMPDIR/op-patches"/*.patch >/dev/null 2>&1
+opg am "$FIXROOT/op-patches"/*.patch >/dev/null 2>&1
+op_assert_inflight am "mid-AM text fixture"
 run_case_msg "detached MAIN mid-AM: remedy is 'am --abort'" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
   'am --abort' 'Re-attach first'
@@ -674,6 +889,7 @@ opg am --abort >/dev/null 2>&1
 # deleting that branch of the detection survives.
 opg checkout -q --detach main
 opg cherry-pick other >/dev/null 2>&1
+op_assert_inflight cherry-pick "mid-CHERRY-PICK text fixture"
 run_case_msg "detached MAIN mid-CHERRY-PICK: remedy is 'cherry-pick --abort'" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
   'cherry-pick --abort' 'Re-attach first'
@@ -681,6 +897,7 @@ opg cherry-pick --abort >/dev/null 2>&1
 
 opg checkout -q --detach main
 opg merge other >/dev/null 2>&1
+op_assert_inflight merge "mid-MERGE text fixture"
 run_case_msg "detached MAIN mid-MERGE: remedy is 'merge --abort'" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
   'merge --abort' 'Re-attach first'
@@ -688,6 +905,7 @@ opg merge --abort >/dev/null 2>&1
 
 opg checkout -q --detach main
 opg revert --no-edit other >/dev/null 2>&1
+op_assert_inflight revert "mid-REVERT text fixture"
 run_case_msg "detached MAIN mid-REVERT: remedy is 'revert --abort'" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
   'revert --abort' 'Re-attach first'
@@ -702,6 +920,7 @@ opg checkout -q main
 opg bisect start >/dev/null 2>&1
 opg bisect bad >/dev/null 2>&1
 opg bisect good "$op_root" >/dev/null 2>&1
+op_assert_inflight bisect "mid-BISECT text fixture"
 run_case_msg "detached MAIN mid-BISECT: remedy is 'bisect reset'" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
   'bisect reset' '--abort' 'Re-attach first'
@@ -710,6 +929,7 @@ opg bisect reset >/dev/null 2>&1
 # 8. NOTHING in progress: the fallback wording is the one that must survive, and
 # it is the row that says the detection is a discriminator rather than a rewrite.
 opg checkout -q --detach main
+op_assert_inflight "" "NOTHING-in-progress fixture"
 run_case_msg "detached MAIN, NOTHING in progress: remedy stays 'switch main'" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$op_repo")" \
   'Re-attach first: git -C' '--abort' 'rebase --continue'
@@ -742,10 +962,16 @@ opg checkout -q main
 # WHAT EACH ROW HOLDS DOWN, measured by mutating the hook and re-running this
 # suite (cdkd numbers; the siblings differ only in the pre-existing case count):
 #
-#   restore `# to abandon it and re-attach`, drop the conditional -> 7 of the 8.
-#     Every operation row. The BISECT row SURVIVES, and that is the honest
-#     number rather than the one predicted: `bisect reset` is a separate arm
-#     with its own claim, which that mutation does not touch.
+#   restore `# to abandon it and re-attach`, drop the conditional -> 7.
+#     Every `--abort` row. The BISECT rows SURVIVE, because `bisect reset` is a
+#     separate arm with its own wording that this mutation does not touch.
+#     THAT SURVIVAL WAS ONCE RECORDED HERE AS "the honest number", and it is --
+#     about the mutation it survived. It was then read as though it also said
+#     the bisect arm's own claim held, which it never said: the arm was
+#     asserting `bisect reset` "restores the branch you started from" in BOTH
+#     start polarities, and that is false in one of them. A row surviving a
+#     mutation aimed somewhere else is evidence about that mutation only. What
+#     was missing was a row in the other polarity, and the two below are it.
 #   force `reattach_to=""`, never reading `head-name`             -> 2.
 #     The two rebase-started-FROM-a-branch rows, one per backend.
 #   force `reattach_to="main"` whenever a rebase is in progress   -> 1.
@@ -753,9 +979,16 @@ opg checkout -q main
 #   `rebase-apply` branch of the sentinel set to `am`             -> 1.
 #     The `rebase --apply` row -- the branch the `am`-direction row above
 #     cannot see, and the one whose wrong answer is silent.
+#   never read `BISECT_START` (bisect `reattach_to` stays empty)  -> 1.
+#     The bisect-started-FROM-a-branch row, and only it.
+#   treat `BISECT_START` as a branch name unconditionally         -> 1.
+#     The bisect-started-DETACHED row, and only it.
+#   restore the old blanket bisect wording                        -> 2.
+#     Both bisect rows -- the twin of the first mutation above, one arm over.
 #
-# All four tallies are identical in cdk-local and cdk-real-drift (7 / 2 / 1 / 1),
-# measured the same way.
+# All seven tallies are identical in cdkd, cdk-local and cdk-real-drift
+# (7 / 2 / 1 / 1 / 1 / 1 / 2), measured the same way. The first four are
+# unchanged from the previous round; the last three are this round's.
 #
 # The fixture is `op_repo` again, left on `main` by the block above. Each row
 # builds its own state; running the printed remedy IS the assertion, and the
@@ -795,31 +1028,10 @@ op_reset() {
   :
 }
 
-# Assert that a row's fixture actually entered the operation it is about. Called
-# right after the setup and before the hook runs, so a fixture that silently did
-# not start reports ITSELF rather than blaming the hook's remedy.
-op_assert_inflight() {
-  local want="$1" label="$2" found=""
-  [ -d "$op_repo/.git/rebase-merge" ] && found="rebase"
-  [ -d "$op_repo/.git/rebase-apply" ] && {
-    if [ -f "$op_repo/.git/rebase-apply/applying" ]; then found="am"; else found="rebase"; fi
-  }
-  [ -f "$op_repo/.git/CHERRY_PICK_HEAD" ] && found="cherry-pick"
-  [ -f "$op_repo/.git/REVERT_HEAD" ] && found="revert"
-  [ -f "$op_repo/.git/MERGE_HEAD" ] && found="merge"
-  [ -f "$op_repo/.git/BISECT_LOG" ] && found="bisect"
-  if [ "$found" != "$want" ]; then
-    fail=$((fail + 1))
-    printf 'FAIL %s: fixture did not enter a %s (git reports: %s)\n' \
-      "$label" "$want" "${found:-nothing}" >&2
-    return 1
-  fi
-  return 0
-}
-
 # 1. rebase (merge backend) started FROM `main`: the ONE arm where `--abort`
 # really does re-attach, and the row that pins the `head-name` READ.
-opg rebase other >/dev/null 2>&1
+opg rebase --merge other >/dev/null 2>&1
+op_assert_inflight rebase "mid-REBASE-from-main fixture"
 run_case_head "mid-REBASE from main: 'rebase --abort' lands on main, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
@@ -831,7 +1043,8 @@ op_reset
 # `rebase`, and git's own `head-name` (the literal `detached HEAD` here, against
 # `refs/heads/main` above) is the only thing that tells the two apart.
 opg checkout -q --detach main
-opg rebase other >/dev/null 2>&1
+opg rebase --merge other >/dev/null 2>&1
+op_assert_inflight rebase "mid-REBASE-started-detached fixture"
 run_case_head "mid-REBASE started DETACHED: 'rebase --abort' stays detached, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
@@ -846,6 +1059,7 @@ op_reset
 # `git rebase --abort` lands on `main`. The reverse crossing is loud (rc=128,
 # `fatal: It looks like 'git am' is in progress. Cannot rebase.`).
 opg rebase --apply other >/dev/null 2>&1
+op_assert_inflight rebase "mid-REBASE--apply fixture"
 run_case_head "mid-REBASE --apply: remedy is 'rebase --abort', never 'am --abort'" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
@@ -856,7 +1070,7 @@ op_reset
 # None of them detaches HEAD itself, so this arm is reachable for them only from
 # an ALREADY-detached tree, and `--abort` restores exactly that.
 opg checkout -q --detach main
-opg am "$TMPDIR/op-patches"/*.patch >/dev/null 2>&1
+opg am "$FIXROOT/op-patches"/*.patch >/dev/null 2>&1
 op_assert_inflight am "mid-AM fixture"
 run_case_head "mid-AM: 'am --abort' leaves HEAD DETACHED, and says so" \
   "$op_repo" \
@@ -891,16 +1105,58 @@ run_case_head "mid-MERGE: 'merge --abort' leaves HEAD DETACHED, and says so" \
   'merge --abort' 'DETACHED' 'NEITHER ending re-attaches HEAD' 'Either ending'
 op_reset
 
-# 8. bisect, whose remedy has a different SHAPE and whose message makes its own
-# claim ("this restores the branch you started from"). This row turns that claim
-# into a measurement, the same way the seven above do for `--abort`.
+# 8 + 9. bisect, whose remedy has a different SHAPE (`bisect reset`, with no
+# `--continue` / `--abort` pair) and whose message makes its own claim about
+# HEAD. TWO rows, one per START polarity, for the reason rows 1 and 2 are two
+# rows: the same operation, the same printed remedy, the opposite outcome.
 opg bisect start >/dev/null 2>&1
 opg bisect bad >/dev/null 2>&1
 opg bisect good "$op_root" >/dev/null 2>&1
-run_case_head "mid-BISECT: 'bisect reset' lands on main, as the message says" \
+# 8. Started FROM a branch: `bisect reset` really does re-attach, and the
+# message says so. This is the polarity the arm was written for, and the only
+# one it had ever been asked about.
+op_assert_inflight bisect "mid-BISECT-from-branch fixture"
+run_case_head "mid-BISECT from main: 'bisect reset' lands on main, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
-  'bisect reset' 'branch main' 'restores the branch you started from' '--abort'
+  'bisect reset' 'branch main' "restores the branch you started from, 'main'" \
+  'does NOT re-attach'
+op_reset
+
+# 9. THE SAME operation started while ALREADY DETACHED -- and this is the row
+# whose absence let the bisect arm repeat, verbatim, the defect rows 1 and 2
+# fixed for rebase. The old wording said the bisect "is what detached HEAD here"
+# and that `bisect reset` "restores the branch you started from"; both are false
+# from a tree that was already detached, and `main-tree-branch-gate.sh` passes
+# `git checkout <sha>` in the main checkout, so that state is one allowed
+# command away. Measured on git 2.53, same fixture both ways:
+#
+#   started FROM a branch   BISECT_START = main    reset -> branch main
+#   started DETACHED        BISECT_START = <sha>   reset -> rc=0, STILL DETACHED
+#
+# The user reads exit 0 as success and the next gated command blocks again with
+# `in progress : nothing` -- the dead end the resulting-HEAD work exists to
+# remove, surviving in the one arm that work had not reached.
+#
+# WHY THE OLD BISECT ROW DID NOT CATCH IT, and it is worth stating because that
+# row was read as evidence: it SURVIVES the "restore the blanket wording"
+# mutation, and the block below recorded that survival as "the honest number".
+# It is honest about what it measured -- the bisect arm is separate wording, so
+# a mutation of the `--abort` sentence does not touch it -- but a row surviving
+# a mutation aimed elsewhere says nothing about whether its OWN claim holds. The
+# only thing that could have caught this was a row in the other polarity, and
+# there was none. A surviving row is not automatically an honest one; it is
+# honest only about the mutation it survived.
+opg checkout -q --detach main
+opg bisect start >/dev/null 2>&1
+opg bisect bad >/dev/null 2>&1
+opg bisect good "$op_root" >/dev/null 2>&1
+op_assert_inflight bisect "mid-BISECT-detached fixture"
+run_case_head "mid-BISECT started DETACHED: 'bisect reset' stays detached, and says so" \
+  "$op_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
+  'bisect reset' 'DETACHED' 'does NOT re-attach HEAD' \
+  'restores the branch you started from'
 op_reset
 echo
 echo "Pass: $pass  Fail: $fail"

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -754,6 +754,15 @@ opg checkout -q main
 # `applying` sentinel red-lined the `am` row (correctly) and then cherry-pick,
 # revert, merge and bisect (cascade) -- 6 rows for a defect that touches 1. A
 # tally that cannot be attributed to a row is not a fence, it is noise.
+#
+# It also VERIFIES that it cleaned up, because `git am` and `git rebase --apply`
+# SHARE `.git/rebase-apply`: if an abort leaves that directory behind, the next
+# `git am` refuses to start ("previous rebase directory ... still exists") and
+# the row that follows measures the RESIDUE instead of its own operation. That
+# is not hypothetical -- it is how this suite went green on git 2.53 locally and
+# red on the CI runner's older git, where the printed `am --abort` exited 128
+# against a rebase-apply directory no am session owned. A fixture that cannot
+# assert its own precondition reports the wrong defect.
 op_reset() {
   opg rebase --abort >/dev/null 2>&1
   opg am --abort >/dev/null 2>&1
@@ -762,7 +771,35 @@ op_reset() {
   opg merge --abort >/dev/null 2>&1
   opg bisect reset >/dev/null 2>&1
   opg checkout -q --force main >/dev/null 2>&1
+  # DEFENCE, not a fence: no mutation on this machine reddens the two lines
+  # below, because git 2.53's own `--abort` already removes them. They exist for
+  # the git the CI runner has, where it did not. Labelled rather than counted.
+  rm -rf "$op_repo/.git/rebase-apply" "$op_repo/.git/rebase-merge" 2>/dev/null
+  rm -f "$op_repo/.git/CHERRY_PICK_HEAD" "$op_repo/.git/REVERT_HEAD" \
+        "$op_repo/.git/MERGE_HEAD" "$op_repo/.git/BISECT_LOG" 2>/dev/null
   :
+}
+
+# Assert that a row's fixture actually entered the operation it is about. Called
+# right after the setup and before the hook runs, so a fixture that silently did
+# not start reports ITSELF rather than blaming the hook's remedy.
+op_assert_inflight() {
+  local want="$1" label="$2" found=""
+  [ -d "$op_repo/.git/rebase-merge" ] && found="rebase"
+  [ -d "$op_repo/.git/rebase-apply" ] && {
+    if [ -f "$op_repo/.git/rebase-apply/applying" ]; then found="am"; else found="rebase"; fi
+  }
+  [ -f "$op_repo/.git/CHERRY_PICK_HEAD" ] && found="cherry-pick"
+  [ -f "$op_repo/.git/REVERT_HEAD" ] && found="revert"
+  [ -f "$op_repo/.git/MERGE_HEAD" ] && found="merge"
+  [ -f "$op_repo/.git/BISECT_LOG" ] && found="bisect"
+  if [ "$found" != "$want" ]; then
+    fail=$((fail + 1))
+    printf 'FAIL %s: fixture did not enter a %s (git reports: %s)\n' \
+      "$label" "$want" "${found:-nothing}" >&2
+    return 1
+  fi
+  return 0
 }
 
 # 1. rebase (merge backend) started FROM `main`: the ONE arm where `--abort`
@@ -805,6 +842,7 @@ op_reset
 # an ALREADY-detached tree, and `--abort` restores exactly that.
 opg checkout -q --detach main
 opg am "$TMPDIR/op-patches"/*.patch >/dev/null 2>&1
+op_assert_inflight am "mid-AM fixture"
 run_case_head "mid-AM: 'am --abort' leaves HEAD DETACHED, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
@@ -813,6 +851,7 @@ op_reset
 
 opg checkout -q --detach main
 opg cherry-pick other >/dev/null 2>&1
+op_assert_inflight cherry-pick "mid-CHERRY-PICK fixture"
 run_case_head "mid-CHERRY-PICK: 'cherry-pick --abort' leaves HEAD DETACHED, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
@@ -821,6 +860,7 @@ op_reset
 
 opg checkout -q --detach main
 opg revert --no-edit other >/dev/null 2>&1
+op_assert_inflight revert "mid-REVERT fixture"
 run_case_head "mid-REVERT: 'revert --abort' leaves HEAD DETACHED, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \
@@ -829,6 +869,7 @@ op_reset
 
 opg checkout -q --detach main
 opg merge other >/dev/null 2>&1
+op_assert_inflight merge "mid-MERGE fixture"
 run_case_head "mid-MERGE: 'merge --abort' leaves HEAD DETACHED, and says so" \
   "$op_repo" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m resolve"}}' "$op_repo")" \

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -661,17 +661,32 @@ EOF
 # behaviour this gate shipped with, kept rather than silently changed here --
 # but the rationale it shipped with, "the sha form is read-only inspection", is
 # FALSE and is not repeated. `git checkout <sha>` REWRITES the shared working
-# tree and leaves a detached HEAD, and the detached HEAD then disarms the
-# sibling gate: `branch-gate.sh` reads
-# `git -C <dir> symbolic-ref --short HEAD`, which is EMPTY while detached, and
-# falls through to its `exit 0`. Measured in a throwaway repo carrying a
-# `.markgate.yml`, driving branch-gate with `git commit -m x`: rc=2 on `main`,
-# rc=0 once detached. So allowing the sha form leaves a two-step path to an
-# ungated commit in the main checkout. Changing the verdict is a behaviour
-# change with its own blast radius (it would refuse a legitimate inspection
-# spelling in three repos) and belongs in its own PR, not smuggled into a parse
-# fix -- recorded here and in .claude/rules/hooks.md so the next reader inherits
-# the measurement rather than the old claim. What IS fixed here is the WORDING:
+# tree and leaves a detached HEAD. That detached HEAD USED TO DISARM the sibling
+# gate: `branch-gate.sh` read `git -C <dir> symbolic-ref --short HEAD`, which is
+# EMPTY while detached, matched neither `main` nor `master`, and fell through to
+# its `exit 0`. Measured in a throwaway repo carrying a `.markgate.yml`, driving
+# branch-gate with `git commit -m x`: rc=2 on `main`, rc=0 once detached -- so
+# the two gates composed into a two-step path to an ungated commit in the SHARED
+# main checkout, a hole neither had alone.
+#
+# THE COMPOSITION IS CLOSED, FROM THE OTHER SIDE (go-to-k/cdkd#2402).
+# `branch-gate.sh` now separates the two readings of an empty `symbolic-ref` --
+# no repo to read (pass) versus a real repo whose tree has LEFT `main` -- and
+# blocks the second when the target is the MAIN checkout. A detached LINKED
+# worktree still passes, because that is the lane-clearing state
+# `stop-unmerged-lane-warn.sh` itself prescribes (`git switch --detach
+# origin/main`). Re-measured on the same fixture: rc=2 detached in the main
+# checkout, rc=0 detached in a linked worktree.
+#
+# THIS GATE'S VERDICT IS UNCHANGED. `git checkout <sha>` here stays ALLOWED;
+# refusing it is a separate behaviour change with its own blast radius (it would
+# refuse a legitimate inspection spelling in three repos) and belongs in its own
+# PR. What #2402 removed is the CONSEQUENCE of allowing it, not the allowance --
+# so the pass below is now a pass with nothing composing off it, rather than a
+# pass with a measured cost. Recorded here and in
+# CLAUDE.md (this repo has no .claude/rules/).
+#
+# What IS fixed here is the WORDING:
 # `git checkout -d <branch>` / `--detach <branch>` really detaches (measured,
 # HEAD went to a raw sha), and the block used to announce it as "switches to
 # feature branch '<branch>'" -- a verdict that was right about an operation git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,9 +607,58 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   `REVERT_HEAD` / `MERGE_HEAD` / `BISECT_LOG` and prints `<op> --continue` /
   `<op> --abort`, or `bisect reset` for the one case where `switch main` is
   accepted but leaves the bisect running; the `applying` sentinel inside
-  `rebase-apply` separates `git am` from `git rebase --apply`. Every printed
-  remedy was executed against the fixture and exited 0, and because both arms
-  exit 2, `branch-gate.test.sh` asserts the MESSAGE TEXT rather than the code.
+  `rebase-apply` separates `git am` from `git rebase --apply`. Because both
+  arms exit 2, `branch-gate.test.sh` asserts the MESSAGE TEXT rather than the
+  code.
+
+  **What the remedy does to HEAD is stated conditionally, because it IS
+  conditional** (round 3). The round above verified that all nine printed
+  commands EXIT 0 — they do — and then promised `--abort` would "abandon it
+  and re-attach", which is false in four of the six. Exit status was the wrong
+  observable. Measured on git 2.53 by running each printed remedy verbatim and
+  reading HEAD afterwards: `am --abort`, `cherry-pick --abort`,
+  `revert --abort` and `merge --abort` all leave HEAD DETACHED, and so does
+  `rebase --abort` when the rebase was started while ALREADY detached; only a
+  rebase started FROM a branch, plus `bisect reset`, re-attaches. Those four
+  never detach HEAD themselves, so this arm is reachable for them only from an
+  already-detached tree and `--abort` restores exactly that pre-op state — the
+  user reads exit 0 as success and the next gated command blocks again with
+  `in progress : nothing`. The discriminator is git's own `head-name`, which
+  both rebase backends write as `refs/heads/<branch>` or as the literal
+  `detached HEAD`; the gate reads it and prints either
+  "Either ending re-attaches HEAD to '<branch>'" or
+  "NEITHER ending re-attaches HEAD" plus the `switch main` still needed
+  afterwards. One sentence covers both endings because the outcome is a
+  property of the SESSION rather than of which ending is picked — a completed
+  `--continue` splits the same way, measured. Eight rows now RUN the printed
+  remedy and assert the resulting HEAD beside that claim.
+
+  **The `applying` sentinel is load-bearing in the direction that fails
+  SILENTLY.** `git am --abort` inside a `git rebase --apply` session exits 0
+  with no output and leaves HEAD DETACHED, where `git rebase --abort` from
+  that same state lands on `main`; the reverse crossing is loud (rc=128,
+  `fatal: It looks like 'git am' is in progress. Cannot rebase.`). The string
+  `fatal: no rebase in progress` is what git says when NOTHING is in progress,
+  a different condition. That `rebase --apply` branch had no row until round
+  3; mutating it to `am` left all three suites fully green.
+
+  **Two stated bounds.** A path containing a NEWLINE still fails open, because
+  awk's records ARE lines, so an embedded newline ends the record early
+  whatever field expression reads it — measured, a detached MAIN checkout at
+  `<tmp>/nl<LF>repo` scores rc=0, and rc=2 with the newline removed.
+  `worktree list --porcelain -z` DOES read it and is deliberately not taken:
+  `-z` is a later addition than `--porcelain`, an unsupported flag makes
+  `worktree list` print NOTHING (failing OPEN, the same bug class this arm
+  exists to close), and once `-z` ran first the awk would stop executing on
+  every git new enough to have it, retiring the spaced-path fence over a shape
+  this repo HAS produced in exchange for one over a shape nobody has. Second,
+  a `rebase-apply/` directory holding neither `applying` nor `head-name` reads
+  as a rebase here, so the printed `rebase --abort` exits 1 with
+  `warning: could not read '.git/rebase-apply/head-name'` — but `git status`
+  calls that same state "You are currently rebasing.", so the hook agrees with
+  git, and no git command produces it (both rebase backends write `head-name`
+  at start and `git am` writes `applying`), which makes it a bound rather than
+  a bug.
 
   `main-tree-branch-gate` was ported from
   cdkd / cdk-local in the FIXED per-segment shape: the target tree is resolved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,24 +614,78 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   **What the remedy does to HEAD is stated conditionally, because it IS
   conditional** (round 3). The round above verified that all nine printed
   commands EXIT 0 — they do — and then promised `--abort` would "abandon it
-  and re-attach", which is false in four of the six. Exit status was the wrong
-  observable. Measured on git 2.53 by running each printed remedy verbatim and
-  reading HEAD afterwards: `am --abort`, `cherry-pick --abort`,
+  and re-attach", which is false in four of the six. Exit status was the
+  wrong observable. Measured on git 2.53 by running each printed remedy
+  verbatim and reading HEAD afterwards: `am --abort`, `cherry-pick --abort`,
   `revert --abort` and `merge --abort` all leave HEAD DETACHED, and so does
-  `rebase --abort` when the rebase was started while ALREADY detached; only a
-  rebase started FROM a branch, plus `bisect reset`, re-attaches. Those four
-  never detach HEAD themselves, so this arm is reachable for them only from an
-  already-detached tree and `--abort` restores exactly that pre-op state — the
-  user reads exit 0 as success and the next gated command blocks again with
-  `in progress : nothing`. The discriminator is git's own `head-name`, which
-  both rebase backends write as `refs/heads/<branch>` or as the literal
-  `detached HEAD`; the gate reads it and prints either
-  "Either ending re-attaches HEAD to '<branch>'" or
+  `rebase --abort` when the rebase was started while ALREADY detached; only
+  a rebase started FROM a branch re-attaches — and `bisect reset` only when
+  the bisect started from a branch too, which is what the round below had to
+  establish. Those four never detach HEAD themselves, so this arm is
+  reachable for them only from an already-detached tree and `--abort`
+  restores exactly that pre-op state — the user reads exit 0 as success and
+  the next gated command blocks again with `in progress : nothing`. The
+  discriminator is git's own `head-name`, which both rebase backends write
+  as `refs/heads/<branch>` or as the literal `detached HEAD`; the gate reads
+  it and prints either "Either ending re-attaches HEAD to '<branch>'" or
   "NEITHER ending re-attaches HEAD" plus the `switch main` still needed
   afterwards. One sentence covers both endings because the outcome is a
-  property of the SESSION rather than of which ending is picked — a completed
-  `--continue` splits the same way, measured. Eight rows now RUN the printed
-  remedy and assert the resulting HEAD beside that claim.
+  property of the SESSION rather than of which ending is picked — a
+  completed `--continue` splits the same way, measured. Eight rows now RUN
+  the printed remedy and assert the resulting HEAD beside that claim.
+
+  **The bisect arm carried the same defect, one arm over** (round 4). It
+  said a `git bisect` "is what detached HEAD here" and that `bisect reset`
+  "restores the branch you started from". Both are false when the bisect
+  began in a tree that was ALREADY detached — one allowed command away,
+  since `main-tree-branch-gate.sh` passes `git checkout <sha>` in the main
+  checkout. Measured on git 2.53, one fixture both ways: started FROM a
+  branch, `.git/BISECT_START` holds `main` and `bisect reset` lands on
+  branch `main`; started DETACHED, it holds a raw SHA and `bisect reset`
+  exits 0 with HEAD STILL DETACHED, so the user reads success and the next
+  gated command blocks again with `in progress : nothing`. `BISECT_START` is
+  to bisect what `head-name` is to rebase, and the gate now reads it. It
+  asks with `show-ref --verify refs/heads/<x>` rather than a 40-hex pattern,
+  because that is the question `git bisect reset` itself ends in: a branch
+  whose NAME is 40 hex characters is then answered the way `git checkout`
+  would answer it, an empty or missing `BISECT_START` is answered "no
+  branch", and a start branch deleted by a low-level `update-ref -d` is too
+  — where `bisect reset` fails loudly with `fatal: invalid reference`. Both
+  polarities now carry a row that RUNS the printed `bisect reset` and reads
+  HEAD. The previous round recorded that the single bisect row "SURVIVES"
+  the blanket-wording mutation; it did, and that was read as evidence the
+  arm was sound. It was not: a row surviving a mutation aimed elsewhere is
+  evidence about that mutation only.
+
+  **The suite no longer inherits the developer's git config** (round 4),
+  which until now decided which arm half its rows exercised. Measured by
+  breaking the hook's `rebase-merge` detection and running the suite: 61
+  pass / 4 fail by default, and 65 pass / 0 fail with a global
+  `rebase.backend = apply` — fully green over a broken hook, because every
+  plain `git rebase` then goes down `rebase-apply/` instead. On the
+  UNMUTATED hook, a global `commit.gpgsign = true` and a global
+  `init.templateDir` pointing at a failing hook each scored 48 pass / 21
+  fail. The author's machine has `init.templateDir` set (git-secrets), so
+  the suite was green only because those hooks happen to exit 0. The fixture
+  now exports `GIT_CONFIG_GLOBAL=/dev/null` and
+  `GIT_CONFIG_SYSTEM=/dev/null` and names each rebase row's backend
+  (`--merge` / `--apply`) instead of inheriting a default. Proven rather
+  than asserted: with the neutraliser in place, setting each of those three
+  global options leaves the tally unmoved at 72/0, and the
+  broken-`rebase-merge` mutant reddens the same 4 rows with or without
+  `rebase.backend = apply`.
+
+  **Four assertable-but-unasserted arms picked up rows** (round 4): `master`
+  — dropping it from the `main|master` arm left the whole suite green; the
+  two fail-CLOSED refusals, for a MISSING and for a TRUNCATED shared matcher
+  library, each of which could be flipped to `exit 0` unnoticed; and the
+  branch-NAME message BODY, which could be gutted while keeping `exit 2`. A
+  row labelled a polarity control for the SPACED linked worktree controlled
+  nothing — the tree was on a branch and its `.markgate.yml` was never
+  tracked, so the hook left at the opt-in check; the fixture now commits
+  that file and detaches the worktree, and the row dies alongside the other
+  linked rows under a mutation that blocks every detached tree. The suite is
+  72 cases, up from 65.
 
   **The `applying` sentinel is load-bearing in the direction that fails
   SILENTLY.** `git am --abort` inside a `git rebase --apply` session exits 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -593,14 +593,15 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   shared tree. Measured on a scratch opted-in repo, same `git commit`
   payload: rc=2 on `main`, rc=0 once detached; rc=2 after the fix. A detached
   LINKED worktree still passes, because that is the lane-clearing state
-  `stop-unmerged-lane-warn.sh` prescribes (`git switch --detach
-  origin/main`). THIS gate's verdicts are untouched — refusing the sha
-  spelling is a separate behaviour change with its own PR.
+  `stop-unmerged-lane-warn.sh` prescribes with
+  `git switch --detach origin/main`. THIS gate's verdicts are untouched —
+  refusing the sha spelling is a separate behaviour change with its own PR.
 
   **The remedy it prints follows the operation in progress**: a conflicted
-  rebase is one of the ways the shared checkout detaches, and there
-  `git switch main` is refused with `fatal: cannot switch branch while
-  rebasing`, so a correct block ended in an impossible instruction. The gate
+  rebase is one of the ways the shared checkout detaches, and there git
+  refuses `git switch main` outright with
+  `fatal: cannot switch branch while rebasing`, so a correct block ended in
+  an impossible instruction. The gate
   reads the TARGET's RESOLVED git dir (not `<dir>/.git`, wrong from a
   subdirectory) for `rebase-merge` / `rebase-apply` / `CHERRY_PICK_HEAD` /
   `REVERT_HEAD` / `MERGE_HEAD` / `BISECT_LOG` and prints `<op> --continue` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -631,7 +631,7 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   "NEITHER ending re-attaches HEAD" plus the `switch main` still needed
   afterwards. One sentence covers both endings because the outcome is a
   property of the SESSION rather than of which ending is picked — a
-  completed `--continue` splits the same way, measured. Eight rows now RUN
+  completed `--continue` splits the same way, measured. Eleven rows now RUN
   the printed remedy and assert the resulting HEAD beside that claim.
 
   **The bisect arm carried the same defect, one arm over** (round 4). It
@@ -658,22 +658,26 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   evidence about that mutation only.
 
   **The suite no longer inherits the developer's git config** (round 4),
-  which until now decided which arm half its rows exercised. Measured by
-  breaking the hook's `rebase-merge` detection and running the suite: 61
-  pass / 4 fail by default, and 65 pass / 0 fail with a global
-  `rebase.backend = apply` — fully green over a broken hook, because every
-  plain `git rebase` then goes down `rebase-apply/` instead. On the
-  UNMUTATED hook, a global `commit.gpgsign = true` and a global
-  `init.templateDir` pointing at a failing hook each scored 48 pass / 21
-  fail. The author's machine has `init.templateDir` set (git-secrets), so
-  the suite was green only because those hooks happen to exit 0. The fixture
-  now exports `GIT_CONFIG_GLOBAL=/dev/null` and
-  `GIT_CONFIG_SYSTEM=/dev/null` and names each rebase row's backend
-  (`--merge` / `--apply`) instead of inheriting a default. Proven rather
-  than asserted: with the neutraliser in place, setting each of those three
-  global options leaves the tally unmoved at 72/0, and the
-  broken-`rebase-merge` mutant reddens the same 4 rows with or without
-  `rebase.backend = apply`.
+  which until now decided which arm half its rows exercised. The exhibit
+  that motivated it was a global `rebase.backend = apply` sending every
+  plain `git rebase` down `rebase-apply/`, so a broken `rebase-merge` arm
+  was never reached and the suite went fully green over it. That exhibit
+  NO LONGER REPRODUCES (round 5) and the code comment now says so: naming
+  each rebase row's backend explicitly (`--merge` / `--apply`) was the
+  other half of the same fix, and an explicit backend outranks the config
+  key, so the broken-arm mutant scores 76 pass / 5 fail with and without
+  `rebase.backend = apply`. What still bites, and what keeps the two
+  exports load-bearing, is anything that breaks the fixture COMMITS: on
+  the UNMUTATED hook a global `commit.gpgsign = true`, and a global
+  `init.templateDir` pointing at a FAILING hook, each score 56 pass / 25
+  fail plus 18 fixture failures. The author's machine has
+  `init.templateDir` set (git-secrets), whose hooks exit 0, which is why
+  the suite looked green. The fixture exports
+  `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null`, and
+  round 5 added a POSITIVE probe that those variables are actually
+  honoured (git 2.32+) rather than exported and ignored. Proven rather
+  than asserted: with the neutraliser in place, setting each of those
+  three global options leaves the tally unmoved at 81/0.
 
   **Four assertable-but-unasserted arms picked up rows** (round 4): `master`
   — dropping it from the `main|master` arm left the whole suite green; the
@@ -685,7 +689,49 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   tracked, so the hook left at the opt-in check; the fixture now commits
   that file and detaches the worktree, and the row dies alongside the other
   linked rows under a mutation that blocks every detached tree. The suite is
-  72 cases, up from 65.
+  went 65 -> 72 in that round, and 72 -> 81 in round 5.
+
+  **Round 5 closed a live fail-open and four assertions that passed for the
+  wrong reason.** The gate's fail-CLOSED guard checked ONE library function,
+  `gate_matches`, while the hook goes on to call `gate_target_dir` as well —
+  and the two are 239 and 962 lines into a 1094-line library. A copy
+  truncated between them defined the first, passed the guard, then died on
+  the second inside a command substitution whose 127 the hook read as "no
+  target dir" and exited 0. Measured against the real hook,
+  `git commit -m oops` in an opted-in repo on `main`, cutting the library at
+  every 25th line: 30 of 44 offsets scored rc=0, NOT BLOCKED, the whole run
+  [251..976]. cdkd's twin had checked every function it calls since
+  go-to-k/cdkd#2130 and blocked at all 104 of its offsets, so this was
+  unported drift rather than an adaptation. The guard now names every
+  function the hook calls: 0 of 44 after. Four assertions in the round-4
+  work itself held nothing down, each proven by a mutation that left the
+  suite fully green before this round and reddens exactly its own row now:
+  the detached arm's four-line DIAGNOSIS block (resolved target dir / main
+  checkout / HEAD / in progress) had no reader, so gutting it kept `exit 2`
+  and stayed green — four rows, plus a fifth for the `in progress` field's
+  non-empty polarity; the `show-ref --verify` lookup could be swapped for
+  the 40-hex PATTERN its own comment rejects, so two rows now build the
+  states that separate them, a branch literally NAMED 40 hex characters and
+  a start branch deleted under the bisect with `update-ref -d`; the two
+  fail-CLOSED rows both needled the library PATH, which both refusals print,
+  so deleting one arm left the other's message satisfying both — each now
+  needles its own tail; and `run_case_head`'s `${line% #*}` remedy strip had
+  no fixture under a path containing `#`, so reverting it to `%%#*` was
+  green — one fixture now lives under `ha#sh/` and reverting the strip
+  reddens 11 of 11 `run_case_head` rows. Three smaller corrections: the
+  bisect negative arm named a CAUSE the code never established ("this bisect
+  started from a tree that was ALREADY detached") where `reattach_to=""`
+  covers five states, and now uses the neutral wording its sibling rebase
+  arm already had; `run_case_head` extracts the remedy by the indent every
+  printed remedy starts with (two spaces, then the word git) rather than
+  by print order, since the prose
+  around a remedy contains the same fragment (re-ordering the message plus
+  the old extraction EVALs an English sentence — measured, 3 rows exit 127);
+  and a FIXTURE failure no longer increments the row counter, so
+  `Pass + Fail` again equals the case count. The config neutraliser also
+  gained a positive probe that git actually HONOURS `GIT_CONFIG_GLOBAL` /
+  `GIT_CONFIG_SYSTEM` (2.32+) rather than exporting them into a git that
+  ignores them silently.
 
   **The `applying` sentinel is load-bearing in the direction that fails
   SILENTLY.** `git am --abort` inside a `git rebase --apply` session exits 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,7 +582,22 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   "create the local branch and switch", which is how a lane's branch usually
   first appears in a checkout. It is the CAUSE-side twin of `branch-gate`, which
   fires on the symptom (a commit or push
-  once the tree is already off `main`) — go-to-k/cdk-real-drift#1845. Ported from
+  once the tree is already off `main`) — go-to-k/cdk-real-drift#1845.
+  **`branch-gate` now recognises a DETACHED HEAD as "off `main`"**
+  (go-to-k/cdkd#2402): it read the state by branch NAME through
+  `symbolic-ref --short HEAD`, which is EMPTY while detached, so the
+  `main|master` case matched neither arm and the commit went through — and
+  the comment there claimed the empty string only ever meant "not inside a
+  git repo". The two gates composed into a hole neither had alone, since the
+  `git checkout <sha>` this gate passes as inspection is what detaches the
+  shared tree. Measured on a scratch opted-in repo, same `git commit`
+  payload: rc=2 on `main`, rc=0 once detached; rc=2 after the fix. A detached
+  LINKED worktree still passes, because that is the lane-clearing state
+  `stop-unmerged-lane-warn.sh` prescribes (`git switch --detach
+  origin/main`). THIS gate's verdicts are untouched — refusing the sha
+  spelling is a separate behaviour change with its own PR.
+
+  `main-tree-branch-gate` was ported from
   cdkd / cdk-local in the FIXED per-segment shape: the target tree is resolved
   from the SAME segment that carries the arguments, so a command spanning two
   trees is judged per segment. Resolving it once per command was live in both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,6 +597,19 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   origin/main`). THIS gate's verdicts are untouched — refusing the sha
   spelling is a separate behaviour change with its own PR.
 
+  **The remedy it prints follows the operation in progress**: a conflicted
+  rebase is one of the ways the shared checkout detaches, and there
+  `git switch main` is refused with `fatal: cannot switch branch while
+  rebasing`, so a correct block ended in an impossible instruction. The gate
+  reads the TARGET's RESOLVED git dir (not `<dir>/.git`, wrong from a
+  subdirectory) for `rebase-merge` / `rebase-apply` / `CHERRY_PICK_HEAD` /
+  `REVERT_HEAD` / `MERGE_HEAD` / `BISECT_LOG` and prints `<op> --continue` /
+  `<op> --abort`, or `bisect reset` for the one case where `switch main` is
+  accepted but leaves the bisect running; the `applying` sentinel inside
+  `rebase-apply` separates `git am` from `git rebase --apply`. Every printed
+  remedy was executed against the fixture and exited 0, and because both arms
+  exit 2, `branch-gate.test.sh` asserts the MESSAGE TEXT rather than the code.
+
   `main-tree-branch-gate` was ported from
   cdkd / cdk-local in the FIXED per-segment shape: the target tree is resolved
   from the SAME segment that carries the arguments, so a command spanning two

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1424,7 +1424,11 @@ check` green). The earlier `TS2591 'process'` errors came from oxc's type-aware
    `vp run check` + test + build; `release.yml` semantic-release; `pr-title-check.yml`),
    `.markgate.yml` (check/docs/verify-pr), `.claude/skills/{check,check-docs,verify-pr}`,
    the `.claude/hooks/` suite (+ `.claude/settings.json`) — `check-gate`,
-   `branch-gate`, `main-tree-branch-gate` (refuses a `git switch` / `git checkout`
+   `branch-gate` (blocks `git commit` / `git push` when the target tree is on
+   `main` / `master`, and — since go-to-k/cdkd#2402 — when the MAIN checkout is
+   on a DETACHED HEAD, which the branch-NAME read could not see; a detached
+   LINKED worktree still passes, being the lane-clearing state the Stop hook
+   prescribes), `main-tree-branch-gate` (refuses a `git switch` / `git checkout`
    onto a feature branch when the target tree is the MAIN checkout — the
    cause-side twin of `branch-gate`, go-to-k/cdk-real-drift#1845),
    `verify-pr-gate`, `ci-green-gate`, `stale-base-gate`,


### PR DESCRIPTION
fix(hooks): tell a detached HEAD apart from a tree the gate cannot see

Closes go-to-k/cdkd#2402.

`branch-gate.sh` blocks `git commit` / `git push` when the target tree is on
`main` / `master`, and it reads the state with

    branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
    case "$branch" in main|master) ... exit 2 ;; esac
    exit 0

A DETACHED HEAD yields the empty string, matches neither arm and falls through
to `exit 0`. **The comment above that line is what hid it**: it said the empty
case means "the dir doesn't exist or isn't inside a git repo" -- something the
gate cannot see. But a detached HEAD in a perfectly valid repo produces the SAME
empty string, and that is not "cannot see it", it is "the tree left `main`". Two
different conditions shared one observable and the comment asserted only the
harmless one.

That composes with the sibling gate into a hole neither has alone:
`main-tree-branch-gate` allows `git checkout <sha>` in the main checkout, the
tree detaches, and `branch-gate` can no longer tell it is off `main`, because it
recognised the state only by branch NAME.

The discriminator needs no new probe. `$target_top` is already in hand from the
opt-in check six lines above, which exited 0 on an empty answer -- so by that
point the target is known to be a real repo WITH A WORK TREE, strictly stronger
than the `rev-parse --git-dir` this was going to use. The new arm blocks only
when that toplevel is the main checkout. A linked worktree's detached HEAD keeps
passing: it is the remedy the Stop hooks themselves print
(`git switch --detach origin/main` to clear a lane), so blocking it would refuse
a documented instruction.

Measured at the real hook, twelve cases, with each target's HEAD printed beside
the rc:

    case                                        HEAD          before  after  want
    main checkout on main                       branch main        2      2     2
    main checkout DETACHED                      DETACHED           0      2     2
    main checkout DETACHED, from a subdir       DETACHED           0      2     2
    main checkout DETACHED via -C from a wt     DETACHED           0      2     2
    push, main checkout DETACHED                DETACHED           0      2     2
    main checkout on a feature branch           branch feat/x      0      0     0
    linked worktree on a branch                 branch lane/y      0      0     0
    linked worktree DETACHED                    DETACHED           0      0     0
    not a git repo                              --                 0      0     0
    opt-out repo (no .markgate.yml) on main     branch main        0      0     0
    opt-out repo DETACHED                       DETACHED           0      0     0
    git status, main checkout DETACHED          DETACHED           0      0     0

Four mismatches before, zero after, in all three repos.
`main-tree-branch-gate.sh`'s verdicts are untouched -- `git checkout <sha>` stays
allowed for inspection. Refusing it is a separate behaviour change.

**Two pieces of the plan were wrong, and measuring them removed code rather than
adding it.** Copying `main_tree_of`'s shape would have been wrong twice. It
compares its RAW `<dir>` argument, so `cd <repo>/src && git commit` on a detached
main checkout passes -- swapping the compare to `$target_dir` turns all five
block rows red. And its `canonicalize` exists only because of that: probed
against a macOS `/var` -> `/private/var` mktemp path, a symlinked parent and a
subdir under a symlinked parent, `rev-parse --show-toplevel` returned the fully
resolved real path in all four shapes, byte-identical to the porcelain entry. A
`canonicalize` copy was written first, no mutation could kill it, and it is
deleted -- one fewer home for a function two files already argue about.

**The bash-3.2 coverage was true of the SUITE and false of the HOOK.**
`branch-gate.test.sh` invoked `"$HOOK"` directly, whose `#!/usr/bin/env bash`
resolves through PATH, so cdkd's runner exported `HOOK_BASH` to a file that
ignored it and every "under 3.2" tally had been taken against 5.x.
cdk-real-drift was worse: its runner has no per-shell loop at all, so nothing
there had ever run under 3.2. Both carry the shim now, in the shape cdk-local's
`gate-command-recognition.test.sh` already had.

And the shim as first written was itself broken, found only by re-running
through the repo's OWN runner rather than a hand-built invocation: `run-tests.sh`
exports the loop CANDIDATE -- the bare word `bash` for the PATH shell -- and
`[ -x bash ]` does no PATH lookup, so the 5.x pass FATAL'd the whole suite while
the 3.2 pass (an absolute path) sailed through. Half the matrix had vanished.
Fixed with a `case */*` resolve-then-test and verified across `bash`,
`/bin/bash`, `/opt/homebrew/bin/bash` and a deliberately bad `HOOK_BASH`.

Note for anyone reading the mutation tallies: a bash parse error exits 2, which
is the BLOCK code, so a broken gate fails CLOSED and the mutant is visible only
on ALLOW rows. That is why the `;;&` injection sits inside the new arm rather
than in the trailing `case`.

Six mutations, each a fence with its tally (delete the arm; block EVERY detached
HEAD; compare `$target_dir` instead of `$target_top`; `awk $2` instead of
`substr($0,10)`; take the LAST worktree entry; the 3.2-only parse error, with the
same mutant under 5.3 as its control). Two mutations SURVIVED and the code they
covered was deleted rather than labelled a control.

One correction to a neighbouring claim, found on the way: `main-tree-branch-gate`
does not fire from a subdirectory of the main checkout in any of the three repos
(`cd <main>/src && git switch -c feat/x` -> rc=0). That is deliberate and its
header names `cd <subdir>` as the escape hatch -- but the same sentence also
named `git -C <main-tree>` as an escape, which is measurably false (rc=2, since
the `-C` form is exactly what per-segment resolution catches). Corrected where it
appears. It is also the strongest argument for comparing the toplevel here: a
subdir escape on the cause side means the symptom side must still see the commit.

cdk-local gains a `branch-gate.test.sh` -- it had no per-gate harness for this
one. Suites, both shells: cdkd 90 suite-runs 0 fail and unit 853 files / 17,617
tests; cdk-local 12 harnesses x 2 shells 24 OK / 0 FAIL and unit 246 / 4,399;
cdk-real-drift 16 x 2 = 32 OK / 0 FAIL and unit 352 / 6,661. No type errors
anywhere.

