### PR TITLE
chore(work-issues): correct four false claims in the flow text, and fence the counts

### DIFF
--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -315,28 +315,36 @@ if [ -n "$self_branch" ]; then
     push_note="It has ${unpushed} commit(s) not yet pushed, so nothing carrying them has been submitted."
   else
     push_state="pushed"
-    # This arm is QUALIFIED on purpose. Unqualified, it told the agent to open a
-    # PR in a state this repo's own flow walks every src/** lane through:
-    # references/gates-and-pr.md orders "commit, push, and open the PR", and
-    # verify-pr-gate.sh then refuses `gh pr create` until the verify-pr marker is
-    # fresh -- so the branch sits on the remote, PR-less, for the whole of a
-    # /verify-pr run. Telling the agent to retry a command a gate is deliberately
-    # holding is advice that cannot be followed, and a warning that cannot be
-    # acted on is how a real one stops being read.
+    # WHICH of the two texts is right depends on whether verify-pr-gate can
+    # actually be holding `gh pr create` for THIS lane, so the predicate is
+    # COMPUTED rather than assumed. An earlier revision appended the qualifier
+    # unconditionally while the comment beside it argued the case was narrow --
+    # a comment describing a conditional the code did not implement, which is
+    # the same defect class the /work-issues text this shipped alongside was
+    # correcting. It also handed the self-assessed escape hatch ("the expected
+    # state, not the failure") to precisely the docs-only lane the hook exists
+    # to catch.
     #
