### PR TITLE
chore: fold four sibling /work-issues lessons into this repo's own wording

### DIFF
--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -112,6 +112,16 @@ recorded copy. A later stage that re-derives `LANE_TREE` from
 `$(git rev-parse --show-toplevel)` or from `pwd` resolves against the reset cwd
 and answers "the main checkout" in precisely the case the `-C` exists to guard.
 
+**The same fault arrives through commands that never MENTION the values** — a
+`sed -n` / `grep` / `cat` on a RELATIVE path, or a bare
+`git branch --show-current` / `git diff`. Read every file this run owns under
+the recorded absolute `<LANE_TREE>`, and treat an answer CONTRADICTING those
+values as a cwd fault, not a finding: in a sibling run (go-to-k/cdkd#2514) a
+`main` from `git branch --show-current` plus an EMPTY
+`git diff --stat origin/main..HEAD` were read as "the branch was switched, the
+PR maybe merged", and two "unfixed prose" defects were reported that were the
+main checkout's copies of text the lane had already fixed.
+
 **`<LANE_TREE>` and `<MAIN_CHECKOUT>` in a later stage are SUBSTITUTION
 PLACEHOLDERS, not shell variables, and the difference is the whole guard.**
 Paste the absolute path from the opening report into the command text. Do NOT

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -99,13 +99,11 @@ four, three cited only as precedent). Do the item now while the context is
 loaded, or re-classify it in the issue body with the reason it still does not
 belong here.
 
-**Re-read the REASON too — it can name a state that has since resolved.**
-Classifying once at creation is right, but a reason phrased in the run's own
-transient state ("the PR carrying it is still open") goes FALSE when that state
-resolves (go-to-k/cdkd#2259: deferred while go-to-k/cdkd#2247 was in review;
-the reason survived unchanged into the wrap after that PR merged). Re-reading
-an expired premise is not re-litigation; keeping a `next` alive on a reason
-that stopped being true is.
+**Re-read the REASON too, and when a hit CONTRADICTS it, the BODY is the stale
+side.** A reason anchored to the filing session's own state goes false while
+the decision it justified still stands — §3-b carries the shape, its boundary
+against the PR-shaped reason that is refused outright, and the incidents.
+Correct the issue when this check catches one.
 
 ### 10-a. Evidence: only what this run actually produced
 
@@ -208,6 +206,13 @@ Every run appending one more bullet is how a long skill becomes an unread one.
     cross-reference against that repo's files — caught four such false claims
     in the first mirror of this section (2026-08-18). This rule lives here, not
     in memory: memory is per-project-path and would not load in the targets.
+  - **Check the TARGET's OPEN PRs before editing a file there.** A mirror lands
+    in `.claude/**`, which no §2 worktree probe covers, and §0-§3 are skipped
+    outright when the port is DIRECTED rather than triaged, so nothing else
+    asks. `gh pr list --state open --json number,files` is the whole check
+    (2026-09-05: this section's own mirror found
+    go-to-k/cdk-real-drift#1882 rewriting `.claude/rules/session-report.md` ten
+    minutes earlier).
   - **Verify the MECHANISM at the SOURCE, not only the applicability at the
     TARGET.** Applicability asks "does this repo have that gate / hook /
     file"; the mechanism asks "was the claim ever true where it was WRITTEN",

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -53,6 +53,24 @@ the peer's new test (2026-08-19, go-to-k/cdk-local#524 failed CI on a line
 go-to-k/cdk-local#520 had merged in parallel). Same cause as §7's
 repo-wide-check collision; the same rebase answers both.
 
+**Before you watch CI, poll until checks EXIST.** `gh pr checks <n> --watch`
+does NOT cover that wait: with none reported it returns AT ONCE rather than
+blocking for them to appear, so an `until` loop wrapping it hot-spins through a
+whole tool timeout. Nor does the JSON form answer with an empty array —
+`--json name,state` prints ZERO bytes and exits 1 with `no checks reported` on
+stderr (measured, gh 2.89.0), so a poll reading a length reads nothing. Poll for
+a ROW, from a backgrounded loop, then `--watch` once one exists:
+
+```bash
+until gh pr checks <n> -R <owner>/<repo> --json name,state 2>/dev/null \
+  | grep -q '"name"'; do sleep 20; done
+```
+
+And the wait is YOURS to keep: `ci-green-gate` FAILS OPEN on that state
+(`CLAUDE.md` → "State of the Repo" records it; cdkd's blocks, and cdk-local
+carries no such gate at all), so nothing stops a merge issued before CI has
+registered.
+
 MAIN-CHECKOUT (SKILL.md "Launch mode") — run THIS block, and not the next one:
 
 ```bash
@@ -77,13 +95,10 @@ the command; an empty variable is not:
 git -C "<MAIN_CHECKOUT>" pull origin main
 ```
 
