### PR TITLE
chore(work-issues): stop ranking issues by recency, and sort agent-tooling ones last

### DIFF
--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -174,18 +174,16 @@ a time, and if the run ends before reaching one, stand it down with a comment ca
 visibly claimable rather than silently locked (the shape go-to-k/cdkd#2417
 measured: three claimed, one merged, two left pickup-ready). Claiming only the
 top candidate is still fine; a QUEUED issue is spoken for rather than
-abandoned. (Until 2026-09-03 this paragraph said "take ONE issue and finish
-it"; that read a hazard about trees existing at the same time as a budget on
-work — the one thing it does not constrain. The same limit was corrected in
-`references/launch-mode.md` row 1 and `references/claim.md` together.)
+abandoned. (The tree hazard is not a budget on WORK — the one thing it does
+not constrain; corrected 2026-09-03 in `references/launch-mode.md` row 1 and
+`references/claim.md` together.)
 
 **The MAIN-CHECKOUT case is the DISJOINTNESS PARAGRAPH below and nothing
-wider.** An earlier revision said "everything below is the MAIN-CHECKOUT case",
-which told an IN-PLACE run to skip the security-first ranking, the `Severity`
-ranking, the premise checks and §3-a's freshness gate — all mode-independent,
-and the last a HARD gate. The rest of what IN-PLACE changes lives in
-`references/launch-mode.md`'s table, which maps ten consequences to §1, §2,
-§4, §5, §7, §9 and §10-d.
+wider** — the security-first ranking, the `Severity` ranking, the premise
+checks and §3-a's freshness gate are mode-independent, and the last is a HARD
+gate (an earlier revision told IN-PLACE runs to skip all four). The rest of
+what IN-PLACE changes lives in `references/launch-mode.md`'s table, which maps
+ten consequences to §1, §2, §3, §4, §5, §7, §9 and §10-d.
 
 **Two lanes must edit DISJOINT files** (same as the worktree rule): two issues
 both landing in `noise.ts` cannot be parallelized — bundle into ONE lane or
