### PR TITLE
ci: add a ci-ok aggregate status check and refuse a stale release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,136 @@ jobs:
       - run: vp install --frozen-lockfile
       - run: vp run build
       - run: vp env exec --node ${{ matrix.node-version }} node dist/cli.js --version
+
+  # A stale standing release PR is MERGEABLE and silently reverts main.
+  # release-please does not rebuild a release PR whose computed release is
+  # unchanged — it logs `PR #N remained the same` and leaves the branch on the
+  # base it was cut from. A `chore:` / `ci:` / `docs:` commit produces no
+  # changelog entry, so it lands on main WITHOUT the release branch following;
+  # if it touched a file release-please owns, merging the PR takes the branch's
+  # older copy, and GitHub reports MERGEABLE throughout.
+  #
+  # The remedy has always been "close the PR, delete its branch, re-run
+  # release.yml"; what was missing is anything that makes the condition VISIBLE
+  # before the merge. A human reading the diff was that check. Auto-merge on
+  # the release PR removes the human, so the check has to become a required
+  # status.
+  #
+  # `package.json` is deliberately NOT inspected: `chore(deps)` PRs touch it
+  # constantly, and release-please's own diff there is the `version` line
+  # alone — a three-way merge of that cannot revert a dependency line, so
+  # including it would block every release PR that is merely behind.
+  #
+  # A fork contributor can name a branch `release-please--x` and enter this job.
+  # That is harmless and deliberately not guarded against: the job reads only
+  # git ancestry and can do nothing but fail their own PR. Guarding on the PR
+  # author instead would add a SECOND way for the job to go silently inert,
+  # which is the failure mode tests/ci-ok-gate.test.ts prevents.
+  release-pr-not-stale:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # The PR HEAD, not the default `refs/pull/N/merge`. That ref has the base
+      # branch already merged into it, so every ancestry question below would
+      # answer "yes" no matter how stale the branch actually is — a vacuous
+      # pass, and the only way this job can be wrong in the unsafe direction.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: release-please-owned files on main must be ancestors of this branch
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin main
+          stale=0
+          for f in CHANGELOG.md .release-please-manifest.json; do
+            tip=$(git rev-list -1 FETCH_HEAD -- "${f}")
+            # An empty answer means the file has no history on main at all —
+            # renamed, deleted, or never committed. The guard cannot answer the
+            # question it was added to answer, and "cannot answer" is a failure
+            # rather than a pass.
+            if [ -z "${tip}" ]; then
+              echo "::error::${f} has no commit history on main. This guard cannot evaluate staleness, so it fails closed. If the file was renamed, update this job."
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "${tip}" HEAD; then
+              echo "::error::${f} was last changed on main by ${tip}, which is NOT an ancestor of this release branch — the branch is stale and merging it would revert that change. Close this PR, delete its branch, and re-run release.yml via workflow_dispatch to recreate it from current main."
+              stale=1
+            fi
+          done
+          [ "${stale}" -eq 0 ]
+
+  # The single check name the `main` branch ruleset requires. It exists instead
+  # of the ruleset naming the real jobs for two reasons:
+  #
+  #   1. `runtime-compat` is a matrix. A required check has to match the
+  #      EXPANDED name (`runtime-compat (20)`), but a matrix job that never
+  #      starts — because `check-build-test` failed — reports under the
+  #      UNEXPANDED name (`runtime-compat`). Requiring either spelling leaves
+  #      the other permanently "Expected", which blocks the PR forever.
+  #   2. Adding or renaming a job above then needs a line in `needs:` here
+  #      rather than an edit to repository settings nothing in this tree can
+  #      review.
+  #
+  # `if: always()` is load-bearing. Without it this job is SKIPPED whenever an
+  # upstream job fails, and a skipped required check counts as PASSING — the
+  # gate would report green exactly when CI is red.
+  #
+  # What this check does and does not attest to, stated so the ruleset change is
+  # made with eyes open: on a `pull_request` trigger the workflow DEFINITION
+  # comes from the PR's own ref, so a fork author can rewrite this job to `exit
+  # 0` and the required check reports green. That is a property of every
+  # `pull_request`-based required check, not something aggregating into one name
+  # introduced — requiring `check-build-test` directly was defeatable the same
+  # way. The controls are unchanged: the edit is visible in the diff, a
+  # first-time contributor's run needs maintainer approval, and a fork token is
+  # read-only. Human review of a workflow diff remains the control.
+  #
+  # Every PR check in this repo is reachable from `needs:` below: no workflow
+  # here carries a `paths:` filter, and `pr-inherit-issue-labels.yml` runs on
+  # `pull_request_target`, which is not a PR check. So `ci-ok` plus
+  # `pr-title-check.yml`'s `check` is the whole required set.
+  ci-ok:
+    if: always()
+    needs: [check-build-test, runtime-compat, release-pr-not-stale]
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      # Through `env:` rather than inline in `run:`. The value space here is a
+      # closed enum so inline is safe today, but expression data reaching a
+      # shell as a variable rather than as source text is the safer default.
+      RESULTS: ${{ join(needs.*.result, ' ') }}
+      # Must equal the length of `needs:` above. Both halves are read out of
+      # this file by tests/ci-ok-gate.test.ts, which also asserts `needs:`
+      # covers every other job — so this cannot drift silently.
+      EXPECTED_UPSTREAM: '3'
+    steps:
+      - name: every upstream job succeeded or was skipped
+        run: |
+          set -euo pipefail
+          # `skipped` is accepted on purpose: release-pr-not-stale skips on
+          # every non-release PR, and a matrix job skipped because its `needs`
+          # failed is already reported by that failing job's own result.
+          echo "upstream results: ${RESULTS}"
+          seen=0
+          for r in ${RESULTS}; do
+            seen=$((seen + 1))
+            case "${r}" in
+              success | skipped) ;;
+              *)
+                echo "::error::an upstream CI job reported '${r}' — this gate is red. See the run summary for which job."
+                exit 1
+                ;;
+            esac
+          done
+          # Without this, "every result was good" and "there were no results"
+          # are the same exit 0: an empty render makes the loop above run zero
+          # times. This job is the SOLE required status check, so a vacuous
+          # green here is a merge gate that examined nothing.
+          if [ "${seen}" -ne "${EXPECTED_UPSTREAM}" ]; then
+            echo "::error::examined ${seen} upstream result(s), expected ${EXPECTED_UPSTREAM}. The needs list did not reach this step, so this gate attests to nothing and fails closed."
+            exit 1
+          fi