-**Release** is BATCHED (release-please via `.github/workflows/release.yml`) —
-merging a `fix:` / `feat:` commit to `main` publishes NOTHING by itself: it
-only creates/updates the standing `chore(release): <ver>` release PR. The npm
-release happens when the maintainer merges that release PR, so do NOT poll for
-a version bump after an ordinary merge, and never merge the release PR unless
-the user asked for a release. Confirm the release PR picked up the merge
-instead:
+**Release** is BATCHED (`CLAUDE.md` → "State of the Repo" owns the rules: an
+ordinary merge publishes nothing by itself, and the standing release PR is
+never yours to merge). This stage owes only the confirmation that it picked
+your merge up:
 
 ```bash
 gh pr list --state open --search "chore(release) in:title"   # the standing release PR

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -381,6 +381,23 @@ the other two repos — probe, corrected shape and rc table all in hand;
 re-classified `now` on the maintainer's challenge, and the port then found four
 more defects a fresh session would not have known to look for).
 
+**And a reason about THIS SESSION's own state expires when the session does.**
+A different failure from the one just above: that is a claim about the PULL
+REQUEST, refused outright. This is a claim about the SESSION that filed the
+issue — "the PR carrying it is still open", "that file is held by another
+lane's diff", "this lane has no live run budgeted". A PR can be named on either
+side, so the mention is not the tell; ask which of the two the sentence is
+ABOUT. Such clauses are legal and merely go STALE, and classifying once does
+not protect them, because it freezes the DECISION, not the PREMISE. So prefer a
+reason the WORK owns; when a session-state clause is written anyway, NAME THE
+EVENT THAT ENDS IT on the same line, so a later reader can see it has expired
+without asking anyone. It bites hardest on a "no file overlap" reason, which is
+a claim about a MOVING target the lane keeps editing after writing it
+(go-to-k/cdkd#2440 is deferred on exactly that wording; go-to-k/cdkd#2259 on
+"that PR is still open", which survived unchanged into the wrap after
+go-to-k/cdkd#2247 merged). §10-0's end-of-run promotion check is the only thing
+that catches one.
+
 **And when the issue body offers more than one fix, say which one the four
 fields cost.** Cost the CHEAPEST one you would actually accept. A deferral
 justified by the expensive option is not a measurement, it is a choice of

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -345,3 +345,21 @@ work and looks complete, which is worse than returning none.
 `references/launch-mode.md` records the same failure on its IN-PLACE table — a
 count written beside a list is maintained, a count written a paragraph away is
 not.
+
+**A probe that DID discriminate is void just as easily: one that changed TWO
+things at once attests to neither.** Measured on go-to-k/cdkd#2612: a comment claimed
+that reordering either consumer "reds four cases", and the probe behind it had
+also edited the rendered line's TEXT in the same pass — so the reds belonged to
+the text edit. Re-measured one mutation at a time, each alone was GREEN and
+only both together red a case: the two mechanisms are mutually redundant, the
+opposite of what the comment said. One mutation per probe, tree restored
+byte-exact between them (`references/implement.md`), and never report a
+mutation result you did not run.
+
+**A probe result written into a SOURCE COMMENT gets the same disposition as a
+number in published prose** — DELETE it (preferred), FENCE it with a test that
+reads the code, or ATTRIBUTE it as a dated measurement. Nothing downstream
+re-checks such a line: go-to-k/cdkd#2612's wrong claim sat in a branch comment
+in source, no test could see it, and only a review round stopped it becoming a
+fence a later editor would trust. What it should have stated is the invariant
+the two mechanisms jointly enforce — re-derivable, so it cannot go stale.

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -118,6 +118,29 @@ const MAX_REFERENCE_FILE_BYTES = 48_000; // RE-DERIVED DOWNWARD 64_000 -> 48_000
 // 150,695); the full round-by-round derivation record lives in this file's
 // git history at origin/main.
 //
+// RE-MEASURED 2026-09-05 by the sibling-lesson mirror round (go-to-k/cdkd#2564
+// / go-to-k/cdkd#2586 / go-to-k/cdkd#2596 / go-to-k/cdkd#2622 folded into this
+// repo's own wording). The floor is UNCHANGED at 118,000 -- references/retro.md
+// section 10-c forbids buying room by raising it. work-issues is now 142,876 B
+// over the same 9 files with implement.md still largest at 25,647 B, so the
+// BINDING requirement is 117,229 and the margin is 771 B. The round added rules
+// to triage.md, verify.md, launch-mode.md, ship.md and retro.md, and paid part
+// of them back by compressing retro.md's stale-deferral-reason bullet into a
+// pointer at triage.md section 3-b, by deleting ship.md's verbatim restatement
+// of CLAUDE.md's release rules, and by cutting two clauses that restated their
+// own paragraph.
+//
+// What it SPENT is the NEAR-FLIP margin the paragraph above sizes, and saying
+// so is the point -- a reader who trusted that derivation would now be wrong.
+// Residuals if each near candidate grew past implement.md: retro.md (23,404 B)
+// 119,472, triage.md (24,261 B) 118,615, verify.md (24,311 B) 118,565. ALL
+// THREE now sit ABOVE the floor, where the paragraph above cleared the worst by
+// 2,465 B. So the flip case is no longer covered by design margin at all: the
+// next stage file to overtake implement.md reds the ASSERTION below at the
+// commit that causes it, and its message names the number. That is the backstop
+// working as designed, and the answer there is compression, never a bigger
+// number.
+//
 // hunt-bugs stays at 60,000: corpus 88,683 B, largest gotchas.md 41,922 B, so
 // 88,683 - 41,922 = 46,761 < 60,000 and its property still holds (untouched by
 // the 2026-09-04 pass). Re-measure both numbers for each skill whenever a


### PR DESCRIPTION
## What

Mirrors the four `/work-issues` retro rounds that landed in the sibling repo on
2026-09-05 (go-to-k/cdkd#2564, go-to-k/cdkd#2586, go-to-k/cdkd#2596,
go-to-k/cdkd#2622) into this repo's own corpus. Per `references/retro.md`
section 10-c this is an adaptation, not a copy: every lesson was first checked
against the mechanism it is about, and three were dropped because that
machinery does not exist here.

## Ported

1. **A deferral reason about THIS SESSION's own state expires when the session
   does.** Landed in `references/triage.md` section 3-b, directly beside the
   PR-shaped reason that section already refuses outright — that boundary is
   what the rule turns on, and 3-b is where the `Session-fit` reason clause is
   actually written in this flow. **Deliberately NOT in
   `.claude/rules/session-report.md`**, where the sibling put it:
   go-to-k/cdk-real-drift#1882 is a live lane (updated minutes before this was
   written) rewriting that file. Its hunks and the insertion point do NOT
   collide textually — that was checked — so the reason is OWNERSHIP, which is
   what this repo's disjoint-file rule is about, not conflict avoidance. Its new
   `issue-deferral-criteria-gate.sh` refuses PR-shaped wording only, so the
   boundary drawn in 3-b survives that merge unchanged. `references/retro.md` section 10-0's
   "Re-read the REASON too" bullet was compressed into a pointer at 3-b and its
   incident MOVED there, so no phrase now sits in both files.

2. **One mutation per probe**, plus **a probe result written into a SOURCE
   COMMENT gets the same disposition as a number in published prose** (delete,
   fence with a test that reads the code, or attribute as a dated
   measurement). Both in `references/verify.md` section 8-z, which so far only
   covered a probe reporting NO discrimination; these are the mirror case, a
   probe that DID discriminate but changed two things at once.
3. **The recorded launch-mode values govern READS, not only re-derivations.**
   A relative `sed`/`grep`/`cat`, or a bare `git branch --show-current`, can
   answer from the main checkout without ever mentioning `LANE_TREE`; an
   answer contradicting the recorded values is a cwd fault, not a finding
   (`references/launch-mode.md`).
4. **`gh pr checks <n> --watch` returns AT ONCE when no check has registered
   yet** — it does not block for checks to appear, so an `until` loop around it
   hot-spins. **Corrected past the sibling's own wording**: the JSON form does
   not answer with an empty array either — measured here on gh 2.89.0,
   `--json name,state` prints ZERO bytes and exits 1 with `no checks reported`
   on stderr, so a poll reading a length reads nothing. `references/ship.md`
   now carries a poll predicate that was EXECUTED in both directions (rc=1 on a
   check-free PR, rc=0 on one with checks). **Adapted, not copied**:
   `ci-green-gate` FAILS OPEN on that state here (cdkd's blocks; cdk-local has
   no such gate at all), so nothing stops a merge issued before CI registers and
   the wait is the agent's to keep. `CLAUDE.md` already records the fail-open,
   so ship.md points at it rather than restating it.

## Added from this round's own evidence

`references/retro.md` section 10-c gains one bullet: **check the TARGET repo's
OPEN PRs before editing a file there.** A mirror lands in `.claude/**`, which no
section 2 worktree probe covers, and sections 0–3 are skipped outright when the
port is DIRECTED rather than triaged — so nothing in the flow asks. This round
found go-to-k/cdk-real-drift#1882 rewriting `.claude/rules/session-report.md`
ten minutes earlier only because it happened to list open PRs for another
reason. `gh pr list --state open --json number,files` is the whole check, and it
was executed here.

## Not ported, and why

- **The recent-defect review up-bias as a mechanical history query.** This
  repo has no `/review-pr` skill, no `.claude/agents` reviewer set, and the
  `pr-review` gate in `.markgate.yml` is INERT and wired to no hook — there is
  no tier to bias. `references/retro.md` section 10-d and
  `references/verify.md` already say the depth is your own read of the whole
  diff plus an independent round.
- **Rewriting a marker's sentinel after setting the marker stales it.** The
  only sentinel-bound gate here is that same inert `pr-review`; `integ` is
  `hash: diff`, and the bug-hunt sentinel is not a markgate marker at all.
- **`Errors` in a vitest summary is not the `Type Errors` line beside it.**
  Measured on this branch: `vp test run` here prints no `Type Errors` line at
  all. It is also not in any of the four commits' diffs.

## Byte budget

No cap and no floor was raised (`references/retro.md` section 10-c forbids it).
The `work-issues` corpus went 138,862 -> 142,876 B against an unchanged 118,000
floor; the binding requirement `corpus - largest` is 117,229, leaving 771 B.
Part of the additions was paid back by compressing `references/retro.md`'s
bullet into a pointer and by deleting `references/ship.md`'s verbatim
restatement of `CLAUDE.md`'s release rules.
`tests/skill-file-payload.test.ts` records the re-derivation and states plainly
that the NEAR-FLIP margin its older comment sizes is now spent: all three near
candidates' residuals now sit ABOVE the floor, so the next stage file to
overtake `implement.md` reds that assertion instead of passing on design
margin.

## Verification

- `vp run typecheck` rc=0; `vp check --fix` rc=0; `vp pack` rc=0.
- `vp test run` first reported 4 failures in 2 subprocess-spawning suites, all
  `Test timed out in 5000ms` at load average 26.9 — the host-load artifact
  `references/verify.md` documents. Re-run as `vp test run --maxWorkers=4`:
  352 files / 6,668 tests, rc=0.
- `vp run test:hooks`: 16 harnesses, 0 failed.
- Prose tier per `references/verify.md`: every gate, hook, path and command the
  new text names was resolved against this repo's files, and the cited sibling
  records were opened and confirmed to say what the sentences claim.
- An independent read-only reviewer round was dispatched against the diff (this
  repo has no reviewer ladder, so the depth was a judgement call — agent
  instructions propagate to every future session). It returned one **blocker**,
  reproduced and fixed here: the poll recipe in item 4 originally claimed
  `--json` prints `[]` when no checks exist. It does not. Two minors were also
  fixed (a restatement of `CLAUDE.md`'s fail-open, and "the siblings" plural
  where only cdkd has the blocking gate).
- No `src/**` in the diff, so no live-test tier and nothing to sweep.