-    # The qualifier is NARROW, and three measured bounds are why it names WHICH
-    # lane it covers rather than dropping the warning outright:
-    #   - verify-pr-gate.sh EXEMPTS a diff touching no src/** (its own
-    #     "docs/tooling-only" arm), so a docs / skills / hooks-only lane never
-    #     enters the state and the plain warning is exactly right for it;
-    #   - nothing heavier than the skill sits behind the marker HERE: the integ
-    #     gate is INERT in this repo (no companion skill, no hook, see
-    #     .markgate.yml), so the wait is one /verify-pr run and not a fixture run;
-    #   - ci-green-gate.sh gates ONLY `gh pr merge` ("create/edit pass -- CI has
-    #     not run yet at create time"), so CI does not force the push either.
-    # The push comes from the FLOW, not from any gate.
-    push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none -- unless this lane touches src/** and /verify-pr has not finished, where verify-pr-gate is still holding gh pr create and the missing PR is the expected state, not the failure."
-    push_note="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches, unless this is a src/** lane still mid-/verify-pr, where verify-pr-gate holds gh pr create until the marker is fresh."
+    # The bound comes from verify-pr-gate.sh itself, which EXEMPTS a diff
+    # touching no `src/**` (its own "docs/tooling-only" arm), so only a src
+    # lane can be held. Two more bounds keep the qualifier from growing: the
+    # integ gate is INERT in this repo (no companion skill, no hook, see
+    # .markgate.yml), so the wait is one /verify-pr run and not a fixture run;
+    # and ci-green-gate.sh gates ONLY `gh pr merge` ("create/edit pass -- CI
+    # has not run yet at create time"), so CI does not force the push either.
+    # The push comes from the FLOW -- references/gates-and-pr.md has the lane
+    # commit, push, then open the PR -- not from any gate.
+    #
+    # Errs toward the PLAIN text: an unresolvable `origin/main` (a fresh clone,
+    # a sandbox fixture) makes the diff empty and the grep fail, and an
+    # indeterminate state must not buy an excuse for not opening a PR.
+    if git -C "$session_root" diff --name-only origin/main...HEAD 2>/dev/null | grep -qE '^src/'; then
+      push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. This lane touches src/**, so if /verify-pr has not finished yet, verify-pr-gate is still holding gh pr create and the missing PR is the expected state rather than the failure. Otherwise, open one."
+      push_note="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. This lane touches src/**, so verify-pr-gate may still be holding gh pr create until the verify-pr marker is fresh."
+    else
+      push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none."
+      push_note="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches."
+    fi
   fi
   # TWO texts for the self-lane case, not one routed twice. The model text is
   # written AT the agent ("you are not done", "rebase, run the gates"), and every
@@ -369,7 +377,7 @@ another PR.
 Every unmerged lane in this checkout:"
   model_msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
 This session's worktree is on '$self_branch', which is committed but not on origin/main, so you are not
-done: rebase, run the gates, open the PR, merge. $push_line
+done: rebase, run the gates, then open the PR and merge. $push_line
 If you are ending the turn with nothing that will re-invoke you, the honest label is STOPPED, not WAITING.
 One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
 becomes an ancestor of origin/main and keeps reading as ahead. If '$self_branch' is already merged, the

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -335,9 +335,14 @@ if [ -n "$self_branch" ]; then
     # The push comes from the FLOW -- references/gates-and-pr.md has the lane
     # commit, push, then open the PR -- not from any gate.
     #
-    # Errs toward the PLAIN text: an unresolvable `origin/main` (a fresh clone,
-    # a sandbox fixture) makes the diff empty and the grep fail, and an
-    # indeterminate state must not buy an excuse for not opening a PR.
+    # The `^src/` test is byte-identical to the gate's, but the BASE is not:
+    # verify-pr-gate.sh tries origin/main, origin/master, main, master in turn,
+    # while this reads origin/main alone. Both diverge in the SAFE direction --
+    # the gate fails closed on a diff it cannot compute and keeps gating, this
+    # falls to the PLAIN text -- so neither invents an exemption. Same reason on
+    # an unresolvable `origin/main` (a fresh clone, a sandbox fixture): the diff
+    # is empty, the grep fails, and an indeterminate state must not buy an
+    # excuse for not opening a PR.
     if git -C "$session_root" diff --name-only origin/main...HEAD 2>/dev/null | grep -qE '^src/'; then
       push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. This lane touches src/**, so if /verify-pr has not finished yet, verify-pr-gate is still holding gh pr create and the missing PR is the expected state rather than the failure. Otherwise, open one."
       push_note="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. This lane touches src/**, so verify-pr-gate may still be holding gh pr create until the verify-pr marker is fresh."

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -315,8 +315,28 @@ if [ -n "$self_branch" ]; then
     push_note="It has ${unpushed} commit(s) not yet pushed, so nothing carrying them has been submitted."
   else
     push_state="pushed"
-    push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none."
-    push_note="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches."
+    # This arm is QUALIFIED on purpose. Unqualified, it told the agent to open a
+    # PR in a state this repo's own flow walks every src/** lane through:
+    # references/gates-and-pr.md orders "commit, push, and open the PR", and
+    # verify-pr-gate.sh then refuses `gh pr create` until the verify-pr marker is
+    # fresh -- so the branch sits on the remote, PR-less, for the whole of a
+    # /verify-pr run. Telling the agent to retry a command a gate is deliberately
+    # holding is advice that cannot be followed, and a warning that cannot be
+    # acted on is how a real one stops being read.
+    #
+    # The qualifier is NARROW, and three measured bounds are why it names WHICH
+    # lane it covers rather than dropping the warning outright:
+    #   - verify-pr-gate.sh EXEMPTS a diff touching no src/** (its own
+    #     "docs/tooling-only" arm), so a docs / skills / hooks-only lane never
+    #     enters the state and the plain warning is exactly right for it;
+    #   - nothing heavier than the skill sits behind the marker HERE: the integ
+    #     gate is INERT in this repo (no companion skill, no hook, see
+    #     .markgate.yml), so the wait is one /verify-pr run and not a fixture run;
+    #   - ci-green-gate.sh gates ONLY `gh pr merge` ("create/edit pass -- CI has
+    #     not run yet at create time"), so CI does not force the push either.
+    # The push comes from the FLOW, not from any gate.
+    push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none -- unless this lane touches src/** and /verify-pr has not finished, where verify-pr-gate is still holding gh pr create and the missing PR is the expected state, not the failure."
+    push_note="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches, unless this is a src/** lane still mid-/verify-pr, where verify-pr-gate holds gh pr create until the marker is fresh."
   fi
   # TWO texts for the self-lane case, not one routed twice. The model text is
   # written AT the agent ("you are not done", "rebase, run the gates"), and every

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -917,6 +917,65 @@ check "...so the SAME subject nudges the model again" "ctx" "$(channel_of "$out"
 git -C "$CLR_REPO" worktree remove --force "$CLR_REPO/wt-clr"
 
 
+# --- The `pushed` arm has TWO texts, and which one is right is a PREDICATE
+# rather than a constant. `verify-pr-gate.sh` EXEMPTS a diff touching no
+# `src/**`, so only a src lane can be held PR-less by it; a docs-only lane told
+# "verify-pr-gate is holding gh pr create" is handed an excuse in exactly the
+# case this hook exists to catch. An earlier revision appended the qualifier
+# UNCONDITIONALLY and this suite stayed green at 121/121, because the only
+# pushed-arm assertion greps a phrase BOTH texts carry -- so both directions are
+# pinned here, and the docs-only one is the direction that bites.
+#
+# A SEPARATE sandbox repo again: the fixtures above are cadence-ordered, and an
+# extra hook invocation against them would shift every subject comparison after
+# it.
+SRC_REPO="$SANDBOX/src-lane-repo"
+mkdir -p "$SRC_REPO/.claude/hooks"
+cp "$HOOK" "$SRC_REPO/.claude/hooks/"
+SRC_RUN="$SRC_REPO/.claude/hooks/$(basename "$HOOK")"
+git -C "$SRC_REPO" init -q .
+git -C "$SRC_REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$SRC_REPO" update-ref refs/remotes/origin/main HEAD
+git -C "$SRC_REPO" config remote.origin.url "$SRC_REPO"
+git -C "$SRC_REPO" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+
+# `push_state` must be `pushed` for either text to be reached at all, so each
+# lane gets a real upstream -- the same refspec-and-config dance the cadence
+# fixtures above needed, and for the same reason: without it `@{u}` fails, the
+# hook reads the lane as unpushed, and both cases below would pass on the
+# unpushed arm while asserting nothing about the one under test.
+make_pushed_lane() {  # <worktree> <branch> <path-to-create>
+  local wt="$1" br="$2" path="$3"
+  git -C "$SRC_REPO" worktree add -q "$wt" -b "$br" HEAD
+  mkdir -p "$(dirname "$wt/$path")"
+  printf 'x\n' > "$wt/$path"
+  git -C "$wt" add -A
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -q -m "work on $br"
+  git -C "$SRC_REPO" update-ref "refs/remotes/origin/$br" "$(git -C "$SRC_REPO" rev-parse "$br")"
+  git -C "$SRC_REPO" config "branch.$br.remote" origin
+  git -C "$SRC_REPO" config "branch.$br.merge" "refs/heads/$br"
+}
+
+make_pushed_lane "$SRC_REPO/wt-docs" feat/docs docs/note.md
+check "the docs lane fixture really is fully pushed" "0" \
+  "$(git -C "$SRC_REPO/wt-docs" rev-list --count '@{u}..' 2>/dev/null || echo MISSING)"
+out=$(run_hook_keep "$SRC_REPO" "$SRC_RUN" "{\"cwd\": \"$SRC_REPO/wt-docs\", \"session_id\": \"sess-docs\"}")
+check "a docs-only lane still gets the pushed-arm warning" "yes" \
+  "$(has "$out" -F 'pushed branch with NO PR')"
+check "...and is NOT told a gate is holding gh pr create" "no" \
+  "$(has "$out" -F 'verify-pr-gate')"
+
+make_pushed_lane "$SRC_REPO/wt-src" feat/src src/thing.ts
+out=$(run_hook_keep "$SRC_REPO" "$SRC_RUN" "{\"cwd\": \"$SRC_REPO/wt-src\", \"session_id\": \"sess-src\"}")
+check "a src lane IS told verify-pr-gate may be holding the PR open" "yes" \
+  "$(has "$out" -F 'verify-pr-gate')"
+check "...and the predicate read THIS lane's own diff to decide" "yes" \
+  "$(has "$out" -F 'touches src/**')"
+
+git -C "$SRC_REPO" worktree remove --force "$SRC_REPO/wt-docs"
+git -C "$SRC_REPO" worktree remove --force "$SRC_REPO/wt-src"
+
+
 # The fence itself, aimed at the HELPER rather than at the hook: point it at a
 # probe that reports the byte count of the stdin it was handed. `$#` keeps an
 # explicit empty payload empty (0 bytes) and still defaults an OMITTED one to
@@ -945,10 +1004,10 @@ clear_nudge_records
 # reads `fail: 0`. No suite in this repo had one, so the only thing standing
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
-CASE_FLOOR=121
+CASE_FLOOR=126
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
-  fail_log+="FAIL case floor: only $((pass + fail)) cases ran, expected at least 121\n"
+  fail_log+="FAIL case floor: only $((pass + fail)) cases ran, expected at least 126\n"
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
 fi
 printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -1005,10 +1005,16 @@ clear_nudge_records
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
 CASE_FLOOR=126
-if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
+ran=$((pass + fail))
+if [ "$ran" -lt "$CASE_FLOOR" ]; then
+  # `ran` is captured BEFORE the increment below. Incrementing `fail` first and
+  # then interpolating `$((pass + fail))` counts the floor's OWN failure as one
+  # of the cases it is counting, so a run of 125 announced "only 126 cases ran,
+  # expected at least 126" -- a message that disproves itself, emitted only when
+  # something is already wrong.
   fail=$((fail + 1))
-  fail_log+="FAIL case floor: only $((pass + fail)) cases ran, expected at least 126\n"
-  printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
+  fail_log+="FAIL case floor: only $ran cases ran, expected at least $CASE_FLOOR\n"
+  printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$ran" "$CASE_FLOOR"
 fi
 printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then

--- a/.claude/skills/check-docs/SKILL.md
+++ b/.claude/skills/check-docs/SKILL.md
@@ -70,10 +70,11 @@ docs describe.
 After documentation is verified consistent (no issues found, or all fixed),
 record the `docs` marker so the markgate `docs` gate is satisfied. Run it from the
 root of the tree you are WORKING in — the worktree, not the main checkout, whenever
-the lane lives in one: the marker store (`.git/markgate`) is shared across
-worktrees, but the hashes come from the cwd's files, so setting it from the main
-checkout records `main`'s content and the gate then fails from your worktree (see
-`/check` for the measurement). Set it in its OWN command too, separate from the
+the lane lives in one: the marker store is PER-WORKTREE
+(`<git rev-parse --absolute-git-dir>/markgate/`), so a marker set from the main
+checkout is not visible to your worktree at all and the gate fails there with
+`no marker` (see `/check` for the three-tree measurement, re-taken 2026-09-03 --
+"shared across worktrees" was wrong). Set it in its OWN command too, separate from the
 `git commit` — `check-gate` is a PreToolUse hook, so it judges a
 `markgate set … && git commit` one-liner before the `set` inside it ever runs. Use
 `mise exec` to avoid PATH issues when shims aren't active:

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -95,13 +95,25 @@ reads it, and this copy has already gone stale once (go-to-k/cdk-real-drift#1837
 widened the gate and had to repair the enumeration here in the same PR).
 
 Run from the root of the tree you are WORKING in — the worktree, not the main
-checkout, whenever the lane lives in one. The marker store is `.git/markgate`,
-shared by every worktree, but the hashes come from the cwd's files, so setting it
-from the main checkout records `main`'s content instead of yours: measured
-2026-08-19, with the worktree dirty and the marker set from the main checkout,
-`markgate verify check` returns rc=1 from the worktree and rc=0 from main. It fails
-CLOSED, so the cost is a wasted gate cycle plus a "run /check first" message right
-after you ran it. Also set it in its OWN command, separate from the `git commit` —
+checkout, whenever the lane lives in one. The marker store is PER-WORKTREE --
+`<git rev-parse --absolute-git-dir>/markgate/`, which resolves to `.git/markgate`
+only for the MAIN checkout and to `.git/worktrees/<name>/markgate/` for a lane --
+so a marker set from the main checkout is not merely computed over the wrong
+files, it is INVISIBLE from the lane. Re-measured 2026-09-03 on the `.mise.toml`
+pin (markgate 0.4.1), three trees of this ONE repo answering
+`markgate status check` three different ways:
+
+| tree                     | store on disk                     | answer                                         |
+| ------------------------ | --------------------------------- | ---------------------------------------------- |
+| main checkout            | `.git/markgate/`                  | `created 2026-07-21T13:17:24Z / mismatch` rc=1 |
+| an existing lane         | `.git/worktrees/<name>/markgate/` | `created 2026-08-29T19:42:42Z / match` rc=0    |
+| a freshly-added worktree | none                              | `state: no marker` rc=1                        |
+
+It fails CLOSED either way, so the cost is a wasted gate cycle plus a "run /check
+first" message right after you ran it -- but the lane prints `no marker`, not a
+digest mismatch, so do not go hunting for one. This paragraph used to say the
+store was `.git/markgate`, SHARED by every worktree, and dated the reading
+2026-08-19; the rc pair it recorded was real, the mechanism behind it was not. Also set it in its OWN command, separate from the `git commit` —
 `check-gate` is a PreToolUse hook and judges the call before anything in it runs, so
 a `markgate set … && git commit` one-liner is blocked in full.
 

--- a/.claude/skills/hunt-bugs/references/plan.md
+++ b/.claude/skills/hunt-bugs/references/plan.md
@@ -48,9 +48,10 @@ the file that holds the ONLY copy of it — `/work-issues` SKILL.md points there
 rather than carrying it.
 IN-PLACE means create nothing and hunt on the branch already checked out here
 (deps and `dist/` are usually already built), and §8 then removes nothing. The
-probe reports a mode and two paths and carries no lane limit of its own; the
-one-lane rule is `/work-issues` prose, and a hunt takes one fix at a time
-anyway, so it costs this skill nothing.
+probe reports a mode, two paths and a branch, and carries no lane limit of its
+own; the serialization rule is `/work-issues` prose — it bounds CONCURRENT lanes
+rather than the issue count — and a hunt takes one fix at a time anyway, so it
+costs this skill nothing.
 
 ### 2. Scaffold fixtures + ARM the cleanup gate
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -44,7 +44,7 @@ worktree": MAIN-CHECKOUT records the MAIN checkout under it, and the
 `git -C "<LANE_TREE>"` recipes consuming it in §4, §5, §7 and §10 are
 IN-PLACE-only arms (every MAIN-CHECKOUT arm beside them uses no `-C`).
 
-`IN-PLACE` changes a great deal more than the lane count: §1's pull, the
+`IN-PLACE` changes a great deal more than the concurrent lane count: §1's pull, the
 collision scan's paths, the claim, the branch recipe, §7's rebase, the worktree
 and branch cleanup, where the retro branch is created, and the `LAUNCH_BRANCH`
 restore that ends the run.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -139,8 +139,8 @@ wants to watch); the stage files apply unchanged either way.
 - **Real-AWS live tests and merges are SERIALIZED across lanes** — the parent
   grants the turn, one lane at a time; a lane subagent never starts either on
   its own. Everything else runs concurrently, subject to two repo-local caveats
-  §9 states in full (the markgate store is SHARED across worktrees, the
-  deploy-autoarm sentinel is per-SESSION). (§9)
+  §9 states in full (the markgate store is PER-WORKTREE, the deploy-autoarm
+  sentinel is per-SESSION). (§9)
 - **English only in every published artifact** — issue bodies/comments, PR
   titles/bodies, commits, code. (CLAUDE.md)
 - **The run ends with the retro (stage 10) and the standard wrap report**

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -24,7 +24,23 @@ of git with `git -C "<LANE_TREE>" branch --show-current`, and it does not exist
 yet: §5 creates it, after this stage. Write "the branch §5 will create in
 `<LANE_TREE>`" and post the claim on time. A claim delayed until the branch
 exists is a claim posted after the first edit, which is the one thing this stage
-forbids. Such a run claims ONE issue (§3), not a set.
+forbids. Such a run's lanes are SERIAL (§3), which bounds CONCURRENCY and not
+the issue count: claiming only the top candidate is fine, and so is claiming a
+whole set — but a claimed set must mark every lane after the first `QUEUED`,
+because a reader has to tell a lane that is RUNNING from one merely spoken for.
+
+```bash
+# The QUEUED form, posted up front with the rest of the set.
+gh issue comment <n> --body "QUEUED behind #<the lane running first> in \
+<LANE_TREE> — this session will start it only after that lane merges. Not \
+started: no branch exists yet and no file is held. If you want this issue, take \
+it and say so here; I will stand down."
+```
+
+When the run ends before reaching one, **stand it down rather than leaving the
+claim standing** — a QUEUED claim outliving its session is a stale lock, and the
+four classification fields in the stand-down comment hand the next session the
+triage instead of making it redo the ranking.
 
 For EACH issue you will start:
 

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -57,13 +57,30 @@ go-to-k/cdk-real-drift#1782):
   the cwd is ALREADY inside that worktree — no timeout, no refusal, and the
   chained edit silently does not run — after any timeout or refusal, `pwd` and
   re-verify what the aborted call was to create. The marker store is
-  `.git/markgate`, SHARED by every worktree, but the hashes come from the cwd's
-  files, so setting from the main checkout records `main`'s content; it fails
-  CLOSED (`markgate verify check` rc=1 from the dirty worktree, rc=0 from main —
-  2026-08-19): a wasted cycle, not a bad merge. `/check` / `/check-docs`'s "repo
-  root" means the WORKTREE root here. The sibling repo shows the same symptom via
-  a DIFFERENT mechanism (per-worktree stores: marker missing, not wrong) —
-  import the advice, not its explanation.
+  PER-WORKTREE — `<git rev-parse --absolute-git-dir>/markgate/`, which is
+  `.git/markgate` only for the MAIN checkout and `.git/worktrees/<name>/markgate/`
+  for a lane — so a marker set from the main checkout is not merely hashed over
+  the wrong files, it is INVISIBLE from the lane, which reports `no marker`. It
+  fails CLOSED either way: a wasted cycle, not a bad merge. `/check` /
+  `/check-docs`'s "repo root" means the WORKTREE root here, and `/check` carries
+  the three-tree measurement.
+  **This paragraph asserted the opposite until 2026-09-03 and the correction is
+  the lesson**: it called the store `.git/markgate`, SHARED by every worktree,
+  and told the reader that the sibling repo reaches the same symptom by a
+  DIFFERENT mechanism — "import the advice, not its explanation". Re-measured on
+  markgate 0.4.1 (the `.mise.toml` pin), three trees of this ONE repo answer
+  `markgate status check` three ways: main `mismatch` rc=1 (created
+  2026-07-21T13:17:24Z), an existing lane `match` rc=0 (created
+  2026-08-29T19:42:42Z), a freshly-added worktree `no marker` rc=1 with no store
+  on disk. The mechanism is the SAME as the sibling's, and the sentence telling
+  the reader to discard the explanation was protecting the wrong half. The
+  ADVICE — set markers from the worktree — never changed, which is exactly why
+  nothing caught it: a false premise reaching a true conclusion produces no
+  failing command. markgate state is the WHOLE of the per-worktree question
+  here: the siblings additionally bind `pr-review` to a `.markgate-pr-review-sha`
+  sentinel, and that gate is INERT in this repo (no companion skill, no hook —
+  `.markgate.yml`) with no such file on disk, so none of its behaviour applies
+  to a cdkrd lane.
 - `cd <worktree> &&` on a GATED command is safe only while the hook conditions
   match it, and twice they did not: go-to-k/cdk-real-drift#1786 (three gates
   lacked the `cd` spelling — `cd <wt> && git commit` ran UNGATED), then

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -371,7 +371,8 @@ into a check.
 **Note WHICH work the copy protects: the bytes the subject held when the
 snapshot was TAKEN.** Content written or extended AFTER that point is reverted
 by the restore, not preserved by it — a lane lost 133 lines of newly written
-tests to precisely that, its harness restoring a snapshot that predated them.
+tests to precisely that (go-to-k/cdkd#2457), its harness restoring a snapshot
+that predated them.
 The restore is doing its job there; the loss is that nothing else held the work.
 That is the destructive half of `references/verify.md`'s pre-probe commit rule,
 and the two are complementary: commit first so the restore cannot cost anything,

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -368,6 +368,15 @@ peer's changes has its own trap). Verify the restore by HASH, not by eye — a
 `shasum -a 256` recorded before the first probe turns "I think I put it back"
 into a check.
 
+**Note WHICH work the copy protects: the bytes the subject held when the
+snapshot was TAKEN.** Content written or extended AFTER that point is reverted
+by the restore, not preserved by it — a lane lost 133 lines of newly written
+tests to precisely that, its harness restoring a snapshot that predated them.
+The restore is doing its job there; the loss is that nothing else held the work.
+That is the destructive half of `references/verify.md`'s pre-probe commit rule,
+and the two are complementary: commit first so the restore cannot cost anything,
+snapshot byte-exactly so the restore itself is not the corruption.
+
 **Both probes above vary the INPUT. The second axis is the STATE the subject is
 in when the input arrives, and that one gets enumerated by ACCIDENT** — every
 case reuses the first case's fixture setup, so the suite covers one row of a

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -129,18 +129,18 @@ pointers. IN-PLACE means this run was launched inside a worktree someone else
 created (an Orca/ADE workspace, a stray `cd`), so it has exactly ONE working
 tree:
 
-| #   | Consequence                                                                                                                                                                                             | Where     |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| 1   | Take ONE issue and finish it — a second lane would need a worktree NESTED inside this one, which dies with the outer workspace and takes its uncommitted work (go-to-k/cdk-real-drift#1842)             | §3        |
-| 2   | §1's `git checkout main && git pull` cannot run here; pull through `git -C "<MAIN_CHECKOUT>"` and read the refs with `git show origin/main:<file>`                                                      | §1        |
-| 3   | §2's worktree probes take `<MAIN_CHECKOUT>/.worktrees/<w>`, not a relative path                                                                                                                         | §2        |
-| 4   | The claim names the tree already checked out here plus the branch §5 WILL create in it — never `LAUNCH_BRANCH`, which belongs to the outer tool                                                         | §4        |
-| 5   | Create no worktree; after confirming the tree is YOURS, branch IN PLACE off `origin/main` — ALWAYS, not only when the tree is detached or its PR has merged — and never commit onto `LAUNCH_BRANCH`     | §5        |
-| 6   | Switch back to `LAUNCH_BRANCH` **as-is** — no pull, no rebase, no fast-forward — and delete only the branches THIS run created; detach only when `LAUNCH_BRANCH` was empty at probe time or is now gone | §9        |
-| 7   | §7's rebase runs `git -C "<LANE_TREE>"`                                                                                                                                                                 | §7        |
-| 8   | Remove no worktree: a lane that removes the tree it runs in deletes its own cwd. Cleanup of the TREE belongs to whoever created it                                                                      | §9, §10-d |
-| 9   | §9's post-merge pull goes through `git -C "<MAIN_CHECKOUT>"` for the same reason as row 2                                                                                                               | §9        |
-| 10  | The retro branch is created in THIS tree too, so the `LAUNCH_BRANCH` restore is the run's LAST step — after the retro PR merges, not inside §9's per-lane cleanup                                       | §10-d     |
+| #   | Consequence                                                                                                                                                                                                     | Where     |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| 1   | Lanes run SERIALLY — a CONCURRENT second lane needs a worktree NESTED inside this one, which dies with the outer workspace and takes its uncommitted work (go-to-k/cdk-real-drift#1842). Not an issue-count cap | §3        |
+| 2   | §1's `git checkout main && git pull` cannot run here; pull through `git -C "<MAIN_CHECKOUT>"` and read the refs with `git show origin/main:<file>`                                                              | §1        |
+| 3   | §2's worktree probes take `<MAIN_CHECKOUT>/.worktrees/<w>`, not a relative path                                                                                                                                 | §2        |
+| 4   | The claim names the tree already checked out here plus the branch §5 WILL create in it — never `LAUNCH_BRANCH`, which belongs to the outer tool                                                                 | §4        |
+| 5   | Create no worktree; after confirming the tree is YOURS, branch IN PLACE off `origin/main` — ALWAYS, not only when the tree is detached or its PR has merged — and never commit onto `LAUNCH_BRANCH`             | §5        |
+| 6   | Switch back to `LAUNCH_BRANCH` **as-is** — no pull, no rebase, no fast-forward — and delete only the branches THIS run created; detach only when `LAUNCH_BRANCH` was empty at probe time or is now gone         | §9        |
+| 7   | §7's rebase runs `git -C "<LANE_TREE>"`                                                                                                                                                                         | §7        |
+| 8   | Remove no worktree: a lane that removes the tree it runs in deletes its own cwd. Cleanup of the TREE belongs to whoever created it                                                                              | §9, §10-d |
+| 9   | §9's post-merge pull goes through `git -C "<MAIN_CHECKOUT>"` for the same reason as row 2                                                                                                                       | §9        |
+| 10  | The retro branch is created in THIS tree too, so the `LAUNCH_BRANCH` restore is the run's LAST step — after the retro PR merges, not inside §9's per-lane cleanup                                               | §10-d     |
 
 There is deliberately no rebuild row. The global install here is
 `vp i -g cdk-real-drift`, BY NAME from npm, so it reads no tree's build output

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -241,8 +241,15 @@ Every run appending one more bullet is how a long skill becomes an unread one.
   leaving the copies corrected and the original still asserting the falsehood —
   which is the drift shape §10-b fences, re-created by the very run sent to end
   it. So for every claim, grep for the OTHER sites before fixing the named one,
-  and count what a list-shaped instruction says it contains (2026-09-03,
-  go-to-k/cdk-real-drift#1861).
+  and count what a list-shaped instruction says it contains.
+  **The worked instance is this rule's own commit.** Correcting the probe-value
+  undercount, that run fixed `hunt-bugs/references/plan.md` and left the
+  identical sentence in `references/triage.md` saying "a mode and two paths" —
+  one claim, two copies, one corrected, shipped in the very commit that adds the
+  paragraph you are reading. A reviewer found it, not the author, which is the
+  point: the author had just written the rule and still could not see the
+  instance, because the second copy was in a file the finding did not name
+  (2026-09-03, go-to-k/cdk-real-drift#1861).
   **Verify the cited EVIDENCE too — open the issue or PR the sentence names and
   confirm it says what the sentence claims.** Wrong evidence is wrong where
   WRITTEN and travels intact past every per-repo noun check: this file claimed

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -204,6 +204,25 @@ Every run appending one more bullet is how a long skill becomes an unread one.
   against that repo's files — caught four such false claims in the first mirror
   of this section (2026-08-18). This rule lives here, not in memory: memory is
   per-project-path and per-machine, so it would not load in the target repos.
+  **Verify the MECHANISM at the SOURCE, not only the applicability at the
+  TARGET.** The two feel like one check and are not. Applicability asks "does
+  this repo have that gate / hook / file", which the target-repo reviewer above
+  answers well. The mechanism asks "was the claim ever true where it was
+  WRITTEN", and once a lesson is in transit nobody is positioned to ask it: the
+  originating repo is no longer being read, and the target repo cannot see a
+  defect in machinery it does not have. Measured 2026-09-03 on the mirror that
+  produced this section's own edits: a lesson arrived describing a leaked
+  `.markgate-pr-review-sha` as a FALSE PASS that would merge a PR on the
+  strength of an already-merged one's review. The recon correctly ruled it
+  INAPPLICABLE here — `pr-review` is inert in this repo and the sentinel file
+  does not exist — and the framing was still wrong at the source: the siblings'
+  `pr-review-gate.sh` passes only on `recorded_sha = head_sha`, so a leaked
+  sentinel MISMATCHES and blocks, printing `bound to <sha> (mismatch)`. Fail
+  CLOSED, not fail open; the real sibling cost is a confusing block naming an
+  unrelated PR's sha. A correctly-REJECTED claim can still be false, and a
+  mirror that only ever asks "does this apply here" launders it intact into
+  every repo that DOES have the machinery. Reading the source hook cost two
+  commands.
   **Verify the cited EVIDENCE too — open the issue or PR the sentence names and
   confirm it says what the sentence claims.** Wrong evidence is wrong where
   WRITTEN and travels intact past every per-repo noun check: this file claimed

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -223,6 +223,22 @@ Every run appending one more bullet is how a long skill becomes an unread one.
   mirror that only ever asks "does this apply here" launders it intact into
   every repo that DOES have the machinery. Reading the source hook cost two
   commands.
+  **A recon or handoff report is a CLAIM SET, not a work list — re-derive its
+  SCOPE, not only its citations.** The mirror that produced this section was
+  handed a read-only recon that had checked every claim against this repo's
+  files, and it was still stale in ten places and wrong about scope twice — both
+  times UNDER-reporting. The false markgate-store claim sat at FIVE sites, not
+  the three it named, and the two it missed were the `/check` and `/check-docs`
+  skills that are the ORIGIN of the measurement the other three cite; adding one
+  item to `verify.md`'s §8-z required moving FOUR counts, not the one it flagged.
+  The two error kinds are not equally dangerous. A drifted line number announces
+  itself the moment you open the file, but an under-reported scope is SILENT: a
+  lane that treats the list as complete lands a partial fix and reports it done,
+  leaving the copies corrected and the original still asserting the falsehood —
+  which is the drift shape §10-b fences, re-created by the very run sent to end
+  it. So for every claim, grep for the OTHER sites before fixing the named one,
+  and count what a list-shaped instruction says it contains (2026-09-03,
+  go-to-k/cdk-real-drift#1861).
   **Verify the cited EVIDENCE too — open the issue or PR the sentence names and
   confirm it says what the sentence claims.** Wrong evidence is wrong where
   WRITTEN and travels intact past every per-repo noun check: this file claimed

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -229,8 +229,12 @@ Every run appending one more bullet is how a long skill becomes an unread one.
   files, and it was still stale in ten places and wrong about scope twice — both
   times UNDER-reporting. The false markgate-store claim sat at FIVE sites, not
   the three it named, and the two it missed were the `/check` and `/check-docs`
-  skills that are the ORIGIN of the measurement the other three cite; adding one
-  item to `verify.md`'s §8-z required moving FOUR counts, not the one it flagged.
+  skills — and `/check` is the ORIGIN the others point back at, so correcting only
+  the three named would have left the source still asserting it. Adding one item
+  to `verify.md`'s §8-z touched FOUR places rather than the one it flagged, and
+  only TWO of those carried a digit that changed; the other two kept their
+  numeral and moved their scope, so even a careful grep for numerals finds half
+  the work and looks finished.
   The two error kinds are not equally dangerous. A drifted line number announces
   itself the moment you open the file, but an under-reported scope is SILENT: a
   lane that treats the list as complete lands a partial fix and reports it done,

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -7,10 +7,11 @@ merge-ready lane at a time its turn — resume that lane agent (SendMessage) to
 run its owed §8 live test + `/sweep-resources` and merge while it holds the
 turn, or run them yourself FROM THAT LANE'S WORKTREE. The worktree matters
 mechanically, not stylistically: gate verdicts are computed against the tree
-the command runs from — this repo's markgate store is shared across worktrees
-but the HASHES come from the cwd's files (the `/check` skill's 2026-08-19
-measurement), and the bughunt-clean gate keys the committing WORKTREE owner —
-so a marker set or a merge issued from the main tree attests to MAIN's
+the command runs from — this repo's markgate store is PER-WORKTREE
+(`<git rev-parse --absolute-git-dir>/markgate/`; §6 carries the 2026-09-03
+re-measurement that corrected "shared across worktrees"), and the bughunt-clean
+gate keys the committing WORKTREE owner — so a marker set from the main tree is
+not even visible to the lane, and a merge issued from there attests to MAIN's
 content, not the lane's. cdkd measured the merge-time failure live on
 2026-08-28 (go-to-k/cdkd#2363 records the cwd-race side of it).
 Live-AWS runs have a second, repo-specific reason to stay inside the granted

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -179,7 +179,8 @@ later runs `git worktree add` or does not.
 **run lanes SERIALLY** — a second CONCURRENT lane would need a worktree nested
 inside this one, which dies with the outer workspace and takes its uncommitted
 work (go-to-k/cdk-real-drift#1842). That serialization limit is stated HERE, in
-prose; the probe reports a mode and two paths and carries no limit of its own.
+prose; the probe reports a mode, two paths and a branch, and carries no limit of
+its own.
 Rank as usual.
 
 **It bounds CONCURRENT lanes, not the ISSUE COUNT** — and until 2026-09-03 this

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -176,11 +176,28 @@ later runs `git worktree add` or does not.
 
 `IN-PLACE` means this run was launched inside a worktree someone else created
 (an Orca/ADE workspace, a stray `cd`), so it has exactly ONE working tree:
-**take ONE issue and finish it** — a second lane would need a worktree nested
+**run lanes SERIALLY** — a second CONCURRENT lane would need a worktree nested
 inside this one, which dies with the outer workspace and takes its uncommitted
-work (go-to-k/cdk-real-drift#1842). That one-lane limit is stated HERE, in
+work (go-to-k/cdk-real-drift#1842). That serialization limit is stated HERE, in
 prose; the probe reports a mode and two paths and carries no limit of its own.
-Rank as usual, claim the top candidate, and leave the rest for the next run.
+Rank as usual.
+
+**It bounds CONCURRENT lanes, not the ISSUE COUNT** — and until 2026-09-03 this
+paragraph said "take ONE issue and finish it ... leave the rest for the next
+run", with the same limit restated in `references/launch-mode.md`'s IN-PLACE
+table row 1 and in `references/claim.md`; all three were corrected together.
+Sequential work in one tree nests nothing: a cdk-local run took FOUR issues one after another, each on a
+branch cut from `origin/main`, deleting the previous branch after its merge, with
+zero collisions. So several issues in one run is fine when they share this tree
+in SEQUENCE: claim them all UP FRONT (§4) with every lane after the first marked
+`QUEUED`, finish them one at a time, and if the run ends before reaching one,
+stand it down with a comment carrying the four classification fields — which
+leaves it visibly claimable rather than silently locked (the shape cdkd measured
+on 2026-09-02, go-to-k/cdkd#2417: three lanes claimed, one merged, two left
+pickup-ready). Claiming only the top candidate is still fine; the point is that a
+QUEUED issue is spoken for rather than abandoned. The old wording read a hazard
+about trees EXISTING AT THE SAME TIME as a budget on work, which is the one thing
+it does not constrain.
 
 **The MAIN-CHECKOUT case is the DISJOINTNESS PARAGRAPH below and nothing
 wider.** An earlier revision said "everything below is the MAIN-CHECKOUT case",

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -297,18 +297,32 @@ directory, so the hazard is identical here.
 ### 8-z. When a mutation probe reports NO discrimination
 
 **First, a rule that applies BEFORE any probe runs: COMMIT the round's real
-fixes, then probe.** A probe deliberately breaks the tree, so an interruption
-mid-probe (a session limit, a crash) leaves deliberate breakage and unfinished
-fixes in ONE undifferentiated dirty tree. Measured 2026-09-02 on the
+fixes, then probe.** The reason is DESTRUCTIVE, not merely tidy: a probe's
+restore puts the subject back to the bytes it held when the snapshot was TAKEN,
+so it reverts anything committed NOWHERE. A lane lost 133 lines of newly written
+tests exactly that way — its harness restored a snapshot predating those tests,
+and no commit, stash or reflog held them. Committing first is what makes the
+restore lossless. `references/implement.md`'s byte-exact `shasum`-verified
+restore is the OTHER half and does not cover this one: it guarantees the subject
+comes back unmangled, which is a promise about the snapshot's bytes, not about
+work the snapshot never contained.
+
+The milder consequence is attribution, and it is why the rule is worth stating
+even when nothing is lost: a probe deliberately breaks the tree, so an
+interruption mid-probe (a session limit, a crash) leaves deliberate breakage and
+unfinished fixes in ONE undifferentiated dirty tree. Measured 2026-09-02 on the
 go-to-k/cdk-real-drift#1841 lane: the subagent died at the 5-hour session limit
 mid-probe with 9 dirty files, and the resuming session had to read the full
 diff to establish that none of it was probe wreckage before it could commit.
 With a pre-probe commit the separator is just `git diff` — anything unstaged
 after a probe is the probe's.
 
-**A probe that reports NO discrimination is a claim about the FENCE, and three
+**A probe that reports NO discrimination is a claim about the FENCE, and four
 other things produce the identical output.** Ask them in order before touching
-the fence — each nearly cost a working assertion in one session (2026-08-25):
+the fence. The first three and the fixture shape below each nearly cost a
+working assertion in one session (2026-08-25); item 4 was added later, from a
+different run, which is why the attribution names a session rather than the
+whole list:
 
 1. **Did the edit land?** `sed`/`perl` one-liners fail silently as "no match":
    a `perl -0pi -e "s|^\|...|...|m"` delimited by the same `|` it escapes
@@ -329,16 +343,40 @@ the fence — each nearly cost a working assertion in one session (2026-08-25):
    else" print identically. Use ABSOLUTE paths and confirm by a property the
    wrong tree cannot fake (`ls -la` mtime).
 
+4. **Did the suite RUN, or did it only print a summary?** A mutation is an
+   EDIT, so it can break the FILE rather than the assertion: delete a single
+   `if` line and the resulting parse error makes `vp test run` print
+   `Tests  no tests` — a summary line that EXISTS but carries no digits. A parse that reads
+   a number out of it sees zero failures and reports the fence UNFENCED, which
+   is the same verdict a genuinely weak fence produces, so the probe's headline
+   finding is indistinguishable from its own breakage. Three conditions, all
+   cheap, and this repo's own §8 note that an exit code lies in BOTH directions
+   is why none of them can be replaced by reading `$?`: the summary must contain
+   DIGITS; the TOTAL must equal a BASELINE recorded before the first probe; and
+   no file may report a file-level FAIL while its case failures are zero. The
+   population check is the one that earns its keep — a whole file silently not
+   loading leaves every OTHER file's count intact, so digits alone still read as
+   green.
+
 And one shape inside the fixture itself: **an expected value must be an
 INDEPENDENT variable from the one under test.** A stub keyed its content on a
 sha whose default was the same literal on the producing and the consuming side,
 so breaking the producing call still served the content and the case could not
 fail.
 
-Only after all four does "the fence is weak" remain as the explanation.
+Only after all five does "the fence is weak" remain as the explanation.
 Deleting an assertion on the strength of an unexamined green is how a working
 guard gets removed.
 
-Ported from cdkd (all four shapes measured in one session: go-to-k/cdkd#2197 /
-go-to-k/cdkd#2200 / go-to-k/cdkd#2198); the mechanism is the shell and the
-tooling, not anything cdkd-specific, so it applies here unchanged.
+The original four shapes were ported from cdkd, all measured in one session
+(go-to-k/cdkd#2197 / go-to-k/cdkd#2200 / go-to-k/cdkd#2198); the mechanism is
+the shell and the tooling, not anything cdkd-specific, so they apply here
+unchanged. Item 4 was added on 2026-09-03 and did NOT come from that session.
+
+**When you add a shape here, move EVERY count in this section, not just the
+closer.** This edit had to move four numbers — the "N other things" opener, the
+"all N" closer, that session-attribution, and the "all four shapes" port note —
+and only the closer is anywhere near the list. `references/launch-mode.md`
+records the same failure on its IN-PLACE table ("Four things" left standing
+after the rows grew), which is the second instance of it in this skill: a count
+written beside a list is maintained, a count written a paragraph away is not.

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -300,8 +300,8 @@ directory, so the hazard is identical here.
 fixes, then probe.** The reason is DESTRUCTIVE, not merely tidy: a probe's
 restore puts the subject back to the bytes it held when the snapshot was TAKEN,
 so it reverts anything committed NOWHERE. A lane lost 133 lines of newly written
-tests exactly that way — its harness restored a snapshot predating those tests,
-and no commit, stash or reflog held them. Committing first is what makes the
+tests exactly that way (go-to-k/cdkd#2457) — its harness restored a snapshot
+predating those tests, and no commit, stash or reflog held them. Committing first is what makes the
 restore lossless. `references/implement.md`'s byte-exact `shasum`-verified
 restore is the OTHER half and does not cover this one: it guarantees the subject
 comes back unmangled, which is a promise about the snapshot's bytes, not about
@@ -374,9 +374,11 @@ the shell and the tooling, not anything cdkd-specific, so they apply here
 unchanged. Item 4 was added on 2026-09-03 and did NOT come from that session.
 
 **When you add a shape here, move EVERY count in this section, not just the
-closer.** This edit had to move four numbers — the "N other things" opener, the
-"all N" closer, that session-attribution, and the "all four shapes" port note —
-and only the closer is anywhere near the list. `references/launch-mode.md`
+closer.** This edit had to move four places: three counts — the "N other things"
+opener, the "all N" closer, the "all four shapes" port note — plus the
+session-attribution line, which is a SCOPE rather than a numeral and is
+therefore the one a sweep for digits does not return. Only the closer is
+anywhere near the list. `references/launch-mode.md`
 records the same failure on its IN-PLACE table ("Four things" left standing
 after the rows grew), which is the second instance of it in this skill: a count
 written beside a list is maintained, a count written a paragraph away is not.

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -373,12 +373,15 @@ The original four shapes were ported from cdkd, all measured in one session
 the shell and the tooling, not anything cdkd-specific, so they apply here
 unchanged. Item 4 was added on 2026-09-03 and did NOT come from that session.
 
-**When you add a shape here, move EVERY count in this section, not just the
-closer.** This edit had to move four places: three counts — the "N other things"
-opener, the "all N" closer, the "all four shapes" port note — plus the
-session-attribution line, which is a SCOPE rather than a numeral and is
-therefore the one a sweep for digits does not return. Only the closer is
-anywhere near the list. `references/launch-mode.md`
+**When you add a shape here, fix every place that COUNTS it — and only half of
+them contain a digit that moves.** Adding item 4 touched four places, of which
+exactly TWO carried a changed numeral: the "N other things" opener (three ->
+four) and the "all N" closer (four -> five). The other two kept their numeral
+and moved their SCOPE — the port note still reads "four shapes", now narrowed to
+the ORIGINAL four, and the session-attribution still names one session, now
+narrowed to the first three plus the fixture shape. So a sweep for changed
+digits returns half of the work and looks complete, which is worse than
+returning none; and only the closer sits anywhere near the list. `references/launch-mode.md`
 records the same failure on its IN-PLACE table ("Four things" left standing
 after the rows grew), which is the second instance of it in this skill: a count
 written beside a list is maintained, a count written a paragraph away is not.

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -50,9 +50,14 @@ const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B a
 // widest cells were shortened -- which, since `vp fmt` pads markdown table columns
 // to the widest cell, reclaimed the padding on all fourteen rows at once.
 // Re-measure whenever an orchestrator is edited -- a cap with an unmeasured margin
-// is one nobody can plan against. work-issues/SKILL.md is UNCHANGED at 11,812 B
-// by the follow-up round (go-to-k/cdk-real-drift#1856), which landed entirely in
-// stage files. The LAUNCH_BRANCH round before it spent 118 B of the 306 B that
+// is one nobody can plan against. work-issues/SKILL.md is 11,812 B again after the
+// mirror round below, having briefly been 11,801 B mid-round: that round corrected
+// "the markgate store is SHARED across worktrees" to "PER-WORKTREE" (-11 B) and
+// then spent the same 11 B making `SKILL.md:47` say "concurrent lane count", so
+// the net is zero and the margin is unchanged at 188 B. Recorded because a figure
+// that returns to its old value is exactly the one a reader assumes was never
+// re-measured. It was UNCHANGED at 11,812 B by the round before
+// (go-to-k/cdk-real-drift#1856), which landed entirely in stage files. The LAUNCH_BRANCH round before it spent 118 B of the 306 B that
 // were left: the fourth probe value has to be NAMED in the
 // always-loaded file (a lane cannot pass on a value it was never told to record),
 // while its reading, its restore recipe and the IN-PLACE consequence rows all
@@ -89,7 +94,24 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // now ASSERTED at the bottom of this file as well as described here, because
 // three consecutive rounds re-derived it BY HAND and one of them found it
 // lapsed.
-// Re-derived 2026-09-02 (go-to-k/cdk-real-drift#1856) at the final tree.
+// Re-derived 2026-09-03 at the final tree of the mirror round. work-issues: 9
+// stage files, corpus 148,057 B, largest implement.md 28,148 B, so the BINDING
+// requirement is 148,057 - 28,148 = 119,909 -- which the 120,000 set the round
+// before cleared by only 91 B. That is the number to watch: the previous round
+// left 7,708 B of margin there and one ordinary round of prose ate 99% of it,
+// without touching this file, because the floor moves with the corpus while the
+// largest file does not. The FLIP case had already gone red: the next candidates
+// to become largest are verify.md at 26,027 B and triage.md at 24,327 B, and the
+// worst of those requires 151,879 - 28,149 = 123,730, which 120,000 sits BELOW --
+// so a later verify.md edit of 2,122 B would have reddened an assertion whose
+// comment told its author the opposite. Raised to 128,000: clears the binding
+// number by 8,091 B and the flip by 4,270 B, and leaves 148,057 - 128,000 =
+// 20,057 B of compression room below the floor, the same shape the 2026-09-02
+// derivation aimed for. The growth this round is the mutation-harness item and
+// the destructive-restore reason in verify.md (+2,723 B) plus the serialization
+// correction in triage.md (+1,188 B).
+//
+// SUPERSEDED, kept because the reasoning is the same and only the numbers moved:
 // work-issues: 9 stage files, corpus 139,801 B, largest implement.md 27,509 B, so
 // the binding requirement is 139,801 - 27,509 = 112,292, which the 116,000 set
 // hours earlier still clears -- the assertion below did NOT fire, and this raise
@@ -115,7 +137,7 @@ const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }>
   // post-compression. 9 files as of 2026-09-01, when the launch-mode probe and its
   // reading moved out of triage.md into references/launch-mode.md, which the PARENT
   // reads before stage 0.
-  'work-issues': { minFiles: 9, minCorpusBytes: 120_000 },
+  'work-issues': { minFiles: 9, minCorpusBytes: 128_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 7, minCorpusBytes: 60_000 },
 };

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -95,50 +95,54 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // three consecutive rounds re-derived it BY HAND and one of them found it
 // lapsed.
 // Re-derived 2026-09-03 at the FINAL tree of the mirror round, every figure at
-// that ONE tree. An earlier revision of this block mixed two trees and quoted
-// the same quantity twice with two different numbers -- and it went stale twice
-// more while being written, because editing a stage file to fix the prose moves
-// the corpus the comment is about. Re-derive this block LAST, after the skill
-// files are final; nothing else in this file shares that hazard.
+// that ONE tree. Re-derive this block LAST, after the stage files are final:
+// earlier revisions of it went stale three times while being written, because
+// editing a stage file to fix prose moves the very corpus the comment is about.
+// Nothing else in this file shares that hazard.
 //
-// work-issues: 9 stage files, corpus 149,851 B, largest implement.md 28,148 B,
-// so the BINDING requirement is 149,851 - 28,148 = 121,703. The 120,000 the
-// previous round set is BELOW that, so this raise is a REPAIR, not a
+// work-issues: 9 stage files, corpus 150,395 B, largest implement.md 28,148 B,
+// so the BINDING requirement is 150,395 - 28,148 = 122,247. The 120,000 the
+// previous round set is BELOW that, so this raise is a REPAIR and not a
 // precaution: the assertion was already red at HEAD on the binding case alone,
-// with no flip needed. Probed rather than reasoned, as this derivation demands
-// -- at 120,000 the suite fails with "the corpus is 149851 B and its largest
-// stage file is 28148 B, so deleting that one file would leave 121703 B and
-// still pass", and 128,000 passes. How the margin went across the round:
-// +7,708 B at the base, +225, +91, then -1,138. One round of PROSE consumed it,
-// touching this file only to raise it, because the floor moves with the corpus
-// while the largest file does not.
+// no flip needed. Probed rather than reasoned, as this derivation demands -- at
+// 120,000 the suite fails with "deleting that one file would leave 122247 B and
+// still pass", and 130,000 passes. How the margin went across the round:
+// +7,708 B at the base, then +225, +91, -1,138. One round of PROSE consumed it
+// while touching this file only to raise it, because the floor moves with the
+// corpus and the largest file does not.
 //
-// THE FLIP CASE, correctly: when a file grows past implement.md and becomes the
-// largest, the residual is `total - v` where v is that file's size BEFORE the
-// growth -- the growth cancels, since it lands in the corpus and in the largest
-// file alike. So the residual is worst for the SMALLEST stage file, not the
-// nearest one: claim.md (5,429 B) would leave 144,422. Being flip-proof against
-// every candidate would therefore need a floor above 144,422, leaving 5,429 B of
-// compression room, which is not this floor's design. It is calibrated against
-// the NEAR candidates instead -- verify.md needs +1,837 and leaves 123,539,
-// triage.md +3,811 leaves 125,513, retro.md +4,015 leaves 125,717 -- so 128,000
-// clears the binding number by 6,297 B and the nearest flips by 2,283 B. For
-// everything past those, the ASSERTION is the backstop by design: it fires at
-// the commit that causes the flip and its message names the number to raise to.
-// Compression room is 149,851 - 128,000 = 21,851 B (14.6%, against 14.2% at the
-// 2026-09-02 derivation -- the same shape).
+// THE FLIP CASE, stated correctly, because two rounds of reviewers and the
+// author all got it wrong here first. When a file grows past implement.md and
+// becomes the largest, the residual is `total - v`, where v is that file's size
+// BEFORE the growth -- the growth cancels, landing in the corpus and in the new
+// largest alike. So the residual is worst for the SMALLEST stage file, not the
+// nearest: claim.md, the SMALLEST at 5,429 B, would leave 144,966. Covering
+// every candidate would need a floor above that, leaving 5,429 B of compression
+// room, which is not this floor's design. It is sized against the NEAR candidates -- triage.md
+// needs +3,811 and leaves 126,057, retro.md +3,471 leaves 125,717, verify.md
+// +1,837 leaves 124,083 -- and note the ranking is not by file size: rank by
+// `total - v`, or the nearest-looking candidate is not the binding one. For
+// everything past those the ASSERTION is the backstop BY DESIGN: it fires at the
+// commit that causes the flip and its message names the number to raise to.
 //
-// HONEST LIMIT: 6,297 B of margin is less than the 7,708 B the previous round
-// consumed in one pass, so this buys roughly ONE round. A cap with an unmeasured
-// margin is one nobody can plan against; so is one whose margin is measured and
-// left unstated.
+// Chosen 130,000, not the 128,000 an earlier revision of this round set. At
+// 128,000 the binding margin was 5,753 B and the worst near flip cleared by only
+// 1,943 B -- less than one ordinary edit -- so it would have red on the next
+// routine round and taught the next author nothing except to raise it again.
+// 130,000 clears binding by 7,753 B (restoring the round base's 7,708 B) and the
+// worst near flip by 3,943 B, leaving 150,395 - 130,000 = 20,395 B of
+// compression room (13.6%, against 14.2% at the 2026-09-02 derivation).
 //
-// The growth this round is +10,050 B across all 8 changed stage files, listed in
+// HONEST LIMIT: 7,753 B is roughly what the previous round consumed in one pass,
+// so this still buys about ONE round. A cap with an unmeasured margin is one
+// nobody can plan against; so is one whose margin is measured and left unstated.
+//
+// The growth this round is +10,594 B across all 8 changed stage files, listed in
 // FULL because a partial list is the same silent under-reporting
-// references/retro.md now carries a rule against: verify.md +3,008,
-// retro.md +2,893, gates-and-pr.md +1,237, triage.md +1,199, claim.md +898,
+// references/retro.md now carries a rule against: retro.md +3,437,
+// verify.md +3,008, gates-and-pr.md +1,237, triage.md +1,199, claim.md +898,
 // implement.md +639, launch-mode.md +96, ship.md +80. Base corpus 139,801 +
-// 10,050 = 149,851, which is the arithmetic that makes the list checkable.
+// 10,594 = 150,395, which is the arithmetic that makes the list checkable.
 //
 // SUPERSEDED, kept because the reasoning is the same and only the numbers moved:
 // work-issues: 9 stage files, corpus 139,801 B, largest implement.md 27,509 B, so
@@ -167,7 +171,7 @@ const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }>
   // post-compression. 9 files as of 2026-09-01, when the launch-mode probe and its
   // reading moved out of triage.md into references/launch-mode.md, which the PARENT
   // reads before stage 0.
-  'work-issues': { minFiles: 9, minCorpusBytes: 128_000 },
+  'work-issues': { minFiles: 9, minCorpusBytes: 130_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 7, minCorpusBytes: 60_000 },
 };

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -94,26 +94,51 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // now ASSERTED at the bottom of this file as well as described here, because
 // three consecutive rounds re-derived it BY HAND and one of them found it
 // lapsed.
-// Re-derived 2026-09-03 at the final tree of the mirror round. work-issues: 9
-// stage files, corpus 149,286 B, largest implement.md 28,148 B, so the BINDING
-// requirement is 149,286 - 28,148 = 121,138 -- and at the 120,000 the round
-// before set, the corpus had cleared it by only 91 B before this round's last
-// edit and would NOT have cleared it after. That is the number to watch: the previous round
-// left 7,708 B of margin there and one ordinary round of prose ate 99% of it,
-// without touching this file, because the floor moves with the corpus while the
-// largest file does not. The FLIP case had already gone red: the next candidates
-// to become largest are verify.md at 26,027 B and triage.md at 24,327 B, and the
-// worst of those requires 151,879 - 28,149 = 123,730, which 120,000 sits BELOW --
-// so a later verify.md edit of 2,122 B would have reddened an assertion whose
-// comment told its author the opposite. Raised to 128,000: clears the binding
-// number by 6,862 B and the worst flip (triage.md, 124,959) by 3,041 B, and
-// leaves 149,286 - 128,000 = 21,286 B of compression room below the floor, the
-// same shape the 2026-09-02 derivation aimed for. Probed rather than reasoned,
-// as that derivation demands: grown to the verify.md flip, the OLD 120,000
-// fails with "would leave 122,030 B and still pass" and 128,000 passes. The
-// growth this round is the mutation-harness item and the destructive-restore
-// reason in verify.md (+2,723 B), the serialization correction in triage.md
-// (+1,188 B) and the recon-scope lesson in retro.md (+1,229 B).
+// Re-derived 2026-09-03 at the FINAL tree of the mirror round, every figure at
+// that ONE tree. An earlier revision of this block mixed two trees and quoted
+// the same quantity twice with two different numbers -- and it went stale twice
+// more while being written, because editing a stage file to fix the prose moves
+// the corpus the comment is about. Re-derive this block LAST, after the skill
+// files are final; nothing else in this file shares that hazard.
+//
+// work-issues: 9 stage files, corpus 149,851 B, largest implement.md 28,148 B,
+// so the BINDING requirement is 149,851 - 28,148 = 121,703. The 120,000 the
+// previous round set is BELOW that, so this raise is a REPAIR, not a
+// precaution: the assertion was already red at HEAD on the binding case alone,
+// with no flip needed. Probed rather than reasoned, as this derivation demands
+// -- at 120,000 the suite fails with "the corpus is 149851 B and its largest
+// stage file is 28148 B, so deleting that one file would leave 121703 B and
+// still pass", and 128,000 passes. How the margin went across the round:
+// +7,708 B at the base, +225, +91, then -1,138. One round of PROSE consumed it,
+// touching this file only to raise it, because the floor moves with the corpus
+// while the largest file does not.
+//
+// THE FLIP CASE, correctly: when a file grows past implement.md and becomes the
+// largest, the residual is `total - v` where v is that file's size BEFORE the
+// growth -- the growth cancels, since it lands in the corpus and in the largest
+// file alike. So the residual is worst for the SMALLEST stage file, not the
+// nearest one: claim.md (5,429 B) would leave 144,422. Being flip-proof against
+// every candidate would therefore need a floor above 144,422, leaving 5,429 B of
+// compression room, which is not this floor's design. It is calibrated against
+// the NEAR candidates instead -- verify.md needs +1,837 and leaves 123,539,
+// triage.md +3,811 leaves 125,513, retro.md +4,015 leaves 125,717 -- so 128,000
+// clears the binding number by 6,297 B and the nearest flips by 2,283 B. For
+// everything past those, the ASSERTION is the backstop by design: it fires at
+// the commit that causes the flip and its message names the number to raise to.
+// Compression room is 149,851 - 128,000 = 21,851 B (14.6%, against 14.2% at the
+// 2026-09-02 derivation -- the same shape).
+//
+// HONEST LIMIT: 6,297 B of margin is less than the 7,708 B the previous round
+// consumed in one pass, so this buys roughly ONE round. A cap with an unmeasured
+// margin is one nobody can plan against; so is one whose margin is measured and
+// left unstated.
+//
+// The growth this round is +10,050 B across all 8 changed stage files, listed in
+// FULL because a partial list is the same silent under-reporting
+// references/retro.md now carries a rule against: verify.md +3,008,
+// retro.md +2,893, gates-and-pr.md +1,237, triage.md +1,199, claim.md +898,
+// implement.md +639, launch-mode.md +96, ship.md +80. Base corpus 139,801 +
+// 10,050 = 149,851, which is the arithmetic that makes the list checkable.
 //
 // SUPERSEDED, kept because the reasoning is the same and only the numbers moved:
 // work-issues: 9 stage files, corpus 139,801 B, largest implement.md 27,509 B, so
@@ -132,8 +157,9 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // in implement.md (+1,628 B) plus the reviewer-reporting and host-load lessons
 // in verify.md (+2,316 B); the round before it was the LAUNCH_BRANCH restore
 // contract across launch-mode.md, ship.md, retro.md and claim.md.
-// hunt-bugs stays at 60,000: re-measured the same day, corpus 88,598 B and
-// largest gotchas.md 41,922 B, so 88,598 - 41,922 = 46,676 < 60,000 and its
+// hunt-bugs stays at 60,000: corpus 88,683 B at this round's final tree (+78 of
+// it from this round's hunt-bugs/references/plan.md edit) and
+// largest gotchas.md 41,922 B, so 88,683 - 41,922 = 46,761 < 60,000 and its
 // property still holds. Re-measure both numbers for each skill whenever a stage
 // file changes size materially -- the property is silent when it lapses.
 const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }> = {

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -95,9 +95,10 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // three consecutive rounds re-derived it BY HAND and one of them found it
 // lapsed.
 // Re-derived 2026-09-03 at the final tree of the mirror round. work-issues: 9
-// stage files, corpus 148,057 B, largest implement.md 28,148 B, so the BINDING
-// requirement is 148,057 - 28,148 = 119,909 -- which the 120,000 set the round
-// before cleared by only 91 B. That is the number to watch: the previous round
+// stage files, corpus 149,286 B, largest implement.md 28,148 B, so the BINDING
+// requirement is 149,286 - 28,148 = 121,138 -- and at the 120,000 the round
+// before set, the corpus had cleared it by only 91 B before this round's last
+// edit and would NOT have cleared it after. That is the number to watch: the previous round
 // left 7,708 B of margin there and one ordinary round of prose ate 99% of it,
 // without touching this file, because the floor moves with the corpus while the
 // largest file does not. The FLIP case had already gone red: the next candidates
@@ -105,11 +106,14 @@ const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B
 // worst of those requires 151,879 - 28,149 = 123,730, which 120,000 sits BELOW --
 // so a later verify.md edit of 2,122 B would have reddened an assertion whose
 // comment told its author the opposite. Raised to 128,000: clears the binding
-// number by 8,091 B and the flip by 4,270 B, and leaves 148,057 - 128,000 =
-// 20,057 B of compression room below the floor, the same shape the 2026-09-02
-// derivation aimed for. The growth this round is the mutation-harness item and
-// the destructive-restore reason in verify.md (+2,723 B) plus the serialization
-// correction in triage.md (+1,188 B).
+// number by 6,862 B and the worst flip (triage.md, 124,959) by 3,041 B, and
+// leaves 149,286 - 128,000 = 21,286 B of compression room below the floor, the
+// same shape the 2026-09-02 derivation aimed for. Probed rather than reasoned,
+// as that derivation demands: grown to the verify.md flip, the OLD 120,000
+// fails with "would leave 122,030 B and still pass" and 128,000 passes. The
+// growth this round is the mutation-harness item and the destructive-restore
+// reason in verify.md (+2,723 B), the serialization correction in triage.md
+// (+1,188 B) and the recon-scope lesson in retro.md (+1,229 B).
 //
 // SUPERSEDED, kept because the reasoning is the same and only the numbers moved:
 // work-issues: 9 stage files, corpus 139,801 B, largest implement.md 27,509 B, so


### PR DESCRIPTION
Mirror lane of a cross-repo `/work-issues` retrospective, adapted to this repo's
gates rather than pasted. Five lessons in one PR, per
`references/retro.md` section 10-c ("Batch a run's lessons into ONE PR per repo
— the gate cycle is the per-PR cost").

Every claim below was re-verified against **this** repo's files before it was
written. Where the incoming narrative did not survive that check it was cut or
reframed, and the two cases where it did not are called out.

## A — the Stop hook contradicted this repo's own gate ordering

`.claude/hooks/stop-unmerged-lane-warn.sh` told the agent that a fully-pushed
branch with NO PR "is exactly the failure this catches. Check, and open one if
there is none." But `verify-pr-gate.sh` refuses `gh pr create` until the
`verify-pr` marker is fresh, so a `src/**` lane necessarily sits pushed and
PR-less for the whole of a `/verify-pr` run. Unqualified, the message tells the
agent to retry a command a gate is deliberately holding.

The arm is now QUALIFIED, and the comment beside it records the three bounds
that keep the qualifier narrow rather than letting it swallow the warning:

- `verify-pr-gate.sh` **EXEMPTS** a diff touching no `src/**` (its own
  "docs/tooling-only" arm, `verify-pr-gate.sh:121`), so a docs / skills /
  hooks-only lane — including this one — never enters the state, and the plain
  warning is exactly right for it. **The contradiction is CONDITIONAL here.**
- Nothing heavier than the skill waits behind the marker: the `integ` gate is
  INERT in this repo (no companion skill, no hook — `.markgate.yml`), so there
  is no fixture run in the way.
- `ci-green-gate.sh` gates ONLY `gh pr merge` ("create/edit pass — CI has not
  run yet at create time", `ci-green-gate.sh:16`), so CI does not force the push
  either.

The push comes from the FLOW (`references/gates-and-pr.md`: "commit, push, and
open the PR"), not from any gate.

Landed on the hook rather than in prose because `references/retro.md` section
10-b ranks a hook above a sentence. `.claude/hooks/stop-unmerged-lane-warn.test.sh`
still passes 121/121; its assertion greps the literal phrase, which the new
wording keeps.

## B — a measured falsehood in this repo's own skill text

`references/gates-and-pr.md` asserted "The marker store is `.git/markgate`,
SHARED by every worktree", echoed at `references/ship.md` and `SKILL.md`, and
told the reader that the sibling repo reaches the same symptom by a DIFFERENT
mechanism — "import the advice, not its explanation".

**That is false on markgate 0.4.1** (the `.mise.toml` pin). Re-measured
2026-09-03 with read-only commands, three trees of this ONE repo answering
`markgate status check` three different ways:

| tree | store on disk | answer |
| --- | --- | --- |
| main checkout | `.git/markgate/` | `created 2026-07-21T13:17:24Z / mismatch` rc=1 |
| an existing lane | `.git/worktrees/<name>/markgate/` | `created 2026-08-29T19:42:42Z / match` rc=0 |
| a freshly-added worktree | none | `state: no marker` rc=1 |

The store is PER-WORKTREE at `<git rev-parse --absolute-git-dir>/markgate/`,
which resolves to `.git/markgate` only for the MAIN checkout. The mechanism is
the SAME as the sibling's, and the sentence telling the reader to discard the
explanation was protecting the wrong half.

The ADVICE — set markers from the worktree — never changed, which is exactly why
nothing caught it: **a false premise reaching a true conclusion produces no
failing command.**

Corrected at **five** sites, not the three the incoming report named. The two it
missed are `.claude/skills/check/SKILL.md` and `.claude/skills/check-docs/SKILL.md`
— the ORIGIN of the "2026-08-19 measurement" the other three cite. Fixing the
copies and leaving the origin would have been the drift shape section 10-b
fences.

Deliberately NOT imported: the incoming narrative's `.markgate-pr-review-sha`
half. That gate is inert here and the sentinel does not exist — and the framing
was also wrong at the source (see the retro note below).

## C — "take ONE issue" constrains CONCURRENT lanes, not the issue count

Stated in three places, all justified solely by worktree NESTING:
`references/triage.md` (canonical prose), `references/launch-mode.md`'s IN-PLACE
table row 1, and `references/claim.md`. **All three move together.**

Sequential work in one tree nests nothing: a cdk-local run took FOUR issues one
after another, each on a branch cut from `origin/main`, deleting the previous
branch after its merge, with zero collisions. The old wording read a hazard
about trees EXISTING AT THE SAME TIME as a budget on work.

Adopts the sibling's refinement (https://github.com/go-to-k/cdkd/issues/2417): claim a set UP FRONT with
every lane after the first marked `QUEUED`, and stand an unstarted one down with
the four classification fields if the run ends first, so it is visibly claimable
rather than silently locked.

`tests/work-issues-launch-mode.test.ts` pins the probe block and the mode
markers, not the table rows — confirmed; it stays green.

**The table row is deliberately SHORTER than the sibling's.** `vp fmt` pads
markdown table columns to the widest cell, so the first draft's full-length row 1
added **3,267 B of pure whitespace** to `launch-mode.md` by re-padding all ten
rows. That is the cost `tests/skill-file-payload.test.ts`'s own comment describes
in reverse ("reclaimed the padding on all fourteen rows at once"). Row 1 now fits
the table's existing width and the detail lives in the canonical prose;
`launch-mode.md` grows by 96 B instead.

## D — the commit-then-probe rule had the weaker reason

`references/verify.md` section 8-z already said "COMMIT the round's real fixes,
then probe", but justified it by attribution: an interruption leaves "ONE
undifferentiated dirty tree".

The destructive framing is that **a restore reverts anything committed NOWHERE**
— a lane lost 133 lines of newly written tests when its harness restored a
snapshot taken before those tests existed. Amended in place, with the attribution
reason kept as the milder second consequence.

`references/implement.md`'s byte-exact `shasum`-verified restore is the second
site and needed the same note: it guarantees the subject comes back unmangled,
which is a promise about the snapshot's BYTES, not about work the snapshot never
contained. The two are complementary, and neither alone is the rule.

## E — a mutation harness must tell "green" from "did not run"

Zero coverage repo-wide before this. A mutation is an EDIT, so it can break the
FILE rather than the assertion: delete a single `if` line and the parse error
makes `vp test run` print `Tests  no tests` — a summary line that EXISTS but
carries no digits. A parse that reads a number out of it sees zero failures and
reports the fence UNFENCED, which is the same verdict a genuinely weak fence
produces.

Three conditions: the summary contains DIGITS, the TOTAL equals a BASELINE
recorded before the first probe, and no file reports a file-level FAIL with zero
case failures. The population check is the one that earns its keep — a whole file
silently not loading leaves every OTHER file's count intact.

Lands as item 4 in section 8-z's list, and is strengthened by this repo's
existing section 8 note that an exit code lies in BOTH directions.

### The recount, which was FOUR numbers and not one

Adding item 4 required moving:

1. the opener, "and **three** other things produce the identical output";
2. the closer, "Only after all **four**";
3. the session attribution, "each nearly cost a working assertion in one session
   (2026-08-25)" — item 4 is from a different run;
4. the port note, "Ported from cdkd (all **four** shapes measured in one
   session)".

Only the closer sits anywhere near the list. `references/launch-mode.md` records the same
failure on its IN-PLACE table ("Four things" left standing after the rows grew),
so this is the second instance in this skill — now recorded in the section
itself, so the next addition moves them all.

## Not shipped

**F (re-review the delta)** was cut. It is already covered three ways with
stronger evidence — `references/verify.md` (twice, one carrying the twelve
rounds of https://github.com/go-to-k/cdk-local/issues/596),
`.claude/skills/verify-pr/SKILL.md`, and
`references/implement.md` — and open issue
https://github.com/go-to-k/cdk-real-drift/issues/1859 already claims that exact
paragraph. `references/verify.md` also actively says blockers are "found by
executing a probe, never by re-reading the diff", so a naive delta line would sit
against an existing rule.

## The retro note this run produced

One line landed in `references/retro.md` section 10-c, amending the existing
"verify the copy against the TARGET repo" rule rather than sitting beside it:
**verify the MECHANISM at the SOURCE, not only the applicability at the TARGET.**

The incoming narrative described a leaked `.markgate-pr-review-sha` as a FALSE
PASS that would merge a PR on an already-merged one's review. The recon
correctly ruled it inapplicable here — and it was still false at the source: the
siblings' `pr-review-gate.sh` passes only on `recorded_sha = head_sha`, so a
leaked sentinel MISMATCHES and blocks, printing `bound to <sha> (mismatch)`.
Fail CLOSED, not fail open. Verified directly in cdk-local's copy of the hook
before writing this.

A correctly-REJECTED claim can still be false, and a mirror that only ever asks
"does this apply here" launders it intact into every repo that DOES have the
machinery.

## Review round

Three read-only reviewers (claim-verification, code, test/fence) — dispatched by
hand, since this repo ships no `/review-pr` and no `.claude/agents/`. All three:
**APPROVE WITH FIXES**, no blockers. Tier chosen: **3-axis**. The mechanical
heuristic says `inline` (251 LOC < 300), but the diff is 100% agent-instruction
text, which the heuristic explicitly refuses to down-bias because a wrong rule
there propagates into every future session — and `references/retro.md` section
10-c independently mandates a reviewer per target repo for a mirror, having
caught four false claims that way before.

They earned it. The code reviewer found a **real defect**: the first commit
appended the qualifier to EVERY pushed lane while the comment beside it argued
the case was narrow. A comment describing a conditional the code did not
implement — the same defect class this PR is correcting — handing the escape
hatch to precisely the docs-only lane the hook exists to catch. **This very
branch is such a lane.** The qualifier is now computed from the lane's own diff,
erring toward the plain text when `origin/main` does not resolve.

### This PR demonstrated its own item 4 on itself

Worth stating plainly, because it is the strongest evidence the item is right.
Item 4 says a probe must tell a GREEN suite from one that did not exercise the
change. The reviewer's mutation probe deleted the **entire** qualifier this PR
introduced and the suite stayed **121/121 green** — an unfenced change, invisible
to a full-suite pass, caught only by a probe of exactly the kind the new item
mandates. And it happened on a branch that is *itself* the docs-only lane the
buggy qualifier mis-handles, so the defect, its detection method and its victim
were all the same commit.

Five cases added pinning both directions, `CASE_FLOOR` 121 → 126 (the floor
exists to catch precisely the silent case-removal that not raising it would
hide). I then probed the new cases myself against scratchpad copies rather than
the tree: forcing the predicate false reds 2 cases, forcing it true — the
reviewer's original bug — reds the docs-only case. Restores verified byte-exact
by `shasum -a 256` against the repo file.

The fence reviewer found a **latent trap nothing would have caught**. The corpus
floor's own invariant — deleting the largest stage file must still fail it — was
passing by **91 B**, down from 7,708 B, eaten by one round of prose that touched
no test file. The flip case had *already* gone red: a later `verify.md` edit of
2,122 B would have reddened an assertion whose comment tells its author the
opposite. Floor raised 120,000 → 128,000, and **probed rather than reasoned**
(the standard that comment sets): grown to the flip, the old floor fails at
exactly `122,030` — matching the computed figure to the byte — and the new one
passes.

The claim reviewer found the one thing that would have undermined the PR from
inside: the "133 lines" measurement carried **no citation**, while the rule this
PR adds says to open the record a sentence names. Now cites
https://github.com/go-to-k/cdkd/issues/2457 at both sites. It also independently reproduced both markgate timestamps to the
second, and found that `verify-pr-gate.sh:20` and `check-gate.sh:28` *already*
said per-worktree — so the old prose contradicted this repo's own hooks.

## Verification

- `vp run typecheck` — clean
- `vp check --fix` — 0 errors
- `vp pack` — clean (invoked directly, not via the caching `run` task)
- `vp test run` — **352 files / 6668 tests passed, rc=0**, exit code read from
  the command itself rather than through a pipe, and the summary carries DIGITS
  (this PR's own new item 4 applied to itself)
- `vp run test:hooks` — **13 suites, 0 failures**; the Stop hook suite is now
  **126/126**
- Live-test: the modified hook driven end-to-end against this real repo in the
  exact pushed-no-PR state it describes — both channels emit valid JSON, rc=0,
  empty stderr, and the two texts stay distinct
- Shared CORE integration suite (step 7): **not applicable** — no `src/**` in the
  diff, no `check`/`revert` hot path, so there is no runtime behavior it covers.
  Stated rather than skipped silently.
- Byte caps re-derived at the FINAL tree: `work-issues/SKILL.md` **11,812 B**
  (cap 12,000, **188 B** headroom); largest reference `implement.md` 28,148 B
  (cap 64,000); work-issues corpus 148,057 B (floor now 128,000); hunt-bugs
  corpus 88,683 B (floor 60,000)

## Collision safety

Touches none of the five files held by open PR
https://github.com/go-to-k/cdk-real-drift/pull/1857 —
`.claude/hooks/branch-gate.sh`, `.claude/hooks/branch-gate.test.sh`,
`.claude/hooks/main-tree-branch-gate.sh`, `CLAUDE.md`, `docs/ARCHITECTURE.md`.

`CLAUDE.md` was checked for staleness rather than assumed clean: its description
of the Stop hook is about the CHANNEL discriminator and the cadence subject,
neither of which this PR changes — only the message TEXT, which that same
sentence already says is where the push state lives. No edit needed, which is
what keeps this PR off that PR's file.

The abandoned `.worktrees/stop-hook-context` lane was left untouched: its PR
https://github.com/go-to-k/cdk-real-drift/pull/1843 was closed unmerged and the
work landed as
https://github.com/go-to-k/cdk-real-drift/pull/1846 instead, so its tip is not an
ancestor of `origin/main` and taking its copy of the Stop hook would have
reverted merged work (measured: `origin/main`'s copy has 9 `prev_push` /
`push_state` hits, the lane's has 0). `origin/main`'s copy is the base used here.

## No `Closes` line

`references/retro.md` section 10-c: the originating session owns all three
landings, and a lane WORKING a mirror does not file onward. This is the landing,
not a claim against a filed issue.

## Follow-up

https://github.com/go-to-k/cdk-real-drift/issues/1862 — section 8-z item 4 is
prose only: nothing fences the rule against deletion-for-bytes, and nothing pins
the toolchain behaviour it asserts (a vite-plus bump that starts printing
`0 passed` would falsify the worked example with nothing going red). Filed as a
residual of this PR, with the measurement and the two candidate fences recorded
so the next session does not re-derive them.

## Second review round (the delta)

The first round reviewed `4472d20e`; 191 LOC over 8 files landed after it,
including the hook predicate the reviewers had only specified in prose. cdkrd's
own `/verify-pr` step 5 requires re-deriving depth at the final sha, so a second
3-axis round ran on the delta. Claim reviewer: **BLOCK**. Code and fence:
**APPROVE WITH FIXES**, no blockers in the executable change.

The blocker was this PR's thesis turned on this PR. The delta adds a rule about
re-deriving a claim's SCOPE and shipped **two mutually contradictory counts of
its own work** — `retro.md` said item 4 moved "FOUR counts", `verify.md` said
"four places: three counts plus a scope". Neither matched the file: four places
were touched and exactly **two** carried a changed digit. Both files now say so
in the same words, and the corrected claim is stronger — a sweep for changed
digits returns half the work and looks complete.

Three more instances of the same shape, all reviewer-found: `triage.md` still
said the probe reports "a mode and two paths" after the delta fixed the identical
sentence in `plan.md` (one claim, two copies, one corrected — in the commit that
adds the rule against that); the floor comment's growth attribution listed 3 of 8
files, 5,140 B of an actual 10,050 B; and `/check-docs` was called an ORIGIN when
it only points at `/check`.

**The flip case was wrong here and in both reviews of it.** The residual after a
flip is `total − v`, where `v` is the flipping file's size *before* it grows — the
growth cancels, landing in the corpus and the largest file alike. So the worst
residual belongs to the **smallest** stage file (claim.md, 144,422), not the
nearest. Flip-proofing against every candidate would need a floor above 144,422,
leaving 5,429 B of compression room, which is not the design: the floor is
calibrated against the near candidates and the assertion is the backstop for the
rest, firing at the commit that causes the flip. Two rounds of reviewers and I
all quoted a "worst flip" that was only the worst *near* one.

Figures re-derived at the final tree and probed: corpus 149,851, binding 121,703,
so the old 120,000 was **already red at HEAD on the binding case alone** — a
repair, not a precaution. The block now says to re-derive it LAST, after the skill
files are final; it went stale twice while being written, because editing a stage
file to fix prose moves the corpus the comment is about.
