### PR TITLE
ci: harden the release-PR staleness check against fork decoys, page eviction, and unreadable answers

### DIFF
--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -70,23 +70,32 @@ jobs:
           # armed PR behaves identically to the arm-time run.
           #
           # SAME-REPO ONLY, and that filter is load-bearing. A fork's head branch
-          # NAME is attacker-chosen, `gh pr list` includes fork PRs, and it
-          # orders newest-first -- so anyone could open a fork PR from a branch
-          # called `release-please--branches--main` and become the `[0]` this
-          # picks. The run would then read `armed` off the DECOY, get `no`, and
-          # exit 0 saying "not armed" while the real, armed, stale release PR
-          # went unchecked and merged. Pushing a branch to THIS repo needs write
-          # access, so restricting to same-repo PRs removes that reach entirely.
+          # NAME is attacker-chosen and open PRs include fork PRs -- so anyone
+          # could open one from a branch called `release-please--branches--main`
+          # and be picked here. The run would then read `armed` off the DECOY,
+          # get `no`, and exit 0 saying "not armed" while the real, armed, stale
+          # release PR went unchecked and merged. Pushing a branch to THIS repo
+          # needs write access, so the same-repo test removes that reach.
+          #
+          # A deleted fork leaves `head.repo` null, which `// ""` turns into a
+          # non-match rather than a jq error -- correct, since it was a fork.
           #
           # Deliberately NOT also matched on author: release-please's PRs are
           # authored by `app/github-actions` today, but switching it to a PAT or
           # a GitHub App changes that silently, and the guard would go inert with
           # nothing saying so -- the same failure mode the `if:` conditions in
           # ci.yml were repeatedly wrong about.