@@ -217,9 +215,21 @@ choosing. §3-a is a second HARD gate applied before any preference below.
   ```
 
   `severity:?` means UNLABELLED, which is **not** `low`. A label-only query
-  UNDER-counts (most of the backlog predates the labels); the label mirrors the
-  body line, never a second source — confirm a surprising one against the body.
+  UNDER-counts wherever an issue is unlabelled; the label mirrors the body
+  line, never a second source — confirm a surprising one against the body.
 
+- **Then the product surface first, AGENT-TOOLING last** (`.claude/**` — hooks
+  / skills / rules / agents — and `CLAUDE.md`): a wrong hook costs a future RUN
+  a detour and a user nothing, and that class is filed BY the runs that read
+  this list, so undemoted it crowds out the detection defect nobody reached. A
+  demotion among candidates otherwise tied, not an exclusion — the `Severity`
+  rule above still puts a `high` instruction defect over a `low` product one,
+  when that rival carries `Severity` too.
+- **Never rank by AGE; where all else ties, take the OLDER issue.** The listing
+  ARRIVES newest-first, so an absent tiebreaker is a recency bias nobody chose,
+  and what it produces is the old defect in the detection path — a wrong or
+  missing drift row a user acts on — that no run ever reaches. Rot does not
+  rank: the premise bullet below catches it at claim time anyway.
 - **An issue's premise may not be TRUE YET — resolve the body against the tree
   before writing anything that depends on it.** A body written from an unmerged
   branch describes THAT branch (go-to-k/cdkd#2246 asked for a doc note naming a

--- a/tests/skill-file-payload.test.ts
+++ b/tests/skill-file-payload.test.ts
@@ -133,7 +133,7 @@ const MAX_REFERENCE_FILE_BYTES = 48_000; // RE-DERIVED DOWNWARD 64_000 -> 48_000
 // What it SPENT is the NEAR-FLIP margin the paragraph above sizes, and saying
 // so is the point -- a reader who trusted that derivation would now be wrong.
 // Residuals if each near candidate grew past implement.md: retro.md (23,404 B)
-// 119,472, triage.md (24,261 B) 118,615, verify.md (24,311 B) 118,565. ALL
+// 120,024, triage.md (24,813 B) 118,615, verify.md (24,311 B) 119,117. ALL
 // THREE now sit ABOVE the floor, where the paragraph above cleared the worst by
 // 2,465 B. So the flip case is no longer covered by design margin at all: the
 // next stage file to overtake implement.md reds the ASSERTION below at the
@@ -152,8 +152,18 @@ const SPLIT_SKILLS: Record<string, { minFiles: number; minCorpusBytes: number }>
   // before the batching pass, which measured 771 B of room and needed 875:
   // the paragraph was paid for by turning section 0 into a pointer at
   // CLAUDE.md's untrusted-content rule, which it had restated at length.
-  // 142,691 B now, largest implement.md 25,647 B, so `corpus - largest` is
-  // 117,044 and this floor clears it by 956 B. That the FIRST attempt went
+  // 142,692 B on `origin/main`; 143,428 B after the 2026-09-06
+  // ranking-criteria port (+736 B, all of it triage.md: the two new ranking
+  // preferences plus a corrected label claim, less what they were paid inside
+  // the same section), largest implement.md 25,647 B, so `corpus - largest` is
+  // 117,781 and this floor clears it by 219 B -- and triage.md, at 24,813 B, is
+  // now 834 B from overtaking implement.md and flipping the leader, the case
+  // the paragraph above sizes. Re-derive every
+  // figure here at the sha you PUSH, and state the BASELINE beside a delta:
+  // two review rounds caught this paragraph quoting numbers measured one fix
+  // too early (5 B stale, the width of a `§3, ` inserted below), and a delta
+  // whose baseline is not written down cannot be checked at all. That the
+  // FIRST attempt went
   // red in CI rather than locally is the note worth keeping: the worktree was
   // cut before go-to-k/cdk-real-drift#1883 landed, so the local corpus was
   // 4,014 B short of the merge ref's -- re-measure against `origin/main`,


### PR DESCRIPTION
## Summary

Port of the maintainer-directed ranking change landed in go-to-k/cdkd, adapted
to this repo. Two preferences join `/work-issues` §3's list, both below the
`Severity` rule and above the premise check:

1. **The product surface ranks ahead of AGENT-TOOLING issues** — `.claude/**`
   (hooks / skills / rules / agents) and `CLAUDE.md`. A wrong hook costs a
   future RUN a detour and a user nothing, and that class is filed BY the runs
   that read the list, so undemoted it crowds out the detection defect nobody
   reached. A demotion among candidates otherwise tied, never an exclusion — the
   `Severity` rule above still puts a `high` instruction defect over a `low`
   product one.
2. **Age never ranks; where all else ties, the OLDER issue wins.** The listing
   ARRIVES newest-first, so having no tiebreaker is itself a recency bias, and
   what it produces is an old defect in the detection path — a wrong or missing
   drift row a user acts on — that no run ever reaches. Rot is not a ranking
   input; the premise bullet below catches it at claim time anyway.

**Partly paid for in the same section** per `retro.md` 10-c: the IN-PLACE
paragraph's four-line account of what it used to say became a one-line
correction carrying the same citation, and the MAIN-CHECKOUT paragraph's
retelling of a superseded revision became a clause. `triage.md` 24,261 -> 24,776 B, inside the 48,000 B
per-file cap. The payload test's byte commentary is re-derived in the same
commit — corpus 143,391 B, `corpus - largest` 117,744, floor cleared by 256 B,
and the residual table refreshed; `triage.md` is now 871 B from overtaking
`implement.md` and flipping the leader, which that comment's own paragraph
sizes. A cross-reference to `launch-mode.md`'s table also regained the §3 it
had been omitting.

## Test plan

- `vp run typecheck` / `vp check --fix` / `vp pack` — pass.
- `vp test run` — 352 files, 6,668 passed (root asserted as this worktree).