--- a/tests/ci-ok-gate.test.ts
+++ b/tests/ci-ok-gate.test.ts
@@ -1,0 +1,376 @@
+import { readFileSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+
+/**
+ * Fence for the two jobs `.github/workflows/ci.yml` grew when the `main` branch
+ * ruleset started requiring a status check — `ci-ok` and `release-pr-not-stale`.
+ *
+ * `ci-ok` is the SINGLE check the ruleset requires, and with auto-merge armed on
+ * the release PR and on dependabot PRs, nobody is reading the checks at the
+ * moment a merge happens. So the failure that matters is not "went red when it
+ * should have been green" — that is loud and self-correcting — but "went GREEN
+ * having examined nothing", which is indistinguishable from a clean run at
+ * every surface a human or a hook looks at. Three such vacuities are reachable:
+ *
+ *   1. A job is added to the file and not to `ci-ok`'s `needs:`. It is then
+ *      outside the gate and can be red under a green `ci-ok`.
+ *   2. `if: always()` is dropped. `ci-ok` is then SKIPPED whenever an upstream
+ *      job fails — and a skipped required check counts as PASSING.
+ *   3. `RESULTS` renders empty. `for r in ${RESULTS}` runs zero times and the
+ *      step exits 0. The `EXPECTED_UPSTREAM` count is the floor, and it is only
+ *      a floor while it EQUALS the `needs:` length, asserted here rather than
+ *      trusted to the comment beside it.
+ *
+ * `release-pr-not-stale` is a CHECKER and carries a checker's obligation: prove
+ * it still REFUSES, not merely that it ran. Three of its properties are fenced:
+ *
+ *   a. The CHECKOUT, not just the shell. Deleting `ref: head.sha` makes the
+ *      runner use the default `refs/pull/N/merge`, which has the base already
+ *      merged in — so every `merge-base --is-ancestor` answers yes and the job
+ *      passes on a stale branch while its shell is still perfectly correct.
+ *   b. EACH ARM of the loop separately. With a fixture that only ever moves
+ *      `CHANGELOG.md` on main, the manifest arm never discriminates and gating
+ *      the ancestry test on the filename survives undetected.
+ *   c. The shell itself, EXTRACTED and EXECUTED, never re-typed — a copy here
+ *      would keep passing after the workflow's copy was broken — and selected
+ *      BY STEP NAME, so inserting a step ahead of it cannot retarget it.
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CI_YML = join(repoRoot, '.github', 'workflows', 'ci.yml');
+const RELEASE_YML = join(repoRoot, '.github', 'workflows', 'release.yml');
+
+const GATE_JOB = 'ci-ok';
+const GATE_STEP = 'every upstream job succeeded or was skipped';
+const STALE_JOB = 'release-pr-not-stale';
+const STALE_STEP = 'release-please-owned files on main must be ancestors of this branch';
+const CHANGELOG = 'CHANGELOG.md';
+const MANIFEST = '.release-please-manifest.json';
+
+interface CiWorkflow {
+  jobs: Record<
+    string,
+    {
+      if?: string;
+      needs?: string[];
+      env?: Record<string, string>;
+      steps?: { name?: string; uses?: string; run?: string; with?: Record<string, unknown> }[];
+    }
+  >;
+}
+
+function workflow(): CiWorkflow {
+  return parseYaml(readFileSync(CI_YML, 'utf8')) as CiWorkflow;
+}
+
+/** A named step's `run:` body, selected by NAME rather than by index. */
+function runBody(jobId: string, stepName: string): string {
+  const step = workflow().jobs[jobId]?.steps?.find((s) => s.name === stepName);
+  expect(
+    step?.run,
+    `the step \`${stepName}\` is gone from job \`${jobId}\` in .github/workflows/ci.yml. ` +
+      `If it was renamed, update this extractor; if it was REMOVED, restore it — this ` +
+      `suite then attests to nothing.`
+  ).toBeTruthy();
+  return step?.run as string;
+}
+
+function bashStatus(
+  script: string,
+  env: Record<string, string>,
+  cwd?: string
+): { status: number; output: string } {
+  try {
+    const output = execFileSync('bash', ['-c', script], {
+      cwd,
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+      stdio: 'pipe',
+    });
+    return { status: 0, output };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, output: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+describe('ci-ok — the single required status check', () => {
+  it('gates every other job in the workflow', () => {
+    const jobs = workflow().jobs;
+    const names = Object.keys(jobs);
+    // Non-vacuity floor: with one job the set equality below is trivially
+    // satisfiable and this case attests to nothing.
+    expect(
+      names.length,
+      'ci.yml has fewer jobs than when this fence was written — re-read it before lowering this floor.'
+    ).toBeGreaterThanOrEqual(4);
+
+    const gated = new Set(jobs[GATE_JOB]?.needs ?? []);
+    const ungated = names.filter((n) => n !== GATE_JOB && !gated.has(n));
+    expect(
+      ungated,
+      `these ci.yml jobs are not in ci-ok's \`needs:\`, so they are outside the merge gate ` +
+        `and can be red while the required check is green: ${ungated.join(', ')}. Add them ` +
+        `to \`needs:\` and bump EXPECTED_UPSTREAM.`
+    ).toEqual([]);
+
+    const phantom = [...gated].filter((n) => !names.includes(n));
+    expect(phantom, `ci-ok \`needs:\` names jobs that do not exist: ${phantom.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  it('runs even when an upstream job failed', () => {
+    expect(workflow().jobs[GATE_JOB]?.if).toBe('always()');
+  });
+
+  it('declares the upstream count its shell checks against', () => {
+    const job = workflow().jobs[GATE_JOB];
+    expect(job?.env?.['EXPECTED_UPSTREAM']).toBe(String(job?.needs?.length ?? -1));
+  });
+
+  it('takes the results through env, not as inlined expression text', () => {
+    expect(runBody(GATE_JOB, GATE_STEP)).not.toContain('${{');
+    expect(workflow().jobs[GATE_JOB]?.env?.['RESULTS']).toContain('join(needs.*.result');
+  });
+
+  describe('the extracted step', () => {
+    const run = (results: string) =>
+      bashStatus(runBody(GATE_JOB, GATE_STEP), { RESULTS: results, EXPECTED_UPSTREAM: '3' }).status;
+
+    it('passes when every upstream job succeeded', () => {
+      expect(run('success success success')).toBe(0);
+    });
+
+    it('passes when an upstream job was skipped', () => {
+      expect(run('success skipped success')).toBe(0);
+    });
+
+    it('fails on a failed upstream job', () => {
+      expect(run('success failure success')).not.toBe(0);
+    });
+
+    it('fails on a cancelled upstream job', () => {
+      expect(run('success cancelled success')).not.toBe(0);
+    });
+
+    it('fails when the results render empty', () => {
+      // THE case this floor exists for: the loop runs zero times, so without
+      // the count check "all good" and "examined nothing" are the same exit 0.
+      expect(run('')).not.toBe(0);
+    });
+
+    it('fails when fewer results arrive than the needs list declares', () => {
+      expect(run('success success')).not.toBe(0);
+    });
+  });
+});
+
+describe('release-pr-not-stale', () => {
+  let scratch: string;
+  let cloneSeq = 0;
+
+  interface Fixture {
+    remote: string;
+    tip: string;
+    base: string;
+  }
+
+  function git(cwd: string, ...args: string[]): string {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        // Hermetic: a maintainer's global config must not decide the verdict.
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_CONFIG_SYSTEM: '/dev/null',
+        GIT_AUTHOR_NAME: 't',
+        GIT_AUTHOR_EMAIL: 't@example.invalid',
+        GIT_COMMITTER_NAME: 't',
+        GIT_COMMITTER_EMAIL: 't@example.invalid',
+      },
+    }).trim();
+  }
+
+  function commit(repo: string, file: string, body: string, subject: string): string {
+    writeFileSync(join(repo, file), body);
+    git(repo, 'add', file);
+    git(repo, 'commit', '-q', '-m', subject);
+    return git(repo, 'rev-parse', 'HEAD');
+  }
+
+  /**
+   * A main history ending in a commit that touches ONLY `lastFile`, so a branch
+   * cut at `base` is stale by that file and by nothing else — which is what
+   * makes each arm of the production loop separately observable.
+   *
+   * `seedManifest: false` builds a history where the manifest NEVER existed, so
+   * `git rev-list -1 ... -- <manifest>` comes back empty and the fail-closed
+   * branch is reached with the CHANGELOG arm passing.
+   */
+  function makeRemote(name: string, lastFile: string, seedManifest = true): Fixture {
+    const origin = join(scratch, `${name}-origin`);
+    mkdirSync(origin);
+    git(origin, 'init', '-q', '-b', 'main');
+    writeFileSync(join(origin, CHANGELOG), '# Changelog\n\n## 0.1.0\n');
+    if (seedManifest) writeFileSync(join(origin, MANIFEST), '{ ".": "0.1.0" }\n');
+    git(origin, 'add', '.');
+    git(origin, 'commit', '-q', '-m', 'chore(release): 0.1.0');
+    const base = commit(origin, 'src.txt', 'work\n', 'feat: something');
+    const tip =
+      lastFile === CHANGELOG
+        ? commit(
+            origin,
+            CHANGELOG,
+            '# Changelog\n\n## 0.1.0 (normalized)\n',
+            'chore(docs): normalize'
+          )
+        : commit(origin, MANIFEST, '{ ".": "0.1.0-edited" }\n', 'chore: hand-edit the manifest');
+
+    const remote = join(scratch, `${name}-remote.git`);
+    execFileSync('git', ['clone', '-q', '--bare', origin, remote], {
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+    return { remote, tip, base };
+  }
+
+  function releaseBranchAt(fixture: Fixture, at: string): string {
+    const wt = join(scratch, `wt-${cloneSeq++}`);
+    execFileSync('git', ['clone', '-q', fixture.remote, wt], {
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+    git(wt, 'checkout', '-q', '-b', 'release-please--branches--main', at);
+    commit(wt, 'RELEASE_NOTE.txt', 'release-please commit\n', 'chore(release): 0.1.1');
+    return wt;
+  }
+
+  const guard = (cwd: string) =>
+    bashStatus(
+      runBody(STALE_JOB, STALE_STEP),
+      { GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+      cwd
+    );
+
+  let changelogFixture: Fixture;
+  let manifestFixture: Fixture;
+  let noManifestFixture: Fixture;
+
+  beforeAll(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'cdkrd-release-stale-'));
+    changelogFixture = makeRemote('changelog', CHANGELOG);
+    manifestFixture = makeRemote('manifest', MANIFEST);
+    noManifestFixture = makeRemote('nomanifest', CHANGELOG, false);
+  });
+
+  afterAll(() => {
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  describe('the checkout the guard depends on', () => {
+    it('takes the PR HEAD, not the default merge ref', () => {
+      // `refs/pull/N/merge` has the base already merged in, so every ancestry
+      // question answers "yes" no matter how stale the branch is. Losing this
+      // `ref:` is the one mutation that makes the whole job vacuous while its
+      // shell is still perfectly correct.
+      const checkout = workflow().jobs[STALE_JOB]?.steps?.find((s) =>
+        (s.uses ?? '').startsWith('actions/checkout@')
+      );
+      expect(checkout, `job \`${STALE_JOB}\` no longer checks anything out`).toBeTruthy();
+      expect(checkout?.with?.['ref']).toBe('${{ github.event.pull_request.head.sha }}');
+    });
+
+    it('fetches the full history the ancestry test needs', () => {
+      const checkout = workflow().jobs[STALE_JOB]?.steps?.find((s) =>
+        (s.uses ?? '').startsWith('actions/checkout@')
+      );
+      expect(checkout?.with?.['fetch-depth']).toBe(0);
+    });
+  });
+
+  describe('each owned file separately', () => {
+    it('passes on a release branch cut from current main', () => {
+      const { status, output } = guard(releaseBranchAt(changelogFixture, 'origin/main'));
+      expect(status).toBe(0);
+      expect(output).not.toContain('::error::');
+    });
+
+    it('fails when main moved CHANGELOG.md after the branch was cut', () => {
+      const { status, output } = guard(releaseBranchAt(changelogFixture, changelogFixture.base));
+      expect(status).not.toBe(0);
+      expect(output).toContain(CHANGELOG);
+      expect(output).toContain(changelogFixture.tip);
+      expect(output).toContain('re-run release.yml');
+      // Only this arm may fire here — otherwise the case cannot tell a
+      // per-file check from one that refuses everything.
+      expect(output).not.toContain(`${MANIFEST} was last changed`);
+    });
+
+    it('fails when main moved the manifest after the branch was cut', () => {
+      // Without this case the manifest arm never discriminates, and gating the
+      // ancestry test on `[ "${f}" = "CHANGELOG.md" ]` survives the suite.
+      const { status, output } = guard(releaseBranchAt(manifestFixture, manifestFixture.base));
+      expect(status).not.toBe(0);
+      expect(output).toContain(MANIFEST);
+      expect(output).toContain(manifestFixture.tip);
+      expect(output).not.toContain(`${CHANGELOG} was last changed`);
+    });
+
+    it('fails closed when an owned file has no history on main', () => {
+      // "The guard cannot answer" must not read as "the guard found nothing
+      // wrong". The CHANGELOG arm passes in this fixture, so the non-zero exit
+      // can only come from the empty-tip branch.
+      const { status, output } = guard(releaseBranchAt(noManifestFixture, 'origin/main'));
+      expect(status).not.toBe(0);
+      expect(output).toContain('cannot evaluate staleness');
+      expect(output).toContain(MANIFEST);
+      expect(output).not.toContain(`${CHANGELOG} has no commit history`);
+    });
+  });
+
+  describe('the job stays wired to the thing it guards', () => {
+    it('checks exactly the files release-please owns', () => {
+      // Read the loop's actual subject list rather than asserting a substring
+      // is absent — `not.toContain('package.json')` passes over an empty string
+      // and over a shell that checks nothing at all.
+      const m = /^for f in (.+); do$/m.exec(runBody(STALE_JOB, STALE_STEP));
+      expect(m, "the guard's `for f in ...; do` loop is gone").not.toBeNull();
+      expect((m as RegExpExecArray)[1]!.trim().split(/\s+/).sort()).toEqual(
+        [CHANGELOG, MANIFEST].sort()
+      );
+    });
+
+    it('is guarded by the branch prefix release-please actually produces', () => {
+      expect(workflow().jobs[STALE_JOB]?.if).toBe(
+        "startsWith(github.head_ref, 'release-please--')"
+      );
+      // RESIDUAL, stated rather than implied away: this repo has not yet had a
+      // release-please-created PR (batched releases landed recently and no
+      // release has been cut), so the prefix is release-please's documented
+      // default rather than an observed branch name here. The FIRST release PR
+      // must be checked — if its head does not start with `release-please--`,
+      // this job skips on every PR and `ci-ok` stays green over it.
+      //
+      // `branch-prefix` is NOT a release-please config key, so asserting its
+      // absence would be a fence over something that can never appear. What can
+      // actually move the prefix is a release-please MAJOR, and the action is
+      // SHA-pinned — so the pin's major is the real change vector: bumping it
+      // must force a re-check, and dependabot's patch bumps must not.
+      const pin = /googleapis\/release-please-action@[0-9a-f]{40} # v(\d+)/.exec(
+        readFileSync(RELEASE_YML, 'utf8')
+      );
+      expect(pin, 'release.yml no longer SHA-pins googleapis/release-please-action').not.toBeNull();
+      expect(
+        (pin as RegExpExecArray)[1],
+        'release-please was bumped to a new MAJOR. Its release branch prefix is a property ' +
+          `of that major — re-verify that a release PR's head still starts with ` +
+          "'release-please--' before updating this expectation."
+      ).toBe('4');
+    });
+  });
+});


