### PR TITLE
ci: disarm auto-merge on a stale release PR, and close four ci-ok vacuities

### DIFF
--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -1,0 +1,125 @@
+name: release-pr-staleness
+
+# Disarm auto-merge on a standing release PR that `main` has moved past.
+#
+# THE HAZARD. release-please does not rebuild a release PR whose computed
+# release is unchanged -- it logs `PR #N remained the same` and leaves the
+# branch on the base it was cut from. A `chore:` / `ci:` / `docs:` commit
+# produces no changelog entry, so it lands on `main` WITHOUT the release branch
+# following, and merging the PR then takes the branch's older copy of any file
+# release-please owns. GitHub reports MERGEABLE throughout.
+#
+# WHY ci.yml's `release-pr-not-stale` JOB CANNOT COVER THIS. That job is the
+# right check in the wrong place: a `pull_request` workflow does NOT re-run when
+# the BASE branch moves (its default activity types are `opened`,
+# `synchronize`, `reopened` -- all head-side). So the release PR keeps the green
+# it earned at its last head push, and the hazard is precisely the case where
+# release-please never pushes again. The job still earns its keep for the
+# ordinary case, where a feat/fix lands and release-please rebuilds; this
+# workflow covers the path it structurally cannot see.
+#
+# WHY TWO TRIGGERS, AND WHY NEITHER ALONE IS ENOUGH.
+#   push to main         -- main moves while auto-merge is ALREADY armed.
+#   auto_merge_enabled   -- auto-merge is armed on a PR main moved past EARLIER.
+# The second is the common one and is easy to miss: a release PR sits for days,
+# a `chore:` commit lands, and the maintainer later arms auto-merge on a PR that
+# is green from an old run. It merges immediately. A push-only check never runs
+# at that moment.
+#
+# `pull_request_target`, not `pull_request`: this needs `pull-requests: write`
+# to disarm, and a `pull_request` token is read-only for forks. It runs only
+# base-controlled code -- `gh` and `git` against refs -- and never checks out or
+# executes anything from the head.
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [auto_merge_enabled]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-pr-staleness
+  cancel-in-progress: false
+
+jobs:
+  disarm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # Full history: `git rev-list -1 <ref> -- <path>` needs the commits that
+      # touched each owned file, which a shallow clone does not carry.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: disarm auto-merge on a release PR main has moved past
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The standing release PR, whatever event brought us here. Reading it
+          # back by head-branch prefix rather than from the event payload keeps
+          # both triggers on one code path, and means a `push` run that finds an
+          # armed PR behaves identically to the arm-time run.
+          pr=$(gh pr list --repo "${REPO}" --state open --json number,headRefName \
+                 --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')
+          if [ -z "${pr}" ]; then
+            echo "No standing release PR. Nothing to check."
+            exit 0
+          fi
+
+          armed=$(gh pr view "${pr}" --repo "${REPO}" --json autoMergeRequest \
+                    --jq 'if .autoMergeRequest == null then "no" else "yes" end')
+          head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
+          git fetch --no-tags --quiet origin "${head_ref}"
+          head=$(git rev-parse FETCH_HEAD)
+
+          stale=""
+          for f in CHANGELOG.md .release-please-manifest.json; do
+            tip=$(git rev-list -1 HEAD -- "${f}")
+            # An empty answer means the file has no history on main at all --
+            # renamed, deleted, or never committed. The check cannot answer the
+            # question it exists to answer, and "cannot answer" is a failure
+            # rather than a pass.
+            if [ -z "${tip}" ]; then
+              echo "::error::${f} has no commit history on main. This check cannot evaluate staleness, so it fails closed. If the file was renamed, update this workflow."
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "${tip}" "${head}"; then
+              stale="${stale}${stale:+, }${f} (main: ${tip})"
+            fi
+          done
+
+          if [ -z "${stale}" ]; then
+            echo "Release PR #${pr} is current with main (auto-merge armed: ${armed})."
+            exit 0
+          fi
+
+          echo "::warning::Release PR #${pr} is stale: ${stale}"
+
+          # Disarming is the only ACTION available, so a PR that is not armed
+          # gets a comment and nothing else -- and gets it once, because a
+          # repeat comment on every push to main would bury the signal. The
+          # arm-time trigger is what catches it later.
+          if [ "${armed}" = "yes" ]; then
+            gh pr merge "${pr}" --repo "${REPO}" --disable-auto
+            gh pr comment "${pr}" --repo "${REPO}" --body "$(cat <<EOF
+          Auto-merge has been **disabled** on this pull request: \`main\` has moved past it.
+
+          Stale against: ${stale}
+
+          release-please does not rebuild a release PR whose computed release is unchanged, so a \`chore:\` / \`ci:\` / \`docs:\` commit lands on \`main\` without this branch following. Merging as-is would take this branch's older copy of the file(s) above and revert that commit, and GitHub reports the PR as mergeable throughout.
+
+          To release: close this PR, delete its branch, and re-run the Release workflow (\`workflow_dispatch\`). release-please recomputes the identical release from current \`main\`.
+          EOF
+          )"
+          else
+            echo "Auto-merge is not armed on #${pr}; nothing to disable. The auto_merge_enabled trigger will re-check when it is."
+          fi

--- a/tests/ci-ok-gate.test.ts
+++ b/tests/ci-ok-gate.test.ts
@@ -53,13 +53,26 @@ const CHANGELOG = 'CHANGELOG.md';
 const MANIFEST = '.release-please-manifest.json';
 
 interface CiWorkflow {
+  on?: Record<
+    string,
+    { paths?: unknown; 'paths-ignore'?: unknown; branches?: unknown; types?: unknown } | null
+  >;
   jobs: Record<
     string,
     {
       if?: string;
       needs?: string[];
       env?: Record<string, string>;
-      steps?: { name?: string; uses?: string; run?: string; with?: Record<string, unknown> }[];
+      permissions?: unknown;
+      'continue-on-error'?: unknown;
+      steps?: {
+        name?: string;
+        uses?: string;
+        run?: string;
+        if?: string;
+        'continue-on-error'?: unknown;
+        with?: Record<string, unknown>;
+      }[];
     }
   >;
 }
@@ -78,6 +91,37 @@ function runBody(jobId: string, stepName: string): string {
       `suite then attests to nothing.`
   ).toBeTruthy();
   return step?.run as string;
+}
+
+/**
+ * Whether a step `if:` is exempt from the unconditional-step rule.
+ *
+ * `always()` is exempt outright — the step runs on every path, so it can never
+ * be why a job reported success having done nothing.
+ *
+ * `failure()` / `cancelled()` are exempt ONLY when the job carries at least one
+ * UNCONDITIONAL step. A diagnostic dump gated on `failure()` beside real work
+ * is correct code (this repo carries exactly that step), but the SAME condition
+ * on a job's only work skips on every green path while the job reports
+ * `success`.
+ *
+ * What stays banned outright is a condition that can be FALSE on an ordinary
+ * run (`github.event_name == 'push'`, an output test).
+ */
+function isExemptStepCondition(condition: string, jobSteps: { if?: string }[]): boolean {
+  const bare = condition
+    .trim()
+    .replace(/^\$\{\{\s*/, '')
+    .replace(/\s*\}\}$/, '')
+    .trim();
+  if (bare === 'always()') return true;
+  if (bare !== 'failure()' && bare !== 'cancelled()') return false;
+  // The qualifier is the whole point: a diagnostic dump gated on `failure()`
+  // BESIDE real work is correct code, but the same condition on a job's ONLY
+  // work skips on every green path while the job reports `success` — exactly
+  // the vacuity ci-ok cannot see. An earlier cut exempted these two
+  // unconditionally and readmitted that mutation.
+  return jobSteps.some((s) => s.if === undefined);
 }
 
 function bashStatus(
@@ -137,6 +181,89 @@ describe('ci-ok — the single required status check', () => {
   it('takes the results through env, not as inlined expression text', () => {
     expect(runBody(GATE_JOB, GATE_STEP)).not.toContain('${{');
     expect(workflow().jobs[GATE_JOB]?.env?.['RESULTS']).toContain('join(needs.*.result');
+  });
+
+  it('lets the shell exit status decide the job', () => {
+    // The cases below EXECUTE the extracted shell, so they attest that its TEXT
+    // is correct — never that the runner acts on its exit status. Two one-line
+    // additions sever that link and make the job report success with nothing
+    // decided: `continue-on-error: true` (the failure stops failing the job)
+    // and a step-level `if:` that is false (the step is skipped). `?? false`
+    // because an explicit `continue-on-error: false` is identical to absence.
+    for (const jobId of [GATE_JOB, STALE_JOB]) {
+      const job = workflow().jobs[jobId];
+      const stepName = jobId === GATE_JOB ? GATE_STEP : STALE_STEP;
+      const step = job?.steps?.find((s) => s.name === stepName);
+      expect(step?.['continue-on-error'] ?? false, `${jobId} step`).toBe(false);
+      expect(step?.if, `${jobId} step`).toBeUndefined();
+      expect(job?.['continue-on-error'] ?? false, `${jobId} job`).toBe(false);
+    }
+  });
+
+  it('keeps every gated job unconditional and failing', () => {
+    // Three levers let an upstream job stop contributing a real verdict while
+    // ci-ok still counts it, each landing a different `needs.*.result`:
+    //   job `if:`               -> `skipped`, which ci-ok ACCEPTS
+    //   job `continue-on-error` -> a FAILED job reports `success`
+    //   step `if:`              -> `success` with the step never executed
+    // All three give `seen == EXPECTED_UPSTREAM` and a green gate over a CI
+    // that decided nothing; the first two also read green in the Checks UI.
+    const jobs = workflow().jobs;
+    const ALLOWED_CONDITIONAL = new Set([GATE_JOB, STALE_JOB]);
+    const offenders: string[] = [];
+    for (const [name, j] of Object.entries(jobs)) {
+      if (j.if !== undefined && !ALLOWED_CONDITIONAL.has(name)) {
+        offenders.push(`${name} (job if:)`);
+      }
+      if ((j['continue-on-error'] ?? false) !== false) {
+        offenders.push(`${name} (job continue-on-error)`);
+      }
+      for (const s of j.steps ?? []) {
+        const label = s.name ?? s.run?.split('\n')[0] ?? '<step>';
+        if (
+          s.if !== undefined &&
+          !ALLOWED_CONDITIONAL.has(name) &&
+          !isExemptStepCondition(s.if, j.steps ?? [])
+        ) {
+          offenders.push(`${name} > ${label} (step if:)`);
+        }
+        // NOT gated on ALLOWED_CONDITIONAL: a step-level `continue-on-error`
+        // is the job-level lever one level down — the step fails, the job
+        // reports `success`, and it reads green in the Checks UI too.
+        if ((s['continue-on-error'] ?? false) !== false) {
+          offenders.push(`${name} > ${label} (step continue-on-error)`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `these ci.yml jobs can report a verdict ci-ok counts without earning it: ` +
+        `${offenders.join(', ')}. ci-ok accepts a SKIPPED upstream and cannot tell a ` +
+        `continue-on-error success from a real one, so any of these makes the gate green ` +
+        `over a CI that ran nothing.`
+    ).toEqual([]);
+  });
+
+  it('pins the least privilege each new job was given', () => {
+    // ci.yml has no top-level `permissions:`, so deleting either of these
+    // silently restores the repo-default token to a job that runs shell.
+    expect(workflow().jobs[GATE_JOB]?.permissions).toEqual({});
+    expect(workflow().jobs[STALE_JOB]?.permissions).toEqual({ contents: 'read' });
+  });
+
+  it('runs on every PR, so ci-ok can be a required check at all', () => {
+    // A `paths:`-filtered workflow does not start when nothing matches, so the
+    // required check never reports and every PR blocks forever at "Expected".
+    // `branches:` narrows the same way.
+    const pr = workflow().on?.['pull_request'];
+    expect(pr, 'ci.yml no longer triggers on `pull_request`').not.toBeUndefined();
+    expect(pr?.paths).toBeUndefined();
+    expect(pr?.['paths-ignore']).toBeUndefined();
+    // `types:` is the same trap with a different key: narrowing it to
+    // `[opened]` means a later push creates a head sha with NO check run, so
+    // the required check sits at "Expected" on that sha forever.
+    expect(pr?.types).toBeUndefined();
+    expect(pr?.branches).toEqual(['main']);
   });
 
   describe('the extracted step', () => {

--- a/tests/release-pr-staleness.test.ts
+++ b/tests/release-pr-staleness.test.ts
@@ -1,0 +1,327 @@
+import { readFileSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
+
+/**
+ * `.github/workflows/release-pr-staleness.yml` — the check that disarms
+ * auto-merge on a standing release PR that `main` has moved past.
+ *
+ * Why it exists rather than the `release-pr-not-stale` job in ci.yml doing the
+ * whole job: a `pull_request` workflow does NOT re-run when the BASE branch
+ * moves, so that job keeps whatever verdict it reached at the release PR's last
+ * head push — and the hazard is precisely the case where release-please never
+ * pushes again (a `chore:` commit produces no changelog entry, so the computed
+ * release is unchanged and the PR is left on its original base).
+ *
+ * Why this suite EXECUTES the workflow's shell against real git repositories
+ * and a stubbed `gh`: the whole check is six git/gh invocations, each of which
+ * rots silently. Drop the `!` from `merge-base`, compare against the wrong ref,
+ * invert the `armed` test — and it stops disarming anything while still exiting
+ * 0 on every run, which is indistinguishable from "nothing was stale". A suite
+ * that pattern-matched the YAML would certify that state.
+ *
+ * The four cases below are the whole decision table:
+ *
+ *   current + armed        -> leave alone
+ *   stale   + armed        -> disable auto-merge, comment once
+ *   stale   + NOT armed    -> no disable, no comment (nothing to disarm; the
+ *                             auto_merge_enabled trigger catches it later)
+ *   owned file has no history on main -> FAIL CLOSED, never a silent pass
+ */
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW = join(repoRoot, '.github', 'workflows', 'release-pr-staleness.yml');
+
+const CHANGELOG = 'CHANGELOG.md';
+const MANIFEST = '.release-please-manifest.json';
+const RELEASE_BRANCH = 'release-please--branches--main';
+
+/**
+ * The `run:` body of the workflow's disarm step, taken from the file rather
+ * than re-typed — a copy here would keep passing after the workflow's copy was
+ * broken. Read as TEXT (this repo ships no YAML library, the reason
+ * `release-please-v0.test.ts` records) by slicing the block scalar and
+ * dedenting it.
+ */
+function disarmShell(): string {
+  const yml = readFileSync(WORKFLOW, 'utf8');
+  const anchor = '      - name: disarm auto-merge on a release PR main has moved past';
+  const start = yml.indexOf(anchor);
+  expect(
+    start,
+    'the disarm step is gone from .github/workflows/release-pr-staleness.yml. If it was ' +
+      'renamed, update this extractor; if it was REMOVED, restore it — a stale release PR ' +
+      'could then auto-merge with nothing objecting.'
+  ).toBeGreaterThan(-1);
+  const lines = yml.slice(start).split('\n');
+  const runIdx = lines.findIndex((l) => /^\s*run: \|\s*$/.test(l));
+  expect(runIdx, 'the disarm step has no `run: |` body').toBeGreaterThan(-1);
+  const first = lines[runIdx + 1] ?? '';
+  const indent = (/^\s*/.exec(first)?.[0] ?? '').length;
+  expect(indent, 'the disarm step body is empty').toBeGreaterThan(0);
+  const body: string[] = [];
+  for (const line of lines.slice(runIdx + 1)) {
+    if (line.trim() === '') {
+      body.push('');
+      continue;
+    }
+    if ((/^\s*/.exec(line)?.[0] ?? '').length < indent) break;
+    body.push(line.slice(indent));
+  }
+  return body.join('\n');
+}
+
+const GIT_ENV = {
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_AUTHOR_NAME: 't',
+  GIT_AUTHOR_EMAIL: 't@example.invalid',
+  GIT_COMMITTER_NAME: 't',
+  GIT_COMMITTER_EMAIL: 't@example.invalid',
+};
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...GIT_ENV },
+  }).trim();
+}
+
+function commit(repo: string, file: string, body: string, subject: string): string {
+  writeFileSync(join(repo, file), body);
+  git(repo, 'add', file);
+  git(repo, 'commit', '-q', '-m', subject);
+  return git(repo, 'rev-parse', 'HEAD');
+}
+
+interface Run {
+  status: number;
+  output: string;
+  /** Every `gh` invocation the shell made, one per line, args space-joined. */
+  ghCalls: string[];
+}
+
+describe('release-pr-staleness', () => {
+  let scratch: string;
+  let seq = 0;
+
+  afterAll(() => {
+    if (scratch) rmSync(scratch, { recursive: true, force: true });
+  });
+
+  beforeAll(() => {
+    scratch = mkdtempSync(join(tmpdir(), 'cdkrd-staleness-'));
+  });
+
+  /**
+   * A repo whose `main` ends in a commit touching only `lastFile` and whose
+   * release branch was cut BEFORE it (`stale: true`) or at the tip
+   * (`stale: false`). Returns the working clone the shell runs in.
+   *
+   * `seedManifest: false` builds a history where the manifest never existed, so
+   * the empty-tip branch is reached with the CHANGELOG arm able to pass.
+   */
+  function fixture(opts: {
+    stale: boolean;
+    armed: boolean;
+    lastFile?: string;
+    seedManifest?: boolean;
+    noReleasePr?: boolean;
+  }): { cwd: string; ghLog: string; tip: string } {
+    const id = `f${seq++}`;
+    const origin = join(scratch, `${id}-origin`);
+    mkdirSync(origin);
+    git(origin, 'init', '-q', '-b', 'main');
+    writeFileSync(join(origin, CHANGELOG), '# Changelog\n\n## 0.1.0\n');
+    if (opts.seedManifest !== false) {
+      writeFileSync(join(origin, MANIFEST), '{ ".": "0.1.0" }\n');
+    }
+    git(origin, 'add', '.');
+    git(origin, 'commit', '-q', '-m', 'chore(release): 0.1.0');
+    const base = commit(origin, 'src.txt', 'work\n', 'feat: something');
+
+    // The release branch, cut from `base` when stale and from the tip when not.
+    // Its own commit touches a file release-please does NOT own, so the branch
+    // is never an ancestor of main in either case — only the owned-file tips
+    // decide, which is the property under test.
+    const lastFile = opts.lastFile ?? CHANGELOG;
+    const tip =
+      lastFile === CHANGELOG
+        ? commit(
+            origin,
+            CHANGELOG,
+            '# Changelog\n\n## 0.1.0 (normalized)\n',
+            'chore(docs): normalize'
+          )
+        : commit(origin, MANIFEST, '{ ".": "0.1.0-edited" }\n', 'chore: hand-edit the manifest');
+
+    git(origin, 'checkout', '-q', '-b', RELEASE_BRANCH, opts.stale ? base : tip);
+    commit(origin, 'RELEASE_NOTE.txt', 'release-please\n', 'chore(release): 0.1.1');
+    git(origin, 'checkout', '-q', 'main');
+
+    const bare = join(scratch, `${id}-remote.git`);
+    execFileSync('git', ['clone', '-q', '--bare', origin, bare], {
+      env: { ...process.env, ...GIT_ENV },
+    });
+    const cwd = join(scratch, `${id}-work`);
+    execFileSync('git', ['clone', '-q', bare, cwd], { env: { ...process.env, ...GIT_ENV } });
+
+    // `gh` stub: canned reads, recorded writes. Writing the log from the stub
+    // (rather than inferring from stdout) is what lets a case assert that
+    // `pr merge --disable-auto` was NOT called.
+    const binDir = join(scratch, `${id}-bin`);
+    mkdirSync(binDir);
+    const ghLog = join(scratch, `${id}-gh.log`);
+    // The stub emulates `--jq`, because the production shell reads the FILTERED
+    // value: `gh pr list --jq '[...][0].number // empty'` yields a bare number
+    // or nothing, never the array. Returning raw JSON here made `$pr` the whole
+    // document and every downstream call nonsense — a stub more permissive than
+    // real `gh` is how a suite certifies a check that cannot work.
+    const prNumber = opts.noReleasePr ? '' : '42';
+    const ghStub = `#!/usr/bin/env bash
+echo "$*" >> ${JSON.stringify(ghLog)}
+case "$*" in
+  *"pr list"*)        printf '%s' ${JSON.stringify(prNumber)} ;;
+  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armed ? 'yes' : 'no')} ;;
+  *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
+  *)                  : ;;
+esac
+`;
+    const ghPath = join(binDir, 'gh');
+    writeFileSync(ghPath, ghStub);
+    chmodSync(ghPath, 0o755);
+
+    return { cwd, ghLog, tip };
+  }
+
+  function run(fx: ReturnType<typeof fixture>): Run {
+    const binDir = dirname(join(fx.ghLog, '..')); // unused placeholder, see below
+    void binDir;
+    const stubDir = fx.ghLog.replace(/-gh\.log$/, '-bin');
+    let status = 0;
+    let output = '';
+    try {
+      output = execFileSync('bash', ['-c', disarmShell()], {
+        cwd: fx.cwd,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ...GIT_ENV,
+          PATH: `${stubDir}:${process.env['PATH'] ?? ''}`,
+          GH_TOKEN: 'x',
+          REPO: 'go-to-k/cdk-real-drift',
+        },
+        stdio: 'pipe',
+      });
+    } catch (error) {
+      const e = error as { status?: number; stdout?: string; stderr?: string };
+      status = e.status ?? 1;
+      output = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    }
+    let ghCalls: string[] = [];
+    try {
+      ghCalls = readFileSync(fx.ghLog, 'utf8').split('\n').filter(Boolean);
+    } catch {
+      ghCalls = [];
+    }
+    return { status, output, ghCalls };
+  }
+
+  const disarmed = (r: Run) => r.ghCalls.some((c) => c.includes('--disable-auto'));
+  const commented = (r: Run) => r.ghCalls.some((c) => c.includes('pr comment'));
+
+  it('leaves a current release PR alone', () => {
+    const r = run(fixture({ stale: false, armed: true }));
+    expect(r.status).toBe(0);
+    expect(r.output).toContain('is current with main');
+    expect(disarmed(r)).toBe(false);
+    expect(commented(r)).toBe(false);
+  });
+
+  it('disarms and comments when main moved CHANGELOG.md past an armed PR', () => {
+    const fx = fixture({ stale: true, armed: true });
+    const r = run(fx);
+    expect(r.status).toBe(0);
+    expect(disarmed(r)).toBe(true);
+    expect(commented(r)).toBe(true);
+    expect(r.output).toContain(CHANGELOG);
+    expect(r.output).toContain(fx.tip);
+  });
+
+  it('disarms when main moved the MANIFEST past an armed PR', () => {
+    // Without this, gating the ancestry test on `[ "${f}" = "CHANGELOG.md" ]`
+    // survives the suite and the manifest arm never discriminates.
+    const fx = fixture({ stale: true, armed: true, lastFile: MANIFEST });
+    const r = run(fx);
+    expect(disarmed(r)).toBe(true);
+    expect(r.output).toContain(MANIFEST);
+    expect(r.output).not.toContain(`${CHANGELOG} (main:`);
+  });
+
+  it('does not comment on a stale PR that is not armed', () => {
+    // There is nothing to disarm, and a comment on every push to main would
+    // bury the signal. The auto_merge_enabled trigger catches it later.
+    const r = run(fixture({ stale: true, armed: false }));
+    expect(r.status).toBe(0);
+    expect(disarmed(r)).toBe(false);
+    expect(commented(r)).toBe(false);
+    expect(r.output).toContain('not armed');
+  });
+
+  it('does nothing when no release PR is open', () => {
+    const r = run(fixture({ stale: true, armed: true, noReleasePr: true }));
+    expect(r.status).toBe(0);
+    expect(r.output).toContain('No standing release PR');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails closed when an owned file has no history on main', () => {
+    // "Cannot answer" must not read as "found nothing wrong": a rename would
+    // otherwise silence this check forever, and it is the last line of defence.
+    const r = run(fixture({ stale: false, armed: true, seedManifest: false }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('cannot evaluate staleness');
+    expect(r.output).toContain(MANIFEST);
+    expect(disarmed(r)).toBe(false);
+  });
+
+  describe('the workflow wiring', () => {
+    const yml = () => readFileSync(WORKFLOW, 'utf8');
+
+    it('fires both when main moves and when auto-merge is armed', () => {
+      // Neither trigger alone is enough. `push` misses a PR armed AFTER main
+      // moved — the common case, since a release PR can sit for days — and
+      // `auto_merge_enabled` misses main moving under an already-armed PR.
+      expect(yml()).toContain('types: [auto_merge_enabled]');
+      expect(yml()).toMatch(/push:\s*\n\s*branches: \[main\]/);
+    });
+
+    it('can actually disarm', () => {
+      // `gh pr merge --disable-auto` needs pull-requests: write, and a
+      // `pull_request` token is read-only for forks — which is why the trigger
+      // is `pull_request_target`.
+      expect(yml()).toContain('pull_request_target:');
+      expect(yml()).toContain('pull-requests: write');
+    });
+
+    it('checks out full history and no head code', () => {
+      // `rev-list -1 <ref> -- <path>` needs the commits that touched each file;
+      // and this workflow must never execute head-controlled content.
+      expect(yml()).toContain('fetch-depth: 0');
+      expect(yml()).toContain('persist-credentials: false');
+      expect(yml()).not.toContain('github.event.pull_request.head.sha');
+    });
+
+    it('checks exactly the files release-please owns', () => {
+      const m = /^for f in (.+); do$/m.exec(disarmShell());
+      expect(m, "the check's `for f in ...; do` loop is gone").not.toBeNull();
+      expect((m as RegExpExecArray)[1]!.trim().split(/\s+/).sort()).toEqual(
+        [CHANGELOG, MANIFEST].sort()
+      );
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to the `ci-ok` PR. Two independent pieces.

## 1. `release-pr-staleness.yml` — the path `release-pr-not-stale` structurally cannot see

The `release-pr-not-stale` job added in the previous PR is the right check in
the wrong place.

**A `pull_request` workflow does not re-run when the BASE branch moves.** Its
default activity types (`opened` / `synchronize` / `reopened`) are all
head-side, so the release PR keeps whatever verdict it reached at its last head
push — and the hazard it guards is *precisely* the case where release-please
never pushes again:

1. release PR is open and green
2. a `chore:` commit touching `CHANGELOG.md` lands on `main`
3. it produces no changelog entry, so the computed release is unchanged and
   release-please logs `PR #N remained the same` — no push
4. no push means no new run, so the check stays green from step 1
5. auto-merge fires and reverts step 2

Step 4 is where the job was supposed to help and cannot. It still earns its keep
for the ordinary case, where a `feat:` / `fix:` lands and release-please
rebuilds.

### Two triggers, because neither alone is enough

| trigger | catches |
| --- | --- |
| `push` to `main` | main moves while auto-merge is **already** armed |
| `pull_request_target: [auto_merge_enabled]` | auto-merge is armed on a PR main moved past **earlier** |

The second is the common one and the easy one to miss: a release PR sits for
days, a `chore:` commit lands, and the maintainer later arms auto-merge on a PR
that is green from an old run. It merges immediately, and a push-only check
never runs at that moment.

`pull_request_target` rather than `pull_request` because disarming needs
`pull-requests: write` and a `pull_request` token is read-only for forks. It runs
only base-controlled code — `gh` and `git` against refs — and never checks out or
executes head content.

Disarming is the only *action* available, so a PR that is not armed gets nothing
rather than a comment repeated on every push to `main`.

## 2. Four more ways `ci-ok` could go green over a CI that ran nothing

Each is an upstream job handing the gate a verdict it did not earn:

- a job-level `continue-on-error: true` makes a **failed** job report `success`
  — which also reads green in the Checks UI, so a CI-green check passes too
- a step-level `continue-on-error` is the same lever one level down
- a step-level `if:` leaves the job reporting `success` with the step never
  executed
- `types:` on `ci.yml`'s own `pull_request:` narrows like `paths:` does —
  `[opened]` means a later push creates a head sha with no check run, so the
  required check sits at "Expected" on it forever

### The step-`if:` exemption, and why it is qualified

`always()` is exempt outright. `failure()` / `cancelled()` are exempt **only
when the job carries at least one unconditional step** — a diagnostic dump
beside real work is correct code and this repo carries exactly that step, but
the same condition on a job's *only* work skips on every green path while the
job reports `success`.

That qualifier is not theoretical: an earlier cut exempted those two
unconditionally and readmitted exactly the mutation the fence exists to catch.

## Verification

Both suites **execute** shell extracted from the workflow rather than
pattern-matching it. Every fence was probed by making the production edit and
confirming the expected case — and only that case — goes red:

| mutation | red |
| --- | --- |
| gate the ancestry test on the filename | manifest-arm case |
| job-level `continue-on-error: true` | the offending job, by name |
| step-level `continue-on-error: true` | the offending step, by name |
| every step in a job gated on `failure()` | each step, by name |
| a diagnostic `if: failure()` beside real work | **nothing** — correctly exempt |
| `types: [opened]` on `pull_request` | the every-PR case |

The last two rows are one probe: with both shapes present simultaneously, only
the dangerous one is reported.

`release-pr-staleness.test.ts` drives the extracted shell against real git
repositories and a stubbed `gh`, covering the whole decision table — current +
armed, stale + armed (each owned file separately), stale + not armed, no release
PR, and an owned file with no history on `main` failing **closed**.
