### PR TITLE
chore: compress the agent-instruction corpus to cut per-session token cost

### DIFF
--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -2,21 +2,21 @@
 
 ## 6. Gates + PR (per lane)
 
-**Before the session's FIRST commit, prove the gates are ALIVE.** Registration is
-not execution — every PreToolUse gate here was once registered yet INERT for a day
-(go-to-k/cdk-real-drift#1801), and an ungated commit looks exactly like one that
-passed; `/hooks` shows registration only. One command does:
+**Before the session's FIRST commit, prove the gates are ALIVE.** Registration
+is not execution — every PreToolUse gate here was once registered yet INERT for
+a day (go-to-k/cdk-real-drift#1801), an ungated commit looks exactly like one
+that passed, and `/hooks` shows registration only. One command does:
 
 ```bash
 git commit --dry-run -m "gate liveness probe"   # from the repo root, on main
 ```
 
 Run it as YOUR OWN Bash tool call — hooks see only the agent's tool calls, so a
-human-typed line proves nothing. `--dry-run` commits nothing
-whatever the tree looks like. Expected: `Blocked by branch-gate` or `Blocked by
-check-gate`. **Git's own output instead (`On branch main`, `nothing to commit`)
-means the gates are not firing** — then run each gate's check by hand and say so
-in the report.
+human-typed line proves nothing. `--dry-run` commits nothing whatever the tree
+looks like. Expected: `Blocked by branch-gate` or `Blocked by check-gate`.
+**Git's own output instead (`On branch main`, `nothing to commit`) means the
+gates are not firing** — then run each gate's check by hand and say so in the
+report.
 
 From inside the worktree — no `dist/` there yet, and 13 tests spawn the built
 CLI, so `vp pack` runs before the suite:
@@ -28,79 +28,65 @@ vp run typecheck && vp check --fix && vp pack && vp test run
 All green, then commit (conventional-commit), push, and open the PR with
 `Closes #<n>`.
 
-**Set the `check` / `docs` markers in their OWN Bash call, from the WORKTREE, and
-after staging.** Three traps, all hit in one lane (2026-08-19,
+**Set the `check` / `docs` markers in their OWN Bash call, from the WORKTREE,
+and after staging.** Three traps, all hit in one lane (2026-08-19,
 go-to-k/cdk-real-drift#1782):
 
-- **A gated command must be the ONLY thing in its Bash call.** A PreToolUse hook
-  judges the call BEFORE anything runs: `markgate set check && markgate set docs
-&& git commit` is blocked in FULL — including the `markgate set` that would
-  have satisfied it — and a denial discards every PREAMBLE SIDE EFFECT: a denied
-  `gh pr create --body-file` dropped its chained heredoc write and the retry's
-  `>>` created the body as a fragment — go-to-k/cdk-local#525 opened with no
-  summary or `Closes` line, go-to-k/cdk-local#509 closed by hand. **Worse is a
+- **A gated command must be the ONLY thing in its Bash call.** A PreToolUse
+  hook judges the call BEFORE anything runs, and a denial discards every
+  PREAMBLE SIDE EFFECT: `markgate set check && markgate set docs && git commit`
+  is blocked in FULL — including the `markgate set` that would have satisfied
+  it — and a denied `gh pr create --body-file` dropped its chained heredoc
+  write, so the retry's `>>` created the body as a fragment
+  (go-to-k/cdk-local#525 opened with no summary or `Closes` line). **Worse is a
   STALE body file from an EARLIER session** — conventional paths
   (`/tmp/pr-body.md`) are shared, so the gate reports violations this session
   never wrote (2026-08-21, cdkd): check the file's mtime first, and use
   per-session body-file names. Gated commands: `git commit` (`check-gate`,
   `branch-gate`, `bughunt-clean-gate`), `git push` (`branch-gate`,
   `stale-base-gate`), `gh pr create` / `gh pr edit` / `gh pr merge`
-  (`verify-pr-gate`, `ci-green-gate`, `non-english-text-gate`). Body file in its
-  own call, markers in theirs, gated command alone.
-- Run `markgate set` from the **worktree**, starting the call with
-  `cd <worktree> &&` EXPLICITLY — the shell cwd does not reliably persist across
-  tool calls, so a wrong-cwd set is the DEFAULT outcome. A KILLED (timeout) or
-  REFUSED call is a named trigger: either can reset the cwd or leave an expected
-  directory uncreated, and a failed `cd` stops an `&&` chain but NOT the later
-  lines of a multi-line call, which write into whatever cwd was current
-  (2026-08-28, go-to-k/cdkd#2370); a relative `cd .worktrees/...` also fails when
-  the cwd is ALREADY inside that worktree — no timeout, no refusal, and the
-  chained edit silently does not run — after any timeout or refusal, `pwd` and
-  re-verify what the aborted call was to create. The marker store is
-  PER-WORKTREE — `<git rev-parse --absolute-git-dir>/markgate/`, which is
-  `.git/markgate` only for the MAIN checkout and `.git/worktrees/<name>/markgate/`
-  for a lane — so a marker set from the main checkout is not merely hashed over
-  the wrong files, it is INVISIBLE from the lane, which reports `no marker`. It
-  fails CLOSED either way: a wasted cycle, not a bad merge. `/check` /
-  `/check-docs`'s "repo root" means the WORKTREE root here, and `/check` carries
-  the three-tree measurement.
-  **This paragraph asserted the opposite until 2026-09-03 and the correction is
-  the lesson**: it called the store `.git/markgate`, SHARED by every worktree,
-  and told the reader that the sibling repo reaches the same symptom by a
-  DIFFERENT mechanism — "import the advice, not its explanation". Re-measured on
-  markgate 0.4.1 (the `.mise.toml` pin), three trees of this ONE repo answer
-  `markgate status check` three ways: main `mismatch` rc=1 (created
-  2026-07-21T13:17:24Z), an existing lane `match` rc=0 (created
-  2026-08-29T19:42:42Z), a freshly-added worktree `no marker` rc=1 with no store
-  on disk. The mechanism is the SAME as the sibling's, and the sentence telling
-  the reader to discard the explanation was protecting the wrong half. The
-  ADVICE — set markers from the worktree — never changed, which is exactly why
-  nothing caught it: a false premise reaching a true conclusion produces no
-  failing command. markgate state is the WHOLE of the per-worktree question
-  here: the siblings additionally bind `pr-review` to a `.markgate-pr-review-sha`
-  sentinel, and that gate is INERT in this repo (no companion skill, no hook —
-  `.markgate.yml`) with no such file on disk, so none of its behaviour applies
-  to a cdkrd lane.
-- `cd <worktree> &&` on a GATED command is safe only while the hook conditions
-  match it, and twice they did not: go-to-k/cdk-real-drift#1786 (three gates
-  lacked the `cd` spelling — `cd <wt> && git commit` ran UNGATED), then
-  go-to-k/cdk-real-drift#1801 (the fix joined spellings with `or`, an
-  unsupported expression — an `if` holding `A or B` matches NOTHING; all eight
-  gates inert for a day). **An `if` carries ONE pattern; a gate guarding two
-  verbs gets two ENTRIES**, written UNANCHORED (`Bash(*git commit*)`) because
-  the matcher only hands the script candidates — the script re-matches
+  (`verify-pr-gate`, `ci-green-gate`, `non-english-text-gate`). Body file in
+  its own call, markers in theirs, gated command alone.
+- **Run `markgate set` from the worktree, starting the call with
+  `cd <worktree> &&` EXPLICITLY** — the shell cwd does not reliably persist
+  across tool calls, so a wrong-cwd set is the DEFAULT outcome. The marker
+  store is PER-WORKTREE — `<git rev-parse --absolute-git-dir>/markgate/`, which
+  is `.git/markgate` only for the MAIN checkout and
+  `.git/worktrees/<name>/markgate/` for a lane — so a marker set from the main
+  checkout is not merely hashed over the wrong files, it is INVISIBLE from the
+  lane (`no marker`). It fails CLOSED either way: a wasted cycle, not a bad
+  merge. `/check` / `/check-docs`'s "repo root" means the WORKTREE root here,
+  and `/check` carries the three-tree measurement. (This paragraph asserted
+  "SHARED across worktrees" until the 2026-09-03 re-measurement on markgate
+  0.4.1 — three trees of this ONE repo answered `markgate status check` three
+  ways — and the correction is the lesson: a false premise reaching a true
+  conclusion produces no failing command. The siblings' `pr-review` sha
+  sentinel does not apply here — that gate is INERT, `.markgate.yml`.) After
+  any TIMEOUT or REFUSED call, `pwd` and re-verify what the aborted call was to
+  create: either can reset the cwd or leave a directory uncreated, a failed
+  `cd` stops an `&&` chain but NOT the later lines of a multi-line call
+  (2026-08-28, go-to-k/cdkd#2370), and a relative `cd .worktrees/...` fails
+  SILENTLY when the cwd is already inside that worktree.
+- **`cd <worktree> &&` on a GATED command is safe only while the hook
+  conditions match it**, and twice they did not: three gates lacked the `cd`
+  spelling — `cd <wt> && git commit` ran UNGATED
+  (go-to-k/cdk-real-drift#1786) — then the fix joined spellings with `or`, an
+  unsupported expression matching NOTHING; all eight gates inert for a day
+  (go-to-k/cdk-real-drift#1801). **An `if` carries ONE pattern; a gate guarding
+  two verbs gets two ENTRIES**, written UNANCHORED (`Bash(*git commit*)`)
+  because the matcher only hands the script candidates — the script re-matches
   precisely. Fenced by `tests/gate-if-matchers-1801.test.ts` (fails on an `or`,
-  on an anchored verb pattern, and on a gate missing an entry). After any change
-  to how a gate is selected, watch it go RED once, by hand.
-- Stage new files first. A marker set while your new test is still untracked does
-  not cover it.
+  an anchored verb pattern, a gate missing an entry). After any change to how a
+  gate is selected, watch it go RED once, by hand.
+- Stage new files first. A marker set while your new test is still untracked
+  does not cover it.
 
 ## 7. If main advanced while you worked (parallel merges)
 
 A peer's merges move `main` (and, when the release PR merges, a
-`chore(release)` commit); `git diff main..<branch>`
-then shows **phantom removals** of the peer's added lines — a stale-base
-artifact, NOT real deletions. Confirm the TRUE diff and rebase:
+`chore(release)` commit); `git diff main..<branch>` then shows **phantom
+removals** of the peer's added lines — a stale-base artifact, NOT real
+deletions. Confirm the TRUE diff and rebase:
 
 ```bash
 git diff --stat $(git merge-base origin/main <branch>)..<branch>   # the real change
@@ -110,8 +96,8 @@ git -C "<LANE_TREE>" rebase origin/main   # the path the launch-mode probe recor
 Re-run gates, `git push --force-with-lease`.
 
 **A rebase CONFLICT on your target file is usually a DUPLICATE, not a merge to
-resolve.** The claim comment does NOT beat a peer who STARTED earlier, so even a
-file-disjoint lane can be raced. Before resolving anything, check whether the
+resolve.** The claim comment does NOT beat a peer who STARTED earlier, so even
+a file-disjoint lane can be raced. Before resolving anything, check whether the
 work already shipped:
 
 ```bash
@@ -120,54 +106,50 @@ git log origin/main --oneline | grep -iE "<n>|<fix-keyword>"   # the peer's merg
 git show origin/main:<your-target-file> | grep -n "<marker>"   # main already carries the fix?
 ```
 
-**A CLEAN merge is not evidence that there was no collision.** Two lanes editing
-the SAME file merge without conflict when they touch disjoint SECTIONS, so §3's
-one-lane-per-file rule fails SILENTLY (go-to-k/cdk-real-drift#1772 /
+**A CLEAN merge is not evidence that there was no collision.** Two lanes
+editing the SAME file merge without conflict when they touch disjoint SECTIONS,
+so §3's one-lane-per-file rule fails SILENTLY (go-to-k/cdk-real-drift#1772 /
 go-to-k/cdk-real-drift#1773 rewrote the same SKILL.md minutes apart; both
 survived by luck). After a merge into a file another PR touched in the same
-window, `git pull` and grep `main` for a marker string from EACH side.
-
-Three things make that check misreport, and all three read as LOST CONTENT:
+window, `git pull` and grep `main` for a marker string from EACH side. Three
+things make that check misreport, and all three read as LOST CONTENT:
 
 - **Source each marker from the MERGED text, never from a draft you read
-  earlier.** Lanes reword between draft and merge, so a draft-sourced marker
+  earlier** — lanes reword between draft and merge, so a draft-sourced marker
   scores 0 and looks like a clobber (go-to-k/cdkd#2000). Take THEIR marker from
   THEIR merge commit:
   `git show "$(gh pr view <n> --json mergeCommit -q .mergeCommit.oid):<file>"`.
-- **One arm of the check is always tautological.** The LAST-merged lane's marker
-  reads back out of the tip for free; the load-bearing arm is the
+- **One arm of the check is always tautological.** The LAST-merged lane's
+  marker reads back out of the tip for free; the load-bearing arm is the
   EARLIER-merged lane's.
 - **Use `grep -cF`, keep the marker on ONE LINE of the merged file, and do not
-  chain the two greps with `&&`.** Regex metacharacters make a bare `grep -c`
-  score 0 (measured here 2026-08-19: a marker containing `[` and `.` scored 0
-  without `-F` and 1 with it), and `grep` is LINE-based while these files are
-  hard-wrapped, so a verbatim phrase spanning the wrap scores 0 too (measured
-  2026-08-19 against go-to-k/cdk-real-drift#1790's merge commit). Pick the phrase from
-  the merged file itself — the wrap column moves with the wording, so
-  go-to-k/cdk-local#532's marker for this same rule does not wrap the same here.
-  Settle a 0 with `git show origin/main:<file> | grep -n "<one short word>"`,
-  which prints the whole line and where it breaks. `grep -c` exits 1 on zero
-  matches — the very case being hunted — so a chained second grep never runs.
-  (Double quotes, not `-F`, are what survive an apostrophe.)
+  chain the two greps with `&&`.** Regex metacharacters score 0 without `-F`,
+  and `grep` is LINE-based while these files are hard-wrapped, so a verbatim
+  phrase spanning the wrap scores 0 too (both measured here 2026-08-19; the
+  wrap column moves with the wording, so a sibling's marker for the same rule
+  does not wrap the same here). `grep -c` exits 1 on zero matches — the very
+  case being hunted — so a chained second grep never runs. Pick the phrase from
+  the merged file itself; settle a 0 with
+  `git show origin/main:<file> | grep -n "<one short word>"`, which prints the
+  whole line and where it breaks. (Double quotes, not `-F`, are what survive an
+  apostrophe.) When a marker genuinely comes back 0, settle it from your lane
+  worktree with `diff <(git show origin/main:<file>) <file>`: the lines YOUR
+  commit removed should be exactly the ones you meant to replace.
 
-When a marker genuinely comes back 0, settle it from your lane worktree with
-`diff <(git show origin/main:<file>) <file>`: the lines YOUR commit removed
-should be exactly the ones you meant to replace.
+**And the two lanes need not touch one file at all: a peer that adds a
+REPO-WIDE check gains jurisdiction over YOUR content.** The collision is their
+TEST against your CONTENT — neither CI exercised the pair. When a peer merges,
+look at WHAT it added, not only which files: anything that globs the tree
+(`git ls-files`, a `readdirSync`, a lint rule) applies to everything you are
+about to land. Rebase and RUN it over your own diff before merging
+(go-to-k/cdk-real-drift#1782 into go-to-k/cdk-real-drift#1783: the check cost
+one command).
 
-**And the two lanes need not touch one file at all: a peer that adds a REPO-WIDE
-check gains jurisdiction over YOUR content.** The collision is their TEST against
-your CONTENT — neither CI exercised the pair (yours ran before their check
-existed, theirs before your content did). When a peer merges, look at WHAT it
-added, not only which files: anything that globs the tree (`git ls-files`, a
-`readdirSync`, a lint rule) applies to everything you are about to land. Rebase
-and RUN it over your own diff before merging (go-to-k/cdk-real-drift#1782 into
-go-to-k/cdk-real-drift#1783: the check cost one command).
-
-If the issue is CLOSED (or main already carries an equivalent fix), **ABANDON the
-lane — do NOT resolve the conflict to re-apply a now-duplicate fix**: `git rebase
---abort`, `gh pr close <pr> --delete-branch` (or never open one), comment the
-collision on the issue, `git worktree remove`. The merge-time twin of §1's
-already-shipped check, at the expensive place: on go-to-k/cdk-real-drift#726 and
-go-to-k/cdk-real-drift#742 it fired here after a full lane was done. The claim
-comment cannot eliminate races; the conflict is your last, authoritative signal
-to stop and check before spending more.
+If the issue is CLOSED (or main already carries an equivalent fix), **ABANDON
+the lane — do NOT resolve the conflict to re-apply a now-duplicate fix**:
+`git rebase --abort`, `gh pr close <pr> --delete-branch` (or never open one),
+comment the collision on the issue, `git worktree remove`. The merge-time twin
+of §1's already-shipped check, at the expensive place (it fired here after a
+full lane was done — go-to-k/cdk-real-drift#726 / go-to-k/cdk-real-drift#742).
+The claim comment cannot eliminate races; the conflict is your last,
+authoritative signal to stop and check before spending more.

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -334,7 +334,9 @@ ran against the corrupted subject and returned verdicts about nothing. Copy the
 file aside first and copy it back (`cp` / `shutil.copyfile`), then re-run the
 suite and confirm GREEN before the next probe. `git checkout -- <file>` is not
 the alternative: at probe time the fix itself is usually uncommitted, so that
-discards the work along with the wreckage. Verify the restore by HASH, not by
+discards the work along with the wreckage (the pre-probe commit rule in
+`references/verify.md` narrows this, and a `git stash` cycle around an
+unrelated peer's changes has its own trap). Verify the restore by HASH, not by
 eye — a `shasum -a 256` recorded before the first probe turns "I think I put it
 back" into a check.
 

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -8,39 +8,35 @@ lane's diffs, test output and review round-trips never land in the parent
 context. Every rule below applies unchanged inside the lane: hooks fire on the
 lane's tool calls, and markgate markers land in the lane's own worktree. Two
 actions are reserved to the parent's serialization turn and are NOT the lane's
-to start: a real-AWS live test (deploy → mutate → revert) and the merge (the
-orchestrator's serialization invariant; §9). A lane stops at merge-ready and
-reports.
+to start: a real-AWS live test (deploy → mutate → revert) and the merge (§9). A
+lane stops at merge-ready and reports.
 
-**That placement is live-proven, not aspirational, and SKILL.md points here for
-the run that proved it**: on 2026-08-28 this repo's own skill-split PR
-(go-to-k/cdk-real-drift#1831), like its sibling go-to-k/cdk-local#621, was built
-END-TO-END by a lane subagent — worktree, implementation, gates, CI — with the
-parent doing only claims, serialized merges and cleanup, and every hook and
-markgate gate firing inside the lane's calls exactly as in the parent.
+**That placement is live-proven**: this repo's own skill-split PR
+(go-to-k/cdk-real-drift#1831), like its sibling go-to-k/cdk-local#621, was
+built END-TO-END by a lane subagent — worktree, implementation, gates, CI —
+with the parent doing only claims, serialized merges and cleanup, and every
+hook and markgate gate firing inside the lane's calls exactly as in the parent.
 
-**Before fixing, ask whether the defect has SIBLING SITES — and if it does, sweep
-them in THIS lane rather than filing them.** Most defects here are a CLASS, not an
-instance; once the root cause is named, grep for the same shape across `src/`
-before writing the fix.
+**Before fixing, ask whether the defect has SIBLING SITES — and if it does,
+sweep them in THIS lane rather than filing them.** Most defects here are a
+CLASS, not an instance; once the root cause is named, grep for the same shape
+across `src/` before writing the fix.
 
 **Query for the PRECONDITION minus the REMEDY, never for the remedy alone.** A
 grep for a MISSING thing returns only sites that already HAVE it — absent sites
 are invisible by construction. Ask: what makes a site ELIGIBLE, and which
-eligible sites lack the fix? (2026-08-27, go-to-k/cdk-local: a remedy grep,
-`docker rmi|docker image rm|docker image prune`, saw 5 of 12 eligible sites;
-eligibility-minus-remedy — builds an image, never removes one — found six more,
-plus a seventh neither finds.) The same run then sized the residue from the ONE
-instance it hit ("one site, ~30 min"; it was seven): **a count derived from the
-instance you happened to hit is not a count**, and `Effort` / `Estimate` are what
-a future session budgets from. The shape recurs wherever the fix is an ADDED
-guard (a missing `handledProperties` entry, a provider without a validation arm,
-a type with no drift comparator): grepping for the guard finds the types that
-have it.
+eligible sites lack the fix? (2026-08-27, cdk-local: a remedy grep saw 5 of 12
+eligible sites; eligibility-minus-remedy found six more, plus a seventh neither
+finds.) The same run then sized the residue from the ONE instance it hit ("one
+site, ~30 min"; it was seven): **a count derived from the instance you happened
+to hit is not a count**, and `Effort` / `Estimate` are what a future session
+budgets from. The shape recurs wherever the fix is an ADDED guard: grepping for
+the guard finds the types that have it.
 
-**N sites of one root cause is ONE issue and ONE PR, never N issues.** Split into
-N, each site pays the full fixed cost for the same edit, the reviewer never sees
-the class, and sites 2..N sit open while site 1's fix drifts. Two boundaries:
+**N sites of one root cause is ONE issue and ONE PR, never N issues.** Split
+into N, each site pays the full fixed cost for the same edit, the reviewer
+never sees the class, and sites 2..N sit open while site 1's fix drifts. Two
+boundaries:
 
 - **A sweep that would make the PR unreviewable is a genuine `next`** — file an
   explicit umbrella naming every site and which sites this lane DID close.
@@ -49,29 +45,25 @@ the class, and sites 2..N sit open while site 1's fix drifts. Two boundaries:
   single sentence describes the fix at every site.
 
 **A COUNT is a claim, and one RELAYED from a subagent is unearned.** Before a
-relayed count goes anywhere durable, run the query yourself and paste the command
-beside the number; a number arriving as a WORD ("nine sites") was counted by a
-person or agent, command output by a machine (2026-08-26, go-to-k/cdkd#2261:
+relayed count goes anywhere durable, run the query yourself and paste the
+command beside the number; a number arriving as a WORD ("nine sites") was
+counted by a person or agent, command output by a machine (go-to-k/cdkd#2261:
 "all nine sibling sites" was 78 across 14 files — ~9x, and it was the
 load-bearing argument for a deferral). **Run it at the sha the artifact will
 describe** and re-derive every number after the LAST fix round — bodies are
-written once while the branch keeps moving (2026-08-27, go-to-k/cdk-local#614:
-four per-round-accurate counts all wrong at merge — a NEW file's true delta is
-vs `main`, not the round start; three reached PR bodies). Durable artifacts
-stale the same way (this file's "nine" harnesses vs a measured 15). No automated
-fence exists here — only §8's prose arm ("the CLAIMS are the artifact").
+written once while the branch keeps moving (go-to-k/cdk-local#614: four
+per-round-accurate counts all wrong at merge — a NEW file's true delta is vs
+`main`, not the round start; three reached PR bodies). No automated fence
+exists here — only §8's prose arm ("the CLAIMS are the artifact").
 
 **And whatever you do file, resolve it against the issues ALREADY OPEN first.**
 The code sweep finds sibling SITES; this finds a sibling ISSUE — written from a
-DIFFERENT site by a different lane, naming different symbols. §10-c runs this
-check rigorously but only for mirrored skill LESSONS; the mid-lane
-defect-follow-up path, where the volume comes from, ran none. The case here is
-prophylactic: this repo's one candidate pair (go-to-k/cdk-real-drift#1786 /
-go-to-k/cdk-real-drift#1799) is NOT a duplicate — different source repos
-(cdk-local's 2026-08-19 run vs cdkd's go-to-k/cdkd#2125) — but the same
-cross-repo mirror flow produced a VERIFIED duplicate pair nine minutes apart in
-a sibling (go-to-k/cdk-local#528 / go-to-k/cdk-local#531), and the check costs
-one search plus one line.
+DIFFERENT site by a different lane, naming different symbols. The case here is
+prophylactic — this repo's one candidate pair (go-to-k/cdk-real-drift#1786 /
+go-to-k/cdk-real-drift#1799) is NOT a duplicate — but the same cross-repo
+mirror flow produced a VERIFIED duplicate pair nine minutes apart in a sibling
+(go-to-k/cdk-local#528 / go-to-k/cdk-local#531), and the check costs one search
+plus one line.
 
 ```bash
 # Search the CONCEPT, not this instance's spelling — the same reason the code sweep
@@ -100,12 +92,11 @@ gh issue view <hit> --json body -q .body > "$U" \
 ```
 
 **The chaining and the `-s` test are load-bearing, not style.** The redirect
-truncates `$U` before `gh` runs; unchained, a failed `view` (wrong number,
-non-repo cwd, transient error) leaves an empty file, `printf` fills it with one
-row, and `edit` replaces the issue's WHOLE body — destroying every previously
-folded finding, the outcome §10-0 says must never happen. `mktemp` for the same
-reason at another scale: two overlapping folds against one issue lose a row —
-never run them concurrently.
+truncates `$U` before `gh` runs; unchained, a failed `view` leaves an empty
+file, `printf` fills it with one row, and `edit` replaces the issue's WHOLE
+body — destroying every previously folded finding, the outcome §10-0 says must
+never happen. `mktemp` for the same reason at another scale: two overlapping
+folds against one issue lose a row — never run them concurrently.
 
 On a MISS, file it, and record the search in the body so the next lane can see
 the window was checked:
@@ -115,8 +106,9 @@ Dup-check: searched open issues for <terms> -- none covers this root cause
 ```
 
 **This is not a filing threshold, and it must never be used as one.** §10-0:
-`filed <= closed` is not a target, and an unfiled finding is strictly worse than
-a filed one. This changes only WHERE a defect is written down, never WHETHER.
+`filed <= closed` is not a target, and an unfiled finding is strictly worse
+than a filed one. This changes only WHERE a defect is written down, never
+WHETHER.
 
 Enforced by `.claude/hooks/issue-dup-check-gate.sh`, which refuses
 `gh issue create` without the `Dup-check:` line; the same refusal covers
@@ -125,15 +117,14 @@ Enforced by `.claude/hooks/issue-dup-check-gate.sh`, which refuses
 
 - **Folding is not CHEAPER than minting** (one command vs three); the gate
   removes minting's advantage rather than creating one for folding.
-- **`gh -R <owner/repo> issue create` IS matched** — §10-c's own mirrored-filing
-  spelling, so it needs the `Dup-check:` line too. The shared `GATE_GH_C`
-  absorbs repo flags in every spelling `gh` accepts — space, `=`, glued
-  (`-Ro/r`) — after the `-C`-only form let `gh -R … pr merge` walk past three
-  other gates. Unlike the `pr` gates it does NOT refuse a foreign `-R`: filing
-  into a sibling is the point.
+- **`gh -R <owner/repo> issue create` IS matched** — §10-c's own
+  mirrored-filing spelling, so it needs the `Dup-check:` line too. The shared
+  `GATE_GH_C` absorbs repo flags in every spelling `gh` accepts — space, `=`,
+  glued (`-Ro/r`) — after the `-C`-only form let `gh -R … pr merge` walk past
+  three other gates. Unlike the `pr` gates it does NOT refuse a foreign `-R`:
+  filing into a sibling is the point.
 - **A `Dup-check:` line in the `--title` does not count** — the marker must be
-  in a BODY value; the scan used to run over the whole command, so
-  `--title 'Dup-check: yes' --body '<no marker>'` satisfied it.
+  in a BODY value; the scan used to run over the whole command.
 - **`gh api …/issues` reads are not gated** — the collection path is also the
   LIST endpoint (`-X GET … --paginate` and `-f state=open` pass); only an
   explicit `POST`, or a `title=` field with no method (gh infers POST), mints.
@@ -151,23 +142,15 @@ mise trust .worktrees/<name>/.mise.toml
 ( cd .worktrees/<name> && vp run build )     # ...and no dist/ -- see below
 ```
 
-`origin/main`, not local `main`, and both arms now agree. This one branched from
-local `main` until 2026-09-01, which only advances on an explicit pull in the
-main checkout, so the lane started whatever the last pull left behind; §1's
-refresh usually hides that, which is exactly why it survived. Both sibling repos
-already spelled it `origin/main`, so this was drift rather than a considered
-difference.
-
-The reason recorded for leaving it — that changing the base changes what
-`stale-base-gate.sh` sees, and that had to be measured — was right to demand the
-measurement and wrong about which way it points. That gate opens with
-`git merge-base --is-ancestor "$base" HEAD || exit 0`, so it fires only on a
-branch that CLAIMS to be current. A lane cut from a stale local `main` does not
-have `origin/main` as an ancestor, so the gate exited 0 and never looked: it was
-INERT for precisely this shape, and the sentence that said it "exists to catch"
-this class had it backwards. Basing on `origin/main` makes `origin/main` an
-ancestor, which is what turns the gate ON for these lanes. The change gains
-coverage rather than risking it.
+`origin/main`, not local `main`, and both arms now agree. This one branched
+from local `main` until 2026-09-01 — drift rather than a considered difference
+(both siblings already spelled it `origin/main`). The reason recorded for
+leaving it — that changing the base changes what `stale-base-gate.sh` sees —
+had the direction backwards: that gate opens with
+`git merge-base --is-ancestor "$base" HEAD || exit 0`, so a lane cut from a
+stale local `main` made it exit 0 without looking — INERT for precisely this
+shape. Basing on `origin/main` is what turns the gate ON for these lanes; the
+change gains coverage rather than risking it.
 
 **IN-PLACE mode (SKILL.md "Launch mode") skips that block entirely**: this run
 was launched inside a linked worktree, so it keeps that tree and creates NO
@@ -204,41 +187,36 @@ fi
 ```
 
 **Every one of them takes `-C "<LANE_TREE>"` for the same reason the switch
-below does, and omitting it costs more here than a wrong branch**: a bare probe run
-after a cwd reset describes the MAIN checkout while READING as a description of
-this lane, so it answers "clean, no claim, no PR" about a tree nobody asked
-about — and the run then adopts a peer's live lane believing it checked. Read
-them under §9's rule that every ownership signal establishes LIFE and never
-absence: any one of them saying "someone is here" means STOP and report — never
-nest a worktree inside a peer's lane to get out of it.
+below does, and omitting it costs more here than a wrong branch**: a bare probe
+run after a cwd reset describes the MAIN checkout while READING as a
+description of this lane — it answers "clean, no claim, no PR" about a tree
+nobody asked about, and the run then adopts a peer's live lane believing it
+checked. Read them under §9's rule that every ownership signal establishes LIFE
+and never absence: any one of them saying "someone is here" means STOP and
+report — never nest a worktree inside a peer's lane to get out of it.
 
 This block comes BEFORE the branch recipe below because it GUARDS it, and a
 previous revision had the two the other way round: a run following the file in
-order took a peer's live lane off its branch and only then checked whose tree it
-was. The order is the guard.
+order took a peer's live lane off its branch and only then checked whose tree
+it was. The order is the guard.
 
 **Only once the tree is confirmed yours**: take a fresh branch here, ALWAYS,
-without leaving the tree. This used to be conditional — a DETACHED tree, or one
-whose branch had already merged (reusing it would push an orphan ref) — and the
-condition is WITHDRAWN. The branch the tree arrived on is `LAUNCH_BRANCH`
+without leaving the tree. This used to be conditional and the condition is
+WITHDRAWN. The branch the tree arrived on is `LAUNCH_BRANCH`
 (`references/launch-mode.md`): the OUTER TOOL's, not this run's, and §9 puts it
 back untouched at the very end, so committing onto it would leave the run
 nothing to restore and hand `gh pr merge --delete-branch` the outer tool's own
 remote branch to delete (go-to-k/cdkd#2417).
 
 ```bash
-# `-C <LANE_TREE>` is load-bearing, and the REASON changed on 2026-09-01.
-# Until then nothing in this repo gated a branch switch, so a BARE
-# `git switch -c` run after the shell's cwd had silently reset to the main
-# checkout (§6's `cd <worktree> &&` rule, and the reason section 9 pulls
-# through -C) took the MAIN checkout off `main`, unblocked, in a tree other
+# `-C <LANE_TREE>` is load-bearing. Until 2026-09-01 nothing here gated a
+# branch switch, so a BARE `git switch -c` run after the shell's cwd had
+# silently reset took the MAIN checkout off `main`, unblocked, in a tree other
 # lanes share. `.claude/hooks/main-tree-branch-gate.sh` now REFUSES that
 # (go-to-k/cdk-real-drift#1845), including the chained `fetch && switch -c`
 # form and the two-tree spellings, so the failure is loud rather than silent.
-# The `-C` stays, because a refusal is not a redirect: the gate stops the wrong
-# tree from being branched, and only `-C <LANE_TREE>` makes the command branch
-# the RIGHT one. Dropping it to match the siblings' `-C`-free spelling is a
-# separate change, tracked on the issue above.
+# The `-C` stays, because a refusal is not a redirect: only `-C <LANE_TREE>`
+# makes the command branch the RIGHT tree.
 # Substitute the ABSOLUTE path the launch-mode probe printed as `LANE_TREE`
 # and the opening report recorded -- the one value captured while the cwd was
 # provably right. Do NOT re-derive it here as
@@ -247,24 +225,23 @@ remote branch to delete (go-to-k/cdkd#2417).
 # it exists for, and inherit the bug it is guarding.
 #
 # The `&&` is load-bearing too: unchained, a failed `fetch` still branches, off
-# a stale `origin/main` -- the class `stale-base-gate.sh` exists to catch, and
-# the one the paragraph above this block is about.
+# a stale `origin/main` -- the class `stale-base-gate.sh` exists to catch.
 git -C "<LANE_TREE>" fetch origin \
   && git -C "<LANE_TREE>" switch -c wt-<name> origin/main
 ```
 
 **Build BEFORE the first test run, and read a fresh worktree's failures with
-that in mind.** A worktree starts with no `dist/`; a test spawning the built CLI
-fails on the missing binary with an assertion about its SUBJECT, and the main
-checkout (which HAS a `dist/`) passes, so every comparison points at main
+that in mind.** A worktree starts with no `dist/`; a test spawning the built
+CLI fails on the missing binary with an assertion about its SUBJECT, and the
+main checkout (which HAS a `dist/`) passes, so every comparison points at main
 (2026-08-27: a docs-only lane had begun writing up 13 such failures as "a peer
 merge broke main"; `vp run build` made them green). **A fresh worktree failing
 where the main checkout passes is evidence about the WORKTREE first.**
 
 Do the fix in the lane's tree (match the existing table/entry pattern exactly;
-ESM relative imports need the `.js` extension). **Always add a unit test that fails
-without the fix and passes with it** — for a fold/FP fix use the issue's exact
-harvested live model; for revert, assert the update document / patch op.
+ESM relative imports need the `.js` extension). **Always add a unit test that
+fails without the fix and passes with it** — for a fold/FP fix use the issue's
+exact harvested live model; for revert, assert the update document / patch op.
 **Check first whether the artifact already has a harness** — fold-table entries
 are covered generically (`tests/classify.test.ts`), and hook behavior by
 standalone `.claude/hooks/*.test.sh` suites run BY HAND
@@ -274,33 +251,30 @@ plus green CI is not verified at all. Run that harness FROM `.claude/hooks/`,
 never from a copy parked elsewhere: every suite resolves its subject from its
 OWN script path (`$(dirname "$0")` / `$(dirname "${BASH_SOURCE[0]}")`) with no
 env override (`BUGHUNT_TRACKER_OVERRIDE` overrides the TRACKER script, not the
-hook), so a copy in a scratch directory points at a sibling that is not there
-and EVERY case fails on exit 127, reading as a regression you did not cause
-(2026-08-19, go-to-k/cdk-real-drift#1777: 13/13 pass in place, 13/13 fail
-copied out). When diffing the OLD suite against your
-NEW hook, do NOT redirect `git show origin/main:.claude/hooks/<name>.test.sh`
-into a temp file elsewhere — write the copy BESIDE the real one as
-`.claude/hooks/_old-<name>.test.sh` and delete it after.
-`tests/skill-doc-paths.test.ts` asserts this self-relative resolution; amend
-the rule if a harness ever grows an override. Extend the harness that exists
-before writing a new one beside it.
+hook), so a copy in a scratch directory points at a sibling that is not
+there and EVERY case fails on exit 127, reading as a regression you did not
+cause (go-to-k/cdk-real-drift#1777: 13/13 pass in place, 13/13 fail copied
+out). When diffing the OLD suite against your NEW hook, do NOT redirect
+`git show origin/main:.claude/hooks/<name>.test.sh` into a temp file elsewhere
+— write the copy BESIDE the real one as `.claude/hooks/_old-<name>.test.sh` and
+delete it after. `tests/skill-doc-paths.test.ts` asserts this self-relative
+resolution; amend the rule if a harness ever grows an override. Extend the
+harness that exists before writing a new one beside it.
 
 **When the fix is a repo-wide SCANNER — a test that greps every committed file
 for a bad pattern — calibrate it against the PRE-FIX broken tree, and do not
 implement the issue's signature literally.** An issue describes ONE instance,
 not a rule with a measured false-positive rate: run the candidate over the
 unrepaired tree, classify every hit by hand, and let the split decide the rule
-(2026-08-19, go-to-k/cdk-real-drift#1771 -> go-to-k/cdk-real-drift#1782: the
-literal signature flagged ~30 spots, mostly idiomatic prose; splitting by SIDE
-— letter-BEFORE-span 5/5 genuine, AFTER-side 6 of 13 the plural suffix
-`` `remove`s `` — shipped as before-side unconditional plus a short `s`/`es`
-allowed after: 12/12 real hits, zero false positives). Then drive the failure direction as §8's no-`src/**` tier
-requires: `git stash push <the repaired file>`, watch the scan report the exact
-hits with line numbers, `git stash pop`.
+(go-to-k/cdk-real-drift#1771 → go-to-k/cdk-real-drift#1782: the literal
+signature flagged ~30 spots, mostly idiomatic prose; splitting by SIDE shipped
+as before-side unconditional plus a short `s`/`es` suffix allowed after — 12/12
+real hits, zero false positives). Then drive the failure direction as §8's
+no-`src/**` tier requires: `git stash push <the repaired file>`, watch the scan
+report the exact hits with line numbers, `git stash pop`.
 
 **Calibration and that stash-pop drive read the SAME instances, so between them
-they never show the rule catching a defect written a DIFFERENT way** — spellings
-the tree does not use today, contexts that defeat the exemption logic. Follow
+they never show the rule catching a defect written a DIFFERENT way.** Follow
 with two more probes against the real tree; every fence here got them on
 2026-08-20 (go-to-k/cdk-real-drift#1797) and four of eight were dead:
 
@@ -313,46 +287,42 @@ with two more probes against the real tree; every fence here got them on
 
   **But when round three is still ADDING spellings, the instrument is wrong —
   change it rather than write a better pattern.** Measured 2026-08-29 in three
-  repos at once, one defect class in a hand-rolled `.markgate.yml` reader. This
-  repo's own instance (go-to-k/cdk-real-drift#1838): the fence learned to read
-  `exclude` as 6-space BLOCK items, so the FLOW spelling still parsed to
-  `exclude: []` and the "no exclude declared" tripwire stayed GREEN a second
-  time while markgate really did subtract from the scope. The sibling
-  go-to-k/cdkd#2383 tallies its own run as **four spellings across four rounds,
-  each patch moving the hole rather than closing it**, ending on a merge key
-  (`<<: *anchor`) splicing an `exclude` declared on a SIBLING gate — which the
+  repos at once, one defect class in a hand-rolled `.markgate.yml` reader: this
+  repo's fence (go-to-k/cdk-real-drift#1838) learned to read `exclude` as
+  block items, so the FLOW spelling still parsed to `exclude: []` and the
+  tripwire stayed GREEN while markgate really did subtract from the scope; the
+  sibling go-to-k/cdkd#2383 tallies four spellings across four rounds, ending
+  on a YAML merge key splicing an `exclude` from a SIBLING gate — which the
   raw-text tripwire added as that very backstop did not fire on. **Three
-  spellings in three rounds is the signal to stop patterning.** Two shapes end it, and neither is a sixth pattern: parse the
-  config with a REAL parser — `yaml` is already a production dependency here,
-  and a third-party, versioned library is not the fence checking its own work —
-  then ALLOW-LIST the tool's own keys, fail CLOSED on anything outside them,
-  and raw-scan the whole map; or, where no parser is available, REFUSE every
-  shape the reader cannot model, which is the STRICTER option, not the weaker
-  one. `tests/check-scope-checker-inputs-1837.test.ts` is this repo's worked
+  spellings in three rounds is the signal to stop patterning.** Two shapes end
+  it, and neither is a sixth pattern: parse the config with a REAL parser
+  (`yaml` is already a production dependency here), ALLOW-LIST the tool's own
+  keys, fail CLOSED on anything outside them, and raw-scan the whole map; or,
+  where no parser is available, REFUSE every shape the reader cannot model —
+  the STRICTER option, not the weaker one.
+  `tests/check-scope-checker-inputs-1837.test.ts` is this repo's worked
   example.
 
 - **Delete the thing the fence REQUIRES, and watch it fail.** This finds a
   wrong POPULATION, and one derived from the DEFECT is the worst kind:
-  `tests/gate-if-matchers-1801.test.ts` (then named for
-  go-to-k/cdk-real-drift#1786) selected gates with
-  `filter(h => h.condition.includes('Bash(git commit*)'))`: deleting the bare
+  `tests/gate-if-matchers-1801.test.ts` originally selected gates with
+  `filter(h => h.condition.includes('Bash(git commit*)'))` — deleting the bare
   form dropped the gate OUT of the population instead of failing it, and
   disarming `stale-base-gate` / `ci-green-gate` outright stayed green. Three
   more that day: a TTY fence listing only 4 of 14 `src/commands/` files; a
   COUNT assertion over `.claude/hooks/*.test.sh` (measures harnesses that exist
-  — cannot report `check-gate.sh`, which has none); a one-plugin-by-name lookup
-  missing `@semantic-release/release-notes-generator`'s absent `parserOpts`
-  (under semantic-release, the release automation of the time — since replaced
-  by release-please), why all 13 `type!:` merges released with no CHANGELOG
-  entry.
+  — cannot report `check-gate.sh`, which had none); a one-plugin-by-name lookup
+  that missed why all 13 `type!:` merges released with no CHANGELOG entry
+  (under semantic-release, since replaced by release-please).
 
 And ask the dumbest question last: **is anything RUNNING it?** The
-`.claude/hooks/*.test.sh` harnesses had no `vp run` task and no CI step — shell,
-so `vp test run` never saw them (`vp run test:hooks` now runs them, in CI too).
+`.claude/hooks/*.test.sh` harnesses had no `vp run` task and no CI step —
+shell, so `vp test run` never saw them (`vp run test:hooks` now runs them, in
+CI too).
 
-The general shape: **a fence is not evidence until you have watched it go red on
-something you had not already counted.** Calibration says it is not noisy; only
-the spelling and deletion probes say it is load-bearing.
+The general shape: **a fence is not evidence until you have watched it go red
+on something you had not already counted.** Calibration says it is not noisy;
+only the spelling and deletion probes say it is load-bearing.
 
 **Restore from a BYTE-EXACT copy of the subject, never by inverting the edit.**
 A probe deliberately breaks a file, so the restore is the half that has to be
@@ -364,37 +334,33 @@ ran against the corrupted subject and returned verdicts about nothing. Copy the
 file aside first and copy it back (`cp` / `shutil.copyfile`), then re-run the
 suite and confirm GREEN before the next probe. `git checkout -- <file>` is not
 the alternative: at probe time the fix itself is usually uncommitted, so that
-discards the work along with the wreckage (the pre-probe commit rule in
-`references/verify.md` narrows this, and a `git stash` cycle around an unrelated
-peer's changes has its own trap). Verify the restore by HASH, not by eye — a
-`shasum -a 256` recorded before the first probe turns "I think I put it back"
-into a check.
+discards the work along with the wreckage. Verify the restore by HASH, not by
+eye — a `shasum -a 256` recorded before the first probe turns "I think I put it
+back" into a check.
 
 **Note WHICH work the copy protects: the bytes the subject held when the
-snapshot was TAKEN.** Content written or extended AFTER that point is reverted
-by the restore, not preserved by it — a lane lost 133 lines of newly written
-tests to precisely that (go-to-k/cdkd#2457), its harness restoring a snapshot
-that predated them.
-The restore is doing its job there; the loss is that nothing else held the work.
-That is the destructive half of `references/verify.md`'s pre-probe commit rule,
-and the two are complementary: commit first so the restore cannot cost anything,
-snapshot byte-exactly so the restore itself is not the corruption.
+snapshot was TAKEN.** Content written AFTER that point is reverted by the
+restore, not preserved by it — a lane lost 133 lines of newly written tests to
+precisely that (go-to-k/cdkd#2457). That is the destructive half of
+`references/verify.md`'s pre-probe commit rule, and the two are complementary:
+commit first so the restore cannot cost anything, snapshot byte-exactly so the
+restore itself is not the corruption.
 
 **Both probes above vary the INPUT. The second axis is the STATE the subject is
 in when the input arrives, and that one gets enumerated by ACCIDENT** — every
 case reuses the first case's fixture setup, so the suite covers one row of a
-table it never drew (2026-08-27, go-to-k/cdk-local#609: a commit gate twice
-shipped green suites — 52 cases, then 93 — each hiding live fail-opens in file
-STATEs the fixture never entered: untracked, tracked-but-modified, deleted on
-disk). DRAW THE GRID: states on one axis, input shapes on the other, write the
-cells out — uncovered cells become NAMEABLE, and the grid surfaces FALSE blocks
-a one-dimensional suite cannot produce. Name the state axis from what the subject
-READS: a
-`.claude/hooks/*.test.sh` case reads the TREE (clean, staged-only, dirty,
-untracked-only, on `main`, on a branch, inside a worktree); a fold or classify
-fence reads the TIER a property lands in (`declared`, `undeclared`, `atDefault`,
-`readGap`) plus the empty-husk shape `isTrivialEmpty` pre-empts — the row
-hand-picked cases most often skip, and where go-to-k/cdk-real-drift#1647 lived.
+table it never drew (go-to-k/cdk-local#609: a commit gate twice shipped green
+suites — 52 cases, then 93 — each hiding live fail-opens in file STATEs the
+fixture never entered: untracked, tracked-but-modified, deleted on disk). DRAW
+THE GRID: states on one axis, input shapes on the other, write the cells out —
+uncovered cells become NAMEABLE, and the grid surfaces FALSE blocks a
+one-dimensional suite cannot produce. Name the state axis from what the subject
+READS: a `.claude/hooks/*.test.sh` case reads the TREE (clean, staged-only,
+dirty, untracked-only, on `main`, on a branch, inside a worktree); a fold or
+classify fence reads the TIER a property lands in (`declared`, `undeclared`,
+`atDefault`, `readGap`) plus the empty-husk shape `isTrivialEmpty` pre-empts —
+the row hand-picked cases most often skip, and where
+go-to-k/cdk-real-drift#1647 lived.
 
 **The spelling and deletion probes test the RULE; a third is needed when the
 subject is a CLASSIFIER, because there the weak part is the POPULATION.** A
@@ -403,14 +369,13 @@ classifier decides which of several shapes an input is — `classifyTransient` /
 `classifyStackStatus` / `isResourceNotFoundError` (`src/aws-errors.ts`),
 `isNestedUndeclared` (`src/revert/plan.ts`). Its defects live in shapes nobody
 wrote down, so hand-picked cases go green on exactly the regressions that
-matter (2026-08-21, go-to-k/cdkd#2001: a predicate shipped THREE green
-revisions, each fixing the named case and breaking a neighbour). The fence that
-ends it is a differential walk: enumerate the input space, run BOTH the new
-implementation and a transcription of the old one (from
-`git show origin/main:<path>`, not memory; confirm they agree where they
-SHOULD), and fail on any difference outside an explicitly enumerated set of
-intended classes — a shape nobody imagined fails by default. Two ways it goes
-inert, both measured on that lane:
+matter (go-to-k/cdkd#2001: a predicate shipped THREE green revisions, each
+fixing the named case and breaking a neighbour). The fence that ends it is a
+differential walk: enumerate the input space, run BOTH the new implementation
+and a transcription of the old one (from `git show origin/main:<path>`, not
+memory; confirm they agree where they SHOULD), and fail on any difference
+outside an explicitly enumerated set of intended classes — a shape nobody
+imagined fails by default. Two ways it goes inert, both measured on that lane:
 
 - **Classify by the resulting VALUE, not by the input's shape.** Bucketing a
   differing cell by which input it was left a total regression inside the
@@ -432,19 +397,18 @@ list, in BOTH directions, before fixing the named entry.** The defect class is
 "this list drifted from the repo", and drift rarely produces exactly the
 noticed instance. Check that every entry still resolves AND that everything
 that belongs is present — the second half gets skipped because the issue only
-names the first (2026-08-19, go-to-k/cdkd#1972: one reported dead path in a
+names the first (go-to-k/cdkd#1972: one reported dead path in a
 security-surface list; the audit found a second dead path plus four live
-authn / credential / exec surfaces never added). Then make the recurrence
-mechanical: a list that must stay in sync with the repo is a TEST, not a
-sentence. go-to-k/cdk-real-drift#1767 — the mirror of this lesson — added
-`tests/skill-doc-paths.test.ts`, asserting every repo path a SKILL.md cites
-still resolves; it caught the class on its first run.
+surfaces never added). Then make the recurrence mechanical: a list that must
+stay in sync with the repo is a TEST, not a sentence
+(go-to-k/cdk-real-drift#1767 — the mirror of this lesson — added
+`tests/skill-doc-paths.test.ts`; it caught the class on its first run).
 
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an
 explicit "do NOT touch other lanes' files; STOP and report if the fix needs a
 forbidden file" guardrail. This file used to warn that a subagent's Bash
-bypasses the PreToolUse gate hooks; that is measured FALSE — on 2026-08-28 the
+bypasses the PreToolUse gate hooks; that is measured FALSE — the
 go-to-k/cdk-real-drift#1831 lane subagent had every gate hook fire on its own
 calls exactly as in the parent. The gates are a backstop, not the plan, either
 way: the orchestrator still holds the MERGE turn (§9).

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -3,16 +3,16 @@
 ## 10. Fold what the run taught you back into this skill
 
 Trigger: after the last lane in §9 is merged and every worktree THIS run added
-is removed — an IN-PLACE run added none, so for it the trigger is the last merge
-— BEFORE the wrap report; the evidence dies with this session's context. Distinct from
-`/verify-pr` step 8's per-LANE retrospective: the subject is **the flow
-itself** (the orchestrator `SKILL.md`, its `references/` stage files, the
-skills it drives — not the lane's code), the scope is the WHOLE run (cross-lane
-patterns are invisible from inside one lane), and it **applies** the fix —
-editing this repo's own agent tooling is a routine call. Escalate through
-`AskUserQuestion` only when the edit changes what the flow PROMISES (dropping a
-gate, lowering a verification tier, loosening §0) — never for wording,
-ordering, or a newly-learned trap.
+is removed — an IN-PLACE run added none, so for it the trigger is the last
+merge — BEFORE the wrap report; the evidence dies with this session's context.
+Distinct from `/verify-pr` step 8's per-LANE retrospective: the subject is
+**the flow itself** (the orchestrator `SKILL.md`, its `references/` stage
+files, the skills it drives — not the lane's code), the scope is the WHOLE run
+(cross-lane patterns are invisible from inside one lane), and it **applies**
+the fix — editing this repo's own agent tooling is a routine call. Escalate
+through `AskUserQuestion` only when the edit changes what the flow PROMISES
+(dropping a gate, lowering a verification tier, loosening §0) — never for
+wording, ordering, or a newly-learned trap.
 
 ### 10-0. Measure the run's net effect on the backlog
 
@@ -50,9 +50,7 @@ area are already filed. Only the first `M > N` reason is healthy:
 **`filed <= closed` (M <= N) is NOT a target, and must never become one.** The
 goal is a correct codebase, not a short list: an unfiled finding is strictly
 worse than a filed one — it removes the defect from the record while leaving it
-in the product. Never let the count justify not filing, softening a finding, or
-merging independent defects into one vague issue. If weighing whether to file,
-file.
+in the product. If weighing whether to file, file.
 
 **Then run the PROMOTION check on every `next` this run filed — a deferral is
 judged against the run that HAPPENED, not the one predicted when it was
@@ -78,10 +76,9 @@ for n in <the numbers this run filed that are still open>; do
     | grep -oE '[A-Za-z0-9_][A-Za-z0-9_./-]*\.[a-z]+' | sort -u \
     | while read -r f; do
         # Suffix match, not equality: an issue body names a file by BASENAME far
-        # more often than by full path (the bare file name, not the full
-        # repo-relative one), and an exact whole-line compare misses
-        # every one of those. Measured: the exact form fired on 1 of this run's 2
-        # deferrals and missed the one whose body used the basename.
+        # more often than by full path, and an exact whole-line compare misses
+        # every one of those. Measured: the exact form fired on 1 of this run's
+        # 2 deferrals and missed the one whose body used the basename.
         grep -E "(^|/)$(printf '%s' "$f" | sed 's/[.[\*^$]/\\&/g')\$" \
           /tmp/run-touched.$$ | while read -r hit; do
             echo "PROMOTE #$n -- this run touched $hit"
@@ -96,31 +93,30 @@ reading as two findings.
 
 **A hit is a prompt for judgement, not a verdict** — it cannot tell a citation
 from a target (measured: one deferral hit its one target file; the other hit
-four, three cited only as precedent). Do not skim a hit: do the item now while
-the context is loaded, or re-classify it in the issue body with the reason it
-still does not belong here.
+four, three cited only as precedent). Do the item now while the context is
+loaded, or re-classify it in the issue body with the reason it still does not
+belong here.
 
 **Re-read the REASON too — it can name a state that has since resolved.**
 Classifying once at creation is right, but a reason phrased in the run's own
-transient state ("the PR carrying it is still open", "a fifth review round")
-goes FALSE when that state resolves (2026-08-26, go-to-k/cdkd#2259: deferred
-while go-to-k/cdkd#2247 was in review; the reason survived unchanged into the
-wrap after that PR merged). Re-reading an expired premise is not re-litigation;
-keeping a `next` alive on a reason that stopped being true is.
+transient state ("the PR carrying it is still open") goes FALSE when that state
+resolves (go-to-k/cdkd#2259: deferred while go-to-k/cdkd#2247 was in review;
+the reason survived unchanged into the wrap after that PR merged). Re-reading
+an expired premise is not re-litigation; keeping a `next` alive on a reason
+that stopped being true is.
 
 ### 10-a. Evidence: only what this run actually produced
 
 Collect, with the concrete instance attached to each:
 
 1. **Corrections the user made** — two on one theme across lanes is a defect in
-   this text; the second occurrence is the signal, one alone may be a one-off.
+   this text; the second occurrence is the signal.
 2. **Text that was WRONG as written** — a failed command, a probe reporting a
    clear field while a lane was live, a flag / path / gate name that no longer
    exists.
 3. **Steps you had to invent** because the skill is silent — the next run would
    re-invent them.
-4. **Right instruction, wrong place** — done, but a step too late (claim posted
-   after triage, rebase discovered after the phantom diff).
+4. **Right instruction, wrong place** — done, but a step too late.
 5. **Followed it and still paid** — the text was obeyed and a retry happened
    anyway.
 
@@ -152,15 +148,13 @@ Collect, with the concrete instance attached to each:
 the repos in one session" ask, a discovery cannot be `Session-fit: next` —
 three tells, any one forcing `now`: filing the SAME issue body in more than one
 repo (the split the request exists to end); a mechanical fix whose evidence is
-live now (repro built, files open, gate cycle running); or the user already
-said "finish it here" for the surrounding task, which the discovery inherits. A
-tidy `Effort` / `Estimate` for work the session is already positioned to do is
-the tell the fields are an excuse, not a measurement (2026-08-20: a run fixing
-inert sibling PreToolUse gates across cdkd, cdk-local and
-go-to-k/cdk-real-drift filed the remaining script-level gap as three separate
-issues until the user objected; then done in the same SESSION as a follow-up PR
-per repo). "Same session" is the bar; "same PR" only when small enough to
-review together.
+live now; or the user already said "finish it here" for the surrounding task,
+which the discovery inherits. A tidy `Effort` / `Estimate` for work the session
+is already positioned to do is the tell the fields are an excuse (2026-08-20: a
+run fixing inert sibling PreToolUse gates across cdkd, cdk-local and
+go-to-k/cdk-real-drift filed the remaining gap as three separate issues until
+the user objected; then done in the same SESSION as a follow-up PR per repo).
+"Same session" is the bar; "same PR" only when small enough to review together.
 
 ### 10-c. How to edit: amend, do not append
 
@@ -170,10 +164,19 @@ Every run appending one more bullet is how a long skill becomes an unread one.
   Gotchas is for traps that span steps, not a run log.
 - **Amend the sentence that was wrong** rather than adding a sibling — two
   near-duplicate bullets blunt each other.
-- **Carry the evidence inline** (date, issue / PR number, what happened) — a
-  rule with no incident cannot be re-judged or retired later.
+- **Carry the evidence inline** (date, issue / PR number, what happened) — but
+  as ONE line: the rule plus a citation, not the narrative. A rule with no
+  incident cannot be re-judged or retired; a rule buried in its own incident
+  report is not read.
 - **Pay for what you add**: cut a line this run proved stale, subsumed, or
-  wrong. Net growth is fine for a new lesson; unbounded growth is not.
+  wrong. **A retro NEVER buys room by raising a byte cap or a corpus floor** —
+  the caps and floors in `tests/skill-file-payload.test.ts` are the mechanical
+  stop on this skill's growth loop, and a retro that raises one converts the
+  stop into a ratchet (this repo's corpus floor climbed 116,000 → 120,000 →
+  130,000 across two days of retro rounds tracking growth before the 2026-09-04
+  compression pass re-derived every bound DOWNWARD). If a lesson genuinely
+  cannot be paid for by compression in its stage file, split the stage; the
+  floor moves DOWN with compression passes, never up to accommodate growth.
 - Do not restate a rule living in `CLAUDE.md` or another step — point at it.
 - A FLOW lesson (not a cdk-real-drift one) lands in all three repos in ONE
   session — this skill plus the same-named `work-issues` skill in the siblings,
@@ -183,93 +186,72 @@ Every run appending one more bullet is how a long skill becomes an unread one.
   PRs, three gate cycles (cdkd blocks tracked-file edits in its main worktree).
   All three is the DEFAULT: a one-repo-at-a-time hop is a duplicate GENERATOR —
   each landing session's own §10 retro files again into the other two
-  (2026-08-19: go-to-k/cdkd#2011 / go-to-k/cdkd#2016, filed twenty minutes
-  apart by two hops, were the SAME three cdk-local lessons).
-  **Filing instead is a WHOLE-REMAINDER exception.** If the session cannot pay
-  the remaining gate cycles, file into EVERY repo not yet landed, in ONE turn,
-  each issue naming the other filings plus the repo already landed — partial
-  filing produced the pair above. Carry §4's `Session-fit` line in each, in
-  English.
-  **A lane WORKING a mirror issue does not mirror onward** — the originating
-  session owns all three landings; re-filing only adds copies. What IS new is
-  what the ADAPTATION teaches (a differing gate name, a probe reading
-  differently), itself subject to this bullet.
-  **Batch a run's lessons into ONE PR per repo**, not one per lesson — the gate
-  cycle is the per-PR cost (go-to-k/cdk-real-drift#1791 and
-  go-to-k/cdk-real-drift#1792 landed in one lane, one PR).
-  **Verify the copy against the TARGET repo, claim by claim, before shipping** —
-  a sentence true here reads as authoritative there while false, and nothing
-  lints instruction prose. A read-only reviewer per target repo — checking each
-  gate name, hook behavior, skill name, path convention and cross-reference
-  against that repo's files — caught four such false claims in the first mirror
-  of this section (2026-08-18). This rule lives here, not in memory: memory is
-  per-project-path and per-machine, so it would not load in the target repos.
-  **Verify the MECHANISM at the SOURCE, not only the applicability at the
-  TARGET.** The two feel like one check and are not. Applicability asks "does
-  this repo have that gate / hook / file", which the target-repo reviewer above
-  answers well. The mechanism asks "was the claim ever true where it was
-  WRITTEN", and once a lesson is in transit nobody is positioned to ask it: the
-  originating repo is no longer being read, and the target repo cannot see a
-  defect in machinery it does not have. Measured 2026-09-03 on the mirror that
-  produced this section's own edits: a lesson arrived describing a leaked
-  `.markgate-pr-review-sha` as a FALSE PASS that would merge a PR on the
-  strength of an already-merged one's review. The recon correctly ruled it
-  INAPPLICABLE here — `pr-review` is inert in this repo and the sentinel file
-  does not exist — and the framing was still wrong at the source: the siblings'
-  `pr-review-gate.sh` passes only on `recorded_sha = head_sha`, so a leaked
-  sentinel MISMATCHES and blocks, printing `bound to <sha> (mismatch)`. Fail
-  CLOSED, not fail open; the real sibling cost is a confusing block naming an
-  unrelated PR's sha. A correctly-REJECTED claim can still be false, and a
-  mirror that only ever asks "does this apply here" launders it intact into
-  every repo that DOES have the machinery. Reading the source hook cost two
-  commands.
-  **A recon or handoff report is a CLAIM SET, not a work list — re-derive its
-  SCOPE, not only its citations.** The mirror that produced this section was
-  handed a read-only recon that had checked every claim against this repo's
-  files, and it was still stale in ten places and wrong about scope twice — both
-  times UNDER-reporting. The false markgate-store claim sat at FIVE sites, not
-  the three it named, and the two it missed were the `/check` and `/check-docs`
-  skills — and `/check` is the ORIGIN the others point back at, so correcting only
-  the three named would have left the source still asserting it. Adding one item
-  to `verify.md`'s §8-z touched FOUR places rather than the one it flagged, and
-  only TWO of those carried a digit that changed; the other two kept their
-  numeral and moved their scope, so even a careful grep for numerals finds half
-  the work and looks finished.
-  The two error kinds are not equally dangerous. A drifted line number announces
-  itself the moment you open the file, but an under-reported scope is SILENT: a
-  lane that treats the list as complete lands a partial fix and reports it done,
-  leaving the copies corrected and the original still asserting the falsehood —
-  which is the drift shape §10-b fences, re-created by the very run sent to end
-  it. So for every claim, grep for the OTHER sites before fixing the named one,
-  and count what a list-shaped instruction says it contains.
-  **The worked instance is this rule's own commit.** Correcting the probe-value
-  undercount, that run fixed `hunt-bugs/references/plan.md` and left the
-  identical sentence in `references/triage.md` saying "a mode and two paths" —
-  one claim, two copies, one corrected, shipped in the very commit that adds the
-  paragraph you are reading. A reviewer found it, not the author, which is the
-  point: the author had just written the rule and still could not see the
-  instance, because the second copy was in a file the finding did not name
-  (2026-09-03, go-to-k/cdk-real-drift#1861).
-  **Verify the cited EVIDENCE too — open the issue or PR the sentence names and
-  confirm it says what the sentence claims.** Wrong evidence is wrong where
-  WRITTEN and travels intact past every per-repo noun check: this file claimed
-  go-to-k/cdk-real-drift#1761 was a flaky rc=0/rc=1 tsgolint artifact; the
-  record is a DETERMINISTIC exit 134 (Vite+ stdout `EAGAIN` panic, 3/3 per
-  go-to-k/cdk-real-drift#1765, no tsgolint), and it reached go-to-k/cdk-local#504
-  verbatim before a reviewer caught it (go-to-k/cdk-real-drift#1768). Checking
-  cost one command per record.
-  **Write every issue / PR reference FULLY QUALIFIED — `owner/repo#N`, never a
-  bare `#N` or half-qualified `cdkd#N` — in every skill doc, this section's own
-  refs included.** A bare `#N` renders against whichever repo is READING it, so
-  mirroring silently rewrites a correct citation: an unqualified `#1761` here
-  lands on go-to-k/cdkd#1761 (real but unrelated), an unqualified `#1765` on
-  go-to-k/cdk-local#1765 (nonexistent). Mechanically detectable, so per §10-b
-  it is a TEST rather than a sentence: `tests/skill-doc-paths.test.ts` fails on
-  any unqualified reference in ANY `.md` under `.claude/skills/**` —
-  orchestrator `SKILL.md` files and `references/` stage files alike
-  (go-to-k/cdk-real-drift#1796 landed the same change here and in cdk-local).
-  It reads plain prose only, so this paragraph's counter-examples can stay
-  written as code spans.
+  (go-to-k/cdkd#2011 / go-to-k/cdkd#2016, filed twenty minutes apart by two
+  hops, were the SAME three cdk-local lessons).
+  - **Filing instead is a WHOLE-REMAINDER exception.** If the session cannot
+    pay the remaining gate cycles, file into EVERY repo not yet landed, in ONE
+    turn, each issue naming the other filings plus the repo already landed —
+    partial filing produced the pair above. Carry §4's `Session-fit` line in
+    each, in English.
+  - **A lane WORKING a mirror issue does not mirror onward** — the originating
+    session owns all three landings; re-filing only adds copies. What IS new is
+    what the ADAPTATION teaches, itself subject to this bullet.
+  - **Batch a run's lessons into ONE PR per repo**, not one per lesson — the
+    gate cycle is the per-PR cost (go-to-k/cdk-real-drift#1791 and
+    go-to-k/cdk-real-drift#1792 landed in one lane, one PR).
+  - **Verify the copy against the TARGET repo, claim by claim, before
+    shipping** — a sentence true here reads as authoritative there while false,
+    and nothing lints instruction prose. A read-only reviewer per target repo —
+    checking each gate name, hook behavior, skill name, path convention and
+    cross-reference against that repo's files — caught four such false claims
+    in the first mirror of this section (2026-08-18). This rule lives here, not
+    in memory: memory is per-project-path and would not load in the targets.
+  - **Verify the MECHANISM at the SOURCE, not only the applicability at the
+    TARGET.** Applicability asks "does this repo have that gate / hook /
+    file"; the mechanism asks "was the claim ever true where it was WRITTEN",
+    and once a lesson is in transit nobody is positioned to ask it. Measured
+    2026-09-03: a lesson arrived describing a leaked `.markgate-pr-review-sha`
+    as a FALSE PASS; the recon correctly ruled it inapplicable here
+    (`pr-review` is inert, no sentinel on disk) — and the framing was still
+    wrong at the SOURCE, whose gate passes only on `recorded_sha = head_sha`,
+    so a leaked sentinel MISMATCHES and blocks (fail CLOSED). A
+    correctly-REJECTED claim can still be false, and a mirror that only asks
+    "does this apply here" launders it intact into every repo that DOES have
+    the machinery. Reading the source hook cost two commands.
+  - **A recon or handoff report is a CLAIM SET, not a work list — re-derive its
+    SCOPE, not only its citations.** The mirror that produced this section was
+    handed a recon checked claim-by-claim against this repo's files, and it was
+    still stale in ten places and wrong about scope twice — both times
+    UNDER-reporting: the false markgate-store claim sat at FIVE sites, not the
+    three it named (the two missed were `/check` and `/check-docs`, and
+    `/check` is the ORIGIN the others point back at); a §8-z addition touched
+    FOUR places of which only TWO carried a digit that changed, so a grep for
+    numerals finds half the work and looks finished. An under-reported scope is
+    SILENT — a lane treating the list as complete lands a partial fix, leaving
+    the copies corrected and the original still asserting the falsehood. For
+    every claim, grep for the OTHER sites before fixing the named one, and
+    count what a list-shaped instruction says it contains. (The worked instance
+    is this rule's own commit: it fixed `hunt-bugs/references/plan.md` and left
+    the identical "a mode and two paths" sentence in `references/triage.md` —
+    one claim, two copies, one corrected; a reviewer found it, not the author —
+    2026-09-03, go-to-k/cdk-real-drift#1861.)
+  - **Verify the cited EVIDENCE too — open the issue or PR the sentence names
+    and confirm it says what the sentence claims.** Wrong evidence is wrong
+    where WRITTEN and travels intact past every per-repo noun check: this file
+    claimed go-to-k/cdk-real-drift#1761 was a flaky rc=0/rc=1 tsgolint
+    artifact; the record is a DETERMINISTIC exit 134 (3/3 per
+    go-to-k/cdk-real-drift#1765), and it reached go-to-k/cdk-local#504 verbatim
+    before a reviewer caught it (go-to-k/cdk-real-drift#1768). One command per
+    record.
+  - **Write every issue / PR reference FULLY QUALIFIED — `owner/repo#N`, never
+    a bare `#N` or half-qualified `cdkd#N` — in every skill doc, this section's
+    own refs included.** A bare `#N` renders against whichever repo is READING
+    it, so mirroring silently rewrites a correct citation (an unqualified
+    `#1761` here lands on go-to-k/cdkd#1761, real but unrelated). Per §10-b it
+    is a TEST: `tests/skill-doc-paths.test.ts` fails on any unqualified
+    reference in ANY `.md` under `.claude/skills/**`
+    (go-to-k/cdk-real-drift#1796). It reads plain prose only, so
+    counter-examples can stay written as code spans.
 
 ### 10-d. Ship it like any other change
 
@@ -293,24 +275,22 @@ pnpm install                  # worktrees have no node_modules
 
 IN-PLACE — run THIS block INSTEAD of the one above, never both: there is no
 worktree to add, and `git worktree add` from inside this tree NESTS the very
-worktree this mode exists to prevent. You are also not on `main`; the lane's own
-tree is still here with its deps installed, so take the retro branch IN IT, and
-the merged lane branch cannot be reused. `B` is re-assigned because a separate
-fenced block is a separate shell (section 9's `MAIN` trap), and the switch is
-addressed with `-C` for the reason §5 gives: a bare one after a cwd reset would
-target the MAIN checkout rather than this lane. Since
-go-to-k/cdk-real-drift#1845 `main-tree-branch-gate` REFUSES that instead of
-letting it through, so the failure is loud — but a refusal is not a redirect,
-and only the `-C` puts the branch in the tree you mean. Substitute the absolute
-path the launch-mode probe printed as `LANE_TREE` and the opening report
-recorded — captured while the cwd was
-provably right — and do NOT re-derive it here from `$(git rev-parse
---show-toplevel)` or `pwd`, which resolve against the reset cwd and hand the
-guard the very tree it is guarding against. Keep the `&&`: unchained, a failed
-`fetch` still branches, off a stale `origin/main`. **Every command after this
-one takes the same `-C "<LANE_TREE>"`** — the edits, `git add`, the commit, the
-push, `gh pr create` — for the identical reason: this block never `cd`s, so a
-later bare command runs in whatever tree the shell is standing in.
+worktree this mode exists to prevent. You are also not on `main`; the lane's
+own tree is still here with its deps installed, so take the retro branch IN IT,
+and the merged lane branch cannot be reused. `B` is re-assigned because a
+separate fenced block is a separate shell (section 9's `MAIN` trap), and the
+switch is addressed with `-C` for the reason §5 gives: a bare one after a cwd
+reset would target the MAIN checkout — since go-to-k/cdk-real-drift#1845
+`main-tree-branch-gate` REFUSES that instead of letting it through, but a
+refusal is not a redirect, and only the `-C` puts the branch in the tree you
+mean. Substitute the absolute path the launch-mode probe printed as
+`LANE_TREE` — captured while the cwd was provably right — and do NOT re-derive
+it here from `$(git rev-parse --show-toplevel)` or `pwd`, which resolve against
+the reset cwd. Keep the `&&`: unchained, a failed `fetch` still branches, off a
+stale `origin/main`. **Every command after this one takes the same
+`-C "<LANE_TREE>"`** — the edits, `git add`, the commit, the push,
+`gh pr create` — for the identical reason: this block never `cd`s, so a later
+bare command runs in whatever tree the shell is standing in.
 
 ```bash
 B=chore/work-issues-retro-$(date +%Y%m%d)
@@ -324,10 +304,8 @@ git -C "<LANE_TREE>" fetch origin \
   time).
 - **`vp fmt` REWRITES this file's indentation, and that can change what a
   paragraph belongs to.** This repo's formatter covers markdown (the siblings'
-  does not — measured 2026-08-19: the same probe file is rewritten here,
-  "excluded by ignore rules" in cdkd and cdk-local), and it re-indents a
-  paragraph following a nested list item from 2 spaces to 4, re-parenting it
-  under that sub-bullet:
+  does not — measured 2026-08-19), and it re-indents a paragraph following a
+  nested list item from 2 spaces to 4, re-parenting it under that sub-bullet:
 
   ```text
   before                                    after `vp fmt`
@@ -337,30 +315,28 @@ git -C "<LANE_TREE>" fetch origin \
   ```
 
   Nothing fails — the file still renders, just saying something else (bit the
-  go-to-k/cdk-real-drift#1793 lane: three verification paragraphs in section
-  10-c absorbed into the clause above them). The shape that survives is a
-  **bold lead paragraph at the parent bullet's own indent**, never prose
-  trailing a sub-bullet; run `vp fmt` TWICE, confirm the second run is a no-op,
-  and read the reformatted diff before committing — the damage is invisible in
-  the source you typed.
+  go-to-k/cdk-real-drift#1793 lane: three verification paragraphs absorbed
+  into the clause above them). The shape that survives is a **bold lead
+  paragraph at the parent bullet's own indent**, never prose trailing a
+  sub-bullet; run `vp fmt` TWICE, confirm the second run is a no-op, and read
+  the reformatted diff before committing — the damage is invisible in the
+  source you typed.
 
 - **A skill doc cannot cite a repo path in order to say it is ABSENT.**
   `tests/skill-doc-paths.test.ts` resolves every path-shaped code span in every
   `.md` under `.claude/skills/**`, with no negation exemption on purpose — a
-  stale path would otherwise hide behind "no longer exists" phrasing, the class
-  the fence exists to catch. Do not add an exemption; reword: the absence in
-  PROSE ("this repo ships no multi-agent reviewer set and no `/review-pr`
-  skill") passes, the same claim as a code span goes red (2026-08-28,
-  go-to-k/cdk-real-drift#1829). Bites MIRROR lanes hardest — adapting a
-  sibling's lesson often means stating its mechanism is missing here. Two fence
-  details: a span is only checked when its FIRST segment is an existing
-  top-level directory (an invented root is never checked; anything under the
-  real `.claude` tree is), and `PATH_LIKE` needs a leading word character, so a
-  skill name like `/review-pr` is never a path. A gate that DOES exist — the
-  INERT `pr-review` entry in `.markgate.yml` — can still be cited by name. Run
-  `vp test run tests/skill-doc-paths.test.ts` before the commit. It is not the
-  only fence a prose-only diff can red, and treating it as such is how the other
-  two get skipped: `tests/markdown-fmt-corruption-1771.test.ts` scans every
+  stale path would otherwise hide behind "no longer exists" phrasing. Do not
+  add an exemption; reword: the absence in PROSE ("this repo ships no
+  multi-agent reviewer set and no `/review-pr` skill") passes, the same claim
+  as a code span goes red (go-to-k/cdk-real-drift#1829). Bites MIRROR lanes
+  hardest — adapting a sibling's lesson often means stating its mechanism is
+  missing here. Two fence details: a span is only checked when its FIRST
+  segment is an existing top-level directory, and `PATH_LIKE` needs a leading
+  word character, so a skill name like `/review-pr` is never a path. A gate
+  that DOES exist — the INERT `pr-review` entry in `.markgate.yml` — can still
+  be cited by name. Run `vp test run tests/skill-doc-paths.test.ts` before the
+  commit — and not alone, which is how the other two fences a prose-only diff
+  can red get skipped: `tests/markdown-fmt-corruption-1771.test.ts` scans every
   tracked `*.md` for the `vp fmt` corruption signature, and
   `tests/check-scope-checker-inputs-1837.test.ts` reds when `/check`'s SKILL.md
   stops matching the `check` gate's real scope. On a prose-only diff, run all
@@ -368,10 +344,10 @@ git -C "<LANE_TREE>" fetch origin \
 
 - A `work-issues`-only edit is INSIDE the `check` gate's scope
   (`tests/skill-file-payload.test.ts` and `tests/skill-doc-paths.test.ts` read
-  `.claude/skills/**`) and outside `docs`; `check-gate` verifies both markers on every
-  commit and a fresh worktree starts with NONE — run `/check` + `/check-docs`
-  there before the commit. `verify-pr-gate` exempts a diff with no `src/**`
-  path, so `/verify-pr` is not required; CI must still be green for
+  `.claude/skills/**`) and outside `docs`; `check-gate` verifies both markers
+  on every commit and a fresh worktree starts with NONE — run `/check` +
+  `/check-docs` there before the commit. `verify-pr-gate` exempts a diff with
+  no `src/**` path, so `/verify-pr` is not required; CI must still be green for
   `ci-green-gate`. No `src/**` change also means no deploy: nothing for
   `/sweep-resources` to tear down, no `deploy-autoarm-gate` token to release.
 - Do not let the small diff set the review depth. This repo has no reviewer
@@ -389,10 +365,10 @@ git -C "<LANE_TREE>" fetch origin \
   the retro branch — the previous instruction here — makes the unmerged-lane
   Stop hook warn every turn (the appendix has the wording), and detaching
   instead is visible-surprising in the outer tool's UI; restoring what the tool
-  created is quiet on both counts. This is `Session-fit: now` on the leaves-main-self-inconsistent
-  criterion (the skill would keep telling the next run to do what this run just
-  proved wrong); its evidence dies with this session, and an open PR is NOT
-  CLOSEABLE besides.
+  created is quiet on both counts. This is `Session-fit: now` on the
+  leaves-main-self-inconsistent criterion (the skill would keep telling the
+  next run to do what this run just proved wrong); its evidence dies with this
+  session, and an open PR is NOT CLOSEABLE besides.
 
 Then report the outcome in one wrap line: what changed, in which step, and the
 run evidence behind it — or "no skill change" plus what held.

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -50,7 +50,9 @@ area are already filed. Only the first `M > N` reason is healthy:
 **`filed <= closed` (M <= N) is NOT a target, and must never become one.** The
 goal is a correct codebase, not a short list: an unfiled finding is strictly
 worse than a filed one — it removes the defect from the record while leaving it
-in the product. If weighing whether to file, file.
+in the product. Never let the count justify not filing, softening a finding,
+or merging independent defects into one vague issue. If weighing whether to
+file, file.
 
 **Then run the PROMOTION check on every `next` this run filed — a deferral is
 judged against the run that HAPPENED, not the one predicted when it was

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -6,63 +6,52 @@ With subagent lanes, this stage is the PARENT's serialization point: grant one
 merge-ready lane at a time its turn — resume that lane agent (SendMessage) to
 run its owed §8 live test + `/sweep-resources` and merge while it holds the
 turn, or run them yourself FROM THAT LANE'S WORKTREE. The worktree matters
-mechanically, not stylistically: gate verdicts are computed against the tree
-the command runs from — this repo's markgate store is PER-WORKTREE
-(`<git rev-parse --absolute-git-dir>/markgate/`; §6 carries the 2026-09-03
-re-measurement that corrected "shared across worktrees"), and the bughunt-clean
-gate keys the committing WORKTREE owner — so a marker set from the main tree is
-not even visible to the lane, and a merge issued from there attests to MAIN's
-content, not the lane's. cdkd measured the merge-time failure live on
-2026-08-28 (go-to-k/cdkd#2363 records the cwd-race side of it).
-Live-AWS runs have a second, repo-specific reason to stay inside the granted
-turn: the deploy-autoarm sentinel is per-SESSION, and a lane subagent's calls
-carry this same session, so one lane's deploy arms the token that blocks EVERY
-lane's commit / PR create / merge until `/sweep-resources` clears it. Never
-two lanes' live tests or merges concurrently; everything after the merge in
-this section (pull → cleanup) stays with the parent.
+mechanically: gate verdicts are computed against the tree the command runs from
+— the markgate store is PER-WORKTREE (§6 carries the 2026-09-03 re-measurement)
+and the bughunt-clean gate keys the committing WORKTREE owner — so a marker set
+from the main tree is invisible to the lane, and a merge issued from there
+attests to MAIN's content (cdkd measured the merge-time failure live:
+go-to-k/cdkd#2363). Live-AWS runs have a second, repo-specific reason to stay
+inside the granted turn: the deploy-autoarm sentinel is per-SESSION, and a lane
+subagent's calls carry this same session, so one lane's deploy arms the token
+that blocks EVERY lane's commit / PR create / merge until `/sweep-resources`
+clears it. Never two lanes' live tests or merges concurrently; everything after
+the merge (pull → cleanup) stays with the parent.
 
 **A `SendMessage` that answers "queued" has NOT been delivered — read the reply
-every time.** The tool returns one of two things: `Resuming agent ...`, meaning
-the agent was stopped and has been RESTARTED to receive it, or `Message queued
-for delivery at its next tool round`, which delivers only if something ELSE
-resumes the agent. A lane that ended its turn on "merge-ready" is stopped by
-definition, so the turn-grant it is waiting for lands in a queue nothing will
-drain — and both sides then look identical to a party waiting on the other.
-Measured 2026-09-02 (go-to-k/cdkd#2417): a lane sat idle about five minutes
-mid-pipeline that way, surfaced only by the maintainer asking why nothing was
-running, and an immediate re-send answered `Resuming agent` and unstuck it. So
-after any send: if the answer was "queued", either confirm the agent actually
-runs (its next completion notification) or re-send at once. A queued message is
-never a granted turn.
+every time.** `Resuming agent ...` means the stopped agent was RESTARTED to
+receive it; `Message queued for delivery ...` delivers only if something ELSE
+resumes the agent — and a lane that ended its turn on "merge-ready" is stopped
+by definition, so the turn-grant lands in a queue nothing will drain. Measured
+2026-09-02 (go-to-k/cdkd#2417): a lane sat idle ~5 minutes that way; an
+immediate re-send answered `Resuming agent` and unstuck it. After any send: if
+the answer was "queued", confirm the agent actually runs (its next completion
+notification) or re-send at once. A queued message is never a granted turn.
 
 ```bash
 gh pr merge <n> --squash --delete-branch     # squash is the repo's only method
 ```
 
 (Local branch delete fails while its worktree exists — expected; the worktree
-removal below clears it.) Merge each verified PR. If a later PR is behind, GitHub
-still merges it when the files are disjoint — but disjoint files are not the whole
-test: if the PR that landed first added a repo-wide check, rebase and run it over
-your diff first (§7).
+removal below clears it.) Merge each verified PR. If a later PR is behind,
+GitHub still merges it when the files are disjoint — but if the PR that landed
+first added a repo-wide check, rebase and run it over your diff first (§7).
 
 **When one lane fixes a full-suite flake, merge THAT lane first.** Every other
-lane's §6 gate run and `/verify-pr` execute the same suite, so until the fix is on
-`main` each rolls the same dice — and the REBASE is what delivers it (a lane
-branched before the merge keeps flaking on its stale base). Standing instance:
-the `json-empty-on-error` suite flakes even with `dist/` packed (§8), so a lane
-fixing it outranks the ship order. Measured cost of skipping: the
-go-to-k/cdk-local#509 lane hit the go-to-k/cdk-local#515 timeout 2/2 while the
-fix sat unmerged in a parallel lane; the first run after merging
+lane's §6 gate run and `/verify-pr` roll the same dice until the fix is on
+`main`, and the REBASE is what delivers it. Standing instance: the
+`json-empty-on-error` suite flakes even with `dist/` packed (§8). Measured cost
+of skipping: go-to-k/cdk-local#509 hit the go-to-k/cdk-local#515 timeout 2/2
+while the fix sat unmerged in a parallel lane; the first run after merging
 go-to-k/cdk-local#522 and rebasing was green (2026-08-19).
 
-**A PR's CI runs on the MERGE ref, not on your branch** — `.github/workflows/ci.yml`
-triggers on `pull_request`, so GitHub tests your branch combined with current
-`main`. A red check can be caused by a PEER's just-merged content your local
-green never saw, and that red also blocks `ci-green-gate` on `gh pr merge`. Fix:
-fetch + rebase + re-run; do NOT start distrusting the peer's new test
-(2026-08-19, go-to-k/cdk-local#524 failed CI on a line go-to-k/cdk-local#520 had
-merged in parallel). Same cause as §7's repo-wide-check collision; the same
-rebase answers both.
+**A PR's CI runs on the MERGE ref, not on your branch** — `pull_request`
+triggers test your branch combined with current `main`, so a red check can be
+caused by a PEER's just-merged content your local green never saw (and it also
+blocks `ci-green-gate`). Fix: fetch + rebase + re-run; do NOT start distrusting
+the peer's new test (2026-08-19, go-to-k/cdk-local#524 failed CI on a line
+go-to-k/cdk-local#520 had merged in parallel). Same cause as §7's
+repo-wide-check collision; the same rebase answers both.
 
 MAIN-CHECKOUT (SKILL.md "Launch mode") — run THIS block, and not the next one:
 
@@ -70,27 +59,23 @@ MAIN-CHECKOUT (SKILL.md "Launch mode") — run THIS block, and not the next one:
 git checkout main && git pull origin main    # bring the merges local
 ```
 
-IN-PLACE — run THIS block INSTEAD, never both: `main` is checked out in the main
-tree, so a `checkout main` here fails with "already used by worktree ...". Never
-leave your own tree; pull the main checkout through `-C`, substituting the
-absolute `<MAIN_CHECKOUT>` the launch-mode probe printed and the opening report
-recorded. Two things that spelling fixes over the `MAIN=$(git worktree list …)`
-form this block used to carry: it does not depend on the main checkout being row
-1 of the listing (true today, not a documented guarantee), and it cannot be
-EMPTY. An empty `$MAIN` is the dangerous half — `git -C "" pull origin main`
-exits 0 and pulls `origin/main` into whatever tree the shell is standing in,
-which IN-PLACE is this lane's branch. A placeholder that was never substituted
-is visible in the command you are about to run; an empty variable is not:
+IN-PLACE — run THIS block INSTEAD, never both: `main` is checked out in the
+main tree, so a `checkout main` here fails with "already used by worktree ..."
+(the same failure §1's pull hits and the appendix records for
+`gh pr merge --delete-branch`; a MAIN-CHECKOUT run has a tree to return to, an
+IN-PLACE run does not). Never leave your own tree; pull the main checkout
+through `-C`, substituting the absolute `<MAIN_CHECKOUT>` the launch-mode probe
+printed and the opening report recorded. That spelling fixes two defects of the
+`MAIN=$(git worktree list …)` form this block used to carry: it does not depend
+on the main checkout being row 1 of the listing, and it cannot be EMPTY — an
+empty `$MAIN` is the dangerous half, since `git -C "" pull origin main` exits 0
+and pulls `origin/main` into whatever tree the shell is standing in, which
+IN-PLACE is this lane's branch. A never-substituted placeholder is visible in
+the command; an empty variable is not:
 
 ```bash
 git -C "<MAIN_CHECKOUT>" pull origin main
 ```
-
-That second form is not IN-PLACE-only trivia: it is the same
-`fatal: 'main' is already used by worktree ...` the appendix records for
-`gh pr merge --delete-branch`, and the same one §1's pull hits. What differs is
-that a MAIN-CHECKOUT run has a tree it may return to and an IN-PLACE run does
-not.
 
 **Release** is BATCHED (release-please via `.github/workflows/release.yml`) —
 merging a `fix:` / `feat:` commit to `main` publishes NOTHING by itself: it
@@ -111,16 +96,15 @@ Only after a release PR merge does the published npm package move; the
 vp i -g cdk-real-drift
 ```
 
-That install is BY NAME from npm, so it is mode-independent: it resolves the
-published package and never reads any tree's build output. (The sibling cdkd
-links its global CLI at the MAIN checkout's `dist/`, which forces a post-merge
-rebuild there; nothing in this repo's ship stage does, so an IN-PLACE run has no
-main-checkout rebuild to perform. Do not add one.) After an ORDINARY merge the
-installed binary is already the latest published version — skip the install
-rather than polling for a bump that is never coming; say so in the wrap. A run
-whose lanes are all `chore:` / `docs:` does not even move the release PR
-(2026-08-19, go-to-k/cdk-real-drift#1767 merged as `chore:` and this text still
-sent the run polling for a bump).
+That install is BY NAME from npm, so it is mode-independent — it never reads
+any tree's build output. (The sibling cdkd links its global CLI at the main
+checkout's `dist/`, forcing a post-merge rebuild there; nothing in this repo's
+ship stage does. Do not add one.) After an ORDINARY merge the installed binary
+is already the latest published version — skip the install rather than polling
+for a bump that is never coming, and say so in the wrap; a run whose lanes are
+all `chore:` / `docs:` does not even move the release PR (2026-08-19,
+go-to-k/cdk-real-drift#1767 merged as `chore:` and this text still sent the run
+polling).
 
 **Remove every worktree you created** (a left-behind worktree is the silent
 residue of this flow).
@@ -134,14 +118,14 @@ git worktree list                            # yours should be gone
 ```
 
 IN-PLACE — run THIS block INSTEAD, never both. **An IN-PLACE run created no
-worktree, so it removes none**: it must not `git worktree remove` the tree it is
-running in (that deletes its own cwd). Cleanup of the TREE belongs to whoever
-created it — the outer tool, or the operator — so the wrap SAYS so instead of
-doing it, and the run ends with the tree still standing. What it DOES owe is the
-BRANCH: put back the one it found, delete the one it made. `<LAUNCH_BRANCH>` and
-`<lane branch>` are SUBSTITUTION PLACEHOLDERS taken from the opening report, not
-shell variables (`references/launch-mode.md` — a fresh Bash call is a fresh
-shell, and an empty `git switch ""` is not the failure you want):
+worktree, so it removes none**: it must not `git worktree remove` the tree it
+is running in (that deletes its own cwd). Cleanup of the TREE belongs to
+whoever created it — the outer tool, or the operator — so the wrap SAYS so
+instead of doing it. What the run DOES owe is the BRANCH: put back the one it
+found, delete the one it made. `<LAUNCH_BRANCH>` and `<lane branch>` are
+SUBSTITUTION PLACEHOLDERS taken from the opening report, not shell variables
+(`references/launch-mode.md` — a fresh Bash call is a fresh shell, and an empty
+`git switch ""` is not the failure you want):
 
 ```bash
 git switch <LAUNCH_BRANCH>     # AS-IS: no pull, no rebase, no fast-forward
@@ -159,53 +143,50 @@ git branch -D <lane branch>
 ```
 
 **Three end states, and only one of them is quiet.** Staying on the lane branch
-leaves a squash-merged tip that the unmerged-lane Stop hook warns about on EVERY
+leaves a squash-merged tip the unmerged-lane Stop hook warns about on EVERY
 turn (its tip is never an ancestor of `main` — the same squash artifact that
-forces `-D` above). Detaching silences that, and was this step's recommendation
-until 2026-09-02 — but it is VISIBLE-SURPRISING in the outer tool's UI, which
-created the workspace ON a branch and displays the detached state prominently;
-the maintainer flagged it live (go-to-k/cdk-real-drift#1854). `LAUNCH_BRANCH`
-restored is both: it sits at whatever tip the outer tool left, 0 commits ahead of
-`origin/main`, so the Stop hook stays silent AND the workspace looks untouched.
+forces `-D` above). Detaching silences that but is VISIBLE-SURPRISING in the
+outer tool's UI, which created the workspace ON a branch — the maintainer
+flagged it live (go-to-k/cdk-real-drift#1854). `LAUNCH_BRANCH` restored is
+both: 0 commits ahead of `origin/main`, so the Stop hook stays silent AND the
+workspace looks untouched.
 
-**AS-IS is the whole rule: RESTORE, never ADJUST.** The first draft of this step
-fast-forwarded `LAUNCH_BRANCH` to `origin/main` on the way back, so it would not
-be left "stale"; that clause is WITHDRAWN. The tree and the branch are the outer
-tool's artifacts and this run's job is to leave them exactly as it found them — a
-fast-forward is an edit to somebody else's branch, made for the convenience of a
-run that is on its way out, and "it was only a fast-forward" is precisely the
-reasoning that produced the detached HEAD this rule replaces. If the branch is
-behind, that is the tool's business.
+**AS-IS is the whole rule: RESTORE, never ADJUST.** The first draft
+fast-forwarded `LAUNCH_BRANCH` to `origin/main` on the way back; that clause is
+WITHDRAWN. The tree and the branch are the outer tool's artifacts and this
+run's job is to leave them exactly as found — "it was only a fast-forward" is
+precisely the reasoning that produced the detached HEAD this rule replaces. If
+the branch is behind, that is the tool's business.
 
 **This step runs LAST, not per-lane.** §10 takes its retro branch in this same
 tree, so restoring here and branching again in §10-d would just undo itself:
-IN-PLACE, do the merge in §9 and come back for the restore once the retro PR has
-merged. `--delete-branch` on each merge still removes the REMOTE branches, which
-is fine and independent of any of this.
+IN-PLACE, do the merge in §9 and come back for the restore once the retro PR
+has merged. `--delete-branch` on each merge still removes the REMOTE branches,
+which is fine and independent of any of this.
 
-**Only the ones YOU created.** A worktree you did not create is a peer lane, and
-`git worktree list` cannot tell you whose it is — a finished run's leftover and a
-live session look identical, including a branch whose tip is already on `main`.
-The closing check is "every worktree I added is gone", never "only the main
-checkout remains" — which an IN-PLACE run satisfies by having added none. **Every ownership signal establishes LIFE, never absence**: a
-dirty tree or an open PR proves a lane is live; the absence of either proves
-nothing. A tip on `main` is not death (the owner may be in ship/retro steps), and
-a claim comment carries CLAIM time, not last activity. Measured both "finished"
-signals failing at once: `.worktrees/vp-bump-1780` sat on `main`'s own tip with
-zero open PRs, yet merged go-to-k/cdk-real-drift#1787 twenty minutes later;
-earlier the same day a "residue" worktree merged go-to-k/cdk-real-drift#1773
-while the removing lane was still open (2026-08-19). So `git log --oneline -1`
-and `gh pr list --state all --head <branch>` can find a reason to LEAVE a
-worktree, never license removing one. When in doubt leave it and say so in the
-wrap.
+**Only the ones YOU created.** A worktree you did not create is a peer lane,
+and `git worktree list` cannot tell whose it is — a finished run's leftover and
+a live session look identical. The closing check is "every worktree I added is
+gone", never "only the main checkout remains" — which an IN-PLACE run satisfies
+by having added none. **Every ownership signal establishes LIFE, never
+absence**: a dirty tree or an open PR proves a lane is live; the absence of
+either proves nothing. A tip on `main` is not death (the owner may be in
+ship/retro steps), and a claim comment carries CLAIM time, not last activity.
+Measured both "finished" signals failing at once (2026-08-19):
+`.worktrees/vp-bump-1780` sat on `main`'s own tip with zero open PRs, yet
+merged go-to-k/cdk-real-drift#1787 twenty minutes later; a "residue" worktree
+merged go-to-k/cdk-real-drift#1773 the same day while the removing lane was
+still open. So `git log --oneline -1` and
+`gh pr list --state all --head <branch>` can find a reason to LEAVE a worktree,
+never license removing one. When in doubt leave it and say so in the wrap.
 
 Finally, comment the outcome on each issue if it was not auto-closed.
 **RELEASE the claim on every issue that did NOT auto-close.** `--delete-branch`
-has just deleted the branch your claim names, so what is left on the issue is a
-lock pointing at nothing: the next session reads "Working on this in branch
-<gone>" and either skips a free issue or has to prove you are finished. Derive
-the population mechanically rather than from memory -- it is every issue this
-run CLAIMED, minus the ones now CLOSED:
+has just deleted the branch your claim names, so what is left is a lock
+pointing at nothing: the next session reads "Working on this in branch <gone>"
+and either skips a free issue or has to prove you are finished. Derive the
+population mechanically — every issue this run CLAIMED, minus the ones now
+CLOSED:
 
 ```bash
 for n in <the issues you claimed>; do
@@ -213,23 +194,16 @@ for n in <the issues you claimed>; do
 done
 ```
 
-Every `OPEN` in that list needs a release comment. **They are exactly the
-partially-closed ones** -- a `Closes #N` PR auto-closes its issue and needs
-nothing, while a lane that shipped part of an umbrella said `Refs` on purpose,
-which auto-closes nothing. So the issues that keep a stale claim are the same
-ones a future session is most likely to pick up, which is what makes this worth
-a mechanical step rather than a habit.
-
-Say three things in the comment, because a bare "released" makes the next
-session re-derive what you already know: that the issue is now UNCLAIMED, what
-the merged PR actually closed, and what remains WITH the reason it was left --
-an unsettled trade-off and a missing design decision read very differently to
-someone deciding whether to start. Carry forward anything expensive the lane
-measured (a live arm it built, a population it derived, a family of bugs it
-found), so the next lane inherits the evidence rather than the diagnosis.
-
-A claim on an issue that DID auto-close needs nothing: a closed issue is not a
-lock, and commenting on it only adds noise.
+Every `OPEN` in that list needs a release comment — they are exactly the
+partially-closed ones (a `Closes #N` PR auto-closes; a lane that shipped part
+of an umbrella said `Refs` on purpose, which auto-closes nothing), the same
+ones a future session is most likely to pick up. Say three things, because a
+bare "released" makes the next session re-derive what you already know: the
+issue is now UNCLAIMED, what the merged PR actually closed, and what remains
+WITH the reason it was left. Carry forward anything expensive the lane measured
+(a live arm, a derived population, a family of bugs), so the next lane inherits
+the evidence rather than the diagnosis. A claim on an issue that DID auto-close
+needs nothing: a closed issue is not a lock.
 
 Do NOT stop here: what the run taught you is still only in this session's
 context, so go on to §10 — which also decides WHERE each lesson belongs (memory

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -69,9 +69,8 @@ gap / CC adapter). Anything non-maintainer → §0.
 
 **Pull `main` first — the backlog and your checkout can BOTH be behind.** A
 FRESH issue is the MOST likely stale: filed at the end of a lane against a
-`main` the filer had left behind — go-to-k/cdk-real-drift#1774 (2026-08-19)
-listed five asks, three shipped in go-to-k/cdk-real-drift#1772 three minutes
-earlier.
+`main` the filer had left behind (go-to-k/cdk-real-drift#1774 listed five asks,
+three shipped in go-to-k/cdk-real-drift#1772 three minutes earlier).
 
 MAIN-CHECKOUT — run THIS block, and not the next one:
 
@@ -126,15 +125,14 @@ git -C "<MAIN_CHECKOUT>/.worktrees/<w>" status --porcelain          # what it is
 two and the claim comment.** Before a lane's first commit its HEAD is still a
 `main` commit, so the first two probes describe someone ELSE's work — pointing
 the wrong way, not merely under-reporting (2026-08-19,
-go-to-k/cdk-real-drift#1779: probe 2 reported `.claude/skills/work-issues/SKILL.md`
-— a false collision — while the live lane was dirty on `docs/ARCHITECTURE.md`).
+go-to-k/cdk-real-drift#1779: probe 2 reported a false collision while the live
+lane was dirty on `docs/ARCHITECTURE.md`).
 
 Read "working on this" comments to the END of each thread, then on every issue
 the thread NAMES (`gh issue view <n> --comments`): a lane that cannot close an
-issue files the REMAINDER as a child and leaves the parent open, so the parent's
-live work can be owned by a claim that never appears on it (2026-08-19,
-go-to-k/cdkd#2035: go-to-k/cdkd#2018's closing comment named child
-go-to-k/cdkd#2026; a run that claimed the PARENT stood down when its remedies
+issue files the REMAINDER as a child and leaves the parent open, so the
+parent's live work can be owned by a claim that never appears on it
+(go-to-k/cdkd#2035: a run that claimed the PARENT stood down when its remedies
 hit the child's declared files). The claim is the WEAKEST file-ownership signal
 — written once, stale as scope grows (go-to-k/cdk-real-drift#1771's claim never
 named `docs/ARCHITECTURE.md`); dirty tree beats claim.
@@ -179,35 +177,31 @@ later runs `git worktree add` or does not.
 **run lanes SERIALLY** — a second CONCURRENT lane would need a worktree nested
 inside this one, which dies with the outer workspace and takes its uncommitted
 work (go-to-k/cdk-real-drift#1842). That serialization limit is stated HERE, in
-prose; the probe reports a mode, two paths and a branch, and carries no limit of
-its own.
-Rank as usual.
+prose; the probe reports a mode, two paths and a branch, and carries no limit
+of its own. Rank as usual.
 
-**It bounds CONCURRENT lanes, not the ISSUE COUNT** — and until 2026-09-03 this
-paragraph said "take ONE issue and finish it ... leave the rest for the next
-run", with the same limit restated in `references/launch-mode.md`'s IN-PLACE
-table row 1 and in `references/claim.md`; all three were corrected together.
-Sequential work in one tree nests nothing: a cdk-local run took FOUR issues one after another, each on a
-branch cut from `origin/main`, deleting the previous branch after its merge, with
+**It bounds CONCURRENT lanes, not the ISSUE COUNT.** Sequential work in one
+tree nests nothing: a cdk-local run took FOUR issues one after another, each on
+a branch cut from `origin/main`, deleting the previous branch after its merge,
 zero collisions. So several issues in one run is fine when they share this tree
-in SEQUENCE: claim them all UP FRONT (§4) with every lane after the first marked
-`QUEUED`, finish them one at a time, and if the run ends before reaching one,
-stand it down with a comment carrying the four classification fields — which
-leaves it visibly claimable rather than silently locked (the shape cdkd measured
-on 2026-09-02, go-to-k/cdkd#2417: three lanes claimed, one merged, two left
-pickup-ready). Claiming only the top candidate is still fine; the point is that a
-QUEUED issue is spoken for rather than abandoned. The old wording read a hazard
-about trees EXISTING AT THE SAME TIME as a budget on work, which is the one thing
-it does not constrain.
+in SEQUENCE: claim them all UP FRONT (§4) with every lane after the first
+marked `QUEUED`, finish them one at a time, and if the run ends before reaching
+one, stand it down with a comment carrying the four classification fields —
+visibly claimable rather than silently locked (the shape go-to-k/cdkd#2417
+measured: three claimed, one merged, two left pickup-ready). Claiming only the
+top candidate is still fine; a QUEUED issue is spoken for rather than
+abandoned. (Until 2026-09-03 this paragraph said "take ONE issue and finish
+it"; that read a hazard about trees existing at the same time as a budget on
+work — the one thing it does not constrain. The same limit was corrected in
+`references/launch-mode.md` row 1 and `references/claim.md` together.)
 
 **The MAIN-CHECKOUT case is the DISJOINTNESS PARAGRAPH below and nothing
 wider.** An earlier revision said "everything below is the MAIN-CHECKOUT case",
 which told an IN-PLACE run to skip the security-first ranking, the `Severity`
-ranking, the premise-check-against-`origin/main` rule and §3-a's freshness gate
-— all mode-independent, and the last a HARD gate. The rest of what IN-PLACE
-changes lives in `references/launch-mode.md`'s table, which maps ten
-consequences to §1, §2, §4, §5, §7, §9 and §10-d — the four this sentence used
-to name were an undercount.
+ranking, the premise checks and §3-a's freshness gate — all mode-independent,
+and the last a HARD gate. The rest of what IN-PLACE changes lives in
+`references/launch-mode.md`'s table, which maps ten consequences to §1, §2,
+§4, §5, §7, §9 and §10-d.
 
 **Two lanes must edit DISJOINT files** (same as the worktree rule): two issues
 both landing in `noise.ts` cannot be parallelized — bundle into ONE lane or
@@ -216,14 +210,13 @@ target file (grep the table name; read the issue's "Fix direction") before
 choosing. §3-a is a second HARD gate applied before any preference below.
 
 - **Security issues come FIRST** — the one class whose cost grows while it
-  waits (shipped behavior, possibly public report). Counts as security:
-  credential / secret handling, redaction / masking, a sensitive value
-  persisted or logged (`src/baseline/baseline-file.ts` or report output —
-  `src/report/redact.ts` is the usual file), IAM / role-assumption scope,
-  command injection, anything GHSA-tied; when in doubt, treat as security.
-  Urgency changes ORDER and waives §3-a's freshness gate; never verification
-  depth — same depth, plus a deliberate read of every place the sensitive value
-  flows.
+  waits. Counts as security: credential / secret handling, redaction / masking,
+  a sensitive value persisted or logged (`src/baseline/baseline-file.ts` or
+  report output — `src/report/redact.ts` is the usual file), IAM /
+  role-assumption scope, command injection, anything GHSA-tied; when in doubt,
+  treat as security. Urgency changes ORDER and waives §3-a's freshness gate;
+  never verification depth — same depth, plus a deliberate read of every place
+  the sensitive value flows.
 - **Then higher `Severity` first, when BOTH candidates carry it** (`high` >
   `medium` > `low`): it was MEASURED by the session that held the evidence, and
   **a proxy (title prefix, hunch) does not outrank the measurement it stands in
@@ -245,17 +238,16 @@ choosing. §3-a is a second HARD gate applied before any preference below.
 
 - **An issue's premise may not be TRUE YET — resolve the body against the tree
   before writing anything that depends on it.** A body written from an unmerged
-  branch describes THAT branch (2026-08-26, go-to-k/cdkd#2246: asked for a doc
-  note naming `nestedStackChildRegionFromLocalArn`; grep at claim time found
-  nothing — it landed 16 minutes later in go-to-k/cdkd#2266). **(1)** grep every
-  symbol / file / behaviour the body asserts, before the first edit; **(2)** on
-  an empty grep, `gh pr list --state all --search <symbol>` separates "premise
-  wrong" (post a correction on the issue) from "on an unmerged branch"
+  branch describes THAT branch (go-to-k/cdkd#2246 asked for a doc note naming a
+  symbol; grep at claim time found nothing — it landed 16 minutes later in
+  go-to-k/cdkd#2266). **(1)** grep every symbol / file / behaviour the body
+  asserts, before the first edit; **(2)** on an empty grep,
+  `gh pr list --state all --search <symbol>` separates "premise wrong" (post a
+  correction on the issue) from "on an unmerged branch"
   (`git fetch && git rebase origin/main`, carry on) — never read an empty grep
   as "the issue is wrong". **Verify the parts you are NOT changing, too** —
-  claims about SURROUNDING code get no compiler and no test (the same issue's
-  claim about the sibling producer's doc was wrong) — and say in the PR body
-  which of issue-vs-tree won.
+  claims about SURROUNDING code get no compiler and no test — and say in the PR
+  body which of issue-vs-tree won.
 - Same file, related class → **bundle** into a single lane/PR (e.g. two
   `revert/plan.ts` fixes → one PR "Subnet set-default + Lambda husk
   (go-to-k/cdk-real-drift#651, go-to-k/cdk-real-drift#650)").
@@ -372,40 +364,30 @@ The ladder, cheapest first — the SECOND entry, which looks like an ordinary
   unverifiable.
 
 **Then ask what the next session will have to RE-DERIVE.** The question above
-names the verification; this one names the cost of the gap between now and it.
-If you can point at something that exists only in THIS session — a table you
-measured, a probe you built, a shape you just proved correct in a sibling repo —
-the deferral is not free and the answer is `now`. Understanding survives in an
-issue body; a measurement does not, and neither does a fix whose correctness you
-established once and would have to establish again.
+names the verification; this one names the cost of the gap. If you can point
+at something that exists only in THIS session — a table you measured, a probe
+you built, a shape you just proved correct in a sibling repo — the deferral is
+not free and the answer is `now`. Understanding survives in an issue body; a
+measurement does not.
 
 **And "it needs its own PR" is NOT a `next` reason.** It is a `now` item that
 gets its own PR. The bar is the SESSION, not the diff — a separate review
-surface, a new file, a hook plus its suite plus its registration are all good
-reasons to split the PR and none of them is a reason to end the session.
-Writing "independent review surface" on a `Session-fit` line is the
-classify-by-MEANS error this section already forbids, arriving through the PR
-boundary instead of through the work's category.
-
+surface, a new file, a hook plus its suite are all reasons to split the PR and
+none is a reason to end the session. Writing "independent review surface" on a
+`Session-fit` line is the classify-by-MEANS error this section already forbids
 (2026-09-01: a hook missing from one sibling was filed `next` on exactly that
-wording — minutes after the same hook's two-directional defect had been
-measured and fixed in the other two repos. The probe, the corrected shape and
-the rc table were all in hand, and a later session would have re-derived all
-three. Re-classified `now` in the same session on the maintainer's challenge,
-and shipped; the port then found four more defects in the shape it was copying,
-none of which a fresh session would have known to look for.)
+wording, minutes after the same hook's defect had been measured and fixed in
+the other two repos — probe, corrected shape and rc table all in hand;
+re-classified `now` on the maintainer's challenge, and the port then found four
+more defects a fresh session would not have known to look for).
+
 **And when the issue body offers more than one fix, say which one the four
 fields cost.** Cost the CHEAPEST one you would actually accept. A deferral
 justified by the expensive option is not a measurement, it is a choice of
-comparand -- and the fields are supposed to be the measurement.
-
-(2026-09-02, an hour after the paragraph above went in: an issue was filed
-listing two fixes -- block the spelling in the gate that let the tree detach, a
-behaviour change across three repos, or teach the OTHER gate to recognise a
-detached HEAD, about six lines and no behaviour change. The `Session-fit: next`
-reason read "a behaviour change across three repos with its own review surface",
-which costs only the first. Nobody had decided which fix to take; the first one
-described became the one measured.)
+comparand (2026-09-02: an issue listed a three-repo behaviour change AND a
+six-line no-behaviour-change alternative; the `next` reason costed only the
+first — nobody had decided which fix to take, and the first one described
+became the one measured).
 
 Origin: go-to-k/cdk-local#560 was deferred on "a fixture / base-image change on
 a different axis" — the KIND of work, not who could check it. The defect was a

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -59,7 +59,9 @@ round to the delta and take its findings all at once, not trickled.
   call; if you add one, dry-run against stubs first.
 - **When a fix round produces the NEXT round's blocker twice, stop reviewing
   the patch and question its SHAPE** (`/verify-pr` step 5 re-reads the whole
-  diff each run). After round two, name what the rounds have in COMMON —
+  diff each run). Blockers in a cascade are found by executing a probe or
+  tracing a window, never by re-reading the diff. After round two, name what
+  the rounds have in COMMON —
   usually one structural absence — then take the NARROW fix, file the
   structural one, and reference it from the narrow fix; new code at round five
   is how round six happens.

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -8,11 +8,10 @@ Run `/verify-pr`. Its live-test rules decide how each PR is verified:
 editing it.** The `integ` gate is `hash: diff` over `src/**` and
 `tests/integration/**`: even a comment-only review fix to an in-scope file
 stales the marker and costs a full fixture run (three real-AWS runs of one
-fixture, the third for a zero-non-comment round — 2026-08-26,
-go-to-k/cdkd#2261). Tell the implementer to batch all remaining findings into
-ONE commit and report when the tree is FINAL — unsaid, it will re-verify per
-finding. Reviewer-side: scope the round to the delta and take its findings all
-at once, not trickled.
+fixture, the third for a zero-non-comment round — go-to-k/cdkd#2261). Tell the
+implementer to batch all remaining findings into ONE commit and report when the
+tree is FINAL — unsaid, it will re-verify per finding. Reviewer-side: scope the
+round to the delta and take its findings all at once, not trickled.
 
 - **fold / FP / classify fix** → the harvested **corpus** case is authoritative
   live data. If it is pinned by `vp test run corpus-replay` AND was live-proven
@@ -29,9 +28,7 @@ at once, not trickled.
     direction driven too. Run _the command your own diff changes_: the hook's
     own `.claude/hooks/<name>.test.sh`, the workflow step's own command, the
     changed task. `vp run check` format-checks `ci.yml` as text and never
-    EXECUTES a step or hook — a probe that cannot fail (2026-08-19:
-    `vp fmt --check .github/workflows/ci.yml` passes on any semantic change).
-    Measure as recorded below.
+    EXECUTES a step or hook — a probe that cannot fail (measured 2026-08-19).
   - **It changes PROSE only** (a skill, rule, doc — including this file) → the
     CLAIMS are the artifact; repeating an adjacent command 5× measures nothing.
     Resolve every gate, hook, skill, path, task and command the text names
@@ -50,86 +47,73 @@ at once, not trickled.
   When a fix keys on state an earlier step wrote, ask **which step writes it in
   the fixture, and which in the reachable case**; if they differ, add the arm
   where one operation does both, and prove it DISCRIMINATES by mutating the
-  fix: the ORIGINAL arm still passes, the new one fails — an arm failing with
-  the old one shows nothing new.
+  fix: the ORIGINAL arm still passes, the new one fails.
 - **A `cleanup` that ALSO runs before the run must not destroy anything the run
-  then needs.** `WORKDIR="$(mktemp -d …)"` at load time + `rm -rf "$WORKDIR"`
-  in `cleanup` + a pre-run `cleanup` call: the directory is gone before its
-  first write, and the symptom is a bare `No such file or directory` hundreds
-  of lines from the cause (cost a real-AWS cycle in cdkd). AWS resources are
-  immune — creating them IS a phase — a scratch path computed at
-  variable-definition time is not. Anything `cleanup` removes must be
-  re-created by a phase or created after the pre-run call. This repo's fixtures
-  arm `trap cleanup EXIT` with no pre-run call; if you add one, dry-run against
-  stubs first.
+  then needs.** A `WORKDIR="$(mktemp -d …)"` computed at load time, removed by
+  `cleanup`, called pre-run: the directory is gone before its first write, and
+  the symptom is a bare `No such file or directory` hundreds of lines from the
+  cause (cost a real-AWS cycle in cdkd). AWS resources are immune — creating
+  them IS a phase — a scratch path computed at variable-definition time is not.
+  Anything `cleanup` removes must be re-created by a phase or created after the
+  pre-run call. This repo's fixtures arm `trap cleanup EXIT` with no pre-run
+  call; if you add one, dry-run against stubs first.
 - **When a fix round produces the NEXT round's blocker twice, stop reviewing
   the patch and question its SHAPE** (`/verify-pr` step 5 re-reads the whole
-  diff each run and re-decides review depth at the final sha). Each fix is
-  locally correct and moves the failure one layer out; blockers are found by
-  executing a probe, never by re-reading the diff. After round two, name what
-  the rounds have in COMMON — usually one structural absence — then take the
-  NARROW fix, file the structural one, and reference it from the narrow fix;
-  new code at round five is how round six happens.
+  diff each run). After round two, name what the rounds have in COMMON —
+  usually one structural absence — then take the NARROW fix, file the
+  structural one, and reference it from the narrow fix; new code at round five
+  is how round six happens.
 
   **Filing the structural fix does not STOP the cascade**
-  (go-to-k/cdk-local#596, 2026-08-27: filed at round five, ran to TWELVE —
-  eleven instances of one defect class in one PR, five introduced by fixes).
-  What ended it: making the artifact **CLAIM LESS** — the sweep now prints raw
-  output and names both outcomes instead of a verdict, because a command that
-  claims nothing cannot claim something false. The tell is each fix being more
-  SOPHISTICATED than the last while the plain rc-only sweeps beside it were
-  right throughout: `grep -q 'does not exist'` also matches botocore's
-  `The source_profile ... does not exist`, raised before any network call, so
-  a broken profile reported CLEAN having queried nothing. The sophistication
-  WAS the defect; expect the fix to feel like a retreat — it converges.
+  (go-to-k/cdk-local#596: filed at round five, ran to TWELVE — eleven instances
+  of one defect class in one PR, five introduced by fixes). What ended it:
+  making the artifact **CLAIM LESS** — printing raw output and naming both
+  outcomes instead of a verdict, because a command that claims nothing cannot
+  claim something false. The tell: each fix more SOPHISTICATED than the last
+  while the plain rc-only sweeps beside it were right throughout
+  (`grep -q 'does not exist'` also matched botocore's
+  `The source_profile ... does not exist`, raised before any network call, so a
+  broken profile reported CLEAN having queried nothing). Expect the fix to feel
+  like a retreat — it converges. Corollaries, both paid for there:
 
-  Corollaries, both paid for there:
   - **Fence the REMEDIATION, not just the detection.** A destroy built from
-    names missing a required suffix exits 0 SILENTLY — success read with the
-    resources still deployed; every fence pinned the DETECTION, so restoring
-    that line left the suite green. If a procedure both detects and repairs,
-    the repair is where the next instance goes.
-  - **Do not pre-commit to a remedy for a finding you have not seen.** "If
+    names missing a required suffix exits 0 SILENTLY; every fence pinned the
+    DETECTION, so restoring that line left the suite green. If a procedure both
+    detects and repairs, the repair is where the next instance goes.
+  - **Do not pre-commit to a remedy for a finding you have not seen.** Say what
+    the next finding would have to SHOW, not what you will do about it ("if
     instance nine appears, delete the whole thing" — when it arrived, deleting
-    would have left NO check at all. Say what the next finding would have to
-    SHOW, not what you will do about it.
+    would have left NO check at all).
 
   Two shapes recur, distinguishable a round apart:
-  - **TWO SPELLINGS OF ONE QUESTION** — make both sites use ONE predicate
-    verbatim; a better second spelling passes its own test and regenerates the
-    cascade. Name the SITE THAT OWNS the question; every other site calls or
-    copies it exactly (go-to-k/cdkd#2134: ended only when the authority's test
-    was copied character for character — the round before, the spellings still
-    disagreed on the empty string, fail-OPEN).
+
+  - **TWO SPELLINGS OF ONE QUESTION** — name the SITE THAT OWNS the question;
+    every other site calls or copies its predicate VERBATIM (go-to-k/cdkd#2134
+    ended only when the authority's test was copied character for character — a
+    better second spelling passes its own test and regenerates the cascade).
   - **A PROXY FOR A QUESTION ONLY ANOTHER COMPONENT CAN ANSWER** — make that
     component REPORT. The tell: each proxy is wrong in BOTH directions at once
-    (misses real cases AND fires on unreal ones; two spellings merely disagree
-    at an edge). When a fix lands on a new OBSERVABLE — "it threw", "the text
-    survived", "a marker exists" — ask whether the fact is derivable outside
-    the component that decides it; if not, the rounds are unbounded
-    (go-to-k/cdkd#2157 / go-to-k/cdkd#2166: "it THREW" missed the
-    warn-and-continue path and over-reported an unrelated failure in the same
-    bag; "raw text SURVIVED" missed downstream rewrites, broke on JSON
-    escaping, fired on PROSE mentioning the syntax). Drift analogue: any
-    question only AWS's own readback can answer — "genuinely drifted, or never
-    returned by the provider?" — which is why the corpus outranks any predicate
-    reasoned about in isolation.
+    (misses real cases AND fires on unreal ones). When a fix lands on a new
+    OBSERVABLE — "it threw", "the text survived", "a marker exists" — ask
+    whether the fact is derivable outside the component that decides it; if
+    not, the rounds are unbounded (go-to-k/cdkd#2157 / go-to-k/cdkd#2166).
+    Drift analogue: any question only AWS's own readback can answer — which is
+    why the corpus outranks any predicate reasoned about in isolation.
 
 - **WITHDRAWING the half that cannot be made right is a legitimate outcome, and
   the residual issue must carry the MEASUREMENTS, not just the diagnosis** —
   each proxy tried, the input that broke it, the number it produced; a
-  diagnosis alone makes the next session re-run every probe. Worked example:
-  go-to-k/cdkd#2166 (three rounds of measurements plus a live arm written,
-  passed, mutation-probed, then reverted — none of it rebuilt).
+  diagnosis alone makes the next session re-run every probe (worked example:
+  go-to-k/cdkd#2166).
 - **When two reviewers CONTRADICT each other, settle it in the code YOURSELF
   before forwarding either** — forwarding both hands the implementer a
   contradiction with LESS context than you have; forwarding only the reassuring
   one is how a blocker ships. Read the disputed lines; say which reviewer was
-  right and why — routine whenever a lane, or you, dispatch read-only reviewers
-  (see the round below, which this repo has no ladder to run for you).
+  right and why.
 
   What to measure in the command arm (all confirmed here 2026-08-19,
   go-to-k/cdk-real-drift#1768):
+
   - **An exit code can lie in EITHER direction, so drive both.** _Non-zero
     meaning nothing_: `vp run check` exited **134** on a clean tree with **0
     errors** (Vite+ stdout `EAGAIN` panic), deterministic 3/3 per state, 0
@@ -138,40 +122,35 @@ at once, not trickled.
     code turning a RED tree green — hence
     `tests/vp-run-check-redirect-1761.test.ts` asserting the `exit 1` survives.
     _Zero meaning nothing_: no measured case here; cite the sibling's
-    go-to-k/cdk-local#504 (`vp test run` rc=0,0,1,0,1 across five identical
-    all-passing runs) as the sibling's, and measure the command YOU changed.
+    go-to-k/cdk-local#504 as the sibling's, and measure the command YOU
+    changed.
   - **`vp pack` BEFORE reading any `vp run test` verdict in a fresh worktree —
     and re-run a red from that one file before believing it.** No `dist/`
     fails 13 tests of `tests/json-empty-on-error.test.ts` deterministically
     (they spawn the built CLI); with `dist/` freshly packed, three of the 13
     failed once and the identical re-run went 343/343 rc=0. Tell them apart by
-    the COUNT — 13 failures means no `dist/`, fewer means the flake — and
-    never let a single red run stand as the verdict.
+    the COUNT — 13 means no `dist/`, fewer means the flake — and never let a
+    single red run stand as the verdict.
   - **The COUNT stops discriminating once the host is loaded; re-run at
     `--maxWorkers=4` instead.** Every suite that SPAWNS the built CLI or `vp`
-    itself is racing the machine's other agents for cores, and a 5,000 ms
-    default timeout is what gives way first — so the reds land in whichever
-    subprocess suites the run happened to schedule during the crunch, at a
-    count that says nothing about `dist/`. Measured 2026-09-02
-    (go-to-k/cdk-real-drift#1854): `json-empty-on-error` plus
-    `markdown-fmt-corruption-1771` failed 10, then 13, then 14 tests across
-    three full runs with `dist/` freshly packed; both files passed run in
-    ISOLATION, and one `vp test run --maxWorkers=4` over the whole suite was
-    352 files / 6,665 tests green. The sibling go-to-k/cdkd reproduced the same
-    class within the hour — a 5,000 ms test failing twice under load, then 3/3
-    once the parallel lanes finished. So the discriminator is the RE-RUN SHAPE,
-    not the count: isolation, reduced parallelism, and simply waiting for the
-    host to quiesce turn a load artifact green while leaving a real failure red.
-    Measure the host before believing any of them — the same day, at
-    `load average 137` with 40 `vitest` processes from peer lanes, `--maxWorkers=4`
-    was no longer enough and one test still timed out running its file ALONE.
-    `uptime` costs nothing and tells you whether the machine, not the diff, is
-    the subject.
+    is racing the machine's other agents for cores, and the 5,000 ms default
+    timeout gives way first — reds land in whichever subprocess suites the run
+    scheduled during the crunch, at a count that says nothing about `dist/`.
+    Measured 2026-09-02 (go-to-k/cdk-real-drift#1854): two files failed 10,
+    then 13, then 14 tests across three full runs with `dist/` freshly packed;
+    both passed in ISOLATION, and one `vp test run --maxWorkers=4` over the
+    whole suite was 352 files / 6,665 tests green. The discriminator is the
+    RE-RUN SHAPE, not the count: isolation, reduced parallelism, and waiting
+    for the host to quiesce turn a load artifact green while leaving a real
+    failure red. Measure the host first — the same day, at `load average 137`,
+    `--maxWorkers=4` was no longer enough and one test timed out running its
+    file ALONE. `uptime` costs nothing and tells you whether the machine, not
+    the diff, is the subject.
   - **Repeating a `vp run <task>` DOES re-execute here** — `check` (5/5) and
     `test` (3/3) reported `not cached because it modified its input`. Do not
-    import the sibling's cache-hit warning; the local cache trap (PR
-    go-to-k/cdk-real-drift#438: a cached GREEN `typecheck` masked a real
-    TS1117) is already handled by `cache: false` in `vite.config.ts`.
+    import the sibling's cache-hit warning; the local cache trap
+    (go-to-k/cdk-real-drift#438) is already handled by `cache: false` in
+    `vite.config.ts`.
   - **Inject the failure anywhere LINTED — here that includes the tests
     tree.** A non-underscore-prefixed unused variable fails `vp run check`
     rc=1 from `src/` AND from `tests/` (`lint.ignorePatterns` re-includes the
@@ -179,9 +158,9 @@ at once, not trickled.
     source-only, so its "never inject into the tests tree" clause is FALSE
     here — the drift §10-c's per-repo check exists to catch.
   - **Then guard the SHAPE of the fix**, since nothing else re-checks a config
-    or hook line: a unit test on the config object for a build-config change
-    (the go-to-k/cdk-real-drift#1765 test above), or the standalone hook suite
-    for a `.claude/hooks/` change — which §5 notes you must run BY HAND.
+    or hook line: a unit test on the config object for a build-config change,
+    or the standalone hook suite for a `.claude/hooks/` change — which §5
+    notes you must run BY HAND.
 
   Both arms end in writing, and `vp fmt` mangles a paragraph that uses bold
   AND contains a double-star glob inside a code span — it corrupted this very
@@ -197,22 +176,22 @@ at once, not trickled.
   real AWS calls (STS + CloudFormation DescribeStacks) and exits 0 with "not
   deployed yet — skipped", so the transport is exercised end-to-end with
   nothing to sweep and no sentinel armed. The oracle is whatever observes the
-  transport — for go-to-k/cdk-real-drift#1841 (PR
-  go-to-k/cdk-real-drift#1852) a ~25-line local logging HTTP CONNECT proxy
-  proved every call tunneled, plus dead-proxy (no silent direct fallback),
-  `NO_PROXY` bypass, and no-proxy control arms. Reach for the deploy tier below
-  only when the change needs a real RESOURCE, not just real calls.
+  transport — for go-to-k/cdk-real-drift#1841 (PR go-to-k/cdk-real-drift#1852)
+  a ~25-line local logging HTTP CONNECT proxy proved every call tunneled, plus
+  dead-proxy, `NO_PROXY` bypass, and no-proxy control arms. Reach for the
+  deploy tier below only when the change needs a real RESOURCE.
 - **revert / read HOT-PATH fix** → live-verify with a MINIMAL, UNIQUE-named
   fixture: deploy → mutate out of band → `check` detects → `revert --yes`
   converges → confirm the live value. A throwaway CDK app works:
   `/tmp/<name>/app.cjs` (require-style CJS so classic module resolution works;
   **ESM `import` ignores `NODE_PATH`**), and `ln -s <repo>/node_modules
-node_modules` to borrow `aws-cdk-lib` (rm any existing dir first — `ln -sfn` into
-  an existing dir nests a symlink). Inline/no-asset stacks need no bootstrap. Build
-  the FIX binary with `vp pack` and run `node "<LANE_TREE>/dist/cli.js"` —
-  the absolute path from the launch-mode probe, not `.worktrees/<w>/…`, which
-  is wrong twice: it is relative to the main checkout, and an IN-PLACE launch
-  tree (an Orca/ADE workspace) need not live under `.worktrees/` at all.
+node_modules` to borrow `aws-cdk-lib` (rm any existing dir first — `ln -sfn`
+  into an existing dir nests a symlink). Inline/no-asset stacks need no
+  bootstrap. Build the FIX binary with `vp pack` and run
+  `node "<LANE_TREE>/dist/cli.js"` — the absolute path from the launch-mode
+  probe, not `.worktrees/<w>/…`, which is wrong twice: it is relative to the
+  main checkout, and an IN-PLACE launch tree need not live under `.worktrees/`
+  at all.
 
 **Fresh deploys: UNIQUE hunt-style stack names only** (`Cdkrd<issue>Verify`),
 never a shared fixed name and never a real prod stack — the account may hold
@@ -251,112 +230,93 @@ this repo has no ladder to fall back on.** A lane's reviewers are its children
 — same brief, same framing — so they clear what the lane already believes, and
 here nothing mechanical catches that: there is no multi-agent reviewer set and
 no review-tier skill, and the `pr-review` entry in `.markgate.yml` is wired to
-no hook. Measured on the sibling go-to-k/cdkd#2383 (2026-08-29), which runs a reviewer
-ladder this repo does not: three rounds of the LANE's own reviewers each found
-the next spelling of one defect, and it took an independent
-orchestrator-level round to find the last one — a YAML merge key, the spelling
-the lane's own raw-text tripwire had been added specifically to backstop and
-did not fire on. This repo's go-to-k/cdk-real-drift#1838 spent its own rounds
-on the same class, its flow-style `exclude:` staying green through the first
-fix for it. So the depth is your own read of the whole diff plus a round you
-dispatch yourself, and a lane's clean round is evidence about the lane's
-assumptions, not about the diff.
+no hook. Measured on the sibling go-to-k/cdkd#2383 (which runs a reviewer
+ladder this repo does not): three rounds of the LANE's own reviewers each found
+the next spelling of one defect, and it took an independent orchestrator-level
+round to find the last one. This repo's go-to-k/cdk-real-drift#1838 spent its
+own rounds on the same class. So the depth is your own read of the whole diff
+plus a round you dispatch yourself; a lane's clean round is evidence about the
+lane's assumptions, not about the diff.
 
 **Reviewer subagents spawned BY A LANE report to the MAIN session, not to the
 lane that spawned them.** Completion notifications go to the top-level session,
 so a lane that dispatches reviewers and then waits on their reports waits for
-something that cannot arrive, while the parent collects verdicts it did not ask
-for and may not connect to a lane. Measured 2026-09-02 (go-to-k/cdkd#2417): a
-lane's two reviewers both delivered upward, the lane blocked, and the parent
-relayed both verdicts by hand. Pick one shape and say which in the dispatch: the
-lane runs its reviewers **synchronously** (so it holds its own turn until they
-return), or the **parent owns the review dispatch** and relays each verdict down
-— the latter under §9's queued-versus-`Resuming` rule, because a lane waiting on
-a review is stopped at exactly the moment the relay is sent.
+something that cannot arrive (measured: go-to-k/cdkd#2417 — a lane blocked ~5
+minutes; the parent relayed both verdicts by hand). Pick one shape and say
+which in the dispatch: the lane runs its reviewers **synchronously** (holding
+its own turn until they return), or the **parent owns the review dispatch** and
+relays each verdict down — the latter under §9's queued-versus-`Resuming` rule,
+because a lane waiting on a review is stopped at exactly the moment the relay
+is sent.
 
 **A reviewer's scratch COPY of a worktree is not detached from git, so its
 `git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
 holding `gitdir: <repo>/.git/worktrees/<name>`, and `cp -R` carries the
 pointer: every git command inside the copy reads and WRITES the real worktree's
-index and HEAD. Measured 2026-08-29 in the sibling cdkd, where a read-only code
-reviewer copied a lane's worktree, ran `git add -A` there, and staged three
-tracked DELETIONS in the live tree that the lane's next commit would have
-shipped — nothing announced it, because the reviewer believed it was on a copy.
-Two lines therefore belong in every read-only reviewer's brief: **run no
-WRITING git verb** (`add` / `commit` / `restore` / `checkout` / `stash` /
-`clean`) anywhere, copy included — and if you must copy, copy OUTSIDE every
-repository, since deleting the `.git` file does not detach the copy, it only
-makes discovery walk UPWARD into whatever encloses it; and **report the TARGET
-worktree's `git status --porcelain` before AND after the round.** The pair is what makes damage attributable rather
-than a mystery a later agent finds: that incident surfaced only because the
-NEXT reviewer volunteered "the tree went dirty mid-review, not mine", after
-which the responsible one repaired the index with `git restore --staged` (index
-only, never the working tree). This repo's lanes live under a `.worktrees/`
-directory, so the hazard is identical here.
+index and HEAD (measured 2026-08-29 in the sibling cdkd: a read-only reviewer's
+`git add -A` in a copy staged three tracked DELETIONS in the live tree, and
+nothing announced it). Two lines belong in every read-only reviewer's brief:
+**run no WRITING git verb** (`add` / `commit` / `restore` / `checkout` /
+`stash` / `clean`) anywhere, copy included — and if you must copy, copy OUTSIDE
+every repository, since deleting the `.git` file does not detach the copy, it
+only makes discovery walk UPWARD; and **report the TARGET worktree's
+`git status --porcelain` before AND after the round** — the pair is what makes
+damage attributable (that incident surfaced only because the NEXT reviewer
+volunteered "the tree went dirty mid-review, not mine"; the responsible one
+repaired the index with `git restore --staged` — index only, never the working
+tree). This repo's lanes live under `.worktrees/`, so the hazard is identical.
 
 ### 8-z. When a mutation probe reports NO discrimination
 
 **First, a rule that applies BEFORE any probe runs: COMMIT the round's real
-fixes, then probe.** The reason is DESTRUCTIVE, not merely tidy: a probe's
-restore puts the subject back to the bytes it held when the snapshot was TAKEN,
-so it reverts anything committed NOWHERE. A lane lost 133 lines of newly written
-tests exactly that way (go-to-k/cdkd#2457) — its harness restored a snapshot
-predating those tests, and no commit, stash or reflog held them. Committing first is what makes the
-restore lossless. `references/implement.md`'s byte-exact `shasum`-verified
-restore is the OTHER half and does not cover this one: it guarantees the subject
-comes back unmangled, which is a promise about the snapshot's bytes, not about
-work the snapshot never contained.
-
-The milder consequence is attribution, and it is why the rule is worth stating
-even when nothing is lost: a probe deliberately breaks the tree, so an
-interruption mid-probe (a session limit, a crash) leaves deliberate breakage and
-unfinished fixes in ONE undifferentiated dirty tree. Measured 2026-09-02 on the
-go-to-k/cdk-real-drift#1841 lane: the subagent died at the 5-hour session limit
+fixes, then probe.** The reason is DESTRUCTIVE: a probe's restore puts the
+subject back to the bytes it held when the snapshot was TAKEN, so it reverts
+anything committed NOWHERE — a lane lost 133 lines of newly written tests that
+way (go-to-k/cdkd#2457); no commit, stash or reflog held them. Committing first
+makes the restore lossless. `references/implement.md`'s byte-exact
+`shasum`-verified restore is the OTHER half: it guarantees the subject comes
+back unmangled — a promise about the snapshot's bytes, not about work the
+snapshot never contained. The milder consequence is attribution: a probe
+deliberately breaks the tree, so an interruption mid-probe leaves deliberate
+breakage and unfinished fixes in ONE undifferentiated dirty tree (measured on
+the go-to-k/cdk-real-drift#1841 lane: a subagent died at the session limit
 mid-probe with 9 dirty files, and the resuming session had to read the full
-diff to establish that none of it was probe wreckage before it could commit.
-With a pre-probe commit the separator is just `git diff` — anything unstaged
-after a probe is the probe's.
+diff before it could commit). With a pre-probe commit the separator is just
+`git diff` — anything unstaged after a probe is the probe's.
 
 **A probe that reports NO discrimination is a claim about the FENCE, and four
 other things produce the identical output.** Ask them in order before touching
 the fence. The first three and the fixture shape below each nearly cost a
 working assertion in one session (2026-08-25); item 4 was added later, from a
-different run, which is why the attribution names a session rather than the
-whole list:
+different run:
 
 1. **Did the edit land?** `sed`/`perl` one-liners fail silently as "no match":
-   a `perl -0pi -e "s|^\|...|...|m"` delimited by the same `|` it escapes
-   matches nothing; a `sed -E`-only alternation (`\|`) is a GNU extension
-   matching nothing on macOS; a `sed: bad flag` prints ABOVE the suite output
-   and scrolls past. Prove it with `grep -c '<the mutated text>'` before
-   reading the result, and prefer `python3` with an `assert anchor in s` — an
-   assertion that throws is louder than a quoting slip that quietly matches
-   zero.
+   a `perl -0pi -e` delimited by the same `|` it escapes matches nothing; a
+   `sed -E`-only alternation (`\|`) is a GNU extension matching nothing on
+   macOS; a `sed: bad flag` prints ABOVE the suite output and scrolls past.
+   Prove it with `grep -c '<the mutated text>'` before reading the result, and
+   prefer `python3` with an `assert anchor in s` — an assertion that throws is
+   louder than a quoting slip that quietly matches zero.
 2. **Does the case's execution path REACH the edited line?** Breaking a hook's
    branch-lookup call left its suite fully green: every case carried an
-   explicit PR number, so the lookup never ran. The fence was fine; the probe
-   was aimed outside the cases' path. The fix is a case that HAS to take that
-   path, not a change to the fence.
+   explicit PR number, so the lookup never ran. The fix is a case that HAS to
+   take that path, not a change to the fence.
 3. **Did the command run where you think it did?** A relative-path edit under a
    silently reset cwd lands in another worktree, and the confirming
    `git status` runs in that same wrong tree — "clean" and "clean somewhere
    else" print identically. Use ABSOLUTE paths and confirm by a property the
    wrong tree cannot fake (`ls -la` mtime).
-
 4. **Did the suite RUN, or did it only print a summary?** A mutation is an
-   EDIT, so it can break the FILE rather than the assertion: delete a single
-   `if` line and the resulting parse error makes `vp test run` print
-   `Tests  no tests` — a summary line that EXISTS but carries no digits. A parse that reads
-   a number out of it sees zero failures and reports the fence UNFENCED, which
-   is the same verdict a genuinely weak fence produces, so the probe's headline
-   finding is indistinguishable from its own breakage. Three conditions, all
-   cheap, and this repo's own §8 note that an exit code lies in BOTH directions
-   is why none of them can be replaced by reading `$?`: the summary must contain
-   DIGITS; the TOTAL must equal a BASELINE recorded before the first probe; and
-   no file may report a file-level FAIL while its case failures are zero. The
-   population check is the one that earns its keep — a whole file silently not
-   loading leaves every OTHER file's count intact, so digits alone still read as
-   green.
+   EDIT, so it can break the FILE rather than the assertion: a parse error
+   makes `vp test run` print `Tests  no tests` — a summary line that EXISTS but
+   carries no digits, so a parse reading a number out of it reports the fence
+   UNFENCED, indistinguishable from a genuinely weak fence. Three conditions,
+   all cheap (and none replaceable by `$?` — this file's own note that an exit
+   code lies in BOTH directions): the summary must contain DIGITS; the TOTAL
+   must equal a BASELINE recorded before the first probe; and no file may
+   report a file-level FAIL while its case failures are zero. The population
+   check earns its keep — a whole file silently not loading leaves every OTHER
+   file's count intact, so digits alone still read as green.
 
 And one shape inside the fixture itself: **an expected value must be an
 INDEPENDENT variable from the one under test.** A stub keyed its content on a
@@ -370,18 +330,16 @@ guard gets removed.
 
 The original four shapes were ported from cdkd, all measured in one session
 (go-to-k/cdkd#2197 / go-to-k/cdkd#2200 / go-to-k/cdkd#2198); the mechanism is
-the shell and the tooling, not anything cdkd-specific, so they apply here
-unchanged. Item 4 was added on 2026-09-03 and did NOT come from that session.
+the shell and the tooling, not anything cdkd-specific. Item 4 was added on
+2026-09-03 and did NOT come from that session.
 
 **When you add a shape here, fix every place that COUNTS it — and only half of
 them contain a digit that moves.** Adding item 4 touched four places, of which
-exactly TWO carried a changed numeral: the "N other things" opener (three ->
-four) and the "all N" closer (four -> five). The other two kept their numeral
-and moved their SCOPE — the port note still reads "four shapes", now narrowed to
-the ORIGINAL four, and the session-attribution still names one session, now
-narrowed to the first three plus the fixture shape. So a sweep for changed
-digits returns half of the work and looks complete, which is worse than
-returning none; and only the closer sits anywhere near the list. `references/launch-mode.md`
-records the same failure on its IN-PLACE table ("Four things" left standing
-after the rows grew), which is the second instance of it in this skill: a count
-written beside a list is maintained, a count written a paragraph away is not.
+exactly TWO carried a changed numeral (the "N other things" opener and the
+"all N" closer); the other two kept their numeral and moved their SCOPE (the
+port note narrowed to the ORIGINAL four, the session attribution to the first
+three plus the fixture shape). A sweep for changed digits returns half of the
+work and looks complete, which is worse than returning none.
+`references/launch-mode.md` records the same failure on its IN-PLACE table — a
+count written beside a list is maintained, a count written a paragraph away is
+not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,8 +532,8 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
     shell's, not git's, and counting them as arguments once relaxed a real
     switch to "file restore" (measured; the round-2 rc tables live in this
     file's git history). Each verb carries its COMPLETE long-option table with per-name
-    arity, because git accepts any unambiguous PREFIX of a long name (`--orph
-<b>` is the branch creation it abbreviates) and the `parse-options`
+    arity, because git accepts any unambiguous PREFIX of a long name
+    (`--orph <b>` is the branch creation it abbreviates) and the `parse-options`
     built-ins absent from `-h` (`--end-of-options`,
     `--git-completion-helper`, `--help-all`, ...) are in the tables at arity 0
     — `--end-of-options` ends the OPTIONS without giving the next token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,16 +271,15 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     (no `src/**` in the diff), which the gate lets through on `check` + `docs`.
     Run the relevant skill before committing or opening the PR.
   - **Hash modes**: `check` / `docs` hash file CONTENT (`hash: files`) — the
-    stricter mode, kept because re-running them is cheap. The inert `integ` gate is
-    the ONE gate on `hash: diff` (markgate 0.4+, #1756): it digests this branch's
-    delta against `merge-base(origin/main, HEAD)` restricted to its include set, so
-    a merge from `main` touching an UNRELATED in-scope file no longer forces a
-    re-run of an expensive real-AWS verification, while a same-file change and any
-    local in-scope edit still stale it. A diff gate ERRORS (exit 2) when run from a
-    clean base branch. The invalidations it removes are provably uninformative; the
-    risk it accepts — undetected cross-FILE interaction, which by definition sits in
-    the zero-overlap cases — is bounded but NOT quantified. Full rationale in
-    `.markgate.yml`.
+    stricter mode, kept because re-running them is cheap. The inert `integ`
+    gate is the ONE gate on `hash: diff` (markgate 0.4+, #1756): it digests
+    this branch's delta against `merge-base(origin/main, HEAD)` restricted to
+    its include set, so an unrelated in-scope merge from `main` no longer
+    stales an expensive real-AWS verification, while a same-file change and any
+    local in-scope edit still do; it ERRORS (exit 2) from a clean base branch.
+    The invalidations removed are provably uninformative; the accepted risk —
+    undetected cross-FILE interaction — is bounded but NOT quantified. Full
+    rationale in `.markgate.yml`.
   - `/hunt-bugs` is the (non-marker) skill that drives a periodic real-AWS bug-hunt:
     deploy UNCOVERED, high-frequency resource types / configs / CFn notations, then
     catch false positives (clean `record`→`check` must be CLEAN) and missed
@@ -300,240 +299,173 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     go-to-k/cdk-real-drift#1844. Run **`/sweep-resources`** to do the
     cleanup + release the gate.
 - **`issue-dup-check-gate` — the one PreToolUse gate that is not a markgate gate.**
-  It blocks `gh issue create`, and the REST mint `gh api repos/<o>/<r>/issues`,
-  unless the body carries a `Dup-check:` line recording that the OPEN issue list was
-  searched for an issue already naming this root cause (`/work-issues` §5 has the
-  search + fold-into-a-checklist-row recipe). `gh issue edit` / `gh issue comment` are
-  deliberately NOT gated: folding a finding into the issue that already covers its
-  root cause is the outcome the gate steers toward, so taxing it would penalise the
-  cheap path and leave the costly one free. It never asks you to drop a finding — §10-0
-  is explicit that an unfiled finding is strictly worse than a filed one; it changes
-  only WHERE the finding is written. Scoped by repo opt-in (`.markgate.yml` at the
-  resolved cwd's repo root), so filing into an unrelated personal repo is not refused.
-  **The local case for it is prophylactic and weaker than either sibling's** — this
-  repo had ZERO open issues on 2026-08-25 and no verified duplicate filing, unlike
-  cdkd (a non-converging count) and cdk-local (two duplicates nine minutes apart,
-  go-to-k/cdk-local#528 / go-to-k/cdk-local#531) —
-  and the gate's own header says so rather than borrowing their numbers.
-  `gh -R <owner/repo> issue create` — the cross-repo mirror flow's own spelling, and
-  therefore this gate's primary shape — IS matched: the shared `GATE_GH_C` absorbs
-  the repo flags in every spelling `gh` accepts (space, `=`, and glued `-Ro/r`).
+  It blocks `gh issue create` (and the REST mint `gh api repos/<o>/<r>/issues`)
+  unless the body carries a `Dup-check:` line recording that the OPEN issue list
+  was searched for an issue already naming this root cause (`/work-issues` §5 has
+  the search + fold-into-a-checklist-row recipe). `gh issue edit` /
+  `gh issue comment` are deliberately NOT gated: folding a finding into the
+  issue that already covers its root cause is the outcome the gate steers
+  toward, so taxing it would penalise the cheap path. It never asks you to drop
+  a finding — §10-0 is explicit that an unfiled finding is strictly worse than a
+  filed one; it changes only WHERE the finding is written. Scoped by repo opt-in
+  (`.markgate.yml` at the resolved cwd's repo root), so filing into an unrelated
+  personal repo is not refused. The local case is prophylactic and weaker than
+  either sibling's — zero open issues here on 2026-08-25 and no verified
+  duplicate, versus cdk-local's two duplicates nine minutes apart
+  (go-to-k/cdk-local#528 / go-to-k/cdk-local#531) — and the gate's own header
+  says so rather than borrowing their numbers.
+  `gh -R <owner/repo> issue create` — the cross-repo mirror flow's own spelling,
+  and therefore this gate's primary shape — IS matched: the shared `GATE_GH_C`
+  absorbs the repo flags in every spelling `gh` accepts (space, `=`, and glued
+  `-Ro/r`).
 - **Naming the repo must never change a gate's verdict, and twice it did.** On
   2026-08-25, `gh -R <owner/repo> pr merge 1 --squash` matched NOTHING in
-  `verify-pr-gate`, `ci-green-gate` and `bughunt-clean-gate` — each measured at
-  exit 2 for the plain form and exit 0 for the `-R` form, i.e. a live bypass of
-  `/verify-pr`, of red CI, and of the un-deleted-AWS-resources check. Two causes,
-  both worth remembering: the shared `GATE_GH_C` absorbed only `-C <path>`, AND
-  those three gates each HAND-ROLLED their own copy of the verb regex, so they
-  would not have inherited a fix to the shared one anyway. Both are closed —
-  `GATE_GH_C` is now `GATE_FLAGS`-style tokenisation (covering space, `=`, and the
-  glued `-Ro/r` that a hand-written flag list misses), and every gate derives its
-  trigger from the shared constants via `gate_re_any` — `branch-gate` was a FOURTH
-  hand-rolled copy, frozen at the pre-`GATE_FLAGS` token, so
-  `git -C "<path with a space>" commit` committed straight to main (rc=0 quoted
-  vs rc=2 unquoted). Two follow-on rules the same audit produced: **matching a
-  flag is not the same as honouring it** — `-R` was absorbed and then discarded,
-  so `gh -R foreign/repo pr merge 5` had each gate inspect THIS repo and permit a
-  merge in one it never looked at, and the three gates that audit repo-specific
+  `verify-pr-gate`, `ci-green-gate` and `bughunt-clean-gate` — measured exit 2
+  plain, exit 0 flagged: a live bypass of `/verify-pr`, of red CI, and of the
+  cleanup check. Two causes, both closed: the shared `GATE_GH_C` absorbed only
+  `-C <path>`, AND those three gates each HAND-ROLLED their own verb regex, so
+  a shared fix would not have propagated. `GATE_GH_C` is now `GATE_FLAGS`-style
+  tokenisation (space, `=`, and the glued `-Ro/r` a hand-written list misses),
+  and every gate derives its trigger from the shared constants via
+  `gate_re_any` — `branch-gate` was a FOURTH hand-rolled copy, frozen at the
+  pre-`GATE_FLAGS` token, so `git -C "<path with a space>" commit` committed
+  straight to main. Follow-on rules from the same audit: **matching a flag is
+  not the same as honouring it** — `-R` was absorbed and then discarded, so
+  `gh -R foreign/repo pr merge 5` had each gate inspect THIS repo and permit a
+  merge in one it never looked at; the three gates that audit repo-specific
   state now REFUSE a foreign `-R` by name (issue-dup-check is exempt: for the
-  cross-repo mirror flow the cwd decides policy and `-R` only decides where the
-  issue lands). And **the selector must come from the matched verb in the matched
-  segment**: `gh` accepts `gh pr merge --squash 1` as readily as
-  `gh pr merge 1 --squash`, and a quoted `gh pr merge 9` inside a `--body` must
-  not donate its number to a later bare merge — both are `gate_pr_selector`'s job
-  now, along with consuming flag VALUES (`gh pr merge -t msg 2195` resolved `msg`,
-  and `--body-file 7 2195` audited PR 7). Two rules came out of that one, both
-  reusable: **enumerate the VALUELESS flags, never the value-takers** — the list
-  goes stale either way, and the safe direction is an unlisted flag eating the
-  number (empty selector, caller falls back) rather than leaving its value in
-  place (wrong PR); and **put a type guard at the end**, so a non-number can never
-  be handed on whatever the flag list does. Fenced by
-  `.claude/hooks/gh-repo-flag-parity.test.sh`, which asserts across every gate that
-  the flagged spellings return the SAME exit code as the plain one **and** that the
-  plain one actually blocks — parity alone is satisfied by a gate inert in both
-  directions, which is the state `non-english-text-gate` was in (it invoked
-  `gh -C`, a flag `gh` does not have, so it failed open on every command). The
-  foreign-`-R` half asserts the refusal MESSAGE, not just the exit code: every
-  gate in that fixture already blocks for its own reasons, so an exit-code-only
-  check stayed green with the refusal deleted.
-- **The two `Stop` hooks: which CHANNEL reaches which audience, and the nudge
-  cadence.** `stop-cleanup-warn.sh` and `stop-unmerged-lane-warn.sh` fire at
-  turn-end rather than on a tool call, and until go-to-k/cdk-real-drift#1844 both
-  picked an output channel their text's audience never reads. Read from the
-  installed Claude Code (2.1.251) rather than the published docs, a Stop hook has
-  exactly three ways out:
-  - `hookSpecificOutput.additionalContext` — reaches the MODEL, and the turn
-    CONTINUES so it can act on what it was told.
-  - `systemMessage` — reaches the USER only (rendered as `<hookName> says: ...`),
-    and the turn ends normally.
-  - stdout / stderr at exit 0 — reaches NOBODY. Hook stderr is surfaced only on a
-    NON-zero exit, and stdout at exit 0 is parsed as JSON and dropped when it is
-    not one.
+  mirror flow the cwd decides policy and `-R` only decides where the issue
+  lands). And **the selector must come from the matched verb in the matched
+  segment**: `gh pr merge --squash 1` parses like `gh pr merge 1 --squash`, a
+  quoted `gh pr merge 9` inside a `--body` donates nothing to a later bare
+  merge, and flag VALUES are consumed (`-t msg 2195` must not resolve `msg`) —
+  all `gate_pr_selector`'s job, with two reusable rules: **enumerate the
+  VALUELESS flags, never the value-takers** (either list goes stale, and the
+  safe stale direction is an unlisted flag eating the number — empty selector,
+  caller falls back — rather than auditing the wrong PR), and **put a type
+  guard at the end** so a non-number is never handed on. Fenced by
+  `.claude/hooks/gh-repo-flag-parity.test.sh`, which asserts across every gate
+  that the flagged spellings return the SAME exit code as the plain one **and**
+  that the plain one actually blocks — parity alone is satisfied by a gate
+  inert in both directions, the state `non-english-text-gate` was in (it
+  invoked `gh -C`, a flag `gh` does not have, so it failed open on every
+  command). The foreign-`-R` half asserts the refusal MESSAGE, not just the
+  exit code — every gate in that fixture already blocks for its own reasons.
+- **The two `Stop` hooks (`stop-cleanup-warn.sh` / `stop-unmerged-lane-warn.sh`):
+  channels, cadence, and the record.** Until go-to-k/cdk-real-drift#1844 each
+  picked an output channel its text's audience never reads. The rules, each
+  measured and fenced by the hooks' own suites:
 
-  There is no fourth option that reaches the model WITHOUT continuing the turn,
-  which is why each hook has to CHOOSE rather than simply emit. The two JSON
-  fields are independent branches in the harness, so one payload may carry both.
-  `stop-cleanup-warn` was in the third state — `echo ... >&2` then `exit 0` — so a
-  BILLING guardrail delivered its warning into a hole for months; the lane hook
-  emitted `systemMessage` only, while every word of it is addressed to the agent.
-
-- **A Stop continuation is not free, and it is not merely slow.** A Stop hook's
-  `additionalContext` travels in the SAME return value as a `decision: "block"`,
-  so both spend one budget — `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, default 8
-  consecutive blocks — after which the harness overrides the hook and ends the turn
-  itself. A hook that nudges at every turn-end therefore spends a budget shared
-  with every other Stop hook, and the one that spends it is not necessarily the one
-  with something urgent to say. Hence the **cadence rule**, which both hooks
-  follow: `stop_hook_active` (a required boolean on the Stop payload) marks a turn
-  the harness has ALREADY resumed on a hook's account, so it drops the MODEL half —
-  and that is all it does. It is deliberately NOT a full stand-down in either hook:
-  both used to `exit 0` on it, on the reasoning that the human had seen the message
-  on the earlier pass of the same turn, and that reasoning is false whenever the
-  condition first becomes TRUE during the continuation (the continuation exists to
-  push the model back to work, and deploying a stack or committing the lane is
-  exactly that work). A bare `systemMessage` does not continue a turn, so the user
-  half costs nothing; a resumed pass writes no cadence record either, so the nudge
-  it did not spend is still available to the next ordinary turn-end.
-
-  Across turns the condition persists, so an unconditional `additionalContext`
-  fires at every turn-end for as long as it holds. Each hook therefore nudges the
-  model at most once per distinct SUBJECT, and a repeat falls back to
-  `systemMessage`: the user still sees it, the turn ends. The subject is chosen so
-  ORDINARY WORK does not change it, or the rule bounds nothing — the lane hook keys
-  on `<own branch>:<pushed|unpushed>` and NOT on the commit count, which changes
-  every time the model commits, while the cleanup hook keys on the sorted set of
-  armed sentinel tokens.
-
-  **The lane hook's predicate is DIRECTED, and a plain inequality is not a
-  simplification of it.** `pushed -> unpushed` is what an ordinary COMMIT looks
-  like, so `prev_subject != subject` re-armed on every commit and again on every
-  push — measured as `commit ctx, repeat sys, push ctx, repeat sys, ...`, two
-  forced continuations per commit/push cycle, which is exactly the per-commit
-  cadence the subject was chosen to avoid. It arms on a new session, a lane never
-  seen, a DIFFERENT branch, a record it cannot parse, or `unpushed -> pushed` only,
-  since that is the one transition opening an action the model did not have before.
-
-  The record is ONE file in the PER-WORKTREE git dir (`stop-nudge-lane` /
-  `stop-nudge-cleanup`) holding `<session id>TAB<subject>TAB<epoch>`, written
-  tmp-then-`mv`; the cleanup hook appends a fourth `armed since` field, which each
-  nudge must not reset. One file rather than one per session, so nothing
-  accumulates in the git dir with nobody to clean it up, and a concurrent session
-  in the same worktree costs an EXTRA nudge rather than a missed one — the safe
-  direction. Three properties of the record are load-bearing and each was a live
-  bug first: it is written on BOTH arms of the lane hook's decision, because it
-  holds the last OBSERVED subject rather than the last NUDGED one (recording only
-  on the arm freezes the push half and silences the next genuine
-  `unpushed -> pushed`); every field is NORMALISED — folded free of tabs and
-  newlines and defaulted when empty — **once, after every source of it has been
-  consulted**, since a tab or an empty leading field in a tab-separated line read
-  back with `IFS=<TAB> read` shifts every later field and the comparison then never
-  matches, an unbounded nudge. The "after every source" half is the part that gets
-  lost: BOTH hooks read the session id from the payload AND from
-  `CLAUDE_CODE_SESSION_ID`, and normalising inside the payload parse leaves the
-  environment path raw. Measured on the lane hook in exactly that state: a
-  well-formed id gave `ctx, sys, sys` while `<TAB>abc`, `a<TAB>b` and `a<NL>b` each
-  gave `ctx, ctx, ctx`. And a record that cannot be PERSISTED (an unresolvable or
-  unwritable git dir) costs the MODEL channel rather than the warning, because a
-  nudge that cannot be recorded cannot be bounded.
-
-  Three corrections landed 2026-09-01, each mutation-proved. **`mv -f` is not
-  proof of a write**: `mv -f <tmp> <dir>` returns 0 and moves the tmp INSIDE the
-  directory, so a record path that is a DIRECTORY set `wrote`/`persisted`, the
-  readback found nothing, and every turn re-armed — unbounded
-  `additionalContext` against `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, arriving
-  through the success check, plus one orphan tmp per turn. Both hooks now
-  confirm the destination is a regular FILE and sweep the stray tmp. **The
-  record's THIRD field is now READ**: the lane hook consults a record only when
-  it is well-formed (exactly three tab-separated fields, numeric epoch), which
-  both makes that field load-bearing and closes the `IFS=<TAB>` fold — a record
-  with an EMPTY subject field shifted the next field into `prev_subject`, and
-  when that field parsed as `<branch>:<state>` the lane went QUIET. **The lane
-  hook DELETES the record when no worktree is ahead**, so the next lane starts
-  armed; without it the stored subject outlived the condition and the same
-  subject returning was downgraded — a missed nudge, reachable through the
-  `git switch --detach origin/main` remedy the hook itself prints. The cleanup
-  hook deliberately does NOT delete, and says why in the file: its subject is
-  the armed-token SET, its `systemMessage` fires every turn regardless, and
-  `REARM_SECONDS` re-arms the model channel within 20 minutes, so the worst case
-  is bounded where the lane hook's was not.
-
-  **A downgrade to `systemMessage` must change VOICE, not only audience.** Both
-  hooks now keep a `user_msg` / `model_msg` pair. The model text is written at the
-  agent ("YOUR OWN lane", "rebase, run the gates", "the honest label is STOPPED"),
-  so routing it down the user channel hands a human instructions addressed to
-  somebody else — go-to-k/cdkd#2389 in miniature, the defect these hooks were
-  rewritten to fix. The lane hook has THREE paths that downgrade a self-lane
-  warning (a cadence repeat, an unpersistable record, a resumed pass) and one
-  shared emitter, which is precisely the shape where fixing one path leaves the
-  others; each is fenced by its own case.
-
-  The same one-emitter-three-paths shape also reproduces in the TEXT rather than
-  in the code, and it needs its own assertion. The user text once said "the agent
-  has already been nudged about this lane once, so this repeat is for you" —
-  true of the cadence repeat and false of the other two: a resumed pass spends no
-  nudge at all, and an unpersistable record drops the model half precisely
-  BECAUSE the record cannot be kept, so the agent is never told and the claim
-  would repeat every turn. Removing the clause is invisible to the voice checks —
-  the sentence names no agent-voice phrase and does name the lane — so the
-  resumed and unpersistable cases assert the ABSENCE of an "already been nudged"
-  claim as well. Measured: restoring the sentence leaves every other case green
-  and reddens exactly those two.
-
-  **The `stop_hook_active` fold follows PYTHON's truthiness in both hooks, and
-  neither obvious spelling gets there.** The cleanup hook parses the field with
-  `jq` and the lane hook with `python3`, so a malformed payload must not mean two
-  different things. Measured: plain jq truthiness makes `0`, `[]` and `{}`
-  continuations while Python says they are not, and `$f == true` makes `1`, `[1]`
-  and `{"a":1}` ordinary turns while Python says they ARE continuations — opposite
-  errors, and the second is the dangerous one for the money hook, which then reads
-  a resumed pass as fresh and spins the turn. The rule both follow is Python's:
-  null, `false`, `0` and an empty container are falsy, every other value is truthy,
-  with the textual spellings of `false` folded down first.
-
-  One shape still diverges, and it is recorded with BOTH sides because "the two
-  hooks must not disagree" is the whole reason the ladder exists. `1e-999` reads
-  truthy in jq (jq 1.8 preserves the literal, so `$f == 0` is false) and falsy in
-  Python, which underflows it to `0.0`. Measured on jq-1.8.1 / CPython 3. On that
-  one payload the cleanup hook reads RESUMED and goes quiet to the model, while
-  the lane hook reads NOT resumed and spends its model nudge — so it is a
-  disagreement, not merely one hook being conservative. Left as is because both
-  halves are bounded: the quiet costs a nudge a later ordinary turn emits anyway,
-  and the lane hook's nudge is held to one by its per-subject cadence record, so
-  neither side spins. And no producer emits it — the harness sends a JSON
-  boolean — so special-casing it would mean teaching jq to underflow, a rule with
-  no other use, to reconcile a value neither hook will see.
-
-- **The two Stop hooks then DIVERGE deliberately, and the difference is the
-  point.** `stop-unmerged-lane-warn` picks ONE channel by OWNERSHIP: the session's
-  own lane (resolved from `cwd` in the payload, falling back to the hook copy's own
-  checkout) goes to the model, another session's lane goes to the user, because the
-  model cannot act on a worktree that is not its own. It has NO wall-clock re-arm —
-  an unmerged lane costs nothing while it sits, so a second telling buys only
-  annoyance, and the same wall of text every turn was the original complaint. Push
-  state is deliberately not its channel discriminator: that would go quiet on a
-  branch pushed with NO PR, one of the two failures the hook exists to catch, so it
-  lives in the cadence subject and in the message TEXT instead.
-  `stop-cleanup-warn` makes the opposite trade on both axes, because its subject is
-  real AWS resources: it emits `systemMessage` on EVERY fire and ADDS
-  `additionalContext` when the cadence arms, since a billing guardrail must never
-  go silent to the human; and it DOES re-arm on a 20-minute wall clock even when
-  the token set is unchanged, because money accrues on the clock rather than per
-  turn, with the escalated message naming how long the tokens have been armed. Both
-  hooks are exercised by `.claude/hooks/stop-cleanup-warn.test.sh` and
-  `.claude/hooks/stop-unmerged-lane-warn.test.sh` (74 and 121 cases), run by
-  `vp run test:hooks`.
-
-  **Both suites run the HOOK under an explicitly chosen interpreter, and that is
-  not cosmetic.** They invoke it as `bash "$HOOK"` and its shebang is
-  `#!/usr/bin/env bash`, so both resolve through PATH — which means launching the
-  SUITE with `/bin/bash` proved nothing at all about the hook, and the bash 3.2
-  cleanliness these files need on macOS was only ever accidental. Each suite now
-  puts a one-symlink shim directory first on PATH so every child `bash` is the
-  fenced interpreter: `/bin/bash` by default, `HOOK_BASH=<path>` to take the other
-  tally. The suites print which one they used on their first line, and an explicitly
-  set `HOOK_BASH` that is not executable is FATAL rather than a silent fall back to
-  PATH bash — falling back would hide a typo in the one setting the fence exists to
-  pin, and report a tally under an interpreter nobody asked for.
+  - A Stop hook has exactly three ways out (read from the installed Claude Code
+    2.1.251, not the published docs): `hookSpecificOutput.additionalContext`
+    reaches the MODEL and the turn CONTINUES; `systemMessage` reaches the USER
+    only (rendered as `<hookName> says: ...`); stdout / stderr at exit 0
+    reaches NOBODY (hook stderr surfaces only on a NON-zero exit, and stdout at
+    exit 0 is parsed as JSON and dropped when it is not one). There is no
+    fourth option reaching the model WITHOUT continuing, so each hook must
+    CHOOSE; the two JSON fields are independent branches, so one payload may
+    carry both. `stop-cleanup-warn` — a BILLING guardrail — spent months in the
+    third state (`echo ... >&2` then `exit 0`); the lane hook emitted
+    `systemMessage` only while every word was addressed to the agent.
+  - **A continuation is not free**: `additionalContext` travels in the SAME
+    return value as a `decision: "block"`, so both spend one budget —
+    `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, default 8 consecutive blocks, SHARED
+    across every Stop hook. Cadence rule, followed by both:
+    `stop_hook_active` (a required boolean marking a turn the harness ALREADY
+    resumed) drops the MODEL half — and ONLY that. A full `exit 0` stand-down
+    is wrong whenever the condition first becomes TRUE during the continuation
+    (deploying a stack or committing the lane is exactly the work the
+    continuation exists to push). A bare `systemMessage` does not continue a
+    turn, so the user half costs nothing; a resumed pass writes no cadence
+    record, so the unspent nudge survives for the next ordinary turn-end.
+  - Each hook nudges the model at most once per distinct SUBJECT; a repeat
+    falls back to `systemMessage`. The subject is chosen so ORDINARY WORK does
+    not change it: the lane hook keys on `<own branch>:<pushed|unpushed>` —
+    NOT the commit count — and the cleanup hook on the sorted armed-token set.
+    **The lane predicate is DIRECTED, and a plain inequality is not a
+    simplification of it**: `pushed -> unpushed` is what an ordinary COMMIT
+    looks like, so `prev != subject` re-armed on every commit and again on
+    every push (measured: two forced continuations per cycle). It arms on a
+    new session, an unseen lane, a DIFFERENT branch, an unparsable record, or
+    `unpushed -> pushed` only — the one transition opening an action the model
+    did not have.
+  - The record is ONE file in the PER-WORKTREE git dir (`stop-nudge-lane` /
+    `stop-nudge-cleanup`) holding `<session id>TAB<subject>TAB<epoch>`,
+    written tmp-then-`mv`; the cleanup hook appends a fourth `armed since`
+    field each nudge must not reset. One file rather than one per session, so
+    nothing accumulates, and a concurrent session in the same worktree costs an
+    EXTRA nudge rather than a missed one — the safe direction. Load-bearing
+    properties, each a live bug first: it is written on BOTH arms (it holds the
+    last OBSERVED subject, not the last NUDGED one — recording only on the arm
+    freezes the push half); every field is NORMALISED — folded free of tabs and
+    newlines, defaulted when empty — **once, after EVERY source of it has been
+    consulted** (both hooks read the session id from the payload AND from
+    `CLAUDE_CODE_SESSION_ID`; normalising inside the payload parse left the
+    environment path raw — measured: a `<TAB>`- or newline-bearing id gave
+    `ctx, ctx, ctx`, an unbounded nudge); and a record that cannot be PERSISTED
+    costs the MODEL channel rather than the warning, because a nudge that
+    cannot be recorded cannot be bounded. Three corrections landed 2026-09-01,
+    each mutation-proved: **`mv -f` is not proof of a write** — a record path
+    that is a DIRECTORY returns 0 and moves the tmp INSIDE it (unbounded
+    re-arm arriving through the success check), so both hooks confirm the
+    destination is a regular FILE and sweep the stray tmp; **the record's
+    THIRD field is READ** — a record is consulted only when well-formed
+    (exactly three tab-separated fields, numeric epoch), closing the
+    `IFS=<TAB>` fold where an EMPTY subject shifted fields and went QUIET;
+    **the lane hook DELETES the record when no worktree is ahead** — else the
+    stored subject outlives the condition and the same subject returning is
+    downgraded, a missed nudge reachable through the hook's own
+    `git switch --detach origin/main` remedy. The cleanup hook deliberately
+    does NOT delete, and says why in the file: its `systemMessage` fires every
+    turn regardless and `REARM_SECONDS` re-arms the model channel within 20
+    minutes, so its worst case is bounded where the lane hook's was not.
+  - **A downgrade to `systemMessage` must change VOICE, not only audience.**
+    Both hooks keep a `user_msg` / `model_msg` pair; the model text is written
+    at the agent ("YOUR OWN lane", "rebase, run the gates"), and routing it
+    down the user channel hands a human instructions addressed to somebody
+    else — go-to-k/cdkd#2389 in miniature. The lane hook has THREE downgrade
+    paths (a cadence repeat, an unpersistable record, a resumed pass) and one
+    shared emitter — exactly the shape where fixing one path leaves the
+    others — so each is fenced by its own case, and the resumed and
+    unpersistable cases also assert the ABSENCE of the "the agent has already
+    been nudged" claim, which is true only of the cadence repeat (measured:
+    restoring the sentence reddens exactly those two).
+  - **The `stop_hook_active` fold follows PYTHON's truthiness in both hooks**
+    (one parses with `jq`, the other with `python3`, and a malformed payload
+    must not mean two different things): null, `false`, `0` and an empty
+    container are falsy, every other value truthy, textual spellings of
+    `false` folded first. Plain jq truthiness and `$f == true` are each wrong
+    in OPPOSITE directions (measured), and the second is the dangerous one —
+    a resumed pass read as fresh spins the turn. One recorded divergence:
+    `1e-999` reads truthy in jq 1.8 and falsy in Python (underflow to `0.0`) —
+    left as is, because both halves are bounded and no producer emits it (the
+    harness sends a JSON boolean).
+  - **The two hooks then DIVERGE deliberately, and the difference is the
+    point.** `stop-unmerged-lane-warn` picks ONE channel by OWNERSHIP — the
+    session's own lane (resolved from the payload's `cwd`, falling back to the
+    hook copy's own checkout) goes to the model, another session's lane to the
+    user, because the model cannot act on a worktree that is not its own — and
+    has NO wall-clock re-arm (an unmerged lane costs nothing while it sits).
+    Push state is deliberately NOT its channel discriminator: that would go
+    quiet on a branch pushed with NO PR, one of the two failures the hook
+    exists to catch, so it lives in the cadence subject and the message TEXT.
+    `stop-cleanup-warn` makes the opposite trade on both axes, because its
+    subject is real AWS resources: `systemMessage` on EVERY fire (a billing
+    guardrail must never go silent to the human) PLUS `additionalContext` when
+    the cadence arms, and a 20-minute wall-clock re-arm even on an unchanged
+    token set — money accrues on the clock, not per turn — with the escalated
+    message naming how long the tokens have been armed. Exercised by
+    `.claude/hooks/stop-cleanup-warn.test.sh` and
+    `.claude/hooks/stop-unmerged-lane-warn.test.sh` (74 and 121 cases), run by
+    `vp run test:hooks`.
+  - **Both suites run the HOOK under an explicitly chosen interpreter, and
+    that is not cosmetic.** The hooks' `#!/usr/bin/env bash` resolves through
+    PATH, so launching the SUITE with `/bin/bash` proved nothing about the
+    hook. Each suite now puts a one-symlink shim directory first on PATH so
+    every child `bash` is the fenced interpreter — `/bin/bash` by default,
+    `HOOK_BASH=<path>` for the other tally — prints which one it used on its
+    first line, and treats an explicitly set but non-executable `HOOK_BASH` as
+    FATAL rather than a silent fallback to PATH bash.
 
 - **Registration is not execution — prove the gates are ALIVE before the first
   commit of a session**: run `git commit --dry-run -m "gate liveness probe"` from
@@ -546,341 +478,177 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   an `if` holding `A or B` matches nothing), which `/hooks` cannot show because it
   lists registration, not firing.
 - **ALWAYS develop in a git worktree — never edit or branch in the main
-  checkout, even for a single "sequential" session.** Sessions that believed
-  they were alone have collided twice: a README clobber, and a branch created in
-  the shared checkout that captured another session's staged R44 commit. Every
-  line of work gets its OWN worktree with DISJOINT files:
+  checkout, even for a single "sequential" session** (sessions that believed
+  they were alone have collided twice: a README clobber, and a branch that
+  captured another session's staged commit). Every line of work gets its OWN
+  worktree with DISJOINT files:
   `git worktree add .worktrees/<name> -b wt-<name> origin/main` →
   `mise trust .worktrees/<name>/.mise.toml` → `pnpm install` (worktrees have no
   `node_modules`) → work → run gates + set markers → commit on the branch.
-  **`origin/main`, not local `main`**, and this is not cosmetic: local `main`
-  only advances on an explicit pull in the main checkout, so a lane cut from it
-  starts wherever the last pull left off — and `stale-base-gate.sh` opens with
-  `git merge-base --is-ancestor "$base" HEAD || exit 0`, so it is INERT for
-  exactly that lane. Basing on `origin/main` is what turns that gate ON. The
-  `/work-issues` copy of this recipe was corrected in
-  go-to-k/cdk-real-drift#1847; every copy in this repo now agrees. The
-  orchestrator integrates by `git checkout <branch> -- <files>` (NEVER `git merge` —
-  the leaked cdkd session hooks block it), then `git worktree remove`. The main
-  checkout is reserved for integration: `main` checkouts, pulls, and PR plumbing
-  only. **That recipe is the MAIN-CHECKOUT case and is wrong from anywhere
-  else** (go-to-k/cdk-real-drift#1842): when the session is ALREADY inside a
-  linked worktree — an Orca/ADE workspace, or a stray `cd` into an existing
-  lane — `git worktree add` NESTS one worktree inside another, and deleting the
-  outer workspace takes the inner directory, its uncommitted work and its git
+  **`origin/main`, not local `main`**: local `main` only advances on an
+  explicit pull, and `stale-base-gate.sh` opens with
+  `git merge-base --is-ancestor "$base" HEAD || exit 0`, so a lane cut from a
+  stale local `main` leaves that gate INERT — basing on `origin/main` is what
+  turns it ON (the `/work-issues` copy was corrected in
+  go-to-k/cdk-real-drift#1847; every copy now agrees). The orchestrator
+  integrates by `git checkout <branch> -- <files>` (NEVER `git merge`), then
+  `git worktree remove`; the main checkout is reserved for integration —
+  `main` checkouts, pulls, and PR plumbing only. **That recipe is the
+  MAIN-CHECKOUT case and is wrong from anywhere else**
+  (go-to-k/cdk-real-drift#1842): when the session is ALREADY inside a linked
+  worktree (an Orca/ADE workspace, a stray `cd` into an existing lane),
+  `git worktree add` NESTS one worktree inside another, and deleting the outer
+  workspace takes the inner directory, its uncommitted work and its git
   registration with it. There, create nothing and remove nothing: work on the
-  branch already checked out, take ONE line of work rather than several, and
-  leave the tree for whoever made it. `/work-issues` computes which case applies
-  before its first stage and `/hunt-bugs` points at that probe; do not
-  re-implement it here.
+  branch already checked out, one lane at a time, and leave the tree for
+  whoever made it. `/work-issues` computes which case applies before its first
+  stage and `/hunt-bugs` points at that probe; do not re-implement it here.
 - **A branch switch in the main checkout is now GATED, not merely discouraged.**
   `.claude/hooks/main-tree-branch-gate.sh` refuses `git switch` / `git checkout`
   onto a feature branch (and `git switch --detach`, and `git switch -` /
-  `git checkout -`) when the TARGET working tree is the main checkout, while
-  passing `main` / `master`, a `git checkout [<tree-ish>] -- <pathspec>` file
-  restore, the restore FLAGS `-p` / `--ours` / `--theirs`, a detached
-  `git checkout <sha>`, `git worktree add`, and every switch made INSIDE a
-  `.worktrees/` lane. **The orchestrator's own `git checkout <branch> -- <files>`
-  integration step passes** — it restores files and leaves HEAD on `main`
-  (measured). The argument tail is PARSED the way git's own parse-options parses
-  it, rather than matched against a list of spellings, and each behaviour was
-  settled against real git first: a leading flag is never mistaken for the branch
-  name (`git checkout -f <branch>` is refused, not waved through); a glued value
-  is read (`-bfeat`, `-fbfeat`, `--orphan=feat`, `--track=direct` all name the
-  branch they really create); a value-taking flag's argument is consumed rather
-  than counted as a pathspec (`git checkout --conflict merge <branch>` really
-  switches); `-` and `@{-1}` are the previous branch under BOTH verbs; and
-  `git checkout <name>` / `git checkout -t origin/<name>` for a branch that
-  exists only on a CONFIGURED remote are refused too — git DWIMs both into
-  "create the local branch and switch", which is how a lane's branch usually
-  first appears in a checkout. It is the CAUSE-side twin of `branch-gate`, which
-  fires on the symptom (a commit or push
-  once the tree is already off `main`) — go-to-k/cdk-real-drift#1845.
-  **`branch-gate` now recognises a DETACHED HEAD as "off `main`"**
-  (go-to-k/cdkd#2402): it read the state by branch NAME through
-  `symbolic-ref --short HEAD`, which is EMPTY while detached, so the
-  `main|master` case matched neither arm and the commit went through — and
-  the comment there claimed the empty string only ever meant "not inside a
-  git repo". The two gates composed into a hole neither had alone, since the
-  `git checkout <sha>` this gate passes as inspection is what detaches the
-  shared tree. Measured on a scratch opted-in repo, same `git commit`
-  payload: rc=2 on `main`, rc=0 once detached; rc=2 after the fix. A detached
-  LINKED worktree still passes, because that is the lane-clearing state
-  `stop-unmerged-lane-warn.sh` prescribes with
-  `git switch --detach origin/main`. THIS gate's verdicts are untouched —
-  refusing the sha spelling is a separate behaviour change with its own PR.
+  `git checkout -` / `@{-1}`) when the TARGET working tree is the main
+  checkout, while passing `main` / `master`, a
+  `git checkout [<tree-ish>] -- <pathspec>` file restore, the restore FLAGS
+  `-p` / `--ours` / `--theirs`, a detached `git checkout <sha>`,
+  `git worktree add`, every switch made INSIDE a `.worktrees/` lane, and the
+  orchestrator's own `git checkout <branch> -- <files>` integration step
+  (measured — it restores files and leaves HEAD on `main`). It is the
+  CAUSE-side twin of `branch-gate`, which fires on the symptom
+  (go-to-k/cdk-real-drift#1845). Key behaviours, each settled against real git
+  first and exercised by `.claude/hooks/main-tree-branch-gate.test.sh`
+  (172 cases, under the pinned-interpreter fence above):
 
-  **The remedy it prints follows the operation in progress**: a conflicted
-  rebase is one of the ways the shared checkout detaches, and there git
-  refuses `git switch main` outright with
-  `fatal: cannot switch branch while rebasing`, so a correct block ended in
-  an impossible instruction. The gate
-  reads the TARGET's RESOLVED git dir (not `<dir>/.git`, wrong from a
-  subdirectory) for `rebase-merge` / `rebase-apply` / `CHERRY_PICK_HEAD` /
-  `REVERT_HEAD` / `MERGE_HEAD` / `BISECT_LOG` and prints `<op> --continue` /
-  `<op> --abort`, or `bisect reset` for the one case where `switch main` is
-  accepted but leaves the bisect running; the `applying` sentinel inside
-  `rebase-apply` separates `git am` from `git rebase --apply`. Because both
-  arms exit 2, `branch-gate.test.sh` asserts the MESSAGE TEXT rather than the
-  code.
-
-  **What the remedy does to HEAD is stated conditionally, because it IS
-  conditional** (round 3). The round above verified that all nine printed
-  commands EXIT 0 — they do — and then promised `--abort` would "abandon it
-  and re-attach", which is false in four of the six. Exit status was the
-  wrong observable. Measured on git 2.53 by running each printed remedy
-  verbatim and reading HEAD afterwards: `am --abort`, `cherry-pick --abort`,
-  `revert --abort` and `merge --abort` all leave HEAD DETACHED, and so does
-  `rebase --abort` when the rebase was started while ALREADY detached; only
-  a rebase started FROM a branch re-attaches — and `bisect reset` only when
-  the bisect started from a branch too, which is what the round below had to
-  establish. Those four never detach HEAD themselves, so this arm is
-  reachable for them only from an already-detached tree and `--abort`
-  restores exactly that pre-op state — the user reads exit 0 as success and
-  the next gated command blocks again with `in progress : nothing`. The
-  discriminator is git's own `head-name`, which both rebase backends write
-  as `refs/heads/<branch>` or as the literal `detached HEAD`; the gate reads
-  it and prints either "Either ending re-attaches HEAD to '<branch>'" or
-  "NEITHER ending re-attaches HEAD" plus the `switch main` still needed
-  afterwards. One sentence covers both endings because the outcome is a
-  property of the SESSION rather than of which ending is picked — a
-  completed `--continue` splits the same way, measured. Eleven rows now RUN
-  the printed remedy and assert the resulting HEAD beside that claim.
-
-  **The bisect arm carried the same defect, one arm over** (round 4). It
-  said a `git bisect` "is what detached HEAD here" and that `bisect reset`
-  "restores the branch you started from". Both are false when the bisect
-  began in a tree that was ALREADY detached — one allowed command away,
-  since `main-tree-branch-gate.sh` passes `git checkout <sha>` in the main
-  checkout. Measured on git 2.53, one fixture both ways: started FROM a
-  branch, `.git/BISECT_START` holds `main` and `bisect reset` lands on
-  branch `main`; started DETACHED, it holds a raw SHA and `bisect reset`
-  exits 0 with HEAD STILL DETACHED, so the user reads success and the next
-  gated command blocks again with `in progress : nothing`. `BISECT_START` is
-  to bisect what `head-name` is to rebase, and the gate now reads it. It
-  asks with `show-ref --verify refs/heads/<x>` rather than a 40-hex pattern,
-  because that is the question `git bisect reset` itself ends in: a branch
-  whose NAME is 40 hex characters is then answered the way `git checkout`
-  would answer it, an empty or missing `BISECT_START` is answered "no
-  branch", and a start branch deleted by a low-level `update-ref -d` is too
-  — where `bisect reset` fails loudly with `fatal: invalid reference`. Both
-  polarities now carry a row that RUNS the printed `bisect reset` and reads
-  HEAD. The previous round recorded that the single bisect row "SURVIVES"
-  the blanket-wording mutation; it did, and that was read as evidence the
-  arm was sound. It was not: a row surviving a mutation aimed elsewhere is
-  evidence about that mutation only.
-
-  **The suite no longer inherits the developer's git config** (round 4),
-  which until now decided which arm half its rows exercised. The exhibit
-  that motivated it was a global `rebase.backend = apply` sending every
-  plain `git rebase` down `rebase-apply/`, so a broken `rebase-merge` arm
-  was never reached and the suite went fully green over it. That exhibit
-  NO LONGER REPRODUCES (round 5) and the code comment now says so: naming
-  each rebase row's backend explicitly (`--merge` / `--apply`) was the
-  other half of the same fix, and an explicit backend outranks the config
-  key, so the broken-arm mutant scores 76 pass / 5 fail with and without
-  `rebase.backend = apply`. What still bites, and what keeps the two
-  exports load-bearing, is anything that breaks the fixture COMMITS: on
-  the UNMUTATED hook a global `commit.gpgsign = true`, and a global
-  `init.templateDir` pointing at a FAILING hook, each score 56 pass / 25
-  fail plus 18 fixture failures. The author's machine has
-  `init.templateDir` set (git-secrets), whose hooks exit 0, which is why
-  the suite looked green. The fixture exports
-  `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null`, and
-  round 5 added a POSITIVE probe that those variables are actually
-  honoured (git 2.32+) rather than exported and ignored. Proven rather
-  than asserted: with the neutraliser in place, setting each of those
-  three global options leaves the tally unmoved at 81/0.
-
-  **Four assertable-but-unasserted arms picked up rows** (round 4): `master`
-  — dropping it from the `main|master` arm left the whole suite green; the
-  two fail-CLOSED refusals, for a MISSING and for a TRUNCATED shared matcher
-  library, each of which could be flipped to `exit 0` unnoticed; and the
-  branch-NAME message BODY, which could be gutted while keeping `exit 2`. A
-  row labelled a polarity control for the SPACED linked worktree controlled
-  nothing — the tree was on a branch and its `.markgate.yml` was never
-  tracked, so the hook left at the opt-in check; the fixture now commits
-  that file and detaches the worktree, and the row dies alongside the other
-  linked rows under a mutation that blocks every detached tree. The suite is
-  went 65 -> 72 in that round, and 72 -> 81 in round 5.
-
-  **Round 5 closed a live fail-open and four assertions that passed for the
-  wrong reason.** The gate's fail-CLOSED guard checked ONE library function,
-  `gate_matches`, while the hook goes on to call `gate_target_dir` as well —
-  and the two are 239 and 962 lines into a 1094-line library. A copy
-  truncated between them defined the first, passed the guard, then died on
-  the second inside a command substitution whose 127 the hook read as "no
-  target dir" and exited 0. Measured against the real hook,
-  `git commit -m oops` in an opted-in repo on `main`, cutting the library at
-  every 25th line: 30 of 44 offsets scored rc=0, NOT BLOCKED, the whole run
-  [251..976]. cdkd's twin had checked every function it calls since
-  go-to-k/cdkd#2130 and blocked at all 104 of its offsets, so this was
-  unported drift rather than an adaptation. The guard now names every
-  function the hook calls: 0 of 44 after. Four assertions in the round-4
-  work itself held nothing down, each proven by a mutation that left the
-  suite fully green before this round and reddens exactly its own row now:
-  the detached arm's four-line DIAGNOSIS block (resolved target dir / main
-  checkout / HEAD / in progress) had no reader, so gutting it kept `exit 2`
-  and stayed green — four rows, plus a fifth for the `in progress` field's
-  non-empty polarity; the `show-ref --verify` lookup could be swapped for
-  the 40-hex PATTERN its own comment rejects, so two rows now build the
-  states that separate them, a branch literally NAMED 40 hex characters and
-  a start branch deleted under the bisect with `update-ref -d`; the two
-  fail-CLOSED rows both needled the library PATH, which both refusals print,
-  so deleting one arm left the other's message satisfying both — each now
-  needles its own tail; and `run_case_head`'s `${line% #*}` remedy strip had
-  no fixture under a path containing `#`, so reverting it to `%%#*` was
-  green — one fixture now lives under `ha#sh/` and reverting the strip
-  reddens 11 of 11 `run_case_head` rows. Three smaller corrections: the
-  bisect negative arm named a CAUSE the code never established ("this bisect
-  started from a tree that was ALREADY detached") where `reattach_to=""`
-  covers five states, and now uses the neutral wording its sibling rebase
-  arm already had; `run_case_head` extracts the remedy by the indent every
-  printed remedy starts with (two spaces, then the word git) rather than
-  by print order, since the prose
-  around a remedy contains the same fragment (re-ordering the message plus
-  the old extraction EVALs an English sentence — measured, 3 rows exit 127);
-  and a FIXTURE failure no longer increments the row counter, so
-  `Pass + Fail` again equals the case count. The config neutraliser also
-  gained a positive probe that git actually HONOURS `GIT_CONFIG_GLOBAL` /
-  `GIT_CONFIG_SYSTEM` (2.32+) rather than exporting them into a git that
-  ignores them silently.
-
-  **The `applying` sentinel is load-bearing in the direction that fails
-  SILENTLY.** `git am --abort` inside a `git rebase --apply` session exits 0
-  with no output and leaves HEAD DETACHED, where `git rebase --abort` from
-  that same state lands on `main`; the reverse crossing is loud (rc=128,
-  `fatal: It looks like 'git am' is in progress. Cannot rebase.`). The string
-  `fatal: no rebase in progress` is what git says when NOTHING is in progress,
-  a different condition. That `rebase --apply` branch had no row until round
-  3; mutating it to `am` left all three suites fully green.
-
-  **Two stated bounds.** A path containing a NEWLINE still fails open, because
-  awk's records ARE lines, so an embedded newline ends the record early
-  whatever field expression reads it — measured, a detached MAIN checkout at
-  `<tmp>/nl<LF>repo` scores rc=0, and rc=2 with the newline removed.
-  `worktree list --porcelain -z` DOES read it and is deliberately not taken:
-  `-z` is a later addition than `--porcelain`, an unsupported flag makes
-  `worktree list` print NOTHING (failing OPEN, the same bug class this arm
-  exists to close), and once `-z` ran first the awk would stop executing on
-  every git new enough to have it, retiring the spaced-path fence over a shape
-  this repo HAS produced in exchange for one over a shape nobody has. Second,
-  a `rebase-apply/` directory holding neither `applying` nor `head-name` reads
-  as a rebase here, so the printed `rebase --abort` exits 1 with
-  `warning: could not read '.git/rebase-apply/head-name'` — but `git status`
-  calls that same state "You are currently rebasing.", so the hook agrees with
-  git, and no git command produces it (both rebase backends write `head-name`
-  at start and `git am` writes `applying`), which makes it a bound rather than
-  a bug.
-
-  `main-tree-branch-gate` was ported from
-  cdkd / cdk-local in the FIXED per-segment shape: the target tree is resolved
-  from the SAME segment that carries the arguments, so a command spanning two
-  trees is judged per segment. Resolving it once per command was live in both
-  siblings and wrong in both directions — measured here, payload cwd = the main
-  checkout, before the fix and after:
-
-  ```text
-                                                    before  after  want
-    git -C <wt> switch -c a && git switch -c b          0      2     2
-    git -C <wt> checkout -b a && git checkout -b b      0      2     2
-    git switch main && git -C <wt> switch -c a          2      0     0
-  ```
-
-  The first two let a branch be created in the SHARED checkout unjudged; the
-  third refused the worktree branch creation the convention mandates.
-
-  **A second round, 2026-09-02, closed six more — one of them a REGRESSION the
-  parse itself introduced.** The token walk read SHELL words, and a redirection,
-  its spaced target, a trailing `&` and a `#` comment are the shell's, not git's:
-  counting them as arguments turned a real switch into a "file restore" and
-  passed it. Measured, with `OLD` being cdkd's `origin/main` copy of the gate so
-  the regressions read as regressions:
-
-  ```text
-    command                                     OLD  NEW  now  want
-    git checkout <branch> 2>/dev/null             2    0    2     2
-    git checkout <branch> # switch lane           2    0    2     2
-    git checkout <branch> --                      2    0    2     2
-    git checkout --orph <b> / --trac origin/<b>   0    0    2     2
-    git switch -- main                            2    2    0     0
-    git checkout --no-guess <remote-only>         0    2    0     0
-    control: git checkout <branch>                2    2    2     2
-  ```
-
-  Four causes, each fixed at the cause: the parse now reads git's ARGV through a
-  new shared `gate_argv` rather than raw shell words; an INCOMPLETE parse may no
-  longer ALLOW (an unresolvable or ambiguous option blocks, naming it), which is
-  the general form of the two defects a positional COUNT produced; each verb
-  carries its COMPLETE long-option table with per-name arity, because git accepts
-  any unambiguous PREFIX of a long name and `-h` does not show that; and `--` is
-  checkout's pathspec separator but only switch's end-of-options, so
-  `git checkout <b> --` switches while `git switch -- main` stays put (both
-  measured). An unbalanced quote is now REFUSED rather than silently truncated —
-  `-b agent's-branch` used to yield the single token `-b` and pass.
-
-  **A fifth cause, found inside the fourth's own fix.** "An incomplete parse may
-  not ALLOW" was implemented for unknown GIT OPTIONS only; `gate_argv` did the
-  OPPOSITE for SHELL WORDS, enumerating the forms it recognised (a redirection, a
-  trailing `&`, a `#` comment) and passing everything else through as a git
-  argument. So a word the shell removes but the stripper does not model became a
-  phantom second positional and the verdict relaxed to "file restore". Measured
-  against the parse above, `OLD` being `origin/main` (which has no copy of this
-  gate at all, so it scores 0 on every row INCLUDING the control), `NEW` the
-  round-3 parse, `now` this one:
-
-  ```text
-    command                                     OLD  NEW  now  want
-    git checkout <branch> $EMPTY                  0    0    2     2
-    git checkout <branch> ${EMPTY}                0    0    2     2
-    git checkout <branch> {fd}>/dev/null          0    0    2     2
-    git checkout <branch> {fd}<f.txt              0    0    2     2
-    git checkout main # don't switch lanes        0    2    0     0
-    git checkout main -- f.txt # agent's file     0    2    0     0
-    git checkout --end-of-options main            0    2    0     0
-    git checkout --end-of-options -- f.txt        0    2    0     0
-    git checkout --git-completion-helper          0    2    0     0
-    control: git checkout <branch>                0    2    2     2
-  ```
-
-  The answer is the same fence applied to the other grammar rather than a fourth
-  enumeration: a word `gate_argv` cannot fully account for sets `parse_certain=0`.
-  `gate_word_is_literal` admits a word only when every character outside a quoted
-  span is on `GATE_INERT_CHARS`, a CLOSED list of characters that trigger no
-  shell processing, each carrying its reason. A shape nobody has thought of lands
-  on BLOCK because every shell construct is SPELLED, so one outside the list
-  necessarily carries a character the list does not hold — `{fd}>/dev/null` is
-  caught by `>` and `{` without either being named as a redirection form. One
-  exemption is proved rather than assumed: a word beginning with the literal
-  `@{-` cannot vanish (no expansion produces or removes those characters), and
-  its verdict is a BLOCK that only more positionals relax.
-
-  **Three claims retired here too.** The `parse_certain` arm was documented as
-  firing "only on commands git itself refuses"; against git 2.53.0 it also fired
-  on `--end-of-options main`, `--end-of-options -- <path>` and
-  `--git-completion-helper`, all rc=0. Those, plus `--git-completion-helper-all`
-  and `--help-all`, are `parse-options` built-ins absent from `-h` and are in the
-  tables now at arity 0 — `--end-of-options` ending the OPTIONS without giving
-  the next token checkout's pathspec meaning, since
-  `git checkout --end-of-options <branch>` really switches. The unbalanced-quote
-  refusal was justified as "the text is a shell syntax error in the first place";
-  `bash -n "git checkout main # don't switch lanes"` reports VALID syntax, and the
-  gate blocked a command git answers with "Already on 'main'" — the comment is now
-  cut BEFORE the split. And `--help` used to return ahead of the fence, the one
-  relaxing verdict that skipped it; it no longer does.
-
-  Two claims are retired rather than carried. This hook said "the same probes run
-  against the sibling gates score them identically wrong"; that stopped being
-  true when the siblings landed their own parse, and they now score those rows
-  correctly — the siblings have since been converged onto THIS repo's
-  `remote_dwim_names`, which was ahead of theirs. And `remote_dwim_names` claimed
-  its list held only names "exactly one remote carries": there is no uniqueness
-  check, and with one name on two remotes git refuses while the gate blocks — the
-  conservative direction, so the behaviour stays and only the sentence goes.
-
-  Exercised by `.claude/hooks/main-tree-branch-gate.test.sh` (172 cases) under an
-  explicitly pinned interpreter, `/bin/bash` by default — see the fence note
-  above.
+  - **The argument tail is PARSED the way git's own parse-options parses it**,
+    never matched against a list of spellings: a leading flag is not mistaken
+    for the branch (`git checkout -f <branch>` is refused); glued values are
+    read (`-bfeat`, `-fbfeat`, `--orphan=feat`, `--track=direct`); a
+    value-taking flag's argument is consumed rather than counted as a pathspec
+    (`git checkout --conflict merge <branch>` really switches); and a branch
+    that exists only on a CONFIGURED remote is refused, `-t origin/<b>`
+    included — git DWIMs both into "create the local branch and switch", which
+    is how a lane's branch usually first appears in a checkout. The parse
+    reads git's ARGV through the shared `gate_argv`, never raw shell words: a
+    redirection, its spaced target, a trailing `&` and a `#` comment are the
+    shell's, not git's, and counting them as arguments once relaxed a real
+    switch to "file restore" (measured; the round-2 rc tables live in this
+    file's git history). Each verb carries its COMPLETE long-option table with per-name
+    arity, because git accepts any unambiguous PREFIX of a long name (`--orph
+<b>` is the branch creation it abbreviates) and the `parse-options`
+    built-ins absent from `-h` (`--end-of-options`,
+    `--git-completion-helper`, `--help-all`, ...) are in the tables at arity 0
+    — `--end-of-options` ends the OPTIONS without giving the next token
+    checkout's pathspec meaning. `--` is checkout's pathspec separator but
+    only switch's end-of-options (`git checkout <b> --` switches while
+    `git switch -- main` stays put; both measured), and `--help` no longer
+    returns ahead of the fence.
+  - **An INCOMPLETE parse may not ALLOW.** An unresolvable or ambiguous
+    option BLOCKS, naming it; an unbalanced quote is REFUSED rather than
+    silently truncated (`-b agent's-branch` used to yield the single token
+    `-b` and pass). The same fence applies to the shell grammar rather than a
+    fourth enumeration: a word `gate_argv` cannot fully account for sets
+    `parse_certain=0`, and `gate_word_is_literal` admits a word only when
+    every character outside a quoted span is on `GATE_INERT_CHARS`, a CLOSED
+    list of characters that trigger no shell processing — a shape nobody has
+    thought of lands on BLOCK because every shell construct is SPELLED with a
+    character the list does not hold (`{fd}>/dev/null` is caught by `>` and
+    `{` without either being named as a redirection form). One exemption is
+    proved rather than assumed: a word beginning with the literal `@{-`
+    cannot vanish. This closed a regression the parse itself introduced —
+    `gate_argv` had ENUMERATED the shell forms it recognised and passed
+    everything else through, so `$EMPTY` and `{fd}>/dev/null` became phantom
+    positionals relaxing the verdict. One retired sentence kept as behaviour:
+    `remote_dwim_names` has no uniqueness check, so a name on two remotes has
+    git refuse while the gate blocks — the conservative direction.
+  - **The target tree is resolved PER SEGMENT, from the SAME segment that
+    carries the arguments** — a command spanning two trees is judged per
+    segment. Resolving it once per command was live in both siblings and
+    wrong in both directions (measured:
+    `git -C <wt> switch -c a && git switch -c b` scored 0 where 2 was wanted,
+    and `git switch main && git -C <wt> switch -c a` refused the worktree
+    branch creation the convention mandates).
+  - **`branch-gate` recognises a DETACHED HEAD in the main checkout as "off
+    `main`"** (go-to-k/cdkd#2402): it read the state by branch NAME through
+    `symbolic-ref --short HEAD`, which is EMPTY while detached, so the
+    `main|master` case matched neither arm and the commit went through — and
+    the `git checkout <sha>` THIS gate passes as inspection is what detaches
+    the shared tree, so the two gates composed into a hole neither had alone
+    (measured on a scratch opted-in repo: rc=0 once detached, rc=2 after the
+    fix). A detached LINKED worktree still passes — that is the lane-clearing
+    state `stop-unmerged-lane-warn.sh` prescribes.
+  - **The refusal's printed remedy follows the operation in progress**: a
+    conflicted rebase is one of the ways the shared checkout detaches, and
+    there git refuses `git switch main` outright — so the gate reads the
+    TARGET's RESOLVED git dir (not `<dir>/.git`, wrong from a subdirectory)
+    for `rebase-merge` / `rebase-apply` / `CHERRY_PICK_HEAD` / `REVERT_HEAD` /
+    `MERGE_HEAD` / `BISECT_LOG` and prints `<op> --continue` / `<op> --abort`,
+    or `bisect reset`. The `applying` sentinel inside `rebase-apply`
+    separates `git am` from `git rebase --apply`, and it is load-bearing in
+    the direction that fails SILENTLY: `git am --abort` inside a
+    `git rebase --apply` session exits 0 with no output and leaves HEAD
+    DETACHED, while the reverse crossing is loud (rc=128). Both arms exit 2,
+    so the suite asserts the MESSAGE TEXT.
+  - **What the remedy does to HEAD is stated CONDITIONALLY, because it IS
+    conditional** — exit status was the wrong observable (all nine printed
+    remedies exit 0). Measured on git 2.53 by RUNNING each printed remedy and
+    reading HEAD afterwards: `am --abort`, `cherry-pick --abort`,
+    `revert --abort` and `merge --abort` all leave HEAD DETACHED (those four
+    never detach HEAD themselves, so this arm is reachable for them only from
+    an already-detached tree, and `--abort` restores exactly that pre-op
+    state); a rebase re-attaches only when started FROM a branch. The
+    discriminator is git's own `head-name`, which both rebase backends write;
+    the gate reads it and prints either "Either ending re-attaches HEAD to
+    '<branch>'" or "NEITHER ending re-attaches HEAD" plus the `switch main`
+    still needed afterwards — one sentence for both endings, because the
+    outcome is a property of the SESSION, not of which ending is picked. The
+    bisect arm carried the same defect one arm over: `bisect reset` restores
+    a branch only when `BISECT_START` holds one (started DETACHED it holds a
+    raw SHA, and `bisect reset` exits 0 with HEAD STILL DETACHED). The gate
+    reads `BISECT_START` and asks with `show-ref --verify refs/heads/<x>`
+    rather than a 40-hex pattern — the question `git bisect reset` itself
+    ends in — so a branch literally NAMED 40 hex characters, an empty
+    `BISECT_START`, and a start branch deleted by `update-ref -d` are each
+    answered the way git answers them. Rows RUN the printed remedies and
+    assert the resulting HEAD, both polarities.
+  - **The suite does not inherit the developer's git config.** It exports
+    `GIT_CONFIG_GLOBAL=/dev/null` / `GIT_CONFIG_SYSTEM=/dev/null`, carries a
+    POSITIVE probe that git actually HONOURS those variables (2.32+) rather
+    than exporting them into a git that ignores them, and names each rebase
+    row's backend explicitly (`--merge` / `--apply`), which outranks a global
+    `rebase.backend`. What still breaks FIXTURES — why the exports are
+    load-bearing — is anything that breaks the fixture COMMITS: a global
+    `commit.gpgsign = true`, or a global `init.templateDir` pointing at a
+    FAILING hook, each scored 56 pass / 25 fail plus 18 fixture failures on
+    the unmutated hook; with the neutraliser, setting all three leaves the
+    tally unmoved (the author's machine HAS `init.templateDir` set, whose
+    hooks exit 0 — why the suite looked green).
+  - **The fail-CLOSED guard names EVERY library function the hook calls.** It
+    used to check ONE (`gate_matches`) while the hook also calls
+    `gate_target_dir` — 239 and 962 lines into a 1094-line library — so a
+    copy truncated between them defined the first, passed the guard, then
+    died inside a command substitution whose 127 the hook read as "no target
+    dir" and exited 0. Measured by cutting the library at every 25th line: 30
+    of 44 offsets NOT BLOCKED before, 0 of 44 after (cdkd's twin had named
+    every called function since go-to-k/cdkd#2130 — this was unported drift).
+    The same rounds gave rows to every assertable-but-unasserted arm:
+    `master` in the `main|master` pattern; both fail-CLOSED refusals, each
+    needling its OWN message tail (deleting one arm no longer satisfies
+    both); the refusal's diagnosis block and branch-name message body; the
+    `show-ref --verify` lookup vs the 40-hex pattern its own comment rejects
+    (two fixtures build the states that separate them); and the harness's
+    `${line% #*}` remedy strip (one fixture now lives under a `#`-bearing
+    path, and the harness extracts the remedy by its two-space-then-git
+    indent, not print order — re-ordering the message plus the old extraction
+    EVALed an English sentence). A fixture failure no longer increments the
+    row counter, so `Pass + Fail` again equals the case count.
+  - **Two stated bounds**, recorded as bounds rather than bugs: a path
+    containing a NEWLINE still fails open — awk's records ARE lines, and
+    `worktree list --porcelain -z` is deliberately not taken (an unsupported
+    flag makes `worktree list` print NOTHING, failing OPEN on every older
+    git: that would retire the spaced-path fence over a shape this repo HAS
+    produced in exchange for one over a shape nobody has). And a
+    `rebase-apply/` directory holding neither `applying` nor `head-name`
+    reads as a rebase here — `git status` calls that same state "rebasing",
+    and no git command produces it.
 
 - **All changes go through a pull request — never commit directly to `main`.**
   Branch (or worktree branch) → run the gates + set markers → commit → push →
@@ -896,19 +664,18 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   pr-review is multi-agent (cdkrd is solo); integ-\* depends on cdkd's
   providers/state/destroy paths cdkrd lacks (see `.markgate.yml`).
 - **Every session-wrap / task-complete report MUST end with a "Remaining work"
-  section AND a "Session close" verdict — unprompted** (mirrors go-to-k/cdkd#1257;
-  the user should never have to ask "any follow-up tasks?" or "can I close this
-  session?"). **Scope: only work THIS session created or touched.** The section
-  reports residuals of the task just finished: gaps in what was shipped, polish
-  deferred while doing it, and issues filed BECAUSE of this work. It is NOT a
+  section AND a "Session close" verdict — unprompted** (mirrors
+  go-to-k/cdkd#1257; the user should never have to ask "any follow-up tasks?"
+  or "can I close this session?"). **Scope: only work THIS session created or
+  touched** — residuals of the task just finished (gaps in what was shipped,
+  polish deferred while doing it, issues filed BECAUSE of this work), never a
   backlog dump. Do not list pre-existing open issues that merely happen to be
   unresolved, and once the session moves on to an unrelated task, stop carrying
-  forward items from the earlier unrelated work. If the current work leaves
-  nothing behind, the answer is "Nothing remaining" even when the repo has open
-  issues elsewhere. **Remaining work** — exactly one of: **TODO (issue #N)**
-  (work that still needs doing later; the ONLY bucket meaning follow-ups
-  exist — every entry MUST have a GitHub issue number, filed BEFORE
-  reporting, AND the four classification fields described below);
+  forward items from the earlier work. If the current work leaves nothing
+  behind, the answer is "Nothing remaining" even when the repo has open issues
+  elsewhere. **Remaining work** — exactly one of: **TODO (issue #N)** (the ONLY
+  bucket meaning follow-ups exist — every entry MUST have a GitHub issue
+  number, filed BEFORE reporting, AND the four classification fields below);
   **Won't-do (decided + recorded)** (things consciously decided AGAINST doing,
   with a one-line reason and where the decision is recorded — PR body, in-code
   comment, issue comment; no action needed); **Nothing remaining** (an explicit
@@ -919,14 +686,13 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   hunts / subagents; no AWS resources pending cleanup (bughunt sentinel clear);
   every TODO filed as an issue.
 
-  **The four TODO fields — decide them WHEN THE ITEM ARISES, not at wrap time.**
-  By wrap time the evidence for the call (which files were open, which
+  **The four TODO fields — decide them WHEN THE ITEM ARISES, not at wrap
+  time.** By wrap time the evidence for the call (which files were open, which
   verification cycle was already being paid for) is gone, and a retrospective
   guess is worth little. Record them **in the issue body** so they outlive the
   session. The issue body and the report use the SAME four lines, one field per
-  line (an issue also carries a `Dup-check:` line — see `/work-issues` §5 — but that
-  is a filing-time record of the open-issue search, not a fifth classification
-  field):
+  line (an issue also carries a filing-time `Dup-check:` line — see
+  `/work-issues` §5 — which is not a fifth classification field):
 
   ```text
   Session-fit: now (do it in this session) | next (not this session) — <reason>
@@ -936,20 +702,18 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   ```
 
   A report adds a fifth line, **`Notes`**, for session-specific context (`none`
-  when there is nothing); the issue body stays at four CLASSIFICATION lines, because
-  what belongs there is only the part that outlives the session. (`Dup-check:` sits
-  alongside them in the body and is not one of the four: it records that the open
-  issue list was searched at filing time, and nothing in the report re-states it.)
+  when there is nothing); the issue body stays at the four CLASSIFICATION
+  lines — what belongs there is only the part that outlives the session.
 
   **The four answer four DIFFERENT questions and none derives from another**:
   `Session-fit` is the decision, `Severity` the cost of leaving it undone,
   `Effort` which verification cycle the fix drags, `Estimate` the hours. In
   particular do not collapse `Severity` into `Session-fit` — a `Severity: high`
-  item can still be `next` (a new fixture has to be written for it) and a `low` one
-  can be `now` (it lands in a file this session already has open). The moment
-  the two track each other, `Severity` is a second spelling of the decision and
-  the field is wasted. Likewise `Effort` is not `Estimate`: "one live run" is a
-  kind of cost, and how many hours it takes depends on which fixture.
+  item can still be `next` (a new fixture has to be written for it) and a `low`
+  one can be `now` (it lands in a file this session already has open); the
+  moment the two track each other, one field is wasted. Likewise `Effort` is
+  not `Estimate`: "one live run" is a kind of cost, and how many hours it takes
+  depends on which fixture.
 
   **The keys are spelled identically everywhere** — issue body, English report,
   Japanese report; never translated or renamed per context. **No bare tokens**,
@@ -957,121 +721,107 @@ branch-gate` / `Blocked by check-gate` line means the hooks fire. Git's ordinary
   `Session-fit: next (not this session)` and never a lone `next`;
   `Effort: large (L)` and never a lone `L`; `Severity` as a word and **never as
   an initial** (the initials collide with `Effort`'s both ways — `M` is
-  `medium` on either scale, and `L` would be _low_, the least urgent thing there
-  is, against _large_, the biggest); and always BOTH `Effort` and `Estimate` —
-  dropping the duration and keeping the letter is exactly the failure this split
-  exists to end.
+  `medium` on either scale, and `L` would be _low_, the least urgent thing
+  there is, against _large_, the biggest); and always BOTH `Effort` and
+  `Estimate` — dropping the duration and keeping the letter is exactly the
+  failure this split exists to end.
 
-  **`Severity` and `Effort` are ALSO LABELS on a filed issue.** The two lines
-  stay exactly as written — nothing about the report or the body changes — and
-  the same two values are mirrored onto the issue as `severity:high` /
-  `severity:medium` / `severity:low` and `effort:small` / `effort:medium` /
-  `effort:large`. Prose is invisible to every query the backlog is actually
-  triaged with, so ranking by `Severity` costs one `gh issue view` per candidate
-  while `gh issue list --label severity:high` is one call. Set them at filing
-  time (`gh issue create ... --label severity:high --label effort:large`) and
-  again when a claim rewrites an old packed body into the four-line shape
-  (`gh issue edit <n> --add-label ...`), which is where `Severity` first exists
-  for most of the backlog. **Only these two get labels**: `Session-fit` is
-  re-decided at claim time and a label silently disagreeing with the body is
-  worse than none, and `Estimate` is a free-form duration whose informative
-  half — what actually eats the time — is exactly what a label cannot hold. The
-  prefixed full words are the "no bare tokens" rule applied to a label: the two
-  scales share the token `medium`, and their initials collide in the dangerous
-  direction. Enforced by `.claude/hooks/issue-classification-label-gate.sh`,
+  **`Severity` and `Effort` are ALSO LABELS on a filed issue** — the two lines
+  stay exactly as written, mirrored as `severity:high` / `severity:medium` /
+  `severity:low` and `effort:small` / `effort:medium` / `effort:large` —
+  because prose is invisible to every query the backlog is actually triaged
+  with (ranking by `Severity` costs one `gh issue view` per candidate;
+  `gh issue list --label severity:high` is one call). Set them at filing time
+  (`gh issue create ... --label severity:high --label effort:large`) and again
+  when a claim rewrites an old packed body into the four-line shape — where
+  `Severity` first exists for most of the backlog. **Only these two get
+  labels**: `Session-fit` is re-decided at claim time and a label silently
+  disagreeing with the body is worse than none; `Estimate` is a free-form
+  duration whose informative half is exactly what a label cannot hold. The
+  prefixed full words are the no-bare-tokens rule applied to a label (the two
+  scales share `medium`, and their initials collide in the dangerous
+  direction). Enforced by `.claude/hooks/issue-classification-label-gate.sh`,
   which refuses a `gh issue create` / `gh issue edit` whose body states a value
-  the issue's labels do not carry (`gh issue comment` is not gated; on `edit` it
-  asks gh what the issue already carries, and fails OPEN when gh cannot answer).
-  **The PR inherits them automatically** —
+  the issue's labels do not carry (`gh issue comment` is not gated; on `edit`
+  it asks gh what the issue already carries, and fails OPEN when gh cannot
+  answer). **The PR inherits them automatically** —
   `.github/workflows/pr-inherit-issue-labels.yml` copies every label of the
-  issues a PR closes onto the PR itself (add-only, minus the release-management
-  family), so never hand-add them to a PR. The copy runs when the PR is opened,
-  reopened, or its body edited, reading the labels the issue carries AT THAT
-  MOMENT — which is why the label belongs on the issue at CLAIM time, before the
-  lane's PR exists.
+  issues a PR closes onto the PR (add-only, minus the release-management
+  family) when the PR is opened, reopened, or its body edited, reading the
+  labels the issue carries AT THAT MOMENT — so label the ISSUE at CLAIM time,
+  before the lane's PR exists, and never hand-add them to a PR.
 
   **Scales.** `Severity`: `high` = a wrong result, data loss, a security
-  surface, or something a user hits in normal operation; `medium` = a capability
-  is missing but there is a workaround, or it only shows up under a specific
-  condition; `low` = internal tidiness, invisible to users. **Rate what a user
-  experiences, never why this session should do it** — "leaving main
-  self-inconsistent" is a `Session-fit: now` trigger, not a Severity level, and
-  copying it here makes that flavour of `high` permanently un-`next`-able.
-  `Effort` measures the verification tail rather
-  than the edit: `small` = edit plus unit tests, riding verification this
-  session already pays for; `medium` = one re-review round, or a live run this
-  session was not otherwise going to make; `large` = a NEW fixture has to be
-  WRITTEN, or a behavior change needing its own PR plus review.
+  surface, or something a user hits in normal operation; `medium` = a
+  capability is missing but there is a workaround, or it only shows up under a
+  specific condition; `low` = internal tidiness, invisible to users. **Rate
+  what a user experiences, never why this session should do it** — "leaving
+  main self-inconsistent" is a `Session-fit: now` trigger, not a Severity
+  level, and copying it here makes that flavour of `high` permanently
+  un-`next`-able. `Effort` measures the verification tail rather than the
+  edit: `small` = edit plus unit tests, riding verification this session
+  already pays for; `medium` = one re-review round, or a live run this session
+  was not otherwise going to make; `large` = a NEW fixture has to be WRITTEN,
+  or a behavior change needing its own PR plus review. Calibration: RUNNING an
+  existing verification is not a reason to defer (measured over the 268 rows
+  of cdkd's integ ledger, 2026-08-20: median run 85 s, mean 4.6 min, p90 8.8
+  min — a passing run costs a few hundred tokens, and one riding the session's
+  current lane costs zero). What is genuinely expensive is WRITING a new
+  fixture, a run that FAILS, and above all review of a larger diff, which
+  grows superlinearly. Defer on those.
 
-  **Calibration: RUNNING an existing integ is not a reason to defer.** Measured
-  over the 268 rows of cdkd's `docs/_generated/integ-last-run.tsv` on 2026-08-20:
-  median run 85 s, mean 4.6 min, p90 8.8 min. A passing run costs a few hundred
-  tokens. If the session is running one for its current lane anyway, a fix riding
-  the same fixture costs zero — the same run refreshes the same gate. What is
-  genuinely expensive is WRITING a new fixture, an integ that FAILS, and above
-  all review of a larger diff, which grows superlinearly because a reviewer reads
-  the whole thing and cross-file interactions multiply. Defer on those.
+  **Before writing `Session-fit: next`, NAME the command that verifies the
+  fix** — concretely (not "run the tests": the test file; not "check it live":
+  the stack and the region) — and say a fresh session will be able to run it.
+  A deferral is a PREDICTION, and an unstated prediction is never checked, so
+  the field decays into naming the KIND of work — classifying by MEANS rather
+  than by PURPOSE, which no list of `now` triggers can catch. If naming it is
+  HARD, that difficulty IS the finding; it is one of four things: the verifier
+  is bound to THIS run's live AWS state (a stack this run must delete before
+  it can ship, a hand-injected drift, a clean window on the shared-name suite)
+  or to credentials a fresh session may not hold; it is bound to THIS host
+  (CPU architecture, an installed toolchain, a pulled container image); it
+  does NOT EXIST yet and writing it is most of the work — the one case where
+  `next` is unambiguously right, and right BECAUSE you could name what is
+  missing; or you cannot name it at all, which is an unbounded deferral.
+  Measured 2026-08-26: go-to-k/cdk-local#560 was deferred on "a fixture /
+  base-image change on a different axis" — a statement about the work's
+  CATEGORY. Its defect was a Go RIE segfault under `linux/amd64` emulation on
+  an arm64 host and the filing machine WAS arm64, so the real verification was
+  "run those fixtures on an arm64 host", which nothing guaranteed a fresh
+  session has; the maintainer caught it, not the flow. The converse is the
+  honest `next`: when you CAN name the check and any machine can run it, say
+  so in one line beside `Session-fit`. `/work-issues` §3-b applies this to a
+  deferral that becomes a filed ISSUE, with the repo-specific shapes here.
 
-  **Before writing `Session-fit: next`, NAME the command that verifies the fix.**
-  A deferral is a PREDICTION — that a later session can finish this — and an
-  unstated prediction is never checked, so the field decays into naming the KIND
-  of work ("a fixture change", "a different subsystem"). That is classifying by
-  MEANS rather than by PURPOSE, and no list of `now` triggers can catch it,
-  because the next miss arrives in a shape the list does not contain. So you may
-  not write `next` until you can name, concretely, the command the NEXT session
-  will run to see the fix work — and can say a fresh session will be able to run
-  it. Not "run the tests": the test file. Not "check it live": the stack and the
-  region. The check is GENERATIVE rather than a lookup, which is the whole point,
-  and if naming it is HARD that difficulty IS the finding. It is one of four
-  things: the verifier is bound to THIS run's live AWS state (a stack this run
-  must delete before it can ship, a drift injected by hand, a clean window on the
-  shared-name suite) or to credentials a fresh session may not hold; it is
-  bound to THIS host (CPU architecture, an installed toolchain, a container image
-  already pulled); it does NOT EXIST yet and writing it is most of the work — the
-  one case where `next` is unambiguously right, and right BECAUSE you could name
-  what is missing; or you cannot name it at all, which is not a deferral but an
-  unbounded one. Measured 2026-08-26: go-to-k/cdk-local#560 was deferred on "a
-  fixture / base-image change on a different axis", a statement about the work's
-  CATEGORY. Its defect is a Go RIE segfault under `linux/amd64` emulation on an
-  arm64 host and the filing machine was arm64, so the real verification was "run
-  those fixtures on an arm64 host" — which nothing guarantees a fresh session
-  has. The maintainer caught the misclassification, not the flow. The converse is
-  the honest `next`: when you CAN name the check and any machine can run it, say
-  so in one line beside `Session-fit`, so the next session starts from the check
-  instead of re-deriving it. `/work-issues` §3-b applies this to a deferral that
-  becomes a filed ISSUE, with the repo-specific shapes the answer takes here.
-
-  **`Session-fit: next` is NOT available for work discovered inside a scope the
-  user framed as "do this across the repos in one session".** Three tells that
+  **`Session-fit: next` is NOT available for work discovered inside a scope
+  the user framed as "do this across the repos in one session".** Three tells
   force `now`: (a) you are about to file the SAME issue body in more than one
-  repo — that is the split the framing exists to end, not triage; (b) the fix is
-  mechanical and its evidence is live right now (the repro is built, the files are
-  open, a gate cycle is already running); (c) the user already said "finish it
-  here" for the surrounding task, and a discovery inside that task inherits the
-  instruction rather than getting its own budget. The four fields exist to make a
-  deferral HONEST, not to make one available — a defensible-looking `Effort` /
-  `Estimate` written for work the session is already positioned to do is the tell
-  that the classification is being used as an excuse. On 2026-08-20 a session
-  asked to consolidate one `/work-issues` lesson across cdkd, cdk-local and this
-  repo discovered that every PreToolUse gate here was inert, fixed the matchers in
-  all three, and then filed the remaining script-level gap as three separate
-  issues — reproducing exactly the per-repo split the request existed to end. It
-  took the user objecting to get the fix done in the same SESSION, as a follow-up
-  PR per repo. "Same session" is the bar; "same PR" is only the bar when the work
-  is small enough to review together.
+  repo — that is the split the framing exists to end, not triage; (b) the fix
+  is mechanical and its evidence is live right now (the repro is built, the
+  files are open, a gate cycle is already running); (c) the user already said
+  "finish it here" for the surrounding task, and a discovery inside it
+  inherits the instruction. The four fields exist to make a deferral HONEST,
+  not to make one available — a defensible-looking `Effort` / `Estimate` for
+  work the session is already positioned to do is the tell (2026-08-20: a
+  session consolidating one lesson across cdkd, cdk-local and this repo fixed
+  the inert gates in all three, then filed the remaining script-level gap as
+  three separate issues — it took the user objecting to get it done in the
+  same SESSION, as a follow-up PR per repo). "Same session" is the bar; "same
+  PR" only when the work is small enough to review together.
 
   **A newly DISCOVERED bug is not a residual.** A residual (deferred polish, a
   nit, a parity gap) is fully describable, so writing it down loses nothing. A
   discovery's expensive part is the EVIDENCE behind it — the repro you built,
-  what you watched actually happen, the number you measured — and that is exactly
-  what an issue body cannot carry cheaply. When a bug surfaces mid-session, ask
-  which it is: if the evidence is session-only, finish it now unless a genuine
-  defer criterion fires, and if you must defer it anyway, put the EVIDENCE in the
-  issue body, not just the diagnosis.
+  what you watched actually happen, the number you measured — and that is
+  exactly what an issue body cannot carry cheaply. When a bug surfaces
+  mid-session, ask which it is: if the evidence is session-only, finish it now
+  unless a genuine defer criterion fires, and if you must defer it anyway, put
+  the EVIDENCE in the issue body, not just the diagnosis.
 
-  **One field per line — never pack two onto one**, and keep the field names and
-  their order identical every time. A field with nothing to say gets an explicit
-  `none`, never omission:
+  **One field per line — never pack two onto one**, and keep the field names
+  and their order identical every time. A field with nothing to say gets an
+  explicit `none`, never omission:
 
   ```text
   ## Remaining work

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -62,120 +62,73 @@ const MAX_ORCHESTRATOR_BYTES = 12_000; // orchestrators were 7,952 B / 6,932 B a
 // always-loaded file (a lane cannot pass on a value it was never told to record),
 // while its reading, its restore recipe and the IN-PLACE consequence rows all
 // went to references/launch-mode.md and references/ship.md.
-const MAX_REFERENCE_FILE_BYTES = 64_000; // largest stage file measured 55,137 B (hunt-bugs gotchas.md); 41,922 B after the rule+citation compression pass (2026-08-28), re-measured unchanged 2026-09-01
+const MAX_REFERENCE_FILE_BYTES = 48_000; // RE-DERIVED DOWNWARD 64_000 -> 48_000 by the 2026-09-04
+// token-diet pass (rule + one-line-citation compression over the work-issues
+// stage files; largest stage file is hunt-bugs gotchas.md at 41,922 B,
+// untouched by that pass and unchanged since 2026-08-28). ~14% headroom over
+// the leader; per references/retro.md section 10-c a retro NEVER buys room by
+// raising this cap -- it compresses, displaces, or splits the stage.
 
 // The split skills' stage files must still exist and still carry the moved
-// content. Floors sit far enough below the at-split measurement that narrative
+// content. Floors sit far enough below the current measurement that narrative
 // COMPRESSION stays legal while wholesale deletion fails.
 // Calibration (probed, not guessed): a byte floor should sit ABOVE the corpus
 // minus its LARGEST stage file, or deleting that one file — the likeliest
 // wholesale drop — stays green (measured: hunt-bugs at a 50,000 B floor
-// survived deleting its 55,137 B gotchas.md). `skill-doc-paths.test.ts` does
-// not catch it either: its citation extractor only resolves spans whose first
-// segment is a repo-root directory, and `references/...` is skill-relative
-// (measured, not assumed).
+// survived deleting its then-55,137 B gotchas.md). `skill-doc-paths.test.ts`
+// does not catch it either: its citation extractor only resolves spans whose
+// first segment is a repo-root directory, and `references/...` is
+// skill-relative (measured, not assumed).
 //
 // A SINGLE deleted stage file is caught by `minFiles`, pinned to the EXACT
 // count on disk rather than left slack. The pointer-integrity block below is
-// NOT that guard, and this comment used to claim it was: deleting a stage file
-// TOGETHER WITH the orchestrator row pointing at it leaves both sides
-// consistent, so `retro.md` or `verify.md` could go with its pointer and stay
-// green (measured 2026-09-01). Pointer integrity catches the OTHER half -- a
-// row left dangling by a deletion -- and the two are complementary, not
-// redundant. Raising `minFiles` when a stage file is ADDED is the price of the
-// exact pin, and it is the same edit that already updates this comment.
+// NOT that guard: deleting a stage file TOGETHER WITH the orchestrator row
+// pointing at it leaves both sides consistent (measured 2026-09-01). Pointer
+// integrity catches the OTHER half -- a row left dangling by a deletion -- and
+// the two are complementary, not redundant. Raising `minFiles` when a stage
+// file is ADDED is the price of the exact pin.
 //
-// The older note declined such a floor for work-issues because it leaves little
-// compression room, and that is still the trade; the call was reversed to match
-// the sibling cdk-local because a floor that cannot catch the likeliest wholesale
-// drop is not a weaker guard but a SILENT one. A genuine compression pass
-// re-derives the floor downward in the same commit -- that stays legal; what
-// the floor stops is a deletion with no re-derivation at all. The property is
-// now ASSERTED at the bottom of this file as well as described here, because
-// three consecutive rounds re-derived it BY HAND and one of them found it
-// lapsed.
-// Re-derived 2026-09-03 at the FINAL tree of the mirror round, every figure at
-// that ONE tree. Re-derive this block LAST, after the stage files are final:
-// earlier revisions of it went stale three times while being written, because
-// editing a stage file to fix prose moves the very corpus the comment is about.
-// Nothing else in this file shares that hazard.
+// A genuine compression pass re-derives the floor DOWNWARD in the same commit
+// -- that stays legal; what the floor stops is a deletion with no
+// re-derivation at all. The floor's own invariant is ASSERTED at the bottom of
+// this file, because three consecutive rounds re-derived it BY HAND and one
+// found it lapsed. Re-derive this block LAST, after the stage files are final:
+// earlier revisions went stale three times while being written, because
+// editing a stage file moves the very corpus the comment is about.
 //
-// Re-measured at the release-please switch: corpus 150,695 B, largest
-// implement.md 28,250 B, binding 150,695 - 28,250 = 122,445 — 130,000 still
-// clears it, so the figures below (from the round that set the floor) stand as
-// the derivation record.
-// work-issues: 9 stage files, corpus 150,395 B, largest implement.md 28,148 B,
-// so the BINDING requirement is 150,395 - 28,148 = 122,247. The 120,000 the
-// previous round set is BELOW that, so this raise is a REPAIR and not a
-// precaution: the assertion was already red at HEAD on the binding case alone,
-// no flip needed. Probed rather than reasoned, as this derivation demands -- at
-// 120,000 the suite fails with "deleting that one file would leave 122247 B and
-// still pass", and 130,000 passes. How the margin went across the round:
-// +7,708 B at the base, then +225, +91, -1,138. One round of PROSE consumed it
-// while touching this file only to raise it, because the floor moves with the
-// corpus and the largest file does not.
-//
-// THE FLIP CASE, stated correctly, because two rounds of reviewers and the
-// author all got it wrong here first. When a file grows past implement.md and
-// becomes the largest, the residual is `total - v`, where v is that file's size
-// BEFORE the growth -- the growth cancels, landing in the corpus and in the new
-// largest alike. So the residual is worst for the SMALLEST stage file, not the
-// nearest: claim.md, the SMALLEST at 5,429 B, would leave 144,966. Covering
-// every candidate would need a floor above that, leaving 5,429 B of compression
-// room, which is not this floor's design. It is sized against the NEAR candidates -- triage.md
-// needs +3,811 and leaves 126,057, retro.md +3,471 leaves 125,717, verify.md
-// +1,837 leaves 124,083 -- and note the ranking is not by file size: rank by
-// `total - v`, or the nearest-looking candidate is not the binding one. For
-// everything past those the ASSERTION is the backstop BY DESIGN: it fires at the
+// RE-DERIVED DOWNWARD 130,000 -> 118,000 by the 2026-09-04 token-diet pass, at
+// the pass's FINAL tree. work-issues: 9 stage files, corpus 138,496 B, largest
+// implement.md 25,503 B, so the BINDING requirement is
+// 138,496 - 25,503 = 112,993. THE FLIP CASE (the reasoning that sized every
+// floor since go-to-k/cdk-real-drift#1854): when a file grows past
+// implement.md and becomes the largest, the residual is `total - v`, where v
+// is that file's size BEFORE the growth -- the growth cancels, landing in the
+// corpus and in the new largest alike. Rank candidates by `total - v`, not by
+// file size; the residual is worst for the SMALLEST file (claim.md at 5,429 B
+// would leave 133,067 -- covering it would leave almost no compression room,
+// which is not this floor's design). The NEAR candidates: retro.md (22,961 B)
+// leaves 115,535, verify.md (22,999 B) leaves 115,497, triage.md (23,089 B)
+// leaves 115,407. Chosen 118,000: clears binding by 5,007 B and the worst near
+// flip by 2,465 B, leaving 138,496 - 118,000 = 20,496 B of compression room
+// (14.8%). HONEST LIMIT: 2,465 B over the near flip is one modest retro round;
+// past that the ASSERTION below is the backstop BY DESIGN -- it fires at the
 // commit that causes the flip and its message names the number to raise to.
+// Before this pass the floor had climbed 116,000 -> 120,000 -> 130,000 across
+// two days of retro rounds tracking growth (corpus 139,801 -> 150,395 ->
+// 150,695); the full round-by-round derivation record lives in this file's
+// git history at origin/main.
 //
-// Chosen 130,000, not the 128,000 an earlier revision of this round set. At
-// 128,000 the binding margin was 5,753 B and the worst near flip cleared by only
-// 1,943 B -- less than one ordinary edit -- so it would have red on the next
-// routine round and taught the next author nothing except to raise it again.
-// 130,000 clears binding by 7,753 B (restoring the round base's 7,708 B) and the
-// worst near flip by 3,943 B, leaving 150,395 - 130,000 = 20,395 B of
-// compression room (13.6%, against 14.2% at the 2026-09-02 derivation).
-//
-// HONEST LIMIT: 7,753 B is roughly what the previous round consumed in one pass,
-// so this still buys about ONE round. A cap with an unmeasured margin is one
-// nobody can plan against; so is one whose margin is measured and left unstated.
-//
-// The growth this round is +10,594 B across all 8 changed stage files, listed in
-// FULL because a partial list is the same silent under-reporting
-// references/retro.md now carries a rule against: retro.md +3,437,
-// verify.md +3,008, gates-and-pr.md +1,237, triage.md +1,199, claim.md +898,
-// implement.md +639, launch-mode.md +96, ship.md +80. Base corpus 139,801 +
-// 10,594 = 150,395, which is the arithmetic that makes the list checkable.
-//
-// SUPERSEDED, kept because the reasoning is the same and only the numbers moved:
-// work-issues: 9 stage files, corpus 139,801 B, largest implement.md 27,509 B, so
-// the binding requirement is 139,801 - 27,509 = 112,292, which the 116,000 set
-// hours earlier still clears -- the assertion below did NOT fire, and this raise
-// is preventive rather than a repair. What no longer clears is the FLIP case the
-// comment has been sized against since go-to-k/cdk-real-drift#1854: the next
-// candidates to become largest are verify.md at 23,304 B and triage.md at
-// 23,139 B, and the worst of those requires 139,801 - 23,139 = 116,662, which
-// 116,000 sits BELOW. Probed rather than reasoned (2026-09-02): with triage.md
-// grown past implement.md, the assertion reports "would leave 116,293 B and
-// still pass" at 116,000 and passes at 120,000. So 120,000 -- clearing the
-// binding number by 7,708 B and the flip by 3,338 B, and leaving ~19 KB
-// (139,801 - 120,000 = 19,801 B) of compression room below the floor. The growth
-// this round is the IN-PLACE branch rule and the byte-exact probe-restore rule
-// in implement.md (+1,628 B) plus the reviewer-reporting and host-load lessons
-// in verify.md (+2,316 B); the round before it was the LAUNCH_BRANCH restore
-// contract across launch-mode.md, ship.md, retro.md and claim.md.
-// hunt-bugs stays at 60,000: corpus 88,683 B at this round's final tree (+78 of
-// it from this round's hunt-bugs/references/plan.md edit) and
-// largest gotchas.md 41,922 B, so 88,683 - 41,922 = 46,761 < 60,000 and its
-// property still holds. Re-measure both numbers for each skill whenever a stage
-// file changes size materially -- the property is silent when it lapses.
+// hunt-bugs stays at 60,000: corpus 88,683 B, largest gotchas.md 41,922 B, so
+// 88,683 - 41,922 = 46,761 < 60,000 and its property still holds (untouched by
+// the 2026-09-04 pass). Re-measure both numbers for each skill whenever a
+// stage file changes size materially -- the property is silent when it lapses.
 const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }> = {
-  // 8 files / 125,139 B measured at the split (2026-08-28); largest 26,621 B; 94,136 B
-  // post-compression. 9 files as of 2026-09-01, when the launch-mode probe and its
-  // reading moved out of triage.md into references/launch-mode.md, which the PARENT
-  // reads before stage 0.
-  'work-issues': { minFiles: 9, minCorpusBytes: 130_000 },
+  // 8 files / 125,139 B measured at the split (2026-08-28); 94,136 B
+  // post-compression; regrown to 150,695 B by 2026-09-03's retro rounds;
+  // 138,496 B after the 2026-09-04 token-diet pass. 9 files as of 2026-09-01,
+  // when the launch-mode probe moved out of triage.md into
+  // references/launch-mode.md, which the PARENT reads before stage 0.
+  'work-issues': { minFiles: 9, minCorpusBytes: 118_000 },
   // 7 files / 108,940 B measured at the split (2026-08-28); largest 55,137 B; 87,180 B post-compression
   'hunt-bugs': { minFiles: 7, minCorpusBytes: 60_000 },
 };


### PR DESCRIPTION
## Summary

Token-diet pass over the agent-instruction corpus, mirroring the compression that landed in the sibling repo as go-to-k/cdkd#2493 — with every sentence re-verified against THIS repo's own files (gates, hooks, skill names and paths differ; several sibling claims are false here and were not imported). The files injected into every session (`CLAUDE.md`) or loaded per stage (`/work-issues` references) were compressed to rule-plus-one-line-citation form. Every rule survives; only narrative bodies, duplicate restatements, and incident walkthroughs whose mechanics live in the hooks and their `.test.sh` suites were cut. No gate, hook, or verification requirement is weakened.

Byte effect:

| File | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `CLAUDE.md` (injected into EVERY context: parent, triage subagent, each lane, retro) | 75,771 | 59,150 | -22% |
| `references/implement.md` | 28,250 | 25,503 | -10% |
| `references/verify.md` | 26,312 | 22,999 | -13% |
| `references/retro.md` | 24,676 | 22,961 | -7% (net of the new anti-regrowth rule) |
| `references/triage.md` | 24,338 | 23,089 | -5% (§0 security screen kept verbatim) |
| `references/ship.md` | 13,623 | 11,787 | -13% |
| `references/gates-and-pr.md` | 10,678 | 9,339 | -13% |
| work-issues references corpus | 150,695 | 138,496 | -8% |

The work-issues corpus regrew +56 KB in the week since its own 2026-08-28 rule+citation split (94,136 B post-split), via per-retro fold-back rounds; this pass takes back the narrative half of that growth and adds the rule that stops the ratchet (below). The biggest single win is `CLAUDE.md`: the Stop-hook, `main-tree-branch-gate` and gh-flag-parity round-by-round incident histories (~32 KB) compress to their rules plus citations — the measured rc tables live in the file's git history and in the hooks' own suites (172 / 121 / 74 cases), which are what actually enforce them.

## What is deliberately preserved

- The `/work-issues` §0 untrusted-content security screen and `CLAUDE.md`'s untrusted-third-party-content rule: **verbatim**.
- `CLAUDE.md`'s Core invariant + fold-strategy decision order (the product's own contract): verbatim.
- Every TEST-BOUND fence anchor, byte-compatible (two fences no test binds byte-wise -- implement.md's `git switch -c` recipe and retro.md's promotion-check block -- had comment lines rewrapped; their command lines are identical): all `ARM_BEARING` mode markers (`MAIN-CHECKOUT` / `IN-PLACE` per file), all `LAUNCH_BRANCH` arms, ship.md's `git switch <LAUNCH_BRANCH>` restore block and its detach fallback (the launch-mode suite asserts the command text and the no-pull/rebase/merge/fetch negative), the launch-mode probe (untouched file, still the only `--git-common-dir` copy).
- Every fenced command recipe and marker/gate mechanic (liveness probe, `markgate set` traps, dup-check fold recipe, §10-0 promotion-check loops, §3-a cutoff query).
- Section numbering (§0–§10, §3-a/§3-b, §8-z, §10-0/a/b/c/d) — cross-references cite sections by number.
- Fully-qualified `go-to-k/<repo>#N` issue references throughout (enforced by `tests/skill-doc-paths.test.ts`; 45 tests green).

## Anti-regrowth mechanism

- `references/retro.md` §10-c now forbids a retro from buying room by raising a byte cap or corpus floor — additions are paid for by compression/displacement, or the stage is split. Citation carried inline: this repo's own floor climbed 116,000 -> 120,000 -> 130,000 across two days of retro rounds before this pass.
- `tests/skill-file-payload.test.ts` bounds re-derived DOWNWARD in the same commit, probed (not reasoned) at the final tree: work-issues `minCorpusBytes` 130,000 -> 118,000 (binding 138,496 - 25,503 = 112,993; the suite goes red at 112,000 naming the exact residual, green at 118,000; near-flip candidates retro/verify/triage cleared by >= 2,465 B with the bottom-of-file assertion as the stated backstop), `MAX_REFERENCE_FILE_BYTES` 64,000 -> 48,000 (largest remaining stage file is hunt-bugs `gotchas.md` at 41,922 B, untouched). Derivation comments rewritten at the final tree; superseded round-by-round records point at git history.

## Won't-do (decided + recorded here)

- **No `.claude/rules/session-report.md` satellite** (the shape cdkd used for its -47% CLAUDE.md cut): this repo has no `.claude/rules/` directory and nothing — no fence, no loader reference — loads one, so a satellite would be dead weight; the session-wrap field reference is compressed in place instead (every field, scale, and spelling rule kept).
- **`claim.md` / `launch-mode.md` unchanged**: fence density — `tests/work-issues-launch-mode.test.ts` executes launch-mode.md's fenced probe verbatim and pins its single-copy property; claim.md is mostly gate-measured claim mechanics.
- **`gotchas.md` unchanged**: 6,233 B appendix, already in rule form; it carries an `ARM_BEARING` marker and the `verify-pr`-marker / `--delete-branch` mechanics.
- **Other skills not compressed** (`verify-pr` 12,571 B, `check` 7,445 B, `check-docs` 4,951 B, `hunt-bugs` orchestrator 6,932 B, `sweep-resources` 6,079 B): each is already at or below the size cdkd's compression pass *targeted* for its equivalents (cdkd's verify-pr landed at 20,556 B); compression payoff is negligible against the risk of touching marker recipes.
- **hunt-bugs `references/` not compressed**: that corpus received its own rule+citation pass on 2026-08-28 (gotchas.md 55,137 -> 41,922 B) and has not regrown.

## Test plan

- Fence suites run after every rewritten file and at the final tree, all green: `skill-file-payload` (27), `skill-doc-paths` (45 — path-citation floor >= 60 and qualified-ref floor >= 120 both still clear), `work-issues-launch-mode` (20 — includes executing the probe in a real repo + linked worktree), `markdown-fmt-corruption-1771` (22), `check-scope-checker-inputs-1837` (14), `gate-if-matchers-1801` (17).
- Floor re-derivation probed in both directions: red at 112,000 with the exact residual in the message, green at 118,000.
- Full unit suite: 352 files / 6,666 tests green. `vp run typecheck`, `vp run check`, `vp pack` green. `vp fmt` idempotent on every edited markdown file (second run a no-op).
- Lost-content audit: code-span diff of every rewritten file against `origin/main`; the only load-bearing loss found (`BUGHUNT_TRACKER_OVERRIDE` overrides the tracker, not the hook) was restored. Remaining lost spans are incident-narrative payloads (exact error strings, probe ids) whose rules and citations survive.
- Gate liveness probed as a Bash tool call before the commit (`git commit --dry-run` -> `Blocked by check-gate`); `check` + `docs` markers set from the worktree after the full check flow.



## Review record

Independent rule-survival review (4 parallel lanes + orchestrator measurement): no blockers; 5 minors fixed in 96056c8 (restored the softening/merging prohibition arms in retro.md section 10-0, the probe-not-diff-reading sentence in verify.md, the stash-trap warning in implement.md; fixed a wrapped code span in CLAUDE.md; corrected this body's fence claim). Full suite 352 files / 6,666 tests green after the fixes.
