### PR TITLE
chore(ci): add workflow_dispatch to Release and record the stale-release-PR trap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,43 @@ name: Release
 # here — merging it via the web UI, and never without the maintainer asking
 # for a release, is convention, not enforcement. Giving the release-please
 # step a PAT instead of GITHUB_TOKEN would restore CI on it.
+#
+# STALE STANDING RELEASE PR — the trap workflow_dispatch below exists for.
+# release-please does NOT rebuild a standing release PR when the release it
+# computes is unchanged: it logs `PR #N remained the same` and leaves the
+# branch on the base it was cut from. So anything that later lands on main in a
+# file release-please OWNS — CHANGELOG.md, package.json's version,
+# .release-please-manifest.json — is simply MISSING from that branch, and
+# GitHub still reports the PR MERGEABLE. Merging it then takes the branch's
+# stale copy of those files and REVERTS whatever landed. There is no conflict
+# to warn you: the symptom is a green, mergeable PR that quietly undoes work.
+# MEASURED in the sibling repo: release PR go-to-k/cdkd#2503 was cut before the
+# CHANGELOG normalization merged, its branch still carried the pre-
+# normalization file, and merging it would have undone 285 header conversions.
+#
+# REMEDY: close the release PR, delete its branch, and re-run this workflow —
+# release-please recomputes the identical release from current main, this time
+# on top of the new commits (verified in the sibling: the recreated PR inserts
+# the entry at the top). It is safe to run at any time because release-please
+# is idempotent: a run that finds nothing new leaves the standing PR alone and
+# publishes nothing.
+#
+# `workflow_dispatch` is what makes that remedy runnable. Without it the only
+# trigger is `push: main`, so re-running the release means re-running an old
+# push run from the Actions UI — which is how the sibling had to do it.
+# Note the `concurrency` group below is a literal, not a trigger-dependent
+# expression, so a dispatched run shares the group with push runs: with
+# `cancel-in-progress: false` it QUEUES behind an in-progress push run rather
+# than cancelling it (and, per the one-pending-run rule noted there,
+# supersedes an older still-pending run). Nothing is lost either way, since
+# every run recomputes from full history.
 
 on:
   push:
     branches:
       - main
+  # Manual re-run, for recreating a stale standing release PR (see above).
+  workflow_dispatch:
 
 # Serialize Release workflow runs so a back-to-back merge (#204 + #205 landed
 # within ~30s under semantic-release and the earlier run's tag push raced the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,23 @@ node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to
   via the web UI, and never without the maintainer asking for a release, is
   convention, not enforcement (a PAT on the release-please step would restore
   CI on it). Changes reach real users, so weigh breaking ones accordingly.
+- **A standing release PR goes STALE and stays MERGEABLE.** release-please does
+  not rebuild a release PR whose computed release is unchanged — it logs
+  `PR #N remained the same` and leaves the branch on the base it was cut from.
+  Anything that lands on `main` afterwards in a file release-please OWNS
+  (`CHANGELOG.md`, `package.json`'s version, `.release-please-manifest.json`)
+  is therefore MISSING from that branch, with no conflict to warn you: GitHub
+  reports the PR mergeable, and merging it takes the branch's stale copy and
+  REVERTS what landed. Measured in the sibling repo (go-to-k/cdkd#2503): the
+  release PR was cut before the CHANGELOG normalization merged, and merging it
+  would have undone 285 header conversions. The remedy is to close the release
+  PR, delete its branch, and re-run the Release workflow (`workflow_dispatch`
+  exists for this) — release-please recomputes the identical release from
+  current `main`, and is idempotent, so a run that finds nothing new changes
+  nothing. **Rule: after any PR that edits `CHANGELOG.md`, the version in
+  `package.json`, or `.release-please-manifest.json`, check whether a release
+  PR is open (`gh pr list --state open --search "chore(release) in:title"`)
+  and recreate it if so.**
 - Baseline files live at `.cdkrd/baselines/<stack>.<accountId>.<region>.json` — git-committed.
   A PR that changes a baseline is a visible, reviewable change to "what real state
   we record".


### PR DESCRIPTION
## Mechanism

release-please does **not** rebuild a standing release PR when the release it computes is unchanged. It logs `PR #N remained the same` and leaves the branch on the base it was cut from.

So anything that lands on `main` afterwards, in a file release-please **owns** — `CHANGELOG.md`, `package.json`'s version, `.release-please-manifest.json` — is simply MISSING from that branch. There is no conflict to warn anyone: GitHub still reports the PR **MERGEABLE**, and merging it takes the branch's stale copy of those files and **REVERTS** whatever landed. The symptom is a green, mergeable PR that quietly undoes work.

## Measurement

Observed live in the sibling repo: release PR go-to-k/cdkd#2503 was cut before the CHANGELOG normalization merged. Its branch still carried the pre-normalization file, and merging it would have undone **285 header conversions**. The remedy — close the release PR, delete its branch, re-run the release workflow — made release-please recompute the identical release from current `main`, this time on top of the new commits, and the recreated PR inserts its entry at the top.

Executing that remedy surfaced a second gap: the release workflow triggered only on `push: main`, so there was no way to re-run it on demand — the sibling had to `gh run rerun` an old push run.

This repo is exposed to exactly the same trap, and its just-merged CHANGELOG normalization (go-to-k/cdk-real-drift#1879) is precisely the class of change that triggers it.

## Changes

**1. `.github/workflows/release.yml` — `workflow_dispatch:` added** alongside the existing `push: main`. The `concurrency` block and every job are unchanged, and the **file name is unchanged**: the npm OIDC trusted publisher binds to the filename, and adding a trigger does not affect that binding. The header now records the stale-standing-PR behavior, its symptom (mergeable while stale), the cdkd measurement, and the close + delete-branch + re-run remedy — noting that re-running is safe at any time because release-please is idempotent (a run that finds nothing new leaves the standing PR alone and publishes nothing).

**Concurrency interaction, verified rather than assumed** (checked against GitHub's workflow-syntax concurrency documentation): the group is the literal `release`, not a trigger-dependent expression, so a dispatched run shares the group with push runs. With `cancel-in-progress: false` it **queues behind** an in-progress push run rather than cancelling it, and — per the one-pending-run rule already documented beside that block — it supersedes an older still-pending run. Nothing is lost either way, since every run recomputes from full history.

**2. `CLAUDE.md` release-flow section — the same warning**, ending with the actionable rule:

> after any PR that edits `CHANGELOG.md`, the version in `package.json`, or `.release-please-manifest.json`, check whether a release PR is open (`gh pr list --state open --search "chore(release) in:title"`) and recreate it if so.

## Deliberately not fenced

No test asserts the presence of `workflow_dispatch`. It is a convenience trigger, not an invariant — the release behavior does not depend on it — and fencing it would make the workflow file harder to edit for no protection. The v0 fence's existing cases still parse this file and are unaffected (verified: `on` resolves to `push` + `workflow_dispatch`, `concurrency` and both jobs intact).

## Test results

Full suite: 352 files / 6668 tests, all passing. `vp run typecheck`, `vp check --fix` (0 errors), `vp pack` all green.