-          prs=$(gh pr list --repo "${REPO}" --state open \
-                  --json number,headRefName,isCrossRepository \
-                  --jq '.[] | select(.isCrossRepository | not)
-                            | select(.headRefName | startswith("release-please--"))
+          # `gh api --paginate`, NOT `gh pr list`. `gh pr list` defaults to
+          # `--limit 30` and applies `--jq` CLIENT-SIDE to that one page, so
+          # ~30 fork PRs -- attacker-chosen, no privilege -- evict the release
+          # PR from the page, the filter returns nothing, and the run exits 0
+          # saying "no standing release PR" while the real armed stale PR
+          # merges. Same suppression as the decoy below, reached by truncation
+          # instead of ordering, and it also fires benignly on a dependabot
+          # burst. Pagination enumerates EVERY open PR, so neither can happen.
+          prs=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
+                  --jq '.[] | select((.head.repo.full_name // "") == .base.repo.full_name)
+                            | select(.head.ref | startswith("release-please--"))
                             | .number')
           if [ -z "${prs}" ]; then
             echo "No standing release PR. Nothing to check."

--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -69,13 +69,20 @@ jobs:
           # both triggers on one code path, and means a `push` run that finds an
           # armed PR behaves identically to the arm-time run.
           #
-          # SAME-REPO ONLY, and that filter is load-bearing. A fork's head branch
-          # NAME is attacker-chosen and open PRs include fork PRs -- so anyone
-          # could open one from a branch called `release-please--branches--main`
-          # and be picked here. The run would then read `armed` off the DECOY,
-          # get `no`, and exit 0 saying "not armed" while the real, armed, stale
-          # release PR went unchecked and merged. Pushing a branch to THIS repo
-          # needs write access, so the same-repo test removes that reach.
+          # SAME-REPO ONLY. A fork's head branch NAME is attacker-chosen and open
+          # PRs include fork PRs, so without this anyone could open one from a
+          # branch called `release-please--branches--main`. Pushing a branch to
+          # THIS repo needs write access, which is the boundary the test draws.
+          #
+          # What that buys, stated against the code as it stands rather than an
+          # earlier draft of it. The `count != 1` refusal below means a decoy
+          # ALONGSIDE the real release PR would exit 1, not pass silently -- so
+          # the two remaining reaches are:
+          #   * DoS. One fork PR wedges every run into that refusal, turning a
+          #     guard that should be quiet into a permanent red anyone can set.
+          #   * Acting on a fork PR. With no real release PR open, a lone decoy
+          #     is `count == 1`, and this job holds `pull-requests: write` -- it
+          #     would read, and could comment on and disarm, a fork's PR.
           #
           # A deleted fork leaves `head.repo` null, which `// ""` turns into a
           # non-match rather than a jq error -- correct, since it was a fork.
@@ -126,20 +133,23 @@ jobs:
           esac
 
           head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
-          # `fetch-depth: 0` on the checkout already populated
-          # `refs/remotes/origin/*`, so the branch is normally local already.
-          # The fetch is the fallback for a ref created after the checkout, and
-          # it runs ANONYMOUSLY because `persist-credentials: false` strips the
-          # token -- fine for this public repo, and the reason a failure here is
-          # reported rather than swallowed by `--quiet`. The likeliest cause is
-          # the head branch having been deleted between the two calls.
-          if ! head=$(git rev-parse --verify --quiet "refs/remotes/origin/${head_ref}"); then
-            if ! git fetch --no-tags --quiet origin "${head_ref}"; then
-              echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
-              exit 1
-            fi
-            head=$(git rev-parse FETCH_HEAD)
+          # ALWAYS fetch; do NOT prefer the `refs/remotes/origin/*` the checkout
+          # already populated. release-please FORCE-PUSHES the release branch
+          # when it rebuilds, so a rebuild landing between the checkout and this
+          # line would leave the cached ref pointing at the OLD head -- and the
+          # run would compare main's tips against it and disarm a PR that had
+          # just been made current. The window is seconds and the direction is
+          # conservative, but a fetch costs nothing and removes it.
+          #
+          # This runs ANONYMOUSLY: `persist-credentials: false` strips the
+          # token. Fine for a public repo, and the reason the failure is
+          # reported rather than swallowed by `--quiet` -- the likeliest cause
+          # is the head branch having been deleted between the two calls.
+          if ! git fetch --no-tags --quiet origin "${head_ref}"; then
+            echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
+            exit 1
           fi
+          head=$(git rev-parse FETCH_HEAD)
 
           # CLAUDE.md names THREE release-please-owned files; `package.json` is
           # deliberately not one of them here. Ordinary `chore(deps)` PRs touch

--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -80,9 +80,17 @@ jobs:
           # the two remaining reaches are:
           #   * DoS. One fork PR wedges every run into that refusal, turning a
           #     guard that should be quiet into a permanent red anyone can set.
-          #   * Acting on a fork PR. With no real release PR open, a lone decoy
-          #     is `count == 1`, and this job holds `pull-requests: write` -- it
-          #     would read, and could comment on and disarm, a fork's PR.
+          #   * Reading a fork PR. With no real release PR open, a lone decoy
+          #     is `count == 1`, so the run picks it up -- and then hard-fails,
+          #     because `git fetch origin "${head_ref}"` below resolves the
+          #     FORK's branch name against THIS repo, which does not carry it.
+          #     So the reach is a second DoS wearing a misleading cause ("may
+          #     have been deleted"), not a write. The comment/disarm this job's
+          #     `pull-requests: write` allows needs BOTH an identically named
+          #     branch still present here AND someone with write access having
+          #     armed auto-merge on that fork PR -- a fork author cannot arm it.
+          #     Stated at that length because two earlier drafts of this bullet
+          #     overstated the reach, each time describing a chain nobody ran.
           #
           # A deleted fork leaves `head.repo` null, which `// ""` turns into a
           # non-match rather than a jq error -- correct, since it was a fork.
@@ -97,9 +105,10 @@ jobs:
           # ~30 fork PRs -- attacker-chosen, no privilege -- evict the release
           # PR from the page, the filter returns nothing, and the run exits 0
           # saying "no standing release PR" while the real armed stale PR
-          # merges. Same suppression as the decoy below, reached by truncation
-          # instead of ordering, and it also fires benignly on a dependabot
-          # burst. Pagination enumerates EVERY open PR, so neither can happen.
+          # merges. This one is the SILENT failure of the two: the decoy above
+          # ends in the loud `count != 1` refusal, while truncation leaves
+          # nothing to count, and it also fires benignly on a dependabot burst.
+          # Pagination enumerates EVERY open PR, so neither can happen.
           prs=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
                   --jq '.[] | select((.head.repo.full_name // "") == .base.repo.full_name)
                             | select(.head.ref | startswith("release-please--"))
@@ -133,6 +142,14 @@ jobs:
           esac
 
           head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
+          # Same fail-closed rule as `armed` above. An empty answer would reach
+          # `git fetch origin ""`, whose failure is reported as "could not read
+          # the head branch ''" -- a misdiagnosis pointing at a deleted branch
+          # when the real fault was `gh`.
+          if [ -z "${head_ref}" ]; then
+            echo "::error::gh returned no head branch name for #${pr}. Refusing to guess which branch to compare."
+            exit 1
+          fi
           # ALWAYS fetch; do NOT prefer the `refs/remotes/origin/*` the checkout
           # already populated. release-please FORCE-PUSHES the release branch
           # when it rebuilds, so a rebuild landing between the checkout and this
@@ -146,7 +163,7 @@ jobs:
           # reported rather than swallowed by `--quiet` -- the likeliest cause
           # is the head branch having been deleted between the two calls.
           if ! git fetch --no-tags --quiet origin "${head_ref}"; then
-            echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
+            echo "::error::could not read the head branch '${head_ref}' of #${pr}. Likeliest causes: the branch was deleted, a transient network failure (this fetch is not retried), or this repo is private and the anonymous fetch was refused."
             exit 1
           fi
           head=$(git rev-parse FETCH_HEAD)

--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -68,19 +68,76 @@ jobs:
           # back by head-branch prefix rather than from the event payload keeps
           # both triggers on one code path, and means a `push` run that finds an
           # armed PR behaves identically to the arm-time run.
-          pr=$(gh pr list --repo "${REPO}" --state open --json number,headRefName \
-                 --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')
-          if [ -z "${pr}" ]; then
+          #
+          # SAME-REPO ONLY, and that filter is load-bearing. A fork's head branch
+          # NAME is attacker-chosen, `gh pr list` includes fork PRs, and it
+          # orders newest-first -- so anyone could open a fork PR from a branch
+          # called `release-please--branches--main` and become the `[0]` this
+          # picks. The run would then read `armed` off the DECOY, get `no`, and
+          # exit 0 saying "not armed" while the real, armed, stale release PR
+          # went unchecked and merged. Pushing a branch to THIS repo needs write
+          # access, so restricting to same-repo PRs removes that reach entirely.
+          #
+          # Deliberately NOT also matched on author: release-please's PRs are
+          # authored by `app/github-actions` today, but switching it to a PAT or
+          # a GitHub App changes that silently, and the guard would go inert with
+          # nothing saying so -- the same failure mode the `if:` conditions in
+          # ci.yml were repeatedly wrong about.
+          prs=$(gh pr list --repo "${REPO}" --state open \
+                  --json number,headRefName,isCrossRepository \
+                  --jq '.[] | select(.isCrossRepository | not)
+                            | select(.headRefName | startswith("release-please--"))
+                            | .number')
+          if [ -z "${prs}" ]; then
             echo "No standing release PR. Nothing to check."
             exit 0
           fi
+          # More than one is an anomaly, not a case to guess at: picking one
+          # would leave the other unchecked and still exit 0.
+          count=$(printf '%s\n' "${prs}" | wc -l | tr -d ' ')
+          if [ "${count}" != "1" ]; then
+            echo "::error::found ${count} open same-repo release PRs ($(printf '%s' "${prs}" | tr '\n' ' ')). Refusing to guess which one auto-merge is armed on — close the extras."
+            exit 1
+          fi
+          pr="${prs}"
 
           armed=$(gh pr view "${pr}" --repo "${REPO}" --json autoMergeRequest \
                     --jq 'if .autoMergeRequest == null then "no" else "yes" end')
-          head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
-          git fetch --no-tags --quiet origin "${head_ref}"
-          head=$(git rev-parse FETCH_HEAD)
+          # Anything other than the two known answers FAILS CLOSED. A bare
+          # `[ "${armed}" = "yes" ]` sends every other value down the no-op
+          # branch and exits 0, which is indistinguishable from a genuinely
+          # unarmed PR -- so a `gh` that exits 0 with empty stdout, or one whose
+          # schema drops `autoMergeRequest`, would silently retire this check.
+          case "${armed}" in
+            yes | no) ;;
+            *)
+              echo "::error::could not read auto-merge state for #${pr} (got '${armed}'). Refusing to treat an unreadable answer as 'not armed'."
+              exit 1
+              ;;
+          esac
 
+          head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
+          # `fetch-depth: 0` on the checkout already populated
+          # `refs/remotes/origin/*`, so the branch is normally local already.
+          # The fetch is the fallback for a ref created after the checkout, and
+          # it runs ANONYMOUSLY because `persist-credentials: false` strips the
+          # token -- fine for this public repo, and the reason a failure here is
+          # reported rather than swallowed by `--quiet`. The likeliest cause is
+          # the head branch having been deleted between the two calls.
+          if ! head=$(git rev-parse --verify --quiet "refs/remotes/origin/${head_ref}"); then
+            if ! git fetch --no-tags --quiet origin "${head_ref}"; then
+              echo "::error::could not read the head branch '${head_ref}' of #${pr}. It may have been deleted, or this repo is private and the anonymous fetch was refused."
+              exit 1
+            fi
+            head=$(git rev-parse FETCH_HEAD)
+          fi
+
+          # CLAUDE.md names THREE release-please-owned files; `package.json` is
+          # deliberately not one of them here. Ordinary `chore(deps)` PRs touch
+          # it constantly, so main's tip for it moves far more often than a
+          # release PR is rebuilt -- every release PR would read as stale. And
+          # release-please's own diff there is the `version` line alone, which a
+          # three-way merge cannot use to revert a dependency line.
           stale=""
           for f in CHANGELOG.md .release-please-manifest.json; do
             tip=$(git rev-list -1 HEAD -- "${f}")
@@ -104,12 +161,23 @@ jobs:
 
           echo "::warning::Release PR #${pr} is stale: ${stale}"
 
-          # Disarming is the only ACTION available, so a PR that is not armed
-          # gets a comment and nothing else -- and gets it once, because a
-          # repeat comment on every push to main would bury the signal. The
-          # arm-time trigger is what catches it later.
+          # Disarming is the only ACTION available, so an UNARMED stale PR gets
+          # nothing but a run-log line: there is no auto-merge to remove, and a
+          # comment repeated on every push to main would bury the signal. The
+          # `auto_merge_enabled` trigger is what catches it the moment arming
+          # makes it actionable.
           if [ "${armed}" = "yes" ]; then
-            gh pr merge "${pr}" --repo "${REPO}" --disable-auto
+            # Guarded because this races the very thing it polices: auto-merge
+            # can fire, or a human can disarm, between the read above and here.
+            # Unguarded, `set -e` would abort with gh's raw error BEFORE the
+            # comment below explains what happened.
+            if ! gh pr merge "${pr}" --repo "${REPO}" --disable-auto; then
+              echo "::error::could not disable auto-merge on #${pr} — it may already have merged, or been disarmed since this run started."
+              exit 1
+            fi
+            # The heredoc body sits at COLUMN 0 on purpose: YAML dedents the
+            # block scalar before bash sees it, so re-indenting these lines to
+            # match the `if` turns the terminator into a syntax error.
             gh pr comment "${pr}" --repo "${REPO}" --body "$(cat <<EOF
           Auto-merge has been **disabled** on this pull request: \`main\` has moved past it.
 

--- a/.github/workflows/release-pr-staleness.yml
+++ b/.github/workflows/release-pr-staleness.yml
@@ -86,9 +86,11 @@ jobs:
           #     FORK's branch name against THIS repo, which does not carry it.
           #     So the reach is a second DoS wearing a misleading cause ("may
           #     have been deleted"), not a write. The comment/disarm this job's
-          #     `pull-requests: write` allows needs BOTH an identically named
-          #     branch still present here AND someone with write access having
-          #     armed auto-merge on that fork PR -- a fork author cannot arm it.
+          #     `pull-requests: write` allows needs THREE things at once: an
+          #     identically named branch still present here, someone with write
+          #     access having armed auto-merge on that fork PR (its author
+          #     cannot -- arming needs merge rights), and that branch being
+          #     STALE, since a current one exits 0 below without writing.
           #     Stated at that length because two earlier drafts of this bullet
           #     overstated the reach, each time describing a chain nobody ran.
           #
@@ -142,12 +144,16 @@ jobs:
           esac
 
           head_ref=$(gh pr view "${pr}" --repo "${REPO}" --json headRefName --jq .headRefName)
-          # Same fail-closed rule as `armed` above. An empty answer would reach
-          # `git fetch origin ""`, whose failure is reported as "could not read
-          # the head branch ''" -- a misdiagnosis pointing at a deleted branch
-          # when the real fault was `gh`.
-          if [ -z "${head_ref}" ]; then
-            echo "::error::gh returned no head branch name for #${pr}. Refusing to guess which branch to compare."
+          # Same ALLOWLIST discipline as `armed` above -- accept only what git
+          # itself calls a valid branch name -- rather than testing one bad
+          # shape. A bare `-z` was the single-shape version and let whitespace
+          # and leading-dash answers through: measured, `check-ref-format`
+          # REJECTS '', '   ' and '--upload-pack=x', and ACCEPTS an ordinary
+          # `release-please--branches--main`. An empty answer reaching
+          # `git fetch origin ""` was also reported as "could not read the head
+          # branch ''", pointing at a deleted branch when the fault was `gh`.
+          if ! git check-ref-format --branch "${head_ref}" >/dev/null 2>&1; then
+            echo "::error::gh gave no usable head branch name for #${pr} (got '${head_ref}'). Refusing to guess which branch to compare."
             exit 1
           fi
           # ALWAYS fetch; do NOT prefer the `refs/remotes/origin/*` the checkout
@@ -162,7 +168,10 @@ jobs:
           # token. Fine for a public repo, and the reason the failure is
           # reported rather than swallowed by `--quiet` -- the likeliest cause
           # is the head branch having been deleted between the two calls.
-          if ! git fetch --no-tags --quiet origin "${head_ref}"; then
+          # `refs/heads/...`, not the bare name: the answer then reaches git in
+          # an unambiguous ref position rather than one where a leading dash
+          # could be read as an option.
+          if ! git fetch --no-tags --quiet origin "refs/heads/${head_ref}"; then
             echo "::error::could not read the head branch '${head_ref}' of #${pr}. Likeliest causes: the branch was deleted, a transient network failure (this fetch is not retried), or this repo is private and the anonymous fetch was refused."
             exit 1
           fi

--- a/tests/release-pr-staleness.test.ts
+++ b/tests/release-pr-staleness.test.ts
@@ -23,13 +23,19 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * 0 on every run, which is indistinguishable from "nothing was stale". A suite
  * that pattern-matched the YAML would certify that state.
  *
- * The four cases below are the whole decision table:
+ * The decision table:
  *
  *   current + armed        -> leave alone
  *   stale   + armed        -> disable auto-merge, comment once
  *   stale   + NOT armed    -> no disable, no comment (nothing to disarm; the
  *                             auto_merge_enabled trigger catches it later)
  *   owned file has no history on main -> FAIL CLOSED, never a silent pass
+ *
+ * plus the failure modes that are NOT in the table and were each a live defect
+ * found in review: a fork PR decoying the lookup, 30+ PRs evicting the real one
+ * off `gh pr list`'s page, two same-repo matches, an unreadable auto-merge
+ * state, a head branch that cannot be read, and `--disable-auto` losing the
+ * race it polices.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -44,9 +50,14 @@ const DISARM_STEP = 'disarm auto-merge on a release PR main has moved past';
 /**
  * The `run:` body of the workflow's disarm step, taken from the file rather
  * than re-typed — a copy here would keep passing after the workflow's copy was
- * broken. Read as TEXT (this repo ships no YAML library, the reason
- * `release-please-v0.test.ts` records) by slicing the block scalar and
- * dedenting it.
+ * broken. Read as TEXT by slicing the block scalar and dedenting it.
+ *
+ * That is a CHOICE here, not a constraint: this repo ships `yaml` and its
+ * sibling workflow suites parse. Keeping this extractor byte-identical to
+ * cdk-local's means one review covers both copies, and the text form fails just
+ * as loudly — the anchor, the `run: |` line and the body indent each carry
+ * their own assertion. (An earlier revision claimed the repo had no YAML
+ * library, which was simply false.)
  */
 function disarmShell(): string {
   const yml = readFileSync(WORKFLOW, 'utf8');
@@ -120,6 +131,17 @@ describe('release-pr-staleness', () => {
   });
 
   beforeAll(() => {
+    // The `gh` stub pipes through real `jq` so the workflow's OWN `--jq`
+    // expression is what runs. Without jq the stub exits 127 and every case
+    // fails as "expected 1 to be 0" — name the cause instead. CI's
+    // ubuntu-latest ships it; a dev machine may not.
+    try {
+      execFileSync('jq', ['--version'], { stdio: 'ignore' });
+    } catch {
+      throw new Error(
+        "this suite needs `jq` on PATH: the gh stub runs the workflow's own --jq filter through it"
+      );
+    }
     scratch = mkdtempSync(join(tmpdir(), 'cdkrd-staleness-'));
   });
 
@@ -137,6 +159,10 @@ describe('release-pr-staleness', () => {
     lastFile?: string;
     seedManifest?: boolean;
     noReleasePr?: boolean;
+    /** Make `gh pr merge --disable-auto` exit non-zero — it races auto-merge firing. */
+    disarmFails?: boolean;
+    /** Drop the release branch from the clone AND its remote, so the head cannot be read. */
+    headRefMissing?: boolean;
     /**
      * Open PRs the stub reports, BEFORE the workflow's jq filter. Supplying
      * this is what lets a case exercise the filter itself — a fork decoy whose
@@ -188,6 +214,14 @@ describe('release-pr-staleness', () => {
     const cwd = join(scratch, `${id}-work`);
     execFileSync('git', ['clone', '-q', bare, cwd], { env: { ...process.env, ...GIT_ENV } });
 
+    // Delete the release branch from the BARE remote, so the clone's fetch of
+    // it fails the way a deleted head branch really does. Deleting only the
+    // clone's own ref would leave the fetch succeeding.
+    if (opts.headRefMissing) {
+      git(bare, 'branch', '-D', RELEASE_BRANCH);
+      git(cwd, 'update-ref', '-d', `refs/remotes/origin/${RELEASE_BRANCH}`);
+    }
+
     // `gh` stub: canned reads, recorded writes. Writing the log from the stub
     // (rather than inferring from stdout) is what lets a case assert that
     // `pr merge --disable-auto` was NOT called.
@@ -219,6 +253,10 @@ describe('release-pr-staleness', () => {
       },
       base: { repo: { full_name: 'go-to-k/cdk-real-drift' } },
     }));
+    // DELIBERATELY UNREACHABLE at HEAD: nothing in the workflow calls
+    // `gh pr list` any more. It exists so the eviction probe stays faithful —
+    // see the comment on the 40-fork case. Delete it only together with that
+    // case.
     // The stub ALSO answers the old `gh pr list` shape, truncated to 30 the
     // way real gh does. That is what makes the eviction probe faithful:
     // reverting the workflow to `gh pr list` reds the 40-fork case because the
@@ -236,13 +274,20 @@ for a in "$@"; do
   prev="$a"
 done
 case "$*" in
-  *"api repos/"*pulls*) printf '%s' ${JSON.stringify(JSON.stringify(restPrs))} | jq -r "$filter" ;;
-  *"pr list"*)          printf '%s' ${JSON.stringify(JSON.stringify(ghListPrs))} | jq -r "$filter" ;;
+  *"api repos/"*pulls*) jq -r "$filter" "$(dirname "$0")/rest.json" ;;
+  *"pr list"*)          jq -r "$filter" "$(dirname "$0")/ghlist.json" ;;
   *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
   *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
+  *"--disable-auto"*) exit ${opts.disarmFails ? 1 : 0} ;;
   *)                  : ;;
 esac
 `;
+    // The payloads go in FILES beside the stub, never interpolated into the
+    // script. Embedding them put JSON inside a bash double-quoted string, so a
+    // `$` or backtick in a head ref would EXPAND — in a suite whose whole point
+    // is modelling attacker-chosen branch names.
+    writeFileSync(join(binDir, 'rest.json'), JSON.stringify(restPrs));
+    writeFileSync(join(binDir, 'ghlist.json'), JSON.stringify(ghListPrs));
     const ghPath = join(binDir, 'gh');
     writeFileSync(ghPath, ghStub);
     chmodSync(ghPath, 0o755);
@@ -421,6 +466,26 @@ esac
     const r = run(fixture({ stale: true, armed: true, armedAnswer: '' }));
     expect(r.status).not.toBe(0);
     expect(r.output).toContain('could not read auto-merge state');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails loudly when disarming loses the race it polices', () => {
+    // auto-merge can fire, or a human can disarm, between the read and the
+    // call. Unguarded, `set -e` aborted with gh's raw error BEFORE the comment
+    // that explains what happened.
+    const r = run(fixture({ stale: true, armed: true, disarmFails: true }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('could not disable auto-merge');
+    expect(commented(r)).toBe(false);
+  });
+
+  it('fails closed when the head branch cannot be read', () => {
+    // A deleted head branch, or a private repo refusing the anonymous fetch
+    // (`persist-credentials: false` strips the token). Swallowed by `--quiet`,
+    // this was a bare git error with no context.
+    const r = run(fixture({ stale: true, armed: true, headRefMissing: true }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('could not read the head branch');
     expect(disarmed(r)).toBe(false);
   });
 

--- a/tests/release-pr-staleness.test.ts
+++ b/tests/release-pr-staleness.test.ts
@@ -142,7 +142,7 @@ describe('release-pr-staleness', () => {
      * this is what lets a case exercise the filter itself — a fork decoy whose
      * head branch carries the release prefix, or two same-repo matches.
      */
-    openPrs?: { number: number; headRefName: string; isCrossRepository: boolean }[];
+    openPrs?: { number: number; headRef: string; fork: boolean }[];
     /**
      * Raw stdout for the `autoMergeRequest` read, overriding `armed`. Lets a
      * case drive the answer the shell must FAIL CLOSED on — an empty string is
@@ -194,7 +194,7 @@ describe('release-pr-staleness', () => {
     const binDir = join(scratch, `${id}-bin`);
     mkdirSync(binDir);
     const ghLog = join(scratch, `${id}-gh.log`);
-    // `pr list` runs the WORKFLOW'S OWN `--jq` expression through real `jq`
+    // The PR lookup runs the WORKFLOW'S OWN `--jq` expression through real `jq`
     // against a canned PR list, rather than returning a canned answer. The
     // filter is the thing under test — restricting to same-repo PRs is what
     // stops a fork decoy named `release-please--…` becoming the `[0]` this
@@ -204,8 +204,28 @@ describe('release-pr-staleness', () => {
     const openPrs =
       opts.openPrs ??
       (opts.noReleasePr
-        ? [{ number: 9, headRefName: 'feat/unrelated', isCrossRepository: false }]
-        : [{ number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false }]);
+        ? [{ number: 9, headRef: 'feat/unrelated', fork: false }]
+        : [{ number: 42, headRef: RELEASE_BRANCH, fork: false }]);
+    // REST shape, because the shell now reads `gh api .../pulls` rather than
+    // `gh pr list` — the latter caps at `--limit 30` and filters that one page
+    // client-side, so ~30 fork PRs evict the release PR and the run exits 0.
+    const restPrs = openPrs.map((o) => ({
+      number: o.number,
+      head: {
+        ref: o.headRef,
+        repo: o.fork
+          ? { full_name: 'attacker/cdk-real-drift' }
+          : { full_name: 'go-to-k/cdk-real-drift' },
+      },
+      base: { repo: { full_name: 'go-to-k/cdk-real-drift' } },
+    }));
+    // The stub ALSO answers the old `gh pr list` shape, truncated to 30 the
+    // way real gh does. That is what makes the eviction probe faithful:
+    // reverting the workflow to `gh pr list` reds the 40-fork case because the
+    // release PR falls off the page, not because the stub stopped matching.
+    const ghListPrs = openPrs
+      .slice(0, 30)
+      .map((o) => ({ number: o.number, headRefName: o.headRef, isCrossRepository: o.fork }));
     const ghStub = `#!/usr/bin/env bash
 echo "$*" >> ${JSON.stringify(ghLog)}
 # Pull the --jq expression out of argv the way real gh consumes it.
@@ -216,7 +236,8 @@ for a in "$@"; do
   prev="$a"
 done
 case "$*" in
-  *"pr list"*)        printf '%s' ${JSON.stringify(JSON.stringify(openPrs))} | jq -r "$filter" ;;
+  *"api repos/"*pulls*) printf '%s' ${JSON.stringify(JSON.stringify(restPrs))} | jq -r "$filter" ;;
+  *"pr list"*)          printf '%s' ${JSON.stringify(JSON.stringify(ghListPrs))} | jq -r "$filter" ;;
   *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
   *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
   *)                  : ;;
@@ -337,8 +358,8 @@ esac
       armed: true,
       openPrs: [
         // Newest first, as gh returns them.
-        { number: 99, headRefName: RELEASE_BRANCH, isCrossRepository: true },
-        { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+        { number: 99, headRef: RELEASE_BRANCH, fork: true },
+        { number: 42, headRef: RELEASE_BRANCH, fork: false },
       ],
     });
     const r = run(fx);
@@ -349,6 +370,31 @@ esac
     expect(targetedPrs(r)).not.toContain('99');
   });
 
+  it('still finds the release PR behind 40 unrelated fork PRs', () => {
+    // `gh pr list` defaults to `--limit 30` and applies `--jq` CLIENT-SIDE to
+    // that one page. So ~30 fork PRs — attacker-chosen, no privilege — evict
+    // the release PR from the page, the filter returns nothing, and the run
+    // exits 0 reporting "no standing release PR" while the real armed stale PR
+    // merges. Same suppression as the decoy above, reached by TRUNCATION
+    // instead of ordering, and it fires benignly on a dependabot burst too.
+    // The shell uses `gh api --paginate` for exactly this reason.
+    const noise = Array.from({ length: 40 }, (_, i) => ({
+      number: 1000 + i,
+      headRef: `feat/noise-${i}`,
+      fork: true,
+    }));
+    const fx = fixture({
+      stale: true,
+      armed: true,
+      openPrs: [...noise, { number: 42, headRef: RELEASE_BRANCH, fork: false }],
+    });
+    const r = run(fx);
+    expect(r.status).toBe(0);
+    expect(r.output).not.toContain('No standing release PR');
+    expect(disarmed(r)).toBe(true);
+    expect(targetedPrs(r)).toContain('42');
+  });
+
   it('refuses rather than guessing when two same-repo release PRs are open', () => {
     // Picking one would leave the other unchecked and still exit 0 — the
     // silent-pass shape this whole workflow exists to remove.
@@ -357,8 +403,8 @@ esac
         stale: true,
         armed: true,
         openPrs: [
-          { number: 43, headRefName: `${RELEASE_BRANCH}--components--x`, isCrossRepository: false },
-          { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+          { number: 43, headRef: `${RELEASE_BRANCH}--components--x`, fork: false },
+          { number: 42, headRef: RELEASE_BRANCH, fork: false },
         ],
       })
     );

--- a/tests/release-pr-staleness.test.ts
+++ b/tests/release-pr-staleness.test.ts
@@ -25,8 +25,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * release is unchanged and the PR is left on its original base).
  *
  * Why this suite EXECUTES the workflow's shell against real git repositories
- * and a stubbed `gh`: the whole check is six git/gh invocations, each of which
- * rots silently. Drop the `!` from `merge-base`, compare against the wrong ref,
+ * and a stubbed `gh`: the whole check is a chain of git/gh invocations, each of
+ * which rots silently. Drop the `!` from `merge-base`, compare against the wrong ref,
  * invert the `armed` test — and it stops disarming anything while still exiting
  * 0 on every run, which is indistinguishable from "nothing was stale". A suite
  * that pattern-matched the YAML would certify that state.
@@ -44,9 +44,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * off `gh pr list`'s page, two same-repo matches, an unreadable auto-merge
  * state, a head branch that cannot be read, `gh` naming no head branch at all,
  * a head branch name carrying shell metacharacters, and `--disable-auto`
- * losing the race it polices. The table's four rows plus those eight are the
- * shell cases; the `describe` below them checks the YAML wiring instead, so do
- * not read a count off one half.
+ * losing the race it polices.
+ *
+ * Deliberately NOT stated as a count. Three successive revisions of this
+ * docblock gave a number ("six invocations", "the ten", "those eight") and all
+ * three were wrong, because nothing re-checks a number in prose. The `describe`
+ * block at the bottom covers the YAML wiring rather than the shell, so any
+ * count taken off one half was going to be wrong anyway.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -525,8 +529,10 @@ esac
     // Distinct from the case above: there the fetch fails, here `gh` answered
     // nothing. Without the guard the empty value reaches `git fetch origin ""`
     // and is reported as a branch that "may have been deleted" — a
-    // misdiagnosis pointing at the repo when the fault was the CLI. Same
-    // fail-closed rule the `armed` read already had.
+    // misdiagnosis pointing at the repo when the fault was the CLI. The guard
+    // is `git check-ref-format`, an ALLOWLIST like the `armed` read's, rather
+    // than a `-z` testing one bad shape: it also rejects whitespace-only and
+    // leading-dash answers.
     const r = run(
       fixture({
         stale: true,
@@ -536,21 +542,33 @@ esac
       })
     );
     expect(r.status).not.toBe(0);
-    expect(r.output).toContain('no head branch name');
+    expect(r.output).toContain('no usable head branch name');
     expect(disarmed(r)).toBe(false);
   });
 
   it('does not evaluate a head branch name that carries shell metacharacters', () => {
     // The one place a head ref reaches a shell is `git fetch … "${head_ref}"`.
+    //
+    // The payload is `$(>pwned)` and NOT `$(touch pwned)`, which is what this
+    // case first used: `git check-ref-format --branch` REJECTS the latter (it
+    // contains a space), so it modelled a value GitHub can never hand back,
+    // while `$(>pwned)` is ref-format VALID and still writes the file under a
+    // parser. Both measured.
+    //
     // What this case does NOT catch, measured rather than assumed: dropping the
-    // quotes changes nothing, because bash does not re-scan a variable's VALUE
-    // for command substitution — `v=$(printf %s 'x$(touch /tmp/p)'); cmd $v`
-    // creates no file. What it DOES catch is the rewrite that makes the value
-    // re-enter the parser: replacing the line with `eval "git fetch … $head_ref"`
-    // reds this case and ONLY this case. The probe is the side effect — if the
-    // `$(…)` ever runs, the file exists. The run itself is expected to fail,
-    // since no such branch exists to fetch.
-    const hostile = `${RELEASE_BRANCH}$(touch pwned)`;
+    // quotes changes nothing here. Two separate reasons, and only the second is
+    // load-bearing — bash does not re-scan a variable's VALUE for command
+    // substitution, AND unquoted expansion still word-splits and globs, which
+    // this payload would trigger if a ref could carry it. It cannot:
+    // `check-ref-format` rejects space, `*`, `?`, `[`, `:`, `\`, `~` and `^`,
+    // and the workflow now runs that same check before the fetch.
+    //
+    // What it DOES catch is the rewrite that makes the value re-enter the
+    // parser: replacing the line with `eval "git fetch … $head_ref"` reds this
+    // case and ONLY this case. The probe is the side effect — if the `$(…)`
+    // ever runs, the file exists. The run itself is expected to fail, since no
+    // such branch exists to fetch.
+    const hostile = `${RELEASE_BRANCH}$(>pwned)`;
     const fx = fixture({
       stale: true,
       armed: true,
@@ -558,6 +576,9 @@ esac
     });
     const r = run(fx);
     expect(r.status).not.toBe(0);
+    // Pins WHICH failure. Without it, a future change that exits 1 before ever
+    // reaching the fetch satisfies both assertions below vacuously.
+    expect(r.output).toContain('could not read the head branch');
     expect(existsSync(join(fx.cwd, 'pwned'))).toBe(false);
     expect(disarmed(r)).toBe(false);
   });

--- a/tests/release-pr-staleness.test.ts
+++ b/tests/release-pr-staleness.test.ts
@@ -39,6 +39,8 @@ const CHANGELOG = 'CHANGELOG.md';
 const MANIFEST = '.release-please-manifest.json';
 const RELEASE_BRANCH = 'release-please--branches--main';
 
+const DISARM_STEP = 'disarm auto-merge on a release PR main has moved past';
+
 /**
  * The `run:` body of the workflow's disarm step, taken from the file rather
  * than re-typed — a copy here would keep passing after the workflow's copy was
@@ -48,7 +50,7 @@ const RELEASE_BRANCH = 'release-please--branches--main';
  */
 function disarmShell(): string {
   const yml = readFileSync(WORKFLOW, 'utf8');
-  const anchor = '      - name: disarm auto-merge on a release PR main has moved past';
+  const anchor = `      - name: ${DISARM_STEP}`;
   const start = yml.indexOf(anchor);
   expect(
     start,
@@ -101,7 +103,11 @@ function commit(repo: string, file: string, body: string, subject: string): stri
 interface Run {
   status: number;
   output: string;
-  /** Every `gh` invocation the shell made, one per line, args space-joined. */
+  /**
+   * Every `gh` invocation's argv, space-joined. NOT one line per call — the
+   * multi-line `--body` puts a call's own newlines in here too, so these are
+   * safe to search with `.some(c => c.includes(...))` and unsafe to COUNT.
+   */
   ghCalls: string[];
 }
 
@@ -131,7 +137,19 @@ describe('release-pr-staleness', () => {
     lastFile?: string;
     seedManifest?: boolean;
     noReleasePr?: boolean;
-  }): { cwd: string; ghLog: string; tip: string } {
+    /**
+     * Open PRs the stub reports, BEFORE the workflow's jq filter. Supplying
+     * this is what lets a case exercise the filter itself — a fork decoy whose
+     * head branch carries the release prefix, or two same-repo matches.
+     */
+    openPrs?: { number: number; headRefName: string; isCrossRepository: boolean }[];
+    /**
+     * Raw stdout for the `autoMergeRequest` read, overriding `armed`. Lets a
+     * case drive the answer the shell must FAIL CLOSED on — an empty string is
+     * what a `gh` that exits 0 without the field would produce.
+     */
+    armedAnswer?: string;
+  }): { cwd: string; ghLog: string; tip: string; binDir: string } {
     const id = `f${seq++}`;
     const origin = join(scratch, `${id}-origin`);
     mkdirSync(origin);
@@ -176,17 +194,30 @@ describe('release-pr-staleness', () => {
     const binDir = join(scratch, `${id}-bin`);
     mkdirSync(binDir);
     const ghLog = join(scratch, `${id}-gh.log`);
-    // The stub emulates `--jq`, because the production shell reads the FILTERED
-    // value: `gh pr list --jq '[...][0].number // empty'` yields a bare number
-    // or nothing, never the array. Returning raw JSON here made `$pr` the whole
-    // document and every downstream call nonsense — a stub more permissive than
-    // real `gh` is how a suite certifies a check that cannot work.
-    const prNumber = opts.noReleasePr ? '' : '42';
+    // `pr list` runs the WORKFLOW'S OWN `--jq` expression through real `jq`
+    // against a canned PR list, rather than returning a canned answer. The
+    // filter is the thing under test — restricting to same-repo PRs is what
+    // stops a fork decoy named `release-please--…` becoming the `[0]` this
+    // picks — and a stub that answered `42` regardless would certify a filter
+    // that had been deleted. (An earlier cut returned the raw JSON array,
+    // ignoring `--jq` altogether; that is the same class one step further out.)
+    const openPrs =
+      opts.openPrs ??
+      (opts.noReleasePr
+        ? [{ number: 9, headRefName: 'feat/unrelated', isCrossRepository: false }]
+        : [{ number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false }]);
     const ghStub = `#!/usr/bin/env bash
 echo "$*" >> ${JSON.stringify(ghLog)}
+# Pull the --jq expression out of argv the way real gh consumes it.
+filter=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--jq" ]; then filter="$a"; fi
+  prev="$a"
+done
 case "$*" in
-  *"pr list"*)        printf '%s' ${JSON.stringify(prNumber)} ;;
-  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armed ? 'yes' : 'no')} ;;
+  *"pr list"*)        printf '%s' ${JSON.stringify(JSON.stringify(openPrs))} | jq -r "$filter" ;;
+  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
   *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
   *)                  : ;;
 esac
@@ -195,13 +226,11 @@ esac
     writeFileSync(ghPath, ghStub);
     chmodSync(ghPath, 0o755);
 
-    return { cwd, ghLog, tip };
+    return { cwd, ghLog, tip, binDir };
   }
 
   function run(fx: ReturnType<typeof fixture>): Run {
-    const binDir = dirname(join(fx.ghLog, '..')); // unused placeholder, see below
-    void binDir;
-    const stubDir = fx.ghLog.replace(/-gh\.log$/, '-bin');
+    const stubDir = fx.binDir;
     let status = 0;
     let output = '';
     try {
@@ -233,6 +262,22 @@ esac
 
   const disarmed = (r: Run) => r.ghCalls.some((c) => c.includes('--disable-auto'));
   const commented = (r: Run) => r.ghCalls.some((c) => c.includes('pr comment'));
+
+  /**
+   * PR numbers the shell actually addressed — the argv token right after a
+   * `pr view` / `pr merge` / `pr comment` verb.
+   *
+   * NOT a substring search over `ghCalls`. The comment's `--body` embeds commit
+   * SHAs, so `c.includes('99')` is satisfied by any run whose fixture happened
+   * to produce a SHA containing those digits — which passes in isolation and
+   * fails under the full suite, since the SHAs differ with the commit
+   * timestamps. Measured exactly that way.
+   */
+  const targetedPrs = (r: Run): string[] =>
+    r.ghCalls.flatMap((c) => {
+      const m = /^pr (?:view|merge|comment) (\d+)\b/.exec(c);
+      return m ? [m[1] as string] : [];
+    });
 
   it('leaves a current release PR alone', () => {
     const r = run(fixture({ stale: false, armed: true }));
@@ -279,6 +324,60 @@ esac
     expect(disarmed(r)).toBe(false);
   });
 
+  it('ignores a FORK PR whose head branch carries the release prefix', () => {
+    // `gh pr list` includes fork PRs and orders newest-first, and a fork's head
+    // branch NAME is attacker-chosen. Without the same-repo filter, a decoy
+    // named `release-please--branches--main` becomes the `[0]` the shell picks:
+    // `armed` is then read off the DECOY (not armed), the run exits 0 saying
+    // "not armed", and the real armed, stale release PR is never checked and
+    // merges. Pushing a branch to THIS repo needs write access, which is what
+    // the filter buys.
+    const fx = fixture({
+      stale: true,
+      armed: true,
+      openPrs: [
+        // Newest first, as gh returns them.
+        { number: 99, headRefName: RELEASE_BRANCH, isCrossRepository: true },
+        { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+      ],
+    });
+    const r = run(fx);
+    expect(r.status).toBe(0);
+    // The real PR is the one acted on — not the decoy.
+    expect(disarmed(r)).toBe(true);
+    expect(targetedPrs(r)).toContain('42');
+    expect(targetedPrs(r)).not.toContain('99');
+  });
+
+  it('refuses rather than guessing when two same-repo release PRs are open', () => {
+    // Picking one would leave the other unchecked and still exit 0 — the
+    // silent-pass shape this whole workflow exists to remove.
+    const r = run(
+      fixture({
+        stale: true,
+        armed: true,
+        openPrs: [
+          { number: 43, headRefName: `${RELEASE_BRANCH}--components--x`, isCrossRepository: false },
+          { number: 42, headRefName: RELEASE_BRANCH, isCrossRepository: false },
+        ],
+      })
+    );
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('found 2 open same-repo release PRs');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails closed when the auto-merge state cannot be read', () => {
+    // A `gh` that exits 0 with empty stdout — a schema change dropping
+    // `autoMergeRequest`, or a build without the field — used to fall through
+    // to the no-op branch and exit 0, which is indistinguishable from a
+    // genuinely unarmed PR. That retires the whole check silently.
+    const r = run(fixture({ stale: true, armed: true, armedAnswer: '' }));
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('could not read auto-merge state');
+    expect(disarmed(r)).toBe(false);
+  });
+
   it('fails closed when an owned file has no history on main', () => {
     // "Cannot answer" must not read as "found nothing wrong": a rename would
     // otherwise silence this check forever, and it is the last line of defence.
@@ -313,7 +412,12 @@ esac
       // and this workflow must never execute head-controlled content.
       expect(yml()).toContain('fetch-depth: 0');
       expect(yml()).toContain('persist-credentials: false');
-      expect(yml()).not.toContain('github.event.pull_request.head.sha');
+      // The realistic regression on a `pull_request_target` workflow is not the
+      // one exact expression — it is ANY head reference reaching the checkout
+      // or a shell, `github.head_ref` and `…head.ref` included. The PR number
+      // and head ref are read back through `gh` precisely so none of them
+      // appears here.
+      expect(yml()).not.toMatch(/github\.(event\.pull_request\.head|head_ref)/);
     });
 
     it('checks exactly the files release-please owns', () => {

--- a/tests/release-pr-staleness.test.ts
+++ b/tests/release-pr-staleness.test.ts
@@ -1,4 +1,12 @@
-import { readFileSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import {
+  readFileSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+  existsSync,
+} from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -34,8 +42,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
  * plus the failure modes that are NOT in the table and were each a live defect
  * found in review: a fork PR decoying the lookup, 30+ PRs evicting the real one
  * off `gh pr list`'s page, two same-repo matches, an unreadable auto-merge
- * state, a head branch that cannot be read, and `--disable-auto` losing the
- * race it polices.
+ * state, a head branch that cannot be read, `gh` naming no head branch at all,
+ * a head branch name carrying shell metacharacters, and `--disable-auto`
+ * losing the race it polices. The table's four rows plus those eight are the
+ * shell cases; the `describe` below them checks the YAML wiring instead, so do
+ * not read a count off one half.
  */
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -175,6 +186,12 @@ describe('release-pr-staleness', () => {
      * what a `gh` that exits 0 without the field would produce.
      */
     armedAnswer?: string;
+    /**
+     * Make the `headRefName` read answer with nothing — a `gh` that exits 0
+     * without the field. Distinct from `headRefMissing`, where `gh` answers
+     * fine and the FETCH is what fails.
+     */
+    headRefAnswerEmpty?: boolean;
   }): { cwd: string; ghLog: string; tip: string; binDir: string } {
     const id = `f${seq++}`;
     const origin = join(scratch, `${id}-origin`);
@@ -231,10 +248,11 @@ describe('release-pr-staleness', () => {
     // The PR lookup runs the WORKFLOW'S OWN `--jq` expression through real `jq`
     // against a canned PR list, rather than returning a canned answer. The
     // filter is the thing under test — restricting to same-repo PRs is what
-    // stops a fork decoy named `release-please--…` becoming the `[0]` this
-    // picks — and a stub that answered `42` regardless would certify a filter
-    // that had been deleted. (An earlier cut returned the raw JSON array,
-    // ignoring `--jq` altogether; that is the same class one step further out.)
+    // keeps a fork decoy named `release-please--…` out of the match set, so
+    // the real PR is the only thing counted — and a stub that answered `42`
+    // regardless would certify a filter that had been deleted. (An earlier cut
+    // returned the raw JSON array, ignoring `--jq` altogether; that is the same
+    // class one step further out.)
     const openPrs =
       opts.openPrs ??
       (opts.noReleasePr
@@ -265,29 +283,39 @@ describe('release-pr-staleness', () => {
       .slice(0, 30)
       .map((o) => ({ number: o.number, headRefName: o.headRef, isCrossRepository: o.fork }));
     const ghStub = `#!/usr/bin/env bash
-echo "$*" >> ${JSON.stringify(ghLog)}
-# Pull the --jq expression out of argv the way real gh consumes it.
+echo "$*" >> "$GH_LOG"
+# Pull the --jq expression, and the PR number, out of argv the way real gh
+# consumes them.
 filter=""
+prnum=""
 prev=""
 for a in "$@"; do
   if [ "$prev" = "--jq" ]; then filter="$a"; fi
+  case "$prev" in view | merge | comment) prnum="$a" ;; esac
   prev="$a"
 done
 case "$*" in
   *"api repos/"*pulls*) jq -r "$filter" "$(dirname "$0")/rest.json" ;;
   *"pr list"*)          jq -r "$filter" "$(dirname "$0")/ghlist.json" ;;
-  *autoMergeRequest*) printf '%s' ${JSON.stringify(opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'))} ;;
-  *headRefName*)      printf '%s' ${JSON.stringify(RELEASE_BRANCH)} ;;
+  *autoMergeRequest*) cat "$(dirname "$0")/armed.txt" ;;
+  # The head ref of the PR the shell ACTUALLY matched, read back out of the
+  # same canned list — not a constant. A constant meant no case could drive an
+  # attacker-shaped branch name into \`git fetch\`, the one place a head ref
+  # reaches a shell, so the earlier hardening protected the STUB and left the
+  # workflow path uncovered.
+  *headRefName*)      ${opts.headRefAnswerEmpty ? ':' : `jq -r --arg n "$prnum" '.[] | select(.number == ($n | tonumber)) | .head.ref' "$(dirname "$0")/rest.json"`} ;;
   *"--disable-auto"*) exit ${opts.disarmFails ? 1 : 0} ;;
   *)                  : ;;
 esac
 `;
-    // The payloads go in FILES beside the stub, never interpolated into the
-    // script. Embedding them put JSON inside a bash double-quoted string, so a
-    // `$` or backtick in a head ref would EXPAND — in a suite whose whole point
-    // is modelling attacker-chosen branch names.
+    // Every payload goes in a FILE beside the stub, or an env var — never
+    // interpolated into the script. Embedding them put JSON inside a bash
+    // double-quoted string, so a `$` or backtick in a head ref (or in the
+    // canned `armed` answer, or the log path) would EXPAND — in a suite whose
+    // whole point is modelling attacker-chosen branch names.
     writeFileSync(join(binDir, 'rest.json'), JSON.stringify(restPrs));
     writeFileSync(join(binDir, 'ghlist.json'), JSON.stringify(ghListPrs));
+    writeFileSync(join(binDir, 'armed.txt'), opts.armedAnswer ?? (opts.armed ? 'yes' : 'no'));
     const ghPath = join(binDir, 'gh');
     writeFileSync(ghPath, ghStub);
     chmodSync(ghPath, 0o755);
@@ -307,6 +335,7 @@ esac
           ...process.env,
           ...GIT_ENV,
           PATH: `${stubDir}:${process.env['PATH'] ?? ''}`,
+          GH_LOG: fx.ghLog,
           GH_TOKEN: 'x',
           REPO: 'go-to-k/cdk-real-drift',
         },
@@ -391,13 +420,15 @@ esac
   });
 
   it('ignores a FORK PR whose head branch carries the release prefix', () => {
-    // `gh pr list` includes fork PRs and orders newest-first, and a fork's head
-    // branch NAME is attacker-chosen. Without the same-repo filter, a decoy
-    // named `release-please--branches--main` becomes the `[0]` the shell picks:
-    // `armed` is then read off the DECOY (not armed), the run exits 0 saying
-    // "not armed", and the real armed, stale release PR is never checked and
-    // merges. Pushing a branch to THIS repo needs write access, which is what
-    // the filter buys.
+    // Open PRs include fork PRs, and a fork's head branch NAME is
+    // attacker-chosen. Without the same-repo filter, a decoy named
+    // `release-please--branches--main` joins the match set, so `count` is 2 and
+    // the run ends in the "refusing to guess which one" refusal — the real
+    // stale PR is never disarmed, and one PR anyone can open reds this guard on
+    // every run. Pushing a branch to THIS repo needs write access, which is
+    // what the filter buys. (This comment described an `[0]`-picks-the-decoy
+    // silent pass for two revisions. There is no `[0]`, and the `count != 1`
+    // refusal landed in the same commit as the filter; measured below.)
     const fx = fixture({
       stale: true,
       armed: true,
@@ -420,9 +451,10 @@ esac
     // that one page. So ~30 fork PRs — attacker-chosen, no privilege — evict
     // the release PR from the page, the filter returns nothing, and the run
     // exits 0 reporting "no standing release PR" while the real armed stale PR
-    // merges. Same suppression as the decoy above, reached by TRUNCATION
-    // instead of ordering, and it fires benignly on a dependabot burst too.
-    // The shell uses `gh api --paginate` for exactly this reason.
+    // merges. This is the SILENT one of the two fork reaches: the decoy above
+    // ends in a loud `count != 1` refusal, while truncation leaves nothing to
+    // count. It fires benignly on a dependabot burst too. The shell uses
+    // `gh api --paginate` for exactly this reason.
     const noise = Array.from({ length: 40 }, (_, i) => ({
       number: 1000 + i,
       headRef: `feat/noise-${i}`,
@@ -486,6 +518,47 @@ esac
     const r = run(fixture({ stale: true, armed: true, headRefMissing: true }));
     expect(r.status).not.toBe(0);
     expect(r.output).toContain('could not read the head branch');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('fails closed when gh returns no head branch name', () => {
+    // Distinct from the case above: there the fetch fails, here `gh` answered
+    // nothing. Without the guard the empty value reaches `git fetch origin ""`
+    // and is reported as a branch that "may have been deleted" — a
+    // misdiagnosis pointing at the repo when the fault was the CLI. Same
+    // fail-closed rule the `armed` read already had.
+    const r = run(
+      fixture({
+        stale: true,
+        armed: true,
+        openPrs: [{ number: 7, headRef: RELEASE_BRANCH, fork: false }],
+        headRefAnswerEmpty: true,
+      })
+    );
+    expect(r.status).not.toBe(0);
+    expect(r.output).toContain('no head branch name');
+    expect(disarmed(r)).toBe(false);
+  });
+
+  it('does not evaluate a head branch name that carries shell metacharacters', () => {
+    // The one place a head ref reaches a shell is `git fetch … "${head_ref}"`.
+    // What this case does NOT catch, measured rather than assumed: dropping the
+    // quotes changes nothing, because bash does not re-scan a variable's VALUE
+    // for command substitution — `v=$(printf %s 'x$(touch /tmp/p)'); cmd $v`
+    // creates no file. What it DOES catch is the rewrite that makes the value
+    // re-enter the parser: replacing the line with `eval "git fetch … $head_ref"`
+    // reds this case and ONLY this case. The probe is the side effect — if the
+    // `$(…)` ever runs, the file exists. The run itself is expected to fail,
+    // since no such branch exists to fetch.
+    const hostile = `${RELEASE_BRANCH}$(touch pwned)`;
+    const fx = fixture({
+      stale: true,
+      armed: true,
+      openPrs: [{ number: 42, headRef: hostile, fork: false }],
+    });
+    const r = run(fx);
+    expect(r.status).not.toBe(0);
+    expect(existsSync(join(fx.cwd, 'pwned'))).toBe(false);
     expect(disarmed(r)).toBe(false);
   });
 


### PR DESCRIPTION
A `pull_request_target` workflow holding `pull-requests: write` that disarms
auto-merge on a standing release PR `main` has moved past. Four review rounds,
and this body is rewritten from the branch as it stands — the previous body was
round-1 text describing code two rounds had already replaced.

## What the branch does now

- **Same-repo only.** Open PRs include fork PRs and a fork's head branch NAME is
  attacker-chosen, so the lookup matches
  `.head.repo.full_name == .base.repo.full_name`. More than one match is a
  refusal, not a guess.
- **`gh api --paginate`, not `gh pr list`.** That command caps at `--limit 30`
  and filters that one page CLIENT-SIDE, so ~30 fork PRs evict the release PR
  and the run exits 0 saying "no standing release PR" while the real armed stale
  PR merges. This is the SILENT fork reach; the decoy is the loud one.
- **Fail closed on every unreadable answer** — auto-merge state, head branch
  name, the fetch, and `--disable-auto` losing the race it polices.
- **Always fetch the head.** release-please FORCE-PUSHES the release branch when
  it rebuilds, so a cached `refs/remotes/origin/*` could be an OLD head and the
  run would disarm a PR just made current.

## The reach was one step too long

The bullet said a lone fork decoy "would read, and could comment on and disarm,
a fork's PR". The read is right. The disarm is not reachable:

```
head_ref  = the FORK's branch name
git fetch --no-tags --quiet origin "${head_ref}"   # resolves against THIS repo
                                                   # which does not carry it
  -> exit 1
```

So the honest reach is a **second DoS** wearing a misleading cause ("may have
been deleted"). Comment/disarm needs *both* an identically named branch still
present in this repo *and* a write-access user having armed auto-merge on the
fork PR — which its author cannot do.

## The debunked story survived in the test

An earlier round rewrote the `[0]`-picks-the-decoy model in the workflow only. The test
carried it verbatim in two places, and that is the copy a reader hits first.
Both now describe what the `count != 1` refusal actually does.

The eviction case's "same suppression as the decoy" is wrong in both files too:
the decoy is the **loud** failure (`count != 1` → exit 1) and truncation is the
silent one. It also said the decoy block was "below" when it is above.

## An empty head ref was not fail-closed

`armed` already refused an unreadable answer; `head_ref` did not. A `gh` exiting
0 with empty stdout reached `git fetch origin ""` and was reported as a branch
that "may have been deleted" — pointing at the repo when the fault was the CLI.

## The hardening had protected the stub, not the workflow

`headRefName` answered a **constant**, so no case could drive an attacker-shaped
branch name into `git fetch` — the one place a head ref reaches a shell. The
stub now reads the matched PR's ref back out of the same canned list, and a case
drives `release-please--branches--main$(touch pwned)` through it.

Measured rather than asserted, because the obvious claim is false:

| mutation | result |
| --- | --- |
| drop the quotes (`origin ${head_ref}`) | **no change** — bash does not re-scan a variable's value |
| `eval "git fetch … $head_ref"` | reds the new case, and **only** that case (17 others green) |
| neutralize the empty-`head_ref` guard | reds the new empty-ref case, and only that one |

All three probes run in all three repos.

## Smaller

- The remaining interpolations into the stub's bash source (the canned `armed`
  answer, the log path) move to a file and an env var.
- The fetch error names transient failure as a cause, since it is not retried.
- The header's case count is replaced with the enumeration — the number was
  already off by two.


## Round 4 — the head ref is now validated against git's own grammar

Two findings, both "right conclusion, wrong reason" — the same class as the
three rounds before.

- The hostile fixture drove `release-please--branches--main$(touch pwned)`
  through the head-ref path. Measured: `git check-ref-format --branch`
  **rejects** that name (it contains a space), so the case probed a branch name
  that cannot exist. `$(>pwned)` is ref-format **valid** and still writes the
  file under a parser — that is the payload now.
- The safety argument said dropping the quotes changes nothing "because bash
  does not re-scan a variable's VALUE". True but not sufficient: unquoted
  expansion still word-splits and globs, and the old payload's space would have
  split it. The load-bearing reason is that no real ref can carry those
  characters — `check-ref-format` rejects space, `*`, `?`, `[`, `:`, `\`, `~`,
  `^`.

So the guard became what it already claimed to be. `[ -z "${head_ref}" ]` was
described as "the same fail-closed rule as `armed`", but `armed` accepts an
enumerated set while that tested **one** bad shape — whitespace-only and
option-shaped answers went straight through. It is now
`git check-ref-format --branch`, and the fetch names the ref in full
(`refs/heads/...`).

Also: the fork-reach bullet was short one condition (the branch must be STALE
too), the metacharacter case gained a message assertion it could otherwise pass
vacuously, and every count in the test docblock — "six invocations" (ten), "the
ten" (twelve), "those eight" (fourteen) — was deleted rather than corrected.
Three wrong revisions is enough evidence that nothing re-checks a number in
prose.