### PR DESCRIPTION
## Why

The `main` branch ruleset requires no status check, so **GitHub never offers
the auto-merge button** — it is only offered on a PR that cannot be merged right
now. The release PR and the dependabot PRs are the two classes the maintainer
merges by hand, and both currently need approve → wait for CI → click merge.
With a required check they become approve → arm auto-merge → walk away.

This PR adds the jobs a required-check ruleset makes load-bearing. The ruleset
change itself lands **after** this merges: requiring a check no branch reports
yet would leave every open PR blocked at "Expected".

The same change is going into go-to-k/cdkd and go-to-k/cdk-real-drift, which
have the same two-rule ruleset, the same release-please setup and the same
`runtime-compat` matrix.

## What

### `ci-ok` — the single name from this workflow the ruleset will require

Requiring the real jobs does not work. `runtime-compat` is a matrix, so a
required check must match the **expanded** name (`runtime-compat (20)`), while a
matrix job that never starts — because `check-build-test` failed — reports under
the **unexpanded** name (`runtime-compat`). Requiring either spelling leaves the
other permanently "Expected", blocking the PR forever. Confirmed live on
go-to-k/cdkd#2999, whose checks report `runtime-compat (20)` / `(22)` / `(24)`.

The aggregate also means adding a job needs a line in `needs:` rather than an
edit to repository settings nothing in this tree can review.

### `release-pr-not-stale` — the hazard auto-merge introduces

release-please does not rebuild a release PR whose computed release is
unchanged; it logs `PR #N remained the same` and leaves the branch on the base
it was cut from. A `chore:` / `ci:` / `docs:` commit produces no changelog
entry, so it lands on `main` **without the release branch following** — and if
it touched a file release-please owns, merging the PR takes the branch's older
copy while GitHub reports MERGEABLE throughout.

This is not hypothetical here: go-to-k/cdk-real-drift#1879 was
`chore(ci): normalize CHANGELOG.md to the format release-please splices into` —
exactly the commit shape that leaves a standing release PR behind.

A human reading the diff was the only thing catching that. Arming auto-merge
removes the human, so the check has to become a required status.

`package.json` is deliberately **not** inspected: `chore(deps)` PRs touch it
constantly and release-please's own diff there is the `version` line alone,
which a three-way merge cannot use to revert a dependency line.

## Tests

Both new jobs carry the vacuity risk that matters for a merge gate — reporting
**green having examined nothing** — so both are fenced by a suite that EXECUTES
the shell extracted from the workflow rather than pattern-matching it. The
workflow is read as text rather than through a YAML parser for the reason
`release-please-v0.test.ts` already records: this repo ships no YAML library.

`ci-ok`:
- `needs:` covers every other job in the file
- `if: always()` is present (without it `ci-ok` is skipped on an upstream
  failure, and a skipped required check counts as **passing**)
- `EXPECTED_UPSTREAM` equals the `needs:` length
- the extracted step over `success` / `skipped` / `failure` / `cancelled`, plus
  the two vacuity cases: an **empty** render and a **short** one

`release-pr-not-stale`:
- the checkout takes `ref: head.sha` and `fetch-depth: 0` — losing the `ref:`
  makes the runner use `refs/pull/N/merge`, which has the base already merged
  in, so every ancestry question answers yes and the job passes on a stale
  branch while its shell is still perfectly correct
- each owned file separately: three synthesized remotes whose last commit
  touches only one file, so `CHANGELOG.md` and the manifest each discriminate
  on their own
- fails **closed** when an owned file has no history on main, in a fixture
  where the other arm passes so the verdict is isolated
- the loop's actual subject list equals the two owned files

Measured before the floor existed: `results=""` gives `iterations=0 exit=0` —
the sole required check green having examined nothing.

Each fence was probed by breaking the production shell and confirming the
expected cases, **and only those**, go red: removing `ref: head.sha`; gating
the ancestry test on the filename; disabling the `EXPECTED_UPSTREAM`
comparison; dropping `runtime-compat` from `needs:`.

## Residual, stated rather than implied away

This repo has not yet had a release-please-created PR, so
`startsWith(github.head_ref, 'release-please--')` is release-please's
documented default rather than an observed branch name here. **The first
release PR must be checked** — if its head does not start with
`release-please--`, the job skips on every PR and `ci-ok` stays green over it.
The test says so at the assertion, and pins the release-please action's major
so a bump forces a re-check.

## Follow-up

Once merged, the `main` ruleset gains **Require status checks to pass** naming
`ci-ok` and `check`. No other PR check exists here that a required check could
miss: no workflow carries a `paths:` filter, and `pr-inherit-issue-labels.yml`
runs on `pull_request_target`, which is not a PR check.
